### PR TITLE
T-29 Balance: Ammo Buff, Burst, and aim_slowdown

### DIFF
--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -2669,11 +2669,29 @@
 /area/mainship/living/cafeteria_starboard)
 "bbj" = (
 /obj/machinery/vending/marineFood,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cafeteria_starboard)
 "bbm" = (
 /obj/machinery/firealarm,
 /obj/machinery/vending/marineFood,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cafeteria_starboard)
 "bbo" = (
@@ -7289,6 +7307,15 @@
 /area/mainship/squads/alpha)
 "bSR" = (
 /obj/machinery/vending/marineFood,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cafeteria_port)
 "bST" = (
@@ -8479,6 +8506,15 @@
 /area/mainship/medical/operating_room_three)
 "cnd" = (
 /obj/machinery/vending/marineFood,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cafeteria_port)
 "cnU" = (
@@ -12688,6 +12724,15 @@
 "knI" = (
 /obj/machinery/vending/marineFood,
 /obj/machinery/alarm,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cafeteria_port)
 "kpc" = (

--- a/code/datums/jobs/job/pmc.dm
+++ b/code/datums/jobs/job/pmc.dm
@@ -92,6 +92,7 @@
 	H.equip_to_slot_or_del(new /obj/item/storage/pill_bottle/tricordrazine, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/standard_smartmachinegun, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/standard_smartmachinegun, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/attachable/magnetic_harness, SLOT_IN_BACKPACK)
 
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/oxycodone, SLOT_IN_R_POUCH)
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/oxycodone, SLOT_IN_R_POUCH)

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -103,7 +103,6 @@
 			/obj/item/stack/throwing_knife = -1,
 			/obj/item/weapon/twohanded/spear/tactical = -1,
 			/obj/item/weapon/twohanded/spear/tactical/harvester = -1,
-			/obj/item/ammo_magazine/standard_smartmachinegun = 4,
 		),
 		"Grenades" = list(
 			/obj/item/explosive/grenade = 600,
@@ -262,7 +261,6 @@
 			/obj/item/weapon/powerfist = -1,
 			/obj/item/stack/throwing_knife = -1,
 			/obj/item/weapon/twohanded/spear/tactical = -1,
-			/obj/item/ammo_magazine/standard_smartmachinegun = 4,
 		),
 		"Grenades" = list(
 			/obj/item/explosive/grenade = 600,

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -954,7 +954,7 @@
 	caliber = CALIBER_10x26_CASELESS //codex
 	max_shells = 300 //codex
 	force = 30
-	aim_slowdown = 0.95
+	aim_slowdown = 1 //you're not supposed to frontline with smart machine gun; you're supposed to be shooting behind marines. Jetpack all you want, but you will still be slow as heck. You want to frontline as smartgunner? Go T-25.
 	wield_delay = 1.3 SECONDS
 	fire_sound = "gun_smartgun"
 	dry_fire_sound = 'sound/weapons/guns/fire/m41a_empty.ogg'
@@ -979,12 +979,12 @@
 	)
 
 	flags_gun_features = GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY|GUN_IFF
-	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_AUTOMATIC)
+	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_BURSTFIRE, GUN_FIREMODE_AUTOMATIC, GUN_FIREMODE_AUTOBURST)
 	starting_attachment_types = list(/obj/item/attachable/stock/t29stock, /obj/item/attachable/t29barrel)
 	gun_skill_category = GUN_SKILL_SMARTGUN //Uses SG skill for the penalties.
 	attachable_offset = list("muzzle_x" = 42, "muzzle_y" = 17,"rail_x" = 15, "rail_y" = 21, "under_x" = 24, "under_y" = 14, "stock_x" = 12, "stock_y" = 13)
 	fire_delay = 0.25 SECONDS
