### PR TITLE
Makes Quick-Clot Plus craftable again

### DIFF
--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -159,7 +159,7 @@
 /datum/chemical_reaction/quickclotplus
 	name = "Quick-Clot Plus"
 	results = list(/datum/reagent/medicine/quickclotplus = 1)
-	required_reagents = list(/datum/reagent/medicine/phoron = 2, /datum/reagent/toxin/quickclot = 2, /datum/reagent/iron = 2)
+	required_reagents = list(/datum/reagent/medicine/quickclot = 2, /datum/reagent/toxin/phoron = 2, /datum/reagent/iron = 2)
 
 /datum/chemical_reaction/hypervene //New purge chem.
 	name = "Hypervene"

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -159,7 +159,7 @@
 /datum/chemical_reaction/quickclotplus
 	name = "Quick-Clot Plus"
 	results = list(/datum/reagent/medicine/quickclotplus = 1)
-	required_reagents = list(/datum/reagent/medicine/meralyne = 1, /datum/reagent/toxin/phoron = 2, /datum/reagent/iron = 2)
+	required_reagents = list(/datum/reagent/medicine/phoron = 2, /datum/reagent/toxin/quickclot = 2, /datum/reagent/iron = 2)
 
 /datum/chemical_reaction/hypervene //New purge chem.
 	name = "Hypervene"

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -159,7 +159,7 @@
 /datum/chemical_reaction/quickclotplus
 	name = "Quick-Clot Plus"
 	results = list(/datum/reagent/medicine/quickclotplus = 1)
-	required_reagents = list(/datum/reagent/medicine/quickclot = 2, /datum/reagent/toxin/phoron = 2, /datum/reagent/iron = 2)
+	required_reagents = list(/datum/reagent/medicine/quickclot = 2, /datum/reagent/medicine/lemoline = 2, /datum/reagent/iron = 2)
 
 /datum/chemical_reaction/hypervene //New purge chem.
 	name = "Hypervene"

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -156,6 +156,11 @@
 	required_reagents = list(/datum/reagent/medicine/kelotane = 2, /datum/reagent/medicine/clonexadone = 2)
 	required_catalysts = list(/datum/reagent/toxin/phoron = 5)
 
+/datum/chemical_reaction/quickclotplus
+	name = "Quick-Clot Plus"
+	results = list(/datum/reagent/medicine/quickclotplus = 1)
+	required_reagents = list(/datum/reagent/medicine/meralyne = 1, /datum/reagent/toxin/phoron = 2, /datum/reagent/iron = 2)
+
 /datum/chemical_reaction/hypervene //New purge chem.
 	name = "Hypervene"
 	results = list(/datum/reagent/hypervene = 3)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes Quick-Clot Plus craftable
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
The recipe for it as follows:
2 part Quick-Clot
2 parts Lemoline
2 parts Iron
## Why It's Good For The Game
The amount of QC+ needed for treatment seems never enough of what is available, the recipe creates 1 unit of QC+ out of 6 units of the recipe. Not enough medics already bother with chems to care anyways.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Kait
expansion: Added a recipe for QC+, making it craftable. The recipe for 1 unit is: 2 parts Lemo, 2 parts Iron, 2 parts Quick-Clot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
