### PR TITLE
Replaces engineer loadout blowtorch with industrial blowtorch

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -337,7 +337,7 @@ GLOBAL_LIST_INIT(engineer_clothes_listed_products, list(
 		/obj/item/storage/pouch/shotgun = list(CAT_POU, "Shotgun shell pouch", 0, "black"),
 		/obj/item/storage/pouch/construction = list(CAT_POU, "Construction pouch", 0, "orange"),
 		/obj/item/storage/pouch/explosive = list(CAT_POU, "Explosive pouch", 0, "black"),
-		/obj/item/storage/pouch/tools/full = list(CAT_POU, "Tools pouch", 0, "black"),
+		/obj/item/storage/pouch/tools/equippedengineer = list(CAT_POU, "Tools pouch", 0, "black"),
 		/obj/item/storage/pouch/grenade/slightlyfull = list(CAT_POU, "Grenade pouch (grenades included)", 0,"black"),
 		/obj/item/storage/pouch/electronics/full = list(CAT_POU, "Electronics pouch", 0, "black"),
 		/obj/item/storage/pouch/magazine/large = list(CAT_POU, "Magazine pouch", 0, "black"),

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -70,7 +70,7 @@
 	. = ..()
 	new /obj/item/tool/screwdriver(src)
 	new /obj/item/tool/wrench(src)
-	new /obj/item/tool/weldingtool(src)
+	new /obj/item/tool/weldingtool/largetank(src)
 	new /obj/item/tool/crowbar(src)
 	new /obj/item/tool/wirecutters(src)
 	new /obj/item/stack/cable_coil(src,30,pick("red","yellow","orange"))

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -693,6 +693,14 @@
 	new /obj/item/tool/weldingtool (src)
 	new /obj/item/tool/wrench (src)
 	new /obj/item/tool/crowbar (src)
+	
+/obj/item/storage/pouch/tools/equippedengineer/Initialize()
+	. = ..()
+	new /obj/item/tool/screwdriver (src)
+	new /obj/item/tool/wirecutters (src)
+	new /obj/item/tool/weldingtool/largetank (src)
+	new /obj/item/tool/wrench (src)
+	new /obj/item/tool/crowbar (src)
 
 /obj/item/storage/pouch/shotgun //New shotgun shell pouch that is actually worth a shit and will be replacing light general in vendors
 	name = "shotgun shell pouch"


### PR DESCRIPTION
## About The Pull Request
Title. I do not know if this is a QoL or Balance, probably both.

## Why It's Good For The Game
Cuts some slack on the hectic engineer prep time by having the engineer spawn with an industrial blowtorch. Honestly, it does not make sense to me that they would not spawn with an industrial blowtorch and have to hack to acquire it given that they are the specialist role that uses it the most.

## Changelog
:cl:
balance: replaces engineer loadout blowtorch with industrial blowtorch
/:cl: