### PR TITLE
Tesla no longer drains plasma from xenos who can't be given plasma

### DIFF
--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -172,11 +172,10 @@
 			continue
 		if(living in blacklistmobs)
 			continue
-		if(!(living.xeno_caste.caste_flags & CASTE_CAN_BE_GIVEN_PLASMA))
-			continue
 		source.beam(living, icon_state="lightning[rand(1,12)]", time = 3, maxdistance = zap_range + 2)
-		living.apply_status_effect(/datum/status_effect/noplasmaregen, 10 SECONDS/length(.))
-		living.apply_status_effect(/datum/status_effect/plasmadrain, 10 SECONDS/length(.))
+		if(living.xeno_caste.caste_flags & CASTE_CAN_BE_GIVEN_PLASMA)
+			living.apply_status_effect(/datum/status_effect/noplasmaregen, 10 SECONDS/length(.))
+			living.apply_status_effect(/datum/status_effect/plasmadrain, 10 SECONDS/length(.))
 		living.adjust_stagger(1)
 		living.add_slowdown(2)
 		log_attack("[living] was zapped by [source]")

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -172,6 +172,8 @@
 			continue
 		if(living in blacklistmobs)
 			continue
+		if(!(living.xeno_caste.caste_flags & CASTE_CAN_BE_GIVEN_PLASMA))
+			continue
 		source.beam(living, icon_state="lightning[rand(1,12)]", time = 3, maxdistance = zap_range + 2)
 		living.apply_status_effect(/datum/status_effect/noplasmaregen, 10 SECONDS/length(.))
 		living.apply_status_effect(/datum/status_effect/plasmadrain, 10 SECONDS/length(.))


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tesla doesn't drain plasma from xenos who can't be given plasma. The flag is currently put on xenos where the plasma code is used for a resource that isn't plasma and is managed differently.

Tesla also gives stagger and slowdown, which are still applied on all xenos.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This makes it so that the plasma gun doesn't mess with the plasma of xenos who have special plasma management, just because they share code. When the plasma gun was made, there weren't such cases and plasma on all xenos was abundant.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Slotbot
balance: tesla gun doesn't drain plasma from xenos who have special plasma management, other tesla debuffs remain the same
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
