### PR TITLE
Cleanses Icy Caves of gamer gear

### DIFF
--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -208,26 +208,14 @@
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "aR" = (
-/obj/structure/closet/crate/weapon,
-/obj/item/weapon/energy/sword,
-/obj/item/weapon/gun/rifle/m16,
-/obj/item/ammo_magazine/rifle/m16,
-/obj/item/ammo_magazine/rifle/m16,
-/obj/item/ammo_magazine/rifle/m16,
-/obj/item/ammo_magazine/rifle/m16,
-/obj/item/ammo_magazine/rifle/m16,
-/obj/item/ammo_magazine/rifle/m16,
-/obj/item/ammo_magazine/rifle/m16,
-/obj/item/ammo_magazine/rifle/m16,
+/obj/structure/largecrate/lisa,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "aS" = (
-/obj/structure/closet/crate/explosives,
-/obj/item/storage/box/visual/grenade/frag,
-/obj/item/explosive/plastique,
-/obj/item/explosive/plastique,
-/obj/item/explosive/plastique,
-/obj/item/explosive/plastique,
+/obj/structure/closet/crate/freezer/rations,
+/obj/item/storage/box/MRE,
+/obj/item/storage/box/MRE,
+/obj/item/storage/box/MRE,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "aT" = (
@@ -252,16 +240,7 @@
 /turf/closed/ice,
 /area/icy_caves/caves/northern)
 "aY" = (
-/obj/structure/closet/crate/ammo,
-/obj/item/ammo_magazine/rifle/bolt,
-/obj/item/ammo_magazine/rifle/bolt,
-/obj/item/ammo_magazine/rifle/bolt,
-/obj/item/ammo_magazine/rifle/bolt,
-/obj/item/ammo_magazine/rifle/bolt,
-/obj/item/ammo_magazine/rifle/bolt,
-/obj/item/ammo_magazine/rifle/bolt,
-/obj/item/ammo_magazine/rifle/bolt,
-/obj/item/ammo_magazine/rifle/bolt,
+/obj/structure/closet/crate/radiation,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "ba" = (
@@ -344,11 +323,11 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
 "bq" = (
-/obj/structure/rack,
 /obj/item/tool/shovel,
 /obj/item/tool/shovel,
 /obj/item/tool/shovel,
 /obj/item/tool/shovel,
+/obj/structure/rack/nometal,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ1)
 "br" = (
@@ -360,14 +339,9 @@
 	},
 /area/icy_caves/outpost/refinery)
 "bs" = (
-/obj/structure/closet/crate/medical,
 /obj/item/defibrillator,
 /obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
 /obj/item/storage/firstaid/fire,
-/obj/item/reagent_containers/glass/beaker/bluespace,
-/obj/item/reagent_containers/glass/beaker/bluespace,
-/obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/reagent_containers/glass/beaker/bluespace,
@@ -932,6 +906,10 @@
 	},
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"el" = (
+/obj/item/clothing/suit/radiation,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/crashed_ship)
 "em" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark,
@@ -1616,6 +1594,10 @@
 	},
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"hB" = (
+/obj/item/clothing/head/radiation,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/crashed_ship)
 "hD" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/floor/plating/ground/ice,
@@ -2883,7 +2865,7 @@
 /area/icy_caves/outpost/mining/east)
 "qi" = (
 /obj/item/tool/pickaxe,
-/obj/structure/rack,
+/obj/structure/rack/nometal,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
 "qj" = (
@@ -2891,8 +2873,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/rack,
 /obj/item/tool/pickaxe,
+/obj/structure/rack/nometal,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
 "ql" = (
@@ -3559,8 +3541,8 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
 "tC" = (
-/obj/structure/rack,
 /obj/structure/largecrate/random/case/small,
+/obj/structure/rack/nometal,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "tD" = (
@@ -4498,9 +4480,8 @@
 /obj/item/storage/box/flashbangs,
 /obj/item/storage/box/m94,
 /obj/item/storage/box/m94,
-/obj/item/explosive/plastique,
-/obj/item/explosive/plastique,
-/obj/structure/closet/crate/secure/explosives,
+/obj/structure/closet/crate/secure/phoron,
+/obj/item/stack/sheet/mineral/phoron,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "Ad" = (
@@ -4774,6 +4755,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
+"BD" = (
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/garage)
 "BI" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -4935,7 +4920,7 @@
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
 "Dk" = (
-/obj/structure/rack,
+/obj/structure/rack/nometal,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "Dl" = (
@@ -5613,6 +5598,10 @@
 /obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
+"Id" = (
+/obj/structure/cargo_container/gorg,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/garage)
 "Ie" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
@@ -5726,14 +5715,15 @@
 	},
 /area/icy_caves/outpost/security)
 "IO" = (
-/obj/structure/closet/crate/construction,
-/obj/item/stack/sheet/metal/medium_stack,
-/obj/item/stack/sheet/plasteel/medium_stack,
-/obj/item/stack/sandbags_empty{
-	amount = 25
-	},
-/obj/item/stack/barbed_wire/half_stack,
 /obj/effect/landmark/excavation_site_spawner,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/seeds/tomatoseed{
+	pixel_y = -5
+	},
+/obj/item/seeds/potatoseed{
+	pixel_x = -5
+	},
+/obj/item/seeds/sunflowerseed,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "IR" = (
@@ -5914,6 +5904,10 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/office)
+"Kc" = (
+/obj/structure/rack/nometal,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/garage)
 "Ke" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -6520,7 +6514,6 @@
 /obj/item/storage/box/lightstick,
 /obj/effect/spawner/random/powercell,
 /obj/item/clothing/glasses/welding,
-/obj/item/explosive/plastique,
 /obj/item/newspaper,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
@@ -6658,9 +6651,10 @@
 /turf/closed/ice,
 /area/icy_caves/caves/east)
 "OZ" = (
-/obj/structure/cargo_container/gorg,
+/obj/item/tool/pickaxe,
+/obj/structure/rack/nometal,
 /turf/open/floor/plating,
-/area/icy_caves/outpost/garage)
+/area/icy_caves/outpost/mining/west)
 "Pd" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/security)
@@ -6892,8 +6886,8 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
 "QM" = (
-/obj/structure/rack,
 /obj/structure/largecrate/random/case,
+/obj/structure/rack/nometal,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "QO" = (
@@ -7307,9 +7301,10 @@
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/east)
 "TL" = (
-/obj/structure/cargo_container/gorg{
-	dir = 4
-	},
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/fire,
+/obj/structure/closet/crate/secure/surgery,
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "TM" = (
@@ -7599,7 +7594,9 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "VE" = (
-/obj/structure/largecrate/random/secure,
+/obj/structure/cargo_container/gorg{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "VG" = (
@@ -7651,6 +7648,7 @@
 "VR" = (
 /obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
+	locked = 1;
 	name = "\improper Underground Security Armory"
 	},
 /obj/structure/cable,
@@ -7684,9 +7682,9 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
 "Wa" = (
-/obj/structure/largecrate/supply/explosives,
 /obj/item/explosive/plastique,
 /obj/item/explosive/plastique,
+/obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "Wb" = (
@@ -7864,10 +7862,9 @@
 /turf/closed/ice/thin/straight,
 /area/icy_caves/caves/northern)
 "Xx" = (
-/obj/structure/closet/crate/explosives,
-/obj/item/storage/box/m94,
-/obj/item/storage/box/m94,
-/obj/item/storage/box/visual/grenade/teargas,
+/obj/structure/closet/crate/internals,
+/obj/item/storage/box/MRE,
+/obj/item/storage/box/MRE,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "XF" = (
@@ -7930,8 +7927,8 @@
 /obj/item/storage/box/lightstick,
 /obj/item/storage/box/lightstick,
 /obj/effect/spawner/random/powercell,
-/obj/item/explosive/plastique,
 /obj/item/weapon/gun/pistol/holdout,
+/obj/item/stack/sheet/mineral/phoron,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "XS" = (
@@ -8164,11 +8161,10 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "Zk" = (
-/obj/machinery/button/door/open_only/landing_zone,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/button/door/open_only/landing_zone{
+	pixel_x = -5
 	},
+/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -10913,7 +10909,7 @@ oI
 oI
 oI
 oI
-oU
+OZ
 xI
 eY
 bH
@@ -13277,7 +13273,7 @@ XO
 WI
 KZ
 Lu
-Sm
+TL
 tQ
 tQ
 Sm
@@ -14530,8 +14526,8 @@ Dk
 Aa
 Qa
 bE
-OZ
-Dk
+Qa
+Id
 Nc
 XR
 tQ
@@ -14686,7 +14682,7 @@ xu
 Ar
 yj
 bE
-TL
+SM
 VE
 Nc
 tQ
@@ -15310,8 +15306,8 @@ KZ
 KZ
 KZ
 tI
-xR
-xR
+BD
+Kc
 iZ
 KZ
 KZ
@@ -24075,7 +24071,7 @@ eJ
 eJ
 MQ
 sH
-sH
+hB
 MQ
 sH
 aj
@@ -24547,7 +24543,7 @@ sH
 MQ
 aS
 IO
-sH
+el
 sH
 MQ
 bz

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -22,6 +22,9 @@
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/plating/dmg1,
 /area/icy_caves/caves/crashed_ship)
+"af" = (
+/turf/closed/wall/r_wall/unmeltable,
+/area/lv624/lazarus/console)
 "ag" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/effect/landmark/nuke_spawn,
@@ -50,11 +53,9 @@
 /turf/open/floor/plating/dmg1,
 /area/icy_caves/caves/crashed_ship)
 "am" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/obj/machinery/telecomms/relay/preset/telecomms,
+/turf/open/floor/plating/icefloor,
+/area/lv624/lazarus/console)
 "an" = (
 /obj/structure/xenoautopsy/tank/broken,
 /obj/effect/decal/cleanable/blood/xeno,
@@ -65,6 +66,10 @@
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
+"ap" = (
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "aq" = (
 /obj/structure/xenoautopsy/tank/broken,
 /turf/open/floor/plating/mainship,
@@ -523,14 +528,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
-"bW" = (
-/obj/structure/cryofeed/right{
-	name = "\improper coolant feed"
-	},
-/turf/open/floor/podhatch/floor{
-	icon_state = "bcircuitoff"
-	},
-/area/icy_caves/caves/northern)
 "bX" = (
 /turf/closed/ice_rock/singlePart,
 /area/icy_caves/caves)
@@ -573,12 +570,6 @@
 	dir = 8
 	},
 /area/icy_caves/caves/northern)
-"ch" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/shuttle/dropship/floor,
-/area/space)
 "ci" = (
 /turf/closed/ice/thin/junction,
 /area/icy_caves/caves/northern)
@@ -604,21 +595,6 @@
 /turf/closed/ice/thin/straight{
 	dir = 4
 	},
-/area/icy_caves/caves/northern)
-"co" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 6
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/mainship/tcomms,
 /area/icy_caves/caves/northern)
 "cp" = (
 /obj/item/lightstick/anchored,
@@ -657,7 +633,7 @@
 /turf/closed/ice/corner{
 	dir = 4
 	},
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "cv" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice/thin/junction{
@@ -680,25 +656,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice/end,
 /area/icy_caves/caves/northern)
-"cD" = (
-/obj/item/tool/surgery/circular_saw,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"cE" = (
-/turf/open/floor/tile/purple/whitepurplecorner{
-	dir = 1
-	},
-/area/icy_caves/caves/northern)
-"cF" = (
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 9
-	},
-/obj/structure/monorail{
-	dir = 5
-	},
-/turf/open/shuttle/escapepod/plain,
-/area/icy_caves/caves/northern)
 "cI" = (
 /turf/closed/ice/thin/single,
 /area/icy_caves/caves/northern)
@@ -713,10 +670,6 @@
 /turf/closed/ice/junction{
 	dir = 8
 	},
-/area/icy_caves/caves/northern)
-"cL" = (
-/obj/structure/monorail,
-/turf/open/floor/mainship_hull,
 /area/icy_caves/caves/northern)
 "cM" = (
 /obj/effect/landmark/xeno_resin_door,
@@ -742,25 +695,10 @@
 	dir = 1
 	},
 /area/icy_caves/caves/northern)
-"cV" = (
-/turf/open/floor/tile/white/warningstripe{
-	dir = 1
-	},
-/area/icy_caves/caves/northern)
 "cW" = (
-/obj/machinery/door/poddoor/mainship/indestructible{
-	dir = 2
-	},
-/turf/open/space/basic,
-/area/space)
-"cX" = (
-/obj/structure/largecrate/supply,
-/obj/machinery/camera/autoname/mainship/dropship_one{
-	dir = 8;
-	pixel_x = 16
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/corner,
+/area/icy_caves/caves/west)
 "cY" = (
 /turf/closed/ice/thin/corner{
 	dir = 8
@@ -779,41 +717,27 @@
 /turf/closed/ice/thin/junction{
 	dir = 1
 	},
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves/west)
 "de" = (
 /turf/closed/ice/thin/junction{
 	dir = 1
 	},
 /area/icy_caves/caves/west)
 "df" = (
-/obj/structure/dropship_piece/two/front/left,
-/turf/open/floor/mainship_hull/dir{
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/corner{
 	dir = 8
 	},
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves/west)
 "dg" = (
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 5
-	},
-/obj/structure/monorail{
-	dir = 9
-	},
-/obj/structure/dropship_piece/two/front,
-/turf/open/shuttle/escapepod/plain,
-/area/icy_caves/caves/northern)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/west)
 "dh" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 1
 	},
 /area/icy_caves/caves/west)
-"di" = (
-/obj/machinery/camera/autoname/mainship/dropship_one{
-	dir = 8;
-	pixel_x = 16
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "dj" = (
 /turf/closed/ice,
 /area/icy_caves/caves/west)
@@ -844,27 +768,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
-"ds" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"du" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"dv" = (
-/obj/machinery/camera/autoname/mainship/dropship_one{
-	dir = 8;
-	pixel_x = 16
-	},
-/obj/structure/largecrate/supply/explosives,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "dw" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 4
@@ -925,20 +828,28 @@
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/caves/northern)
 "dL" = (
-/obj/effect/ai_node,
+/obj/structure/closet/crate/science,
+/obj/item/stack/sheet/mineral/phoron/medium_stack,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves/west)
+"dM" = (
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "dN" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves/west)
 "dO" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves/west)
+"dP" = (
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "dQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -982,14 +893,13 @@
 /turf/closed/ice/thin/end,
 /area/icy_caves/caves/east)
 "dZ" = (
-/turf/closed/shuttle/dropship2{
-	icon_state = "24"
-	},
-/area/icy_caves/caves/northern)
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "ea" = (
 /obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves/west)
 "eb" = (
 /turf/closed/ice/end,
 /area/icy_caves/caves/west)
@@ -1001,12 +911,12 @@
 "ed" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves/west)
 "eg" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
 "eh" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -1014,13 +924,13 @@
 /area/icy_caves/caves/west)
 "ei" = (
 /obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
 "ej" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
 "em" = (
 /obj/effect/decal/cleanable/blood,
@@ -1041,11 +951,11 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
 "eo" = (
-/obj/item/tool/pickaxe/plasmacutter,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
 	},
 /obj/effect/ai_node,
+/obj/item/tool/pickaxe,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
 "ep" = (
@@ -1081,16 +991,27 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
 "ev" = (
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"ew" = (
-/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+/obj/structure/closet/crate,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick,
+/obj/item/storage/box/lightstick,
+/obj/effect/spawner/random/powercell,
+/obj/item/clothing/glasses/welding,
+/obj/item/explosive/plastique,
+/obj/machinery/light/small{
 	dir = 8
+	},
+/obj/item/tool/pickaxe,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
+"ew" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 6
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves/west)
 "ex" = (
 /obj/machinery/door/airlock/mainship/secure/locked/free_access{
 	name = "\improper Mining Storage"
@@ -1100,7 +1021,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves/west)
 "ey" = (
 /turf/closed/ice,
 /area/icy_caves/caves/crashed_ship)
@@ -1125,20 +1046,10 @@
 	dir = 9
 	},
 /area/icy_caves/caves/northern)
-"eC" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "Canteen"
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"eD" = (
-/obj/structure/table,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "eF" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
 "eG" = (
 /obj/machinery/light{
@@ -1181,26 +1092,29 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"eM" = (
+/obj/structure/closet/crate,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick,
+/obj/item/storage/box/lightstick,
+/obj/effect/spawner/random/powercell,
+/obj/item/explosive/plastique,
+/obj/item/tool/pickaxe,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "eN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"eO" = (
-/obj/structure/table/reinforced,
-/obj/item/tool/surgery/scalpel/laser3,
-/obj/item/reagent_containers/spray/pepper,
-/turf/open/floor/tile/purple/whitepurplecorner{
-	dir = 8
-	},
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves/west)
 "eP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves/west)
 "eR" = (
 /turf/closed/ice/end{
 	dir = 1
@@ -1208,18 +1122,18 @@
 /area/icy_caves/caves/south)
 "eS" = (
 /obj/machinery/light,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
 "eT" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves/west)
 "eU" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
 "eV" = (
 /obj/structure/ore_box,
@@ -1251,11 +1165,11 @@
 	},
 /area/icy_caves/caves)
 "eZ" = (
-/obj/item/tool/pickaxe/plasmacutter,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/item/tool/pickaxe,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
 "fa" = (
@@ -1273,19 +1187,13 @@
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/fire,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"fc" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves/west)
 "fd" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/powercell,
 /obj/effect/spawner/random/powercell,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves/west)
 "fe" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/tech_supply,
@@ -1296,7 +1204,7 @@
 /obj/item/clothing/glasses/welding,
 /obj/machinery/light/small,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves/west)
 "ff" = (
 /obj/structure/rack,
 /obj/structure/rack,
@@ -1304,7 +1212,7 @@
 /obj/effect/spawner/random/toolbox,
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves/west)
 "fg" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/tool,
@@ -1312,7 +1220,7 @@
 /obj/effect/spawner/random/tool,
 /obj/item/storage/belt/utility/full,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves/west)
 "fh" = (
 /turf/closed/ice/thin/junction,
 /area/icy_caves/caves/south)
@@ -1347,20 +1255,10 @@
 	dir = 1
 	},
 /area/icy_caves/caves/east)
-"fq" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/LZ1)
 "fs" = (
-/obj/structure/barricade/guardrail{
-	dir = 1
-	},
-/obj/structure/dropship_piece/two/front,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/shuttle/dropship/seven,
-/area/space)
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ1)
 "ft" = (
 /turf/closed/ice/thin/junction{
 	dir = 4
@@ -1412,16 +1310,6 @@
 	dir = 9
 	},
 /area/icy_caves/caves/south)
-"fD" = (
-/obj/machinery/power/apc/drained,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
 "fE" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
@@ -1440,9 +1328,6 @@
 	dir = 1
 	},
 /area/icy_caves/caves/south)
-"fI" = (
-/turf/closed/ice/thin,
-/area/icy_caves/outpost/LZ2)
 "fK" = (
 /turf/closed/ice/thin/corner{
 	dir = 1
@@ -1593,51 +1478,17 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
-"gK" = (
-/obj/structure/monorail,
-/obj/structure/dropship_piece/two/front,
-/turf/open/floor/mainship_hull,
-/area/icy_caves/caves/northern)
 "gL" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/closed/ice_rock/corners,
 /area/icy_caves/caves)
-"gM" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 5
-	},
-/turf/open/floor/mainship/cargo,
-/area/icy_caves/caves/northern)
 "gN" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
-"gP" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/blood/xtracks,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
-"gQ" = (
-/obj/structure/dropship_piece/one/corner/middleright,
-/obj/structure/dropship_piece/two/corner/rearright,
-/turf/open/floor/mainship_hull/dir{
-	dir = 10
-	},
-/area/icy_caves/caves/northern)
 "gS" = (
 /turf/closed/ice/thin/end{
 	dir = 8
@@ -1660,23 +1511,12 @@
 	},
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
-"gZ" = (
-/obj/effect/decal/cleanable/blood,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
 "hb" = (
 /turf/closed/ice/junction,
 /area/icy_caves/caves/south)
 "hc" = (
 /turf/closed/ice/straight,
 /area/icy_caves/caves/east)
-"hd" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 10
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern)
 "he" = (
 /turf/closed/ice/junction{
 	dir = 4
@@ -1776,10 +1616,6 @@
 	},
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
-"hB" = (
-/obj/structure/largecrate/supply,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "hD" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/floor/plating/ground/ice,
@@ -1789,13 +1625,6 @@
 	dir = 8
 	},
 /area/icy_caves/caves/east)
-"hG" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/research_and_development,
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "hI" = (
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/ai_node,
@@ -1806,11 +1635,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
-"hM" = (
-/turf/closed/ice_rock/corners{
-	dir = 10
-	},
-/area/icy_caves/caves/northern)
 "hO" = (
 /turf/closed/ice/thin/single,
 /area/icy_caves/caves/east)
@@ -1822,11 +1646,6 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
-"hT" = (
-/obj/machinery/vending/medical,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "hU" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/ice,
@@ -1834,12 +1653,6 @@
 "hV" = (
 /turf/closed/ice_rock/singlePart,
 /area/icy_caves/caves/south)
-"hW" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
 "hX" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/effect/ai_node,
@@ -1877,22 +1690,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
-"in" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall/unmeltable,
-/area/icy_caves/caves/northern)
-"io" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"ip" = (
-/obj/structure/closet/l3closet/janitor,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
 "iu" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -1904,37 +1701,29 @@
 /obj/structure/cable,
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves/west)
 "iG" = (
 /turf/open/floor/tile/dark/yellow2{
 	dir = 4
 	},
 /area/icy_caves/outpost/engineering)
 "iJ" = (
-/obj/machinery/computer/intel_computer,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
+/obj/structure/cable,
+/obj/machinery/power/apc/lowcharge,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "iK" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/LZ2)
-"iN" = (
-/obj/structure/window/framed/colony/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/outpost/outside)
 "iQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
-"iS" = (
-/obj/machinery/door/poddoor/mainship,
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
 "iT" = (
 /turf/closed/ice/end{
 	dir = 1
@@ -1953,36 +1742,11 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
-"jc" = (
-/obj/machinery/door/poddoor/mainship/indestructible,
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
-"jd" = (
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
 "je" = (
 /turf/closed/ice/thin/corner{
 	dir = 1
 	},
 /area/icy_caves/outpost/outside)
-"jf" = (
-/obj/item/stool,
-/obj/effect/decal/cleanable/vomit,
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
-"jk" = (
-/obj/structure/table/mainship,
-/obj/item/tool/surgery/cautery,
-/obj/item/tool/surgery/retractor,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"jo" = (
-/obj/effect/ai_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
 "jt" = (
 /obj/machinery/floodlight/landing,
 /obj/effect/decal/warning_stripes,
@@ -2007,17 +1771,13 @@
 /turf/closed/ice/thin/single,
 /area/icy_caves/caves/west)
 "jA" = (
-/obj/item/tool/pickaxe/plasmacutter,
+/obj/item/tool/pickaxe,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
 "jB" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
-"jC" = (
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "jE" = (
 /obj/structure/table/reinforced,
 /obj/effect/landmark/dropship_console_spawn_lz1,
@@ -2029,23 +1789,12 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
-"jI" = (
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/caves)
 "jJ" = (
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
-"jL" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mainship_hull/dir{
-	dir = 8
-	},
-/area/icy_caves/caves/northern)
 "jM" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = /obj/item/storage/backpack/satchel/norm;
@@ -2058,7 +1807,7 @@
 	name = "Shaft Miner"
 	},
 /obj/effect/decal/cleanable/blood,
-/obj/item/tool/pickaxe/plasmacutter,
+/obj/item/tool/pickaxe,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
 "jN" = (
@@ -2101,19 +1850,6 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/research)
-"jX" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 9
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"jY" = (
-/obj/machinery/door/airlock/mainship/security,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "ka" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -2130,18 +1866,9 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
-"kd" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "ke" = (
 /turf/closed/ice/junction,
 /area/icy_caves/outpost/outside)
-"kf" = (
-/obj/machinery/computer3/server/rack,
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
 "kg" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/mining/east)
@@ -2168,17 +1895,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
-"kn" = (
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 9
-	},
-/obj/structure/monorail{
-	dir = 5
-	},
-/obj/structure/dropship_piece/two/front,
-/turf/open/shuttle/escapepod/plain,
-/area/icy_caves/caves/northern)
 "ko" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -2306,11 +2022,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
-"kL" = (
-/turf/closed/ice_rock/singlePart{
-	dir = 5
-	},
-/area/icy_caves/outpost/LZ2)
 "kM" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/singlePart{
@@ -2328,14 +2039,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"kR" = (
-/obj/structure/table/mainship,
-/obj/machinery/computer/security/wooden_tv,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
 "kS" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -2364,12 +2067,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/office)
-"kY" = (
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
 "lc" = (
 /turf/closed/ice/straight{
 	dir = 4
@@ -2441,12 +2138,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
-"lv" = (
-/obj/machinery/door/poddoor/two_tile_ver,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "lx" = (
 /obj/machinery/light{
 	dir = 8
@@ -2456,7 +2147,7 @@
 "lA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "lB" = (
 /obj/structure/table,
 /obj/structure/paper_bin,
@@ -2471,7 +2162,7 @@
 /turf/closed/ice/junction{
 	dir = 1
 	},
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "lD" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark/brown2{
@@ -2487,17 +2178,6 @@
 	dir = 5
 	},
 /area/icy_caves/caves)
-"lH" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/mining/west)
-"lL" = (
-/turf/closed/ice/thin/corner{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ2)
 "lM" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -2509,14 +2189,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
-"lO" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
 "lP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -2529,12 +2201,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"lR" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "lS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -2562,13 +2228,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"ma" = (
-/obj/structure/dropship_piece/one/corner/middleleft,
-/obj/structure/dropship_piece/two/corner/rearleft,
-/turf/open/floor/mainship_hull/dir{
-	dir = 6
-	},
-/area/icy_caves/caves/northern)
 "mb" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/outpost/LZ1)
@@ -2584,36 +2243,14 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/refinery)
-"mg" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "mh" = (
 /turf/closed/ice/thin/junction{
 	dir = 4
 	},
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "mi" = (
-/turf/closed/wall/r_wall/unmeltable,
-/area/lv624/lazarus/console)
-"mj" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/obj/machinery/camera/autoname/mainship/dropship_one{
-	dir = 4;
-	pixel_x = -16
-	},
-/turf/open/floor/mainship/tcomms,
-/area/icy_caves/caves/northern)
+/turf/closed/ice/thin/end,
+/area/icy_caves/outpost/LZ1)
 "mk" = (
 /obj/docking_port/stationary/marine_dropship/lz2,
 /turf/open/floor/plating,
@@ -2638,10 +2275,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
-"mq" = (
-/obj/machinery/miner/damaged/platinum,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "mr" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
@@ -2661,25 +2294,9 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"mu" = (
-/obj/machinery/vending/security,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
 "mv" = (
-/turf/closed/ice_rock/corners,
-/area/space)
-"mw" = (
-/obj/structure/bookcase/manuals/research_and_development,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 9
-	},
-/area/icy_caves/caves/northern)
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves)
 "mx" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 8
@@ -2799,11 +2416,6 @@
 /obj/item/storage/donut_box,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"mV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "mY" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -2813,10 +2425,6 @@
 /obj/item/storage/firstaid/o2,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"mZ" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
 "nb" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -2900,35 +2508,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
-"ns" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "nu" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"nv" = (
-/obj/structure/table,
-/obj/item/corncob,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"nw" = (
-/obj/structure/window/framed/colony/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
-"nx" = (
-/obj/structure/window/framed/colony,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/mining/west)
 "ny" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/ice_rock/single,
@@ -2937,22 +2521,11 @@
 /obj/docking_port/stationary/crashmode,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/LZ2)
-"nB" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/outpost/outside)
 "nD" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"nF" = (
-/obj/structure/janitorialcart,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves/west)
 "nH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -2963,10 +2536,6 @@
 "nI" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ2)
-"nK" = (
-/obj/structure/largecrate/random/secure,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "nL" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/outside/center)
@@ -3016,9 +2585,6 @@
 	dir = 10
 	},
 /area/icy_caves/outpost/garage)
-"od" = (
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/mining/west)
 "of" = (
 /turf/closed/ice/thin/end{
 	dir = 4
@@ -3052,14 +2618,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"op" = (
-/obj/structure/prop/mainship/sensor_computer3/sd,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/tcomms,
-/area/icy_caves/caves/northern)
 "or" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/structure/cable,
@@ -3107,12 +2665,6 @@
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
-"oM" = (
-/obj/structure/dropship_piece/two/front/right,
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "oO" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -3120,36 +2672,10 @@
 "oP" = (
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ2)
-"oQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 8
-	},
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
-"oR" = (
-/obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 6
-	},
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
 "oS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
-"oT" = (
-/obj/structure/largecrate/supply/floodlights,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
 "oU" = (
 /obj/item/tool/pickaxe,
 /obj/structure/rack,
@@ -3162,17 +2688,11 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
-"pa" = (
-/turf/closed/wall,
-/area/icy_caves/outpost/outside)
 "pb" = (
 /turf/closed/ice_rock/corners{
 	dir = 9
 	},
 /area/icy_caves/caves/west)
-"pc" = (
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
 "pf" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = /obj/item/storage/backpack/satchel/norm;
@@ -3194,12 +2714,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"ph" = (
-/obj/machinery/atmospherics/pipe/manifold/green/hidden{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "pj" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -3208,8 +2722,9 @@
 /turf/closed/ice/straight,
 /area/icy_caves/caves/northern)
 "pl" = (
-/turf/closed/wall/r_wall/unmeltable,
-/area/icy_caves/caves/northern)
+/obj/structure/ore_box,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/mining/west)
 "pm" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/cable,
@@ -3218,7 +2733,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "po" = (
 /turf/open/floor/tile/dark/purple2{
 	dir = 4
@@ -3229,12 +2744,6 @@
 	dir = 1
 	},
 /area/icy_caves/caves)
-"pr" = (
-/obj/structure/window/framed/colony/reinforced,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "ps" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/dmg1,
@@ -3243,14 +2752,8 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/refinery)
-"pu" = (
-/obj/structure/barricade/guardrail{
-	dir = 4
-	},
-/obj/item/clothing/head/warning_cone,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "pw" = (
+/obj/structure/ore_box,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -3293,11 +2796,6 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside)
-"pE" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/icy_caves/caves/northern)
 "pF" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/smg/m25,
@@ -3308,51 +2806,18 @@
 /obj/item/ammo_magazine/smg/m25,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
-"pH" = (
-/turf/closed/ice_rock/corners{
-	dir = 10
-	},
-/area/icy_caves/caves/west)
-"pL" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"pN" = (
-/obj/structure/janitorialcart,
-/turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern)
 "pO" = (
 /obj/item/ammo_casing,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
-"pP" = (
-/obj/structure/closet/crate,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick,
-/obj/item/storage/box/lightstick,
-/obj/item/tool/pickaxe/plasmacutter,
-/obj/effect/spawner/random/powercell,
-/obj/item/explosive/plastique,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "pR" = (
 /obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/LZ2)
-"pS" = (
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/outpost/outside)
 "pT" = (
 /obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "pU" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -3373,15 +2838,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
-"pZ" = (
-/obj/item/paper/crumpled/bloody,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "qa" = (
-/turf/open/floor/mainship_hull/dir{
-	dir = 8
-	},
-/area/space)
+/obj/machinery/miner/damaged,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/outside)
 "qb" = (
 /obj/machinery/conveyor{
 	dir = 5
@@ -3412,7 +2872,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "qg" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plating,
@@ -3435,12 +2895,6 @@
 /obj/item/tool/pickaxe,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
-"qk" = (
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 4
-	},
-/turf/open/shuttle/dropship/seven,
-/area/icy_caves/caves/northern)
 "ql" = (
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
@@ -3485,13 +2939,6 @@
 	dir = 10
 	},
 /area/icy_caves/outpost/refinery)
-"qu" = (
-/obj/structure/dropship_piece/one/corner/middleleft,
-/obj/structure/dropship_piece/two/corner/rearleft,
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "qw" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1
@@ -3512,15 +2959,6 @@
 "qz" = (
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves)
-"qA" = (
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/shuttle/dropship/seven,
-/area/icy_caves/caves/northern)
 "qB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/tile/dark,
@@ -3550,6 +2988,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"qM" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside)
 "qN" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -3567,9 +3011,6 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
-"qR" = (
-/turf/closed/ice_rock/northWall,
-/area/icy_caves/caves/west)
 "qS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -3634,11 +3075,6 @@
 "rf" = (
 /turf/closed/ice/thin/end,
 /area/icy_caves/caves/northern)
-"rg" = (
-/turf/open/floor/mainship_hull/dir{
-	dir = 5
-	},
-/area/icy_caves/caves/northern)
 "rh" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/machinery/door/airlock/multi_tile/mainship/research{
@@ -3646,13 +3082,6 @@
 	},
 /turf/open/floor/tile/dark/purple2,
 /area/icy_caves/outpost/research)
-"rk" = (
-/obj/structure/table/reinforced,
-/obj/structure/xenoautopsy,
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 1
-	},
-/area/icy_caves/caves/northern)
 "rl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8
@@ -3673,7 +3102,7 @@
 /turf/closed/ice/thin/end{
 	dir = 4
 	},
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/outside)
 "rq" = (
 /obj/structure/closet/fireaxecabinet,
 /turf/closed/wall/r_wall,
@@ -3806,11 +3235,11 @@
 /area/icy_caves/outpost/research)
 "rS" = (
 /obj/structure/table,
-/obj/item/tool/pickaxe/plasmacutter,
 /obj/effect/spawner/random/powercell,
 /obj/item/clothing/head/welding,
 /obj/item/clothing/glasses/welding,
 /obj/item/explosive/plastique,
+/obj/effect/spawner/random/powercell,
 /turf/open/floor/tile/dark/yellow2{
 	dir = 1
 	},
@@ -3852,8 +3281,8 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
 "sb" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow/layer1,
+/obj/machinery/floodlight/landing,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "sc" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
@@ -3945,9 +3374,6 @@
 /obj/effect/landmark/corpsespawner/doctor,
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
-"ss" = (
-/turf/open/floor/tile/dark/green2,
-/area/icy_caves/outpost/medbay)
 "st" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table,
@@ -4004,10 +3430,10 @@
 	},
 /area/icy_caves/outpost/medbay)
 "sD" = (
-/obj/effect/landmark/fob_sentry_rebel,
-/turf/closed/ice_rock/singleEnd{
+/obj/machinery/landinglight/ds1/delaythree{
 	dir = 8
 	},
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "sE" = (
 /obj/machinery/light/small{
@@ -4015,11 +3441,6 @@
 	},
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"sG" = (
-/obj/structure/bed/chair,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "sH" = (
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
@@ -4027,9 +3448,8 @@
 /turf/closed/ice/thin/corner,
 /area/icy_caves/caves/east)
 "sK" = (
-/obj/machinery/power/apc/lowcharge,
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
+/obj/docking_port/stationary/marine_dropship/lz1,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "sN" = (
 /obj/structure/table/flipped,
@@ -4055,13 +3475,6 @@
 /obj/item/weapon/gun/rifle/ak47,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
-"ta" = (
-/obj/effect/decal/cleanable/vomit,
-/obj/machinery/camera{
-	dir = 5
-	},
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
 "tb" = (
 /obj/structure/sink,
 /obj/machinery/light{
@@ -4115,10 +3528,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
-"tp" = (
-/obj/item/lightstick/anchored,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
 "tq" = (
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/plating/ground/ice,
@@ -4136,16 +3545,12 @@
 	dir = 2
 	},
 /turf/closed/ice/junction,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "tw" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 1
 	},
-/area/icy_caves/outpost/LZ2)
-"tx" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/refinery)
+/area/icy_caves/outpost/outside)
 "tB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -4173,11 +3578,6 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/engineering)
-"tF" = (
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "tH" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/research)
@@ -4228,11 +3628,6 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
-"tT" = (
-/obj/structure/table/mainship,
-/obj/machinery/computer/med_data,
-/turf/open/floor/mainship/mono,
-/area/icy_caves/caves/northern)
 "tU" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -4302,15 +3697,6 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
-"ul" = (
-/obj/structure/dropship_piece/two/corner/rearright,
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
-"un" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "uo" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -4333,18 +3719,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ2)
-"us" = (
-/obj/structure/shuttle/engine/router{
-	dir = 1
-	},
-/obj/structure/dropship_equipment/weapon/heavygun,
-/obj/structure/dropship_equipment/weapon/rocket_pod,
-/turf/open/shuttle/dropship/floor,
-/area/space)
-"uu" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern)
 "uv" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/grilledcheese,
@@ -4353,16 +3727,6 @@
 "uw" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
-"ux" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/mass_spectrometer/adv,
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 5
-	},
-/area/icy_caves/caves/northern)
 "uy" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -4404,15 +3768,11 @@
 /turf/closed/ice/straight{
 	dir = 4
 	},
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "uN" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
-"uO" = (
-/obj/structure/dropship_piece/two/corner/rearleft,
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
 "uP" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -4439,13 +3799,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/medbay)
-"uT" = (
-/obj/effect/landmark/weed_node,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "uX" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -4477,12 +3830,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
-"ve" = (
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "vf" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/outpost/outside)
@@ -4513,11 +3860,6 @@
 	dir = 10
 	},
 /area/icy_caves/outpost/engineering)
-"vn" = (
-/turf/closed/shuttle/dropship2{
-	icon_state = "25"
-	},
-/area/icy_caves/caves/northern)
 "vo" = (
 /obj/machinery/light{
 	dir = 1
@@ -4538,10 +3880,6 @@
 	dir = 6
 	},
 /area/icy_caves/outpost/garage)
-"vr" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/closed/ice/thin/straight,
-/area/icy_caves/outpost/LZ1)
 "vs" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -4552,10 +3890,6 @@
 /obj/structure/bed/roller,
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
-"vv" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall,
-/area/icy_caves/caves/northern)
 "vx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
@@ -4617,7 +3951,7 @@
 "vR" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/end,
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/outside)
 "vS" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/tile/dark,
@@ -4627,7 +3961,7 @@
 	dir = 1
 	},
 /turf/closed/ice/corner,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/east)
 "vX" = (
 /obj/item/flashlight,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4662,30 +3996,16 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
-"wf" = (
-/obj/structure/barricade/guardrail{
-	dir = 1
-	},
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
 "wg" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
-"wh" = (
-/obj/structure/morgue/crematorium,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "wi" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/tile/dark/green2{
 	dir = 4
 	},
 /area/icy_caves/outpost/medbay)
-"wj" = (
-/obj/structure/largecrate/random/barrel/yellow,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "wk" = (
 /turf/open/floor/tile/dark/red2/corner,
 /area/icy_caves/outpost/security)
@@ -4707,17 +4027,6 @@
 /turf/closed/ice/end{
 	dir = 8
 	},
-/area/icy_caves/caves/northern)
-"wq" = (
-/obj/machinery/light,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
-"ws" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "wu" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
@@ -4749,19 +4058,15 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/medbay)
-"wG" = (
-/obj/effect/spawner/gibspawner/human,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
 "wH" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/refinery)
 "wL" = (
-/turf/open/floor/mech_bay_recharge_floor,
+/obj/machinery/landinglight/ds1/delaythree{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "wM" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -4772,12 +4077,7 @@
 "wN" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/LZ2)
-"wO" = (
-/turf/open/floor/mainship/red{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
+/area/icy_caves/outpost/outside)
 "wP" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -4791,19 +4091,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
-"wT" = (
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 5
-	},
-/obj/structure/monorail{
-	dir = 9
-	},
-/obj/machinery/door/poddoor/mainship/indestructible{
-	dir = 2
-	},
-/turf/open/shuttle/escapepod/plain,
-/area/space)
 "wW" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
@@ -4861,21 +4148,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
-"xo" = (
-/obj/structure/closet/crate,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick,
-/obj/item/storage/box/lightstick,
-/obj/item/tool/pickaxe/plasmacutter,
-/obj/effect/spawner/random/powercell,
-/obj/item/clothing/glasses/welding,
-/obj/item/explosive/plastique,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "xr" = (
 /obj/machinery/mineral/stacking_machine,
 /obj/machinery/conveyor{
@@ -4883,10 +4155,6 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/refinery)
-"xs" = (
-/obj/structure/barricade/guardrail,
-/turf/open/floor/mainship/red/full,
-/area/icy_caves/caves/northern)
 "xu" = (
 /obj/structure/cargo_container/green,
 /turf/open/floor/plating,
@@ -4938,10 +4206,6 @@
 "xR" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
-"xS" = (
-/obj/machinery/computer3/server,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "xT" = (
 /turf/open/floor/tile/dark/green2/corner{
 	dir = 4
@@ -4954,38 +4218,13 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
-"xW" = (
-/obj/structure/largecrate/supply/explosives/mortar_flare,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "xX" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/caves/south)
-"xZ" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 2
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "ya" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves)
-"yb" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
-"yd" = (
-/obj/structure/monorail,
-/obj/machinery/door/poddoor/mainship/indestructible{
-	dir = 2
-	},
-/turf/open/floor/mainship_hull,
-/area/space)
 "yg" = (
 /obj/structure/bookcase/manuals,
 /obj/machinery/light{
@@ -4998,12 +4237,6 @@
 "yh" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/northern)
-"yi" = (
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
 /area/icy_caves/caves/northern)
 "yj" = (
 /obj/structure/closet/crate/secure/weapon,
@@ -5028,12 +4261,6 @@
 "yq" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/outpost/LZ2)
-"yv" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/shuttle/dropship/seven,
-/area/space)
 "yw" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/machinery/light,
@@ -5042,10 +4269,6 @@
 "yx" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/engineering)
-"yz" = (
-/obj/structure/bed/chair,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "yB" = (
 /turf/closed/ice/thin/junction{
 	dir = 8
@@ -5062,14 +4285,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
-"yF" = (
-/obj/machinery/door/poddoor/mainship/indestructible{
-	dir = 2
-	},
-/turf/open/floor/mainship_hull/dir{
-	dir = 8
-	},
-/area/space)
 "yG" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -5078,12 +4293,6 @@
 	dir = 8
 	},
 /area/icy_caves/caves)
-"yH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1
-	},
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
 "yJ" = (
 /obj/structure/closet/crate/construction,
 /obj/item/cell/hyper,
@@ -5120,17 +4329,20 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/garage)
-"yV" = (
-/obj/effect/spawner/gibspawner/human,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
+"yW" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
 	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"ze" = (
-/obj/structure/largecrate/random/case/double,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
+/turf/closed/ice_rock/singlePart{
+	dir = 6
+	},
+/area/icy_caves/outpost/outside)
+"zb" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/ice_rock/fourway,
+/area/icy_caves/outpost/outside)
 "zh" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -5139,14 +4351,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"zi" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/closed/ice_rock/corners{
-	dir = 9
-	},
-/area/icy_caves/caves)
 "zk" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleT{
@@ -5160,7 +4364,7 @@
 /turf/closed/ice/corner{
 	dir = 8
 	},
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "zm" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/drained,
@@ -5186,15 +4390,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/garage)
-"zt" = (
-/turf/open/floor/tile/white/warningstripe{
-	dir = 6
-	},
-/area/icy_caves/caves/northern)
-"zu" = (
-/obj/machinery/door/airlock/multi_tile/mainship/secdoor,
-/turf/open/floor/mainship/red/full,
-/area/icy_caves/caves/northern)
 "zw" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -5215,9 +4410,6 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/refinery)
-"zB" = (
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
 "zC" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/tile/dark,
@@ -5246,8 +4438,10 @@
 /turf/closed/ice_rock/singlePart,
 /area/icy_caves/caves)
 "zM" = (
-/obj/machinery/landinglight/ds1/delaytwo,
-/turf/open/floor/tile/dark,
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "zN" = (
 /obj/effect/landmark/excavation_site_spawner,
@@ -5266,9 +4460,9 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
 "zS" = (
-/obj/machinery/landinglight/ds1/delaytwo,
-/obj/machinery/floodlight/landing,
-/turf/open/floor/tile/dark,
+/turf/closed/ice/end{
+	dir = 4
+	},
 /area/icy_caves/outpost/LZ1)
 "zT" = (
 /obj/machinery/iv_drip,
@@ -5300,14 +4494,6 @@
 	dir = 9
 	},
 /area/icy_caves/outpost/medbay)
-"zZ" = (
-/obj/machinery/door/airlock/mainship/secure/locked/free_access{
-	dir = 1;
-	id = "safe_room";
-	name = "\improper Lambda Lab Secure Storage"
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Aa" = (
 /obj/item/storage/box/flashbangs,
 /obj/item/storage/box/m94,
@@ -5317,10 +4503,6 @@
 /obj/structure/closet/crate/secure/explosives,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"Ab" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
 "Ad" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -5330,19 +4512,12 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/garage)
-"Ae" = (
-/turf/closed/ice_rock/eastWall,
-/area/icy_caves/caves/northern)
-"Af" = (
-/obj/vehicle/multitile/root/cm_armored/tank{
-	dir = 1;
-	layer = 1
+"Ag" = (
+/obj/machinery/landinglight/ds1/delaytwo{
+	dir = 4
 	},
-/obj/structure/dropship_equipment/weapon/laser_beam_gun,
-/obj/effect/turf_overlay/shuttle/heater,
-/obj/structure/dropship_equipment/weapon/rocket_pod,
-/turf/open/shuttle/dropship/floor,
-/area/space)
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ1)
 "Ah" = (
 /obj/effect/landmark/corpsespawner/security{
 	corpsebelt = /obj/item/weapon/gun/revolver/cmb;
@@ -5372,12 +4547,6 @@
 /obj/machinery/processor,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"Aq" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/snow,
-/area/icy_caves/outpost/LZ1)
 "Ar" = (
 /obj/structure/closet/crate/secure/ammo,
 /obj/item/ammo_magazine/smg/m25,
@@ -5463,25 +4632,23 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/office)
+"AH" = (
+/obj/machinery/landinglight/ds1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ1)
 "AI" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 4
 	},
 /area/icy_caves/outpost/refinery)
-"AJ" = (
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
 "AK" = (
 /turf/closed/ice/end{
 	dir = 1
 	},
 /area/icy_caves/outpost/outside)
-"AL" = (
-/turf/closed/ice/corner{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "AM" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/cable,
@@ -5494,19 +4661,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
-"AQ" = (
-/obj/machinery/disposal,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"AR" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 1
-	},
-/area/icy_caves/caves/northern)
 "AS" = (
 /obj/machinery/power/geothermal,
 /obj/machinery/light/small{
@@ -5557,10 +4711,6 @@
 	dir = 4
 	},
 /area/icy_caves/caves)
-"Bb" = (
-/obj/structure/fence,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/caves/west)
 "Bd" = (
 /obj/machinery/door/airlock/multi_tile/mainship/secdoor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -5573,11 +4723,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
-"Bf" = (
-/turf/open/floor/tile/dark/green2{
-	dir = 8
-	},
-/area/icy_caves/caves/northern)
 "Bi" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/prison/kitchen,
@@ -5592,12 +4737,6 @@
 	dir = 1
 	},
 /area/icy_caves/caves/east)
-"Bo" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Bq" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/prison/kitchen,
@@ -5605,11 +4744,6 @@
 "Bs" = (
 /turf/open/floor/podhatch/floor,
 /area/icy_caves/outpost/engineering)
-"Bt" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/obj/effect/ai_node,
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
 "Bu" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -5640,19 +4774,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
-"BB" = (
-/obj/structure/cryofeed,
-/turf/open/floor/podhatch/floor{
-	icon_state = "bcircuitoff"
-	},
-/area/icy_caves/caves/northern)
-"BF" = (
-/obj/structure/window/framed/colony/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "BI" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -5670,18 +4791,6 @@
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/dorms)
-"BN" = (
-/turf/closed/shuttle/dropship2{
-	icon_state = "52"
-	},
-/area/icy_caves/caves/northern)
-"BO" = (
-/obj/machinery/door/airlock/multi_tile/secure{
-	dir = 2
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "BP" = (
 /turf/closed/ice/junction{
 	dir = 4
@@ -5717,12 +4826,6 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"BW" = (
-/obj/structure/bed/chair/comfy{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "BX" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -5732,25 +4835,10 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "BY" = (
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 6
+/turf/closed/ice/thin/end{
+	dir = 8
 	},
-/obj/structure/monorail{
-	dir = 10
-	},
-/turf/open/shuttle/escapepod/plain,
-/area/space)
-"BZ" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Ch" = (
-/obj/machinery/computer3/server/rack,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/outpost/LZ1)
 "Ci" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -5764,24 +4852,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
-"Cl" = (
-/obj/machinery/camera{
-	dir = 5
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Cm" = (
-/obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Cq" = (
-/turf/closed/ice/thin/end{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ2)
 "Cs" = (
 /obj/item/ammo_casing,
 /turf/open/floor/wood,
@@ -5803,11 +4873,6 @@
 /obj/item/clothing/shoes/rainbow,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"CH" = (
-/turf/open/floor/mainship_hull/dir{
-	dir = 10
-	},
-/area/icy_caves/caves/northern)
 "CN" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/south)
@@ -5835,10 +4900,6 @@
 	dir = 9
 	},
 /area/icy_caves/outpost/refinery)
-"CX" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "CZ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -5883,13 +4944,6 @@
 	},
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
-"Dm" = (
-/obj/structure/largecrate/random/secure,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
 "Dn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -5897,15 +4951,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
-"Do" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
 "Dp" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleEnd{
@@ -5956,13 +5001,6 @@
 /obj/effect/decal/cleanable/blood/writing,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"DH" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/closed/ice/end{
-	dir = 1
-	},
-/area/icy_caves/caves/northern)
 "DJ" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 4
@@ -5978,7 +5016,7 @@
 /turf/closed/ice/thin/corner{
 	dir = 8
 	},
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/outside)
 "DM" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 10
@@ -5989,22 +5027,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"DS" = (
-/obj/structure/dropship_piece/one/corner/middleright,
-/obj/structure/dropship_piece/two/corner/rearright,
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
-"DU" = (
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
-"DV" = (
-/obj/structure/mopbucket,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
 "DW" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -6015,11 +5037,6 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/garage)
-"DX" = (
-/turf/closed/ice_rock/corners{
-	dir = 9
-	},
-/area/icy_caves/outpost/LZ1)
 "DY" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
@@ -6028,12 +5045,6 @@
 	dir = 6
 	},
 /area/icy_caves/caves/west)
-"Ea" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Eb" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/effect/ai_node,
@@ -6058,14 +5069,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"Eh" = (
-/obj/machinery/door/poddoor/mainship/indestructible{
-	dir = 2
-	},
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
-	},
-/area/space)
 "Ej" = (
 /obj/structure/table,
 /obj/item/stack/nanopaste,
@@ -6073,11 +5076,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/medbay)
-"Ek" = (
-/obj/structure/table/mainship,
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern)
 "El" = (
 /obj/structure/table/reinforced,
 /obj/effect/landmark/dropship_console_spawn_lz2,
@@ -6088,7 +5086,7 @@
 	dir = 2
 	},
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "Ep" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -6114,15 +5112,10 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
-"Ex" = (
-/obj/effect/decal/cleanable/mucus,
-/obj/structure/table,
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
 "Ey" = (
 /obj/effect/landmark/fob_sentry_rebel,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/outside)
 "Ez" = (
 /obj/structure/bed,
 /turf/open/floor/wood,
@@ -6170,34 +5163,20 @@
 /area/icy_caves/caves/south)
 "EO" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/closed/ice/thin/junction,
-/area/icy_caves/outpost/LZ1)
-"EP" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/turf/closed/wall/r_wall,
+/area/icy_caves/outpost/outside)
 "EQ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/corner{
 	dir = 4
 	},
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/outside)
 "ES" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/closed/ice_rock/westWall,
 /area/icy_caves/caves)
-"EU" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"EX" = (
-/obj/structure/largecrate/supply/floodlights,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
 "EZ" = (
 /obj/item/ammo_casing,
 /obj/structure/cable,
@@ -6236,17 +5215,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
-"Fj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Fk" = (
-/obj/structure/barricade/guardrail,
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 4
-	},
-/turf/open/shuttle/dropship/seven,
-/area/space)
 "Fm" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -6264,10 +5232,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"Fq" = (
-/obj/effect/spawner/gibspawner/human,
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
 "Fr" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/purple2{
@@ -6303,18 +5267,9 @@
 	dir = 1
 	},
 /area/icy_caves/caves/northern)
-"Fw" = (
-/turf/open/floor/tile/white/warningstripe{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "Fy" = (
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
-"FB" = (
-/obj/machinery/light,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "FF" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -6358,11 +5313,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
-"FR" = (
-/turf/closed/shuttle/dropship2/transparent{
-	icon_state = "109"
-	},
-/area/icy_caves/caves/northern)
 "FU" = (
 /obj/structure/cargo_container/ch_red,
 /turf/open/floor/plating,
@@ -6403,26 +5353,6 @@
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"Gf" = (
-/obj/effect/spawner/gibspawner/human,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Gh" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/machinery/power/monitor{
-	name = "Core Power Monitoring"
-	},
-/obj/structure/table/mainship,
-/obj/structure/cable,
-/turf/open/floor/mainship/tcomms,
-/area/icy_caves/caves/northern)
-"Gj" = (
-/obj/machinery/computer/operating,
-/obj/structure/table/reinforced,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Gk" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -6440,10 +5370,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
-"Gn" = (
-/obj/structure/largecrate/random/barrel/green,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Go" = (
 /turf/open/floor/tile/dark/purple2/corner{
 	dir = 1
@@ -6457,43 +5383,25 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
-"Gs" = (
-/turf/closed/ice_rock/corners,
-/area/icy_caves/caves/northern)
 "Gu" = (
 /turf/closed/ice,
 /area/icy_caves/outpost/outside)
 "Gw" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/refinery)
-"Gx" = (
-/obj/structure/mopbucket,
-/obj/machinery/power/apc/drained,
-/turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern)
 "Gz" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleT,
 /area/icy_caves/caves)
+"GC" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/snow,
+/area/icy_caves/outpost/LZ1)
 "GD" = (
 /turf/open/floor/tile/dark/red2/corner{
 	dir = 1
 	},
 /area/icy_caves/outpost/security)
-"GE" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
-"GF" = (
-/turf/closed/wall,
-/area/icy_caves/caves/west)
-"GG" = (
-/turf/closed/ice/thin/corner{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "GH" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/ice,
@@ -6505,7 +5413,7 @@
 /turf/closed/ice/thin/corner{
 	dir = 1
 	},
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "GK" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
@@ -6526,32 +5434,6 @@
 	dir = 4
 	},
 /area/icy_caves/caves)
-"GN" = (
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 9
-	},
-/obj/structure/monorail{
-	dir = 5
-	},
-/obj/machinery/door/poddoor/mainship/indestructible{
-	dir = 2
-	},
-/turf/open/shuttle/escapepod/plain,
-/area/space)
-"GO" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/LZ2)
-"GQ" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
 "GR" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -6566,12 +5448,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"GU" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "GV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -6599,10 +5475,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
-"He" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Hf" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/dorms)
@@ -6622,18 +5494,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
-"Hj" = (
-/obj/structure/table/mainship,
-/obj/machinery/recharger,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
 "Hl" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/outside)
 "Hm" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -6658,10 +5522,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"Hw" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/closed/wall/r_wall,
-/area/icy_caves/caves/northern)
 "HA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -6675,13 +5535,10 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "HC" = (
-/obj/structure/monorail,
-/obj/structure/lattice,
-/obj/structure/monorail{
+/turf/closed/ice_rock/singlePart{
 	dir = 4
 	},
-/turf/open/floor/mainship_hull,
-/area/space)
+/area/icy_caves/outpost/LZ1)
 "HE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -6689,11 +5546,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
-"HF" = (
-/turf/closed/ice/corner{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ2)
 "HG" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/south)
@@ -6704,18 +5556,13 @@
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/outside)
 "HJ" = (
 /obj/machinery/vending/MarineMed/Blood,
 /turf/open/floor/tile/dark/green2{
 	dir = 4
 	},
 /area/icy_caves/outpost/medbay)
-"HL" = (
-/turf/open/floor/mainship_hull/dir{
-	dir = 6
-	},
-/area/icy_caves/caves/northern)
 "HM" = (
 /obj/item/ammo_casing,
 /turf/open/floor/tile/dark/brown2/corner{
@@ -6730,21 +5577,6 @@
 /obj/item/clothing/head/nun_hood,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"HP" = (
-/obj/machinery/atmospherics/pipe/manifold/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"HQ" = (
-/obj/structure/bed/chair/comfy{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "HR" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -6761,18 +5593,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"HT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"HU" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
 "HV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/corners{
@@ -6796,32 +5616,12 @@
 "Ie" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
-"If" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 6
-	},
-/turf/open/floor/mainship/cargo,
-/area/icy_caves/caves/northern)
-"Ig" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
 "Ih" = (
 /obj/structure/cargo_container/green{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"Ij" = (
-/obj/structure/largecrate/random/barrel/green,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
 "Ik" = (
 /obj/structure/table,
 /obj/item/storage/box/flashbangs,
@@ -6830,13 +5630,9 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/security)
-"Il" = (
-/turf/closed/ice_rock/southWall,
-/area/icy_caves/caves/northern)
 "Im" = (
-/obj/item/shard,
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
+/turf/open/floor/plating/ground/snow,
+/area/icy_caves/outpost/outside)
 "In" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -6923,23 +5719,12 @@
 	},
 /turf/open/floor/tile/dark/red2,
 /area/icy_caves/outpost/security)
-"II" = (
-/obj/item/paper/crumpled/bloody/csheet,
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
 "IJ" = (
 /obj/machinery/vending/security,
 /turf/open/floor/tile/dark/red2{
 	dir = 9
 	},
 /area/icy_caves/outpost/security)
-"IK" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "IO" = (
 /obj/structure/closet/crate/construction,
 /obj/item/stack/sheet/metal/medium_stack,
@@ -6951,14 +5736,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
-"IP" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "IR" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
@@ -6972,26 +5749,10 @@
 "IT" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"IU" = (
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "IX" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
-"IY" = (
-/obj/item/tool/surgery/hemostat,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"IZ" = (
-/obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 9
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Je" = (
 /turf/closed/ice/thin/end{
 	dir = 8
@@ -7031,10 +5792,7 @@
 /turf/closed/ice/thin/junction{
 	dir = 4
 	},
-/area/icy_caves/outpost/LZ2)
-"Jn" = (
-/turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern)
+/area/icy_caves/outpost/outside)
 "Jo" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
@@ -7050,7 +5808,7 @@
 /turf/closed/ice/end{
 	dir = 1
 	},
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/east)
 "Jq" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/dark,
@@ -7097,13 +5855,6 @@
 /obj/item/lightstick/anchored,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
-"JF" = (
-/obj/machinery/vending/cola,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "JH" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/pepper,
@@ -7136,16 +5887,6 @@
 	dir = 5
 	},
 /area/icy_caves/caves)
-"JR" = (
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 5
-	},
-/obj/structure/monorail{
-	dir = 9
-	},
-/turf/open/shuttle/escapepod/plain,
-/area/icy_caves/caves/northern)
 "JS" = (
 /obj/structure/closet/crate/freezer/rations,
 /turf/open/floor/tile/dark,
@@ -7156,16 +5897,11 @@
 	dir = 6
 	},
 /area/icy_caves/outpost/medbay)
-"JW" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside/center)
 "JX" = (
 /turf/closed/ice/end,
 /area/icy_caves/caves/south)
 "JY" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating,
+/turf/closed/ice/thin/single,
 /area/icy_caves/outpost/LZ1)
 "Ka" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -7178,12 +5914,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/office)
-"Kd" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark/brown2/corner{
-	dir = 1
-	},
-/area/icy_caves/outpost/refinery)
 "Ke" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -7213,7 +5943,7 @@
 /area/icy_caves/outpost/dorms)
 "Ko" = (
 /turf/closed/ice_rock/singleEnd,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "Kp" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
@@ -7274,18 +6004,12 @@
 "KJ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow,
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/outside)
 "KK" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 1
 	},
 /area/icy_caves/caves/south)
-"KL" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "KM" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 9
@@ -7294,14 +6018,9 @@
 "KO" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/structure/closet/cabinet,
-/obj/item/clothing/suit/hgpirate,
+/obj/item/clothing/under/colonist,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"KP" = (
-/turf/closed/shuttle/dropship2{
-	icon_state = "54"
-	},
-/area/icy_caves/caves/northern)
 "KS" = (
 /turf/open/floor/tile/dark/red2{
 	dir = 5
@@ -7320,14 +6039,6 @@
 "KZ" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/garage)
-"La" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/white/warningstripe{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "Lb" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/tile/dark,
@@ -7371,31 +6082,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
-"Lo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	on = 1
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Lp" = (
-/turf/open/floor/tile/white/warningstripe,
-/area/icy_caves/caves/northern)
 "Lq" = (
 /obj/machinery/power/geothermal,
 /obj/machinery/light/small,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
-"Lr" = (
-/obj/item/shard,
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
-"Ls" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Lt" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = null;
@@ -7415,10 +6107,6 @@
 "Lv" = (
 /turf/closed/ice/thin,
 /area/icy_caves/outpost/outside)
-"Lw" = (
-/obj/structure/closet/l3closet/virology,
-/turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern)
 "Lx" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 10
@@ -7449,13 +6137,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
-"LF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	on = 1
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "LH" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
@@ -7487,9 +6168,9 @@
 /area/icy_caves/outpost/garage)
 "LL" = (
 /obj/machinery/landinglight/ds1/delaytwo{
-	dir = 4
+	dir = 8
 	},
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "LO" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -7502,7 +6183,7 @@
 /turf/closed/ice/thin/end{
 	dir = 8
 	},
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/outside)
 "LQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -7558,17 +6239,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
-"Me" = (
-/turf/open/floor/mainship_hull/dir{
-	dir = 8
-	},
-/area/icy_caves/caves/northern)
-"Mf" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mainship/red/full,
-/area/icy_caves/caves/northern)
 "Mg" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 5
@@ -7614,15 +6284,10 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
-"Mq" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
 "Ms" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "Mt" = (
 /obj/item/ammo_casing,
 /turf/open/floor/tile/dark/red2{
@@ -7637,34 +6302,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
-"Mv" = (
-/obj/machinery/optable,
-/obj/effect/decal/cleanable/blood/xtracks,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Mw" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
-"Mx" = (
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Mz" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/corner{
 	dir = 4
 	},
 /area/icy_caves/outpost/LZ1)
-"MA" = (
-/obj/structure/barricade/guardrail,
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
 "MB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -7680,11 +6323,6 @@
 	dir = 8
 	},
 /area/icy_caves/caves/south)
-"MH" = (
-/turf/closed/ice/thin/end{
-	dir = 1
-	},
-/area/icy_caves/caves)
 "MJ" = (
 /turf/closed/ice/corner{
 	dir = 1
@@ -7710,10 +6348,10 @@
 	},
 /area/icy_caves/caves/south)
 "MO" = (
-/obj/machinery/landinglight/ds1/delaytwo{
-	dir = 8
+/obj/machinery/landinglight/ds1{
+	dir = 1
 	},
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "MP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -7726,11 +6364,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
-"MT" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/cheeseburger,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "MV" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -7742,21 +6375,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
-"MX" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
-"MY" = (
-/obj/item/reagent_containers/spray/pepper,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 6
-	},
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
 "MZ" = (
 /obj/machinery/door/airlock/mainship/command/free_access{
 	dir = 1;
@@ -7808,10 +6426,10 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/outside)
 "Np" = (
 /turf/closed/ice/intersection,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "Nq" = (
 /turf/closed/ice/end{
 	dir = 4
@@ -7825,16 +6443,11 @@
 /obj/structure/cable,
 /obj/effect/landmark/fob_sentry,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "Nt" = (
 /obj/item/ammo_magazine/smg/m25,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
-"Nu" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "Nv" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -7871,12 +6484,6 @@
 	},
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/refinery)
-"NH" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
 "NJ" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -7898,13 +6505,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
-"NM" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "NN" = (
 /obj/structure/filingcabinet,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -7918,10 +6518,10 @@
 /obj/item/storage/box/lightstick/red,
 /obj/item/storage/box/lightstick,
 /obj/item/storage/box/lightstick,
-/obj/item/tool/pickaxe/plasmacutter,
 /obj/effect/spawner/random/powercell,
 /obj/item/clothing/glasses/welding,
 /obj/item/explosive/plastique,
+/obj/item/newspaper,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "NS" = (
@@ -7936,15 +6536,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/outside)
-"NU" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 10
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"NW" = (
-/turf/open/shuttle/dropship/seven,
-/area/space)
 "Ob" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark,
@@ -7953,16 +6544,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
-"Od" = (
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 6
-	},
-/obj/structure/monorail{
-	dir = 10
-	},
-/turf/open/shuttle/escapepod/plain,
-/area/icy_caves/caves/northern)
 "Oe" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark/brown2{
@@ -8013,13 +6594,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"Ox" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/mainship/tcomms,
-/area/icy_caves/caves/northern)
+/area/icy_caves/outpost/outside)
 "Oy" = (
 /obj/docking_port/mobile/crashmode/bigbury,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -8036,7 +6611,7 @@
 "OD" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "OE" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/dark/brown2,
@@ -8057,10 +6632,9 @@
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
 "OI" = (
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
-	},
-/area/space)
+/obj/machinery/computer/intel_computer,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/mining/west)
 "OJ" = (
 /turf/closed/ice/end,
 /area/icy_caves/outpost/outside)
@@ -8076,9 +6650,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
-"OP" = (
-/turf/open/floor/mainship/red/full,
-/area/icy_caves/caves/northern)
 "OQ" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/kitchen,
@@ -8093,12 +6664,6 @@
 "Pd" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/security)
-"Pg" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Pi" = (
 /turf/closed/ice/corner{
 	dir = 8
@@ -8119,12 +6684,6 @@
 	dir = 8
 	},
 /area/icy_caves/caves/south)
-"Pp" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/turf/open/floor/tile/white/warningstripe{
-	dir = 5
-	},
-/area/icy_caves/caves/northern)
 "Pq" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 8
@@ -8163,7 +6722,7 @@
 /turf/closed/ice/junction{
 	dir = 8
 	},
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/east)
 "PD" = (
 /turf/closed/ice/corner{
 	dir = 4
@@ -8188,13 +6747,6 @@
 	dir = 8
 	},
 /area/icy_caves/caves)
-"PN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 8;
-	welded = 1
-	},
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
 "PO" = (
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
@@ -8204,14 +6756,6 @@
 /obj/item/weapon/gun/smg/m25,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
-"PR" = (
-/turf/closed/ice/junction{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
-"PS" = (
-/turf/closed/ice/thin/corner,
-/area/icy_caves/outpost/LZ2)
 "PT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -8247,9 +6791,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
-"PZ" = (
-/turf/open/floor/tile/dark/green2,
-/area/icy_caves/caves/northern)
 "Qa" = (
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
@@ -8262,24 +6803,12 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
-"Qe" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "Qf" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/green2{
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
-"Qg" = (
-/obj/structure/prop/mainship/sensor_computer2,
-/obj/structure/cable,
-/turf/open/floor/mainship/tcomms,
-/area/icy_caves/caves/northern)
 "Qh" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 6
@@ -8296,23 +6825,11 @@
 "Qk" = (
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"Qn" = (
-/obj/structure/barricade/guardrail,
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 8
-	},
-/turf/open/shuttle/dropship/seven,
-/area/space)
-"Qo" = (
-/turf/closed/ice_rock/corners{
-	dir = 9
-	},
-/area/icy_caves/caves/northern)
 "Qp" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 8
 	},
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "Qq" = (
 /turf/closed/ice/corner{
 	dir = 4
@@ -8341,12 +6858,6 @@
 /obj/effect/decal/cleanable/blood/writing,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"QD" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mainship/red/full,
-/area/icy_caves/caves/northern)
 "QF" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating,
@@ -8390,15 +6901,6 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/outside)
-"QQ" = (
-/obj/structure/bed/chair/comfy{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "QR" = (
 /obj/machinery/light,
 /turf/open/floor/tile/dark/brown2,
@@ -8503,15 +7005,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
-"Rt" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Ru" = (
 /obj/structure/table/woodentable,
 /obj/structure/paper_bin,
@@ -8521,18 +7014,6 @@
 "Rv" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves)
-"Rw" = (
-/turf/closed/shuttle/dropship2{
-	icon_state = "103"
-	},
-/area/icy_caves/caves/northern)
-"Rx" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/blood,
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "Ry" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 8
@@ -8547,7 +7028,7 @@
 /area/icy_caves/outpost/security)
 "RA" = (
 /turf/closed/ice_rock/singleT,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "RB" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/brown2{
@@ -8584,18 +7065,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
-"RL" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
-"RM" = (
-/obj/structure/monorail,
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 4
-	},
-/turf/open/floor/mainship_hull,
-/area/icy_caves/caves/northern)
 "RN" = (
 /turf/closed/ice_rock/corners{
 	dir = 5
@@ -8609,7 +7078,7 @@
 /area/icy_caves/outpost/dorms)
 "RQ" = (
 /turf/closed/ice_rock/fourway,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "RS" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/southWall,
@@ -8639,20 +7108,6 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
-"Se" = (
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
-/area/icy_caves/caves/northern)
-"Sf" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
 "Sg" = (
 /turf/closed/ice/end{
 	dir = 4
@@ -8662,16 +7117,8 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/closed/ice_rock/singleEnd{
-	dir = 8
-	},
+/turf/closed/ice_rock/single,
 /area/icy_caves/caves)
-"Si" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
 "Sk" = (
 /obj/machinery/space_heater,
 /turf/open/floor/tile/dark/red2{
@@ -8701,20 +7148,16 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/security)
-"Ss" = (
-/turf/closed/shuttle/dropship2{
-	icon_state = "104"
-	},
-/area/icy_caves/caves/northern)
 "Sv" = (
 /turf/closed/ice_rock/singleT{
 	dir = 4
 	},
 /area/icy_caves/caves/south)
 "Sw" = (
-/obj/machinery/telecomms/relay/preset/telecomms,
-/turf/open/floor/plating/icefloor,
-/area/lv624/lazarus/console)
+/turf/closed/ice_rock/singleEnd{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ1)
 "Sy" = (
 /turf/open/floor/tile/dark/green2/corner{
 	dir = 8
@@ -8725,11 +7168,6 @@
 	dir = 4
 	},
 /area/icy_caves/caves/south)
-"SB" = (
-/turf/closed/ice/thin/end{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ1)
 "SD" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 4
@@ -8747,13 +7185,18 @@
 "SI" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
+"SJ" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/ice_rock/singlePart{
+	dir = 4
+	},
+/area/icy_caves/outpost/outside)
 "SM" = (
 /obj/structure/closet/crate/internals,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"SO" = (
-/turf/closed/ice_rock/eastWall,
-/area/icy_caves/caves/west)
 "SP" = (
 /turf/closed/ice_rock/singleT{
 	dir = 1
@@ -8784,12 +7227,6 @@
 	},
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/caves)
-"SY" = (
-/obj/structure/bookcase/manuals/research_and_development,
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 1
-	},
-/area/icy_caves/caves/northern)
 "Tb" = (
 /turf/closed/ice_rock/singleT{
 	dir = 1
@@ -8810,44 +7247,21 @@
 /turf/closed/ice_rock/singleEnd{
 	dir = 8
 	},
-/area/icy_caves/outpost/LZ1)
-"Th" = (
-/obj/structure/barricade/guardrail{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Tj" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside)
 "Tk" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside/center)
-"Tl" = (
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/LZ2)
 "Tm" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/closed/ice/thin/straight,
-/area/icy_caves/outpost/LZ1)
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
 "Tr" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
-"Ts" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Tu" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 1
@@ -8861,17 +7275,6 @@
 	dir = 5
 	},
 /area/icy_caves/caves)
-"Tx" = (
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor{
-	name = "\improper Lambda Lab"
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Tz" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "TB" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -8882,22 +7285,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
-"TC" = (
-/obj/structure/barricade/guardrail{
-	dir = 4
-	},
-/obj/structure/xenoautopsy/tank/escaped,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/shuttle/dropship/seven,
-/area/icy_caves/caves/northern)
-"TD" = (
-/obj/machinery/camera{
-	dir = 9
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "TE" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -8911,17 +7298,14 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
 "TI" = (
-/obj/machinery/landinglight/ds1/delaythree{
-	dir = 8
+/obj/machinery/landinglight/ds1/delaytwo{
+	dir = 1
 	},
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "TJ" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/east)
-"TK" = (
-/turf/open/floor/mainship/red,
-/area/icy_caves/caves/northern)
 "TL" = (
 /obj/structure/cargo_container/gorg{
 	dir = 4
@@ -8931,17 +7315,12 @@
 "TM" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/LZ1)
-"TN" = (
-/obj/effect/spawner/gibspawner/human,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "TQ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/outside)
 "TR" = (
 /obj/structure/table/flipped,
 /turf/open/floor/tile/dark/red2{
@@ -8951,7 +7330,7 @@
 "TT" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/outside)
 "TU" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/docking_port/mobile/crashmode/bigbury,
@@ -8975,16 +7354,6 @@
 	dir = 6
 	},
 /area/icy_caves/caves)
-"TZ" = (
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 10
-	},
-/obj/structure/monorail{
-	dir = 6
-	},
-/turf/open/shuttle/escapepod/plain,
-/area/space)
 "Ub" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 1
@@ -9010,10 +7379,8 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "Ud" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
+/obj/machinery/floodlight/landing,
+/turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ1)
 "Ug" = (
 /obj/machinery/power/apc/drained,
@@ -9027,7 +7394,7 @@
 	dir = 2
 	},
 /turf/closed/ice/intersection,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "Uk" = (
 /turf/closed/ice/thin/end,
 /area/icy_caves/caves/south)
@@ -9042,14 +7409,14 @@
 	dir = 1
 	},
 /turf/closed/ice/intersection,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/east)
 "Uq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
 	},
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "Us" = (
 /turf/closed/ice_rock/singleT{
 	dir = 8
@@ -9122,10 +7489,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/security)
-"UR" = (
-/obj/structure/largecrate/supply/medicine/medivend,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "US" = (
 /obj/structure/table,
 /obj/item/clothing/suit/chef/classic,
@@ -9137,10 +7500,6 @@
 /obj/item/clothing/shoes/blue,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"UU" = (
-/obj/machinery/atmospherics/pipe/manifold/green/hidden,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "UV" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 8
@@ -9161,12 +7520,6 @@
 /obj/item/analyzer,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
-"UZ" = (
-/obj/structure/dropship_piece/two/front,
-/turf/closed/shuttle/dropship2/transparent{
-	icon_state = "109"
-	},
-/area/icy_caves/caves/northern)
 "Vb" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 10
@@ -9176,7 +7529,7 @@
 /turf/closed/ice/thin/junction{
 	dir = 1
 	},
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "Vd" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/corners,
@@ -9200,10 +7553,6 @@
 /obj/item/storage/fancy/vials,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/research)
-"Vj" = (
-/obj/effect/decal/cleanable/blood/gibs/limb,
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
 "Vk" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow,
@@ -9212,39 +7561,18 @@
 /obj/structure/table,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"Vq" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 10
-	},
-/turf/open/floor/mainship/cargo,
-/area/icy_caves/caves/northern)
 "Vr" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/closed/ice_rock/southWall,
 /area/icy_caves/caves)
-"Vs" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 5
-	},
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
-"Vt" = (
-/turf/open/floor/mainship_hull/dir{
-	dir = 9
-	},
-/area/icy_caves/caves/northern)
 "Vu" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/corner{
 	dir = 1
 	},
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/outside)
 "Vx" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -9266,10 +7594,6 @@
 	dir = 4
 	},
 /area/icy_caves/caves/west)
-"VC" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside/center)
 "VD" = (
 /obj/structure/largecrate/supply/medicine/iv,
 /turf/open/floor/plating,
@@ -9279,20 +7603,14 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "VG" = (
-/obj/structure/barricade/guardrail{
-	dir = 8
-	},
-/obj/structure/xenoautopsy/tank,
-/turf/open/shuttle/dropship/seven,
-/area/icy_caves/caves/northern)
+/turf/closed/ice/thin/junction,
+/area/icy_caves/outpost/outside)
 "VI" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/northern)
 "VJ" = (
-/obj/machinery/landinglight/ds1{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "VK" = (
 /obj/machinery/light{
@@ -9308,18 +7626,6 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/security)
-"VL" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
-	},
-/turf/open/floor/mainship/cargo,
-/area/icy_caves/caves/northern)
 "VM" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/security)
@@ -9350,12 +7656,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
-"VS" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/icy_caves/caves/northern)
 "VT" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/outpost/LZ1)
@@ -9383,71 +7683,32 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"VZ" = (
-/obj/item/shard,
-/obj/effect/decal/cleanable/blood/xtracks,
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
 "Wa" = (
 /obj/structure/largecrate/supply/explosives,
 /obj/item/explosive/plastique,
 /obj/item/explosive/plastique,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"Wc" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 2;
-	name = "Canteen"
+"Wb" = (
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 4
 	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Wd" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/obj/machinery/atmospherics/pipe/manifold/green/hidden{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ1)
 "We" = (
 /turf/closed/ice/junction{
 	dir = 1
 	},
 /area/icy_caves/outpost/outside/center)
 "Wg" = (
-/obj/structure/barricade/guardrail{
-	dir = 4
-	},
-/obj/structure/xenoautopsy/tank/alien,
-/turf/open/shuttle/dropship/seven,
-/area/icy_caves/caves/northern)
-"Wi" = (
-/obj/machinery/atmospherics/pipe/manifold/green/hidden{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/obj/effect/landmark/fob_sentry_rebel,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
 "Wj" = (
 /turf/closed/ice/thin/end{
 	dir = 4
 	},
 /area/icy_caves/caves/south)
-"Wm" = (
-/obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Wp" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Wr" = (
-/obj/machinery/door/airlock/mainship/maint,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Ws" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
 "Wt" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs,
@@ -9459,7 +7720,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "Ww" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -9468,26 +7729,12 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
-"Wx" = (
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/caves/west)
-"Wy" = (
-/turf/open/shuttle/dropship/floor,
-/area/space)
 "WA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
 /turf/closed/ice/thin/end,
-/area/icy_caves/outpost/LZ2)
-"WB" = (
-/obj/machinery/vending/dinnerware,
-/obj/machinery/camera/autoname/mainship/dropship_one{
-	dir = 8;
-	pixel_x = 16
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/outpost/outside)
 "WD" = (
 /turf/open/floor/plating/ground/snow,
 /area/icy_caves/outpost/LZ1)
@@ -9498,28 +7745,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"WF" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/icy_caves/caves/northern)
-"WG" = (
-/turf/closed/ice_rock/corners,
-/area/icy_caves/caves/west)
 "WI" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside)
 "WK" = (
-/obj/docking_port/stationary/marine_dropship/lz1,
-/turf/open/floor/plating,
+/turf/open/floor/mech_bay_recharge_floor,
 /area/icy_caves/outpost/LZ1)
-"WO" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"WP" = (
-/obj/effect/decal/cleanable/vomit,
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
 "WQ" = (
 /turf/closed/ice/thin/end{
 	dir = 8
@@ -9535,10 +7766,8 @@
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/caves)
 "WT" = (
-/obj/machinery/landinglight/ds1{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
+/obj/machinery/landinglight/ds1/delaytwo,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "WU" = (
 /obj/structure/closet/cabinet,
@@ -9547,30 +7776,12 @@
 /obj/item/clothing/head/pirate,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"WW" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"WX" = (
-/obj/machinery/computer3/laptop,
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "WY" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/medbay)
 "Xa" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/closed/ice/thin/end{
-	dir = 1
-	},
+/obj/machinery/landinglight/ds1/delayone,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "Xf" = (
 /obj/effect/landmark/start/job/survivor,
@@ -9586,12 +7797,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"Xh" = (
-/obj/structure/bed/chair/comfy{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Xi" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -9633,21 +7838,16 @@
 	},
 /area/icy_caves/caves)
 "Xq" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
+/obj/machinery/landinglight/ds1,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "Xr" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/dmg3,
 /area/icy_caves/caves/crashed_ship)
 "Xs" = (
-/obj/machinery/landinglight/ds1/delaythree{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
+/obj/machinery/landinglight/ds1/delaythree,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "Xu" = (
 /turf/closed/ice/end{
@@ -9670,27 +7870,6 @@
 /obj/item/storage/box/visual/grenade/teargas,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"Xy" = (
-/obj/machinery/door/poddoor/mainship/indestructible{
-	dir = 2
-	},
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
-"Xz" = (
-/obj/structure/window/framed/colony/reinforced,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"XA" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/east)
-"XD" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/shuttle/dropship/seven,
-/area/space)
 "XF" = (
 /turf/closed/ice/corner,
 /area/icy_caves/caves/west)
@@ -9725,13 +7904,6 @@
 "XJ" = (
 /turf/closed/ice_rock/singleEnd,
 /area/icy_caves/caves/west)
-"XL" = (
-/obj/structure/barricade/guardrail{
-	dir = 1
-	},
-/obj/structure/dropship_piece/two/front,
-/turf/open/shuttle/dropship/seven,
-/area/space)
 "XM" = (
 /obj/structure/bed/chair,
 /obj/effect/landmark/corpsespawner/colonist,
@@ -9751,19 +7923,15 @@
 "XP" = (
 /turf/closed/ice_rock/singleEnd,
 /area/icy_caves/caves/northern)
-"XQ" = (
-/obj/machinery/door/poddoor/mainship/indestructible,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "XR" = (
 /obj/structure/closet/crate,
 /obj/item/storage/box/lightstick/red,
 /obj/item/storage/box/lightstick/red,
 /obj/item/storage/box/lightstick,
 /obj/item/storage/box/lightstick,
-/obj/item/tool/pickaxe/plasmacutter,
 /obj/effect/spawner/random/powercell,
 /obj/item/explosive/plastique,
+/obj/item/weapon/gun/pistol/holdout,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "XS" = (
@@ -9776,7 +7944,7 @@
 /turf/closed/ice/thin/junction{
 	dir = 1
 	},
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/outside)
 "XU" = (
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 1
@@ -9819,10 +7987,6 @@
 	dir = 1
 	},
 /area/icy_caves/caves)
-"Yh" = (
-/obj/machinery/power/apc/drained,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Yi" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/green2{
@@ -9830,18 +7994,11 @@
 	},
 /area/icy_caves/outpost/medbay)
 "Yj" = (
-/obj/machinery/landinglight/ds1/delaytwo{
+/obj/machinery/landinglight/ds1/delaythree{
 	dir = 4
 	},
-/obj/machinery/floodlight/landing,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
-"Yk" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 5
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Ym" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/swat,
@@ -9864,16 +8021,18 @@
 /turf/closed/ice/thin/junction{
 	dir = 8
 	},
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/outside)
 "Yv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "Yw" = (
-/obj/machinery/landinglight/ds1/delaytwo,
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "Yx" = (
@@ -9898,16 +8057,6 @@
 "YA" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/kitchen)
-"YB" = (
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 10
-	},
-/obj/structure/monorail{
-	dir = 6
-	},
-/turf/open/shuttle/escapepod/plain,
-/area/icy_caves/caves/northern)
 "YF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -9919,8 +8068,8 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/LZ1)
+/turf/closed/ice_rock/singleT,
+/area/icy_caves/outpost/outside)
 "YI" = (
 /turf/closed/ice/thin/end{
 	dir = 1
@@ -9945,15 +8094,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
-"YP" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "YQ" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/space)
@@ -9969,14 +8109,6 @@
 "YT" = (
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
-"YV" = (
-/obj/effect/ai_node,
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	on = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern)
 "YW" = (
 /turf/closed/ice,
 /area/icy_caves/caves/south)
@@ -10042,9 +8174,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ1)
-"Zl" = (
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Zm" = (
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ1)
@@ -10115,7 +8244,7 @@
 "ZE" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/outside)
 "ZF" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -10136,11 +8265,10 @@
 /turf/closed/ice/straight,
 /area/icy_caves/caves/south)
 "ZK" = (
-/obj/machinery/floodlight/landing,
-/obj/machinery/landinglight/ds1/delaytwo{
+/obj/machinery/landinglight/ds1{
 	dir = 8
 	},
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "ZL" = (
 /obj/machinery/power/apc/drained,
@@ -10157,14 +8285,10 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/outside)
 "ZU" = (
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
-"ZV" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
 "ZW" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -10183,12 +8307,6 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
-"ZZ" = (
-/obj/structure/morgue{
-	dir = 2
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 
 (1,1,1) = {"
 YQ
@@ -10348,12 +8466,12 @@ YQ
 "}
 (2,1,1) = {"
 YQ
-mi
-mi
-mi
-mv
-mv
-mv
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
 Yf
 Yf
 Yf
@@ -10504,12 +8622,6 @@ YQ
 "}
 (3,1,1) = {"
 YQ
-mi
-Sw
-mi
-mv
-mv
-mv
 Yf
 Yf
 Yf
@@ -10537,16 +8649,22 @@ Yf
 Yf
 Yf
 Yf
-WF
-WF
-WF
-WF
-WF
-WF
-dF
-dF
-dF
-dF
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
 Yf
 Yf
 Yf
@@ -10660,12 +8778,6 @@ YQ
 "}
 (4,1,1) = {"
 YQ
-mi
-mi
-mi
-mv
-mv
-mv
 Yf
 Yf
 Yf
@@ -10693,16 +8805,22 @@ Yf
 Yf
 Yf
 Yf
-WF
-mw
-cE
-ta
-hW
-kY
-Vj
-AJ
-eO
-dF
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
 Yf
 Yf
 Yf
@@ -10790,25 +8908,25 @@ Zk
 Zm
 UE
 UE
-fq
 Uu
 Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
+qz
+aG
+pq
+aI
+pq
+eY
+zS
+JY
+JY
+zS
+aG
+pq
+aI
+pq
+eY
+XH
+qz
 lX
 Bu
 bD
@@ -10816,12 +8934,6 @@ YQ
 "}
 (5,1,1) = {"
 YQ
-mv
-mv
-mv
-mv
-mv
-mv
 Yf
 Yf
 Yf
@@ -10849,16 +8961,22 @@ Yf
 Yf
 Yf
 Yf
-WF
-SY
-AJ
-AJ
-jf
-Ex
-II
-AJ
-kf
-dF
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
 Yf
 Yf
 Yf
@@ -10940,31 +9058,31 @@ qs
 uA
 TW
 qz
-wL
-uw
-Xs
-Xs
-WT
-Ud
-LL
-Xs
-WT
-Ud
-LL
-Xs
-Ud
-Ud
-LL
-Xs
-WT
-Xq
-LL
-Xs
-WT
-Xq
-Yj
-uw
-uw
+UE
+WD
+Zm
+Zm
+UE
+UE
+UE
+UE
+UE
+UE
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+UE
+UE
+UE
+UE
+UE
+Uu
+Uu
+Uu
 Vb
 Ww
 bD
@@ -10972,12 +9090,6 @@ YQ
 "}
 (6,1,1) = {"
 YQ
-mv
-mv
-mv
-mv
-mv
-mv
 Yf
 Yf
 Yf
@@ -11005,16 +9117,6 @@ Yf
 Yf
 Yf
 Yf
-WF
-AR
-VZ
-AJ
-AJ
-Fq
-AJ
-AJ
-kf
-dF
 Yf
 Yf
 Yf
@@ -11067,24 +9169,40 @@ Yf
 Yf
 Yf
 Yf
-MH
-MH
 Yf
 Yf
-MH
-MH
-re
 Yf
-MH
-MH
 Yf
 Yf
 Yf
 Yf
 Yf
 Yf
-qy
-qy
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
 Yf
 Yf
 Yf
@@ -11096,31 +9214,31 @@ qs
 ED
 qz
 UM
-uw
-zM
-Yn
-Yn
-JY
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-JY
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-JY
-Yw
-uw
-uw
+WD
+WD
+WD
+GC
+WD
+UE
+WD
+WD
+WD
+UE
+UE
+UM
+fs
+UE
+UE
+UE
+UE
+UE
+WD
+WD
+GC
+UE
+Uu
+Ud
+Uu
 VU
 uc
 bD
@@ -11161,16 +9279,6 @@ Yf
 Yf
 Yf
 Yf
-WF
-rk
-AJ
-WP
-AJ
-AJ
-MY
-gZ
-yH
-dF
 Yf
 Yf
 Yf
@@ -11221,28 +9329,38 @@ Yf
 Yf
 Yf
 Yf
-MH
-YI
-YI
-YI
-ZU
-ZU
-ZU
-GF
-re
-re
-re
-MH
 Yf
 Yf
 Yf
 Yf
-MH
-MH
-qy
-qy
-qy
-MH
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
 Yf
 Yf
 Yf
@@ -11250,33 +9368,33 @@ Yf
 Yf
 qy
 RC
-TM
-uw
-uw
-zM
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yw
-uw
-uw
+WD
+UE
+WK
+Yj
+Yj
+AH
+Wb
+Ag
+Yj
+AH
+Wb
+Ag
+Yj
+WK
+Wb
+Ag
+Yj
+AH
+Wb
+Ag
+Yj
+AH
+Wb
+Ag
+WK
+Uu
+Uu
 qH
 Ww
 bD
@@ -11289,27 +9407,6 @@ Yf
 Yf
 Yf
 Yf
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
 Yf
 Yf
 Yf
@@ -11317,16 +9414,37 @@ Yf
 Yf
 Yf
 Yf
-WF
-ux
-hG
-Rx
-AJ
-AJ
-HU
-AJ
-Lr
-dF
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
 Yf
 Yf
 Yf
@@ -11378,38 +9496,48 @@ Yf
 Yf
 Yf
 Yf
-ZU
-YI
-ZU
-ZU
-Wx
-Wx
-Bb
-WI
-WI
-WI
-WI
-MH
 Yf
 Yf
 Yf
-MH
-MH
-WI
-WI
 Yf
 Yf
-MH
-MH
-MH
-MH
-DX
-AB
-zi
-TM
-uw
-uw
-zM
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qy
+aG
+Ww
+Sw
+UE
+WT
+Yn
+Yn
+VJ
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+VJ
 Yn
 Yn
 Yn
@@ -11418,21 +9546,11 @@ Yn
 Yn
 Yn
 Yn
+VJ
 Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yw
-uw
-uw
+wL
+UE
+UE
 XH
 Ne
 Yf
@@ -11445,27 +9563,6 @@ Yf
 Yf
 Yf
 Yf
-WF
-Qg
-mj
-GQ
-yb
-dF
-Ls
-Zl
-EU
-Zl
-Zl
-EU
-Zl
-nK
-Gn
-dF
-EU
-Zl
-LF
-Zl
-WF
 Yf
 Yf
 Yf
@@ -11473,16 +9570,37 @@ Yf
 Yf
 Yf
 Yf
-WF
-EP
-EP
-dF
-AJ
-AJ
-HU
-AJ
-GE
-dF
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
 Yf
 Yf
 Yf
@@ -11531,41 +9649,40 @@ Yf
 Yf
 Yf
 Yf
-MH
-MH
 Yf
-ZU
-ZU
-gx
-ZU
-ZU
-ZU
-Bb
-WI
-pa
-Si
-WI
-WI
-MH
-MH
-MH
-MH
-pa
-Si
-WI
-WI
-MH
-MH
-MH
-Uu
-Uu
-DX
-DX
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
+VU
+qz
 Sh
-sK
-bU
-uw
-zM
+HC
+UE
+Xa
 Yn
 Yn
 Yn
@@ -11586,9 +9703,10 @@ Yn
 Yn
 Yn
 Yn
-Yw
-uw
-uw
+Yn
+MO
+WD
+UE
 VU
 Ne
 Yf
@@ -11601,57 +9719,57 @@ Yf
 Yf
 Yf
 Yf
-WF
-op
-Ox
-yi
-Dm
-dF
-Zl
-Zl
-Zl
-Zl
-He
-Zl
-Zl
-Zl
-wj
-dF
-Zl
-Zl
-BZ
-Zl
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-Zl
-He
-dF
-EP
-Zl
-YP
-EP
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-dF
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+re
+re
+re
+re
+re
+re
+re
 Yf
 Yf
 Yf
@@ -11688,63 +9806,63 @@ Yf
 Yf
 Yf
 Yf
-YI
-ZU
-ZU
-ZU
-ZU
-ZU
-ZU
-ZU
-Bb
-WI
-Tj
-SI
-SI
-SI
-SI
-SI
-SI
-SI
-SI
-WI
-WI
-WI
-WI
-WI
-WI
-Uu
-Uu
-DX
-Ml
-Tf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
+aK
+VU
+yW
 TM
-bU
-uw
+UE
+Xq
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
 zM
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yw
-uw
-uw
+UE
+UE
 bH
 Ne
 Yf
@@ -11752,62 +9870,62 @@ YQ
 "}
 (11,1,1) = {"
 YQ
-pl
-pl
-pl
-pl
-pl
-WF
-Gh
-co
-oR
-lO
-iN
-Tz
-Tz
-Wm
-ph
-Tz
-Tz
-Tz
-Tz
-Tz
-kd
-Tz
-Tz
-UU
-Zl
-Xz
-Zl
-Zl
-Cl
-EU
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-cV
-IU
-MX
-Lp
-Zl
-Zl
-Zl
-Zl
-EU
-Zl
-LF
-Zl
-dF
-Zl
-Mx
-NM
-xo
-pP
-dF
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+af
+af
+af
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
+dy
+dy
+dy
+dy
+dy
+dy
+dy
 bD
 Yf
 Yf
@@ -11844,40 +9962,39 @@ Yf
 Yf
 Yf
 Yf
-ZU
-gx
-ez
-ZU
-ZU
-ZU
-ZU
-ZU
-Bb
-WI
-WI
-SI
-SI
-SI
-SI
-SI
-SI
-SI
-SI
-AW
-WI
-XO
-XO
-XO
-WI
-Uu
-Uu
-Uu
-Ml
-Tf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qy
+XH
+XH
+YH
 TM
-bU
 uw
-zS
+Xs
 Yn
 Yn
 Yn
@@ -11888,7 +10005,6 @@ Yn
 Yn
 Yn
 Yn
-WK
 Yn
 Yn
 Yn
@@ -11898,9 +10014,11 @@ Yn
 Yn
 Yn
 Yn
-Yw
-uw
-uw
+Yn
+Yn
+TI
+UE
+UE
 bH
 Ne
 Yf
@@ -11908,62 +10026,62 @@ YQ
 "}
 (12,1,1) = {"
 YQ
-pl
-bW
-bW
-bW
-bW
-in
-mu
-yi
-oQ
-yi
-zu
-TK
-Zl
-Zl
-BZ
-Zl
-Zl
-Zl
-Zl
-Zl
-Wp
-Zl
-Zl
-Wd
-Tz
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+af
 am
-Tz
-Tz
-Tz
-Tz
-TN
-Tz
-Yk
-Zl
-Zl
-Zl
-Zl
-Pp
-Fw
-La
-zt
-Zl
-Zl
-Zl
-He
-Zl
-Zl
-BZ
-Zl
-dF
+af
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
+dy
 dL
-Zl
+dZ
 ev
-Zl
+eM
 fb
-dF
+dy
 bD
 Yf
 Yf
@@ -12000,40 +10118,39 @@ Yf
 Yf
 Yf
 Yf
-ZU
-ZU
-ZU
-ZU
-ZU
-ZU
+Yf
+Yf
+Yf
+Yf
+Yf
 re
 re
 re
-WI
-WI
-SI
-SI
-WI
-WI
-WI
-WI
-SI
-SI
-WI
-WI
-WI
-WI
-WI
-WI
-sb
-Uu
-Uu
-Uu
-Aq
+re
+re
+re
+re
+re
+re
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+re
+re
+qy
+qz
+qz
+qz
+YH
 TM
-bU
-uw
-zM
+iJ
+WT
 Yn
 Yn
 Yn
@@ -12054,9 +10171,10 @@ Yn
 Yn
 Yn
 Yn
-Yw
-uw
-uw
+Yn
+wL
+WD
+UE
 bH
 Ne
 Yf
@@ -12064,62 +10182,62 @@ YQ
 "}
 (13,1,1) = {"
 YQ
-pl
-BB
-BB
-BB
-BB
-nw
-Sf
-yi
-wG
-yi
-OP
-TK
-Zl
-Zl
-BZ
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-BZ
-Zl
-ev
-He
-Zl
-Zl
-Zl
-Zl
-Zl
-Wi
-Tz
-Tz
-Tz
-Tz
-Tz
-Tz
-UU
-Zl
-Zl
-Zl
-Gf
-Zl
-Zl
-Zl
-BZ
-Zl
-zZ
-Zl
-Zl
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+af
+af
+af
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
+dy
+dM
+ap
 ix
 eN
 fd
-dF
+dy
 bD
 Yf
 Yf
@@ -12156,40 +10274,39 @@ Yf
 Yf
 re
 re
-ZU
-ZU
-ZU
-ZU
-Di
-Di
+re
+re
+re
+re
+re
+re
 lG
 lX
 lG
-AW
-WI
-SI
-SI
-WI
-pD
-WI
-WI
-SI
-SI
-WI
-WI
-WI
-WI
-WI
-WI
-Uu
-Uu
-Uu
-Uu
-YH
+lX
+lG
+lX
+lG
+re
+re
+re
+re
+re
+Yf
+Yf
+Yf
+Yf
+qs
+VU
+aG
+aH
+TW
+VU
+qz
+SJ
 TM
 bU
-uw
-zM
+Xa
 Yn
 Yn
 Yn
@@ -12200,6 +10317,7 @@ Yn
 Yn
 Yn
 Yn
+sK
 Yn
 Yn
 Yn
@@ -12210,9 +10328,9 @@ Yn
 Yn
 Yn
 Yn
-Yw
-uw
-uw
+MO
+UE
+UE
 bH
 Ne
 Yf
@@ -12220,62 +10338,62 @@ YQ
 "}
 (14,1,1) = {"
 YQ
-pl
-bW
-bW
-bW
-bW
-nw
-gP
-jo
-yi
-yi
-EP
-Zl
-Zl
-Zl
-BZ
-Zl
-Zl
-Zl
-Zl
-Zl
-EP
-Zl
-Zl
-BZ
-Zl
-Xz
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-pL
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Wi
-Tz
-un
-Tz
-Tz
-Tz
-Tz
-Tz
-HP
-un
-Hw
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
+dy
 dN
-Tz
+dP
 ew
 eP
 fe
-dF
+dy
 bD
 Yf
 Yf
@@ -12309,66 +10427,66 @@ re
 re
 re
 re
-ZU
-ZU
-SF
-ZU
-ZU
-ZU
-ZU
-Di
-Mg
+re
+qy
+lX
+mv
+mv
+mv
+bX
+pq
+lG
 ec
 Vb
 eY
-Ig
-WI
-SI
-SI
-WI
-WI
-WI
-WI
-SI
-SI
-WI
-WI
-MH
-qs
-WI
-WI
-Uu
-Uu
-Uu
-Ml
-Tf
+Vb
+eY
+Vb
+eY
+qz
+qz
+qz
+eY
+re
+re
+re
+re
+re
+qy
+XH
+lX
+aK
+lX
+eY
+Qh
+zb
 Tb
 XW
-uw
+Xq
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
 zM
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yw
-uw
-uw
+UE
+Uu
 XH
 Ne
 Yf
@@ -12376,62 +10494,62 @@ YQ
 "}
 (15,1,1) = {"
 YQ
-pl
-BB
-BB
-BB
-BB
-WF
-fD
-yi
-Do
-wq
-dF
-Bo
-Zl
-Zl
-BZ
-Zl
-He
-Zl
-Zl
-Zl
-dF
-dL
-Zl
-BZ
-Zl
-WF
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-BZ
-Pg
-ve
-Zl
-Zl
-Zl
-Zl
-BZ
-Zl
-Zl
-Pg
-TD
-Zl
-Zl
-Zl
-Zl
-Zl
-dF
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
+dy
 dO
 ea
-WW
+dQ
 eT
 ff
-dF
+dy
 bD
 Yf
 Yf
@@ -12464,44 +10582,43 @@ TW
 dj
 Di
 XF
-DZ
+Di
+XF
+qz
+mv
 ZU
 ZU
-SF
-ZU
-gx
 ZU
 ZU
-RG
-ec
+aG
+eY
 fT
 xI
 xI
 xI
-nx
-od
-lH
-nx
 xI
 xI
 xI
-SI
-SI
-WI
-MH
-Yf
-Yf
-MH
-WI
-Uu
-Uu
-sD
-Ml
+xI
+xI
+xI
+xI
+pq
+aG
+pq
+lG
+lX
+pq
+lG
+XH
+XH
+XH
+qz
+Qp
 Tf
 Ml
 XW
-uw
-zM
+Xs
 Yn
 Yn
 Yn
@@ -12522,9 +10639,10 @@ Yn
 Yn
 Yn
 Yn
-Yw
-uw
-uw
+Yn
+TI
+UE
+Uu
 VU
 Ne
 Yf
@@ -12532,62 +10650,62 @@ YQ
 "}
 (16,1,1) = {"
 YQ
-pl
-dF
-dF
-dF
-dF
-dF
-wO
-yi
-Hj
-kR
-dF
-Zl
-Zl
-dL
-ds
-Zl
-Zl
-Zl
-Zl
-FB
-dF
-dv
-hB
-BZ
-Zl
-pE
-WF
-WF
-WF
-ev
-BO
-WF
-VS
-dF
-dF
-dF
-dF
-dF
-Zl
-YP
-dF
-dF
-dF
-dF
-dF
-Wr
-dF
-dF
-dF
-dF
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
+dy
 nD
 ed
-nB
-Zl
+ZW
+dP
 fg
-dF
+dy
 bD
 Yf
 Yf
@@ -12619,56 +10737,44 @@ XH
 qz
 ZU
 gz
+Jg
+Jg
+DK
+ez
+ZU
+ZU
 ZU
 ZU
 ZU
 ez
-SF
 ZU
-ZU
-ZU
-ZU
-ez
-SF
 ZU
 nO
 oI
 wW
-oI
+pl
 pw
-oI
+OI
 pf
 oZ
 oK
 xI
-SI
-SI
+VU
+lX
+pq
+WS
+eY
+VU
+XH
+aG
+TW
+qz
 WI
-MH
-Yf
-Yf
-Yf
-MH
-Uu
-Uu
-Uu
-UE
-TQ
+Wg
+Tm
 Uu
 Vk
-uw
-zM
-Yn
-Yn
-JY
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-JY
+WT
 Yn
 Yn
 Yn
@@ -12677,10 +10783,22 @@ Yn
 Yn
 Yn
 Yn
-JY
-Yw
-uw
-uw
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+wL
+UE
+Uu
 qH
 Ne
 Yf
@@ -12688,62 +10806,62 @@ YQ
 "}
 (17,1,1) = {"
 YQ
-Gs
-Gs
-Gs
-Gs
-Gs
-dF
-jY
-dF
-EP
-EP
-dF
-pu
-dF
-dF
-dF
-Zl
-VL
-Vq
-Vq
-Vq
-dF
-dF
-dF
-BZ
-Zl
-WF
-Gs
-WF
-hT
-Zl
-Zl
-Zl
-AQ
-dF
-Gs
-Gs
-Gs
-dF
-Zl
-BZ
-dF
-DV
-EX
-jd
-jd
-jd
-dF
-Gs
-Il
-dF
-dF
-dF
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
+dy
+dy
+dy
 ex
-dF
-dF
-dF
+dy
+dy
+dy
 bh
 Yf
 Yf
@@ -12761,12 +10879,12 @@ eb
 ZU
 ZU
 ZU
-SF
 ZU
 ZU
 ZU
 ZU
-SF
+ZU
+ZU
 ZU
 ZU
 ez
@@ -12775,8 +10893,8 @@ ZU
 ZU
 ZU
 ZU
-ZU
-ZU
+gz
+DK
 ez
 ZU
 dx
@@ -12785,7 +10903,7 @@ gA
 Mg
 ZU
 ZU
-SF
+ZU
 fT
 xI
 oJ
@@ -12797,46 +10915,46 @@ oI
 oI
 oU
 xI
-SI
-SI
-MH
-Yf
-Yf
-Yf
-qs
-qs
-Uu
-Uu
-Uu
-Uu
+eY
+bH
+VU
+XH
+aG
+aI
+TW
+qz
+WI
+WI
+WI
+XO
 TQ
 Uu
 bU
-uw
-uw
-TI
+Xa
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
 MO
-GU
-VJ
-TI
-MO
-GU
-TI
-TI
-MO
-GU
-VJ
-TI
-MO
-GU
-VJ
-TI
-MO
-MO
-MO
-ZK
-uw
-uw
+UE
+Uu
 XH
 Ne
 Yf
@@ -12844,70 +10962,70 @@ YQ
 "}
 (18,1,1) = {"
 YQ
-YQ
-YQ
-dF
-dF
-dF
-dF
-OP
-OP
-OP
-Se
-xs
-OP
-Mf
-OP
-dF
-dF
-Se
-Se
-Se
-Se
-Vt
-CH
-dF
-mg
-Zl
-WF
-Gs
-WF
-tT
-Zl
-pZ
-IY
-BZ
-dF
-Gs
-Gs
-Gs
-dF
-Zl
-Wi
-Ts
-ZV
-ZV
-Vs
-Jn
-Jn
-dF
-Gs
-Il
-bI
-XP
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
+lX
+TW
 eg
 ZW
 eU
-dw
-DZ
-Mg
-qR
-WG
-WG
-WG
-pb
-SD
-SD
+VU
+lX
+lG
+bD
+Yf
+Yf
+Yf
+qy
+nM
+nM
 ZU
 ZU
 ZU
@@ -12917,12 +11035,12 @@ ZU
 ZU
 ez
 ZU
-SF
+ZU
 Eb
 ZU
 ZU
 gx
-SF
+ZU
 ez
 ZU
 gx
@@ -12953,117 +11071,117 @@ qo
 qO
 oU
 xI
-NH
-SI
+VU
+XH
+qH
+TW
+qz
 WI
-jI
-jI
-jI
 WI
-jI
-Uu
-UE
-UE
-UE
+WI
+WI
+XO
+XO
+XO
 TQ
 UE
 XW
-uw
-uw
-uw
-uw
-uw
-uw
-dW
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-dW
-uw
-uw
-uw
-uw
-uw
-uw
-uw
+Xq
+Yn
+Yn
+VJ
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+VJ
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+VJ
+Yn
+zM
+UE
+Uu
 VU
 Ne
 Yf
 YQ
 "}
 (19,1,1) = {"
-cW
-qa
-yF
-jL
-Me
-Me
-df
-Rw
-BN
-BN
-iS
-BN
-BN
-BN
-qu
-Rw
-BN
-jc
-jc
-XQ
-XQ
-dZ
-ma
-dF
-BZ
-Zl
-WF
-Gs
-WF
-Ch
-Zl
-cD
-Zl
-pL
-dF
-Gs
-Gs
-Gs
-dF
-Lo
-UU
-dF
-nF
-mZ
-PN
-Lw
-Lw
-dF
-Gs
-Il
-bR
-SR
-RL
+YQ
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
+bH
+ZU
+eh
 ZW
-zB
-Lx
-Ga
-ec
-qR
-WG
-WG
-pb
-DZ
-Rj
-ec
+ZU
+Vb
+aI
+eY
+bD
+Yf
+Yf
+qy
+lX
+WS
+eY
 gx
 ZU
 ZU
@@ -13096,7 +11214,7 @@ Lx
 ec
 ZU
 ZU
-gx
+ZU
 da
 DK
 xI
@@ -13109,116 +11227,116 @@ pX
 oI
 oU
 xI
-SI
-SI
+eY
+aG
+eY
 WI
 WI
 WI
 WI
 WI
 WI
-Uu
-Uu
-UE
-UE
+WI
+XO
+XO
 TQ
 WD
 XW
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-uw
+WK
+Yw
+Yw
+ZK
+sD
+LL
+Yw
+ZK
+sD
+LL
+Yw
+WK
+sD
+LL
+Yw
+ZK
+sD
+LL
+Yw
+ZK
+sD
+LL
+WK
+UE
+Uu
 qH
 Ne
 Yf
 YQ
 "}
 (20,1,1) = {"
-cW
-BY
-wT
-Od
-JR
-Od
-dg
-FR
-qk
-wf
-pc
-MA
-TC
-Wg
-Ss
-ul
-Fk
-NW
-XD
-NW
-NW
-fs
-UZ
-Zl
-BZ
-Zl
-WF
-Gs
-WF
-WX
-Zl
-Gf
-Mv
-ns
-dF
-dF
-dF
-dF
-dF
-Zl
-BZ
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-Gs
-Il
-bJ
-XP
-zB
+YQ
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
+Vb
+TW
+ZU
 ZW
-RL
+eh
 ZU
 Di
 XF
-pH
-SO
-pb
-RG
-Rj
-ec
+bh
+re
+qy
+aG
+WS
+eY
 ZU
 ZU
 ZU
@@ -13265,20 +11383,20 @@ qp
 oI
 oK
 xI
-SI
-SI
+XO
+XO
 XO
 WI
 WI
 WI
 WI
 WI
-Uu
-fq
+WI
+AW
+XO
+XO
+TQ
 UE
-UE
-Aq
-Ml
 gI
 UE
 WD
@@ -13289,9 +11407,9 @@ uw
 uw
 uw
 uw
-dW
 uw
 uw
+sb
 dW
 HE
 uw
@@ -13301,79 +11419,79 @@ uw
 uw
 uw
 HB
-uw
-uw
-uw
-uw
+WD
+UE
+UM
+Uu
 XH
 Ne
 Yf
 YQ
 "}
 (21,1,1) = {"
-cW
-HC
-yd
-RM
-cL
-RM
-gK
-FR
-pc
-pc
-Bt
-pc
-pc
-MA
-Xy
-pc
-Wy
-Wy
-ch
-Af
-us
-Wy
-FR
-Zl
-BZ
-Zl
-WF
-Gs
-WF
-xS
-Zl
-IY
-jk
-BZ
-dF
-EX
-jd
-ze
-dF
-Zl
-BZ
-dF
-Gs
-Gs
-Gs
-Gs
-Gs
-Gs
-Gs
-Il
-PD
-Ho
+YQ
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
+Di
+eb
 ei
 ZW
-zB
+ZU
 Xu
 Jg
 DK
-DZ
-dh
-Mg
+lX
+pq
+lG
 fT
-dD
+XH
 ZU
 ez
 ZU
@@ -13412,7 +11530,7 @@ ZU
 gz
 XF
 xI
-iJ
+oZ
 oI
 wW
 oI
@@ -13429,12 +11547,12 @@ WI
 WI
 WI
 WI
+WI
+XO
+XO
+XO
+TQ
 Uu
-UE
-UE
-UE
-Tm
-Ml
 Vk
 XW
 bU
@@ -13457,79 +11575,79 @@ uw
 uw
 uw
 uw
-uw
-uw
-uw
-uw
+WD
+WD
+UE
+Uu
 XH
 uy
 Yf
 YQ
 "}
 (22,1,1) = {"
-cW
-TZ
-GN
-YB
-cF
-YB
-kn
-FR
-qA
-wf
-Im
-MA
-VG
-VG
-Rw
-uO
-Qn
-NW
-XD
-yv
-NW
-XL
-UZ
-Zl
-BZ
-dL
-WF
-Gs
-WF
-Gj
-cD
-Cl
-Zl
-ds
-dF
-Ij
-jd
-jd
-Ea
-He
-BZ
-dF
-Ae
-Ae
-Ae
-Gs
-Gs
-Ae
-Ae
-Qo
-ce
-SR
-zB
+YQ
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+re
+re
+re
+re
+re
+Yf
+Yf
+re
+re
+qy
+do
+ZU
+ZU
 ZW
-zB
+ZU
 Xu
 Jg
 eb
-hn
-xa
-dD
-xa
-xa
+bH
+qz
+XH
+qz
+qz
 ez
 ZU
 DZ
@@ -13579,34 +11697,34 @@ xI
 xI
 Za
 SI
-XO
+Za
 XO
 WI
-AW
+WI
 WI
 XO
-UE
-UE
-UE
-UE
+XO
+XO
+XO
+XO
 LP
-VT
-VT
-VT
-VT
+UE
+UE
+UE
+WD
 WD
 uw
 vi
 WD
 WD
-AB
-AB
+WD
+UE
 AB
 Nr
 jE
 Zm
 bq
-Ml
+BY
 UE
 UE
 UE
@@ -13614,8 +11732,8 @@ WD
 uw
 uw
 Zm
-VT
-Ml
+WD
+UE
 VU
 VU
 uc
@@ -13623,65 +11741,65 @@ bD
 YQ
 "}
 (23,1,1) = {"
-cW
-OI
-Eh
-IP
-DU
-DU
-oM
-Ss
-KP
-KP
-iS
-KP
-KP
-KP
-DS
-Ss
-KP
-jc
-jc
-vn
-vn
-vn
-gQ
-dF
-BZ
-Zl
-WF
-Gs
-WF
-ws
-He
-Zl
-ZZ
-Zl
-dF
-dF
-dF
-dF
-dF
-Zl
-BZ
-dF
+YQ
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
+PD
+pk
 cJ
 bA
 Nd
-hM
-Qo
-cd
-Tu
-XP
-ot
-Ho
-zB
+bh
+qy
+bX
+pq
+TW
+da
+eb
+ZU
 ZW
-zB
+ZU
 Xu
 Jg
 XF
-dD
+XH
 fi
 gp
 Sn
@@ -13718,11 +11836,11 @@ ZU
 ZU
 lj
 ZU
-gx
+ZU
 EB
 EB
 ez
-SF
+ZU
 XO
 XO
 XO
@@ -13735,43 +11853,43 @@ WI
 WI
 XO
 SI
+Za
 XO
 XO
 XO
 XO
 XO
 XO
-UE
-Uu
-UE
-AB
+WI
+XO
+lW
 Yq
 VT
-VT
-VT
-VT
+Nr
+UE
+UE
 Zm
 uw
 vi
 Zm
 Zm
-Ml
-Ml
+WD
+UE
 AB
 mb
 Nr
-JA
-JA
+TM
+TM
 JA
 fN
-Ml
-Ml
-VT
+mi
+UE
+Zm
 uw
 uw
-VT
-Ml
-XH
+Zm
+UE
+aG
 WS
 WS
 Ww
@@ -13780,60 +11898,60 @@ YQ
 "}
 (24,1,1) = {"
 YQ
-YQ
-YQ
-dF
-dF
-dF
-dF
-OP
-OP
-xs
-tF
-xs
-OP
-QD
-OP
-dF
-dF
-tF
-lv
-dF
-dF
-rg
-HL
-dF
-mg
-Zl
-WF
-Gs
-WF
-wh
-TD
-Pg
-ZZ
-ve
-dF
-Gs
-Gs
-Ae
-dF
-Zl
-BZ
-dF
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+re
+re
+qy
+ce
+PD
 cK
 bM
 Fu
-bS
-bI
-XP
+qz
+lX
+TW
 qT
-cP
-Sg
-SR
-RL
+cW
+dp
+ZU
+eh
 ZW
-zB
+ZU
 ZU
 dp
 do
@@ -13877,11 +11995,11 @@ Bw
 ZU
 ZU
 cY
-gx
-SF
+ZU
+ZU
 XO
 Za
-XO
+Za
 Za
 Za
 Dn
@@ -13897,10 +12015,10 @@ XO
 XO
 XO
 XO
-Uu
-UE
-UE
-UE
+WI
+XO
+XO
+XO
 TT
 EQ
 XT
@@ -13912,8 +12030,8 @@ HI
 ZE
 ZE
 KJ
-Xa
-Xa
+TT
+ZE
 Vu
 DL
 EO
@@ -13921,13 +12039,13 @@ EO
 rp
 Vu
 vR
-vr
-vr
+TT
+ZE
 Hl
 Hl
-vr
-vr
-vr
+ZE
+TT
+TT
 PL
 PL
 HV
@@ -13941,55 +12059,55 @@ Yf
 Yf
 Yf
 Yf
-dF
-Wr
-dF
-dF
-Zl
-Th
-Th
-dF
-dF
-dF
-Zl
-gM
-If
-Zl
-dF
-dF
-dF
-dF
-BZ
-Zl
-WF
-Gs
-WF
-dF
-dF
-dF
-dF
-dF
-dF
-Gs
-Qo
-bP
-dF
-Zl
-BZ
-dF
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qy
+VU
+VU
+qz
+ce
+Sg
 yh
 SR
 Sg
-Io
-eB
+aG
+eY
 qT
 IC
 dd
-SR
-SR
-zB
+ZU
+ZU
+ZU
 ZW
-zB
+ZU
 eh
 ZU
 dp
@@ -14034,12 +12152,12 @@ fz
 ZU
 ZU
 ja
-SF
+ZU
 XO
 XO
 XO
 oO
-XO
+Za
 Dn
 SI
 Za
@@ -14054,37 +12172,37 @@ Za
 XO
 XO
 XO
-UE
-UE
-UE
-UE
-SB
-SB
+XO
+XO
+XO
+XO
+of
+of
 Ey
-UE
-UE
-uw
-vi
-Zm
-Zm
-WD
-UE
-UE
-UE
-UE
-UE
-UE
-UE
-UE
-UE
-UE
-Zm
-uw
-uw
-Zm
+XO
+XO
+SI
+Dn
+Za
+Za
+Im
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+Za
+SI
+SI
+Za
 Ey
-UE
-UE
+XO
+XO
 qz
 bD
 Yf
@@ -14097,42 +12215,42 @@ Yf
 Yf
 Yf
 Yf
-dF
-Jn
-pN
-dF
-Zl
-Zl
-dL
-LF
-Zl
-Zl
-Zl
-Zl
-dL
-Zl
-Zl
-EU
-pS
-Zl
-Wi
-HT
-WF
-Gs
-Gs
-Gs
-Gs
-Gs
-Gs
-Gs
-Ae
-Qo
-bI
-Rh
-dF
-Zl
-yV
-dF
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+re
+qy
+lX
+WS
+WS
+TW
+Sg
+SR
 cb
 SR
 SR
@@ -14140,12 +12258,12 @@ SR
 cj
 IC
 cg
-ct
-SR
-SR
-zB
+df
+ZU
+ZU
+ZU
 ZW
-zB
+ZU
 ZU
 gx
 jb
@@ -14158,14 +12276,14 @@ ZU
 ZU
 ZU
 ZU
-SF
+ZU
 ZU
 ZU
 ZU
 ZU
 gx
 ZU
-SF
+ZU
 ZU
 ZU
 ZU
@@ -14187,7 +12305,7 @@ ZU
 dE
 Sn
 xa
-dE
+xa
 ez
 ZU
 ht
@@ -14210,37 +12328,37 @@ CV
 Za
 Za
 Za
-Zm
-Zm
-Zm
-UE
-UE
-UE
-UE
-Zm
-Zm
-uw
-vi
-Zm
-Zm
-Zm
-Zm
-Zm
-Zm
-Zm
-Zm
-Zm
-Zm
-Zm
-Zm
-Zm
-Zm
-uw
-uw
-Zm
-Zm
-Zm
-UE
+Za
+Za
+Za
+XO
+XO
+XO
+XO
+Za
+Za
+SI
+Dn
+Za
+Za
+Za
+Za
+Za
+Za
+Za
+Za
+Za
+Za
+Za
+Za
+Za
+Za
+SI
+SI
+Za
+Za
+Za
+XO
 bF
 Yf
 Yf
@@ -14253,42 +12371,42 @@ Yf
 Yf
 Yf
 Yf
-dF
-oT
-Jn
-dF
-Bo
-Zl
-Zl
-BZ
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-pL
-Zl
-WF
-Gs
-Gs
-Gs
-Gs
-Gs
-Ae
-Qo
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+re
+qy
 PD
 Ho
-bJ
-eB
-dF
-Zl
-YP
-dF
+Vb
+eY
+XH
+SR
+SR
+SR
 yh
 SR
 SR
@@ -14296,12 +12414,12 @@ im
 bC
 QK
 SR
-yh
-SR
-im
-zB
+dg
+ZU
+gx
+ZU
 ZW
-Ws
+ez
 ZU
 ZU
 SF
@@ -14314,14 +12432,14 @@ ZU
 ZU
 ZU
 gx
-SF
+ZU
 ZU
 ZU
 ez
 ZU
 ZU
 ZU
-SF
+ZU
 ZU
 ez
 gx
@@ -14366,37 +12484,37 @@ pY
 Al
 vy
 vy
-Mw
-Nu
-Nu
-Nu
-Nu
-Nu
+Al
+vy
+vy
+vy
+vy
+vy
 Nn
-Nu
-Nu
-Mw
-Qe
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-dW
-uw
-uw
-uw
-uw
-uw
-uw
-uw
-dW
-uw
-uw
-dW
-UE
+vy
+vy
+Al
+qf
+SI
+SI
+SI
+SI
+SI
+SI
+SI
+Ln
+SI
+SI
+SI
+SI
+SI
+SI
+SI
+Ln
+SI
+SI
+Ln
+XO
 bD
 Yf
 Yf
@@ -14409,32 +12527,32 @@ Yf
 Yf
 Yf
 Yf
-dF
-Ek
-uu
-dF
-Zl
-Zl
-Zl
-BZ
-Zl
-He
-Zl
-Zl
-Zl
-lR
-lR
-Zl
-Zl
-Zl
-Cm
-Zl
-WF
-Gs
-Gs
-Gs
-Gs
-Qo
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qy
 PD
 bA
 VI
@@ -14442,9 +12560,9 @@ Ho
 yh
 SR
 SR
-Zl
-uT
-Zl
+SR
+im
+SR
 yh
 wo
 SR
@@ -14452,10 +12570,10 @@ SR
 SR
 bl
 we
-yh
-SR
-SR
-zB
+dg
+ZU
+ZU
+ZU
 dQ
 eF
 ZU
@@ -14470,7 +12588,7 @@ ZU
 ZU
 ZU
 ZU
-SF
+ZU
 gx
 ZU
 ZU
@@ -14508,7 +12626,7 @@ XO
 XO
 XO
 XO
-XO
+qa
 XO
 XO
 XO
@@ -14522,17 +12640,17 @@ SI
 SI
 SI
 SI
-uw
-uw
-uw
-uw
-uw
-uw
-vi
-uw
-uw
-uw
-uw
+SI
+SI
+SI
+SI
+SI
+SI
+Dn
+SI
+SI
+SI
+SI
 SI
 SI
 SI
@@ -14549,10 +12667,10 @@ SI
 SI
 SI
 SI
-uw
-uw
-uw
-UE
+SI
+SI
+SI
+XO
 bD
 Yf
 Yf
@@ -14565,31 +12683,31 @@ Yf
 Yf
 Yf
 Yf
-dF
-Gx
-YV
-dF
-Zl
-Zl
-Zl
-Wi
-Tz
-Tz
-Tz
-Tz
-du
-Hw
-Hw
-sG
-Tz
-Tz
-UU
-Zl
-WF
-Gs
-Gs
-Gs
-Il
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
 PD
 Fu
 ot
@@ -14598,9 +12716,9 @@ bl
 yh
 SR
 im
-Zl
-Cm
-Zl
+SR
+bl
+ok
 cO
 VI
 Nd
@@ -14608,12 +12726,12 @@ SR
 SR
 SR
 SR
-yh
-im
-SR
-zB
+dg
+gx
+ZU
+ZU
 ZW
-zB
+ZU
 ZU
 ZU
 dx
@@ -14645,7 +12763,7 @@ ZU
 ZU
 ez
 ZU
-SF
+ZU
 ZU
 ZU
 ZU
@@ -14659,7 +12777,7 @@ ZU
 ZU
 YI
 cY
-SF
+ZU
 XO
 XO
 XO
@@ -14669,7 +12787,7 @@ WI
 WI
 WI
 XO
-np
+XO
 XO
 XO
 Za
@@ -14683,12 +12801,12 @@ XO
 XO
 XO
 XO
-uw
-vi
-Zm
-Zm
-Zm
-Zm
+SI
+Dn
+Za
+Za
+Za
+Za
 XO
 XO
 XO
@@ -14721,31 +12839,31 @@ Yf
 Yf
 Yf
 Yf
-dF
-ip
-hd
-Ts
-Tz
-Tz
-Tz
-UU
-Zl
-di
-Pg
-Zl
-KL
-dF
-dF
-yz
-Zl
-Zl
-BZ
-Zl
-WF
-Gs
-Gs
-Gs
-Il
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
 ce
 ot
 by
@@ -14754,9 +12872,9 @@ SR
 yh
 SR
 wo
-mq
-BZ
-Zl
+GH
+SR
+SR
 yh
 Lm
 by
@@ -14764,12 +12882,12 @@ SR
 SR
 SR
 SR
-bI
-bL
-SR
-zB
+DZ
+Mg
+ZU
+ZU
 ZW
-zB
+ZU
 ZU
 Xu
 Jg
@@ -14801,21 +12919,21 @@ ZU
 ZU
 kE
 ZU
-SF
-ZU
-ZU
-ZU
-gx
 ZU
 ZU
 ZU
 ZU
-SF
-gx
+ZU
+ZU
+ZU
+ZU
+ZU
+ZU
+ZU
 ez
 ZU
 ZU
-SF
+ZU
 ZU
 XO
 AW
@@ -14877,31 +12995,31 @@ Yf
 Yf
 Yf
 Yf
-dF
-dF
-dF
-WF
-Zl
-Zl
-Zl
-BZ
-dF
-dF
-dF
-xW
-Zl
-Rt
-fc
-Zl
-Zl
-Zl
-BZ
-He
-WF
-Gs
-Gs
-Gs
-Il
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
 ce
 ce
 SR
@@ -14910,22 +13028,22 @@ SR
 yh
 PD
 Fu
-Zl
-Cm
-FB
-vv
+SR
+bl
+SR
+yh
 SR
 bl
 im
 SR
 bl
 Io
-Rh
-Rh
-bL
-zB
+Rj
+Rj
+Mg
+ZU
 ZW
-zB
+ZU
 Xu
 VB
 Jg
@@ -14966,12 +13084,12 @@ ZU
 Qd
 ZU
 ZU
-SF
 ZU
 ZU
 ZU
-gx
-SF
+ZU
+ZU
+ZU
 ZU
 WI
 WI
@@ -15036,28 +13154,28 @@ Yf
 Yf
 Yf
 Yf
-WF
-dL
-Zl
-Zl
-BZ
-dF
-Gs
-dF
-cX
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-BZ
-FB
-WF
-Gs
-Gs
-Gs
-Qo
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qy
 ce
 Sg
 SR
@@ -15066,9 +13184,9 @@ SR
 kl
 bM
 VI
-Zl
-BZ
-Zl
+Nd
+SR
+wo
 yh
 yh
 yh
@@ -15076,10 +13194,10 @@ yh
 yh
 cN
 cP
-bJ
-Rh
-eB
-zB
+Lx
+Rj
+ec
+ZU
 ZW
 eS
 dy
@@ -15141,7 +13259,7 @@ sk
 sx
 Pq
 Pq
-Kd
+XU
 DY
 DY
 gB
@@ -15192,28 +13310,28 @@ Yf
 Yf
 Yf
 Yf
-WF
-Zl
-Zl
-Zl
-BZ
-dF
-Gs
-dF
-UR
-Zl
-dL
-Zl
-Zl
-Zl
-Zl
-BZ
-Zl
-WF
-Gs
-Gs
-Il
-bS
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
+qz
 Sg
 SR
 SR
@@ -15222,9 +13340,9 @@ SR
 cs
 bN
 Lm
-Zl
-BZ
-Zl
+VI
+pk
+VI
 Ho
 SR
 SR
@@ -15232,12 +13350,12 @@ SR
 qT
 bT
 KU
-Zt
-Ry
-im
-zB
+EB
+dD
+gx
+ZU
 ZW
-zB
+ZU
 YI
 ft
 EB
@@ -15348,28 +13466,28 @@ Yf
 Yf
 Yf
 Yf
-WF
-Zl
-Zl
-Zl
-ns
-dF
-Gs
-dF
-dF
-Zl
-dF
-dF
-Zl
-Zl
-Gf
-BZ
-Zl
-WF
-Gs
-Gs
-Il
-bP
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
+VU
 qT
 rf
 SR
@@ -15378,22 +13496,22 @@ cj
 ct
 cn
 bN
-Zl
-BZ
-Zl
-rf
+Sg
+bN
+Sg
+SR
 SR
 im
 SR
 KU
 Zt
 qT
-cm
-SR
-SR
-zB
+de
+ZU
+ZU
+ZU
 ZW
-zB
+ZU
 ZU
 dE
 de
@@ -15445,7 +13563,7 @@ eb
 SD
 Gw
 qc
-tx
+DY
 qQ
 RZ
 DY
@@ -15502,30 +13620,30 @@ Yf
 Yf
 Yf
 Yf
-WF
-WF
-WF
-EP
-Zl
-Wc
-BF
-dF
-Gs
-Gs
-dF
-Zl
-dF
-dF
-Zl
-Zl
-Zl
-BZ
-Zl
-WF
-Gs
-Gs
-Il
-QZ
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
+nM
 KU
 rf
 SR
@@ -15534,9 +13652,9 @@ SR
 cs
 cn
 cn
-Zl
-BZ
-Zl
+bN
+cn
+qT
 rf
 SR
 SR
@@ -15544,12 +13662,12 @@ SR
 Zb
 KU
 IC
-IC
-Zt
-Zb
-zB
+Bw
+EB
+BQ
+ZU
 ZW
-Ab
+gx
 ZU
 YI
 de
@@ -15658,54 +13776,54 @@ Yf
 Yf
 Yf
 Yf
-WF
-Zl
-EU
-Zl
-Bf
-Bf
-BZ
-dF
-dF
-dF
-dF
-Bo
-Zl
-Zl
-Zl
-Zl
-dL
-BZ
-Zl
-WF
-Gs
-Gs
-Il
-cc
-XP
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
+qH
+TW
 SR
 SR
 SR
 cj
 cv
 IC
-ci
-Zl
-BZ
-Zl
-rf
-SR
-SR
-SR
-SR
-SR
-KU
+IC
 bT
+cn
 KU
 rf
-zB
+SR
+SR
+SR
+SR
+SR
+KU
+cY
+dE
+Sn
+ZU
 ZW
-zB
+ZU
 ZU
 fi
 de
@@ -15814,31 +13932,31 @@ Yf
 Yf
 Yf
 Yf
-WF
-Zl
-Zl
-dL
-Gf
-Zl
-BZ
-Zl
-Zl
-dF
-Zl
-Fj
-Tz
-Tz
-Tz
-Tz
-Tz
-UU
-Zl
-WF
-Gs
-Ae
-Qo
-cc
-bL
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+re
+qy
+qH
+lG
 bp
 SR
 bl
@@ -15846,9 +13964,9 @@ cj
 cw
 cm
 ci
-Zl
-BZ
-Zl
+Xw
+Xw
+rf
 SR
 Zb
 SR
@@ -15856,12 +13974,12 @@ SR
 PD
 Nd
 PD
-Nd
-PD
-Ho
-zB
+XF
+Di
+eb
+ZU
 ZW
-zB
+ZU
 YI
 fz
 cY
@@ -15906,7 +14024,7 @@ dp
 gS
 dD
 ZU
-gx
+ZU
 ZU
 dx
 xa
@@ -15970,41 +14088,41 @@ Yf
 Yf
 Yf
 Yf
-WF
-Xh
-Xh
-Zl
-Zl
-Zl
-HQ
-Xh
-Zl
-EP
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-BZ
-FB
-WF
-Il
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
 PD
 Nd
-bJ
-eB
+Vb
+eY
 SR
 SR
 bI
 XP
 cx
 QK
-dF
-Bo
-BZ
-Zl
+cn
+qT
+Zt
+qT
 rf
 PI
 PI
@@ -16012,12 +14130,12 @@ PI
 Lm
 VI
 Fu
-ot
-by
-SR
-zB
+da
+DK
+ZU
+ZU
 ZW
-zB
+ZU
 Xu
 xP
 xP
@@ -16126,27 +14244,27 @@ Yf
 Yf
 Yf
 Yf
-WF
-MT
-eD
-Zl
-Zl
-Zl
-nv
-MT
-PZ
-eC
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-He
-BZ
-Zl
-WF
-Il
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
 ce
 Lm
 Nd
@@ -16158,9 +14276,9 @@ bI
 Tu
 bL
 ci
-Zl
-BZ
-Zl
+cm
+KU
+bT
 SR
 SR
 SR
@@ -16168,12 +14286,12 @@ SR
 SR
 Sg
 Lm
-by
-SR
-SR
-zB
+DK
+ZU
+ZU
+ZU
 ZW
-zB
+ZU
 ZU
 RG
 fB
@@ -16282,27 +14400,27 @@ Yf
 Yf
 Yf
 Yf
-WF
-eD
-eD
-Zl
-He
-Zl
-IK
-eD
-PZ
-Zl
-Zl
-dL
-Zl
-Zl
-Zl
-Zl
-Zl
-BZ
-Zl
-WF
-Qo
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+re
+re
+re
+re
+re
+qy
 ce
 PD
 by
@@ -16314,9 +14432,9 @@ Rh
 XP
 QZ
 QK
-Zl
-BZ
-Zl
+QK
+SR
+SR
 SR
 im
 bl
@@ -16324,12 +14442,12 @@ SR
 SR
 SR
 im
-SR
-SR
-SR
-zB
+ZU
+ZU
+ZU
+ZU
 ZW
-Ws
+ez
 ZU
 RG
 fS
@@ -16361,7 +14479,7 @@ ZU
 ZU
 ZU
 ZU
-SF
+ZU
 ZU
 ZU
 ZU
@@ -16438,26 +14556,26 @@ Yf
 Yf
 Yf
 Yf
-WF
-BW
-BW
-Zl
-Zl
-Zl
-QQ
-BW
-Zl
-EP
-di
-Pg
-Zl
-Zl
-Zl
-Zl
-Zl
-BZ
-Zl
-WF
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
+lX
+pq
+TW
+bX
+lG
 PD
 by
 Sg
@@ -16470,9 +14588,7 @@ bR
 Io
 Rh
 XP
-WO
-BZ
-Zl
+im
 SR
 SR
 SR
@@ -16482,10 +14598,12 @@ SR
 SR
 SR
 SR
-SR
-zB
+ZU
+ZU
+ZU
+ZU
 rP
-zB
+ZU
 RG
 fB
 Rj
@@ -16517,8 +14635,8 @@ ZU
 gx
 ZU
 ZU
-SF
-gx
+ZU
+ZU
 ZU
 ZU
 ZU
@@ -16594,26 +14712,26 @@ Yf
 Yf
 Yf
 Yf
-WF
-Yh
-Zl
-Fj
-Tz
-Tz
-IZ
-dL
-FB
-WF
-WF
-WF
-WF
-WF
-Zl
-Zl
-dL
-BZ
-Zl
-WF
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
+bH
+qT
+Ir
+Zt
+XH
 ot
 Ho
 SR
@@ -16625,10 +14743,10 @@ cc
 Rh
 XP
 Ry
-Zl
-Zl
-BZ
-Zl
+SR
+SR
+SR
+SR
 bN
 SR
 SR
@@ -16636,12 +14754,12 @@ SR
 wo
 SR
 PD
-Nd
-SR
-SR
-zB
+XF
+ZU
+ZU
+ZU
 ZW
-zB
+ZU
 DZ
 Rj
 Rj
@@ -16750,41 +14868,41 @@ Yf
 Yf
 Yf
 Yf
-WF
-Zl
-Zl
-WB
-JF
-CX
-Zl
-Zl
-Zl
-WF
 Yf
 Yf
-Gs
-WF
-Bo
-Zl
-Zl
-BZ
-Zl
-Xz
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+re
+qy
+bH
+KU
+IC
+IC
+Zt
+Sg
 SR
 SR
 SR
 SR
 SR
-dF
 Io
 ca
 Ry
 bS
 SR
-WO
-Zl
-BZ
-Zl
+im
+SR
+SR
+qT
 cm
 SR
 SR
@@ -16792,12 +14910,12 @@ ok
 VI
 bA
 VI
-bM
-Nd
-SR
-zB
+Om
+XF
+ZU
+ZU
 ZW
-zB
+ZU
 Lx
 Ga
 Ga
@@ -16906,41 +15024,41 @@ Yf
 Yf
 Yf
 Yf
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
 Yf
 Yf
-Il
-WF
-LF
-Zl
-Zl
-BZ
-Zl
-Tx
-Zl
-WO
-Zl
-Zl
-Zl
-EU
-Zl
-Zl
-Zl
-Zl
-Zl
-LF
-Zl
-BZ
-WF
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+qs
+lX
+pq
+WS
+TW
+KU
+cg
+bT
+SR
+im
+SR
+bP
+SR
+SR
+SR
+bJ
+XP
+SR
+SR
+SR
+SR
+cj
+IC
 bT
 SR
 SR
@@ -16948,12 +15066,12 @@ ok
 VI
 bM
 by
-PD
-by
-bS
-zB
+Di
+DK
+xa
+ZU
 ZW
-zB
+ZU
 gx
 ZU
 ZU
@@ -17074,29 +15192,29 @@ Yf
 Yf
 Yf
 Yf
-Il
-WF
-NU
-Tz
-Tz
-HP
-Tz
-mV
-Tz
-Tz
-Tz
-Tz
-Tz
-Tz
-Tz
-Tz
-Tz
-Tz
-Tz
-HP
-Tz
-jX
-WF
+qs
+bH
+lX
+eY
+SR
+SR
+SR
+SR
+SR
+SR
+Io
+eB
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+PD
+Nd
+QK
 SR
 im
 SR
@@ -17104,12 +15222,12 @@ SR
 Lm
 Nd
 PD
-by
-bP
-bP
-zB
+DK
+dw
+dw
+ZU
 ZW
-Ws
+ez
 ZU
 ZU
 ZU
@@ -17135,9 +15253,9 @@ Lx
 Mg
 dE
 Sn
-SF
-SF
-SF
+ZU
+ZU
+ZU
 dE
 Bw
 Bw
@@ -17231,28 +15349,28 @@ Yf
 Yf
 Yf
 qs
-WF
-Zl
-Zl
-dL
-Zl
-Zl
-pr
-Zl
-Zl
-Zl
-Zl
-Zl
-dL
-Zl
-WO
-jC
-Zl
-Zl
-DH
-WF
-WF
-WF
+bH
+bH
+SR
+bp
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+bl
+SR
+im
+we
+SR
+SR
+ok
+VI
+VI
+Ho
 SR
 SR
 SR
@@ -17265,7 +15383,7 @@ Rj
 dy
 ej
 ZW
-zB
+ZU
 fi
 ft
 EB
@@ -17387,13 +15505,13 @@ Yf
 Yf
 re
 qy
-WF
-Xz
-ev
-xZ
-Xz
-WF
-WF
+bH
+XH
+SR
+SR
+SR
+PD
+Nd
 aX
 bN
 bN
@@ -17419,9 +15537,9 @@ Tu
 dh
 Ga
 dD
-zB
+ZU
 ZW
-zB
+ZU
 dE
 Bw
 fz
@@ -17547,7 +15665,7 @@ XH
 SR
 SR
 SR
-SR
+PD
 VI
 VI
 Nd
@@ -17575,9 +15693,9 @@ Tu
 dh
 XJ
 ZU
-zB
+ZU
 ZW
-zB
+ZU
 fi
 Bw
 ft
@@ -17731,9 +15849,9 @@ Zt
 dj
 dx
 ZU
-zB
+ZU
 ZW
-tp
+BQ
 dE
 cY
 dE
@@ -17887,9 +16005,9 @@ QK
 Xu
 Jg
 eb
-zB
+ZU
 ZW
-zB
+ZU
 ZU
 Xu
 xP
@@ -18043,9 +16161,9 @@ Ir
 EB
 do
 dj
-zB
+ZU
 ZW
-zB
+ZU
 ZU
 Xu
 xP
@@ -18199,9 +16317,9 @@ IC
 de
 do
 ZU
-zB
+ZU
 ZW
-zB
+ZU
 DZ
 Mg
 fT
@@ -18355,9 +16473,9 @@ cg
 ME
 xb
 Yp
-Td
+ym
 gG
-Td
+ym
 EM
 fC
 dC
@@ -18511,9 +16629,9 @@ Tu
 fx
 Qw
 MM
-Td
+ym
 gG
-Td
+ym
 YS
 KK
 Iy
@@ -18539,9 +16657,9 @@ dC
 dC
 hb
 Yp
-ij
-ij
-ij
+ym
+ym
+ym
 YS
 gT
 ZB
@@ -18667,9 +16785,9 @@ qT
 Uk
 YK
 ym
-Td
+ym
 gG
-Td
+ym
 ym
 fF
 UL
@@ -18823,9 +16941,9 @@ IC
 Uk
 dz
 ym
-Td
+ym
 gG
-Td
+ym
 ym
 ym
 Wj
@@ -18972,7 +17090,7 @@ ci
 rf
 SR
 SR
-im
+SR
 SR
 cn
 QK
@@ -19157,7 +17275,7 @@ ym
 ym
 ym
 ym
-Be
+ym
 ym
 gX
 ym
@@ -19172,7 +17290,7 @@ li
 lx
 li
 li
-VC
+li
 li
 li
 lx
@@ -19193,7 +17311,7 @@ li
 WY
 rB
 se
-ss
+Ai
 sg
 uR
 RK
@@ -19301,7 +17419,7 @@ Td
 Qs
 Td
 Td
-Qs
+Td
 fE
 Td
 Td
@@ -19334,7 +17452,7 @@ my
 my
 my
 my
-JW
+my
 my
 my
 my
@@ -19628,7 +17746,7 @@ Td
 Td
 Td
 Td
-Qs
+Td
 Td
 Td
 Td
@@ -19636,7 +17754,7 @@ Td
 xE
 my
 my
-JW
+my
 my
 my
 my
@@ -19751,7 +17869,7 @@ pk
 Ho
 SR
 SR
-im
+SR
 SR
 SR
 wo
@@ -19769,7 +17887,7 @@ Be
 ym
 ym
 ym
-Be
+ym
 ym
 ym
 ym
@@ -19801,7 +17919,7 @@ li
 li
 li
 li
-VC
+li
 li
 li
 li
@@ -20729,7 +18847,7 @@ Xj
 Je
 ym
 ym
-Be
+ym
 ym
 Wj
 fh
@@ -21043,7 +19161,7 @@ Uk
 ym
 cl
 ym
-Be
+ym
 dT
 Wj
 SA
@@ -21669,7 +19787,7 @@ YW
 hb
 Yp
 ym
-Be
+ym
 ym
 ym
 Ps
@@ -22108,7 +20226,7 @@ Ps
 ym
 ym
 ym
-Be
+ym
 ym
 ym
 ym
@@ -22135,7 +20253,7 @@ YW
 YW
 hb
 JX
-Be
+ym
 ym
 ym
 ym
@@ -22424,7 +20542,7 @@ ST
 ST
 ym
 ym
-Be
+ym
 ym
 ym
 ym
@@ -22904,7 +21022,7 @@ ym
 ym
 gT
 gq
-Be
+ym
 ym
 ym
 fF
@@ -23052,7 +21170,7 @@ ZB
 gq
 ym
 ym
-Be
+ym
 ym
 xb
 MM
@@ -23079,7 +21197,7 @@ JX
 cl
 ym
 ym
-Be
+ym
 ym
 ym
 ym
@@ -23222,7 +21340,7 @@ fx
 ym
 cl
 ym
-Be
+ym
 ym
 ym
 QL
@@ -23240,7 +21358,7 @@ ym
 ym
 ym
 ym
-Be
+ym
 ym
 ym
 ym
@@ -23528,7 +21646,7 @@ ym
 ym
 ym
 ym
-Be
+ym
 ym
 ym
 ym
@@ -23542,7 +21660,7 @@ TH
 ym
 ym
 ym
-Be
+ym
 ym
 ZP
 Ps
@@ -23844,7 +21962,7 @@ Je
 dT
 ym
 ym
-Be
+ym
 ym
 ym
 ym
@@ -24007,7 +22125,7 @@ ym
 Qw
 Yp
 zQ
-Be
+ym
 ym
 YK
 KK
@@ -24174,7 +22292,7 @@ ZB
 fx
 Ps
 ym
-Be
+ym
 ym
 fF
 fW
@@ -24633,7 +22751,7 @@ fp
 TJ
 TV
 YT
-eK
+YT
 JD
 Bn
 xN
@@ -25226,7 +23344,7 @@ YT
 fo
 YT
 YT
-eK
+YT
 YT
 Tr
 dq
@@ -25999,7 +24117,7 @@ SR
 SR
 wo
 YT
-eK
+YT
 Bz
 YT
 YT
@@ -26179,7 +24297,7 @@ fy
 lc
 YT
 YT
-eK
+YT
 YT
 YT
 YT
@@ -26305,7 +24423,7 @@ Xw
 Xw
 rf
 SR
-im
+SR
 SR
 ok
 VI
@@ -26539,10 +24657,10 @@ qG
 qm
 Ee
 tH
-nI
-nI
-nI
-nI
+WI
+WI
+WI
+WI
 GY
 Gu
 bh
@@ -26655,39 +24773,39 @@ XO
 XO
 XO
 km
-nI
-nI
-nI
-oP
-oP
-oP
-oP
-nI
-nI
-nI
-oP
-oP
-wa
-oP
-oP
-oP
-nI
-nI
-nI
-oP
-GO
-oP
-oP
-oP
-nI
-nI
-nI
-nI
-nI
-Cq
-nI
-nI
-oP
+WI
+WI
+WI
+XO
+XO
+XO
+XO
+WI
+WI
+WI
+XO
+XO
+Za
+XO
+XO
+XO
+WI
+WI
+WI
+XO
+km
+XO
+XO
+XO
+WI
+WI
+WI
+WI
+WI
+of
+WI
+WI
+XO
 tH
 Ck
 nH
@@ -26695,10 +24813,10 @@ hh
 vM
 fu
 tH
-nI
-nI
-nI
-nI
+WI
+WI
+WI
+WI
 GZ
 GY
 Gu
@@ -26782,7 +24900,7 @@ YT
 AU
 Bz
 AU
-eK
+YT
 YT
 fR
 gw
@@ -26811,39 +24929,39 @@ XO
 Za
 XO
 XO
-nI
-nI
-oP
-wa
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-nI
-nI
-nI
-nI
-nI
-oP
-wa
-oP
-oP
-nI
+WI
+WI
+XO
+Za
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+WI
+WI
+WI
+WI
+WI
+XO
+Za
+XO
+XO
+WI
 OD
-nI
-nI
-nI
-nI
-oP
-oP
-oP
+WI
+WI
+WI
+WI
+XO
+XO
+XO
 tH
 CC
 jU
@@ -26851,8 +24969,8 @@ UH
 po
 rn
 tH
-nI
-nI
+WI
+WI
 xM
 Gu
 bh
@@ -26967,39 +25085,39 @@ XO
 XO
 XO
 XO
-Tl
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-wa
-oP
-oP
-oP
-nI
-nI
-nI
-oP
-oP
-oP
-oP
-oP
+OO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+Za
+XO
+XO
+XO
+WI
+WI
+WI
+XO
+XO
+XO
+XO
+XO
 tH
 Mh
 kK
@@ -27007,8 +25125,8 @@ rh
 Mh
 tH
 tH
-nI
-nI
+WI
+WI
 GZ
 GY
 BL
@@ -27123,48 +25241,48 @@ XO
 Za
 Za
 Za
-wa
-wa
-uq
-wa
-wa
-wa
-wa
-oP
-oP
-wa
-wa
-uq
-wa
-wa
-wa
-wa
-wa
-wa
-wa
-wa
+Za
+Za
+oO
+Za
+Za
+Za
+Za
+XO
+XO
+Za
+Za
+oO
+Za
+Za
+Za
+Za
+Za
+Za
+Za
+Za
 Uq
-IT
-IT
-IT
-oP
-oP
-oP
-oP
-sT
-IT
-IT
-IT
-IT
-IT
-IT
-io
-IT
-oP
-oP
-oP
-nI
-nI
+SI
+SI
+SI
+XO
+XO
+XO
+XO
+np
+SI
+SI
+SI
+SI
+SI
+SI
+FV
+SI
+XO
+XO
+XO
+WI
+WI
 AK
 KV
 xM
@@ -27279,49 +25397,49 @@ vy
 vy
 vy
 vy
-Mq
-Mq
-Mq
-Mq
-Mq
-Mq
-Mq
-Mq
-Mq
-Mq
+vy
+vy
+vy
+vy
+vy
+vy
+vy
+vy
+vy
+vy
 Ns
-Mq
-Mq
-Mq
-Mq
-Mq
-Mq
-Mq
-Mq
+vy
+vy
+vy
+vy
+vy
+vy
+vy
+vy
 Yv
 Ow
-Mq
-Mq
-Mq
-Mq
-Mq
-Mq
-Mq
+vy
+vy
+vy
+vy
+vy
+vy
+vy
 Ns
-Mq
-Mq
-Mq
-Mq
-Mq
-Mq
+vy
+vy
+vy
+vy
+vy
+vy
 qf
-IT
-wa
-wa
-wa
-oP
-oP
-nI
+SI
+Za
+Za
+Za
+XO
+XO
+WI
 BL
 xM
 bD
@@ -27391,7 +25509,7 @@ SR
 SR
 SR
 SR
-im
+SR
 SR
 SR
 SR
@@ -27405,7 +25523,7 @@ AU
 AU
 dI
 eI
-XA
+AU
 AU
 AU
 YT
@@ -27435,11 +25553,11 @@ YT
 XO
 np
 Za
-wa
-wa
-uq
-wa
-wa
+Za
+Za
+oO
+Za
+Za
 lA
 lA
 wN
@@ -27471,12 +25589,12 @@ wN
 wN
 wN
 lA
-oP
-oP
-oP
-wa
-oP
-oP
+XO
+XO
+XO
+Za
+XO
+XO
 AK
 KV
 xM
@@ -27591,50 +25709,50 @@ fo
 WI
 XO
 XO
-oP
-oP
-oP
-wa
-CP
+XO
+XO
+XO
+Za
+lW
 Jm
-PS
-OA
+jO
+Hh
 mh
-yq
-nW
-wa
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-at
-IT
-oP
-oP
-oP
-oP
-oP
-nI
-nI
-nI
-OA
+hj
+mI
+Za
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+Dn
+SI
+XO
+XO
+XO
+XO
+XO
+WI
+WI
+WI
+Hh
 mh
 mh
 mh
-PS
-oP
+jO
+XO
 iK
-oP
-oP
-fI
-oP
-wa
-oP
-nI
-nI
+XO
+XO
+Lv
+XO
+Za
+XO
+WI
+WI
 BL
 xM
 Yf
@@ -27747,17 +25865,17 @@ Tc
 WI
 XO
 XO
-oP
-oP
-oP
-wa
+XO
+XO
+XO
+Za
 pR
 GI
 Vc
-qC
-wv
+VG
+vf
 mh
-nW
+mI
 oP
 wa
 CP
@@ -27776,20 +25894,20 @@ wa
 CP
 yq
 yq
-yB
-yB
-yB
-lL
-Cq
-oP
+QO
+QO
+QO
+wm
+of
+XO
 iK
-oP
-nI
-fI
-oP
-wa
-oP
-oP
+XO
+WI
+Lv
+XO
+Za
+XO
+XO
 AK
 NT
 xM
@@ -27903,17 +26021,17 @@ gt
 fZ
 XO
 WI
-oP
-fI
-wa
-wa
-nI
+XO
+Lv
+Za
+Za
+WI
 Wu
 oP
-WQ
-GG
-wv
-PS
+Zx
+je
+vf
+jO
 oP
 wa
 oP
@@ -27932,19 +26050,19 @@ wa
 oP
 nI
 nI
-fI
-fI
-fI
-fI
-WQ
-oP
+Lv
+Lv
+Lv
+Lv
+Zx
+XO
 iK
-oP
-oP
-fI
-oP
-oP
-oP
+XO
+XO
+Lv
+XO
+XO
+XO
 AK
 zy
 NT
@@ -28059,17 +26177,17 @@ oW
 RN
 WI
 WI
-nI
-oP
-oP
-wa
-oP
+WI
+XO
+XO
+Za
+XO
 Wu
 CP
-wv
-PS
-GG
-lL
+vf
+jO
+je
+wm
 oP
 wa
 ka
@@ -28088,20 +26206,20 @@ ka
 ka
 wa
 nI
-fI
-fI
-fI
-OA
-wv
-PS
+Lv
+Lv
+Lv
+Hh
+vf
+jO
 En
-wa
-oP
-oP
-oP
-wa
-oP
-nI
+Za
+XO
+XO
+XO
+Za
+XO
+WI
 GZ
 KV
 bF
@@ -28215,17 +26333,17 @@ Yf
 qs
 WI
 WI
-nI
-oP
-oP
-wa
-oP
+WI
+XO
+XO
+Za
+XO
 Wu
 oP
-GG
-wv
-PS
-WQ
+je
+vf
+jO
+Zx
 nI
 oP
 ka
@@ -28244,19 +26362,19 @@ nb
 ka
 wa
 wa
-fI
-fI
-OA
-wv
-wv
-yB
+Lv
+Lv
+Hh
+vf
+vf
+QO
 WA
 pT
-oP
-wa
-oP
-oP
-nI
+XO
+Za
+XO
+XO
+WI
 lX
 lG
 Gu
@@ -28371,17 +26489,17 @@ Yf
 qs
 WI
 WI
-oP
-fI
-oP
-oP
-oP
-CZ
+XO
+Lv
+XO
+XO
+XO
+qM
 wa
 oP
-GG
-yB
-lL
+je
+QO
+wm
 nI
 wa
 on
@@ -28401,17 +26519,17 @@ on
 oP
 oP
 tw
-kL
-GG
-yB
-lL
+PK
+je
+QO
+wm
 oP
 En
-wa
-wa
-oP
-oP
-nI
+Za
+Za
+XO
+XO
+WI
 lX
 WS
 eY
@@ -28511,7 +26629,7 @@ YT
 YT
 YT
 YT
-eK
+YT
 YT
 YT
 YT
@@ -28527,12 +26645,12 @@ Yf
 qs
 WI
 WI
-oP
-oP
-sT
-oP
-wa
-CZ
+XO
+XO
+np
+XO
+Za
+qM
 nI
 nI
 nI
@@ -28563,10 +26681,10 @@ nI
 oP
 oP
 iK
-oP
-oP
-oP
-nI
+XO
+XO
+XO
+WI
 lX
 WS
 eY
@@ -28650,7 +26768,7 @@ XP
 Sg
 SR
 SR
-im
+SR
 YT
 dq
 YT
@@ -28683,11 +26801,11 @@ Yf
 qs
 WI
 XO
-oP
-oP
-oP
-oP
-oP
+XO
+XO
+XO
+XO
+XO
 ZS
 oP
 oP
@@ -28716,12 +26834,12 @@ oP
 RA
 Ko
 oP
-OA
-nW
+Hh
+mI
 iK
-oP
-oP
-nI
+XO
+XO
+WI
 lX
 WS
 eY
@@ -28872,10 +26990,10 @@ sT
 Qp
 oP
 oP
-Cq
+of
 wa
 En
-oP
+XO
 aG
 pq
 WS
@@ -29271,7 +27389,7 @@ QK
 SR
 SR
 SR
-im
+SR
 SR
 SR
 Zy
@@ -29341,7 +27459,7 @@ wa
 oP
 wa
 oP
-HF
+KE
 Uj
 OJ
 bF
@@ -29497,7 +27615,7 @@ oP
 oP
 wa
 oP
-AL
+GZ
 Uj
 GY
 bD
@@ -29809,7 +27927,7 @@ nI
 nI
 wa
 oP
-iT
+AK
 lC
 xM
 bD
@@ -30121,7 +28239,7 @@ yB
 nW
 wa
 oP
-iT
+AK
 lC
 xM
 bD
@@ -30277,7 +28395,7 @@ nW
 oP
 wa
 oP
-HF
+KE
 Uj
 NT
 bD
@@ -30432,8 +28550,8 @@ yB
 nW
 wa
 wa
-iT
-PR
+AK
+NT
 tv
 KV
 bD
@@ -30588,7 +28706,7 @@ nI
 oP
 wa
 oP
-HF
+KE
 Np
 zl
 bF
@@ -30744,8 +28862,8 @@ oP
 oP
 wa
 oP
-AL
-mH
+GZ
+KV
 kW
 Yf
 Yf

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -5,6 +5,7 @@
 	icon_state = "densecrate"
 	density = TRUE
 	anchored = FALSE
+	var/dropmetal = TRUE
 	resistance_flags = XENO_DAMAGEABLE
 	max_integrity = 100
 	hit_sound = 'sound/effects/woodhit.ogg'
@@ -140,7 +141,8 @@
 
 
 /obj/structure/largecrate/random/barrel/deconstruct(disassembled = TRUE)
-	new /obj/item/stack/sheet/metal/small_stack(src)
+	if(dropmetal)
+		new /obj/item/stack/sheet/metal/small_stack(src)
 	return ..()
 
 
@@ -169,6 +171,7 @@
 	desc = "A blue storage barrel"
 	icon_state = "barrel_blue"
 	hit_sound = 'sound/effects/metalhit.ogg'
+	dropmetal = FALSE
 
 /obj/structure/largecrate/random/barrel/blue
 	name = "blue barrel"

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -579,6 +579,7 @@
 	anchored = TRUE
 	throwpass = TRUE	//You can throw objects over this, despite it's density.
 	climbable = TRUE
+	var/dropmetal = TRUE   //if true drop metal when destroyed; mostly used when we need large amounts of racks without marines hoarding the metal 
 	max_integrity = 40
 	resistance_flags = XENO_DAMAGEABLE
 	var/parts = /obj/item/frame/rack
@@ -631,12 +632,15 @@
 		deconstruct(FALSE)
 
 /obj/structure/rack/deconstruct(disassembled = TRUE)
-	if(disassembled && parts)
+	if(disassembled && parts && dropmetal)
 		new parts(loc)
-	else
+	else if(dropmetal)
 		new /obj/item/stack/sheet/metal(loc)
 	density = FALSE
 	return ..()
+
+/obj/structure/rack/nometal
+	dropmetal = FALSE
 
 #undef TABLE_STATUS_WEAKENED
 #undef TABLE_STATUS_FIRM


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Marines have gotten into a habit of rushing the Icy Caves pirate coat, this PR removes it along with all ground side plasma cutters. 

## Why It's Good For The Game

The ground side pirate captain suit has apparently gotten known enough to the point where it's showing up each round and disrupting balance. The plasma cutters were in the same situation and also needed removed.

## Changelog
:cl:
balance: Icy Caves is back to it's original self, without the lab complex to the NW of the map.
balance: All Icy Caves plasma cutters have been replaced with pickaxes.
balance: The Icy Caves pirate coat has been replaced with a regular colonist uniform.
balance: Barrels no longer drop 10 metal by default when destroyed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
