### PR TITLE
Fixes warrior punch

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -481,6 +481,8 @@
 			to_chat(src, span_danger("The splint on your [L.display_name] comes apart!"))
 
 		L.take_damage_limb(damage, 0, FALSE, FALSE, run_armor_check(target_zone))
+	else
+		apply_damage(damage, BRUTE, target_zone, run_armor_check(target_zone))
 
 	if(push)
 		var/facing = get_dir(X, src)
@@ -499,7 +501,6 @@
 
 		throw_at(T, 2, 1, X, 1) //Punch em away
 
-	apply_damage(damage, BRUTE, target_zone, run_armor_check(target_zone))
 	var/target_location_feedback = get_living_limb_descriptive_name(target_zone)
 	X.visible_message(span_xenodanger("\The [X] hits [src] in the [target_location_feedback] with a [punch_description] punch!"), \
 		span_xenodanger("We hit [src] in the [target_location_feedback] with a [punch_description] punch!"), visible_message_flags = COMBAT_MESSAGE)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a mistake I made in the warrior primordial PR, giving warrior punch twice the damage output of a regular slash.
Meaning a lunge+punch combo would be equivalent to eating 4 slashes.
Sorry to every player who lost limbs because of that mistake.
## Why It's Good For The Game

Marines will maybe stop losing their feet

## Changelog
:cl:
fix: fixed warrior punch doing more damage than it's suposed to
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
