### PR TITLE
Martini rebalance

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -980,12 +980,13 @@ datum/ammo/bullet/revolver/tp44
 	hud_state = "sniper_crude"
 	handful_amount = 5
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
-	damage = 120
+	damage = 90
 	penetration = 20
 	sundering = 10
+	damage_falloff = -5
 
 /datum/ammo/bullet/sniper/martini/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, weaken = 1, stagger = 1, knockback = 2, slowdown = 0.5, max_range = 5)
+	staggerstun(M, P, weaken = 1, stagger = 1, knockback = 2, slowdown = 0.5, max_range = 6)
 
 /datum/ammo/bullet/sniper/elite
 	name = "supersonic sniper bullet"

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -372,7 +372,7 @@
 
 /obj/item/weapon/gun/shotgun/double/martini
 	name = "\improper Martini Henry lever action rifle"
-	desc = "A lever action with room for a single round of .557/440 ball. Perfect for any kind of hunt, be it elephant or xeno."
+	desc = "A lever action with room for a single round of .557/440 ball. Perfect for any kind of hunt, be it elephant or xeno. Due to low velocity, it mushrooms better and deals more damage at a medium range."
 	flags_equip_slot = ITEM_SLOT_BACK
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "martini"
@@ -403,6 +403,8 @@
 
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
 	attachable_offset = list("muzzle_x" = 45, "muzzle_y" = 23,"rail_x" = 17, "rail_y" = 25, "under_x" = 19, "under_y" = 14, "stock_x" = 15, "stock_y" = 12)
+	actions_types = list(/datum/action/item_action/aim_mode)
+	aim_speed_modifier = 10 // Probably overkill, but you ain't moving with this much.
 
 	fire_delay = 1 SECONDS
 	accuracy_mult = 1.45


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Rebalances martini
Base damage reduced to 90
Damage falloff is reversed for the Martini, and now it gains 5 damage per tile instead of losing.
stagger stun tile range increased to 6.
--
aim mode added
--

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The Martini is a useless meme gun that literally nobody uses and doesn't even have a funny gimmick considering I could just use slug ts-34 for the same mechanic.
This gives it some uniqueness in how it works, functions and plays and makes it not terrible in CQC.
The max damage btw is 195 at 21 tiles, if you somehow get that far, however this overall deals less damage overall.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Martini has gotten a rework to make it feel more unique, it's damage has been reduced to 90, it now has reversed falloff (it gains 5 damage per tile it flies through, maxing out at around 195.). It has gained aim mode (but you can barely move while in aim mode) and it's status effects on hitting a mob has been increased in range by one tile.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
