### PR TITLE
Engineering storage module tweak

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/storage.dm
+++ b/code/modules/clothing/modular_armor/attachments/storage.dm
@@ -138,7 +138,7 @@
 	storage =  /obj/item/storage/internal/modular/engineering
 
 /obj/item/storage/internal/modular/engineering
-	max_storage_space = 15
+	max_storage_space = 30
 	storage_slots = 5
 	max_w_class = WEIGHT_CLASS_BULKY
 	can_hold = list(


### PR DESCRIPTION
## About The Pull Request
Increases the max storage space of engineering storage module from 15 to 30, same as the medical storage module. 

## Why It's Good For The Game
With the expanded list and added slot, there are situations where you aren't able to make full use of all 5 slots because of the max storage space limitation making for awkward resource management. This fixes that so you are able to make use of all 5 slots no matter what.

## Changelog
:cl:
balance: tweaks engineering storage module 
/:cl:
