### PR TITLE
Makes psychic link usable while moving

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -509,6 +509,8 @@
 #define COMSIG_XENOMORPH_WRAITH_RECALL "xenomorph_wraith_recall"
 	#define COMPONENT_BANISH_TARGETS_EXIST (1<<0)
 
+#define COMSIG_XENO_PSYCHIC_LINK_REMOVED "xeno_psychic_link_removed"
+
 //human signals
 #define COMSIG_CLICK_QUICKEQUIP "click_quickequip"
 

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -107,6 +107,7 @@
 #define TRAIT_FLOORED "floored" //User is forced to the ground on a prone position.
 #define TRAIT_IMMOBILE "immobile" //User is unable to move by its own volition.
 #define TRAIT_IS_RESURRECTING "resurrecting"
+#define TRAIT_PSY_LINKED "psy_linked"
 /// Prevents usage of manipulation appendages (picking, holding or using items, manipulating storage).
 #define TRAIT_HANDS_BLOCKED "handsblocked"
 #define TRAIT_STUNIMMUNE "stun_immunity"

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -80,7 +80,6 @@
 
 	amount_mod += min(amount * 0.75, 40)
 
-#define PSYCHIC_LINK_REST_MOD 0.2
 #define PSYCHIC_LINK_COLOR "#2a888360"
 #define CALC_DAMAGE_REDUCTION(amount, amount_mod) \
 	if(amount <= 0) { \
@@ -110,11 +109,7 @@
 	duration = set_duration
 	src.target_mob = target_mob
 	src.link_range = link_range
-	if(scaling)
-		src.redirect_mod = owner.resting ? redirect_mod : redirect_mod * PSYCHIC_LINK_REST_MOD
-		RegisterSignal(owner, list(COMSIG_XENOMORPH_REST, COMSIG_XENOMORPH_UNREST), .proc/handle_resting)
-	else
-		src.redirect_mod = redirect_mod
+	src.redirect_mod = redirect_mod
 	src.minimum_health = minimum_health
 	instance_id = "[src][owner][target_mob]"
 	ADD_TRAIT(target_mob, TRAIT_PSY_LINKED, instance_id)
@@ -141,14 +136,6 @@
 	target_mob.remove_filter(instance_id)
 	to_chat(target_mob, span_xenonotice("[owner] has unlinked from you."))
 	SEND_SIGNAL(src, COMSIG_XENO_PSYCHIC_LINK_REMOVED)
-
-///Handles stat modifications based on resting status
-/datum/status_effect/xeno_psychic_link/proc/handle_resting(datum/source)
-	SIGNAL_HANDLER
-	if(owner.resting)
-		redirect_mod = redirect_mod / PSYCHIC_LINK_REST_MOD
-	else
-		redirect_mod = redirect_mod * PSYCHIC_LINK_REST_MOD
 
 ///Handles the link breaking due to dying
 /datum/status_effect/xeno_psychic_link/proc/handle_mob_dead(datum/source)

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -100,20 +100,21 @@
 	var/redirect_mod
 	///Minimum health threshold before the effect is deactivated
 	var/minimum_health
-	///Id of psychic link instance
-	var/instance_id = ""
+
+/datum/status_effect/xeno_psychic_link/on_apply()
+	. = ..()
+	if(HAS_TRAIT(target_mob, TRAIT_PSY_LINKED))
+		return FALSE
 
 /datum/status_effect/xeno_psychic_link/on_creation(mob/living/new_owner, set_duration, mob/living/carbon/target_mob, link_range, redirect_mod, minimum_health, scaling = FALSE)
-	. = ..()
 	owner = new_owner
 	duration = set_duration
 	src.target_mob = target_mob
 	src.link_range = link_range
 	src.redirect_mod = redirect_mod
 	src.minimum_health = minimum_health
-	instance_id = "[src][owner][target_mob]"
-	ADD_TRAIT(target_mob, TRAIT_PSY_LINKED, instance_id)
-	ADD_TRAIT(owner, TRAIT_PSY_LINKED, instance_id)
+	ADD_TRAIT(target_mob, TRAIT_PSY_LINKED, REF(src))
+	ADD_TRAIT(owner, TRAIT_PSY_LINKED, REF(src))
 	RegisterSignal(owner, COMSIG_MOB_DEATH, .proc/handle_mob_dead)
 	RegisterSignal(target_mob, COMSIG_MOB_DEATH, .proc/handle_mob_dead)
 	RegisterSignal(target_mob, COMSIG_XENOMORPH_BURN_DAMAGE, .proc/handle_burn_damage)
@@ -124,16 +125,17 @@
 		RegisterSignal(owner, COMSIG_MOVABLE_MOVED, .proc/handle_dist)
 		RegisterSignal(target_mob, COMSIG_MOVABLE_MOVED, .proc/handle_dist)
 	to_chat(target_mob, span_xenonotice(link_message))
-	owner.add_filter(instance_id, 2, outline_filter(2, PSYCHIC_LINK_COLOR))
-	target_mob.add_filter(instance_id, 2, outline_filter(2, PSYCHIC_LINK_COLOR))
+	owner.add_filter(REF(src), 2, outline_filter(2, PSYCHIC_LINK_COLOR))
+	target_mob.add_filter(REF(src), 2, outline_filter(2, PSYCHIC_LINK_COLOR))
+	return ..()
 
 /datum/status_effect/xeno_psychic_link/on_remove()
 	. = ..()
 	UnregisterSignal(target_mob, list(COMSIG_XENOMORPH_BRUTE_DAMAGE, COMSIG_XENOMORPH_BURN_DAMAGE))
-	REMOVE_TRAIT(target_mob, TRAIT_PSY_LINKED, instance_id)
-	REMOVE_TRAIT(owner, TRAIT_PSY_LINKED, instance_id)
-	owner.remove_filter(instance_id)
-	target_mob.remove_filter(instance_id)
+	REMOVE_TRAIT(target_mob, TRAIT_PSY_LINKED, REF(src))
+	REMOVE_TRAIT(owner, TRAIT_PSY_LINKED, REF(src))
+	owner.remove_filter(REF(src))
+	target_mob.remove_filter(REF(src))
 	to_chat(target_mob, span_xenonotice("[owner] has unlinked from you."))
 	SEND_SIGNAL(src, COMSIG_XENO_PSYCHIC_LINK_REMOVED)
 

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -108,8 +108,8 @@
 	src.link_range = link_range
 	src.redirect_mod = redirect_mod
 	src.minimum_health = minimum_health
-	ADD_TRAIT(target_mob, TRAIT_PSY_LINKED, id)
-	ADD_TRAIT(owner, TRAIT_PSY_LINKED, id)
+	ADD_TRAIT(target_mob, TRAIT_PSY_LINKED, TRAIT_STATUS_EFFECT(id))
+	ADD_TRAIT(owner, TRAIT_PSY_LINKED, TRAIT_STATUS_EFFECT(id))
 	RegisterSignal(owner, COMSIG_MOB_DEATH, .proc/handle_mob_dead)
 	RegisterSignal(target_mob, COMSIG_MOB_DEATH, .proc/handle_mob_dead)
 	RegisterSignal(target_mob, COMSIG_XENOMORPH_BURN_DAMAGE, .proc/handle_burn_damage)
@@ -127,8 +127,8 @@
 /datum/status_effect/xeno_psychic_link/on_remove()
 	. = ..()
 	UnregisterSignal(target_mob, list(COMSIG_XENOMORPH_BRUTE_DAMAGE, COMSIG_XENOMORPH_BURN_DAMAGE))
-	REMOVE_TRAIT(target_mob, TRAIT_PSY_LINKED, id)
-	REMOVE_TRAIT(owner, TRAIT_PSY_LINKED, id)
+	REMOVE_TRAIT(target_mob, TRAIT_PSY_LINKED, TRAIT_STATUS_EFFECT(id))
+	REMOVE_TRAIT(owner, TRAIT_PSY_LINKED, TRAIT_STATUS_EFFECT(id))
 	owner.remove_filter(id)
 	target_mob.remove_filter(id)
 	to_chat(target_mob, span_xenonotice("[owner] has unlinked from you."))

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -123,9 +123,9 @@
 	RegisterSignal(target_mob, COMSIG_MOB_DEATH, .proc/handle_mob_dead)
 	RegisterSignal(target_mob, COMSIG_XENOMORPH_BURN_DAMAGE, .proc/handle_burn_damage)
 	RegisterSignal(target_mob, COMSIG_XENOMORPH_BRUTE_DAMAGE, .proc/handle_brute_damage)
-	var/link_message = "[owner] has linked to you and is redirecting some of your injuries. If they get too hurt, the link may be broken. "
+	var/link_message = "[owner] has linked to you and is redirecting some of your injuries. If they get too hurt, the link may be broken."
 	if(link_range > 0)
-		link_message += "Keep within [link_range] tiles to maintain it."
+		link_message += " Keep within [link_range] tiles to maintain it."
 		RegisterSignal(owner, COMSIG_MOVABLE_MOVED, .proc/handle_dist)
 		RegisterSignal(target_mob, COMSIG_MOVABLE_MOVED, .proc/handle_dist)
 	to_chat(target_mob, span_xenonotice(link_message))

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -101,11 +101,6 @@
 	///Minimum health threshold before the effect is deactivated
 	var/minimum_health
 
-/datum/status_effect/xeno_psychic_link/on_apply()
-	. = ..()
-	if(HAS_TRAIT(target_mob, TRAIT_PSY_LINKED))
-		return FALSE
-
 /datum/status_effect/xeno_psychic_link/on_creation(mob/living/new_owner, set_duration, mob/living/carbon/target_mob, link_range, redirect_mod, minimum_health, scaling = FALSE)
 	owner = new_owner
 	duration = set_duration
@@ -113,8 +108,8 @@
 	src.link_range = link_range
 	src.redirect_mod = redirect_mod
 	src.minimum_health = minimum_health
-	ADD_TRAIT(target_mob, TRAIT_PSY_LINKED, REF(src))
-	ADD_TRAIT(owner, TRAIT_PSY_LINKED, REF(src))
+	ADD_TRAIT(target_mob, TRAIT_PSY_LINKED, id)
+	ADD_TRAIT(owner, TRAIT_PSY_LINKED, id)
 	RegisterSignal(owner, COMSIG_MOB_DEATH, .proc/handle_mob_dead)
 	RegisterSignal(target_mob, COMSIG_MOB_DEATH, .proc/handle_mob_dead)
 	RegisterSignal(target_mob, COMSIG_XENOMORPH_BURN_DAMAGE, .proc/handle_burn_damage)
@@ -125,17 +120,17 @@
 		RegisterSignal(owner, COMSIG_MOVABLE_MOVED, .proc/handle_dist)
 		RegisterSignal(target_mob, COMSIG_MOVABLE_MOVED, .proc/handle_dist)
 	to_chat(target_mob, span_xenonotice(link_message))
-	owner.add_filter(REF(src), 2, outline_filter(2, PSYCHIC_LINK_COLOR))
-	target_mob.add_filter(REF(src), 2, outline_filter(2, PSYCHIC_LINK_COLOR))
+	owner.add_filter(id, 2, outline_filter(2, PSYCHIC_LINK_COLOR))
+	target_mob.add_filter(id, 2, outline_filter(2, PSYCHIC_LINK_COLOR))
 	return ..()
 
 /datum/status_effect/xeno_psychic_link/on_remove()
 	. = ..()
 	UnregisterSignal(target_mob, list(COMSIG_XENOMORPH_BRUTE_DAMAGE, COMSIG_XENOMORPH_BURN_DAMAGE))
-	REMOVE_TRAIT(target_mob, TRAIT_PSY_LINKED, REF(src))
-	REMOVE_TRAIT(owner, TRAIT_PSY_LINKED, REF(src))
-	owner.remove_filter(REF(src))
-	target_mob.remove_filter(REF(src))
+	REMOVE_TRAIT(target_mob, TRAIT_PSY_LINKED, id)
+	REMOVE_TRAIT(owner, TRAIT_PSY_LINKED, id)
+	owner.remove_filter(id)
+	target_mob.remove_filter(id)
 	to_chat(target_mob, span_xenonotice("[owner] has unlinked from you."))
 	SEND_SIGNAL(src, COMSIG_XENO_PSYCHIC_LINK_REMOVED)
 

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -82,7 +82,6 @@
 
 #define PSYCHIC_LINK_REST_MOD 0.2
 #define PSYCHIC_LINK_COLOR "#2a888360"
-#define PSYCHIC_LINK_COLOR_WEAK "#b8732536"
 #define CALC_DAMAGE_REDUCTION(amount, amount_mod) \
 	if(amount <= 0) { \
 		return; \
@@ -148,12 +147,8 @@
 	SIGNAL_HANDLER
 	if(owner.resting)
 		redirect_mod = redirect_mod / PSYCHIC_LINK_REST_MOD
-		owner.add_filter(instance_id, 2, outline_filter(2, PSYCHIC_LINK_COLOR))
-		target_mob.add_filter(instance_id, 2, outline_filter(2, PSYCHIC_LINK_COLOR))
 	else
 		redirect_mod = redirect_mod * PSYCHIC_LINK_REST_MOD
-		owner.add_filter(instance_id, 2, outline_filter(2, PSYCHIC_LINK_COLOR_WEAK))
-		target_mob.add_filter(instance_id, 2, outline_filter(2, PSYCHIC_LINK_COLOR_WEAK))
 
 ///Handles the link breaking due to dying
 /datum/status_effect/xeno_psychic_link/proc/handle_mob_dead(datum/source)

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -266,7 +266,7 @@
 /datum/action/xeno_action/activable/psychic_link
 	name = "Psychic Link"
 	action_icon_state = "psychic_link"
-	mechanics_text = "Link to a xenomorph and take some damage in their place. The link is weaker when you are not resting. Activate ability again to cancel."
+	mechanics_text = "Link to a xenomorph and take some damage in their place. Unrest to cancel."
 	cooldown_timer = 50 SECONDS
 	plasma_cost = 0
 	target_flags = XABB_MOB_TARGET

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -302,6 +302,7 @@
 		return FALSE
 	return TRUE
 
+///Runs checks while the status is being applied
 /datum/action/xeno_action/activable/psychic_link/proc/channel_checks(atom/target)
 	if(get_dist(owner, target) > GORGER_PSYCHIC_LINK_RANGE)
 		return FALSE
@@ -322,6 +323,7 @@
 	owner_xeno.balloon_alert(target, "[owner_xeno] has linked to you.")
 	succeed_activate()
 
+///Cancels the status effect
 /datum/action/xeno_action/activable/psychic_link/proc/status_removed(datum/source)
 	UnregisterSignal(source, COMSIG_XENO_PSYCHIC_LINK_REMOVED)
 	add_cooldown()

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -266,7 +266,7 @@
 /datum/action/xeno_action/activable/psychic_link
 	name = "Psychic Link"
 	action_icon_state = "psychic_link"
-	mechanics_text = "Link to a xenomorph and take some damage in their place. During this time, you can't move. Use rest action to cancel."
+	mechanics_text = "Link to a xenomorph and take some damage in their place. The link is weaker when you are not resting. Activate ability again to cancel."
 	cooldown_timer = 50 SECONDS
 	plasma_cost = 0
 	target_flags = XABB_MOB_TARGET
@@ -283,6 +283,10 @@
 			to_chat(owner, span_notice("We can only link to familiar biological lifeforms."))
 		return FALSE
 	var/mob/living/carbon/xenomorph/owner_xeno = owner
+	if(owner_xeno.has_status_effect(STATUS_EFFECT_XENO_PSYCHIC_LINK))
+		if(!silent)
+			to_chat(owner, span_notice("You are already linked to a xenomorph."))
+		return FALSE
 	if(owner_xeno.health <= owner_xeno.maxHealth * GORGER_PSYCHIC_LINK_MIN_HEALTH)
 		if(!silent)
 			to_chat(owner, span_notice("You are too hurt to link."))
@@ -291,25 +295,36 @@
 		if(!silent)
 			to_chat(owner, span_notice("It is beyond our reach, we must be close and our way must be clear."))
 		return FALSE
-	if(!do_mob(owner, target, GORGER_PSYCHIC_LINK_CHANNEL, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
+	if(!do_mob(owner, target, GORGER_PSYCHIC_LINK_CHANNEL, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL, ignore_flags = IGNORE_LOC_CHANGE, extra_checks = new/datum/callback/(src, .proc/channel_checks, target)))
+		if(!silent)
+			to_chat(owner, span_warning("The link was interrupted and we need to recover before another attempt."))
+		add_cooldown(10 SECONDS)
 		return FALSE
 	return TRUE
 
-/datum/action/xeno_action/activable/psychic_link/use_ability(atom/target)
-	var/mob/living/carbon/xenomorph/owner_xeno = owner
-	owner_xeno.apply_status_effect(STATUS_EFFECT_XENO_PSYCHIC_LINK, -1, target, GORGER_PSYCHIC_LINK_RANGE, GORGER_PSYCHIC_LINK_REDIRECT, owner_xeno.maxHealth * GORGER_PSYCHIC_LINK_MIN_HEALTH)
-	target.balloon_alert(owner_xeno, "Link successul.")
-	owner_xeno.balloon_alert(target, "[owner_xeno] has linked to you.")
-	if(!owner_xeno.resting)
-		owner_xeno.set_resting(TRUE, TRUE)
-	RegisterSignal(owner_xeno, COMSIG_XENOMORPH_UNREST, .proc/cancel_psychic_link)
-	add_cooldown()
-	succeed_activate()
+/datum/action/xeno_action/activable/psychic_link/proc/channel_checks(atom/target)
+	if(get_dist(owner, target) > GORGER_PSYCHIC_LINK_RANGE)
+		return FALSE
+	return TRUE
 
-///Cancels the status effect
-/datum/action/xeno_action/activable/psychic_link/proc/cancel_psychic_link(datum/source)
+/datum/action/xeno_action/activable/psychic_link/action_activate()
+	. = ..()
 	var/mob/living/carbon/xenomorph/owner_xeno = owner
 	owner_xeno.remove_status_effect(STATUS_EFFECT_XENO_PSYCHIC_LINK)
+
+/datum/action/xeno_action/activable/psychic_link/use_ability(atom/target)
+	var/mob/living/carbon/xenomorph/owner_xeno = owner
+	var/psychic_link_status = owner_xeno.apply_status_effect(STATUS_EFFECT_XENO_PSYCHIC_LINK, -1, target, GORGER_PSYCHIC_LINK_RANGE, GORGER_PSYCHIC_LINK_REDIRECT, owner_xeno.maxHealth * GORGER_PSYCHIC_LINK_MIN_HEALTH)
+	if(!psychic_link_status)
+		return
+	RegisterSignal(psychic_link_status, COMSIG_XENO_PSYCHIC_LINK_REMOVED, .proc/status_removed)
+	target.balloon_alert(owner_xeno, "Link successul.")
+	owner_xeno.balloon_alert(target, "[owner_xeno] has linked to you.")
+	succeed_activate()
+
+/datum/action/xeno_action/activable/psychic_link/proc/status_removed(datum/source)
+	UnregisterSignal(source, COMSIG_XENO_PSYCHIC_LINK_REMOVED)
+	add_cooldown()
 
 /datum/action/xeno_action/activable/psychic_link/ai_should_use(atom/target)
 	return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -283,13 +283,6 @@
 			to_chat(owner, span_notice("We can only link to familiar biological lifeforms."))
 		return FALSE
 	var/mob/living/carbon/xenomorph/owner_xeno = owner
-	if(owner_xeno.has_status_effect(STATUS_EFFECT_XENO_PSYCHIC_LINK))
-		if(!silent)
-			to_chat(owner, span_notice("You are already linked to a xenomorph."))
-		return FALSE
-	if(HAS_TRAIT(target, TRAIT_PSY_LINKED))
-		to_chat(owner, span_notice("[target] is already linked to a xenomorph."))
-		return FALSE
 	if(owner_xeno.health <= owner_xeno.maxHealth * GORGER_PSYCHIC_LINK_MIN_HEALTH)
 		if(!silent)
 			to_chat(owner, span_notice("You are too hurt to link."))
@@ -298,23 +291,31 @@
 		if(!silent)
 			to_chat(owner, span_notice("It is beyond our reach, we must be close and our way must be clear."))
 		return FALSE
+	if(HAS_TRAIT(owner, TRAIT_PSY_LINKED))
+		if(!silent)
+			to_chat(owner, span_notice("You are already linked to a xenomorph."))
+		return FALSE
+	if(HAS_TRAIT(target, TRAIT_PSY_LINKED))
+		if(!silent)
+			to_chat(owner, span_notice("[target] is already linked to a xenomorph."))
+		return FALSE
 	if(!do_mob(owner, target, GORGER_PSYCHIC_LINK_CHANNEL, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL, ignore_flags = IGNORE_LOC_CHANGE, extra_checks = new/datum/callback/(src, .proc/channel_checks, target)))
 		if(!silent)
 			to_chat(owner, span_warning("The linking was interrupted."))
 		return FALSE
+	if(HAS_TRAIT(owner, TRAIT_PSY_LINKED))
+		if(!silent)
+			to_chat(owner, span_notice("You are already linked to a xenomorph."))
+		return FALSE
 	if(HAS_TRAIT(target, TRAIT_PSY_LINKED))
-		to_chat(owner, span_notice("[target] is already linked to a xenomorph."))
+		if(!silent)
+			to_chat(owner, span_notice("[target] is already linked to a xenomorph."))
 		return FALSE
 	return TRUE
 
 ///Runs checks while the status is being applied
 /datum/action/xeno_action/activable/psychic_link/proc/channel_checks(atom/target)
 	return (get_dist(owner, target) <= GORGER_PSYCHIC_LINK_RANGE)
-
-/datum/action/xeno_action/activable/psychic_link/action_activate()
-	. = ..()
-	var/mob/living/carbon/xenomorph/owner_xeno = owner
-	owner_xeno.remove_status_effect(STATUS_EFFECT_XENO_PSYCHIC_LINK)
 
 /datum/action/xeno_action/activable/psychic_link/use_ability(atom/target)
 	var/mob/living/carbon/xenomorph/owner_xeno = owner

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -287,6 +287,9 @@
 		if(!silent)
 			to_chat(owner, span_notice("You are already linked to a xenomorph."))
 		return FALSE
+	if(HAS_TRAIT(target, TRAIT_PSY_LINKED))
+		to_chat(owner, span_notice("[target] is already linked to a xenomorph."))
+		return FALSE
 	if(owner_xeno.health <= owner_xeno.maxHealth * GORGER_PSYCHIC_LINK_MIN_HEALTH)
 		if(!silent)
 			to_chat(owner, span_notice("You are too hurt to link."))
@@ -297,8 +300,10 @@
 		return FALSE
 	if(!do_mob(owner, target, GORGER_PSYCHIC_LINK_CHANNEL, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL, ignore_flags = IGNORE_LOC_CHANGE, extra_checks = new/datum/callback/(src, .proc/channel_checks, target)))
 		if(!silent)
-			to_chat(owner, span_warning("The link was interrupted and we need to recover before another attempt."))
-		add_cooldown(10 SECONDS)
+			to_chat(owner, span_warning("The linking was interrupted."))
+		return FALSE
+	if(HAS_TRAIT(target, TRAIT_PSY_LINKED))
+		to_chat(owner, span_notice("[target] is already linked to a xenomorph."))
 		return FALSE
 	return TRUE
 
@@ -315,10 +320,8 @@
 
 /datum/action/xeno_action/activable/psychic_link/use_ability(atom/target)
 	var/mob/living/carbon/xenomorph/owner_xeno = owner
-	var/psychic_link_status = owner_xeno.apply_status_effect(STATUS_EFFECT_XENO_PSYCHIC_LINK, -1, target, GORGER_PSYCHIC_LINK_RANGE, GORGER_PSYCHIC_LINK_REDIRECT, owner_xeno.maxHealth * GORGER_PSYCHIC_LINK_MIN_HEALTH)
-	if(!psychic_link_status)
-		return
-	RegisterSignal(psychic_link_status, COMSIG_XENO_PSYCHIC_LINK_REMOVED, .proc/status_removed)
+	var/psychic_link = owner_xeno.apply_status_effect(STATUS_EFFECT_XENO_PSYCHIC_LINK, -1, target, GORGER_PSYCHIC_LINK_RANGE, GORGER_PSYCHIC_LINK_REDIRECT, owner_xeno.maxHealth * GORGER_PSYCHIC_LINK_MIN_HEALTH, TRUE)
+	RegisterSignal(psychic_link, COMSIG_XENO_PSYCHIC_LINK_REMOVED, .proc/status_removed)
 	target.balloon_alert(owner_xeno, "Link successul.")
 	owner_xeno.balloon_alert(target, "[owner_xeno] has linked to you.")
 	succeed_activate()

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -324,10 +324,20 @@
 	RegisterSignal(psychic_link, COMSIG_XENO_PSYCHIC_LINK_REMOVED, .proc/status_removed)
 	target.balloon_alert(owner_xeno, "Link successul.")
 	owner_xeno.balloon_alert(target, "[owner_xeno] has linked to you.")
+	if(!owner_xeno.resting)
+		owner_xeno.set_resting(TRUE, TRUE)
+	RegisterSignal(owner_xeno, COMSIG_XENOMORPH_UNREST, .proc/cancel_psychic_link)
 	succeed_activate()
+
+///Removes the status effect on unrest
+/datum/action/xeno_action/activable/psychic_link/proc/cancel_psychic_link(datum/source)
+	SIGNAL_HANDLER
+	var/mob/living/carbon/xenomorph/owner_xeno = owner
+	owner_xeno.remove_status_effect(STATUS_EFFECT_XENO_PSYCHIC_LINK)
 
 ///Cancels the status effect
 /datum/action/xeno_action/activable/psychic_link/proc/status_removed(datum/source)
+	SIGNAL_HANDLER
 	UnregisterSignal(source, COMSIG_XENO_PSYCHIC_LINK_REMOVED)
 	add_cooldown()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -309,9 +309,7 @@
 
 ///Runs checks while the status is being applied
 /datum/action/xeno_action/activable/psychic_link/proc/channel_checks(atom/target)
-	if(get_dist(owner, target) > GORGER_PSYCHIC_LINK_RANGE)
-		return FALSE
-	return TRUE
+	return (get_dist(owner, target) <= GORGER_PSYCHIC_LINK_RANGE)
 
 /datum/action/xeno_action/activable/psychic_link/action_activate()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -174,10 +174,6 @@
 	for(var/i in amount_mod)
 		amount -= i
 
-	adjustBruteLossDirect(amount, updating_health)
-
-///Adjusts bruteloss without sending a signal. Useful when it can cause a signal loop
-/mob/living/carbon/xenomorph/proc/adjustBruteLossDirect(amount, updating_health = FALSE)
 	HANDLE_OVERHEAL(amount)
 
 	bruteloss = max(bruteloss + amount, 0)
@@ -190,10 +186,7 @@
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_BURN_DAMAGE, amount, amount_mod)
 	for(var/i in amount_mod)
 		amount -= i
-	adjustFireLossDirect(amount, updating_health)
 
-///Adjusts fireloss without sending a signal. Useful when it can cause a signal loop
-/mob/living/carbon/xenomorph/proc/adjustFireLossDirect(amount, updating_health = FALSE)
 	HANDLE_OVERHEAL(amount)
 
 	fireloss = max(fireloss + amount, 0)

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -169,12 +169,15 @@
 	} \
 
 /mob/living/carbon/xenomorph/adjustBruteLoss(amount, updating_health = FALSE)
-
 	var/list/amount_mod = list()
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_BRUTE_DAMAGE, amount, amount_mod)
 	for(var/i in amount_mod)
 		amount -= i
 
+	adjustBruteLossDirect(amount, updating_health)
+
+///Adjusts bruteloss without sending a signal. Useful when it can cause a signal loop
+/mob/living/carbon/xenomorph/proc/adjustBruteLossDirect(amount, updating_health = FALSE)
 	HANDLE_OVERHEAL(amount)
 
 	bruteloss = max(bruteloss + amount, 0)
@@ -182,14 +185,15 @@
 	if(updating_health)
 		updatehealth()
 
-
 /mob/living/carbon/xenomorph/adjustFireLoss(amount, updating_health = FALSE)
-
 	var/list/amount_mod = list()
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_BURN_DAMAGE, amount, amount_mod)
 	for(var/i in amount_mod)
 		amount -= i
+	adjustFireLossDirect(amount, updating_health)
 
+///Adjusts fireloss without sending a signal. Useful when it can cause a signal loop
+/mob/living/carbon/xenomorph/proc/adjustFireLossDirect(amount, updating_health = FALSE)
 	HANDLE_OVERHEAL(amount)
 
 	fireloss = max(fireloss + amount, 0)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes psychic link channel-able while moving.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Xenos don't stand still when gorger is using the ability on them and the ability ends up being underused.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: psychic link is now channel-able while moving
fix: fixes signal loop in psychic link damage redirect
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
