### PR TITLE
Fixes CAS issues with LV and Chigusa

### DIFF
--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -2748,6 +2748,7 @@
 "aNT" = (
 /obj/machinery/floodlight,
 /obj/item/ammo_casing,
+/obj/effect/landmark/dropship_start_location,
 /turf/open/floor/plating,
 /area/lv624/lazarus/tablefort)
 "aNZ" = (

--- a/_maps/map_files/desertdam/desertdam.dmm
+++ b/_maps/map_files/desertdam/desertdam.dmm
@@ -64149,6 +64149,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/west_tunnel)
+"tcK" = (
+/obj/effect/landmark/dropship_start_location,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
 "tcS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -98218,7 +98224,7 @@ bAK
 bAK
 bAK
 bAK
-bwv
+tcK
 aFo
 bwv
 iVQ


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The latest LV rework broke CAS without flares due to an oversight, Chigusa never had the appropriate landmark to actually start CAS without flares so I fixed that while I was at it.

## Why It's Good For The Game

Bugs bad, also PO's would probably like to fly their planes without waiting for a flare.

## Changelog
:cl:
fix: Fixed a bug preventing CAS without flares on LV624.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
