### PR TITLE
Make mini pepperball mags smaller

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -463,6 +463,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	max_shells = 20
 	default_ammo_type = /obj/item/ammo_magazine/rifle/pepperball/pepperball_mini
 	allowed_ammo_types = list(/obj/item/ammo_magazine/rifle/pepperball/pepperball_mini)
+	w_class = 2
 	force = 5
 	attachable_allowed = list()
 	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC)

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -463,7 +463,6 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	max_shells = 20
 	default_ammo_type = /obj/item/ammo_magazine/rifle/pepperball/pepperball_mini
 	allowed_ammo_types = list(/obj/item/ammo_magazine/rifle/pepperball/pepperball_mini)
-	w_class = 2
 	force = 5
 	attachable_allowed = list()
 	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC)

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -260,6 +260,7 @@
 	icon_state = "pepperball_mini"
 	default_ammo = /datum/ammo/bullet/pepperball/pepperball_mini
 	max_rounds = 20
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/ammo_magazine/minigun_powerpack
 	name = "\improper T-100 powerpack"


### PR DESCRIPTION
Make mini pepperball mags smaller

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Didn't consider the size of the mags while making the pepperball attachment, the mini magazines hold less bullets than regular pepperball so they should be smaller.
Also considered letting marines put mini pepperballs into pistol mag pouches but unsure yet.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mini pepperball magazines currently take up too much space.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Change mini pepperball magazine size from 3 to 2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
