### PR TITLE
Fixes patching burns with wire and burn overlays not updating

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -508,8 +508,8 @@ GLOBAL_LIST(cable_radial_layer_list)
 	while(affecting.burn_dam && do_after(user, repair_time, TRUE, src, BUSY_ICON_BUILD) && use(1))
 		user.visible_message(span_warning("\The [user] fixes some wires in [H == user ? "[H.p_their()]" : "[H]'s"] [affecting.display_name] with \the [src]."), \
 			span_warning("You patch some wires in [H == user ? "your" : "[H]'s"] [affecting.display_name]."))
-		affecting.heal_limb_damage(0, 15, robo_repair = TRUE, updating_health = TRUE)
-		H.UpdateDamageIcon()
+		if(affecting.heal_limb_damage(0, 15, robo_repair = TRUE, updating_health = TRUE))
+			H.UpdateDamageIcon()
 		if(!amount)
 			return TRUE
 	return TRUE

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -502,13 +502,14 @@ GLOBAL_LIST(cable_radial_layer_list)
 	if(H == user)
 		repair_time *= 3
 
-	user.visible_message(span_notice("[user] starts to fix some of the wires in [H]'s [affecting.display_name]."),\
+	user.visible_message(span_notice("[user] starts to fix some of the wires in [H == user ? "[H.p_their()]" : "[H]'s"] [affecting.display_name]."),\
 		span_notice("You start fixing some of the wires in [H == user ? "your" : "[H]'s"] [affecting.display_name]."))
 
 	while(affecting.burn_dam && do_after(user, repair_time, TRUE, src, BUSY_ICON_BUILD) && use(1))
-		user.visible_message(span_warning("\The [user] fixes some wires in [H == user ? "your" : "[H]'s"] [affecting.display_name] with \the [src]."), \
+		user.visible_message(span_warning("\The [user] fixes some wires in [H == user ? "[H.p_their()]" : "[H]'s"] [affecting.display_name] with \the [src]."), \
 			span_warning("You patch some wires in [H == user ? "your" : "[H]'s"] [affecting.display_name]."))
 		affecting.heal_limb_damage(0, 15, robo_repair = TRUE, updating_health = TRUE)
+		H.UpdateDamageIcon()
 		if(!amount)
 			return TRUE
 	return TRUE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Fixes the message so it doesn't look wrong
- Makes the burn overlays update after you repair em

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game


Bug bad

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Burn overlays update when you patch yourself with cable
fix: Fixes patching burnt wires with cable giving the wrong message
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
