### PR TITLE
I can't BELIEVE it's not shoe MRE's!

### DIFF
--- a/code/modules/clothing/shoes/marine_shoes.dm
+++ b/code/modules/clothing/shoes/marine_shoes.dm
@@ -24,6 +24,7 @@
 		/obj/item/weapon/gun/shotgun/double/derringer,
 		/obj/item/attachable/bayonetknife,
 		/obj/item/stack/throwing_knife,
+		/obj/item/storage/box/MRE,
 	)
 
 /obj/item/clothing/shoes/marine/Initialize()


### PR DESCRIPTION
## About The Pull Request
Added `/obj/item/storage/box/MRE` to the list of allowed items that can be put inside of the marine combat boots.

This PR has been fully tested on a local build with zero (0) runtimes or errors (the shoe sprite not updating, #8950, is unrelated)
![2021-12-11_12-08-50](https://user-images.githubusercontent.com/17747087/145674641-25e67fb2-a616-4cb2-94aa-ab3d5c4c3d79.gif)

Fixes the grievances outlined in #8856
## Why It's Good For The Game
As the issues outlined in #8856 the grievances caused by lack of spaghetti MRE filled shoes is clear, without the marine ability to put MRE's in their boots to be ready for consumption in battle it will severely affect their morale and ability to fight in such a way that it can affect the balance of the in-game round and therefor cause an unfair advantage to xenos.

Also this'd work nicely for those whom wish to have a mid-fight snack.

## Changelog
:cl: Vondiech
balance: You can now store MRE's in your combat boots for a mid-fight snack!
/:cl: