### PR TITLE
Adds Nanites to Research Rewards

### DIFF
--- a/code/game/objects/items/reagent_containers/glass/bottle.dm
+++ b/code/game/objects/items/reagent_containers/glass/bottle.dm
@@ -272,4 +272,8 @@
 	icon_state = "bottle-5"
 	list_reagents = list(/datum/reagent/medicine/lemoline = 10)
 
-
+/obj/item/reagent_containers/glass/bottle/nanites
+	name = "\improper Nanites bottle"
+	desc = "A small bottle. Contains 10 units of nanites, living robots used in certain recipes."
+	icon_state = "bottle-4"
+	list_reagents = list(/datum/reagent/toxin/nanites = 10)

--- a/code/game/objects/machinery/research.dm
+++ b/code/game/objects/machinery/research.dm
@@ -49,6 +49,7 @@
 				/obj/item/research_product/money/uncommon,
 				/obj/item/implanter/blade,
 				/obj/item/attachable/shoulder_mount,
+				/obj/item/reagent_containers/glass/bottle/nanites,
 			),
 			RES_TIER_RARE = list(
 				/obj/item/research_product/money/rare,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds 10u bottles of nanites to researcher uncommon rewards tier, coupled with #9012 .

## Why It's Good For The Game

Stops people insulting me on Discord for removing the unintended source of nanites in the form of razorwire grenades (more commonly used to spam dropper wire and not for medical nanites). Means medical nanites and razorwire can be produced in limited quantities with an active researcher.

## Changelog
:cl:
add: Nanite bottles added to Research Rewards.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
