### PR TITLE
Synthetic spawns with high-capacity industrial blowtorch

### DIFF
--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -694,7 +694,7 @@
 	spawned_gear_list = list(
 		/obj/item/stack/sheet/plasteel/medium_stack,
 		/obj/item/stack/sheet/metal/large_stack,
-		/obj/item/tool/weldingtool/hugetank
+		/obj/item/tool/weldingtool/hugetank,
 		/obj/item/lightreplacer,
 		/obj/item/healthanalyzer,
 		/obj/item/tool/handheld_charger,

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -694,6 +694,7 @@
 	spawned_gear_list = list(
 		/obj/item/stack/sheet/plasteel/medium_stack,
 		/obj/item/stack/sheet/metal/large_stack,
+		/obj/item/tool/weldingtool/hugetank
 		/obj/item/lightreplacer,
 		/obj/item/healthanalyzer,
 		/obj/item/tool/handheld_charger,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

As promised in https://github.com/tgstation/TerraGov-Marine-Corps/pull/8892, I shall give synthetics the high-capacity industrial blowtorch in spawn so that they have QoL and show that contributors observe. Engineers have to buy one for 15 points, but since synthetic is dedicated support role, they need all the help they need. No sane synthetic would give away the high-capacity industrial blowtorch to any engineer.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Synthetic spawns with high-capacity industrial blowtorch
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
