### PR TITLE
Add tool vendor to crash

### DIFF
--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -551,12 +551,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
-"cM" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/shuttle/canterbury)
 "cR" = (
 /obj/machinery/door/window/right{
 	dir = 8
@@ -1016,6 +1010,13 @@
 "TE" = (
 /turf/open/floor/mainship/tcomms,
 /area/shuttle/canterbury)
+"TS" = (
+/obj/machinery/vending/tool,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/orange/full,
+/area/shuttle/canterbury)
 "Ub" = (
 /obj/machinery/light{
 	dir = 8
@@ -1345,7 +1346,7 @@ an
 ac
 uT
 sR
-ab
+TS
 bw
 Ot
 ap
@@ -1378,7 +1379,7 @@ an
 ac
 ac
 ac
-cM
+ac
 ac
 as
 ac

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -258,14 +258,6 @@
 /obj/effect/landmark/start/job/crash/squadmarine,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
-"aM" = (
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 1
-	},
-/obj/machinery/light/small,
-/obj/effect/landmark/start/job/crash/squadmarine,
-/turf/open/floor/mainship/mono,
-/area/shuttle/canterbury)
 "aN" = (
 /obj/machinery/autolathe,
 /turf/open/floor/mainship/cargo,
@@ -286,13 +278,6 @@
 "aR" = (
 /obj/structure/window/framed/mainship/canterbury,
 /turf/open/floor/plating,
-/area/shuttle/canterbury)
-"aS" = (
-/obj/machinery/vending/engivend,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/mainship/orange/full,
 /area/shuttle/canterbury)
 "aT" = (
 /obj/item/fuelCell/full,
@@ -353,10 +338,6 @@
 /area/shuttle/canterbury)
 "be" = (
 /turf/open/floor/mainship,
-/area/shuttle/canterbury)
-"bf" = (
-/obj/machinery/marine_selector/clothes/synth,
-/turf/open/floor/mainship/orange/full,
 /area/shuttle/canterbury)
 "bg" = (
 /obj/structure/cable,
@@ -532,10 +513,6 @@
 /obj/structure/window/framed/mainship/white/canterbury,
 /turf/open/floor/plating,
 /area/shuttle/canterbury/medical)
-"bM" = (
-/obj/item/weapon/gun/sentry/big_sentry/premade,
-/turf/open/floor/plating/plating_catwalk,
-/area/shuttle/canterbury)
 "bO" = (
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
@@ -822,10 +799,6 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/shuttle/canterbury)
-"cX" = (
-/obj/item/weapon/gun/sentry/big_sentry/premade,
-/turf/open/floor/plating/plating_catwalk,
-/area/shuttle/canterbury)
 "cY" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -859,10 +832,30 @@
 	},
 /turf/open/floor/mainship/red,
 /area/shuttle/canterbury)
+"vY" = (
+/obj/machinery/vending/tool,
+/turf/open/floor/mainship/orange/full,
+/area/shuttle/canterbury)
 "zE" = (
 /obj/structure/window/framed/mainship/canterbury,
 /obj/structure/cable,
 /turf/open/floor/plating,
+/area/shuttle/canterbury)
+"zN" = (
+/obj/machinery/vending/engivend,
+/obj/machinery/light/small{
+	dir = 8;
+	status = 0
+	},
+/turf/open/floor/mainship/orange/full,
+/area/shuttle/canterbury)
+"Bu" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 1
+	},
+/obj/effect/landmark/start/job/crash/squadmarine,
+/obj/machinery/light/small,
+/turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "Hv" = (
 /obj/structure/window/reinforced/toughened{
@@ -878,6 +871,10 @@
 "RS" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/mainship/mono,
+/area/shuttle/canterbury)
+"UG" = (
+/obj/machinery/marine_selector/clothes/synth,
+/turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 
 (1,1,1) = {"
@@ -957,7 +954,7 @@ an
 av
 aB
 aI
-aL
+Bu
 an
 aR
 bb
@@ -980,9 +977,9 @@ ab
 ab
 cV
 aJ
-aM
-an
-aS
+aL
+aN
+zN
 cv
 aT
 bo
@@ -1004,8 +1001,8 @@ ab
 cF
 aJ
 cR
-aN
-bf
+UG
+vY
 bg
 bl
 bo
@@ -1060,7 +1057,7 @@ bO
 aJ
 aJ
 aJ
-cX
+aI
 cZ
 co
 "}
@@ -1140,7 +1137,7 @@ aa
 an
 ax
 cQ
-bM
+aI
 cU
 an
 aW


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds tool vendors to canterbury and bigbury, removes a wall and moves a lamp on each.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
On crash combat robots/synths/engineers have no real source of cables/blowtorches/replacement tools except looting toolbelts and toolboxes causing these to be in high demand, especially on higher pop or late into the game.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: add tool vendors to canterbury and bigbury
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
