### PR TITLE
Detpack Buff

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -75,7 +75,8 @@ GLOBAL_LIST_INIT(engineer_gear_listed_products, list(
 		/obj/item/storage/box/minisentry = list(CAT_ENGSUP, "UA-580 point defense sentry kit", 50, "black"),
 		/obj/item/attachable/buildasentry = list(CAT_ENGSUP, "Build-A-Sentry Attachment", 30, "black"),
 		/obj/item/explosive/plastique = list(CAT_ENGSUP, "Plastique explosive", 2, "black"),
-		/obj/item/detpack = list(CAT_ENGSUP, "Detonation pack", 5, "black"),
+		/obj/item/detpack = list(CAT_ENGSUP, "Detonation pack", 2, "black"),
+		/obj/item/assembly/signaler = list(CAT_ENGSUP, "Signaler (for detpacks)", 1, "black"),
 		/obj/item/tool/shovel/etool = list(CAT_ENGSUP, "Entrenching tool", 1, "black"),
 		/obj/item/tool/handheld_charger = list(CAT_ENGSUP, "Hand-held cell charger", 3, "black"),
 		/obj/item/tool/weldingtool/hugetank = list(CAT_ENGSUP, "High-capacity industrial blowtorch", 15, "black"),
@@ -90,7 +91,6 @@ GLOBAL_LIST_INIT(engineer_gear_listed_products, list(
 		/obj/item/explosive/grenade/chem_grenade/razorburn_smol = list(CAT_ENGSUP, "Razorburn grenade", 3, "black"),
 		/obj/item/multitool = list(CAT_ENGSUP, "Multitool", 1, "black"),
 		/obj/item/circuitboard/general = list(CAT_ENGSUP, "General circuit board", 1, "black"),
-		/obj/item/assembly/signaler = list(CAT_ENGSUP, "Signaler (for detpacks)", 1, "black"),
 		/obj/item/stack/voucher/sentry = list(CAT_ENGSUP, "UA 571-C Base defense sentry voucher", 26, "black"),
 	))
 

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -320,6 +320,24 @@
 		/obj/item/ammo_magazine/standard_smartmachinegun,
 	)
 
+/obj/item/storage/pouch/explosive/engineerdetpack/Initialize()
+	name = "Squad engineer's detpack pouch"
+	desc = "A squad engineer's best friend. It holds six detpacks and one signaler."
+	icon_state = "large_explosive"
+	storage_slots = 7
+	max_w_class = 3
+	can_hold = list(
+		/obj/item/detpack,
+		/obj/item/assembly/signaler,
+	)
+	. = ..()
+	new /obj/item/detpack(src)
+	new /obj/item/detpack(src)
+	new /obj/item/detpack(src)
+	new /obj/item/detpack(src)
+	new /obj/item/detpack(src)
+	new /obj/item/detpack(src)
+	new /obj/item/assembly/signaler(src)
 
 /obj/item/storage/pouch/explosive
 	name = "explosive pouch"

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -320,25 +320,6 @@
 		/obj/item/ammo_magazine/standard_smartmachinegun,
 	)
 
-/obj/item/storage/pouch/explosive/engineerdetpack/Initialize()
-	name = "Squad engineer's detpack pouch"
-	desc = "A squad engineer's best friend. It holds six detpacks and one signaler."
-	icon_state = "large_explosive"
-	storage_slots = 7
-	max_w_class = 3
-	can_hold = list(
-		/obj/item/detpack,
-		/obj/item/assembly/signaler,
-	)
-	. = ..()
-	new /obj/item/detpack(src)
-	new /obj/item/detpack(src)
-	new /obj/item/detpack(src)
-	new /obj/item/detpack(src)
-	new /obj/item/detpack(src)
-	new /obj/item/detpack(src)
-	new /obj/item/assembly/signaler(src)
-
 /obj/item/storage/pouch/explosive
 	name = "explosive pouch"
 	desc = "It can contain grenades, plastiques, mine boxes, and other explosives."
@@ -376,6 +357,20 @@
 /obj/item/storage/pouch/explosive/upp
 	fill_type = /obj/item/explosive/grenade/upp
 	fill_number = 4
+
+/obj/item/storage/pouch/detpack
+	name = "detpack pouch"
+	desc = "A squad engineer's best friend. It holds six detpacks and one signaler."
+	icon_state = "large_explosive"
+	storage_slots = 7
+	max_w_class = 3
+	can_hold = list(
+		/obj/item/detpack,
+		/obj/item/assembly/signaler,
+	)
+	fill_type = /obj/item/detpack
+	fill_number = 6
+	
 
 /obj/item/storage/pouch/grenade
 	name = "Grenade pouch"

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -370,7 +370,6 @@
 	)
 	fill_type = /obj/item/detpack
 	fill_number = 6
