### PR TITLE
Somolent crit heal

### DIFF
--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1308,6 +1308,23 @@
 	scannable = TRUE
 	overdose_threshold = REAGENTS_OVERDOSE
 	taste_description = "naptime"
+	
+/datum/reagent/medicine/somolent/on_mob_add(mob/living/L, metabolism)
+	var/mob/living/carbon/human/H = L
+	if(TIMER_COOLDOWN_CHECK(L, name))
+		return
+	if(L.health < H.health_threshold_crit && volume > 9 && L.stat == UNCONSCIOUS) //If you are in crit, unconscious, and someone injects at least 10u into you at once, you will heal 15% of your physical damage instantly and organ below 25.
+		to_chat(L, span_userdanger("you feel much better but very exhausted"))
+		L.adjustStaminaLoss(50*effect_str)
+		L.adjustBruteLoss(-L.getBruteLoss() * 0.15)
+		L.adjustFireLoss(-L.getFireLoss() * 0.15)
+		L.jitter(5)
+		for(var/datum/internal_organ/I AS in H.internal_organs)
+			if(I.damage)
+				if(I.damage < 25)
+					return
+				I.heal_organ_damage((I.damage-25) *effect_str)
+		TIMER_COOLDOWN_START(L, name, 300 SECONDS)
 
 /datum/reagent/medicine/research/somolent/on_mob_life(mob/living/L, metabolism)
 	switch(current_cycle)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1309,7 +1309,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	taste_description = "naptime"
 	
-/datum/reagent/medicine/somolent/on_mob_add(mob/living/L, metabolism)
+/datum/reagent/medicine/research/somolent/on_mob_add(mob/living/L, metabolism)
 	var/mob/living/carbon/human/H = L
 	if(TIMER_COOLDOWN_CHECK(L, name))
 		return


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds inaprov like crit heal to somolent.
Condition: Patient in crit, more or equal 10 units administered, and unconscious.
Heals 15% all burn&brute
Organ damage to 25.
Does 50 stamina damage.
Has 300 seconds cooldown like everything else.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Somolent is described as "highly potent regenerative drug, designed to heal critically injured personnel", now its true :).
Being research gimmick, annoying to craft and its niche usage only unconscious, it needs more then just healing. Crit stabilization at a cost of hard stamina damage to me seems fair trade to make it little bit more useful then it is now.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Kait
balance: Somolent can crit heal
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
