### PR TITLE
INFINITE FIRE EXTINGUISHERS!!!!

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -98,6 +98,8 @@
 			/obj/item/ammo_magazine/flamer_tank/backtank = 4,
 			/obj/item/ammo_magazine/flamer_tank/large = 20,
 			/obj/item/ammo_magazine/flamer_tank = 20,
+			/obj/item/tool/extinguisher = -1
+			/obj/item/tool/extinguisher/mini = -1
 			/obj/item/weapon/shield/riot/marine = 6,
 			/obj/item/weapon/powerfist = -1,
 			/obj/item/stack/throwing_knife = -1,

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -98,8 +98,8 @@
 			/obj/item/ammo_magazine/flamer_tank/backtank = 4,
 			/obj/item/ammo_magazine/flamer_tank/large = 20,
 			/obj/item/ammo_magazine/flamer_tank = 20,
-			/obj/item/tool/extinguisher = -1
-			/obj/item/tool/extinguisher/mini = -1
+			/obj/item/tool/extinguisher = -1,
+			/obj/item/tool/extinguisher/mini = -1,
 			/obj/item/weapon/shield/riot/marine = 6,
 			/obj/item/weapon/powerfist = -1,
 			/obj/item/stack/throwing_knife = -1,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

You can find infinite fire extinguishers, both big and mini, in the Specialized tab underneath the Automated Weapons Rack.

You can ALSO have fire extinguishers in loadout!

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Currently, you get fire extinguishers in two ways: in limited supplies from fire locker or mass produce from autolathe. The former is how almost everyone gets it and the latter is how almost no one gets it. Since friendly fire from fire is common and the demand for fire extinguisher is always on the rise, it is time to make the process of acquiring fire extinguisher easier!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: infinite fire extinguishers are now in vendors! Find it in the Specialized tab under flamethrowers. I wonder why I put infinite fire extinguishers underneath flamethrowers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
