### PR TITLE
(Medical) Nanomachines: For all!

### DIFF
--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -261,6 +261,14 @@
 		/datum/reagent/medicine/rezadone = 15,
 	)
 
+/obj/item/reagent_containers/hypospray/autoinjector/medicalnanites
+	name = "nanomachines autoinjector"
+	desc = "An auto-injector loaded with medical nanites. A potent new method of healing that that reproduces using a subject's blood and has a brief but potentially dangerous activation period! Beware of Neurotoxin!
+	icon_state = "autoinjector-6"
+	amount_per_transfer_from_this = 1
+	volume = 1
+	list_reagents = list(/datum/reagent/medicine/research/medicalnanites = 1)
+
 /obj/item/reagent_containers/hypospray/autoinjector/pain //made for debugging
 	name = "liquid pain autoinjector"
 	desc = "An auto-injector loaded with liquid pain. Ow."

--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -263,7 +263,7 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/medicalnanites
 	name = "nanomachines autoinjector"
-	desc = "An auto-injector loaded with medical nanites. A potent new method of healing that that reproduces using a subject's blood and has a brief but potentially dangerous activation period! Beware of Neurotoxin!
+	desc = "An auto-injector loaded with medical nanites. A potent new method of healing that that reproduces using a subject's blood and has a brief but potentially dangerous activation period! Beware of Neurotoxin!"
 	icon_state = "autoinjector-6"
 	amount_per_transfer_from_this = 1
 	volume = 1

--- a/code/game/objects/items/reagent_containers/glass/bottle.dm
+++ b/code/game/objects/items/reagent_containers/glass/bottle.dm
@@ -266,6 +266,12 @@
 	icon_state = "bottle2"
 	list_reagents = list(/datum/reagent/medicine/polyhexanide = 30)
 
+/obj/item/reagent_containers/glass/bottle/medicalnanites
+	name = "\improper Polyhexanide bottle"
+	desc = "A small bottle. Contains nanomachines modified for medical use, A potent new method of healing that that reproduces using a subject's blood and has a brief but potentially dangerous activation period!"
+	icon_state = "bottle7"
+	list_reagents = list(/datum/reagent/medicine/research/medicalnanites = 5)
+
 /obj/item/reagent_containers/glass/bottle/lemoline
 	name = "\improper Lemoline bottle"
 	desc = "A small bottle. Contains 10 units of lemoline, a reagent used in the creation of advanced medicine."

--- a/code/game/objects/items/reagent_containers/glass/bottle.dm
+++ b/code/game/objects/items/reagent_containers/glass/bottle.dm
@@ -267,7 +267,7 @@
 	list_reagents = list(/datum/reagent/medicine/polyhexanide = 30)
 
 /obj/item/reagent_containers/glass/bottle/medicalnanites
-	name = "\improper Polyhexanide bottle"
+	name = "\improper Nanomachines bottle"
 	desc = "A small bottle. Contains nanomachines modified for medical use, A potent new method of healing that that reproduces using a subject's blood and has a brief but potentially dangerous activation period!"
 	icon_state = "bottle7"
 	list_reagents = list(/datum/reagent/medicine/research/medicalnanites = 5)

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -646,6 +646,7 @@
 			/obj/item/reagent_containers/hypospray/autoinjector/hypervene = 16,
 			/obj/item/reagent_containers/hypospray/autoinjector/isotonic = 16,
 			/obj/item/reagent_containers/hypospray/autoinjector/quickclot = 16,
+			/obj/item/reagent_containers/hypospray/autoinjector/medicalnanites = 20,
 			/obj/item/reagent_containers/hypospray/autoinjector/synaptizine = 0,
 		),
 		"Heal Pack" = list(

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -162,6 +162,7 @@
 			/obj/item/reagent_containers/glass/bottle/tramadol = 4,
 			/obj/item/reagent_containers/glass/bottle/oxycodone = 4,
 			/obj/item/reagent_containers/glass/bottle/polyhexanide = 2,
+			/obj/item/reagent_containers/glass/bottle/medicalnanites = 2,
 		),
 		"Pill Bottle" = list(
 			/obj/item/storage/pill_bottle/peridaxon = 2,


### PR DESCRIPTION
Okay, so, we know nanomachines are crummy, they drain your blood and usually end up doing more harm than good, sure, we could buff them.

Or we could give them to everyone, JPR mentioned them being a fun toy for researchers. Let's make it a fun toy for everyone!

## About The Pull Request

Adds Nanomachine injectors and Bottles to the Marinemed and Chemistry vendors respectively, for all to use.

Due to the current questions about razorwire nades and such, i'm hoping to throw my hat in for a solution to the new Medical Nanomachine problem, partly due to Nanomachines not being obtainable in such a case (Reffer to PR #9012).

## Why It's Good For The Game

I believe, that while (Medical) Nanomachines are practically useless, several players have mentioned they're fun to use.
Now, I think Mera/Dermaline already fits the bill for Lemoline healing, with the added bonus of not sucking your blood dry or giving you toxin damage.

Along with that, balance wise, I don't think it'll affect much, partly due to being a gimmick chem and partly because other Lemoline based medicines have alternative obtainment methods (For example Ambrosia Deus for Somolent, Blood tomatos for QC+, some other plant for Quietus.)

## Changelog
:cl:
add: Added Medical Nanites to the common marine vendors, son!
/:cl: