### PR TITLE
MKH changes

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1385,6 +1385,6 @@
 
 	accuracy_mult = 1.1
 	burst_amount = 1
-	fire_delay = 0.15 SECONDS
+	fire_delay = 0.2 SECONDS
 	scatter = 2
 	wield_delay = 0.5 SECONDS

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1353,20 +1353,20 @@
 
 /obj/item/weapon/gun/rifle/mkh
 	name = "\improper MKH-98 storm rifle"
-	desc = "A certified classic, this design was hailed as the first successful assault rifle concept, generally termed a 'storm rifle'. This version of it chambers 7.62x39mm."
+	desc = "A certified classic, this design was hailed as the first successful assault rifle concept, generally termed a 'storm rifle'. Has a higher than usual firerate for it's class, but suffers in capacity. This version of it chambers 7.62x39mm."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "mkh98"
 	item_state = "mkh98"
 	caliber = CALIBER_762X39 //codex
 	muzzleflash_iconstate = "muzzle_flash_medium"
-	max_shells = 26 //codex
+	max_shells = 30 //codex
 	fire_sound = 'sound/weapons/guns/fire/ak47.ogg'
 	unload_sound = 'sound/weapons/guns/interact/ak47_unload.ogg'
 	reload_sound = 'sound/weapons/guns/interact/ak47_reload.ogg'
 	cocked_sound = 'sound/weapons/guns/interact/ak47_cocked.ogg'
 	default_ammo_type = /obj/item/ammo_magazine/rifle/mkh
 	allowed_ammo_types = list(/obj/item/ammo_magazine/rifle/mkh)
-	aim_slowdown = 0.45
+	aim_slowdown = 0.35
 	attachable_allowed = list(
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/bipod,
@@ -1385,6 +1385,6 @@
 
 	accuracy_mult = 1.1
 	burst_amount = 1
-	fire_delay = 0.25 SECONDS
+	fire_delay = 0.15 SECONDS
 	scatter = 2
-	wield_delay = 0.6 SECONDS
+	wield_delay = 0.5 SECONDS

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -341,5 +341,5 @@
 	caliber = CALIBER_762X39
 	icon_state = "mkh98"
 	default_ammo = /datum/ammo/bullet/rifle/heavy
-	max_rounds = 26
+	max_rounds = 30
 	icon_state_mini = "mag_rifle"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
0.25->0.2 fire delay (so effectiively 5 BPS from 4)
26->30 magazine capacity.
0.45->0.35 wield slowdown.
0.6->0.5 wield delay.

This makes the MKH stand out in it's class, it suffers from low magazine capacity compared to most other assault rifle damage weapons (30 vs 40 on the AK, it's direct competitor.) but has good fire delay compared to everything else.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the MKH98 more unique compared to the rest of it's peers, and makes it stand out as a unique choice, it still suffers in utility options and attachments, and it's a seasonal.
Gives it an edge against other guns like the AK, at worst I'd like to atleast see it moved to 0.2 and 30 rounds with the slowdown change.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: MKH98 changes- 0.2 fire delay from 0.25, 30 round magazines, 0.5 wield delay from 0.6, 0.35 aim slowdown from 0.45.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
