### PR TITLE
Remove redundant point code

### DIFF
--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -1,6 +1,5 @@
 /obj/effect/overlay
 	name = "overlay"
-	var/i_attached//Added for possible image attachments to objects. For hallucinations and the like.
 
 /obj/effect/overlay/beam//Not actually a projectile, just an effect.
 	name="beam"

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -312,12 +312,6 @@
 	hud_to_add = GLOB.huds[DATA_HUD_XENO_DEBUFF]
 	hud_to_add.add_hud_to(src)
 
-/mob/living/carbon/xenomorph/point_to_atom(atom/A, turf/T)
-	TIMER_COOLDOWN_START(src, COOLDOWN_POINT, 1 SECONDS)
-	new /obj/effect/overlay/temp/point/big(T)
-	visible_message("<b>[src]</b> points to [A]")
-	return TRUE
-
 /mob/living/carbon/xenomorph/get_permeability_protection()
 	return XENO_PERM_COEFF
 


### PR DESCRIPTION
## About The Pull Request

Removes the xeno specific point code

## Why It's Good For The Game

It did basically the same thing, but without the features of the existing code.
Xeno points are now also _thrown_.

## Changelog
:cl:
code: Removed xeno specific throw card.
/:cl:
