### PR TITLE
Content Patches for the Minerva, Volume 2

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -1436,6 +1436,7 @@
 /area/mainship/hull/port_hull)
 "eR" = (
 /obj/vehicle/ridden/powerloader,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/mainship/orange{
 	dir = 1
 	},
@@ -2208,6 +2209,10 @@
 /obj/structure/sign/pods,
 /turf/closed/wall/mainship,
 /area/mainship/living/evacuation)
+"hv" = (
+/obj/machinery/loadout_vendor,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/general)
 "hw" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/living/evacuation)
@@ -2569,13 +2574,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
-"iH" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/loadout_vendor,
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/general)
 "iK" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 2;
@@ -3157,14 +3155,14 @@
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
 "kX" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/landmark/start/job/researcher,
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
 "kY" = (
 /obj/machinery/vending/weapon,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
 "kZ" = (
@@ -4333,6 +4331,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/silver{
 	dir = 5
 	},
@@ -4637,7 +4636,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/mainship/silver/corner{
 	dir = 8
 	},
@@ -4659,6 +4657,7 @@
 	},
 /obj/effect/ai_node,
 /obj/structure/disposalpipe/segment/corner,
+/obj/structure/cable,
 /turf/open/floor/mainship/silver{
 	dir = 4
 	},
@@ -4976,7 +4975,6 @@
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
 "qJ" = (
-/obj/structure/cable,
 /turf/open/floor/mainship/silver{
 	dir = 8
 	},
@@ -4985,6 +4983,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/mainship/silver{
 	dir = 4
 	},
@@ -5317,6 +5316,13 @@
 "rY" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
+"rZ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/port_hull)
 "sa" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -5477,13 +5483,13 @@
 /area/mainship/living/evacuation)
 "sE" = (
 /obj/machinery/door/airlock/multi_tile/mainship/research,
-/obj/structure/cable,
 /turf/open/floor/mainship/silver/full,
 /area/mainship/medical/medical_science)
 "sF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/mainship/silver/full,
 /area/mainship/medical/medical_science)
 "sG" = (
@@ -5606,6 +5612,11 @@
 /obj/item/frame/table,
 /obj/item/frame/table,
 /obj/structure/rack,
+/obj/machinery/door_control{
+	dir = 8;
+	id = "reqaccess";
+	name = "Requisitions Access"
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "sX" = (
@@ -5714,6 +5725,10 @@
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/port_hallway)
+"ts" = (
+/obj/machinery/door/airlock/mainship/marine/requisitions,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "tu" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/gas,
@@ -5819,12 +5834,6 @@
 	dir = 1
 	},
 /area/mainship/medical/lower_medical)
-"tP" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/lower_medical)
 "tQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -5839,6 +5848,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -6499,14 +6509,6 @@
 /turf/open/floor/mainship/orange{
 	dir = 1
 	},