-	burst_amount = 0
+	burst_amount = 3
 	accuracy_mult_unwielded = 0.5
 	accuracy_mult = 1.2
 	scatter = -20

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -985,6 +985,8 @@
 	attachable_offset = list("muzzle_x" = 42, "muzzle_y" = 17,"rail_x" = 15, "rail_y" = 21, "under_x" = 24, "under_y" = 14, "stock_x" = 12, "stock_y" = 13)
 	fire_delay = 0.25 SECONDS
 	burst_amount = 3
+	burst_delay = 0.2
+	extra_delay = 1 SECONDS
 	accuracy_mult_unwielded = 0.5
 	accuracy_mult = 1.2
 	scatter = -20

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -244,7 +244,7 @@
 	icon_state = "t29"
 	w_class = WEIGHT_CLASS_NORMAL
 	default_ammo = /datum/ammo/bullet/smartmachinegun
-	max_rounds = 350
+	max_rounds = 300
 	reload_delay = 2.5 SECONDS
 	icon_state_mini = "mag_t29"
 

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -244,7 +244,7 @@
 	icon_state = "t29"
 	w_class = WEIGHT_CLASS_NORMAL
 	default_ammo = /datum/ammo/bullet/smartmachinegun
-	max_rounds = 200
+	max_rounds = 350
 	reload_delay = 2.5 SECONDS
 	icon_state_mini = "mag_t29"
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Buff T-29 drum from 200 to 300. Also, remove the 4 initial T-29 drums from surplus since this buff is intended to replace that.

Also, give PMC smartgunner a mag harness. Weird that they didn't have it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

T-29 is falling behind the T-25. Nostaglic smartgunners want more ammo for T-29, yet their prayers remain unanswered.

This PR is to help T-29 smartgunners.

Currently, a T-29 smartgunner spawns with 4 SG drums, which is a total of 800 ammo (not including the other 4 SG drums that surplus gives).  A T-60 can carry more ammo than a T-29 even if both max out all the storage they can hold, yet the T-29 is supposed to be the IFF weapon system to be the superior IFF machine gun.

Over at CM SS13, a single drum holds 500 ammo, and a single CM smartgunner spawns at least 7 drums, totaling up to 3,500. While CM xenomorphs are literally bullet sponges and a tough CM round for a CM smartgunner can use more than 10,000 ammo (I have done my share and still am), a T-29 smartgunner will never see that number because (1) TGMC xenomorphs aren't bullet sponges and (2) T-29 drums don't permit that. Despite that minions and acid / resin turrets have become bullet sponges, nothing has changed for the T-29 that have to use its ammo against the increased number of xenomorph targets.

With this PR, a T-29 smartgunner will spawn with 4 SG drums with a total number of 1,200 ammo. I also delete the 4 SG drums in surplus since those 4 SG drums help early T-29 smartgunners more than late T-29 smartgunners. For context, if a T-29 smartgunner that hog all the SG drums in early game, they will have a total of 1,600 ammo, leaving the rest of T-29 smartgunners to have 800 ammo assuming they don't buy more drums. The 1,200 ammo is enough for T-29 smartgunners to get req points and continue to engage while the order is being process and deliever.

However, I know that smartgunners will abuse the new profound 1,200 ammo by attempting to run through xenomorphs, so I increase aim_slowdown. This forces T-29 smartgunners to really choose to either pointman the marine push and can barely move of the way OR snug themselves between marines in light of their aim_slowdown. Note that aim_slowdown is close to being on par with T-60 not in aim mode.

The burst fire is to synergize with being a turtle. If T-25 is not going to get it, let T-29 have it. It does have a long delay between each burst fire, but as a smartgunner you should have conservation of resources in mind all the time even with this ammo buff.

## TL;DR
T-29 smartgunners spawn with 1,200 ammo
T-29 smartgunners have increase aim_slowdown, meaning they are slower when using T-29
T-29 smartgunners have burst fire

MJP, you better be okay with this in light of the better choice that is T-25. Let T-29 have more ammo as it should.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: T-29 smartgunners spawn with 1,200 ammo, but T-29 smartgunners have increase aim_slowdown, meaning they are slower when using T-29, so T-29 smartgunners have burst fire
del: Surplus doesn't have 4 SG drums
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
