### PR TITLE
Add T-25 ammo box in SG vendor UNDER CERTAIN PARAMETERS

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -155,7 +155,8 @@ GLOBAL_LIST_INIT(smartgunner_gear_listed_products, list(
 	/obj/item/weapon/gun/rifle/standard_smartmachinegun = list(CAT_LEDSUP, "T-29 Smartmachinegun", 30 , "white"),
 	/obj/item/ammo_magazine/standard_smartmachinegun = list(CAT_LEDSUP, "T-29 Smartmachinegun ammo", 5 , "black"),
 	/obj/item/weapon/gun/rifle/standard_smartrifle = list(CAT_LEDSUP, "T-25 smartrifle", 30 , "white"),
-	/obj/item/ammo_magazine/rifle/standard_smartrifle = list(CAT_LEDSUP, "T-25 smartrifle ammo", 2 , "black"),
+	/obj/item/ammo_magazine/rifle/standard_smartrifle = list(CAT_LEDSUP, "T-25 smartrifle magazine", 2 , "black"),
+	/obj/item/ammo_magazine/packet/t25 = list(CAT_LEDSUP, "T-25 smartrifle ammo box", 6 , "black"),
 	))
 
 

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -156,7 +156,7 @@ GLOBAL_LIST_INIT(smartgunner_gear_listed_products, list(
 	/obj/item/ammo_magazine/standard_smartmachinegun = list(CAT_LEDSUP, "T-29 Smartmachinegun ammo", 5 , "black"),
 	/obj/item/weapon/gun/rifle/standard_smartrifle = list(CAT_LEDSUP, "T-25 smartrifle", 30 , "white"),
 	/obj/item/ammo_magazine/rifle/standard_smartrifle = list(CAT_LEDSUP, "T-25 smartrifle magazine", 2 , "black"),
-	/obj/item/ammo_magazine/packet/t25 = list(CAT_LEDSUP, "T-25 smartrifle ammo box", 5 , "black"),
+	/obj/item/ammo_magazine/packet/t25 = list(CAT_LEDSUP, "T-25 smartrifle ammo box", 6 , "black"),
 	))
 
 

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -156,7 +156,7 @@ GLOBAL_LIST_INIT(smartgunner_gear_listed_products, list(
 	/obj/item/ammo_magazine/standard_smartmachinegun = list(CAT_LEDSUP, "T-29 Smartmachinegun ammo", 5 , "black"),
 	/obj/item/weapon/gun/rifle/standard_smartrifle = list(CAT_LEDSUP, "T-25 smartrifle", 30 , "white"),
 	/obj/item/ammo_magazine/rifle/standard_smartrifle = list(CAT_LEDSUP, "T-25 smartrifle magazine", 2 , "black"),
-	/obj/item/ammo_magazine/packet/t25 = list(CAT_LEDSUP, "T-25 smartrifle ammo box", 6 , "black"),
+	/obj/item/ammo_magazine/packet/t25 = list(CAT_LEDSUP, "T-25 smartrifle ammo box", 5 , "black"),
 	))
 
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title; read next part

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Fundamentally, the T-25 ammo box is a demand for any sane T-25 smartgunner. They rush to requisition to get more ammo (at least, this is what I do). This PR will allow smartgunners to have T-25 ammo boxes UNDER CERTAIN PARAMETERS!

All smartgunners have 50 SG points to buy their weapon and ammo. The current round start T-25 smartgunner spawns with 8 T-25 magazines, totaling up to 640 ammo. T-25 costs 35 SG points, and T-25 mags costs 2 SG point, giving a remainer of 1 SG point.

I propose to let T-25 smargunners be able to choose to get T-25 ammo boxes but no more than 2. One T-25 ammo box will cost 6 SG points and containing 320 ammo, so they can choose to use 12 SG points to get 640 ammo.

Yes, 6 points from buying 3 T-25 mags result in 240 ammo since 80*3 = 240, making getting T-25 ammo boxes with SG points more bank. This means that with this PR, T-25 smargunners will get 160 more ammo by buying 2 T-25 ammo boxes with SG points IN ADDITION to more storage. However, T-25 players already have this gameplay loop in req, and this should be rewarded with SG points as well.

## THREE SET UPS FOR T-25 SMARTGUNNER PLAYERS WITH SG POINTS FROM PR

1) 1 T-25 magazine in Smartrifle + 7 purchased T-25 magazines = 640 ammo since 80 * 8 = 640
2) 1 T-25 magazine in Smartrifle + 4 purchased T-25 magazines + 1 T-25 ammo box = 640 ammo since [(80 * 5) + 320] = 720
3) 1 T-25 magazine in Smartrifle + 1 purchased T-25 magazine +2 T-25 ammo boxes = 800 ammo since [(80 * 2) + (320*2)] = 800

## Changelog
:cl:
balance: Add in T-25 ammo box for smartgunners to buy in their vendor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