-/area/mainship/squads/req)
-"wc" = (
-/obj/machinery/door_control{
-	dir = 8;
-	id = "reqaccess";
-	name = "Requisitions Access"
-	},
-/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "wd" = (
 /obj/structure/cable,
@@ -9272,11 +9274,6 @@
 /area/mainship/living/numbertwobunks)
 "ES" = (
 /obj/structure/closet/secure_closet/medical2,
-/obj/item/tool/kitchen/knife/butcher{
-	blood_overlay = null;
-	desc = "A huge thing used for chopping and chopping up meat. You sense this one has been involved in something terrible, best not to question it.";
-	name = "Stainless butcher's cleaver"
-	},
 /obj/item/limb/l_hand,
 /obj/item/limb/l_arm,
 /turf/open/floor/mainship/sterile/dark,
@@ -9781,9 +9778,10 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip{
-	pixel_x = -10;
-	pixel_y = 13
+	pixel_x = -15;
+	pixel_y = 18
 	},
+/obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
 "Gb" = (
@@ -12605,6 +12603,14 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"Pe" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "Pf" = (
 /obj/machinery/recycler{
 	dir = 8
@@ -13545,6 +13551,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/command/self_destruct)
+"Ss" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "St" = (
 /obj/vehicle/unmanned/droid/scout,
 /obj/machinery/mech_bay_recharge_port{
@@ -19463,7 +19473,7 @@ XE
 XE
 fD
 ep
-eS
+rZ
 fx
 Le
 gQ
@@ -20449,8 +20459,8 @@ gm
 bE
 hK
 iw
-jk
-kq
+vw
+ns
 kX
 mi
 ns
@@ -21047,7 +21057,7 @@ pD
 qJ
 qJ
 sE
-tP
+qM
 uX
 vK
 wB
@@ -21712,7 +21722,7 @@ ua
 az
 OS
 bT
-VC
+Ss
 VC
 aW
 dO
@@ -24969,7 +24979,7 @@ sq
 sW
 gY
 gY
-wc
+gY
 wR
 SA
 yC
@@ -25067,7 +25077,7 @@ SA
 SA
 ul
 ul
-SA
+ts
 SA
 SA
 cj
@@ -25165,7 +25175,7 @@ jM
 jM
 WS
 WS
-jM
+WS
 eg
 dC
 rL
@@ -25464,8 +25474,8 @@ sr
 sr
 yG
 zW
-sr
-sr
+hv
+hv
 Dq
 zW
 sr
@@ -25562,11 +25572,11 @@ ta
 uq
 yG
 tc
-ta
-iH
+tc
+tc
 Dq
 tc
-tc
+uq
 tc
 vk
 sr
@@ -25661,7 +25671,7 @@ tc
 yJ
 Pl
 KY
-Pl
+Pe
 Dt
 FN
 md

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -7044,19 +7044,7 @@
 /area/mainship/medical/lower_medical)
 "xM" = (
 /obj/structure/table/mainship,
-/obj/item/storage/belt/medical{
-	pixel_y = 9
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 9
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 9
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 9
-	},
-/obj/item/healthanalyzer,
+/obj/machinery/recharger,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "xO" = (
@@ -7067,6 +7055,16 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/storage/belt/medical{
+	pixel_y = 9
+	},
+/obj/item/storage/belt/medical{
+	pixel_y = 9
+	},
+/obj/item/storage/belt/medical{
+	pixel_y = 9
+	},
+/obj/item/healthanalyzer,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "xP" = (

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -4511,6 +4511,7 @@
 /area/mainship/shipboard/port_missiles)
 "pd" = (
 /obj/structure/rack,
+/obj/item/tool/crowbar/red,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/port_missiles)
 "pf" = (
@@ -4865,6 +4866,7 @@
 /area/mainship/shipboard/starboard_missiles)
 "qk" = (
 /obj/structure/rack,
+/obj/item/tool/crowbar/red,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/starboard_missiles)
 "ql" = (
@@ -7381,6 +7383,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/general)
+"yI" = (
+/obj/machinery/roomba,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "yJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -7855,6 +7861,10 @@
 	dir = 8
 	},
 /area/mainship/living/cryo_cells)
+"Ab" = (
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/living/grunt_rnr)
 "Ac" = (
 /obj/machinery/light{
 	dir = 1
@@ -7935,10 +7945,6 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
-"Ap" = (
-/obj/machinery/roomba,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/briefing)
 "Aq" = (
 /obj/structure/table/mainship,
 /obj/item/pizzabox,
@@ -8021,6 +8027,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lounge)
+"AC" = (
+/obj/structure/sign/nosmoking_2,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "AD" = (
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/mainship/sterile/dark,
@@ -8280,13 +8290,6 @@
 /obj/structure/cable,
 /turf/open/floor/freezer,
 /area/mainship/living/cafeteria_starboard)
-"Bs" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic/cryo{
-	dir = 1
-	},
-/obj/structure/sign/nosmoking_2,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/general)
 "Bu" = (
 /obj/machinery/power/apc/mainship{
 	dir = 8
@@ -8373,6 +8376,7 @@
 /obj/machinery/alarm{
 	dir = 8
 	},
+/obj/item/paper/hydroponics,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/port_garden)
 "BN" = (
@@ -8496,6 +8500,9 @@
 /area/mainship/medical/lower_medical)
 "Cd" = (
 /obj/machinery/vending/MarineMed,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
@@ -8513,16 +8520,6 @@
 /area/mainship/hallways/hangar)
 "Cg" = (
 /turf/closed/wall/mainship,
-/area/mainship/living/briefing)
-"Ch" = (
-/obj/structure/flora/pottedplant/twentyone,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/alarm{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "Ci" = (
 /turf/open/floor/mainship/mono,
@@ -8705,9 +8702,6 @@
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "CV" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/rack,
 /obj/item/defibrillator,
 /obj/item/defibrillator,
@@ -8715,6 +8709,9 @@
 /obj/item/bodybag/cryobag,
 /obj/item/bodybag/cryobag,
 /obj/item/bodybag/cryobag,
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
@@ -8763,6 +8760,7 @@
 	},
 /area/mainship/living/briefing)
 "Dg" = (
+/obj/machinery/alarm,
 /turf/open/floor/mainship/orange{
 	dir = 5
 	},
@@ -9132,6 +9130,9 @@
 /obj/machinery/vending/MarineMed,
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
@@ -10481,6 +10482,10 @@
 	dir = 1
 	},
 /area/mainship/medical/chemistry)
+"In" = (
+/obj/machinery/computer/arcade,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/living/grunt_rnr)
 "Io" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -10652,6 +10657,7 @@
 /obj/structure/mirror{
 	pixel_y = 28
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/living/grunt_rnr)
 "IU" = (
@@ -11276,6 +11282,7 @@
 /obj/machinery/power/apc/mainship{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/black{
 	dir = 8
 	},
@@ -12905,7 +12912,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/port_atmos)
 "Qg" = (
@@ -14338,6 +14344,13 @@
 "UZ" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"Vb" = (
+/obj/structure/table/mainship,
+/obj/item/paper/crumpled,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 4
+	},
+/area/mainship/medical/chemistry)
 "Vc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -15415,6 +15428,7 @@
 /area/mainship/command/airoom)
 "YV" = (
 /obj/structure/table/mainship,
+/obj/item/paper/crumpled,
 /turf/open/floor/mainship/sterile/purple/corner{
 	dir = 1
 	},
@@ -20975,7 +20989,7 @@ Gb
 GS
 HQ
 Iq
-sc
+Vb
 eK
 wd
 sc
@@ -23907,7 +23921,7 @@ xS
 Ot
 Io
 Jo
-Ch
+Lp
 Db
 Bp
 bm
@@ -24404,7 +24418,7 @@ Fm
 Gs
 Cg
 HV
-Ap
+Ci
 Jy
 Ci
 Cl
@@ -24880,7 +24894,7 @@ gY
 gY
 gY
 gY
-gY
+yI
 gY
 wQ
 SA
@@ -25664,7 +25678,7 @@ mE
 sr
 sY
 us
-tc
+AC
 sr
 tc
 tc
@@ -26747,7 +26761,7 @@ sr
 sr
 sr
 yG
-Bs
+Ah
 sr
 sr
 DB
@@ -26954,7 +26968,7 @@ yf
 HY
 IK
 IK
-IK
+Ab
 IK
 IK
 Mw
@@ -27344,7 +27358,7 @@ Fx
 xd
 yf
 xg
-IK
+In
 IK
 IK
 IK

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -13737,6 +13737,22 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/powered)
+"Tg" = (
+/obj/machinery/vending/marineFood,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
+/area/mainship/living/cafeteria_starboard)
 "Ti" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -26866,11 +26882,11 @@ wX
 ya
 yO
 Ai
-wZ
+Tg
 Yw
 DG
 Ai
-wZ
+Tg
 Yw
 Hx
 xg

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -80,6 +80,12 @@
 /obj/structure/ship_ammo/minirocket,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"aw" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/mainship/green{
+	dir = 4
+	},
+/area/mainship/living/port_garden)
 "ax" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -89,7 +95,7 @@
 	dir = 6
 	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "ay" = (
 /obj/structure/cable,
@@ -139,6 +145,15 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"aG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/purple{
+	dir = 4
+	},
+/area/mainship/living/briefing)
 "aH" = (
 /obj/machinery/light,
 /turf/open/floor/mainship/tcomms,
@@ -213,6 +228,11 @@
 /obj/structure/window/framed/mainship/hull,
 /turf/open/floor/plating,
 /area/mainship/hull/starboard_hull)
+"aP" = (
+/turf/open/floor/mainship/black{
+	dir = 5
+	},
+/area/mainship/hallways/starboard_hallway)
 "aQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -224,6 +244,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
+"aR" = (
+/obj/effect/decal/cleanable/blood/oil{
+	name = "grease";
+	pixel_x = -10
+	},
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "aT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -271,7 +300,7 @@
 	},
 /obj/effect/ai_node,
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "aY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -394,6 +423,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
+"bm" = (
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/mainship/living/briefing)
 "bn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -403,7 +437,7 @@
 	dir = 9
 	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
 "bo" = (
 /obj/machinery/door/poddoor/mainship/droppod{
@@ -486,6 +520,13 @@
 	dir = 1
 	},
 /area/mainship/command/cic)
+"bC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/black/full,
+/area/mainship/squads/general)
 "bD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -649,6 +690,10 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/starboard_hallway)
+"cg" = (
+/obj/structure/mirror,
+/turf/closed/wall/mainship,
+/area/mainship/squads/general)
 "ci" = (
 /obj/machinery/camera/autoname/mainship,
 /obj/structure/closet/toolcloset,
@@ -658,15 +703,21 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
 /area/mainship/hallways/starboard_hallway)
 "cl" = (
 /obj/item/radio/intercom/general,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
 /area/mainship/hallways/starboard_hallway)
 "cn" = (
 /obj/machinery/vending/nanomed,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
 /area/mainship/hallways/starboard_hallway)
 "co" = (
 /obj/structure/window/framed/mainship/canterbury,
@@ -691,6 +742,11 @@
 "cs" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/port_garden)
+"cu" = (
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
+/area/mainship/living/briefing)
 "cv" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -753,6 +809,15 @@
 "cF" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"cG" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = -4;
+	pixel_y = -5
+	},
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
+/area/mainship/living/briefing)
 "cH" = (
 /turf/open/floor/mainship/terragov/north{
 	dir = 8
@@ -838,6 +903,11 @@
 	icon_state = "carpetside"
 	},
 /area/mainship/command/corporateliaison)
+"cX" = (
+/turf/open/floor/mainship/black/corner{
+	dir = 4
+	},
+/area/mainship/hallways/starboard_hallway)
 "cY" = (
 /obj/item/weapon/gun/pistol/vp70,
 /obj/item/ammo_magazine/pistol/vp70,
@@ -900,7 +970,7 @@
 /obj/structure/flora/pottedplant/twentyone{
 	icon_state = "plant-10"
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black,
 /area/mainship/hallways/starboard_hallway)
 "dl" = (
 /obj/machinery/power/apc/mainship{
@@ -1011,7 +1081,9 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
 /area/mainship/hallways/starboard_hallway)
 "dD" = (
 /obj/machinery/disposal,
@@ -1020,6 +1092,11 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
+"dE" = (
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
+/area/mainship/hallways/starboard_hallway)
 "dF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1035,6 +1112,26 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
+"dH" = (
+/obj/structure/window/framed/mainship/white,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
+"dI" = (
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/squads/general)
+"dJ" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = 5;
+	pixel_y = -10
+	},
+/obj/item/ammo_casing/bullet{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "dK" = (
 /obj/structure/bed/chair/sofa/right,
 /obj/structure/disposalpipe/segment/corner,
@@ -1095,6 +1192,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"dU" = (
+/turf/open/floor/mainship/black/corner{
+	dir = 8
+	},
+/area/mainship/hallways/starboard_hallway)
 "dV" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -1146,7 +1248,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
 /area/mainship/hallways/starboard_hallway)
 "eh" = (
 /obj/structure/table/woodentable,
@@ -1192,6 +1296,11 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
+"et" = (
+/turf/open/floor/mainship/purple{
+	dir = 1
+	},
+/area/mainship/squads/general)
 "eu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -1337,6 +1446,11 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
+"eU" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/autodoc,
+/turf/open/floor/mainship/sterile,
+/area/mainship/medical/lower_medical)
 "eV" = (
 /obj/structure/sign/custodian,
 /turf/closed/wall/mainship,
@@ -1408,7 +1522,7 @@
 	dir = 5
 	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
 "ff" = (
 /obj/structure/dropship_equipment/sentry_holder,
@@ -1429,6 +1543,14 @@
 /obj/structure/closet/crate/medical,
 /turf/open/floor/plating,
 /area/mainship/squads/req)
+"fj" = (
+/obj/structure/sign/electricshock{
+	name = "Engineer Preparations"
+	},
+/turf/open/floor/mainship/purple{
+	dir = 1
+	},
+/area/mainship/squads/general)
 "fk" = (
 /obj/structure/rack,
 /obj/item/paper/factoryhowto,
@@ -1465,7 +1587,9 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
 /area/mainship/hallways/starboard_hallway)
 "fq" = (
 /obj/machinery/door/airlock/mainship/generic/pilot/bunk{
@@ -1613,15 +1737,35 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"fP" = (
+/obj/effect/decal/cleanable/blood/oil{
+	name = "grease";
+	pixel_x = -7
+	},
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "fQ" = (
 /obj/machinery/computer/supplycomp,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"fT" = (
+/obj/effect/decal/cleanable/blood/oil{
+	name = "grease";
+	pixel_x = 8
+	},
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/mainship/living/briefing)
 "fU" = (
 /obj/structure/flora/pottedplant/twentyone{
 	icon_state = "plant-14"
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
 /area/mainship/hallways/starboard_hallway)
 "fV" = (
 /obj/machinery/vending/uniform_supply,
@@ -1807,6 +1951,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
+"gB" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/starboard_hull)
 "gC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -1833,6 +1983,13 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
+"gG" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/turf/open/floor/mainship/orange,
+/area/mainship/living/briefing)
 "gH" = (
 /obj/structure/bed/chair/sofa/left,
 /turf/open/floor/plating/plating_catwalk,
@@ -1955,7 +2112,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "hc" = (
-/obj/machinery/alarm,
+/obj/machinery/alarm{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "hd" = (
@@ -1976,6 +2135,16 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
+"hg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/item/ammo_casing/bullet{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "hh" = (
 /turf/open/floor/mainship/green{
 	dir = 8
@@ -1988,6 +2157,11 @@
 /obj/item/tool/crowbar,
 /turf/open/floor/plating,
 /area/mainship/squads/req)
+"hj" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/mainship/research,
+/area/mainship/medical/medical_science)
 "hk" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/hull/starboard_hull)
@@ -2084,15 +2258,6 @@
 	dir = 1
 	},
 /area/mainship/hallways/port_hallway)
-"hJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/mainship/silver{
-	dir = 1
-	},
-/area/mainship/hallways/port_hallway)
 "hK" = (
 /obj/machinery/light{
 	dir = 1
@@ -2182,6 +2347,16 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hull/starboard_hull)
+"hZ" = (
+/obj/effect/decal/cleanable/blood/oil{
+	name = "grease";
+	pixel_x = -5;
+	pixel_y = -6
+	},
+/turf/open/floor/mainship/purple{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "ia" = (
 /obj/machinery/cryopod/right,
 /obj/machinery/light{
@@ -2324,6 +2499,11 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
+"ix" = (
+/turf/open/floor/mainship/blue/corner{
+	dir = 1
+	},
+/area/mainship/squads/general)
 "iy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -2389,6 +2569,13 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
+"iH" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/loadout_vendor,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "iK" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 2;
@@ -2444,12 +2631,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/green,
 /area/mainship/hull/starboard_hull)
-"iT" = (
-/obj/effect/landmark/start/job/squadmarine,
-/turf/open/floor/mainship/blue{
-	dir = 1
-	},
-/area/mainship/living/cryo_cells)
 "iU" = (
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/living/cryo_cells)
@@ -2564,6 +2745,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/self_destruct)
+"ju" = (
+/turf/open/floor/mainship/purple/corner{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "jv" = (
 /obj/effect/attach_point/weapon/dropship2{
 	dir = 8;
@@ -2649,6 +2835,15 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
+"jK" = (
+/obj/effect/decal/cleanable/blood/oil{
+	name = "grease";
+	pixel_x = 8
+	},
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/living/briefing)
 "jL" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/structure/cable,
@@ -2663,6 +2858,11 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
+"jM" = (
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
+/area/mainship/hallways/starboard_hallway)
 "jP" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/bulletproof,
@@ -2728,7 +2928,9 @@
 /area/mainship/hull/starboard_hull)
 "jW" = (
 /obj/effect/landmark/start/job/squadmarine,
-/turf/open/floor/mainship/blue,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
 /area/mainship/living/cryo_cells)
 "jX" = (
 /turf/open/floor/mainship/terragov/north{
@@ -2747,6 +2949,11 @@
 /obj/structure/prop/mainship/name_stencil,
 /turf/open/floor/mainship_hull,
 /area/space)
+"kb" = (
+/turf/open/floor/mainship/black/corner{
+	dir = 1
+	},
+/area/mainship/living/grunt_rnr)
 "kd" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/shipboard/port_missiles)
@@ -2800,6 +3007,11 @@
 	dir = 4
 	},
 /area/mainship/hallways/port_hallway)
+"kp" = (
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "kq" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/medical_science)
@@ -2808,10 +3020,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/silver/full,
 /area/mainship/medical/medical_science)
 "ks" = (
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/silver/full,
 /area/mainship/medical/medical_science)
 "kt" = (
 /turf/closed/wall/mainship/white,
@@ -2862,6 +3074,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cryo_cells)
+"kC" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
+/area/mainship/living/briefing)
 "kE" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/shipboard/starboard_missiles)
@@ -2961,11 +3182,17 @@
 /area/mainship/medical/medical_science)
 "lb" = (
 /obj/structure/table/mainship,
-/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/machinery/reagentgrinder,
+/obj/item/stack/sheet/mineral/phoron{
+	amount = 10;
+	pixel_x = 3;
+	pixel_y = 3
+	},
 /obj/item/storage/box/beakers{
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
 "lc" = (
@@ -2984,7 +3211,7 @@
 /area/mainship/medical/medical_science)
 "lh" = (
 /obj/structure/morgue,
-/turf/open/floor/mainship/sterile/plain,
+/turf/open/floor/mainship/silver/full,
 /area/mainship/medical/lower_medical)
 "li" = (
 /obj/machinery/light{
@@ -2996,14 +3223,16 @@
 /obj/structure/morgue{
 	dir = 8
 	},
-/turf/open/floor/mainship/sterile/plain,
+/turf/open/floor/mainship/silver/full,
 /area/mainship/medical/lower_medical)
 "ll" = (
 /obj/structure/morgue/crematorium,
 /obj/machinery/crema_switch{
 	pixel_x = 24
 	},
-/turf/open/floor/mainship/sterile/plain,
+/turf/open/floor/mainship/silver{
+	dir = 8
+	},
 /area/mainship/medical/lower_medical)
 "lm" = (
 /obj/machinery/door/airlock/mainship/marine/requisitions,
@@ -3104,6 +3333,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
 "lz" = (
+/obj/machinery/power/apc/mainship,
+/obj/structure/cable,
 /turf/open/floor/mainship/cargo,
 /area/mainship/shipboard/firing_range)
 "lA" = (
@@ -3112,6 +3343,7 @@
 /obj/item/ammo_magazine/revolver/standard_revolver,
 /obj/item/ammo_magazine/revolver/standard_revolver,
 /obj/item/ammo_magazine/revolver/standard_revolver,
+/obj/machinery/door/window/right,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
 "lB" = (
@@ -3202,6 +3434,12 @@
 	dir = 4
 	},
 /area/mainship/command/cic)
+"lK" = (
+/turf/open/floor/carpet{
+	dir = 9;
+	icon_state = "carpetside"
+	},
+/area/mainship/living/bridgebunks)
 "lL" = (
 /obj/machinery/light,
 /turf/open/floor/plating/plating_catwalk,
@@ -3270,6 +3508,12 @@
 	dir = 1
 	},
 /area/mainship/medical/medical_science)
+"md" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/purple{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "me" = (
 /turf/closed/wall/mainship/research/containment/wall/north,
 /area/mainship/medical/medical_science)
@@ -3299,6 +3543,12 @@
 	},
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
+"mk" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "ml" = (
 /obj/structure/bed/stool{
 	pixel_y = 8
@@ -3319,7 +3569,10 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
-/turf/open/floor/mainship/sterile/plain,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/mainship/silver{
+	dir = 10
+	},
 /area/mainship/medical/lower_medical)
 "mp" = (
 /obj/machinery/camera/autoname/mainship{
@@ -3339,6 +3592,7 @@
 	name = "Delta Overwatch Console"
 	},
 /obj/structure/table/reinforced,
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "mu" = (
@@ -3416,10 +3670,16 @@
 /area/mainship/shipboard/firing_range)
 "mF" = (
 /obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor/mainship/cargo,
 /area/mainship/shipboard/firing_range)
 "mG" = (
 /obj/structure/table/reinforced,
+/obj/machinery/door/window/right,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 5
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
 "mH" = (
@@ -3481,26 +3741,18 @@
 	},
 /obj/structure/cable,
 /obj/effect/landmark/start/job/squadcorpsman,
-/turf/open/floor/mainship/blue{
-	dir = 1
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
 	},
 /area/mainship/living/cryo_cells)
 "mO" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/job/squadcorpsman,
-/turf/open/floor/mainship/blue{
-	dir = 1
-	},
+/turf/open/floor/mainship/floor,
 /area/mainship/living/cryo_cells)
 "mP" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/cargo/arrow,
-/area/mainship/living/cryo_cells)
-"mQ" = (
-/obj/effect/landmark/start/job/squadengineer,
-/turf/open/floor/mainship/blue{
-	dir = 1
-	},
 /area/mainship/living/cryo_cells)
 "mR" = (
 /turf/open/floor/mainship/cargo/arrow{
@@ -3539,6 +3791,7 @@
 /obj/structure/window/reinforced/toughened{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/port_missiles)
 "mW" = (
@@ -3610,6 +3863,17 @@
 "nh" = (
 /turf/closed/wall/mainship/research/containment/wall/west,
 /area/mainship/medical/medical_science)
+"ni" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet{
+	icon_state = "carpetside"
+	},
+/area/mainship/living/bridgebunks)
 "nj" = (
 /turf/open/floor/mainship/research/containment/floor2{
 	dir = 9
@@ -3670,16 +3934,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
-"nv" = (
-/obj/structure/table/mainship,
-/obj/machinery/reagentgrinder,
-/obj/item/stack/sheet/mineral/phoron{
-	amount = 5;
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/mainship/research,
-/area/mainship/medical/medical_science)
 "nx" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/mainship/research,
@@ -3688,13 +3942,6 @@
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"nA" = (
-/obj/machinery/power/apc/mainship{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/shipboard/firing_range)
 "nB" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/cargo,
@@ -3703,6 +3950,11 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/monkeycubes,
 /obj/structure/cable,
+/obj/machinery/door/window/right,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 5
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
 "nD" = (
@@ -3716,6 +3968,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/red,
 /area/mainship/shipboard/firing_range)
+"nE" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/red{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "nF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -3743,7 +4003,9 @@
 /area/mainship/shipboard/firing_range)
 "nK" = (
 /obj/effect/landmark/start/job/squadcorpsman,
-/turf/open/floor/mainship/blue,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
 /area/mainship/living/cryo_cells)
 "nL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -3751,7 +4013,9 @@
 	},
 /obj/effect/landmark/start/job/squadcorpsman,
 /obj/effect/landmark/start/latejoin,
-/turf/open/floor/mainship/blue,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
 /area/mainship/living/cryo_cells)
 "nM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3782,11 +4046,13 @@
 	},
 /obj/effect/landmark/start/job/squadengineer,
 /obj/effect/landmark/start/latejoin,
-/turf/open/floor/mainship/blue,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
 /area/mainship/living/cryo_cells)
 "nR" = (
 /obj/effect/landmark/start/job/squadengineer,
-/turf/open/floor/mainship/blue,
+/turf/open/floor/mainship/floor,
 /area/mainship/living/cryo_cells)
 "nS" = (
 /obj/structure/prop/mainship/missile_tube,
@@ -3827,6 +4093,18 @@
 	dir = 8
 	},
 /area/mainship/shipboard/port_missiles)
+"nX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/purple{
+	dir = 4
+	},
+/area/mainship/living/briefing)
+"nY" = (
+/obj/structure/sign/prop1{
+	name = "Squad Leader Preparations"
+	},
+/turf/closed/wall/mainship,
+/area/mainship/squads/general)
 "nZ" = (
 /obj/machinery/light{
 	dir = 4
@@ -3922,7 +4200,7 @@
 /obj/machinery/door/poddoor/shutters/mainship/cell,
 /obj/machinery/door/airlock/mainship/research/glass/cell,
 /obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/sterile,
+/turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
 "op" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3969,6 +4247,15 @@
 	dir = 1
 	},
 /area/mainship/medical/medical_science)
+"ou" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "ov" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -4021,6 +4308,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/silver{
 	dir = 1
 	},
@@ -4045,8 +4333,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
 /turf/open/floor/mainship/silver{
 	dir = 5
 	},
@@ -4172,12 +4458,17 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
 "oV" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access = null
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/shipboard/firing_range)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/effect/ai_node,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/port_hull)
 "oW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -4261,6 +4552,14 @@
 	dir = 10
 	},
 /area/mainship/medical/medical_science)
+"pp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/mainship/living/briefing)
 "pq" = (
 /obj/machinery/light/small,
 /turf/open/floor/mainship/research/containment/floor2,
@@ -4305,7 +4604,7 @@
 	dir = 4
 	},
 /obj/structure/sign/testchamber,
-/turf/open/floor/mainship/research,
+/turf/open/floor/mainship/silver/full,
 /area/mainship/medical/medical_science)
 "py" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -4343,14 +4642,23 @@
 	dir = 8
 	},
 /area/mainship/medical/medical_science)
+"pE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/silver/full,
+/area/mainship/medical/medical_science)
 "pF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/junction,
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
 /obj/effect/ai_node,
+/obj/structure/disposalpipe/segment/corner,
 /turf/open/floor/mainship/silver{
 	dir = 4
 	},
@@ -4426,7 +4734,7 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black,
 /area/mainship/hallways/starboard_hallway)
 "pP" = (
 /obj/structure/window/framed/mainship,
@@ -4483,7 +4791,9 @@
 	dir = 4
 	},
 /obj/docking_port/stationary/marine_dropship/crash_target,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
 /area/mainship/hallways/starboard_hallway)
 "pW" = (
 /obj/machinery/disposal,
@@ -4565,6 +4875,12 @@
 	dir = 4
 	},
 /area/mainship/shipboard/starboard_missiles)
+"qm" = (
+/obj/structure/sign/prop1{
+	name = "Smartgunner Preparations"
+	},
+/turf/closed/wall/mainship,
+/area/mainship/squads/general)
 "qn" = (
 /turf/open/floor/mainship/black{
 	dir = 8
@@ -4652,6 +4968,7 @@
 	dir = 1;
 	on = 1
 	},
+/obj/structure/curtain/medical,
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
 "qI" = (
@@ -4690,6 +5007,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/alarm{
+	dir = 8
+	},
 /turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/lower_medical)
 "qO" = (
@@ -4847,16 +5167,7 @@
 /area/mainship/shipboard/firing_range)
 "rs" = (
 /obj/effect/landmark/start/job/squadsmartgunner,
-/turf/open/floor/mainship/blue{
-	dir = 1
-	},
-/area/mainship/living/cryo_cells)
-"rt" = (
-/obj/effect/landmark/start/job/squadsmartgunner,
-/obj/effect/landmark/start/latejoin,
-/turf/open/floor/mainship/blue{
-	dir = 1
-	},
+/turf/open/floor/mainship/floor,
 /area/mainship/living/cryo_cells)
 "ru" = (
 /obj/structure/cable,
@@ -4864,25 +5175,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/living/cryo_cells)
-"rv" = (
-/obj/effect/landmark/start/job/squadleader,
-/obj/effect/landmark/start/latejoin,
-/turf/open/floor/mainship/blue{
-	dir = 1
-	},
-/area/mainship/living/cryo_cells)
 "rw" = (
 /obj/effect/landmark/start/job/squadleader,
 /obj/effect/landmark/start/job/squadleader,
-/turf/open/floor/mainship/blue{
-	dir = 1
-	},
-/area/mainship/living/cryo_cells)
-"rx" = (
-/obj/effect/landmark/start/job/squadleader,
-/turf/open/floor/mainship/blue{
-	dir = 1
-	},
+/turf/open/floor/mainship/floor,
 /area/mainship/living/cryo_cells)
 "rz" = (
 /turf/open/floor/mainship/red,
@@ -4905,6 +5201,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/evacuation)
+"rD" = (
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/turf/open/floor/mainship/blue{
+	dir = 5
+	},
+/area/mainship/living/grunt_rnr)
 "rE" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/skills,
@@ -4931,6 +5235,17 @@
 /obj/item/storage/box/monkeycubes,
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
+"rL" = (
+/turf/open/floor/mainship/black/corner{
+	dir = 1
+	},
+/area/mainship/hallways/starboard_hallway)
+"rM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "rO" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -4970,6 +5285,13 @@
 /obj/machinery/light,
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
+"rV" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/turf/open/floor/mainship/purple,
+/area/mainship/living/briefing)
 "rW" = (
 /obj/structure/table/mainship,
 /obj/structure/paper_bin,
@@ -4978,6 +5300,7 @@
 	pixel_x = -6;
 	pixel_y = 1
 	},
+/obj/structure/sign/science,
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
 "rX" = (
@@ -5059,6 +5382,11 @@
 /obj/effect/landmark/start/job/shiptech,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"sn" = (
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "sp" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/mono,
@@ -5081,32 +5409,45 @@
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "\improper Firing Range"
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "st" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
 /area/mainship/squads/general)
 "su" = (
 /obj/effect/landmark/start/job/squadsmartgunner,
-/turf/open/floor/mainship/blue,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
 /area/mainship/living/cryo_cells)
 "sw" = (
 /obj/effect/landmark/start/job/squadsmartgunner,
 /obj/effect/landmark/start/latejoin,
-/turf/open/floor/mainship/blue,
+/turf/open/floor/mainship/floor,
 /area/mainship/living/cryo_cells)
 "sx" = (
 /obj/effect/landmark/start/job/squadleader,
 /obj/effect/landmark/start/latejoin,
-/turf/open/floor/mainship/blue,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
 /area/mainship/living/cryo_cells)
+"sy" = (
+/obj/structure/table/woodentable,
+/obj/item/reagent_containers/food/snacks/limecakeslice,
+/turf/open/floor/wood,
+/area/mainship/medical/lounge)
 "sz" = (
 /obj/effect/landmark/start/job/squadleader,
-/turf/open/floor/mainship/blue,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
 /area/mainship/living/cryo_cells)
 "sA" = (
 /obj/machinery/power/apc/mainship{
@@ -5137,13 +5478,13 @@
 "sE" = (
 /obj/machinery/door/airlock/multi_tile/mainship/research,
 /obj/structure/cable,
-/turf/open/floor/mainship/research,
+/turf/open/floor/mainship/silver/full,
 /area/mainship/medical/medical_science)
 "sF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/mainship/research,
+/turf/open/floor/mainship/silver/full,
 /area/mainship/medical/medical_science)
 "sG" = (
 /obj/structure/bed/chair/comfy/black{
@@ -5437,6 +5778,19 @@
 "tH" = (
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lounge)
+"tI" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/living/briefing)
+"tJ" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/job/squadcorpsman,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/mainship/living/cryo_cells)
 "tL" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/mainship/sterile/side{
@@ -5461,7 +5815,6 @@
 /area/mainship/medical/lower_medical)
 "tO" = (
 /obj/machinery/cloning_console/vats,
-/obj/machinery/alarm,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -5569,6 +5922,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"ui" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/port_hull)
 "uk" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
@@ -5601,13 +5958,19 @@
 /obj/machinery/door/airlock/mainship/marine/general/smart,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/general)
+"uu" = (
+/obj/effect/landmark/start/job/squadmarine,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/cryo_cells)
 "uv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
 /area/mainship/squads/general)
 "uw" = (
 /obj/machinery/door/airlock/mainship/marine/general/sl,
@@ -5707,7 +6070,7 @@
 "uI" = (
 /obj/machinery/computer/droppod_control,
 /obj/structure/table/mainship,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
 "uJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -5932,10 +6295,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"vj" = (
-/obj/structure/sign/prop1,
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/general)
 "vk" = (
 /obj/machinery/loadout_vendor,
 /obj/machinery/light{
@@ -5957,7 +6316,9 @@
 /area/mainship/command/self_destruct)
 "vn" = (
 /obj/effect/landmark/start/latejoin,
-/turf/open/floor/mainship/blue/full,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
 /area/mainship/living/cryo_cells)
 "vo" = (
 /obj/machinery/camera/autoname/mainship{
@@ -6000,6 +6361,7 @@
 /area/mainship/hallways/port_hallway)
 "vy" = (
 /obj/structure/table,
+/obj/item/trash/cheesie,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "vz" = (
@@ -6037,6 +6399,10 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/medical/lounge)
+"vG" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/mainship/sterile/plain,
+/area/mainship/medical/lower_medical)
 "vH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
@@ -6148,22 +6514,12 @@
 	dir = 6
 	},
 /area/mainship/medical/chemistry)
-"we" = (
-/turf/open/floor/mainship/blue/corner{
-	dir = 1
-	},
-/area/mainship/living/cryo_cells)
 "wf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /mob/living/simple_animal/corgi/Ranger,
 /turf/open/floor/mainship/mono,
-/area/mainship/living/cryo_cells)
-"wg" = (
-/turf/open/floor/mainship/blue/corner{
-	dir = 4
-	},
 /area/mainship/living/cryo_cells)
 "wh" = (
 /obj/machinery/door/airlock/mainship/maint{
@@ -6289,12 +6645,12 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "wD" = (
-/obj/machinery/autodoc,
-/turf/open/floor/mainship/sterile/dark,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/mainship/sterile/plain,
 /area/mainship/medical/lower_medical)
 "wE" = (
-/obj/machinery/autodoc_console,
-/turf/open/floor/mainship/sterile/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mainship/sterile/plain,
 /area/mainship/medical/lower_medical)
 "wF" = (
 /obj/structure/cable,
@@ -6411,6 +6767,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"wS" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "wT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -6569,6 +6932,13 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lounge)
+"xt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/curtain/medical,
+/turf/open/floor/mainship/research,
+/area/mainship/medical/medical_science)
 "xv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -6739,7 +7109,9 @@
 /obj/structure/flora/pottedplant/twentyone{
 	icon_state = "plant-12"
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
 /area/mainship/hallways/starboard_hallway)
 "xX" = (
 /obj/machinery/vending/armor_supply,
@@ -6747,7 +7119,9 @@
 /area/mainship/squads/general)
 "xY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
 /area/mainship/squads/general)
 "xZ" = (
 /obj/machinery/vending/uniform_supply,
@@ -6886,6 +7260,14 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lounge)
+"yr" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = -3
+	},
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "ys" = (
 /obj/machinery/door/airlock/mainship/medical/glass{
 	dir = 2
@@ -6901,14 +7283,12 @@
 /area/mainship/medical/lower_medical)
 "yu" = (
 /obj/structure/table/mainship,
-/obj/item/radio/headset/mainship/marine/rebel/alpha,
-/obj/item/radio/headset/mainship/marine/rebel/alpha,
-/obj/item/radio/headset/mainship/marine/rebel/bravo,
-/obj/item/radio/headset/mainship/marine/rebel/bravo,
-/obj/item/radio/headset/mainship/marine/rebel/charlie,
-/obj/item/radio/headset/mainship/marine/rebel/charlie,
-/obj/item/radio/headset/mainship/marine/rebel/delta,
-/obj/item/radio/headset/mainship/marine/rebel/delta,
+/obj/item/radio/headset/mainship,
+/obj/item/radio/headset/mainship,
+/obj/item/radio/headset/mainship,
+/obj/item/radio/headset/mainship,
+/obj/item/radio/headset/mainship,
+/obj/item/radio/headset/mainship,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "yv" = (
@@ -6962,8 +7342,20 @@
 "yC" = (
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
 /area/mainship/hallways/starboard_hallway)
+"yD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/ammo_casing/bullet{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/turf/open/floor/mainship/purple{
+	dir = 4
+	},
+/area/mainship/living/briefing)
 "yE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -6987,20 +7379,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/general)
-"yH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/general)
 "yJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/general)
 "yK" = (
 /obj/machinery/door/airlock/mainship/secure/tcomms{
@@ -7021,7 +7406,7 @@
 "yL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/general)
 "yM" = (
 /obj/structure/cable,
@@ -7029,14 +7414,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/general)
-"yN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/general)
 "yO" = (
 /obj/structure/cable,
@@ -7089,7 +7467,7 @@
 /obj/item/weapon/claymore/mercsword/machete,
 /obj/item/weapon/claymore/mercsword/machete,
 /obj/item/weapon/claymore/mercsword/machete,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
 "yU" = (
 /obj/structure/cable,
@@ -7134,7 +7512,7 @@
 /area/mainship/living/cafeteria_starboard)
 "za" = (
 /obj/structure/window/framed/mainship/requisitions,
-/turf/open/floor/plating,
+/turf/open/floor/mainship/mono,
 /area/mainship/living/cafeteria_starboard)
 "zb" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -7266,13 +7644,9 @@
 /area/mainship/medical/lounge)
 "zx" = (
 /obj/structure/closet/secure_closet/medical1,
-/turf/open/floor/mainship/sterile/corner{
-	dir = 1
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
 	},
-/area/mainship/medical/lounge)
-"zy" = (
-/obj/structure/closet/secure_closet/medical3,
-/turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/lounge)
 "zA" = (
 /obj/structure/closet/secure_closet/engineering_welding,
@@ -7291,6 +7665,13 @@
 	dir = 8
 	},
 /area/mainship/medical/lower_medical)
+"zD" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = 5;
+	pixel_y = -8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "zE" = (
 /obj/machinery/body_scanconsole,
 /turf/open/floor/mainship/sterile/dark,
@@ -7315,14 +7696,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/vending/nanomed,
+/obj/machinery/computer/crew,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
 /area/mainship/medical/lower_medical)
+"zI" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = -7
+	},
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/living/briefing)
 "zK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -7344,11 +7731,10 @@
 /turf/closed/wall/mainship,
 /area/mainship/living/grunt_rnr)
 "zN" = (
-/obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/lower_medical)
 "zO" = (
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "zP" = (
 /obj/structure/cable,
@@ -7453,8 +7839,26 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "zZ" = (
+/obj/machinery/door/window{
+	dir = 1
+	},
+/obj/machinery/door/window{
+	dir = 2
+	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
+"Aa" = (
+/obj/effect/landmark/start/job/squadengineer,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/mainship/living/cryo_cells)
+"Ac" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/space)
 "Ae" = (
 /obj/machinery/marine_selector/clothes,
 /obj/structure/window/reinforced{
@@ -7472,7 +7876,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
 /area/mainship/squads/general)
 "Ag" = (
 /obj/structure/cable,
@@ -7527,6 +7933,10 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
+"Ap" = (
+/obj/machinery/roomba,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "Aq" = (
 /obj/structure/table/mainship,
 /obj/item/pizzabox,
@@ -7562,11 +7972,15 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/green{
+	dir = 5
+	},
 /area/mainship/living/port_garden)
 "Aw" = (
 /obj/machinery/portable_atmospherics/hydroponics,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/green{
+	dir = 9
+	},
 /area/mainship/living/port_garden)
 "Ax" = (
 /obj/machinery/vending/hydroseeds,
@@ -7598,18 +8012,12 @@
 	dir = 8
 	},
 /turf/open/floor/mainship/sterile/side{
-	dir = 8
+	dir = 4
 	},
 /area/mainship/medical/lounge)
 "AB" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lounge)
-"AC" = (
-/obj/structure/closet/secure_closet/medical3,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
 /area/mainship/medical/lounge)
 "AD" = (
 /obj/structure/closet/secure_closet/medical2,
@@ -7715,6 +8123,10 @@
 	dir = 4
 	},
 /area/mainship/medical/lower_medical)
+"AP" = (
+/obj/docking_port/stationary/marine_dropship/crash_target,
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/lower_medical)
 "AQ" = (
 /obj/machinery/door_control/mainship/droppod{
 	dir = 1
@@ -7738,7 +8150,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "AU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -7773,8 +8185,18 @@
 /obj/structure/flora/pottedplant/twentyone{
 	icon_state = "plant-09"
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black,
 /area/mainship/hallways/starboard_hallway)
+"Ba" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/ammo_casing/bullet{
+	pixel_x = 5;
+	pixel_y = -8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "Bb" = (
 /obj/machinery/door/poddoor/mainship/ammo{
 	dir = 2;
@@ -7788,11 +8210,16 @@
 /area/mainship/hull/starboard_hull)
 "Bc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black,
 /area/mainship/hallways/starboard_hallway)
+"Bd" = (
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/living/briefing)
 "Bf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black,
 /area/mainship/hallways/starboard_hallway)
 "Bh" = (
 /obj/structure/rack,
@@ -7814,7 +8241,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
 /area/mainship/squads/general)
 "Bm" = (
 /obj/machinery/power/apc/mainship{
@@ -7827,6 +8256,15 @@
 /obj/structure/table/mainship,
 /turf/open/floor/freezer,
 /area/mainship/living/cafeteria_starboard)
+"Bp" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/mainship/living/briefing)
 "Bq" = (
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/food/snacks/creamcheesebreadslice,
@@ -7840,6 +8278,13 @@
 /obj/structure/cable,
 /turf/open/floor/freezer,
 /area/mainship/living/cafeteria_starboard)
+"Bs" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic/cryo{
+	dir = 1
+	},
+/obj/structure/sign/nosmoking_2,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/general)
 "Bu" = (
 /obj/machinery/power/apc/mainship{
 	dir = 8
@@ -7854,6 +8299,7 @@
 /area/mainship/hull/port_hull)
 "By" = (
 /obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/port_hull)
 "Bz" = (
@@ -7908,6 +8354,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
+"BI" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/mainship/green{
+	dir = 5
+	},
+/area/mainship/living/port_garden)
 "BJ" = (
 /obj/item/reagent_containers/glass/fertilizer/ez,
 /obj/item/reagent_containers/glass/fertilizer/ez,
@@ -7940,8 +8392,8 @@
 /area/mainship/medical/lounge)
 "BP" = (
 /obj/machinery/computer/med_data,
-/turf/open/floor/mainship/sterile/corner{
-	dir = 8
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
 	},
 /area/mainship/medical/lounge)
 "BQ" = (
@@ -7952,8 +8404,8 @@
 /area/mainship/medical/lounge)
 "BR" = (
 /obj/structure/closet/secure_closet/medical3,
-/turf/open/floor/mainship/sterile/corner{
-	dir = 4
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
 	},
 /area/mainship/medical/lounge)
 "BS" = (
@@ -8077,6 +8529,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
+"Ck" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "Cl" = (
 /obj/structure/window/framed/mainship/requisitions,
 /turf/open/floor/mainship/mono,
@@ -8092,10 +8552,17 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
+"Co" = (
+/turf/open/floor/mainship/blue{
+	dir = 1
+	},
+/area/mainship/squads/general)
 "Cr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
 /area/mainship/squads/general)
 "Cs" = (
 /obj/structure/cable,
@@ -8119,7 +8586,7 @@
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/mainship/mono,
 /area/mainship/living/cafeteria_starboard)
 "Cx" = (
 /obj/machinery/vending/nanomed,
@@ -8214,14 +8681,6 @@
 /obj/machinery/bioprinter/stocked,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_one)
-"CR" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/medical/lower_medical)
 "CS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -8229,8 +8688,18 @@
 /obj/machinery/holopad,
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
+"CT" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/mainship/purple{
+	dir = 1
+	},
+/area/mainship/squads/general)
 "CU" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
+/obj/machinery/autodoc_console,
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "CV" = (
@@ -8276,7 +8745,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/red{
+	dir = 1
+	},
 /area/mainship/living/briefing)
 "Db" = (
 /turf/open/floor/mainship/red{
@@ -8317,7 +8788,9 @@
 /area/mainship/living/briefing)
 "Dm" = (
 /obj/machinery/vending/tool,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/blue{
+	dir = 1
+	},
 /area/mainship/living/briefing)
 "Dn" = (
 /obj/machinery/vending/MarineMed,
@@ -8349,13 +8822,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/general)
-"Dr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/general)
 "Ds" = (
 /obj/structure/window/framed/mainship/hull,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -8367,7 +8833,7 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/general)
 "Du" = (
 /obj/machinery/light{
@@ -8381,7 +8847,7 @@
 	dir = 1
 	},
 /obj/machinery/holopad,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/general)
 "DA" = (
 /obj/structure/cable,
@@ -8390,7 +8856,7 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/general)
 "DB" = (
 /obj/structure/cable,
@@ -8400,7 +8866,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/general)
 "DC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -8424,17 +8890,7 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/general)
-"DF" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/general)
 "DG" = (
 /obj/structure/cable,
@@ -8579,6 +9035,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/port_garden)
+"Eb" = (
+/obj/structure/window/framed/mainship/hull,
+/obj/machinery/door/poddoor/mainship/ai/exterior{
+	dir = 2
+	},
+/turf/open/floor/mainship/ai,
+/area/mainship/command/airoom)
 "Ec" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -8592,6 +9055,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/port_garden)
+"Ef" = (
+/obj/effect/landmark/start/latejoin,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/mainship/living/cryo_cells)
 "Eg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8642,6 +9111,9 @@
 /area/mainship/medical/operating_room_two)
 "Eq" = (
 /obj/machinery/sleeper,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
@@ -8665,12 +9137,16 @@
 /area/mainship/medical/lower_medical)
 "Eu" = (
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/red{
+	dir = 8
+	},
 /area/mainship/living/briefing)
 "Ev" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/purple{
+	dir = 4
+	},
 /area/mainship/living/briefing)
 "Ew" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -8680,14 +9156,18 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/purple{
+	dir = 8
+	},
 /area/mainship/squads/general)
 "Ex" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
 /area/mainship/squads/general)
 "Ey" = (
 /obj/structure/cable,
@@ -8746,6 +9226,14 @@
 	dir = 9
 	},
 /area/mainship/hull/port_hull)