-	
 
 /obj/item/storage/pouch/grenade
 	name = "Grenade pouch"

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -655,6 +655,7 @@
 	spawned_gear_list = list(
 		/obj/item/explosive/plastique,
 		/obj/item/storage/pouch/detpack,
+		/obj/item/assembly/signaler,
 		/obj/item/explosive/grenade/chem_grenade/razorburn_smol,
 		/obj/item/clothing/glasses/welding,
 		/obj/item/clothing/gloves/marine/insulated,

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -661,6 +661,7 @@
 		/obj/item/tool/shovel/etool,
 		/obj/item/lightreplacer,
 		/obj/item/circuitboard/general,
+		/obj/item/storage/pouch/explosive/engineerdetpack
 	)
 
 /obj/effect/essentials_set/leader

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -654,6 +654,7 @@
 /obj/effect/essentials_set/engi
 	spawned_gear_list = list(
 		/obj/item/explosive/plastique,
+		/obj/item/storage/pouch/detpack,
 		/obj/item/explosive/grenade/chem_grenade/razorburn_smol,
 		/obj/item/clothing/glasses/welding,
 		/obj/item/clothing/gloves/marine/insulated,
@@ -661,7 +662,6 @@
 		/obj/item/tool/shovel/etool,
 		/obj/item/lightreplacer,
 		/obj/item/circuitboard/general,
-		/obj/item/storage/pouch/explosive/engineerdetpack,
 	)
 
 /obj/effect/essentials_set/leader

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -661,7 +661,7 @@
 		/obj/item/tool/shovel/etool,
 		/obj/item/lightreplacer,
 		/obj/item/circuitboard/general,
-		/obj/item/storage/pouch/explosive/engineerdetpack
+		/obj/item/storage/pouch/explosive/engineerdetpack,
 	)
 
 /obj/effect/essentials_set/leader

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -517,7 +517,7 @@ EXPLOSIVES
 	)
 	cost = 10
 
-/datum/supply_packs/explosives/detpack
+/datum/supply_packs/explosives/manydetpack
 	name = "A LOT of detpack explosives"
 	contains = list(
 		/obj/item/detpack,

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -509,6 +509,29 @@ EXPLOSIVES
 	contains = list(
 		/obj/item/detpack,
 		/obj/item/detpack,
+		/obj/item/detpack,
+		/obj/item/detpack,
+		/obj/item/detpack,
+		/obj/item/detpack,
+		/obj/item/assembly/signaler,
+	)
+	cost = 10
+
+/datum/supply_packs/explosives/detpack
+	name = "A LOT of detpack explosives"
+	contains = list(
+		/obj/item/detpack,
+		/obj/item/detpack,
+		/obj/item/detpack,
+		/obj/item/detpack,
+		/obj/item/detpack,
+		/obj/item/detpack,
+		/obj/item/detpack,
+		/obj/item/detpack,
+		/obj/item/detpack,
+		/obj/item/detpack,
+		/obj/item/detpack,
+		/obj/item/detpack,
 		/obj/item/assembly/signaler,
 	)
 	cost = 15

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -517,25 +517,6 @@ EXPLOSIVES
 	)
 	cost = 10
 
-/datum/supply_packs/explosives/manydetpack
-	name = "A LOT of detpack explosives"
-	contains = list(
-		/obj/item/detpack,
-		/obj/item/detpack,
-		/obj/item/detpack,
-		/obj/item/detpack,
-		/obj/item/detpack,
-		/obj/item/detpack,
-		/obj/item/detpack,
-		/obj/item/detpack,
-		/obj/item/detpack,
-		/obj/item/detpack,
-		/obj/item/detpack,
-		/obj/item/detpack,
-		/obj/item/assembly/signaler,
-	)
-	cost = 15
-
 /datum/supply_packs/explosives/mortar
 	name = "M402 mortar crate"
 	contains = list(/obj/item/mortar_kit)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adding the following:

1) detpack explosive in req now cost 10 points and have 6 detpacks
2) a LOT of detpack in req, which costs 15 points and 12 detpacks
3) new squad engineer detpack pouch which holds 6 detpacks
4) said detpack pouch is in essential set
5) reduce price of individual detpack in squad engineer

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Araulius wanted it, and when I saw how much detpacks squad engineers have, they don't even spawn with one compared to a C4. Also, release the ordnance nature of squad engineer. Total balance, I swear.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: A lot of detpacks
expansion: Give more detpacks in req
qol: Let squad engineer have more detpacks by letting them spawn in with detpack
balance: A lot of detpacks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
