### PR TITLE
Razorwire grenades can no longer be opened

### DIFF
--- a/code/game/objects/items/explosives/grenades/chem_grenade.dm
+++ b/code/game/objects/items/explosives/grenades/chem_grenade.dm
@@ -102,10 +102,10 @@
 			return
 
 	else if(stage == CG_READY && I.tool_behaviour == TOOL_WIRECUTTER && !active)
-		if(name == "Razorburn Grenade")
+		if(ispath(/obj/item/explosive/grenade/chem_grenade/razorburn_smol))
 			to_chat(user, span_notice("The [initial(name)] does not open."))
 			return
-		if(name == "Razorburn Canister")
+		if(ispath(/obj/item/explosive/grenade/chem_grenade/razorburn_large))
 			to_chat(user, span_notice("The [initial(name)] does not open."))
 			return
 		stage_change(CG_WIRED)

--- a/code/game/objects/items/explosives/grenades/chem_grenade.dm
+++ b/code/game/objects/items/explosives/grenades/chem_grenade.dm
@@ -102,6 +102,9 @@
 			return
 
 	else if(stage == CG_READY && I.tool_behaviour == TOOL_WIRECUTTER && !active)
+		if(name == "Razorburn Grenade")
+			to_chat(user, span_notice("The [initial(name)] does not open."))
+			return
 		stage_change(CG_WIRED)
 		to_chat(user, span_notice("You unlock the [initial(name)] assembly."))
 

--- a/code/game/objects/items/explosives/grenades/chem_grenade.dm
+++ b/code/game/objects/items/explosives/grenades/chem_grenade.dm
@@ -105,6 +105,9 @@
 		if(name == "Razorburn Grenade")
 			to_chat(user, span_notice("The [initial(name)] does not open."))
 			return
+		if(name == "Razorburn Canister")
+			to_chat(user, span_notice("The [initial(name)] does not open."))
+			return
 		stage_change(CG_WIRED)
 		to_chat(user, span_notice("You unlock the [initial(name)] assembly."))
 

--- a/code/game/objects/items/explosives/grenades/chem_grenade.dm
+++ b/code/game/objects/items/explosives/grenades/chem_grenade.dm
@@ -40,6 +40,13 @@
 		else
 			return ..()
 
+/obj/item/explosive/grenade/chem_grenade/razorburn_smol/attackby(obj/item/I, mob/user, params)
+	to_chat(user, span_notice("The [initial(name)] is hermetically sealed, and does not open."))
+	return
+
+/obj/item/explosive/grenade/chem_grenade/razorburn_large/attackby(obj/item/I, mob/user, params)
+	to_chat(user, span_notice("The [initial(name)] is hermetically sealed, and does not open."))
+	return
 
 /obj/item/explosive/grenade/chem_grenade/attackby(obj/item/I, mob/user, params)
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)
@@ -102,12 +109,6 @@
 			return
 
 	else if(stage == CG_READY && I.tool_behaviour == TOOL_WIRECUTTER && !active)
-		if(ispath(/obj/item/explosive/grenade/chem_grenade/razorburn_smol))
-			to_chat(user, span_notice("The [initial(name)] does not open."))
-			return
-		if(ispath(/obj/item/explosive/grenade/chem_grenade/razorburn_large))
-			to_chat(user, span_notice("The [initial(name)] does not open."))
-			return
 		stage_change(CG_WIRED)
 		to_chat(user, span_notice("You unlock the [initial(name)] assembly."))
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Razorwire grenades and canister can no longer be opened with wirecutters and the containers inside removed.

## Why It's Good For The Game

Previous fixes have not worked to stop this.

Certain individuals have been abusing the razorwire recipe and the fact that the razorwire grenades can be opened to coat maps in razorwire, in combination with plasmacutting everything in sight. This has made rounds with those individuals online generally unfun for xenos, in that they're extremely restricted due to the sheer volume of it.

This solves one of those problems by making purchaseable razorwire grenades, in line with regular grenades, unopenable. The contents of said grenades remain the same so their intended use will be unchanged, and the recipe remains the same for admin shenanigans. Tested, and works as intended with no visible issues.

(Yes it's yanderedev-tier if statements I know)

## Changelog
:cl:

balance: Razorwire grenades and canisters can no longer have their contents removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