+"EH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "EI" = (
 /turf/open/floor/mainship/orange{
 	dir = 1
@@ -8784,6 +9272,13 @@
 /area/mainship/living/numbertwobunks)
 "ES" = (
 /obj/structure/closet/secure_closet/medical2,
+/obj/item/tool/kitchen/knife/butcher{
+	blood_overlay = null;
+	desc = "A huge thing used for chopping and chopping up meat. You sense this one has been involved in something terrible, best not to question it.";
+	name = "Stainless butcher's cleaver"
+	},
+/obj/item/limb/l_hand,
+/obj/item/limb/l_arm,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
 "ET" = (
@@ -8794,6 +9289,7 @@
 	dir = 4;
 	on = 1
 	},
+/obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
 "EU" = (
@@ -8898,6 +9394,15 @@
 	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
+"Fb" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/port_hallway)
 "Fc" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction/flipped{
@@ -8950,7 +9455,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "Fi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -8979,6 +9484,10 @@
 /area/mainship/hallways/hangar)
 "Fm" = (
 /obj/machinery/holopad,
+/obj/item/ammo_casing/bullet{
+	pixel_x = -7;
+	pixel_y = 5
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "Fn" = (
@@ -8986,7 +9495,9 @@
 	dir = 1
 	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
 /area/mainship/squads/general)
 "Fo" = (
 /obj/structure/disposalpipe/segment{
@@ -8999,7 +9510,9 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
 /area/mainship/squads/general)
 "Fr" = (
 /obj/machinery/disposal,
@@ -9023,6 +9536,14 @@
 	dir = 4
 	},
 /area/mainship/living/cafeteria_starboard)
+"Fu" = (
+/obj/effect/decal/cleanable/blood/oil{
+	name = "grease";
+	pixel_x = -2;
+	pixel_y = -6
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "Fv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -9091,6 +9612,15 @@
 	dir = 4
 	},
 /area/mainship/hull/port_hull)
+"FG" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = 4;
+	pixel_y = -9
+	},
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "FH" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -9100,9 +9630,17 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
+"FI" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = -7
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "FJ" = (
 /obj/machinery/door_control/mainship/droppod,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
 /area/mainship/hallways/starboard_hallway)
 "FK" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -9125,6 +9663,11 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/bridgebunks)
+"FN" = (
+/turf/open/floor/mainship/purple{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "FO" = (
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
@@ -9225,6 +9768,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_x = 6;
+	pixel_y = 22
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
 "Ga" = (
@@ -9232,6 +9779,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_x = -10;
+	pixel_y = 13
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
 "Gb" = (
@@ -9242,6 +9794,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
 "Ge" = (
@@ -9265,6 +9818,10 @@
 /obj/structure/window/framed/mainship/white,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
+"Gg" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "Gh" = (
 /obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 2
@@ -9301,12 +9858,14 @@
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "Gn" = (
 /obj/structure/rack,
 /obj/item/storage/box/sentry,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/red{
+	dir = 8
+	},
 /area/mainship/living/briefing)
 "Gp" = (
 /obj/structure/table/reinforced,
@@ -9458,6 +10017,16 @@
 /obj/item/megaphone,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
+"GP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/item/ammo_casing/bullet{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "GQ" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -9472,7 +10041,9 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/surgical_tray,
 /obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/light,
+/obj/machinery/light{
+	light_color = "#da2f1b"
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
 "GS" = (
@@ -9502,8 +10073,8 @@
 /area/mainship/medical/lower_medical)
 "GZ" = (
 /obj/machinery/light,
-/obj/structure/sign/chemistry2,
 /obj/structure/rack,
+/obj/item/roller,
 /obj/item/roller,
 /obj/item/roller,
 /obj/item/roller,
@@ -9540,7 +10111,9 @@
 /area/mainship/medical/lower_medical)
 "He" = (
 /obj/machinery/computer/camera_advanced/remote_fob,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/red{
+	dir = 8
+	},
 /area/mainship/living/briefing)
 "Hf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -9559,14 +10132,22 @@
 	dir = 1;
 	on = 1
 	},
-/turf/open/floor/mainship/mono,
+/obj/item/ammo_casing/bullet{
+	pixel_x = 10;
+	pixel_y = 4
+	},
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
 /area/mainship/living/briefing)
 "Hi" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
 /area/mainship/living/briefing)
 "Hj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -9578,11 +10159,22 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/port_atmos)
+"Hk" = (
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "Hm" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/obj/item/ammo_casing/bullet{
+	pixel_x = 9;
+	pixel_y = 5
+	},
+/turf/open/floor/mainship/purple{
+	dir = 8
+	},
 /area/mainship/living/briefing)
 "Hn" = (
 /turf/closed/wall/mainship,
@@ -9592,7 +10184,9 @@
 	dir = 1
 	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/purple{
+	dir = 4
+	},
 /area/mainship/living/briefing)
 "Hp" = (
 /obj/machinery/camera/autoname/mainship{
@@ -9614,17 +10208,26 @@
 "Hs" = (
 /obj/structure/disposalpipe/segment,
 /obj/docking_port/stationary/marine_dropship/crash_target,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/blue/corner{
+	dir = 4
+	},
 /area/mainship/squads/general)
 "Hu" = (
-/obj/structure/sign/nosmoking_2,
-/turf/open/floor/mainship/floor,
+/obj/machinery/light,
+/turf/open/floor/mainship/blue{
+	dir = 1
+	},
 /area/mainship/squads/general)
 "Hv" = (
 /obj/item/radio/intercom/general{
 	dir = 1
 	},
-/turf/open/floor/mainship/floor,
+/obj/structure/sign/greencross{
+	name = "Corpsman Preparations"
+	},
+/turf/open/floor/mainship/blue{
+	dir = 1
+	},
 /area/mainship/squads/general)
 "Hx" = (
 /obj/machinery/camera/autoname/mainship{
@@ -9689,6 +10292,9 @@
 /obj/item/fuelCell/full,
 /obj/item/assembly/prox_sensor,
 /obj/item/fuelCell/full,
+/obj/effect/decal/cleanable/cobweb{
+	dir = 8
+	},
 /turf/open/floor/mainship/orange{
 	dir = 6
 	},
@@ -9747,7 +10353,9 @@
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/red{
+	dir = 8
+	},
 /area/mainship/living/briefing)
 "HV" = (
 /obj/machinery/vending/weapon,
@@ -9784,17 +10392,36 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "Ib" = (
-/turf/open/floor/mainship/mono,
+/obj/structure/table/woodentable,
+/obj/item/paper,
+/obj/item/folder{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/tool/pen,
+/turf/open/floor/carpet,
 /area/mainship/living/bridgebunks)
 "Ic" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/carpet{
+	dir = 1;
+	icon_state = "carpetside"
+	},
 /area/mainship/living/bridgebunks)
-"Ie" = (
-/obj/structure/bed/chair/office/dark,
+"Id" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2;
+	name = "Firing Range"
+	},
 /turf/open/floor/mainship/mono,
+/area/mainship/shipboard/firing_range)
+"Ie" = (
+/turf/open/floor/carpet{
+	dir = 1;
+	icon_state = "carpetside"
+	},
 /area/mainship/living/bridgebunks)
 "Ig" = (
 /obj/structure/cable,
@@ -9805,7 +10432,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/carpet{
+	dir = 5;
+	icon_state = "carpetside"
+	},
 /area/mainship/living/bridgebunks)
 "Ii" = (
 /obj/machinery/disposal,
@@ -9835,6 +10465,14 @@
 	dir = 8
 	},
 /area/mainship/command/cic)
+"Il" = (
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/turf/open/floor/mainship/blue{
+	dir = 6
+	},
+/area/mainship/living/grunt_rnr)
 "Im" = (
 /obj/machinery/light{
 	dir = 1
@@ -9939,18 +10577,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/general)
 "IF" = (
-/obj/structure/mirror{
-	dir = 1;
-	pixel_x = -25
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/general)
-"IG" = (
-/obj/structure/mirror{
-	dir = 1;
-	pixel_x = 23
-	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/roomba,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "IH" = (
@@ -9962,7 +10589,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black{
+	dir = 9
+	},
 /area/mainship/living/grunt_rnr)
 "IK" = (
 /turf/open/floor/plating/plating_catwalk,
@@ -10012,7 +10641,8 @@
 "IS" = (
 /obj/structure/toilet,
 /obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/mono,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/living/grunt_rnr)
 "IT" = (
 /obj/machinery/light{
@@ -10024,7 +10654,7 @@
 /obj/structure/mirror{
 	pixel_y = 28
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/living/grunt_rnr)
 "IU" = (
 /obj/structure/cable,
@@ -10064,24 +10694,22 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "IY" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/carpet{
+	dir = 8;
+	icon_state = "carpetside"
+	},
 /area/mainship/living/bridgebunks)
 "IZ" = (
-/obj/structure/table/mainship,
-/obj/item/tool/pen,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/carpet,
 /area/mainship/living/bridgebunks)
 "Ja" = (
-/obj/structure/table/mainship,
-/obj/item/folder/blue,
-/obj/item/tool/pen,
-/turf/open/floor/mainship/mono,
+/obj/structure/bed/chair/comfy/beige{
+	dir = 4
+	},
+/turf/open/floor/carpet,
 /area/mainship/living/bridgebunks)
 "Jc" = (
 /obj/structure/table/mainship,
@@ -10107,36 +10735,26 @@
 	},
 /area/mainship/command/cic)
 "Je" = (
-/obj/structure/table/mainship,
-/obj/structure/paper_bin{
-	pixel_y = 5
-	},
-/turf/open/floor/mainship/mono,
+/obj/structure/table/woodentable,
+/obj/item/storage/fancy/cigar,
+/obj/item/tool/lighter/zippo,
+/turf/open/floor/carpet,
 /area/mainship/living/bridgebunks)
 "Ji" = (
-/obj/structure/table/mainship,
-/obj/item/folder/yellow,
-/obj/item/tool/pen,
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/bridgebunks)
-"Jj" = (
-/obj/structure/table/mainship,
-/obj/item/folder/red,
-/obj/item/tool/pen,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/bridgebunks)
-"Jk" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/bed/chair/comfy/beige{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/carpet,
 /area/mainship/living/bridgebunks)
 "Jl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/carpet{
+	dir = 4;
+	icon_state = "carpetside"
+	},
 /area/mainship/living/bridgebunks)
 "Jm" = (
 /obj/effect/ai_node,
@@ -10148,6 +10766,9 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/living/bridgebunks)
+"Jo" = (
+/turf/open/floor/mainship/black,
+/area/mainship/hallways/starboard_hallway)
 "Jp" = (
 /obj/structure/table/mainship,
 /obj/item/tool/hand_labeler,
@@ -10211,7 +10832,9 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/red{
+	dir = 8
+	},
 /area/mainship/living/briefing)
 "Jy" = (
 /obj/structure/disposalpipe/segment{
@@ -10224,7 +10847,9 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
 /area/mainship/living/briefing)
 "JA" = (
 /obj/structure/disposalpipe/segment{
@@ -10239,7 +10864,9 @@
 	},
 /obj/structure/cable,
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
 /area/mainship/living/briefing)
 "JC" = (
 /obj/structure/cable,
@@ -10250,7 +10877,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
 /area/mainship/hallways/starboard_hallway)
 "JF" = (
 /obj/structure/cable,
@@ -10285,20 +10914,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/general)
 "JK" = (
-/obj/structure/mirror{
-	dir = 1;
-	pixel_x = -25
-	},
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "JL" = (
-/obj/structure/mirror{
-	dir = 1;
-	pixel_x = 23
-	},
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
@@ -10332,7 +10953,10 @@
 "JQ" = (
 /obj/structure/table/woodentable,
 /obj/item/pizzabox/meat,
-/turf/open/floor/mainship/mono,
+/obj/item/spacecash/c100,
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
 /area/mainship/living/grunt_rnr)
 "JR" = (
 /turf/open/floor/mainship/mono,
@@ -10388,7 +11012,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/carpet{
+	dir = 10;
+	icon_state = "carpetside"
+	},
 /area/mainship/living/bridgebunks)
 "Kb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -10398,12 +11025,11 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/carpet{
+	icon_state = "carpetside"
+	},
 /area/mainship/living/bridgebunks)
 "Kc" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -10411,12 +11037,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/carpet{
+	icon_state = "carpetside"
+	},
 /area/mainship/living/bridgebunks)
 "Ke" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -10425,17 +11050,9 @@
 	},
 /obj/machinery/light,
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/bridgebunks)
-"Kf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/turf/open/floor/carpet{
+	icon_state = "carpetside"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "Kg" = (
 /obj/machinery/door/poddoor/shutters/mainship/cic/armory{
@@ -10454,7 +11071,10 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/carpet{
+	dir = 6;
+	icon_state = "carpetside"
+	},
 /area/mainship/living/bridgebunks)
 "Ki" = (
 /obj/machinery/power/apc/mainship{
@@ -10545,7 +11165,7 @@
 /area/mainship/living/briefing)
 "KA" = (
 /obj/machinery/light,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/red,
 /area/mainship/living/briefing)
 "KB" = (
 /turf/open/floor/mainship/red{
@@ -10563,6 +11183,13 @@
 	},
 /area/mainship/living/briefing)
 "KE" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = -7
+	},
+/obj/item/ammo_casing/bullet{
+	pixel_x = -7;
+	pixel_y = 5
+	},
 /turf/open/floor/mainship/purple{
 	dir = 10
 	},
@@ -10587,8 +11214,11 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/blue,
 /area/mainship/living/briefing)
+"KK" = (
+/turf/open/floor/mainship/black,
+/area/mainship/living/grunt_rnr)
 "KL" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -10609,10 +11239,19 @@
 /obj/machinery/light,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
+"KO" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/mainship/green{
+	dir = 10
+	},
+/area/mainship/living/port_garden)
 "KP" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
@@ -10621,6 +11260,9 @@
 /obj/item/facepaint/green,
 /obj/item/facepaint/brown,
 /obj/item/facepaint/black,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "KR" = (
@@ -10636,19 +11278,21 @@
 /obj/machinery/power/apc/mainship{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
 /area/mainship/living/grunt_rnr)
 "KT" = (
 /obj/structure/flora/pottedplant/twentyone{
 	icon_state = "plant-14"
 	},
-/turf/open/floor/mainship/green/full,
+/turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "KU" = (
 /obj/structure/flora/pottedplant/twentyone{
 	icon_state = "plant-09"
 	},
-/turf/open/floor/mainship/green/full,
+/turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "KV" = (
 /obj/structure/window/reinforced{
@@ -10658,6 +11302,7 @@
 	dir = 8
 	},
 /obj/structure/curtain/shower,
+/obj/item/tool/soap/nanotrasen,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/grunt_rnr)
 "KW" = (
@@ -10673,6 +11318,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
+"KY" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "KZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -10686,6 +11337,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
+"Ld" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = -2
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "Le" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -10771,14 +11428,14 @@
 /turf/open/floor/engine,
 /area/mainship/engineering/port_atmos)
 "Lo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "Lp" = (
@@ -10799,7 +11456,9 @@
 /obj/structure/table/woodentable,
 /obj/item/pizzabox/meat,
 /obj/item/clothing/under/pizza,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
 /area/mainship/living/grunt_rnr)
 "Ls" = (
 /obj/structure/sign/securearea{
@@ -10864,15 +11523,22 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "LE" = (
 /obj/machinery/alarm,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
 /area/mainship/hallways/starboard_hallway)
 "LF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
 /area/mainship/hallways/starboard_hallway)
 "LG" = (
 /obj/effect/ai_node,
@@ -10881,6 +11547,26 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
+"LH" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
+/area/mainship/living/briefing)
+"LK" = (
+/obj/machinery/bodyscanner{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "LM" = (
 /obj/machinery/light{
 	dir = 1
@@ -10890,7 +11576,9 @@
 /area/mainship/hallways/starboard_hallway)
 "LN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
 /area/mainship/hallways/starboard_hallway)
 "LO" = (
 /obj/structure/janitorialcart,
@@ -10955,6 +11643,11 @@
 /obj/effect/landmark/start/job/staffofficer,
 /turf/open/floor/wood,
 /area/mainship/living/bridgebunks)
+"Mb" = (
+/turf/open/floor/mainship/purple{
+	dir = 4
+	},
+/area/mainship/living/briefing)
 "Md" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/med_data,
@@ -10969,7 +11662,6 @@
 "Mf" = (
 /obj/machinery/light,
 /obj/structure/table/mainship,
-/obj/item/paper/chemistry,
 /turf/open/floor/mainship/sterile/purple/side,
 /area/mainship/medical/chemistry)
 "Mg" = (
@@ -10987,6 +11679,9 @@
 	},
 /area/mainship/medical/chemistry)
 "Mk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/purple/side,
 /area/mainship/medical/chemistry)
 "Ml" = (
@@ -11147,6 +11842,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/grunt_rnr)
+"MB" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "MC" = (
 /obj/machinery/suit_storage_unit/carbon_unit,
 /obj/machinery/camera/autoname/mainship{
@@ -11186,7 +11887,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
 /area/mainship/hallways/starboard_hallway)
 "MO" = (
 /turf/open/floor/mainship/tcomms,
@@ -11195,6 +11898,12 @@
 /obj/machinery/alarm,
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/weapon_room)
+"MR" = (
+/obj/structure/disposalpipe/junction/flipped{
+	dir = 4
+	},
+/turf/open/floor/mainship/silver,
+/area/mainship/medical/medical_science)
 "MS" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -11213,6 +11922,9 @@
 /obj/machinery/door/airlock/mainship/medical/free_access{
 	dir = 2
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "MW" = (
@@ -11224,7 +11936,7 @@
 /area/mainship/hallways/hangar)
 "MX" = (
 /obj/machinery/light,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black,
 /area/mainship/hallways/starboard_hallway)
 "MY" = (
 /turf/closed/wall/mainship/outer,
@@ -11234,6 +11946,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
+"Na" = (
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "Nb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -11242,7 +11959,7 @@
 /area/mainship/hallways/starboard_hallway)
 "Nc" = (
 /obj/machinery/light,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/black,
 /area/mainship/living/grunt_rnr)
 "Nd" = (
 /obj/structure/cable,
@@ -11289,9 +12006,21 @@
 	},
 /turf/closed/wall/mainship/outer,
 /area/mainship/hull/port_hull)
+"Np" = (
+/turf/open/floor/mainship/red{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "Nq" = (
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/weapon_room)
+"Nr" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = 6;
+	pixel_y = -7
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "Ns" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/weapon_room)
@@ -11332,6 +12061,15 @@
 "NA" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"NB" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/turf/open/floor/mainship/purple{
+	dir = 1
+	},
+/area/mainship/living/briefing)
 "NC" = (
 /obj/structure/closet/firecloset,
 /obj/item/clothing/mask/gas,
@@ -11362,7 +12100,7 @@
 /area/mainship/engineering/engineering_workshop)
 "NI" = (
 /obj/structure/window/framed/mainship/requisitions,
-/turf/open/floor/plating,
+/turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "NJ" = (
 /obj/machinery/door/airlock/mainship/engineering{
@@ -11402,6 +12140,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/airoom)
+"NQ" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/mainship/orange{
+	dir = 6
+	},
+/area/mainship/engineering/engineering_workshop)
 "NR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -11454,12 +12198,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/mainship,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "Artillery Control"
+/obj/machinery/door/airlock/mainship/security/glass{
+	name = "Artillery Control";
+	req_access = list(2,7)
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
@@ -11553,6 +12297,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"Of" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
+/area/mainship/living/briefing)
 "Og" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -11636,6 +12386,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"Ot" = (
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
+/area/mainship/hallways/starboard_hallway)
 "Ou" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -11665,13 +12420,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/mainship/orange,
+/turf/open/floor/mainship/floor,
 /area/mainship/engineering/engineering_workshop)
 "OC" = (
 /obj/machinery/alarm,
-/turf/open/floor/mainship/orange{
-	dir = 6
-	},
+/turf/open/floor/mainship/floor,
 /area/mainship/engineering/engineering_workshop)
 "OD" = (
 /obj/structure/cable,
@@ -11776,6 +12529,14 @@
 "OS" = (
 /turf/closed/wall/mainship,
 /area/mainship/hallways/hangar)
+"OT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/purple{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "OU" = (
 /obj/structure/table/mainship,
 /obj/item/stack/cable_coil,
@@ -11845,7 +12606,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "Pf" = (
-/obj/machinery/recycler,
+/obj/machinery/recycler{
+	dir = 8
+	},
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "lower_garbage"
@@ -11885,6 +12648,11 @@
 	},
 /turf/open/floor/mainship/ai,
 /area/mainship/command/airoom)
+"Pl" = (
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "Pn" = (
 /turf/open/floor/mainship/ai,
 /area/mainship/command/airoom)
@@ -11953,6 +12721,10 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
+"PA" = (
+/obj/structure/curtain/medical,
+/turf/open/floor/mainship/research,
+/area/mainship/medical/medical_science)
 "PB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
@@ -12137,6 +12909,13 @@
 	},
 /turf/open/floor/mainship/ai,
 /area/mainship/command/airoom)
+"Qh" = (
+/obj/effect/landmark/start/job/squadsmartgunner,
+/obj/effect/landmark/start/latejoin,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/mainship/living/cryo_cells)
 "Qi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -12294,7 +13073,7 @@
 /area/mainship/command/self_destruct)
 "QF" = (
 /obj/structure/window/framed/mainship/requisitions,
-/turf/open/floor/plating,
+/turf/open/floor/mainship/mono,
 /area/mainship/engineering/ce_room)
 "QG" = (
 /obj/machinery/door/airlock/mainship/engineering/CSEoffice{
@@ -12317,6 +13096,12 @@
 	},
 /turf/open/floor/engine,
 /area/mainship/engineering/port_atmos)
+"QJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "QK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -12504,8 +13289,8 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "Rw" = (
-/obj/machinery/power/apc/mainship,
 /obj/structure/cable,
+/obj/machinery/power/apc/mainship/hardened,
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
 "Rx" = (
@@ -12533,6 +13318,7 @@
 	name = "Alpha Overwatch Console"
 	},
 /obj/structure/table/reinforced,
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "RB" = (
@@ -12541,6 +13327,7 @@
 	dir = 1
 	},
 /obj/structure/table/reinforced,
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "RC" = (
@@ -12664,6 +13451,10 @@
 /obj/item/lightreplacer,
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
+"Sd" = (
+/obj/structure/sign/chemistry2,
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/lower_medical)
 "Se" = (
 /obj/structure/table/mainship,
 /obj/item/lightreplacer,
@@ -12671,6 +13462,24 @@
 	dir = 6
 	},
 /area/mainship/engineering/engineering_workshop)
+"Sf" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/green{
+	dir = 6
+	},
+/area/mainship/living/port_garden)
+"Sg" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/mainship/living/briefing)
 "Si" = (
 /turf/open/floor/mainship/black{
 	dir = 10
@@ -12788,6 +13597,14 @@
 	dir = 1
 	},
 /area/mainship/shipboard/weapon_room)
+"SH" = (
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/turf/open/floor/mainship/blue{
+	dir = 10
+	},
+/area/mainship/living/grunt_rnr)
 "SI" = (
 /obj/structure/bed/chair/ob_chair,
 /obj/machinery/computer/orbital_cannon_console,
@@ -12814,6 +13631,9 @@
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/shipboard/weapon_room)
+"SL" = (
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/living/grunt_rnr)
 "SM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -12821,6 +13641,11 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
+"SN" = (
+/turf/open/floor/mainship/purple{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "SO" = (
 /obj/machinery/door/poddoor/mainship/open/cic,
 /obj/machinery/door/firedoor/mainship,
@@ -12905,6 +13730,12 @@
 	dir = 6
 	},
 /area/mainship/command/cic)
+"Tf" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/powered)
 "Ti" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -13022,6 +13853,11 @@
 /obj/structure/dropship_equipment/mg_holder,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"Tx" = (
+/turf/open/floor/mainship/red{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "Ty" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/skills,
@@ -13263,13 +14099,13 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/weapon_room)
 "Uq" = (
-/obj/machinery/door/firedoor/mainship,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/door/airlock/mainship/maint{
-	name = "Artillery Control"
+/obj/machinery/door/airlock/mainship/security/glass{
+	name = "Artillery Control";
+	req_access = list(2,7)
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
@@ -13342,9 +14178,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "UF" = (
-/obj/machinery/power/apc/mainship,
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/machinery/power/apc/mainship/hardened,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
 "UH" = (
@@ -13373,6 +14209,16 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
+"UJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/ammo_casing/bullet{
+	pixel_x = -9;
+	pixel_y = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "UK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -13383,6 +14229,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
+"UL" = (
+/obj/effect/landmark/start/job/squadcorpsman,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/cryo_cells)
 "UM" = (
 /obj/machinery/computer/camera_advanced/overwatch/bravo{
 	name = "Charlie Overwatch Console"
@@ -13391,6 +14241,7 @@
 	dir = 1
 	},
 /obj/structure/table/reinforced,
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "UN" = (
@@ -13462,6 +14313,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"UW" = (
+/turf/open/floor/mainship/purple{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "UX" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/mainship/mono,
@@ -13542,6 +14398,15 @@
 "Vo" = (
 /turf/closed/wall/mainship,
 /area/mainship/hallways/hangar/droppod)
+"Vp" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/mainship/living/briefing)
 "Vq" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/mainship/orange{
@@ -13613,7 +14478,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engine_core)
 "VH" = (
 /obj/structure/cable,
@@ -13622,20 +14487,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engine_core)
-"VI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/engineering/engine_core)
 "VJ" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engine_core)
 "VK" = (
 /obj/structure/cable,
@@ -13643,7 +14501,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engine_core)
 "VL" = (
 /obj/structure/cable,
@@ -13693,6 +14551,17 @@
 	dir = 8
 	},
 /area/mainship/command/airoom)
+"VV" = (
+/obj/effect/landmark/start/latejoin,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/cryo_cells)
+"VW" = (
+/obj/structure/cable,
+/turf/open/floor/carpet{
+	dir = 1;
+	icon_state = "carpetside"
+	},
+/area/mainship/living/bridgebunks)
 "VX" = (
 /obj/machinery/light{
 	dir = 4
@@ -13796,6 +14665,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
 "Wr" = (
@@ -13863,6 +14733,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
+"WG" = (
+/obj/structure/sign/science,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "WH" = (
 /obj/machinery/power/smes/preset,
 /obj/structure/cable,
@@ -13934,6 +14808,14 @@
 "WS" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
+"WT" = (
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/turf/open/floor/mainship/blue{
+	dir = 9
+	},
+/area/mainship/living/grunt_rnr)
 "WU" = (
 /obj/machinery/alarm{
 	dir = 8
@@ -14005,7 +14887,7 @@
 /area/mainship/command/telecomms)
 "Xg" = (
 /obj/structure/window/framed/mainship/requisitions,
-/turf/open/floor/plating,
+/turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "Xh" = (
 /obj/machinery/computer/telecomms/monitor,
@@ -14033,6 +14915,7 @@
 /obj/structure/window/reinforced/toughened{
 	dir = 1
 	},
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/command/cic)
 "Xn" = (
@@ -14053,13 +14936,14 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/command/cic)
 "Xp" = (
-/obj/machinery/computer/med_data,
+/obj/machinery/computer/crew,
 /turf/open/floor/mainship/green{
 	dir = 9
 	},
 /area/mainship/command/cic)
 "Xq" = (
 /obj/machinery/cic_maptable,
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/green{
 	dir = 5
 	},
@@ -14091,6 +14975,7 @@
 /obj/structure/window/reinforced/toughened{
 	dir = 1
 	},
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/command/cic)
 "Xv" = (
@@ -14139,6 +15024,11 @@
 "XH" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/engineering/port_atmos)
+"XI" = (
+/obj/effect/landmark/start/job/squadleader,
+/obj/effect/landmark/start/latejoin,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/cryo_cells)
 "XJ" = (
 /turf/open/floor/engine,
 /area/mainship/engineering/port_atmos)
@@ -14146,6 +15036,15 @@
 /obj/machinery/portable_atmospherics/canister/empty,
 /turf/open/floor/engine,
 /area/mainship/engineering/port_atmos)
+"XL" = (
+/obj/effect/decal/cleanable/blood/oil{
+	name = "grease";
+	pixel_x = 8
+	},
+/turf/open/floor/mainship/purple{
+	dir = 4
+	},
+/area/mainship/living/briefing)
 "XM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -14220,16 +15119,6 @@
 /obj/item/storage/bag/trash,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
-"XY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/engineering/port_atmos)
 "XZ" = (
 /turf/open/floor/mainship/red/corner{
 	dir = 1
@@ -14288,9 +15177,9 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/shipboard/weapon_room)
 "Yf" = (
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/airlock/mainship/maint{
-	name = "Artillery Control"
+/obj/machinery/door/airlock/mainship/security/glass{
+	name = "Artillery Control";
+	req_access = list(2,7)
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
@@ -14418,6 +15307,12 @@
 	dir = 1
 	},
 /area/space)
+"YC" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/mainship/green{
+	dir = 8
+	},
+/area/mainship/living/port_garden)
 "YD" = (
 /obj/machinery/vending/weapon,
 /turf/open/floor/mainship/red{
@@ -14436,6 +15331,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"YG" = (
+/turf/open/floor/mainship/purple/corner{
+	dir = 1
+	},
+/area/mainship/squads/general)
 "YI" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -14450,7 +15350,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engine_core)
 "YK" = (
 /obj/structure/cable,
@@ -14458,13 +15358,6 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/engineering/engine_core)
-"YM" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
 "YN" = (
 /obj/machinery/power/terminal{
@@ -14474,7 +15367,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engine_core)
 "YP" = (
 /obj/structure/cable,
@@ -14482,7 +15375,7 @@
 	dir = 9
 	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engine_core)
 "YQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -14720,6 +15613,12 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/port_atmos)
+"ZG" = (
+/obj/effect/landmark/start/job/squadmarine,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/mainship/living/cryo_cells)
 "ZI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -14755,6 +15654,12 @@
 /obj/machinery/light,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
+"ZR" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/mainship/green{
+	dir = 6
+	},
+/area/mainship/living/port_garden)
 "ZS" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/mainship/mono,
@@ -16721,7 +17626,7 @@ XE
 XE
 va
 Bz
-Bz
+ui
 DT
 EJ
 Bz
@@ -16894,7 +17799,7 @@ ZK
 ZK
 YB
 fD
-aQ
+oV
 bs
 bD
 bD
@@ -18109,8 +19014,8 @@ kl
 kl
 NX
 Pt
-vw
-vw
+NC
+hD
 vw
 uJ
 vw
@@ -18306,7 +19211,7 @@ Nv
 iw
 jk
 vw
-vw
+Yh
 vw
 vw
 We
@@ -18484,8 +19389,8 @@ xp
 Hn
 zq
 Av
-Aw
-Av
+aw
+Sf
 DZ
 EM
 FL
@@ -18589,7 +19494,7 @@ EM
 FO
 GG
 HN
-Ib
+lK
 IY
 Ka
 HN
@@ -18680,8 +19585,8 @@ xr
 co
 cs
 Aw
-Aw
-Aw
+YC
+KO
 Ed
 EO
 EO
@@ -18777,9 +19682,9 @@ wp
 xr
 co
 zs
-cs
-cs
-cs
+BI
+aw
+ZR
 Eg
 EQ
 FP
@@ -18787,7 +19692,7 @@ GH
 EO
 Ie
 Ja
-Ka
+ni
 EM
 GF
 LZ
@@ -18885,7 +19790,7 @@ GI
 EO
 Ie
 Je
-Ka
+ni
 HN
 GG
 Ma
@@ -18981,7 +19886,7 @@ EO
 FS
 GJ
 HO
-Ig
+VW
 Ji
 Kc
 EM
@@ -19080,7 +19985,7 @@ FT
 GK
 EO
 Ic
-Jj
+IZ
 Ke
 EM
 GF
@@ -19177,9 +20082,9 @@ ER
 ER
 ER
 ER
-Ib
-Jk
-Kf
+Ie
+Ja
+Kc
 HN
 GG
 Ma
@@ -19275,9 +20180,9 @@ ER
 FU
 GM
 ER
+Ie
 Ib
-Ib
-Kf
+Kc
 EM
 EM
 EM
@@ -19353,14 +20258,14 @@ kq
 kq
 kq
 kq
-oq
+pE
 px
 kq
 kq
 kq
 tF
 uS
-vE
+sy
 wt
 xA
 ty
@@ -19382,7 +20287,7 @@ KZ
 MT
 Nx
 NZ
-Pv
+vw
 Qt
 Pv
 Pv
@@ -19444,7 +20349,7 @@ fc
 fA
 gk
 gT
-hJ
+SM
 iv
 jk
 kq
@@ -19453,7 +20358,7 @@ kW
 nr
 or
 py
-qG
+xt
 rO
 kq
 tG
@@ -19480,7 +20385,7 @@ Ig
 Ig
 Ny
 Oa
-Pw
+SM
 Qv
 Pw
 SM
@@ -19551,7 +20456,7 @@ mi
 ns
 ot
 pz
-mi
+PA
 rQ
 kq
 tH
@@ -19658,8 +20563,8 @@ vH
 wx
 xE
 ty
-zy
-AC
+BR
+BR
 BR
 ty
 Ek
@@ -19824,7 +20729,7 @@ Uy
 Uy
 VC
 VC
-az
+aW
 OS
 bN
 NA
@@ -20034,13 +20939,13 @@ gn
 OS
 VC
 iy
-VC
+WG
 kq
 lb
 mi
-nt
+hj
 oz
-pz
+MR
 mi
 rW
 kq
@@ -20136,7 +21041,7 @@ VC
 kq
 ld
 ml
-nv
+nt
 oA
 pD
 qJ
@@ -20248,8 +21153,8 @@ xH
 yx
 zB
 AJ
-zB
-zB
+dH
+dH
 Ep
 EX
 Ep
@@ -20341,13 +21246,13 @@ kq
 tT
 uX
 rY
-wD
+rY
 xJ
 yy
-zC
+LK
 uW
 zC
-CR
+vJ
 Eq
 EY
 Gf
@@ -20427,9 +21332,9 @@ ey
 hM
 iy
 jq
-kt
+AP
 lh
-lh
+mn
 lh
 oD
 kt
@@ -20439,7 +21344,7 @@ sG
 tU
 uX
 rY
-wE
+rY
 xJ
 rY
 zE
@@ -20528,7 +21433,7 @@ VC
 kt
 li
 mn
-mn
+wD
 oE
 kt
 qM
@@ -20547,7 +21452,7 @@ CS
 BX
 Fa
 kt
-kt
+Sd
 HQ
 Is
 HQ
@@ -20625,7 +21530,7 @@ iy
 VC
 kt
 lj
-lj
+mn
 lj
 oF
 pG
@@ -20641,7 +21546,7 @@ yz
 zG
 AL
 Es
-Es
+eU
 Es
 Fc
 Gj
@@ -20723,7 +21628,7 @@ iy
 VC
 kt
 lh
-lh
+mn
 lh
 oH
 kt
@@ -20827,7 +21732,7 @@ mn
 kt
 qP
 sd
-mn
+wE
 kt
 vc
 rY
@@ -20850,8 +21755,8 @@ Lo
 LD
 Mk
 MU
-vw
-iw
+rM
+Fb
 jk
 Qx
 RM
@@ -20925,7 +21830,7 @@ mn
 kt
 qQ
 sf
-mn
+vG
 kt
 vd
 vR
@@ -21649,8 +22554,8 @@ zT
 ZB
 AW
 gs
-gs
-gs
+qf
+qf
 JC
 AW
 ZB
@@ -21660,7 +22565,7 @@ aU
 aU
 aU
 aU
-XE
+Ac
 hr
 ZK
 ZK
@@ -21954,7 +22859,7 @@ gs
 ZW
 aH
 aU
-XE
+Ac
 hr
 ZK
 ZK
@@ -22237,8 +23142,8 @@ zT
 ZB
 AW
 gs
-gs
-gs
+qf
+qf
 JC
 AW
 ZB
@@ -22248,7 +23153,7 @@ aU
 aU
 aU
 aU
-XE
+Ac
 hr
 ZK
 ZK
@@ -22342,7 +23247,7 @@ YY
 ZB
 KH
 aU
-lY
+Tf
 XE
 Zl
 Zl
@@ -22734,7 +23639,7 @@ Dh
 Dh
 AX
 aU
-Du
+Tf
 ZK
 ZK
 ZK
@@ -22768,7 +23673,7 @@ ID
 QM
 cd
 Io
-WS
+Jo
 SA
 SA
 SA
@@ -22777,15 +23682,15 @@ SA
 SA
 SA
 SA
-dA
-dA
+ug
+ug
 SA
 lm
 SA
 SA
 SA
-dA
-dA
+ug
+ug
 SA
 sM
 ue
@@ -22799,15 +23704,15 @@ AZ
 Cg
 CZ
 Eu
-Ci
+Np
 Gn
 He
 HU
-Ci
+Np
 Jx
 Ky
 Cg
-WS
+Ot
 zU
 MX
 NH
@@ -22866,7 +23771,7 @@ bl
 Vo
 cf
 Io
-WS
+Jo
 SA
 ea
 ea
@@ -22891,23 +23796,23 @@ gY
 vS
 wJ
 xR
-WS
+Ot
 Io
-WS
+Jo
 Cg
 Da
 Ci
-Ci
+zD
 Gp
 Gt
 Gr
 Ci
-Jy
+UJ
 KA
 Cg
-WS
+Ot
 zU
-WS
+Jo
 NH
 Ov
 PF
@@ -22989,23 +23894,23 @@ gY
 vT
 wL
 xS
-WS
+Ot
 Io
-WS
+Jo
 Ch
 Db
-Ci
-Ci
-Ci
-Ci
-Ci
-Ci
-Jy
+Bp
+bm
+bm
+Sg
+fT
+Vp
+pp
 KB
 Lp
-WS
+Ot
 zU
-WS
+Jo
 NI
 Ox
 PG
@@ -23062,7 +23967,7 @@ yT
 Vo
 cj
 Io
-WS
+Jo
 dA
 ea
 ea
@@ -23087,11 +23992,11 @@ gY
 vU
 wL
 xS
-WS
+Ot
 Io
-WS
+Jo
 Ci
-Ci
+Fu
 Ci
 Ci
 Gq
@@ -23101,11 +24006,11 @@ Ci
 Jy
 Ci
 Ci
-WS
+Ot
 zU
-WS
+Jo
 NI
-Oy
+NQ
 PH
 QG
 RX
@@ -23158,7 +24063,7 @@ TY
 SP
 Vo
 Vo
-WS
+Ot
 Io
 dk
 dA
@@ -23185,21 +24090,21 @@ vf
 vV
 wL
 gY
-WS
+Ot
 zQ
 Bc
 Cj
 De
-Cj
-Cj
-Cj
+GP
+QJ
+hg
 Hh
-Ci
-Ci
-Jy
+fP
+Hk
+EH
 KC
 Ci
-WS
+Ot
 zU
 MX
 NH
@@ -23258,7 +24163,7 @@ bo
 by
 WS
 Io
-WS
+Jo
 dA
 ec
 ea
@@ -23285,21 +24190,21 @@ SA
 SA
 yA
 Io
-WS
+Jo
 Ci
-Ci
-Ci
-Ci
+LH
+wS
+Nr
 Gr
 Gt
 Gp
 Ci
 Jy
+gG
 Ci
-Ci
-WS
+Ot
 zU
-WS
+Jo
 NH
 OC
 PF
@@ -23356,7 +24261,7 @@ bp
 by
 WS
 Io
-WS
+Jo
 dA
 ea
 ea
@@ -23381,21 +24286,21 @@ vg
 vW
 wN
 xT
-WS
+Ot
 Io
-WS
+Jo
 Cg
 Dg
-Eu
-Ci
-Ci
+tI
+Bd
+jK
 Hi
-Ci
-Ci
+Bd
+zI
 Jz
 KD
 Cg
-WS
+Ot
 Mo
 En
 NJ
@@ -23454,7 +24359,7 @@ bq
 Ec
 Ec
 cL
-WS
+Jo
 dA
 ea
 ea
@@ -23479,9 +24384,9 @@ vh
 vX
 wO
 xT
-WS
+Ot
 Io
-WS
+Jo
 Cl
 Ci
 Ci
@@ -23489,13 +24394,13 @@ Fm
 Gs
 Cg
 HV
-Ci
+Ap
 Jy
 Ci
 Cl
-WS
+Ot
 zU
-WS
+Jo
 NH
 OE
 PL
@@ -23552,7 +24457,7 @@ bo
 by
 by
 Io
-WS
+Jo
 SA
 eb
 ea
@@ -23577,21 +24482,21 @@ vi
 wb
 wO
 xT
-WS
+Ot
 Io
-WS
+Jo
 Cg
 Di
-Ci
-Ci
-Ci
+SN
+SN
+hZ
 Hm
-Ci
-Ci
-Jy
+SN
+SN
+OT
 KE
 Cg
-WS
+Ot
 zU
 MX
 NH
@@ -23650,7 +24555,7 @@ bp
 by
 WS
 Io
-WS
+Jo
 SA
 ea
 hi
@@ -23677,19 +24582,19 @@ wP
 SA
 cj
 Io
-WS
+Jo
 Ci
-Ci
-Ci
+NB
+dJ
 Ci
 Gr
 Gp
 Gt
+FI
+Ba
+rV
 Ci
-Jy
-Ci
-Ci
-WS
+Ot
 Mp
 MZ
 NK
@@ -23748,7 +24653,7 @@ bo
 Am
 WS
 Io
-WS
+Jo
 SA
 SA
 SA
@@ -23779,17 +24684,17 @@ Bf
 Cm
 Dk
 Ev
-Cm
-Cm
+yD
+nX
 Ho
-Ci
-Ci
-Jz
+XL
+Mb
+aG
 KG
 Ci
-WS
+Ot
 Mq
-WS
+Jo
 NH
 OH
 PN
@@ -23873,7 +24778,7 @@ sp
 xV
 yB
 zS
-WS
+Jo
 Ci
 Ci
 Ci
@@ -23885,9 +24790,9 @@ Ci
 Jy
 Ci
 Ci
-WS
+Ot
 zU
-WS
+Jo
 NI
 OI
 PN
@@ -23950,8 +24855,8 @@ ee
 eH
 fm
 fQ
-SA
-gZ
+ug
+gY
 gY
 gY
 gY
@@ -23971,21 +24876,21 @@ wQ
 SA
 cj
 zU
-WS
+Jo
 Cn
 Dl
-Ci
-Ci
-Ci
-Ci
-Ci
-Ci
-Jy
+kp
+kp
+ou
+aR
+yr
+FG
+Ck
 KI
 Cn
-WS
+Ot
 zU
-WS
+Jo
 NI
 OJ
 PN
@@ -24042,13 +24947,13 @@ fe
 Vo
 cl
 Io
-WS
+Jo
 SA
 ef
 rE
 fo
 KW
-SA
+ug
 hc
 hU
 iO
@@ -24069,15 +24974,15 @@ wR
 SA
 yC
 zU
-WS
+Jo
 Cg
 Dm
-Ci
+Ld
 Ci
 Gt
 Gp
 Gr
-Ci
+Gg
 JA
 KJ
 Cg
@@ -24098,7 +25003,7 @@ Wz
 Wz
 XH
 XH
-XY
+RH
 XH
 XE
 XE
@@ -24140,23 +25045,23 @@ VP
 Vo
 cn
 Io
-WS
+Jo
+SA
+SA
+ug
+SA
+ug
 SA
 SA
 SA
 SA
-SA
-SA
-SA
-SA
-SA
-dA
-dA
+ug
+ug
 SA
 mz
 SA
-dA
-dA
+ug
+ug
 SA
 SA
 SA
@@ -24170,18 +25075,18 @@ zU
 AZ
 Cg
 Dn
-Eu
-Ci
-Ci
-Ci
-Ci
-Ci
+Of
+cG
+cu
+cu
+kC
+cu
 JB
 KL
 Cg
-WS
+Ot
 zU
-WS
+Jo
 NH
 ON
 PO
@@ -24236,50 +25141,50 @@ XE
 Hr
 tX
 QM
-WS
+Ot
 Io
-WS
+dU
 dC
 eg
-WS
-WS
-WS
-WS
+jM
+jM
+jM
+jM
 eg
-WS
+jM
 dC
-WS
-WS
+jM
+jM
 eg
 mA
-WS
-WS
+jM
+jM
 pV
 eg
+jM
+jM
 WS
 WS
-WS
-WS
-WS
+jM
 eg
 dC
-WS
+rL
 zU
-WS
+dU
 eg
-WS
-WS
-WS
-WS
-WS
-WS
-WS
+jM
+jM
+jM
+jM
+jM
+jM
+jM
 JE
-WS
+jM
 eg
-WS
+rL
 zU
-WS
+Jo
 NI
 OP
 PQ
@@ -24377,7 +25282,7 @@ Bj
 Bj
 Bj
 Mr
-WS
+Jo
 NI
 OR
 PT
@@ -24431,32 +25336,32 @@ XE
 XE
 Hr
 ID
-QM
-WS
+gB
+aP
 cN
-WS
-WS
+dE
+dE
 MN
-WS
+dE
 fp
 fU
 QK
 MN
-WS
+dE
 cf
 cd
-WS
+dE
 MN
-WS
-WS
-WS
-WS
+dE
+dE
+dE
+dE
 MN
-WS
-WS
-WS
-WS
-WS
+dE
+dE
+dE
+dE
+dE
 MN
 xW
 yF
@@ -24466,16 +25371,16 @@ xW
 Dp
 WS
 xW
-WS
-WS
+dE
+dE
 cf
 cd
-WS
-WS
-WS
-WS
+dE
+dE
+dE
+cX
 zU
-WS
+Jo
 NH
 OU
 PT
@@ -24546,8 +25451,8 @@ wM
 wM
 lw
 mD
-lw
-lw
+mE
+Id
 mD
 lw
 sr
@@ -24644,7 +25549,7 @@ eh
 wM
 ly
 mE
-nA
+mE
 oR
 pW
 rk
@@ -24655,13 +25560,13 @@ sX
 sr
 ta
 uq
-yH
-tc
-tc
-uq
-Dr
+yG
 tc
 ta
+iH
+Dq
+tc
+tc
 tc
 vk
 sr
@@ -24669,9 +25574,9 @@ IB
 JG
 KM
 sr
-WS
+Ot
 zU
-WS
+Jo
 NI
 OW
 PT
@@ -24749,19 +25654,19 @@ mE
 sr
 sY
 us
-vj
+tc
 sr
 tc
 tc
 yJ
-tc
-us
-tc
+Pl
+KY
+Pl
 Dt
-tc
-us
-tc
-tc
+FN
+md
+FN
+ju
 HW
 tc
 JH
@@ -24769,17 +25674,17 @@ KN
 sr
 LE
 zU
-WS
+Jo
 NI
 OZ
 PT
 QZ
 NH
 TJ
-VI
+VH
 WE
 WE
-YM
+YK
 WE
 ds
 in
@@ -24851,15 +25756,15 @@ sZ
 sr
 wU
 xX
-yH
+yG
 zY
 tc
 zY
-Dr
+Dq
 zY
 tc
 zY
-tc
+et
 HW
 tc
 JI
@@ -24867,7 +25772,7 @@ Hp
 sr
 LF
 Ms
-WS
+Jo
 NH
 Pa
 PT
@@ -24945,25 +25850,25 @@ rl
 sr
 sr
 ut
+qm
 sr
-sr
 tc
 tc
-yH
+yG
 zZ
 tc
 zZ
-Dr
+Dq
 zZ
 tc
 zZ
-tc
+fj
 sr
 IE
 JJ
 KM
 sr
-WS
+Ot
 Mt
 Nb
 NL
@@ -25047,23 +25952,23 @@ vk
 tc
 tc
 xX
-yH
+yG
 Ae
 tc
 Ae
-Dr
+Dq
 Ae
 tc
 Ae
-Hp
+CT
+cg
+cg
 sr
 sr
 sr
-sr
-sr
-WS
+Ot
 zU
-WS
+Jo
 NH
 NH
 PW
@@ -25139,22 +26044,22 @@ oU
 qd
 mJ
 ss
-tc
-tc
-tc
-tc
-tc
+Na
+Na
+Na
+Na
+Na
 xY
 yL
-uq
-tc
-tc
+nE
+Tx
+Tx
 Dv
 Ew
+UW
+UW
+YG
 tc
-tc
-tc
-uq
 IF
 JK
 KP
@@ -25236,7 +26141,7 @@ nG
 oU
 qe
 rn
-st
+bC
 st
 uv
 st
@@ -25250,10 +26155,10 @@ Cr
 DA
 Ex
 Fn
-Gu
+MB
 Hs
-Ex
-IG
+Gu
+Gu
 JL
 KQ
 Lq
@@ -25341,7 +26246,7 @@ vl
 tc
 tc
 xZ
-yH
+yG
 zY
 tc
 zY
@@ -25350,14 +26255,14 @@ zY
 Fo
 zY
 Hu
-sr
-sr
+cg
+cg
 sr
 sr
 sr
 cf
 zU
-WS
+Jo
 NH
 Pf
 PY
@@ -25435,11 +26340,11 @@ rq
 sr
 sr
 uw
-sr
+nY
 sr
 sY
 tc
-yH
+yG
 zZ
 tc
 zZ
@@ -25455,7 +26360,7 @@ KR
 sr
 LN
 Mv
-WS
+Jo
 NH
 Pg
 PY
@@ -25537,7 +26442,7 @@ te
 sr
 wU
 xZ
-yH
+yG
 Ae
 tc
 Ae
@@ -25545,15 +26450,15 @@ DB
 Ae
 Fo
 Ae
-tc
+Co
 HX
 tc
 JN
 Hp
 sr
-WS
+Ot
 zU
-WS
+Jo
 NH
 NH
 PZ
@@ -25625,25 +26530,25 @@ Hr
 lM
 mE
 nG
-oV
+oU
 mE
 mE
 sr
 sY
 us
-vj
+tc
 sr
 wV
 tc
 yJ
-tc
-us
-tc
+dI
+mk
+dI
 DD
-tc
+sn
 Fq
-tc
-tc
+sn
+ix
 HX
 tc
 JO
@@ -25733,7 +26638,7 @@ tf
 sr
 ta
 ux
-yH
+yG
 Ag
 Bm
 Cs
@@ -25747,9 +26652,9 @@ IH
 JP
 KR
 sr
-WS
+Ot
 zU
-WS
+Jo
 NH
 Pj
 Qb
@@ -25831,23 +26736,23 @@ sr
 sr
 sr
 sr
-yN
+yG
+Bs
+sr
+sr
+DB
 Ah
 sr
 sr
-DF
-Ah
 sr
 sr
 sr
 sr
 sr
 sr
-sr
-sr
-WS
+Ot
 zU
-WS
+Jo
 NH
 NH
 NH
@@ -25913,7 +26818,7 @@ Hr
 ID
 ho
 ia
-iT
+jW
 jW
 kz
 ia
@@ -25921,7 +26826,7 @@ mN
 nK
 ib
 ia
-rs
+su
 su
 kz
 ia
@@ -25943,9 +26848,9 @@ IJ
 JQ
 KS
 Lr
-JR
+kb
 Mw
-JR
+KK
 NO
 Pk
 Qc
@@ -26011,19 +26916,19 @@ Hr
 ID
 ho
 ib
-iT
-jW
+uu
+uu
 ib
 ib
 mO
-nK
+UL
 ib
 ib
 rs
 sw
 ib
 ib
-vn
+VV
 ho
 wZ
 yb
@@ -26043,7 +26948,7 @@ IK
 IK
 IK
 Mw
-JR
+KK
 NO
 Pn
 Qd
@@ -26109,16 +27014,16 @@ Hr
 tX
 ho
 ib
-iT
+jW
 jW
 ib
 ib
-mO
+tJ
 nL
 ib
 ib
-rt
-sw
+Qh
+Qh
 ib
 ib
 vn
@@ -26220,7 +27125,7 @@ iU
 id
 id
 iU
-we
+id
 xd
 yc
 yR
@@ -26236,14 +27141,14 @@ xg
 IM
 JR
 KT
-JR
-JR
+Il
+rD
 My
-JR
+KK
 NO
 Pn
 Qg
-NO
+Eb
 Sp
 TZ
 VR
@@ -26334,14 +27239,14 @@ xg
 IO
 JR
 KU
-JR
-JR
+SH
+WT
 Mz
 Nd
 NP
 Po
 Qi
-NO
+Eb
 Sq
 TZ
 VR
@@ -26416,7 +27321,7 @@ iU
 kA
 kA
 iU
-wg
+kA
 xd
 yf
 yW
@@ -26439,7 +27344,7 @@ MA
 NO
 Pn
 Qk
-NO
+Eb
 Sp
 TZ
 VR
@@ -26501,19 +27406,19 @@ Hr
 tX
 ho
 ib
-iT
-jW
+ZG
+ZG
 ib
 ib
-mQ
+Aa
 nQ
 ib
 ib
-rv
+sx
 sx
 ib
 ib
-vn
+Ef
 ho
 wZ
 yf
@@ -26599,19 +27504,19 @@ Hr
 ID
 ho
 ib
-iT
-jW
+uu
+uu
 ib
 ib
-mQ
+nR
 nR
 ib
 ib
 rw
-sx
+XI
 ib
 ib
-vn
+VV
 ho
 wZ
 yf
@@ -26626,8 +27531,8 @@ xd
 yf
 xg
 IS
-JR
-JR
+SL
+SL
 IQ
 LR
 MC
@@ -26697,19 +27602,19 @@ Hr
 ID
 ho
 ig
-iT
-jW
+ZG
+ZG
 kB
 ig
-mQ
-nR
+Aa
+Aa
 ib
 ig
-rx
+sz
 sz
 kB
 ig
-vn
+Ef
 ho
 xf
 yg
@@ -26724,7 +27629,7 @@ Gw
 HD
 xg
 IT
-JR
+SL
 KV
 IQ
 by

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -253,6 +253,14 @@
 	dir = 8
 	},
 /area/mainship/living/briefing)
+"aS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/mainship/floor,
+/area/mainship/engineering/engineering_workshop)
 "aT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -881,12 +889,9 @@
 /obj/structure/cable,
 /turf/open/floor/grass,
 /area/mainship/living/port_garden)
-"cR" = (
-/obj/item/clothing/head/helmet/marine/leader,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/port_garden)
 "cS" = (
 /obj/effect/ai_node,
+/obj/item/paper/memorial,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/port_garden)
 "cT" = (
@@ -1536,14 +1541,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"fh" = (
-/obj/structure/closet/crate/weapon,
-/turf/open/floor/plating,
-/area/mainship/squads/req)
-"fi" = (
-/obj/structure/closet/crate/medical,
-/turf/open/floor/plating,
-/area/mainship/squads/req)
 "fj" = (
 /obj/structure/sign/electricshock{
 	name = "Engineer Preparations"
@@ -1718,14 +1715,6 @@
 	dir = 8
 	},
 /area/mainship/hallways/hangar)
-"fL" = (
-/obj/structure/closet/crate/construction,
-/turf/open/floor/plating,
-/area/mainship/squads/req)
-"fM" = (
-/obj/structure/closet/crate/ammo,
-/turf/open/floor/plating,
-/area/mainship/squads/req)
 "fN" = (
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/red{
@@ -1891,15 +1880,9 @@
 /area/mainship/hallways/hangar)
 "gq" = (
 /obj/effect/decal/warning_stripes/thick,
-/obj/structure/closet/crate,
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/mainship/squads/req)
-"gr" = (
-/obj/effect/decal/warning_stripes/thick,
-/obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/mainship/squads/req)
 "gs" = (
@@ -2298,10 +2281,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/closet/crate/weapon,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "hQ" = (
 /obj/structure/cable,
+/obj/structure/closet/crate/medical,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "hR" = (
@@ -2763,10 +2748,7 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "jx" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
+/obj/structure/closet/crate,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "jy" = (
@@ -2822,6 +2804,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
+"jH" = (
+/obj/structure/closet/crate/construction,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "jI" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/structure/cable,
@@ -3026,16 +3012,16 @@
 "kt" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/lower_medical)
+"ku" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/mainship/mono,
+/area/mainship/engineering/engineering_workshop)
 "kv" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"kw" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "kx" = (
 /obj/machinery/door/airlock/mainship/maint{
@@ -6853,17 +6839,6 @@
 	},
 /area/mainship/living/cafeteria_starboard)
 "xf" = (
-/obj/machinery/vending/marineFood,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
@@ -8247,6 +8222,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
+"Bk" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "Bl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
@@ -8714,6 +8699,10 @@
 	dir = 4
 	},
 /area/mainship/medical/lower_medical)
+"CW" = (
+/obj/structure/closet/crate/ammo,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "CX" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -10261,6 +10250,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/mirror,
 /turf/open/floor/mainship/black{
 	dir = 6
 	},
@@ -10651,9 +10641,6 @@
 	},
 /obj/structure/sink/bathroom{
 	pixel_y = 14
-	},
-/obj/structure/mirror{
-	pixel_y = 28
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/sterile/dark,
@@ -13814,6 +13801,10 @@
 	dir = 1
 	},
 /area/mainship/engineering/port_atmos)
+"Tn" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/mainship/floor,
+/area/mainship/engineering/engineering_workshop)
 "To" = (
 /obj/structure/window/framed/mainship/requisitions,
 /turf/open/floor/plating,
@@ -15155,8 +15146,6 @@
 /area/mainship/command/airoom)
 "Yb" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
-/obj/item/clothing/under/mime,
-/obj/item/clothing/mask/gas/mime,
 /turf/open/floor/mainship/red{
 	dir = 10
 	},
@@ -15297,6 +15286,25 @@
 	dir = 5
 	},
 /area/mainship/command/self_destruct)
+"Yw" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/vending/marineFood,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
+/area/mainship/living/cafeteria_starboard)
 "Yx" = (
 /obj/machinery/power/apc/mainship{
 	dir = 4
@@ -23605,8 +23613,8 @@ eD
 fK
 gp
 gW
-VC
 iF
+VC
 VC
 dz
 az
@@ -23797,14 +23805,14 @@ Jo
 SA
 ea
 ea
-fh
-fL
+ea
+ea
 gq
 gX
 hP
-gY
+jH
 jx
-kv
+Bk
 lo
 mr
 nz
@@ -23895,14 +23903,14 @@ pO
 SA
 eb
 ea
-fi
-fM
-gr
+ea
+ea
+gt
 gY
 hQ
-gY
+CW
+jx
 jz
-gY
 lo
 mu
 gY
@@ -23999,8 +24007,8 @@ gt
 gY
 hR
 hS
+hS
 jA
-kw
 lp
 mv
 mv
@@ -24427,7 +24435,7 @@ NH
 OE
 PL
 QO
-QO
+Tn
 TB
 Vs
 NH
@@ -25013,7 +25021,7 @@ zU
 MX
 NH
 OK
-PN
+aS
 QW
 Sk
 TD
@@ -25654,7 +25662,7 @@ aO
 ID
 To
 cq
-cR
+cs
 dn
 Hn
 ei
@@ -26385,7 +26393,7 @@ Mv
 Jo
 NH
 Pg
-PY
+ku
 Rd
 NH
 TR
@@ -26858,12 +26866,12 @@ wX
 ya
 yO
 Ai
-Ai
-ya
+wZ
+Yw
 DG
 Ai
-Ai
-ya
+wZ
+Yw
 Hx
 xg
 IJ
@@ -27442,7 +27450,7 @@ ib
 ib
 Ef
 ho
-wZ
+xd
 yf
 yX
 Ar
@@ -27540,7 +27548,7 @@ ib
 ib
 VV
 ho
-wZ
+xd
 yf
 yY
 As

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -511,3 +511,7 @@ then, for every time you included a field, increment fields. */
 	name = "Notice from Terragov"
 	info = {"After a routine inspection from the Terragov Chemical Regulatory comittee, we have found that this vessel has, one, an unlicensed access issue that must be amended, and two, nearly double the authorized deployment of chemical vendors. <BR>
 	We are updating the access requirements on your chemistry bay, as well as confiscating the additional vendors until further notice. Have a nice day."}
+
+/obj/item/paper/memorial
+	name = "Memorial Note"
+	info = {"May the souls of our fallen brothers be at rest; not that we may find solace in their passing, but that we should take our due initiative to press on in their memory."}


### PR DESCRIPTION
## About The Pull Request

Corrects further issues from Minerva post-launch. Improves tilework, adds lived-in content (General debris, etc), and replaces the cloning radios that kept blowing up vatborns.

## Why It's Good For The Game

Improvements to an existing shipmap, increases usability.

## Changelog
:cl:
fix: Fixes a few issues on the Minerva, such as explosive radios.
/:cl: