### PR TITLE
Valkyrie Scanner gets keybind

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -722,6 +722,7 @@
 #define COMSIG_KB_AIMMODE "keybinding_aimmode"
 #define COMSIG_KB_FIREMODE "keybind_firemode"
 #define COMSIG_KB_GIVE "keybind_give"
+#define COMSIG_KB_VALKSCAN "keybind_valkyrie_module_scan"
 
 // Ability adding/removing signals
 #define ACTION_GIVEN "gave_an_action"		//from base of /datum/action/proc/give_action(): (datum/action)

--- a/code/datums/components/suit_autodoc.dm
+++ b/code/datums/components/suit_autodoc.dm
@@ -343,7 +343,6 @@
 /datum/component/suit_autodoc/proc/scan_user(datum/source)
 	SIGNAL_HANDLER
 	INVOKE_ASYNC(analyzer, /obj/item.proc/attack, wearer, wearer, TRUE)
-	return COMSIG_KB_VALKSCAN
 
 /**
 	Proc to show the suit configuration page

--- a/code/datums/components/suit_autodoc.dm
+++ b/code/datums/components/suit_autodoc.dm
@@ -445,7 +445,7 @@
 /datum/action/suit_autodoc/scan
 	name = "Suit Automedic User Scan"
 	action_icon_state = "suit_scan"
-	return COMSIG_KB_VALKSCAN
+	keybind_signal = COMSIG_KB_VALKSCAN
 
 /datum/action/suit_autodoc/configure
 	name = "Configure Suit Automedic"

--- a/code/datums/components/suit_autodoc.dm
+++ b/code/datums/components/suit_autodoc.dm
@@ -445,7 +445,6 @@
 /datum/action/suit_autodoc/scan
 	name = "Suit Automedic User Scan"
 	action_icon_state = "suit_scan"
-	keybind_signal = COMSIG_KB_VALKSCAN
 
 /datum/action/suit_autodoc/configure
 	name = "Configure Suit Automedic"

--- a/code/datums/components/suit_autodoc.dm
+++ b/code/datums/components/suit_autodoc.dm
@@ -343,6 +343,7 @@
 /datum/component/suit_autodoc/proc/scan_user(datum/source)
 	SIGNAL_HANDLER
 	INVOKE_ASYNC(analyzer, /obj/item.proc/attack, wearer, wearer, TRUE)
+	return COMSIG_KB_VALKSCAN
 
 /**
 	Proc to show the suit configuration page

--- a/code/datums/components/suit_autodoc.dm
+++ b/code/datums/components/suit_autodoc.dm
@@ -445,6 +445,7 @@
 /datum/action/suit_autodoc/scan
 	name = "Suit Automedic User Scan"
 	action_icon_state = "suit_scan"
+	return COMSIG_KB_VALKSCAN
 
 /datum/action/suit_autodoc/configure
 	name = "Configure Suit Automedic"

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -60,3 +60,9 @@
 	full_name = "Give"
 	description = "Give the held item to the nearby marine"
 	keybind_signal = COMSIG_KB_GIVE
+
+/datum/keybinding/human/valkscan
+	name = "valkyrie module scan"
+	full_name = "Use Suit Automedic User Scan"
+	description = "Keybind for Valkyrie's Suit Automedical User Scan"
+	keybind_signal = COMSIG_KB_VALKSCAN


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

TGMC's marine robustness philosophy is based on only using the mouse cursor for shooting xenomorphs / just aiming in general and reloading. Anything else is for keybind. Since valkyrie is a popular module, it is a quality of life to have it in keybind.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Keybind for valkyrie scan!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
