### PR TITLE
Give researcher medical radio access and put researcher under support

### DIFF
--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -866,7 +866,7 @@ While the Corporate Liaison is not your boss, it would be wise to consult them o
 	jobtype = /datum/job/terragov/medical/researcher
 	id = /obj/item/card/id
 	belt = /obj/item/storage/belt/medical
-	ears = /obj/item/radio/headset/mainship/res
+	ears = /obj/item/radio/headset/mainship/doc
 	w_uniform = /obj/item/clothing/under/marine/officer/researcher
 	wear_suit = /obj/item/clothing/suit/storage/labcoat/armored_coat
 	shoes = /obj/item/clothing/shoes/laceup

--- a/tgui/packages/tgui/interfaces/PlayerPreferences/JobPreferences.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPreferences/JobPreferences.tsx
@@ -33,6 +33,7 @@ export const JobPreferences = (props, context) => {
     'Requisitions Officer',
     'Chief Medical Officer',
     'Medical Doctor',
+    'Medical Researcher',
   ];
   const marineJobs = [
     'Squad Marine',
@@ -41,7 +42,7 @@ export const JobPreferences = (props, context) => {
     'Squad Smartgunner',
     'Squad Leader',
   ];
-  const flavourJobs = ['Corporate Liaison', 'Medical Researcher'];
+  const flavourJobs = ['Corporate Liaison'];
 
   const JobList = ({ name, jobs }) => (
     <Section title={name}>


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Why researcher doesn't have medical radio is a mystery that doesn't need to get solved. It will get resolved by giving researcher medical radio without having them greytide and get radio.

Also, researcher is no longer in the same job category as CL.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Researcher has medical radio to talk in medical.
fix: Researcher is under support now instead of flavour.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
