### PR TITLE
Bring back grenade chain explosion

### DIFF
--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -75,7 +75,7 @@
 
 /obj/item/explosive/grenade/update_overlays()
 	. = ..()
-	if(dangerous)
+	if(dangerous && active)
 		overlays += new /obj/effect/overlay/danger
 
 
@@ -85,6 +85,17 @@
 
 /obj/item/explosive/grenade/flamer_fire_act()
 	activate()
+
+/obj/item/explosive/grenade/ex_act(severity)
+	switch(severity)
+		if(EXPLODE_DEVASTATE)
+			prime()
+		if(EXPLODE_HEAVY)
+			activate()
+		if(EXPLODE_LIGHT)
+			if(prob(50))
+				activate()
+
 
 /obj/item/explosive/grenade/attack_hand(mob/living/user)
 	. = ..()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. A grenade struck by a light explosion has 50% change to activate

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I removed it by mistake in the grenade pr. This should prevent insta grenade stack kill, while still allowing fun.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Bring back grenade chain explosion
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
