### PR TITLE
Removes Tyr head module from Requisitions order

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -809,7 +809,6 @@ ARMOR
 	name = "Jaeger Tyr mark 2 module"
 	contains = list(
 		/obj/item/armor_module/module/tyr_extra_armor,
-		/obj/item/armor_module/module/tyr_head,
 	)
 	cost = 12
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the Tyr head module from the Mark 2 Requisitions order crate.

## Why It's Good For The Game

You can already get it for free from the surplus armor vendors, as there isn't a Mark 2 specific variant.

## Changelog
:cl:

del: Removed Tyr helmet attachment from Mark 2 crate, as it's free in surplus vendors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
