### PR TITLE
The OB now refuses to chamber the warhead unless it is loaded alongside the required amount of solid fuel or more

### DIFF
--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -208,8 +208,8 @@
 	notify_ghosts("<b>[user]</b> has just fired \the <b>[src]</b> !", source = T, action = NOTIFY_JUMP)
 
 
-/obj/structure/orbital_cannon/proc/impact_callback(target,inaccurate_fuel)
-	tray.warhead.warhead_impact(target, inaccurate_fuel)
+/obj/structure/orbital_cannon/proc/impact_callback(target)
+	tray.warhead.warhead_impact(target)
 
 	ob_cannon_busy = FALSE
 	chambered_tray = FALSE

--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -193,7 +193,7 @@
 		if("plasma")
 			inaccurate_fuel = abs(GLOB.marine_main_ship?.ob_type_fuel_requirements[4] - tray.fuel_amt)
 
-	var/turf/target = locate(T.x + inaccurate_fuel * pick(-1,1),T.y + inaccurate_fuel * pick(-1,1),T.z)
+	var/turf/target = locate(T.x + inaccurate_fuel * pick(-3,3),T.y + inaccurate_fuel * pick(-3,3),T.z)
 
 	playsound_z_humans(target.z, 'sound/effects/OB_warning_announce.ogg', 100) //for marines on ground
 	playsound(target, 'sound/effects/OB_warning_announce_novoiceover.ogg', 125, FALSE, 30, 10) //VOX-less version for xenomorphs


### PR DESCRIPTION
## About The Pull Request
![bild](https://user-images.githubusercontent.com/17747087/145716970-dfcc3913-578f-430a-aa47-f0ce840e351c.png)
When attempting to chamber OB, it checks for if you have the required amount of solid fuel, if you don't it refuses to chamber it.

Also removed OB deviance since it's useless without the ability to fire OB's with the less than required solid fuel.

This PR fixes #8798

This PR has been fully tested on a local build with four (4) runtimes or errors (all the runtimes/errors were unrelated to the chambering and firing of the orbital bombardment)
https://streamable.com/zdcxwg

## Why It's Good For The Game
Spamming one HE warhead and one fuel cell is silly yet pretty much nothing stops you from doing it, with these changes you will not be able to fire OB's without the required amount of solid fuel.

## Changelog
:cl:
balance: The TGMC has decided that OB's that do not have the required amount of solid fuel for their warheads (which also deviates upon impact) are too dangerous, and have simply decided to change their orbital bombardment cannons to refuses to chamber any warheads that have not been loaded alongside the required amount of solid fuel.
/:cl:
