### PR TITLE
Every shipside AND planetside maps have standardized landing zone tiles

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -14578,11 +14578,6 @@
 /obj/machinery/landinglight/ds2/delaythree,
 /turf/open/floor/marking/asteroidwarning,
 /area/shuttle/drop2/lz2)
-"bhA" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
-/area/shuttle/drop2/lz2)
 "bhB" = (
 /obj/docking_port/stationary/marine_dropship/lz2,
 /turf/open/floor/marking/asteroidwarning{
@@ -19505,6 +19500,10 @@
 /obj/item/paper/clockresearch1,
 /turf/closed/wall/r_wall,
 /area/bigredv2/caves/southeast)
+"bHH" = (
+/obj/effect/attach_point/electronics/dropship1,
+/turf/open/floor/plating,
+/area/shuttle/drop1/lz1)
 "bIb" = (
 /obj/structure/bookcase{
 	density = 0
@@ -19798,11 +19797,6 @@
 	dir = 10
 	},
 /area/bigredv2/outside/nw)
-"czO" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 6
-	},
-/area/shuttle/drop2/lz2)
 "cAN" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -19956,6 +19950,11 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northwest)
+"cRP" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 6
+	},
+/area/shuttle/drop1/lz1)
 "cSg" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -20168,11 +20167,6 @@
 /obj/item/stack/sheet/wood,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/north)
-"dvk" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 9
-	},
-/area/shuttle/drop2/lz2)
 "dvU" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/marking/asteroidwarning{
@@ -20242,6 +20236,15 @@
 	dir = 4
 	},
 /area/bigredv2/outside/w)
+"dJu" = (
+/obj/effect/attach_point/weapon/dropship1{
+	dir = 8;
+	icon_state = "equip_base_l_wing"
+	},
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/shuttle/drop1/lz1)
 "dKh" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/cable,
@@ -20556,6 +20559,11 @@
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"eGt" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 10
+	},
+/area/shuttle/drop2/lz2)
 "eHI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/white,
@@ -20618,11 +20626,6 @@
 	dir = 1
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
-"eOW" = (
-/turf/open/floor/plating{
-	icon_state = "warnplatecorner"
-	},
-/area/shuttle/drop2/lz2)
 "ePj" = (
 /turf/open/floor/tile/dark2,
 /area/bigredv2/caves/southeast)
@@ -20805,6 +20808,9 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/nw)
+"fkV" = (
+/turf/open/floor/plating/icefloor/warnplate,
+/area/shuttle/drop1/lz1)
 "flV" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/plating,
@@ -21027,7 +21033,9 @@
 	dir = 8;
 	icon_state = "equip_base_l_wing"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
 /area/shuttle/drop2/lz2)
 "fLO" = (
 /obj/effect/ai_node,
@@ -21294,6 +21302,11 @@
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"gpQ" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 6
+	},
+/area/shuttle/drop2/lz2)
 "gqo" = (
 /obj/structure/table/woodentable,
 /obj/effect/landmark/weed_node,
@@ -21327,6 +21340,11 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/north)
+"gse" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 9
+	},
+/area/shuttle/drop2/lz2)
 "gst" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -22469,11 +22487,10 @@
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/caves/northwest)
 "jHW" = (
-/obj/effect/attach_point/weapon/dropship1,
 /turf/open/floor/plating/icefloor/warnplate{
-	dir = 1
+	dir = 9
 	},
-/area/shuttle/drop2/lz2)
+/area/shuttle/drop1/lz1)
 "jJZ" = (
 /obj/structure/table,
 /obj/structure/cable,
@@ -22524,6 +22541,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
+"jNf" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 5
+	},
+/area/shuttle/drop2/lz2)
 "jNI" = (
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/s)
@@ -22749,6 +22771,12 @@
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
+"kvI" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/shuttle/drop1/lz1)
 "kvV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -22841,7 +22869,7 @@
 "kDB" = (
 /obj/machinery/camera/autoname/lz_camera,
 /turf/open/floor/plating/icefloor/warnplate{
-	dir = 4
+	dir = 8
 	},
 /area/shuttle/drop2/lz2)
 "kEl" = (
@@ -22992,12 +23020,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
-"lcH" = (
-/turf/open/floor/plating{
-	dir = 8;
-	icon_state = "warnplatecorner"
-	},
-/area/shuttle/drop2/lz2)
 "len" = (
 /turf/open/floor/plating/dmg1,
 /area/bigredv2/outside/space_port)
@@ -23373,6 +23395,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
+"mhf" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/shuttle/drop1/lz1)
 "mkI" = (
 /obj/effect/landmark/weed_node,
 /turf/open/shuttle/elevator/grating,
@@ -23738,11 +23766,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
-"noZ" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 4
-	},
-/area/shuttle/drop2/lz2)
 "npC" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -24020,11 +24043,10 @@
 /turf/closed/wall/r_wall,
 /area/bigredv2/caves/rock)
 "nZm" = (
-/obj/effect/attach_point/electronics/dropship1,
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 1
 	},
-/area/shuttle/drop2/lz2)
+/area/shuttle/drop1/lz1)
 "oah" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -24196,7 +24218,7 @@
 /area/bigredv2/outside/dorms)
 "otR" = (
 /turf/open/floor/plating/icefloor/warnplate{
-	dir = 5
+	dir = 8
 	},
 /area/shuttle/drop2/lz2)
 "ouJ" = (
@@ -24244,6 +24266,11 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
+"oAa" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/shuttle/drop1/lz1)
 "oAf" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -24404,9 +24431,10 @@
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/southeast)
 "oXh" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating/icefloor/warnplate,
-/area/shuttle/drop2/lz2)
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 5
+	},
+/area/shuttle/drop1/lz1)
 "oXG" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/shuttle/drop2/lz2)
@@ -24868,6 +24896,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"qsL" = (
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating,
+/area/shuttle/drop1/lz1)
 "qtn" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/limb,
 /obj/item/ammo_casing/shell,
@@ -25307,6 +25339,11 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/n)
+"rxa" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 10
+	},
+/area/shuttle/drop1/lz1)
 "rxn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -25566,6 +25603,11 @@
 /obj/item/explosive/grenade/flashbang,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"sis" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/shuttle/drop1/lz1)
 "siv" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -25917,7 +25959,7 @@
 "sYV" = (
 /obj/machinery/camera/autoname/lz_camera,
 /turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
+	dir = 4
 	},
 /area/shuttle/drop2/lz2)
 "sZi" = (
@@ -26502,7 +26544,7 @@
 /area/bigredv2/outside/sw)
 "uDp" = (
 /turf/open/floor/plating/icefloor/warnplate{
-	dir = 10
+	dir = 4
 	},
 /area/shuttle/drop2/lz2)
 "uDL" = (
@@ -27237,10 +27279,7 @@
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/w)
 "wHp" = (
-/turf/open/floor/plating{
-	dir = 4;
-	icon_state = "warnplatecorner"
-	},
+/turf/open/floor/plating/icefloor/warnplate,
 /area/shuttle/drop2/lz2)
 "wIc" = (
 /obj/effect/landmark/weed_node,
@@ -32665,27 +32704,27 @@ ktH
 aae
 gFh
 plO
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aaF
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
+jHW
+oAa
+oAa
+oAa
+oAa
+oAa
+oAa
+dJu
+oAa
+oAa
+mhf
+oAa
+oAa
+oAa
+oAa
+oAa
+oAa
+oAa
+oAa
+oAa
+rxa
 aeh
 ags
 aam
@@ -32882,27 +32921,27 @@ ktH
 aae
 gFh
 aaj
+nZm
+aao
+aaF
+qsL
+aao
+aao
+aao
+aao
+aao
+aao
+aao
+aao
+aao
+aao
+aao
+aao
 aao
 aao
 aaF
 aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aaF
-aao
-aao
+fkV
 oGY
 bLG
 bLG
@@ -33099,6 +33138,10 @@ ktH
 aae
 gFh
 aak
+nZm
+aao
+aao
+bHH
 aao
 aao
 aao
@@ -33115,11 +33158,7 @@ aao
 aao
 aao
 aao
-aao
-aao
-aao
-aao
-aao
+fkV
 aej
 bLG
 bLG
@@ -33316,6 +33355,7 @@ ktH
 aae
 gFh
 aal
+nZm
 aao
 aao
 aao
@@ -33335,8 +33375,7 @@ aao
 aao
 aao
 aao
-aao
-aao
+fkV
 agQ
 bLG
 bLG
@@ -33533,6 +33572,7 @@ ktH
 aae
 gFh
 plO
+nZm
 aao
 aao
 aao
@@ -33552,8 +33592,7 @@ aao
 aao
 aao
 aao
-aao
-aao
+fkV
 aeh
 bLG
 bLG
@@ -33750,7 +33789,7 @@ ktH
 aae
 iUZ
 aaj
-aao
+nZm
 aao
 aao
 aao
@@ -33770,7 +33809,7 @@ aao
 aao
 aao
 aao
-aao
+fkV
 oGY
 bLG
 bLG
@@ -33967,6 +34006,7 @@ ktH
 aae
 gFh
 aak
+nZm
 aao
 aao
 aao
@@ -33986,8 +34026,7 @@ aao
 aao
 aao
 aao
-aao
-aao
+fkV
 aej
 bLG
 lvj
@@ -34067,27 +34106,27 @@ oXG
 qyl
 faR
 bhu
-bie
-bie
-eOW
-noZ
-czO
-bie
-bie
+gse
+otR
+otR
+otR
+otR
+otR
+otR
 fLB
 otR
-noZ
+otR
 kDB
-noZ
-noZ
-czO
-bie
-bie
-bie
-bie
-bie
-rCq
-noZ
+otR
+otR
+otR
+otR
+otR
+otR
+otR
+otR
+otR
+eGt
 bsb
 mAw
 mAw
@@ -34184,6 +34223,7 @@ ktH
 aae
 gFh
 aal
+nZm
 aao
 aao
 aao
@@ -34203,8 +34243,7 @@ aao
 aao
 aao
 aao
-aao
-aao
+fkV
 aek
 bLG
 bLG
@@ -34284,9 +34323,9 @@ uqN
 jwj
 faR
 bhv
+rCq
 bie
-bie
-oXh
+bje
 sGV
 bie
 bie
@@ -34303,8 +34342,8 @@ bie
 bie
 bie
 bje
-rCq
-rCq
+bie
+wHp
 bsc
 mAw
 mAw
@@ -34401,6 +34440,10 @@ ktH
 aae
 gFh
 plO
+nZm
+aao
+aao
+bHH
 aao
 aao
 aao
@@ -34417,11 +34460,7 @@ aao
 aao
 aao
 aao
-aao
-aao
-aao
-aao
-aao
+fkV
 aeh
 bLG
 bLG
@@ -34501,9 +34540,9 @@ vXv
 xSR
 faR
 bhw
-noZ
-noZ
-czO
+rCq
+bie
+bie
 awd
 bie
 bie
@@ -34520,8 +34559,8 @@ bie
 bie
 bie
 bie
-rCq
-rCq
+bie
+wHp
 bsd
 mAw
 mAw
@@ -34618,27 +34657,27 @@ ktH
 aae
 gFh
 aaj
+nZm
+aao
+aaF
+qsL
+aao
+aao
+aao
+aao
+aao
+aao
+aao
+aao
+aao
+aao
+aao
+aao
 aao
 aao
 aaF
 aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aaF
-aao
-aao
+fkV
 oGY
 bLG
 bLG
@@ -34737,7 +34776,7 @@ bie
 bie
 bie
 bie
-bhA
+bie
 wHp
 bse
 mAw
@@ -34835,27 +34874,27 @@ ktH
 aae
 gFh
 aak
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aaF
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
+oXh
+sis
+sis
+sis
+sis
+sis
+sis
+sis
+sis
+sis
+kvI
+sis
+sis
+sis
+sis
+sis
+sis
+sis
+sis
+sis
+cRP
 aej
 big
 ahe
@@ -34954,8 +34993,8 @@ bie
 bie
 bie
 bie
-dvk
-bhA
+bie
+wHp
 bsb
 mAw
 mAw
@@ -35171,8 +35210,8 @@ bie
 bie
 bie
 bie
-rCq
 bie
+wHp
 bsc
 mAw
 mAw
@@ -35388,8 +35427,8 @@ bie
 bie
 bie
 bie
-otR
-noZ
+bie
+wHp
 bsd
 mAw
 mAw
@@ -35605,8 +35644,8 @@ bie
 bie
 bie
 bie
-noZ
-lcH
+bie
+wHp
 bse
 mAw
 mAw
@@ -35803,27 +35842,27 @@ mAw
 mAw
 faR
 bhu
-bhA
-bhA
-bhA
-nZm
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
 rCq
-rCq
+bie
+bie
+awd
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+wHp
 bsb
 mAw
 mAw
@@ -36020,27 +36059,27 @@ gMM
 gMM
 bdJ
 bhv
+rCq
+bie
+bje
+sGV
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+bie
 bie
 bie
 bje
-jHW
 bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bje
-rCq
-rCq
+wHp
 bsc
 mAw
 mAw
@@ -36237,27 +36276,27 @@ qyl
 qyl
 bdJ
 bhw
-bie
-bie
-bie
-bhA
-bhA
-rCq
-bie
-bie
-dvk
-bhA
-sYV
-bhA
-bhA
+jNf
 uDp
-bie
-bie
-bie
-bie
-bie
-rCq
-bhA
+uDp
+uDp
+uDp
+uDp
+uDp
+uDp
+uDp
+uDp
+sYV
+uDp
+uDp
+uDp
+uDp
+uDp
+uDp
+uDp
+uDp
+uDp
+gpQ
 bsd
 mAw
 mAw

--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -6147,6 +6147,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
+"awd" = (
+/obj/effect/attach_point/electronics/dropship1,
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "awe" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -14575,8 +14579,15 @@
 /turf/open/floor/marking/asteroidwarning,
 /area/shuttle/drop2/lz2)
 "bhA" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/shuttle/drop2/lz2)
+"bhB" = (
+/obj/docking_port/stationary/marine_dropship/lz2,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 8
+	},
 /area/shuttle/drop2/lz2)
 "bhD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19787,6 +19798,11 @@
 	dir = 10
 	},
 /area/bigredv2/outside/nw)
+"czO" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 6
+	},
+/area/shuttle/drop2/lz2)
 "cAN" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -20152,6 +20168,11 @@
 /obj/item/stack/sheet/wood,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/north)
+"dvk" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 9
+	},
+/area/shuttle/drop2/lz2)
 "dvU" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/marking/asteroidwarning{
@@ -20597,6 +20618,11 @@
 	dir = 1
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"eOW" = (
+/turf/open/floor/plating{
+	icon_state = "warnplatecorner"
+	},
+/area/shuttle/drop2/lz2)
 "ePj" = (
 /turf/open/floor/tile/dark2,
 /area/bigredv2/caves/southeast)
@@ -20996,6 +21022,13 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
+"fLB" = (
+/obj/effect/attach_point/weapon/dropship1{
+	dir = 8;
+	icon_state = "equip_base_l_wing"
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "fLO" = (
 /obj/effect/ai_node,
 /turf/open/floor/marking/asteroidwarning{
@@ -22435,6 +22468,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/caves/northwest)
+"jHW" = (
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/shuttle/drop2/lz2)
 "jJZ" = (
 /obj/structure/table,
 /obj/structure/cable,
@@ -22799,6 +22838,12 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/bigredv2/outside/s)
+"kDB" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/shuttle/drop2/lz2)
 "kEl" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/marking/bot,
@@ -22947,6 +22992,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"lcH" = (
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "warnplatecorner"
+	},
+/area/shuttle/drop2/lz2)
 "len" = (
 /turf/open/floor/plating/dmg1,
 /area/bigredv2/outside/space_port)
@@ -23687,6 +23738,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"noZ" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/shuttle/drop2/lz2)
 "npC" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -23963,6 +24019,12 @@
 "nYw" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/caves/rock)
+"nZm" = (
+/obj/effect/attach_point/electronics/dropship1,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/shuttle/drop2/lz2)
 "oah" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -24132,6 +24194,11 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/dorms)
+"otR" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 5
+	},
+/area/shuttle/drop2/lz2)
 "ouJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -24336,6 +24403,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/southeast)
+"oXh" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate,
+/area/shuttle/drop2/lz2)
 "oXG" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/shuttle/drop2/lz2)
@@ -25285,6 +25356,11 @@
 	},
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/bigredv2/outside/nw)
+"rCq" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/shuttle/drop2/lz2)
 "rEy" = (
 /obj/effect/decal/sandedge/corner,
 /turf/open/floor/freezer,
@@ -25706,6 +25782,10 @@
 	},
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/se)
+"sGV" = (
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "sHx" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/red2{
@@ -25834,6 +25914,12 @@
 	dir = 8
 	},
 /area/bigredv2/caves/south)
+"sYV" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/shuttle/drop2/lz2)
 "sZi" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor,
@@ -26414,6 +26500,11 @@
 	dir = 8
 	},
 /area/bigredv2/outside/sw)
+"uDp" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 10
+	},
+/area/shuttle/drop2/lz2)
 "uDL" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/blue/whitebluefull,
@@ -27145,6 +27236,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/w)
+"wHp" = (
+/turf/open/floor/plating{
+	dir = 4;
+	icon_state = "warnplatecorner"
+	},
+/area/shuttle/drop2/lz2)
 "wIc" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -33330,7 +33427,7 @@ uqN
 uqN
 bht
 uqN
-uqN
+bhB
 uqN
 uqN
 uqN
@@ -33972,25 +34069,25 @@ faR
 bhu
 bie
 bie
+eOW
+noZ
+czO
+bie
+bie
+fLB
+otR
+noZ
+kDB
+noZ
+noZ
+czO
 bie
 bie
 bie
 bie
 bie
-bie
-bie
-bie
-bje
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
+rCq
+noZ
 bsb
 mAw
 mAw
@@ -34189,25 +34286,25 @@ faR
 bhv
 bie
 bie
+oXh
+sGV
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+bie
+bie
 bje
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bje
-bie
-bie
+rCq
+rCq
 bsc
 mAw
 mAw
@@ -34404,6 +34501,10 @@ vXv
 xSR
 faR
 bhw
+noZ
+noZ
+czO
+awd
 bie
 bie
 bie
@@ -34419,12 +34520,8 @@ bie
 bie
 bie
 bie
-bie
-bie
-bie
-bie
-bie
-bie
+rCq
+rCq
 bsd
 mAw
 mAw
@@ -34621,6 +34718,7 @@ oXG
 qyl
 faR
 bhx
+rCq
 bie
 bie
 bie
@@ -34639,9 +34737,8 @@ bie
 bie
 bie
 bie
-bie
-bie
-bie
+bhA
+wHp
 bse
 mAw
 mAw
@@ -34838,6 +34935,7 @@ oXG
 fxL
 faR
 bhu
+rCq
 bie
 bie
 bie
@@ -34856,9 +34954,8 @@ bie
 bie
 bie
 bie
-bie
-bie
-bie
+dvk
+bhA
 bsb
 mAw
 mAw
@@ -35055,7 +35152,7 @@ oXG
 qyl
 faR
 bhy
-bie
+rCq
 bie
 bie
 bie
@@ -35074,7 +35171,7 @@ bie
 bie
 bie
 bie
-bie
+rCq
 bie
 bsc
 mAw
@@ -35272,6 +35369,7 @@ fpw
 qyl
 faR
 bhw
+rCq
 bie
 bie
 bie
@@ -35290,9 +35388,8 @@ bie
 bie
 bie
 bie
-bie
-bie
-bie
+otR
+noZ
 bsd
 mAw
 mAw
@@ -35489,6 +35586,7 @@ uqN
 uqN
 faR
 bhz
+rCq
 bie
 bie
 bie
@@ -35507,9 +35605,8 @@ bie
 bie
 bie
 bie
-bie
-bie
-bie
+noZ
+lcH
 bse
 mAw
 mAw
@@ -35707,6 +35804,9 @@ mAw
 faR
 bhu
 bhA
+bhA
+bhA
+nZm
 bie
 bie
 bie
@@ -35722,11 +35822,8 @@ bie
 bie
 bie
 bie
-bie
-bie
-bie
-bie
-bie
+rCq
+rCq
 bsb
 mAw
 mAw
@@ -35926,7 +36023,7 @@ bhv
 bie
 bie
 bje
-bie
+jHW
 bie
 bie
 bie
@@ -35942,8 +36039,8 @@ bie
 bie
 bie
 bje
-bie
-bie
+rCq
+rCq
 bsc
 mAw
 mAw
@@ -36143,24 +36240,24 @@ bhw
 bie
 bie
 bie
+bhA
+bhA
+rCq
+bie
+bie
+dvk
+bhA
+sYV
+bhA
+bhA
+uDp
 bie
 bie
 bie
 bie
 bie
-bie
-bie
-bje
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
-bie
+rCq
+bhA
 bsd
 mAw
 mAw

--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -678,7 +678,9 @@
 /area/ice_colony/surface/engineering/generator)
 "acU" = (
 /obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
 /area/ice_colony/exterior/surface/landing_pad2)
 "acV" = (
 /obj/structure/table,
@@ -31622,6 +31624,15 @@
 	dir = 4
 	},
 /area/ice_colony/exterior/surface/landing_pad2)
+"dqR" = (
+/obj/effect/attach_point/weapon/dropship1{
+	dir = 8;
+	icon_state = "equip_base_l_wing"
+	},
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/ice_colony/exterior/surface/landing_pad2)
 "dtg" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/ice_rock/eastWall,
@@ -31711,6 +31722,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/hallway/south_east)
+"eaK" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 10
+	},
+/area/ice_colony/exterior/surface/landing_pad2)
 "ebw" = (
 /obj/effect/landmark/dropship_start_location,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -31816,6 +31832,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/hallway/south_east)
+"eDG" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/ice_colony/exterior/surface/landing_pad2)
 "eDT" = (
 /obj/effect/turf_underlay/icefloor,
 /obj/effect/landmark/weed_node,
@@ -32214,6 +32236,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/engineering)
+"gQQ" = (
+/obj/effect/attach_point/electronics/dropship1,
+/turf/open/floor/plating,
+/area/ice_colony/exterior/surface/landing_pad2)
 "gSb" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark2,
@@ -34587,6 +34613,10 @@
 	},
 /turf/open/floor/plating/ground/snow/layer1,
 /area/ice_colony/exterior/surface/valley/southwest)
+"tkL" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating,
+/area/ice_colony/exterior/surface/landing_pad2)
 "tlK" = (
 /turf/open/shuttle/dropship/three,
 /area/ice_colony/underground/responsehangar)
@@ -35223,6 +35253,10 @@
 	dir = 8
 	},
 /area/ice_colony/surface/storage_unit/power)
+"wHy" = (
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating,
+/area/ice_colony/exterior/surface/landing_pad2)
 "wIE" = (
 /turf/open/floor/plating,
 /area/ice_colony/exterior/underground/caves/open)
@@ -38918,27 +38952,27 @@ bSw
 aae
 xGZ
 aay
-afd
-afd
+xBE
+cTP
+cTP
+cTP
+cTP
+cTP
+cTP
+dqR
+cTP
+cTP
 acU
-afd
-afd
-afd
-afd
-afd
-afd
-afd
-acU
-afd
-afd
-afd
-afd
-afd
-afd
-afd
-afd
-acU
-afd
+cTP
+cTP
+cTP
+cTP
+cTP
+cTP
+cTP
+cTP
+cTP
+eaK
 akM
 hOW
 aym
@@ -39175,6 +39209,10 @@ bSw
 jQk
 abq
 vhv
+dWh
+afd
+tkL
+wHy
 afd
 afd
 afd
@@ -39189,13 +39227,9 @@ afd
 afd
 afd
 afd
+tkL
 afd
-afd
-afd
-afd
-afd
-afd
-afd
+sQr
 oiZ
 hOW
 aym
@@ -39432,6 +39466,10 @@ bSw
 aae
 xGZ
 cvo
+dWh
+afd
+afd
+gQQ
 afd
 afd
 afd
@@ -39448,11 +39486,7 @@ afd
 afd
 afd
 afd
-afd
-afd
-afd
-afd
-afd
+sQr
 wpJ
 hOW
 aym
@@ -39689,6 +39723,7 @@ bSw
 aae
 xGZ
 uNj
+dWh
 afd
 afd
 afd
@@ -39708,8 +39743,7 @@ afd
 afd
 afd
 afd
-afd
-afd
+sQr
 ihF
 hOW
 ayn
@@ -39946,6 +39980,7 @@ bSw
 aae
 xGZ
 aay
+dWh
 afd
 afd
 afd
@@ -39965,8 +40000,7 @@ afd
 afd
 afd
 afd
-afd
-afd
+sQr
 yjW
 uxH
 adY
@@ -40203,7 +40237,7 @@ bSw
 aae
 xGZ
 vhv
-afd
+dWh
 afd
 afd
 afd
@@ -40223,7 +40257,7 @@ afd
 afd
 afd
 afd
-afd
+sQr
 alI
 uxH
 wDM
@@ -40460,6 +40494,7 @@ bSw
 aae
 xGZ
 cvo
+dWh
 afd
 afd
 afd
@@ -40479,8 +40514,7 @@ afd
 afd
 afd
 afd
-afd
-afd
+sQr
 wpJ
 uxH
 ayn
@@ -40717,6 +40751,7 @@ bSw
 aae
 xGZ
 uNj
+dWh
 afd
 afd
 afd
@@ -40736,8 +40771,7 @@ afd
 afd
 afd
 afd
-afd
-afd
+sQr
 ihF
 uxH
 aym
@@ -40974,6 +41008,10 @@ bSw
 jQk
 abq
 aay
+dWh
+afd
+afd
+gQQ
 afd
 afd
 afd
@@ -40990,11 +41028,7 @@ afd
 afd
 afd
 afd
-afd
-afd
-afd
-afd
-afd
+sQr
 yjW
 uxH
 aBi
@@ -41231,6 +41265,10 @@ bSw
 aae
 xGZ
 vhv
+dWh
+afd
+tkL
+wHy
 afd
 afd
 afd
@@ -41245,13 +41283,9 @@ afd
 afd
 afd
 afd
+tkL
 afd
-afd
-afd
-afd
-afd
-afd
-afd
+sQr
 oiZ
 uxH
 atf
@@ -41488,27 +41522,27 @@ bSw
 aae
 xGZ
 cvo
-afd
-afd
-acU
-afd
-afd
-afd
-afd
-afd
-afd
-afd
-acU
-afd
-afd
-afd
-afd
-afd
-afd
-afd
-afd
-acU
-afd
+rgk
+doh
+doh
+doh
+doh
+doh
+doh
+doh
+doh
+doh
+eDG
+doh
+doh
+doh
+doh
+doh
+doh
+doh
+doh
+doh
+tGL
 wpJ
 uxH
 hOW

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -648,6 +648,11 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/west1)
+"akm" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 9
+	},
+/area/shuttle/drop1/lz1)
 "akq" = (
 /turf/open/floor/plating,
 /area/lv624/ground/sand8)
@@ -3494,6 +3499,11 @@
 	dir = 8
 	},
 /area/lv624/ground/sand8)
+"bar" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 5
+	},
+/area/shuttle/drop1/lz1)
 "bau" = (
 /turf/open/ground/coast/corner{
 	dir = 4
@@ -5361,6 +5371,11 @@
 	dir = 4
 	},
 /area/lv624/ground/jungle5)
+"bZH" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/shuttle/drop1/lz1)
 "cae" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -6071,6 +6086,9 @@
 	dir = 9
 	},
 /area/lv624/lazarus/fitness)
+"cRC" = (
+/turf/open/floor/plating/icefloor/warnplate,
+/area/shuttle/drop2/lz2)
 "cRI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6514,6 +6532,11 @@
 	icon_state = "whiteyellowfull"
 	},
 /area/lv624/lazarus/sandtemple)
+"drX" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 6
+	},
+/area/shuttle/drop2/lz2)
 "dsh" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder,
@@ -8835,6 +8858,10 @@
 	},
 /turf/open/floor,
 /area/lv624/lazarus/spaceport2)
+"gfm" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor,
+/area/shuttle/drop2/lz2)
 "gfH" = (
 /obj/structure/jungle/planttop1,
 /turf/open/ground/grass,
@@ -9932,6 +9959,11 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/grass/grass2,
 /area/lv624/lazarus/atmos/outside)
+"hwv" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 6
+	},
+/area/shuttle/drop1/lz1)
 "hxa" = (
 /turf/open/floor/bcircuit/off,
 /area/lv624/lazarus/sandtemple)
@@ -11263,6 +11295,12 @@
 	dir = 1
 	},
 /area/lv624/lazarus/corporate_affairs)
+"jbX" = (
+/obj/effect/decal/cleanable/blood/oil{
+	icon_state = "armorblood"
+	},
+/turf/open/floor/plating/icefloor,
+/area/shuttle/drop2/lz2)
 "jci" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
@@ -12350,6 +12388,11 @@
 	},
 /turf/open/floor,
 /area/lv624/ground/jungle7)
+"kqj" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/shuttle/drop2/lz2)
 "kqC" = (
 /obj/effect/ai_node,
 /turf/open/floor/wood/broken,
@@ -12789,8 +12832,9 @@
 /turf/open/floor/tile/barber,
 /area/lv624/lazarus/fitness)
 "kSE" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
 /area/shuttle/drop2/lz2)
 "kTb" = (
 /obj/item/shard,
@@ -12933,6 +12977,12 @@
 	dir = 6
 	},
 /area/lv624/lazarus/spaceport)
+"lbk" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/shuttle/drop1/lz1)
 "lbt" = (
 /obj/item/weapon/claymore/mercsword/machete,
 /turf/open/floor/tile/whiteyellow/full,
@@ -12958,7 +13008,7 @@
 /area/lv624/ground/sand3)
 "lcv" = (
 /obj/docking_port/stationary/marine_dropship/lz2,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icefloor,
 /area/shuttle/drop2/lz2)
 "ldf" = (
 /obj/structure/rack,
@@ -14251,6 +14301,15 @@
 	icon_state = "grimy"
 	},
 /area/lv624/lazarus/bar)
+"mzV" = (
+/obj/effect/attach_point/weapon/dropship1{
+	dir = 8;
+	icon_state = "equip_base_l_wing"
+	},
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/shuttle/drop1/lz1)
 "mzX" = (
 /obj/structure/jungle/vines,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -14379,6 +14438,11 @@
 "mGq" = (
 /turf/closed/wall,
 /area/lv624/ground/jungle7)
+"mGr" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 10
+	},
+/area/shuttle/drop2/lz2)
 "mGL" = (
 /obj/structure/jungle/vines,
 /obj/structure/jungle/vines/heavy,
@@ -16167,6 +16231,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/barber,
 /area/lv624/lazarus/main_hall)
+"oVU" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating/icefloor,
+/area/shuttle/drop2/lz2)
 "oVV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -16746,6 +16814,12 @@
 /obj/machinery/light,
 /turf/open/floor/wood,
 /area/lv624/lazarus/bar)
+"pFJ" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/shuttle/drop1/lz1)
 "pGL" = (
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
@@ -16954,6 +17028,9 @@
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/ground/river,
 /area/lv624/lazarus/atmos)
+"pSp" = (
+/turf/open/floor/plating/icefloor/warnplate,
+/area/shuttle/drop1/lz1)
 "pSz" = (
 /obj/machinery/door/airlock/colony/medical/hydroponics{
 	dir = 1
@@ -17034,6 +17111,11 @@
 "pWt" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner2,
 /area/lv624/lazarus/spaceport)
+"pWC" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 5
+	},
+/area/shuttle/drop2/lz2)
 "pXl" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
@@ -17241,6 +17323,11 @@
 	dir = 5
 	},
 /area/lv624/lazarus/research)
+"qqj" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/shuttle/drop2/lz2)
 "qqm" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirt,
@@ -17564,6 +17651,12 @@
 /obj/structure/jungle/plantbot1,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle5)
+"qKu" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/shuttle/drop2/lz2)
 "qKz" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
@@ -17963,6 +18056,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/engineering)
+"reG" = (
+/obj/effect/attach_point/electronics/dropship1,
+/turf/open/floor/plating,
+/area/shuttle/drop1/lz1)
 "reH" = (
 /obj/item/tool/shovel,
 /turf/open/floor/tile/green/greentaupe{
@@ -18298,6 +18395,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/n)
+"rBn" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 10
+	},
+/area/shuttle/drop1/lz1)
 "rBs" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -19182,6 +19284,9 @@
 	dir = 4
 	},
 /area/lv624/lazarus/fitness)
+"szs" = (
+/turf/open/floor/plating/icefloor,
+/area/shuttle/drop2/lz2)
 "sAv" = (
 /obj/item/clothing/suit/redtag,
 /obj/structure/closet/athletic_mixed,
@@ -19695,6 +19800,10 @@
 /obj/structure/jungle/vines,
 /turf/open/ground/river,
 /area/lv624/ground/river1)
+"tcA" = (
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating,
+/area/shuttle/drop1/lz1)
 "tcH" = (
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/research)
@@ -22188,6 +22297,12 @@
 /obj/item/weapon/claymore/mercsword/machete,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle9)
+"vOZ" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/shuttle/drop2/lz2)
 "vPd" = (
 /obj/structure/table,
 /obj/item/tool/crowbar,
@@ -22853,6 +22968,11 @@
 	dir = 4
 	},
 /area/lv624/lazarus/spaceport)
+"wvz" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/shuttle/drop1/lz1)
 "wvT" = (
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/spaceport)
@@ -23304,8 +23424,9 @@
 /turf/open/floor,
 /area/lv624/lazarus/spaceport)
 "wVT" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
 /area/shuttle/drop1/lz1)
 "wWA" = (
 /obj/effect/decal/riverdecal,
@@ -24165,7 +24286,9 @@
 	},
 /area/lv624/lazarus/main_hall)
 "xNh" = (
-/turf/open/floor/plating,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 9
+	},
 /area/shuttle/drop2/lz2)
 "xNG" = (
 /obj/structure/fence,
@@ -24500,6 +24623,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/barber,
 /area/lv624/lazarus/kitchen)
+"ycR" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating,
+/area/shuttle/drop1/lz1)
 "ydh" = (
 /obj/structure/jungle/plantbot1/alien,
 /obj/effect/ai_node,
@@ -36485,26 +36612,26 @@ rOf
 vvX
 urD
 xNh
-xNh
 kSE
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
 kSE
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
 kSE
-xNh
+kSE
+kSE
+kSE
+kSE
+kSE
+kSE
+kSE
+vOZ
+kSE
+kSE
+kSE
+kSE
+kSE
+kSE
+kSE
+kSE
+mGr
 kYG
 uvP
 wfA
@@ -36661,27 +36788,27 @@ tSf
 rOf
 vvX
 ugM
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
+kqj
+szs
+gfm
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+jbX
+gfm
+szs
+cRC
 mFI
 uvP
 wfA
@@ -36838,27 +36965,27 @@ tSf
 rOf
 vvX
 bHL
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
+kqj
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+oVU
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+cRC
 uej
 uvP
 wfA
@@ -37015,27 +37142,27 @@ tSf
 rOf
 vvX
 uNU
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
+kqj
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+cRC
 lYY
 uvP
 tBK
@@ -37192,27 +37319,27 @@ tSf
 rOf
 vvX
 urD
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
+kqj
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+cRC
 kYG
 uvP
 rRx
@@ -37369,27 +37496,27 @@ tSf
 rOO
 vvX
 ugM
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
+kqj
+szs
+szs
+szs
+oVU
+szs
+szs
+szs
+szs
+szs
 lcv
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+cRC
 mFI
 uvP
 rRx
@@ -37546,27 +37673,27 @@ tSf
 rOf
 vvX
 bHL
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
+kqj
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+oVU
+szs
+cRC
 uej
 uvP
 tSf
@@ -37723,27 +37850,27 @@ tSf
 rOf
 vvX
 uNU
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
+kqj
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+jbX
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+cRC
 lYY
 uvP
 tSf
@@ -37900,27 +38027,27 @@ tSf
 rOf
 tee
 urD
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
+kqj
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+cRC
 kYG
 uvP
 tSf
@@ -38077,27 +38204,27 @@ tSf
 rOf
 vvX
 ugM
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
+kqj
+szs
+gfm
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+szs
+jbX
+szs
+szs
+szs
+gfm
+szs
+cRC
 mFI
 uvP
 tSf
@@ -38254,27 +38381,27 @@ tSf
 rOf
 vvX
 bHL
-xNh
-xNh
-kSE
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-kSE
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-xNh
-kSE
-xNh
+pWC
+qqj
+qqj
+qqj
+qqj
+qqj
+qqj
+qqj
+qqj
+qqj
+qqj
+qKu
+qqj
+qqj
+qqj
+qqj
+qqj
+qqj
+qqj
+qqj
+drX
 uej
 uvP
 jkz
@@ -59146,27 +59273,27 @@ uIV
 dPz
 hWp
 kLN
-ydT
-ydT
+akm
 wVT
-ydT
-ydT
-ydT
-ydT
-ydT
-ydT
-ydT
 wVT
-ydT
-ydT
-ydT
-ydT
-ydT
-ydT
-ydT
-ydT
 wVT
-ydT
+wVT
+wVT
+wVT
+mzV
+wVT
+wVT
+pFJ
+wVT
+wVT
+wVT
+wVT
+wVT
+wVT
+wVT
+wVT
+wVT
+rBn
 arP
 uYo
 euA
@@ -59323,6 +59450,10 @@ uIV
 dPz
 hWp
 csS
+wvz
+ydT
+ycR
+tcA
 ydT
 ydT
 ydT
@@ -59337,13 +59468,9 @@ ydT
 ydT
 ydT
 ydT
+ycR
 ydT
-ydT
-ydT
-ydT
-ydT
-ydT
-ydT
+pSp
 uRx
 uYo
 euA
@@ -59500,6 +59627,10 @@ keT
 dPz
 hWp
 avj
+wvz
+ydT
+ydT
+reG
 ydT
 ydT
 ydT
@@ -59516,11 +59647,7 @@ ydT
 ydT
 ydT
 ydT
-ydT
-ydT
-ydT
-ydT
-ydT
+pSp
 uUf
 uYo
 euA
@@ -59677,6 +59804,7 @@ pVg
 dPz
 whI
 dwe
+wvz
 ydT
 ydT
 ydT
@@ -59696,8 +59824,7 @@ ydT
 ydT
 ydT
 ydT
-ydT
-ydT
+pSp
 rub
 uYo
 euA
@@ -59854,6 +59981,7 @@ vXt
 dPz
 cTW
 kLN
+wvz
 ydT
 ydT
 ydT
@@ -59873,8 +60001,7 @@ ydT
 ydT
 ydT
 ydT
-ydT
-ydT
+pSp
 arP
 uYo
 euA
@@ -60031,7 +60158,7 @@ nFD
 euA
 hWp
 csS
-ydT
+wvz
 ydT
 ydT
 ydT
@@ -60051,7 +60178,7 @@ ydT
 ydT
 ydT
 ydT
-ydT
+pSp
 uRx
 uYo
 euA
@@ -60208,6 +60335,7 @@ nFD
 euA
 hWp
 avj
+wvz
 ydT
 ydT
 ydT
@@ -60227,8 +60355,7 @@ ydT
 ydT
 ydT
 ydT
-ydT
-ydT
+pSp
 uUf
 uYo
 euA
@@ -60385,6 +60512,7 @@ lOL
 euA
 hWp
 dwe
+wvz
 ydT
 ydT
 ydT
@@ -60404,8 +60532,7 @@ ydT
 ydT
 ydT
 ydT
-ydT
-ydT
+pSp
 rub
 uYo
 euA
@@ -60562,6 +60689,10 @@ lOL
 euA
 hWp
 kLN
+wvz
+ydT
+ydT
+reG
 ydT
 ydT
 ydT
@@ -60578,11 +60709,7 @@ ydT
 ydT
 ydT
 ydT
-ydT
-ydT
-ydT
-ydT
-ydT
+pSp
 arP
 uYo
 euA
@@ -60739,6 +60866,10 @@ lOL
 euA
 hWp
 csS
+wvz
+ydT
+ycR
+tcA
 ydT
 ydT
 ydT
@@ -60753,13 +60884,9 @@ ydT
 ydT
 ydT
 ydT
+ycR
 ydT
-ydT
-ydT
-ydT
-ydT
-ydT
-ydT
+pSp
 uRx
 uYo
 euA
@@ -60916,27 +61043,27 @@ lOL
 euA
 hWp
 avj
-ydT
-ydT
-wVT
-ydT
-ydT
-ydT
-ydT
-ydT
-ydT
-ydT
-wVT
-ydT
-ydT
-ydT
-ydT
-ydT
-ydT
-ydT
-ydT
-wVT
-ydT
+bar
+bZH
+bZH
+bZH
+bZH
+bZH
+bZH
+bZH
+bZH
+bZH
+lbk
+bZH
+bZH
+bZH
+bZH
+bZH
+bZH
+bZH
+bZH
+bZH
+hwv
 uUf
 uYo
 euA

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -325,6 +325,11 @@
 	},
 /turf/open/lavaland/lava/lpiece,
 /area/magmoor/compound/west)
+"arw" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 9
+	},
+/area/magmoor/landing)
 "arU" = (
 /obj/item/tool/pickaxe/drill,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -1156,6 +1161,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/magmoor/security/lobby)
+"bem" = (
+/obj/effect/attach_point/weapon/dropship1{
+	dir = 8;
+	icon_state = "equip_base_l_wing"
+	},
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/magmoor/landing)
 "beU" = (
 /obj/effect/decal/cleanable/blood/writing,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -1590,6 +1604,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/magmoor/security)
+"bzA" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/magmoor/landing/two)
 "bzU" = (
 /turf/closed/glass/thin/end{
 	dir = 8
@@ -3062,6 +3081,11 @@
 	dir = 6
 	},
 /area/magmoor/cave/north)
+"czm" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 10
+	},
+/area/magmoor/landing/two)
 "czr" = (
 /turf/open/lavaland/basalt/cave/corner{
 	dir = 1
@@ -7676,10 +7700,9 @@
 	},
 /area/magmoor/research)
 "ftZ" = (
-/obj/effect/decal/warning_stripes/thin{
+/turf/open/floor/plating/icefloor/warnplate{
 	dir = 4
 	},
-/turf/open/floor/plating,
 /area/magmoor/landing)
 "fuf" = (
 /obj/effect/ai_node,
@@ -10007,6 +10030,11 @@
 	icon_state = "carpetside"
 	},
 /area/magmoor/research/researchdirector)
+"hgs" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/magmoor/landing)
 "hgy" = (
 /obj/machinery/conveyor{
 	dir = 8
@@ -10080,10 +10108,6 @@
 /obj/structure/flora/rock/alt2,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/magmoor/cave/west)
-"hjS" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating,
-/area/magmoor/landing)
 "hjY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -13220,6 +13244,11 @@
 	dir = 1
 	},
 /area/magmoor/compound/west)
+"jvz" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 5
+	},
+/area/magmoor/landing)
 "jvG" = (
 /turf/open/floor/mainship/sterile/corner{
 	dir = 4
@@ -15612,10 +15641,9 @@
 /turf/open/lavaland/basalt/cave,
 /area/magmoor/cave/west)
 "lhz" = (
-/obj/effect/decal/warning_stripes/thin{
+/turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
 	},
-/turf/open/floor/plating,
 /area/magmoor/compound/east)
 "lhP" = (
 /turf/closed/wall/indestructible/mineral,
@@ -16274,6 +16302,10 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/concrete,
 /area/magmoor/cave/west)
+"lGT" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating,
+/area/magmoor/landing/two)
 "lHp" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -16381,6 +16413,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/magmoor/engi/atmos)
+"lJj" = (
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating,
+/area/magmoor/landing)
 "lJm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -16806,6 +16842,10 @@
 /obj/machinery/vending/cigarette/colony,
 /turf/open/floor/mainship/orange,
 /area/magmoor/engi/storage)
+"mbL" = (
+/obj/effect/attach_point/electronics/dropship1,
+/turf/open/floor/plating,
+/area/magmoor/landing)
 "mbP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
@@ -18162,6 +18202,11 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
 /area/magmoor/security/arrivals/south)
+"nbk" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 6
+	},
+/area/magmoor/landing/two)
 "nbE" = (
 /obj/structure/cargo_container/horizontal{
 	dir = 4
@@ -18753,11 +18798,10 @@
 	},
 /area/magmoor/engi/power)
 "nyO" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating,
 /area/magmoor/landing)
 "nzf" = (
 /obj/machinery/power/terminal{
@@ -19893,6 +19937,11 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/magmoor/cave/southeast)
+"okW" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 10
+	},
+/area/magmoor/landing)
 "old" = (
 /obj/machinery/landinglight/ds1{
 	dir = 4
@@ -19958,6 +20007,10 @@
 	dir = 4
 	},
 /area/magmoor/hydroponics/south)
+"omJ" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating,
+/area/magmoor/landing)
 "omN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -21287,6 +21340,10 @@
 	dir = 8
 	},
 /area/magmoor/cargo/storage)
+"pdA" = (
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating,
+/area/magmoor/landing/two)
 "peg" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/mainship/sterile/side{
@@ -21665,6 +21722,10 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/concrete/lines,
 /area/magmoor/compound/northeast)
+"poQ" = (
+/obj/effect/attach_point/electronics/dropship1,
+/turf/open/floor/plating,
+/area/magmoor/landing/two)
 "poS" = (
 /turf/closed/glass/thin/corner{
 	dir = 4
@@ -21824,11 +21885,10 @@
 /turf/open/floor/tile,
 /area/magmoor/mining/refinery)
 "pvz" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
 	},
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating,
 /area/magmoor/landing)
 "pvM" = (
 /obj/structure/bed/chair{
@@ -24272,11 +24332,10 @@
 	},
 /area/magmoor/engi/storage)
 "rce" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
 	},
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating,
 /area/magmoor/landing/two)
 "rcg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -24338,10 +24397,9 @@
 /turf/open/floor/mainship/mono,
 /area/magmoor/engi/storage)
 "rek" = (
-/obj/effect/decal/warning_stripes/thin{
+/turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
 	},
-/turf/open/floor/plating,
 /area/magmoor/landing)
 "rex" = (
 /obj/effect/landmark/weed_node,
@@ -24940,6 +24998,11 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/mainship/orange,
 /area/magmoor/engi/storage)
+"ryg" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 9
+	},
+/area/magmoor/landing/two)
 "ryj" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/xeno_resin_wall,
@@ -25998,6 +26061,15 @@
 /obj/structure/plasticflaps,
 /turf/open/floor/plating,
 /area/magmoor/engi/storage)
+"ses" = (
+/obj/effect/attach_point/weapon/dropship1{
+	dir = 8;
+	icon_state = "equip_base_l_wing"
+	},
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/magmoor/landing/two)
 "sev" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/xeno_resin_wall,
@@ -26771,8 +26843,7 @@
 /turf/closed/glass/thin/single,
 /area/magmoor/compound/east)
 "sDi" = (
-/obj/effect/decal/warning_stripes/thin,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icefloor/warnplate,
 /area/magmoor/landing)
 "sDj" = (
 /obj/effect/landmark/weed_node,
@@ -29694,6 +29765,11 @@
 	dir = 8
 	},
 /area/magmoor/landing/two)
+"uzt" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 5
+	},
+/area/magmoor/landing/two)
 "uzu" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -31032,6 +31108,11 @@
 	},
 /turf/open/floor/freezer,
 /area/magmoor/civilian/clean/toilet)
+"vmu" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 6
+	},
+/area/magmoor/landing)
 "vmF" = (
 /obj/machinery/door/airlock/multi_tile/mainship/comdoor/free_access{
 	name = "\improper Colony Offices"
@@ -31355,8 +31436,7 @@
 /turf/open/floor/mainship/mono,
 /area/magmoor/landing/two)
 "vuS" = (
-/obj/effect/decal/warning_stripes/thin,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icefloor/warnplate,
 /area/magmoor/landing/two)
 "vvL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -32141,10 +32221,6 @@
 	},
 /turf/open/floor/plating,
 /area/magmoor/compound/north)
-"vXL" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating,
-/area/magmoor/landing/two)
 "vYa" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
@@ -34616,10 +34692,9 @@
 	},
 /area/magmoor/landing/two)
 "xpT" = (
-/obj/effect/decal/warning_stripes/thin{
+/turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
 	},
-/turf/open/floor/plating,
 /area/magmoor/landing/two)
 "xqz" = (
 /turf/open/lavaland/basalt/cave,
@@ -34630,10 +34705,9 @@
 	},
 /area/magmoor/compound/south)
 "xqP" = (
-/obj/effect/decal/warning_stripes/thin{
+/turf/open/floor/plating/icefloor/warnplate{
 	dir = 4
 	},
-/turf/open/floor/plating,
 /area/magmoor/landing/two)
 "xqS" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
@@ -35603,11 +35677,10 @@
 	},
 /area/magmoor/compound/northeast)
 "xRI" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating,
 /area/magmoor/landing/two)
 "xRS" = (
 /obj/effect/landmark/weed_node,
@@ -57844,27 +57917,27 @@ peM
 kEk
 kEk
 hTR
-pVi
-pVi
-hjS
-pVi
-pVi
-pVi
-pVi
-pVi
+arw
+rek
+rek
+rek
+rek
+rek
+rek
+bem
 rek
 rek
 pvz
 rek
 rek
-pVi
-pVi
-pVi
-pVi
-pVi
-pVi
-hjS
-pVi
+rek
+rek
+rek
+rek
+rek
+rek
+rek
+okW
 rxn
 peM
 wtL
@@ -58077,6 +58150,10 @@ peM
 kEk
 kEk
 pzk
+hgs
+pVi
+omJ
+lJj
 pVi
 pVi
 pVi
@@ -58091,13 +58168,9 @@ pVi
 pVi
 pVi
 pVi
+omJ
 pVi
-pVi
-pVi
-pVi
-pVi
-pVi
-pVi
+sDi
 sKY
 nID
 ftf
@@ -58310,6 +58383,10 @@ mJq
 kEk
 kEk
 sLe
+hgs
+pVi
+pVi
+mbL
 pVi
 pVi
 pVi
@@ -58326,11 +58403,7 @@ pVi
 pVi
 pVi
 pVi
-pVi
-pVi
-pVi
-pVi
-pVi
+sDi
 aXu
 peM
 wtL
@@ -58543,6 +58616,7 @@ peM
 kEk
 kEk
 jKZ
+hgs
 pVi
 pVi
 pVi
@@ -58562,8 +58636,7 @@ pVi
 pVi
 pVi
 pVi
-pVi
-pVi
+sDi
 rXL
 peM
 wtL
@@ -58776,7 +58849,7 @@ peM
 kEk
 kEk
 odU
-pVi
+hgs
 pVi
 pVi
 pVi
@@ -59009,7 +59082,7 @@ peM
 kEk
 kEk
 pzk
-pVi
+hgs
 pVi
 pVi
 pVi
@@ -59242,7 +59315,7 @@ peM
 kEk
 kEk
 sLe
-pVi
+hgs
 pVi
 pVi
 pVi
@@ -59475,6 +59548,7 @@ mJq
 kEk
 kEk
 hdd
+hgs
 pVi
 pVi
 pVi
@@ -59494,8 +59568,7 @@ pVi
 pVi
 pVi
 pVi
-pVi
-pVi
+sDi
 rXL
 peM
 wtL
@@ -59708,6 +59781,10 @@ peM
 kEk
 kEk
 hTR
+hgs
+pVi
+pVi
+mbL
 pVi
 pVi
 pVi
@@ -59724,11 +59801,7 @@ pVi
 pVi
 pVi
 pVi
-pVi
-pVi
-pVi
-pVi
-pVi
+sDi
 rxn
 peM
 wtL
@@ -59941,6 +60014,10 @@ peM
 kEk
 kEk
 pzk
+hgs
+pVi
+omJ
+lJj
 pVi
 pVi
 pVi
@@ -59955,13 +60032,9 @@ pVi
 pVi
 pVi
 pVi
+omJ
 pVi
-pVi
-pVi
-pVi
-pVi
-pVi
-pVi
+sDi
 sKY
 tCG
 xIJ
@@ -60174,27 +60247,27 @@ peM
 kEk
 kEk
 aNt
-pVi
-pVi
-hjS
-pVi
-pVi
-pVi
-pVi
-pVi
+jvz
+ftZ
+ftZ
+ftZ
+ftZ
+ftZ
+ftZ
+ftZ
 ftZ
 ftZ
 nyO
 ftZ
 ftZ
-pVi
-pVi
-pVi
-pVi
-pVi
-pVi
-hjS
-pVi
+ftZ
+ftZ
+ftZ
+ftZ
+ftZ
+ftZ
+ftZ
+vmu
 aXu
 peM
 wtL
@@ -77331,27 +77404,27 @@ uNy
 xSV
 hpC
 qJq
-xSV
-xSV
-vXL
-xSV
-xSV
-xSV
-xSV
-xSV
+ryg
+xpT
+xpT
+xpT
+xpT
+xpT
+xpT
+ses
 xpT
 xpT
 rce
 xpT
 lhz
-xee
-xee
-xee
-xee
-xee
-xSV
-vXL
-xSV
+lhz
+lhz
+lhz
+lhz
+lhz
+xpT
+xpT
+czm
 ibk
 sUD
 uaX
@@ -77564,10 +77637,10 @@ uOd
 xNt
 qls
 vpF
+bzA
 xSV
-xSV
-xSV
-xSV
+lGT
+pdA
 xSV
 xSV
 xSV
@@ -77582,9 +77655,9 @@ xee
 xee
 xee
 xee
+lGT
 xSV
-xSV
-xSV
+vuS
 lsQ
 sUD
 uaX
@@ -77797,10 +77870,10 @@ uOj
 uOj
 vgA
 vpN
+bzA
 xSV
 xSV
-xSV
-xSV
+poQ
 xSV
 xSV
 xSV
@@ -77817,7 +77890,7 @@ xee
 xee
 xSV
 xSV
-xSV
+vuS
 raz
 sUD
 uaX
@@ -78030,6 +78103,7 @@ xSV
 xSV
 hpC
 urh
+bzA
 xSV
 xSV
 xSV
@@ -78049,8 +78123,7 @@ xSV
 xSV
 xSV
 xSV
-xSV
-xSV
+vuS
 wtA
 sUD
 uaX
@@ -78263,7 +78336,7 @@ xSV
 xSV
 hpC
 wtu
-xSV
+bzA
 xSV
 xSV
 xSV
@@ -78496,7 +78569,7 @@ xSV
 xSV
 hpC
 vpF
-xSV
+bzA
 xSV
 xSV
 xSV
@@ -78729,7 +78802,7 @@ xNt
 xNt
 vfA
 vpN
-xSV
+bzA
 xSV
 xSV
 xSV
@@ -78962,6 +79035,7 @@ uOj
 uOj
 qzp
 urh
+bzA
 xSV
 xSV
 xSV
@@ -78981,8 +79055,7 @@ xSV
 xSV
 xSV
 xSV
-xSV
-xSV
+vuS
 wtA
 sUD
 uaX
@@ -79195,6 +79268,10 @@ xSV
 xSV
 hpC
 wtu
+bzA
+xSV
+xSV
+poQ
 xSV
 xSV
 xSV
@@ -79211,11 +79288,7 @@ xSV
 xSV
 xSV
 xSV
-xSV
-xSV
-xSV
-xSV
-xSV
+vuS
 ibk
 sUD
 uaX
@@ -79428,6 +79501,10 @@ xSV
 xSV
 hpC
 vpF
+bzA
+xSV
+lGT
+pdA
 xSV
 xSV
 xSV
@@ -79442,13 +79519,9 @@ xSV
 xSV
 xSV
 xSV
+lGT
 xSV
-xSV
-xSV
-xSV
-xSV
-xSV
-xSV
+vuS
 lsQ
 sUD
 uaX
@@ -79661,27 +79734,27 @@ xSV
 xSV
 hpC
 vpN
-xSV
-xSV
-vXL
-xSV
-xSV
-xSV
-xSV
-xSV
+uzt
+xqP
+xqP
+xqP
+xqP
+xqP
+xqP
+xqP
 xqP
 xqP
 xRI
 xqP
 xqP
-xSV
-xSV
-xSV
-xSV
-xSV
-xSV
-vXL
-xSV
+xqP
+xqP
+xqP
+xqP
+xqP
+xqP
+xqP
+nbk
 raz
 sUD
 uaX

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -1726,6 +1726,12 @@
 	dir = 8
 	},
 /area/mainship/hallways/hangar)
+"fM" = (
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "fN" = (
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/red{
@@ -1751,6 +1757,12 @@
 /obj/machinery/computer/supplycomp,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"fS" = (
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "warnplatecorner"
+	},
+/area/mainship/hallways/hangar)
 "fT" = (
 /obj/effect/decal/cleanable/blood/oil{
 	name = "grease";
@@ -2470,6 +2482,11 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
+"is" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 10
+	},
+/area/mainship/hallways/hangar)
 "it" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -4530,6 +4547,12 @@
 /obj/item/tool/crowbar/red,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/port_missiles)
+"pe" = (
+/turf/open/floor/plating{
+	dir = 4;
+	icon_state = "warnplatecorner"
+	},
+/area/mainship/hallways/hangar)
 "pf" = (
 /turf/open/floor/mainship/red/corner{
 	dir = 4
@@ -6304,10 +6327,9 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "ve" = (
-/obj/machinery/light{
-	dir = 1
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
 	},
-/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "vf" = (
 /obj/machinery/cic_maptable,
@@ -6968,6 +6990,11 @@
 	dir = 1
 	},
 /area/mainship/medical/lounge)
+"xx" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "xA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -7566,6 +7593,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
+"zi" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 6
+	},
+/area/mainship/hallways/hangar)
 "zk" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -8307,6 +8339,11 @@
 /obj/structure/cable,
 /turf/open/floor/freezer,
 /area/mainship/living/cafeteria_starboard)
+"Bs" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 9
+	},
+/area/mainship/hallways/hangar)
 "Bu" = (
 /obj/machinery/power/apc/mainship{
 	dir = 8
@@ -8402,6 +8439,11 @@
 /obj/item/paper/hydroponics,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/port_garden)
+"BK" = (
+/turf/open/floor/plating{
+	icon_state = "warnplatecorner"
+	},
+/area/mainship/hallways/hangar)
 "BN" = (
 /obj/structure/table/mainship,
 /obj/structure/paper_bin,
@@ -8654,6 +8696,9 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
+"CH" = (
+/turf/open/floor/plating/icefloor/warnplate,
+/area/mainship/hallways/hangar)
 "CI" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -11707,6 +11752,11 @@
 /obj/machinery/light,
 /turf/open/floor/mainship/sterile/purple/side,
 /area/mainship/medical/chemistry)
+"Mh" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 5
+	},
+/area/mainship/hallways/hangar)
 "Mi" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -12079,6 +12129,12 @@
 	dir = 4
 	},
 /area/mainship/hallways/port_hallway)
+"Nw" = (
+/obj/effect/attach_point/electronics/dropship1,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "Nx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -14126,6 +14182,11 @@
 /obj/vehicle/ridden/powerloader,
 /turf/open/floor/mainship/cargo,
 /area/mainship/shipboard/weapon_room)
+"Uf" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/mainship/hallways/hangar)
 "Ug" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
@@ -22425,25 +22486,25 @@ aW
 tW
 ez
 ez
-ez
-ez
-ez
+BK
+ve
+zi
 ez
 ez
 Cf
+Mh
+ve
+ve
+ve
+ve
+zi
 ez
 ez
 ez
 ez
 ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
+xx
+ve
 hN
 iy
 VC
@@ -22521,9 +22582,9 @@ qR
 OS
 sJ
 tZ
-ve
 ez
 ez
+CH
 xP
 ez
 ez
@@ -22540,8 +22601,8 @@ ez
 ez
 ez
 ez
-ez
-ez
+xx
+xx
 hN
 iy
 VC
@@ -22619,9 +22680,9 @@ ez
 sh
 aW
 ud
-ez
-ez
-ez
+ve
+ve
+zi
 xQ
 ez
 ez
@@ -22638,8 +22699,8 @@ ez
 ez
 ez
 ez
-ez
-ez
+xx
+xx
 hN
 iy
 jq
@@ -22717,6 +22778,7 @@ ez
 hN
 aW
 dO
+xx
 ez
 ez
 ez
@@ -22735,9 +22797,8 @@ ez
 ez
 ez
 ez
-ez
-ez
-ez
+Uf
+pe
 hN
 iy
 Al
@@ -22815,6 +22876,7 @@ ez
 hN
 aW
 dO
+xx
 ez
 ez
 ez
@@ -22833,9 +22895,8 @@ ez
 ez
 ez
 ez
-ez
-ez
-ez
+Bs
+Uf
 an
 On
 Py
@@ -22913,7 +22974,7 @@ ez
 hN
 aW
 dO
-ez
+xx
 ez
 ez
 ez
@@ -22932,7 +22993,7 @@ ez
 ez
 ez
 ez
-ez
+xx
 ez
 an
 ic
@@ -23011,6 +23072,7 @@ ez
 hN
 aW
 dO
+xx
 ez
 ez
 ez
@@ -23029,9 +23091,8 @@ ez
 ez
 ez
 ez
-ez
-ez
-ez
+Mh
+ve
 an
 Oo
 PB
@@ -23109,6 +23170,7 @@ ez
 hN
 aW
 dO
+xx
 ez
 ez
 ez
@@ -23127,9 +23189,8 @@ ez
 ez
 ez
 ez
-ez
-ez
-ez
+ve
+fS
 hN
 iy
 VC
@@ -23207,13 +23268,10 @@ ez
 sg
 aW
 tW
-ez
-ez
-ez
-xQ
-ez
-ez
-ez
+Uf
+Uf
+Uf
+Nw
 ez
 ez
 ez
@@ -23228,6 +23286,9 @@ ez
 ez
 ez
 ez
+ez
+xx
+xx
 hN
 iy
 jq
@@ -23305,12 +23366,10 @@ qR
 OS
 sJ
 tZ
-ve
 ez
 ez
-xP
 ez
-ez
+fM
 ez
 ez
 ez
@@ -23326,6 +23385,8 @@ ez
 ez
 ez
 ez
+xx
+xx
 hN
 iy
 VC
@@ -23406,24 +23467,24 @@ ud
 ez
 ez
 ez
+Uf
+Uf
+xx
+ez
+ez
+Bs
+Uf
+Uf
+Uf
+Uf
+is
 ez
 ez
 ez
 ez
 ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
+xx
+Uf
 hN
 iy
 VC

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -48,6 +48,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"an" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "ao" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/mainship/mono,
@@ -2361,6 +2369,19 @@
 /obj/machinery/cryopod/right,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cryo_cells)
+"ic" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/hangar)
 "id" = (
 /turf/open/floor/mainship/blue{
 	dir = 8
@@ -8298,6 +8319,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
+"Bw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/hangar)
 "By" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/blood/oil,
@@ -12338,6 +12365,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"Om" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/hangar)
 "On" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -12349,7 +12383,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "Oo" = (
 /obj/structure/cable,
@@ -12362,7 +12396,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "Op" = (
 /obj/structure/cable,
@@ -22201,8 +22235,8 @@ js
 js
 AY
 js
-js
-js
+Om
+Om
 Fk
 js
 js
@@ -22802,7 +22836,7 @@ ez
 ez
 ez
 ez
-hN
+an
 On
 Py
 QA
@@ -22900,8 +22934,8 @@ ez
 ez
 ez
 ez
-hN
-iy
+an
+ic
 VC
 QB
 cF
@@ -22998,7 +23032,7 @@ ez
 ez
 ez
 ez
-hN
+an
 Oo
 PB
 QC
@@ -23573,8 +23607,8 @@ bw
 zP
 bw
 bw
-bw
-bw
+Bw
+Bw
 bw
 bw
 bw

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -8581,7 +8581,9 @@
 	dir = 8;
 	icon_state = "equip_base_l_wing"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
 /area/mainship/hallways/hangar)
 "Cg" = (
 /turf/closed/wall/mainship,
@@ -22489,8 +22491,8 @@ ez
 BK
 ve
 zi
-ez
-ez
+Uf
+Uf
 Cf
 Mh
 ve
@@ -22498,11 +22500,11 @@ ve
 ve
 ve
 zi
-ez
-ez
-ez
-ez
-ez
+Uf
+Uf
+Uf
+Uf
+Uf
 xx
 ve
 hN
@@ -23468,21 +23470,21 @@ ez
 ez
 ez
 Uf
-Uf
-xx
-ez
-ez
+is
+ve
+ve
+ve
 Bs
 Uf
 Uf
 Uf
 Uf
 is
-ez
-ez
-ez
-ez
-ez
+ve
+ve
+ve
+ve
+ve
 xx
 Uf
 hN

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -2906,6 +2906,11 @@
 	icon_state = "carpetside"
 	},
 /area/mainship/command/corporateliaison)
+"jF" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 6
+	},
+/area/mainship/hallways/hangar)
 "jG" = (
 /obj/effect/decal/siding{
 	dir = 8
@@ -3672,6 +3677,12 @@
 /obj/machinery/computer/emails,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
+"lM" = (
+/turf/open/floor/plating{
+	dir = 4;
+	icon_state = "warnplatecorner"
+	},
+/area/mainship/hallways/hangar)
 "lN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4214,6 +4225,9 @@
 /obj/machinery/body_scanconsole,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
+"nv" = (
+/turf/open/floor/plating/icefloor/warnplate,
+/area/mainship/hallways/hangar)
 "nw" = (
 /obj/structure/window/framed/mainship,
 /turf/open/floor/plating,
@@ -5314,6 +5328,11 @@
 "rg" = (
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/starboard_hallway)
+"ri" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 10
+	},
+/area/mainship/hallways/hangar)
 "rj" = (
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/mainship/mono,
@@ -5773,6 +5792,12 @@
 "sG" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/hallways/starboard_hallway)
+"sH" = (
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "warnplatecorner"
+	},
+/area/mainship/hallways/hangar)
 "sI" = (
 /obj/machinery/door/airlock/mainship/command/officer{
 	dir = 2
@@ -5831,6 +5856,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"sP" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/mainship/hallways/hangar)
 "sQ" = (
 /obj/machinery/door/airlock/mainship/marine/general/smart,
 /obj/machinery/door/firedoor/mainship,
@@ -8703,6 +8733,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"Bq" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 5
+	},
+/area/mainship/hallways/hangar)
 "Br" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner{
@@ -12783,6 +12818,12 @@
 	dir = 8
 	},
 /area/mainship/living/cryo_cells)
+"Nv" = (
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "Nw" = (
 /obj/structure/cable,
 /obj/machinery/light/small{
@@ -13036,6 +13077,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
+"Oi" = (
+/obj/effect/attach_point/electronics/dropship1,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "Oj" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -15811,6 +15858,11 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"Xa" = (
+/turf/open/floor/plating{
+	icon_state = "warnplatecorner"
+	},
+/area/mainship/hallways/hangar)
 "Xc" = (
 /obj/machinery/light{
 	dir = 1
@@ -16219,6 +16271,11 @@
 	},
 /turf/open/shuttle/escapepod/four,
 /area/mainship/command/self_destruct)
+"Yk" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 9
+	},
+/area/mainship/hallways/hangar)
 "Yl" = (
 /obj/effect/landmark/start/job/squadcorpsman,
 /turf/open/floor/mainship/cargo/arrow{
@@ -16496,6 +16553,11 @@
 /obj/effect/landmark/start/latejoin,
 /turf/open/floor/mainship,
 /area/mainship/living/cryo_cells)
+"Zd" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/mainship/hallways/hangar)
 "Ze" = (
 /obj/machinery/vending/medical,
 /obj/machinery/light{
@@ -16613,6 +16675,11 @@
 	dir = 8
 	},
 /area/mainship/medical/chemistry)
+"ZA" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "ZC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor/mainship/mono,
@@ -43321,25 +43388,25 @@ fd
 aZ
 bh
 bh
-bh
-bh
-bh
+Xa
+Zd
+jF
 bh
 bh
 cR
+Bq
+Zd
+Zd
+Zd
+Zd
+jF
 bh
 bh
 bh
 bh
 bh
-bh
-bh
-bh
-bh
-bh
-bh
-bh
-bh
+ZA
+Zd
 Yf
 YS
 ap
@@ -43578,7 +43645,7 @@ eJ
 aS
 bh
 bh
-bh
+nv
 bA
 bh
 bh
@@ -43595,8 +43662,8 @@ bh
 bh
 bh
 bh
-bh
-bh
+ZA
+ZA
 PX
 mh
 GQ
@@ -43833,9 +43900,9 @@ fn
 ap
 eJ
 aT
-bh
-bh
-bh
+Zd
+Zd
+jF
 bB
 bh
 bh
@@ -43852,8 +43919,8 @@ bh
 bh
 bh
 bh
-bh
-bh
+ZA
+ZA
 QM
 YS
 ap
@@ -44090,6 +44157,7 @@ dA
 ap
 eJ
 aV
+ZA
 bh
 bh
 bh
@@ -44108,9 +44176,8 @@ bh
 bh
 bh
 bh
-bh
-bh
-bh
+sP
+lM
 VA
 YS
 ap
@@ -44347,6 +44414,7 @@ az
 VN
 eJ
 aZ
+ZA
 bh
 bh
 bh
@@ -44365,9 +44433,8 @@ bh
 bh
 bh
 bh
-bh
-bh
-bh
+Yk
+sP
 kH
 qE
 ap
@@ -44604,7 +44671,7 @@ az
 ap
 eJ
 aS
-bh
+ZA
 bh
 bh
 bh
@@ -44623,7 +44690,7 @@ bh
 bh
 bh
 bh
-bh
+ZA
 bh
 kI
 fB
@@ -44861,6 +44928,7 @@ az
 ac
 eJ
 aT
+ZA
 bh
 bh
 bh
@@ -44879,9 +44947,8 @@ bh
 bh
 bh
 bh
-bh
-bh
-bh
+Bq
+Zd
 kJ
 qE
 ap
@@ -45118,6 +45185,7 @@ az
 Zx
 eJ
 aV
+ZA
 bh
 bh
 bh
@@ -45136,9 +45204,8 @@ bh
 bh
 bh
 bh
-bh
-bh
-bh
+Zd
+sH
 VA
 YS
 ap
@@ -45375,13 +45442,10 @@ oa
 se
 eJ
 aZ
-bh
-bh
-bh
-bB
-bh
-bh
-bh
+sP
+sP
+sP
+Oi
 bh
 bh
 bh
@@ -45396,6 +45460,9 @@ bh
 bh
 bh
 bh
+bh
+ZA
+ZA
 Yf
 YS
 ap
@@ -45635,7 +45702,7 @@ bb
 bh
 bh
 bh
-bA
+Nv
 bh
 bh
 bh
@@ -45651,8 +45718,8 @@ bh
 bh
 bh
 bh
-bh
-bh
+ZA
+ZA
 PX
 YS
 Np
@@ -45892,24 +45959,24 @@ aT
 bh
 bh
 bh
+sP
+sP
+ZA
+bh
+bh
+Yk
+sP
+sP
+sP
+sP
+ri
 bh
 bh
 bh
 bh
 bh
-bh
-bh
-bh
-bh
-bh
-bh
-bh
-bh
-bh
-bh
-bh
-bh
-bh
+ZA
+sP
 QM
 YS
 ap

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -861,7 +861,9 @@
 	dir = 8;
 	icon_state = "equip_base_l_wing"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
 /area/mainship/hallways/hangar)
 "cS" = (
 /obj/machinery/autodoc,
@@ -43391,8 +43393,8 @@ bh
 Xa
 Zd
 jF
-bh
-bh
+sP
+sP
 cR
 Bq
 Zd
@@ -43400,11 +43402,11 @@ Zd
 Zd
 Zd
 jF
-bh
-bh
-bh
-bh
-bh
+sP
+sP
+sP
+sP
+sP
 ZA
 Zd
 Yf
@@ -45960,21 +45962,21 @@ bh
 bh
 bh
 sP
-sP
-ZA
-bh
-bh
+ri
+Zd
+Zd
+Zd
 Yk
 sP
 sP
 sP
 sP
 ri
-bh
-bh
-bh
-bh
-bh
+Zd
+Zd
+Zd
+Zd
+Zd
 ZA
 sP
 QM

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -41212,6 +41212,11 @@
 	icon_state = "asteroid"
 	},
 /area/prison/residential/central)
+"cFh" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 10
+	},
+/area/prison/hangar/civilian)
 "cFk" = (
 /obj/machinery/light/small,
 /turf/open/floor/wood/broken,
@@ -41438,6 +41443,12 @@
 /obj/structure/lattice,
 /turf/open/space/sea,
 /area/space)
+"dsK" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/prison/hangar/main)
 "dtT" = (
 /turf/open/floor/prison{
 	dir = 10;
@@ -41513,6 +41524,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/medbay)
+"dLE" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 5
+	},
+/area/prison/hangar/civilian)
 "dMY" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
@@ -41565,6 +41581,9 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/wood,
 /area/prison/residential/central)
+"dXl" = (
+/turf/open/floor/plating/icefloor/warnplate,
+/area/prison/hangar/main)
 "dXA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -41782,6 +41801,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
+"evv" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/prison/hangar/civilian)
 "evK" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red{
@@ -41880,6 +41905,11 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/access/south)
+"eQi" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 10
+	},
+/area/prison/hangar/main)
 "eQl" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/prison/sterilewhite,
@@ -42115,6 +42145,11 @@
 	dir = 8
 	},
 /area/prison/hangar/main)
+"fFS" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 5
+	},
+/area/prison/hangar/main)
 "fGm" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -42172,6 +42207,11 @@
 	},
 /turf/open/floor/prison,
 /area/prison/execution)
+"fRl" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/prison/hangar/civilian)
 "fRP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -42868,6 +42908,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/visitation)
+"iaK" = (
+/obj/effect/attach_point/weapon/dropship1{
+	dir = 8;
+	icon_state = "equip_base_l_wing"
+	},
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/prison/hangar/civilian)
 "ibS" = (
 /turf/open/floor/prison/red{
 	dir = 1
@@ -42928,6 +42977,11 @@
 	dir = 4
 	},
 /area/prison/security/checkpoint/vip)
+"ikz" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 9
+	},
+/area/prison/hangar/civilian)
 "ikQ" = (
 /turf/open/floor/prison/darkred{
 	dir = 4
@@ -43119,6 +43173,9 @@
 "iNU" = (
 /turf/open/floor/plating/ground/dirt,
 /area/prison/hallway/central)
+"iOg" = (
+/turf/open/floor/plating/icefloor/warnplate,
+/area/prison/hangar/civilian)
 "iOM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -43167,6 +43224,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
+"iVq" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/prison/hangar/main)
 "iVD" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 2;
@@ -43869,6 +43931,11 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/north)
+"kMX" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 6
+	},
+/area/prison/hangar/main)
 "kNK" = (
 /turf/open/floor/plating,
 /area/prison/command/office)
@@ -44119,6 +44186,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
+"lPJ" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating,
+/area/prison/hangar/main)
 "lPU" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/prison/blue{
@@ -44162,6 +44233,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/se)
+"lXn" = (
+/obj/effect/attach_point/electronics/dropship1,
+/turf/open/floor/plating,
+/area/prison/hangar/civilian)
 "lXO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -44201,6 +44276,11 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/prison/darkred/full,
 /area/prison/cellblock/maxsec/north)
+"mlR" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 6
+	},
+/area/prison/hangar/civilian)
 "mmI" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
@@ -44596,6 +44676,12 @@
 	dir = 8
 	},
 /area/prison/research/secret/containment)
+"ndS" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/prison/hangar/main)
 "neb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -45017,6 +45103,10 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/space/sea,
 /area/space)
+"ogM" = (
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating,
+/area/prison/hangar/civilian)
 "ohC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -46500,6 +46590,11 @@
 "spw" = (
 /turf/open/floor/plating,
 /area/prison/cellblock/highsec/south/south)
+"sqF" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/prison/hangar/civilian)
 "sqQ" = (
 /obj/structure/cable,
 /turf/open/floor/prison/yellow{
@@ -46678,6 +46773,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/security/monitoring/highsec)
+"sLV" = (
+/obj/effect/attach_point/electronics/dropship1,
+/turf/open/floor/plating,
+/area/prison/hangar/main)
 "sMg" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -46874,6 +46973,12 @@
 "tnU" = (
 /obj/machinery/light,
 /turf/open/floor/prison,
+/area/prison/hangar/civilian)
+"tqT" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
 /area/prison/hangar/civilian)
 "tqX" = (
 /obj/effect/landmark/weed_node,
@@ -47316,6 +47421,11 @@
 	dir = 1
 	},
 /area/prison/cellblock/mediumsec/north)
+"uHL" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/prison/hangar/main)
 "uHQ" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating,
@@ -47462,6 +47572,11 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"veZ" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/prison/hangar/civilian)
 "vfh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -47601,6 +47716,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
+"vAB" = (
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating,
+/area/prison/hangar/main)
 "vBj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/secure_data,
@@ -47916,6 +48035,10 @@
 /obj/effect/landmark/weapon_spawn/tier2_weapon_spawn,
 /turf/open/floor/carpet,
 /area/prison/command/quarters)
+"woF" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating,
+/area/prison/hangar/civilian)
 "woW" = (
 /obj/machinery/door/airlock/mainship/maint/free_access,
 /obj/effect/landmark/lv624/fog_blocker,
@@ -47935,6 +48058,11 @@
 "wpW" = (
 /turf/open/floor/prison/green/full,
 /area/prison/cellblock/lowsec/ne)
+"wtm" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 9
+	},
+/area/prison/hangar/main)
 "wus" = (
 /obj/machinery/shower{
 	dir = 4
@@ -47973,6 +48101,11 @@
 	dir = 8
 	},
 /area/prison/medbay)
+"wwv" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/prison/hangar/main)
 "wwH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48197,6 +48330,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
+"xgV" = (
+/obj/effect/attach_point/weapon/dropship1{
+	dir = 8;
+	icon_state = "equip_base_l_wing"
+	},
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/prison/hangar/main)
 "xhO" = (
 /obj/structure/window/framed/prison/reinforced,
 /turf/open/floor/plating,
@@ -50731,27 +50873,27 @@ iHW
 hdB
 mXp
 hZS
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
+ikz
+fRl
+fRl
+fRl
+fRl
+fRl
+fRl
+iaK
+fRl
+fRl
+evv
+fRl
+fRl
+fRl
+fRl
+fRl
+fRl
+fRl
+fRl
+fRl
+cFh
 ctn
 qhf
 qhf
@@ -50988,6 +51130,10 @@ iHW
 amu
 rnW
 oxD
+sqF
+qhf
+woF
+ogM
 qhf
 qhf
 qhf
@@ -51002,13 +51148,9 @@ qhf
 qhf
 qhf
 qhf
+woF
 qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
+iOg
 cto
 qhf
 wPa
@@ -51245,6 +51387,10 @@ iHW
 hdB
 mRK
 gCN
+sqF
+qhf
+qhf
+lXn
 qhf
 qhf
 qhf
@@ -51261,11 +51407,7 @@ qhf
 qhf
 qhf
 qhf
-qhf
-qhf
-qhf
-qhf
-qhf
+iOg
 ctq
 qhf
 qhf
@@ -51502,6 +51644,7 @@ iHW
 hdB
 mRK
 gne
+sqF
 qhf
 qhf
 qhf
@@ -51521,8 +51664,7 @@ qhf
 qhf
 qhf
 qhf
-qhf
-qhf
+iOg
 ctr
 qhf
 qhf
@@ -51759,6 +51901,7 @@ iHW
 hdB
 mRK
 hZS
+sqF
 qhf
 qhf
 qhf
@@ -51778,8 +51921,7 @@ qhf
 qhf
 qhf
 qhf
-qhf
-qhf
+iOg
 ctn
 qhf
 qhf
@@ -52016,7 +52158,7 @@ iHW
 amu
 tKy
 oxD
-qhf
+sqF
 qhf
 qhf
 qhf
@@ -52036,7 +52178,7 @@ qhf
 qhf
 qhf
 qhf
-qhf
+iOg
 cto
 qhf
 wPa
@@ -52273,6 +52415,7 @@ iHW
 hdB
 mRK
 gCN
+sqF
 qhf
 qhf
 qhf
@@ -52292,8 +52435,7 @@ qhf
 qhf
 qhf
 qhf
-qhf
-qhf
+iOg
 ctq
 qhf
 qhf
@@ -52530,6 +52672,7 @@ iHW
 hdB
 mRK
 gne
+sqF
 qhf
 qhf
 qhf
@@ -52549,8 +52692,7 @@ qhf
 qhf
 qhf
 qhf
-qhf
-qhf
+iOg
 ctr
 qhf
 qhf
@@ -52787,6 +52929,10 @@ iHW
 hdB
 mRK
 hZS
+sqF
+qhf
+qhf
+lXn
 qhf
 qhf
 qhf
@@ -52803,11 +52949,7 @@ qhf
 qhf
 qhf
 qhf
-qhf
-qhf
-qhf
-qhf
-qhf
+iOg
 ctn
 qhf
 qhf
@@ -53044,6 +53186,10 @@ iHW
 amu
 gyL
 oxD
+sqF
+qhf
+woF
+ogM
 qhf
 qhf
 qhf
@@ -53058,13 +53204,9 @@ qhf
 qhf
 qhf
 qhf
+woF
 qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
+iOg
 cto
 qhf
 wPa
@@ -53301,27 +53443,27 @@ pYD
 amu
 qBi
 gCN
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
-qhf
+dLE
+veZ
+veZ
+veZ
+veZ
+veZ
+veZ
+veZ
+veZ
+veZ
+tqT
+veZ
+veZ
+veZ
+veZ
+veZ
+veZ
+veZ
+veZ
+veZ
+mlR
 ctq
 qhf
 qhf
@@ -108298,27 +108440,27 @@ obp
 nTj
 nTj
 baF
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
+wtm
+uHL
+uHL
+uHL
+uHL
+uHL
+uHL
+xgV
+uHL
+uHL
+ndS
+uHL
+uHL
+uHL
+uHL
+uHL
+uHL
+uHL
+uHL
+uHL
+eQi
 bwp
 bnQ
 mSO
@@ -108555,6 +108697,10 @@ obp
 nTj
 nTj
 gNc
+wwv
+nTj
+lPJ
+vAB
 nTj
 nTj
 nTj
@@ -108569,13 +108715,9 @@ nTj
 nTj
 nTj
 nTj
+lPJ
 nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
+dXl
 bwq
 bnQ
 mSO
@@ -108812,6 +108954,10 @@ obp
 nTj
 nTj
 baH
+wwv
+nTj
+nTj
+sLV
 nTj
 nTj
 nTj
@@ -108828,11 +108974,7 @@ nTj
 nTj
 nTj
 nTj
-nTj
-nTj
-nTj
-nTj
-nTj
+dXl
 bwr
 bnQ
 mSO
@@ -109069,6 +109211,7 @@ obp
 nTj
 nTj
 baI
+wwv
 nTj
 nTj
 nTj
@@ -109088,8 +109231,7 @@ nTj
 nTj
 nTj
 nTj
-nTj
-nTj
+dXl
 bws
 bnQ
 mSO
@@ -109326,6 +109468,7 @@ aXt
 aYN
 nTj
 baF
+wwv
 nTj
 nTj
 nTj
@@ -109345,8 +109488,7 @@ nTj
 nTj
 nTj
 nTj
-nTj
-nTj
+dXl
 bwp
 bnQ
 nRo
@@ -109583,7 +109725,7 @@ obp
 nTj
 nTj
 gNc
-nTj
+wwv
 nTj
 nTj
 nTj
@@ -109603,7 +109745,7 @@ nTj
 nTj
 nTj
 nTj
-nTj
+dXl
 bwq
 bnQ
 byi
@@ -109840,6 +109982,7 @@ obp
 nTj
 nTj
 qPG
+wwv
 nTj
 nTj
 nTj
@@ -109859,8 +110002,7 @@ nTj
 nTj
 nTj
 nTj
-nTj
-nTj
+dXl
 bwr
 bnQ
 byi
@@ -110097,6 +110239,7 @@ obp
 nTj
 nTj
 baI
+wwv
 nTj
 nTj
 nTj
@@ -110116,8 +110259,7 @@ nTj
 nTj
 nTj
 nTj
-nTj
-nTj
+dXl
 bws
 bnQ
 byi
@@ -110354,6 +110496,10 @@ obp
 nTj
 nTj
 baF
+wwv
+nTj
+nTj
+sLV
 nTj
 nTj
 nTj
@@ -110370,11 +110516,7 @@ nTj
 nTj
 nTj
 nTj
-nTj
-nTj
-nTj
-nTj
-nTj
+dXl
 bwp
 bnQ
 byi
@@ -110611,6 +110753,10 @@ obp
 nTj
 nTj
 gNc
+wwv
+nTj
+lPJ
+vAB
 nTj
 nTj
 nTj
@@ -110625,13 +110771,9 @@ nTj
 nTj
 nTj
 nTj
+lPJ
 nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
+dXl
 bwq
 bnQ
 byi
@@ -110868,27 +111010,27 @@ obp
 nTj
 nTj
 baH
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
+fFS
+iVq
+iVq
+iVq
+iVq
+iVq
+iVq
+iVq
+iVq
+iVq
+dsK
+iVq
+iVq
+iVq
+iVq
+iVq
+iVq
+iVq
+iVq
+iVq
+kMX
 bwr
 bnQ
 byi

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -10216,7 +10216,9 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
-/turf/open/floor/prison/bright_clean,
+/turf/open/floor/prison/arrow/clean{
+	dir = 4
+	},
 /area/sulaco/hangar)
 "bvh" = (
 /obj/structure/cable,
@@ -10481,6 +10483,19 @@
 "bWL" = (
 /turf/open/floor/prison,
 /area/sulaco/engineering)
+"bXx" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/structure/cable,
+/obj/machinery/landinglight/ds1/delaytwo{
+	dir = 8
+	},
+/turf/open/floor/prison/arrow/clean{
+	dir = 8
+	},
+/area/sulaco/hangar)
 "bXW" = (
 /obj/machinery/light/small,
 /obj/structure/table/mainship,
@@ -10615,6 +10630,9 @@
 /obj/item/storage/bag/trash,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint2)
+"clz" = (
+/turf/open/floor/prison/cleanmarked,
+/area/sulaco/hangar)
 "cmN" = (
 /obj/machinery/firealarm,
 /turf/open/floor/prison,
@@ -12301,7 +12319,9 @@
 /obj/machinery/landinglight/ds1/delaythree{
 	dir = 8
 	},
-/turf/open/floor/prison/bright_clean,
+/turf/open/floor/prison/arrow/clean{
+	dir = 8
+	},
 /area/sulaco/hangar)
 "fqu" = (
 /obj/structure/cable,
@@ -13438,6 +13458,17 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/ai,
 /area/sulaco/command/ai)
+"hHl" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/landinglight/ds1/delaytwo{
+	dir = 1
+	},
+/turf/open/floor/prison/arrow/clean{
+	dir = 1
+	},
+/area/sulaco/hangar)
 "hHK" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 2
@@ -19583,6 +19614,17 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
+"sbF" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/landinglight/ds1{
+	dir = 1
+	},
+/turf/open/floor/prison/arrow/clean{
+	dir = 1
+	},
+/area/sulaco/hangar)
 "sbP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -19916,6 +19958,10 @@
 /obj/machinery/door/airlock/mainship/marine/general/engi,
 /turf/open/floor/prison/green/full,
 /area/sulaco/marine)
+"sAh" = (
+/obj/effect/ai_node,
+/turf/open/floor/prison/cleanmarked,
+/area/sulaco/hangar)
 "sAL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/red{
@@ -19954,7 +20000,9 @@
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 1
 	},
-/turf/open/floor/prison/bright_clean,
+/turf/open/floor/prison/arrow/clean{
+	dir = 1
+	},
 /area/sulaco/hangar)
 "sCw" = (
 /obj/effect/ai_node,
@@ -19968,7 +20016,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
-/turf/open/floor/prison/bright_clean,
+/turf/open/floor/prison/cleanmarked,
 /area/sulaco/hangar)
 "sCO" = (
 /obj/machinery/light/small{
@@ -22709,7 +22757,9 @@
 /obj/machinery/landinglight/ds1{
 	dir = 4
 	},
-/turf/open/floor/prison/bright_clean,
+/turf/open/floor/prison/arrow/clean{
+	dir = 4
+	},
 /area/sulaco/hangar)
 "xjC" = (
 /obj/structure/cable,
@@ -57195,7 +57245,7 @@ aRd
 bRu
 tgw
 bbu
-tgw
+clz
 sCF
 tgw
 tgw
@@ -58750,8 +58800,8 @@ aPZ
 aPZ
 aPZ
 aPZ
-wbU
-tgw
+sbF
+clz
 aYD
 aPY
 gHU
@@ -59008,7 +59058,7 @@ aPZ
 aPZ
 aPZ
 sBW
-tgw
+clz
 tgw
 bap
 tgw
@@ -59264,8 +59314,8 @@ aPZ
 aPZ
 aPZ
 aPZ
-agy
-tgw
+hHl
+clz
 xou
 aPY
 rkI
@@ -60537,7 +60587,7 @@ pht
 ppF
 nmW
 fqg
-vRn
+bXx
 koP
 nmW
 hPF
@@ -60793,8 +60843,8 @@ tgw
 tgw
 qds
 tgw
-mwr
-tgw
+sAh
+clz
 tgw
 tgw
 tgw

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -7799,9 +7799,7 @@
 /turf/open/floor/prison/green/full,
 /area/sulaco/marine)
 "aMT" = (
-/obj/docking_port/stationary/marine_dropship/hangar/one{
-	name = "Sulaco Hangar Pad One"
-	},
+/obj/docking_port/stationary/marine_dropship/hangar/one,
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/plating,
 /area/sulaco/hangar)
@@ -11006,6 +11004,11 @@
 /obj/structure/closet/basketball,
 /turf/open/floor/tile/darkgreen/darkgreen2,
 /area/mainship/living/basketball)
+"cOO" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/sulaco/hangar)
 "cOP" = (
 /obj/structure/bed/chair,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
@@ -12413,6 +12416,11 @@
 	dir = 1
 	},
 /area/sulaco/medbay)
+"fAI" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 5
+	},
+/area/sulaco/hangar)
 "fBA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
@@ -12975,6 +12983,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/prison,
 /area/mainship/living/pilotbunks)
+"gGN" = (
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/sulaco/hangar)
 "gHU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/bright_clean,
@@ -13111,6 +13125,11 @@
 /obj/item/book/manual/medical_diagnostics_manual,
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay/cmo)
+"gUO" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 6
+	},
+/area/sulaco/hangar)
 "gVp" = (
 /obj/machinery/gibber,
 /turf/open/floor/prison/sterilewhite,
@@ -13526,6 +13545,10 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hydro)
+"hLi" = (
+/obj/effect/attach_point/electronics/dropship1,
+/turf/open/floor/plating,
+/area/sulaco/hangar)
 "hLm" = (
 /obj/effect/decal/siding{
 	dir = 9
@@ -15571,6 +15594,13 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plating,
 /area/sulaco/bridge/office)
+"lrz" = (
+/obj/effect/attach_point/weapon/dropship1{
+	dir = 8;
+	icon_state = "equip_base_l_wing"
+	},
+/turf/open/floor/plating,
+/area/sulaco/hangar)
 "lrA" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
@@ -15722,6 +15752,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall2)
+"lCA" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/sulaco/hangar)
 "lDs" = (
 /obj/structure/table/mainship,
 /obj/item/camera,
@@ -17200,6 +17235,12 @@
 	dir = 10
 	},
 /area/mainship/living/basketball)
+"oed" = (
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "warnplatecorner"
+	},
+/area/sulaco/hangar)
 "ofF" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
@@ -17902,6 +17943,11 @@
 "oYE" = (
 /turf/open/floor/plating,
 /area/sulaco/hub/top)
+"oZc" = (
+/turf/open/floor/plating{
+	icon_state = "warnplatecorner"
+	},
+/area/sulaco/hangar)
 "pbw" = (
 /obj/structure/table/mainship,
 /obj/machinery/light/small,
@@ -18705,6 +18751,10 @@
 /obj/item/reagent_containers/food/drinks/bottle/sake,
 /turf/open/floor/wood,
 /area/sulaco/liaison/quarters)
+"quv" = (
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating,
+/area/sulaco/hangar)
 "qvV" = (
 /obj/machinery/door_control/unmeltable{
 	dir = 4;
@@ -20029,6 +20079,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint2)
+"sEx" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 10
+	},
+/area/sulaco/hangar)
 "sFd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -20647,6 +20702,11 @@
 /obj/item/toy/beach_ball/basketball,
 /turf/open/floor/tile/darkgreen/darkgreen2,
 /area/mainship/living/basketball)
+"txC" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/sulaco/hangar)
 "txF" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall/mainship/gray,
@@ -21727,6 +21787,12 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/engineering/atmos)
+"vqh" = (
+/obj/effect/attach_point/electronics/dropship1,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/sulaco/hangar)
 "vrP" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -21789,6 +21855,9 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark2,
 /area/mainship/living/basketball)
+"vwQ" = (
+/turf/open/floor/plating/icefloor/warnplate,
+/area/sulaco/hangar)
 "vxZ" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -22671,6 +22740,12 @@
 	},
 /turf/open/floor/tile/hydro,
 /area/sulaco/hydro)
+"xbA" = (
+/turf/open/floor/plating{
+	dir = 4;
+	icon_state = "warnplatecorner"
+	},
+/area/sulaco/hangar)
 "xbD" = (
 /obj/structure/window/framed/mainship/gray/toughened,
 /turf/open/floor/plating/platebotc,
@@ -22843,6 +22918,11 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/sulaco/command/ai)
+"xpS" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 9
+	},
+/area/sulaco/hangar)
 "xrh" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
@@ -57753,25 +57833,25 @@ vVE
 rts
 aPZ
 aPZ
+oZc
+lCA
+gUO
+aPZ
+aPZ
+lrz
+fAI
+lCA
+lCA
+lCA
+lCA
+gUO
 aPZ
 aPZ
 aPZ
 aPZ
 aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
+txC
+lCA
 wbU
 tgw
 tgw
@@ -58010,6 +58090,8 @@ tgw
 hgI
 aPZ
 aPZ
+vwQ
+quv
 aPZ
 aPZ
 aPZ
@@ -58025,10 +58107,8 @@ aPZ
 aPZ
 aPZ
 aPZ
-aPZ
-aPZ
-aPZ
-aPZ
+txC
+txC
 sjS
 tgw
 tgw
@@ -58265,6 +58345,10 @@ tgw
 tgw
 tgw
 wVa
+lCA
+lCA
+gUO
+hLi
 aPZ
 aPZ
 aPZ
@@ -58280,12 +58364,8 @@ aPZ
 aPZ
 aPZ
 aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
+txC
+txC
 agy
 gHU
 tgw
@@ -58522,6 +58602,7 @@ xca
 jQS
 tgw
 wXL
+txC
 aPZ
 aPZ
 aPZ
@@ -58540,9 +58621,8 @@ aPZ
 aPZ
 aPZ
 aPZ
-aPZ
-aPZ
-aPZ
+cOO
+xbA
 lQB
 tgw
 gHU
@@ -58779,6 +58859,7 @@ wjr
 tgw
 gHU
 oiu
+txC
 aPZ
 aPZ
 aPZ
@@ -58797,9 +58878,8 @@ aPZ
 aPZ
 aPZ
 aPZ
-aPZ
-aPZ
-aPZ
+xpS
+cOO
 sbF
 clz
 aYD
@@ -59036,7 +59116,7 @@ qHe
 jik
 jik
 uhG
-aPZ
+txC
 aPZ
 aPZ
 aPZ
@@ -59055,7 +59135,7 @@ aPZ
 aPZ
 aPZ
 aPZ
-aPZ
+txC
 aPZ
 sBW
 clz
@@ -59293,6 +59373,7 @@ wjr
 tgw
 tgw
 wVa
+txC
 aPZ
 aPZ
 aPZ
@@ -59311,9 +59392,8 @@ aPZ
 aPZ
 aPZ
 aPZ
-aPZ
-aPZ
-aPZ
+fAI
+lCA
 hHl
 clz
 xou
@@ -59550,6 +59630,7 @@ wjr
 tgw
 tgw
 aYw
+txC
 aPZ
 aPZ
 aPZ
@@ -59568,9 +59649,8 @@ aPZ
 aPZ
 aPZ
 aPZ
-aPZ
-aPZ
-aPZ
+lCA
+oed
 lQB
 tgw
 gHU
@@ -59807,6 +59887,10 @@ xca
 tgw
 tgw
 xrh
+cOO
+cOO
+cOO
+vqh
 aPZ
 aPZ
 aPZ
@@ -59822,12 +59906,8 @@ aPZ
 aPZ
 aPZ
 aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
+txC
+txC
 wbU
 tgw
 tgw
@@ -60067,6 +60147,7 @@ hgI
 aPZ
 aPZ
 aPZ
+gGN
 aPZ
 aPZ
 aPZ
@@ -60082,9 +60163,8 @@ aPZ
 aPZ
 aPZ
 aPZ
-aPZ
-aPZ
-aPZ
+txC
+txC
 sjS
 tgw
 tgw
@@ -60324,24 +60404,24 @@ wVa
 aPZ
 aPZ
 aPZ
+cOO
+cOO
+txC
+aPZ
+aPZ
+xpS
+cOO
+cOO
+cOO
+cOO
+sEx
 aPZ
 aPZ
 aPZ
 aPZ
 aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
+txC
+cOO
 agy
 gHU
 tgw

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -15599,7 +15599,9 @@
 	dir = 8;
 	icon_state = "equip_base_l_wing"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
 /area/sulaco/hangar)
 "lrA" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
@@ -57836,8 +57838,8 @@ aPZ
 oZc
 lCA
 gUO
-aPZ
-aPZ
+cOO
+cOO
 lrz
 fAI
 lCA
@@ -57845,11 +57847,11 @@ lCA
 lCA
 lCA
 gUO
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
+cOO
+cOO
+cOO
+cOO
+cOO
 txC
 lCA
 wbU
@@ -60405,21 +60407,21 @@ aPZ
 aPZ
 aPZ
 cOO
-cOO
-txC
-aPZ
-aPZ
+sEx
+lCA
+lCA
+lCA
 xpS
 cOO
 cOO
 cOO
 cOO
 sEx
-aPZ
-aPZ
-aPZ
-aPZ
-aPZ
+lCA
+lCA
+lCA
+lCA
+lCA
 txC
 cOO
 agy

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -15420,7 +15420,9 @@
 	dir = 8;
 	icon_state = "equip_base_l_wing"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
 /area/mainship/hallways/hangar)
 "oPm" = (
 /obj/structure/cable,
@@ -46714,8 +46716,8 @@ blA
 kLN
 ehi
 cxA
-blA
-blA
+wVS
+wVS
 oMq
 srb
 ehi
@@ -46723,11 +46725,11 @@ ehi
 ehi
 ehi
 cxA
-blA
-blA
-blA
-blA
-blA
+wVS
+wVS
+wVS
+wVS
+wVS
 dmw
 ehi
 bPp
@@ -49283,21 +49285,21 @@ blA
 blA
 blA
 wVS
-wVS
-dmw
-blA
-blA
+iBD
+ehi
+ehi
+ehi
 nJf
 wVS
 wVS
 wVS
 wVS
 iBD
-blA
-blA
-blA
-blA
-blA
+ehi
+ehi
+ehi
+ehi
+ehi
 dmw
 wVS
 bPr

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -3211,6 +3211,12 @@
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
+"bgX" = (
+/obj/effect/attach_point/electronics/dropship1,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "bhc" = (
 /obj/machinery/light{
 	dir = 4
@@ -5306,6 +5312,10 @@
 	dir = 8
 	},
 /area/mainship/engineering/lower_engineering)
+"byo" = (
+/obj/effect/attach_point/electronics/dropship1,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "byp" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -5554,6 +5564,9 @@
 	dir = 8
 	},
 /area/mainship/engineering/lower_engineering)
+"bBa" = (
+/turf/open/floor/plating/icefloor/warnplate,
+/area/mainship/hallways/hangar)
 "bBe" = (
 /obj/machinery/keycard_auth{
 	pixel_y = 25
@@ -5585,6 +5598,7 @@
 /area/mainship/living/port_emb)
 "bBz" = (
 /obj/docking_port/stationary/marine_dropship/hangar/one,
+/obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "bBI" = (
@@ -8658,6 +8672,11 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/basketball)
+"cxA" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 6
+	},
+/area/mainship/hallways/hangar)
 "cxR" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
@@ -9107,6 +9126,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
+"dmw" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "doe" = (
 /obj/machinery/autodoc_console,
 /turf/open/floor/mainship/sterile,
@@ -9578,6 +9602,11 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_umbilical)
+"ehi" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/mainship/hallways/hangar)
 "ehv" = (
 /obj/machinery/vending/engivend,
 /turf/open/floor/mainship/orange{
@@ -11881,6 +11910,11 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/aft_hallway)
+"iBD" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 10
+	},
+/area/mainship/hallways/hangar)
 "iBQ" = (
 /obj/docking_port/stationary/supply,
 /turf/open/floor/mainship/empty,
@@ -13029,6 +13063,11 @@
 	dir = 1
 	},
 /area/mainship/medical/surgery_hallway)
+"kLN" = (
+/turf/open/floor/plating{
+	icon_state = "warnplatecorner"
+	},
+/area/mainship/hallways/hangar)
 "kLV" = (
 /obj/machinery/light{
 	dir = 1
@@ -13529,6 +13568,10 @@
 "lAe" = (
 /turf/open/shuttle/escapepod/five,
 /area/mainship/command/self_destruct)
+"lBc" = (
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "lBr" = (
 /obj/effect/landmark/start/job/ai,
 /turf/open/floor/mainship/ai,
@@ -14776,6 +14819,11 @@
 /obj/item/storage/firstaid/adv,
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/surgery_hallway)
+"nJf" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 9
+	},
+/area/mainship/hallways/hangar)
 "nJL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -15367,6 +15415,13 @@
 	dir = 1
 	},
 /area/mainship/shipboard/brig)
+"oMq" = (
+/obj/effect/attach_point/weapon/dropship1{
+	dir = 8;
+	icon_state = "equip_base_l_wing"
+	},
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "oPm" = (
 /obj/structure/cable,
 /obj/machinery/camera/autoname/mainship{
@@ -15546,6 +15601,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/orange,
 /area/mainship/hallways/starboard_hallway)
+"pgm" = (
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "pgn" = (
 /obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2
@@ -17393,6 +17454,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/bridge)
+"srb" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 5
+	},
+/area/mainship/hallways/hangar)
 "ssC" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner,
@@ -19547,6 +19613,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
+"wDA" = (
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "warnplatecorner"
+	},
+/area/mainship/hallways/hangar)
 "wEQ" = (
 /obj/machinery/robotic_fabricator,
 /turf/open/floor/mainship/sterile/side{
@@ -19719,6 +19791,11 @@
 	dir = 5
 	},
 /area/mainship/medical/medical_science)
+"wVS" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/mainship/hallways/hangar)
 "wXn" = (
 /obj/machinery/shower{
 	dir = 4
@@ -20272,6 +20349,12 @@
 "xUR" = (
 /turf/closed/wall/mainship,
 /area/mainship/shipboard/brig_cells)
+"xUV" = (
+/turf/open/floor/plating{
+	dir = 4;
+	icon_state = "warnplatecorner"
+	},
+/area/mainship/hallways/hangar)
 "xUW" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/mono,
@@ -46628,25 +46711,25 @@ wxQ
 bYM
 blA
 blA
+kLN
+ehi
+cxA
+blA
+blA
+oMq
+srb
+ehi
+ehi
+ehi
+ehi
+cxA
 blA
 blA
 blA
 blA
 blA
-blA
-cjV
-cjV
-cjV
-cjV
-cjV
-blA
-blA
-blA
-blA
-blA
-blA
-blA
-blA
+dmw
+ehi
 bPp
 lOP
 lvI
@@ -46885,6 +46968,8 @@ wxQ
 bCx
 blA
 blA
+bBa
+lBc
 blA
 blA
 blA
@@ -46900,10 +46985,8 @@ blA
 blA
 blA
 blA
-blA
-blA
-blA
-blA
+dmw
+dmw
 bPq
 lOP
 lvI
@@ -47140,6 +47223,10 @@ blt
 byf
 wxQ
 bZy
+ehi
+ehi
+cxA
+byo
 blA
 blA
 blA
@@ -47155,12 +47242,8 @@ blA
 blA
 blA
 blA
-blA
-blA
-blA
-blA
-blA
-blA
+dmw
+dmw
 bPr
 lOP
 lvI
@@ -47397,6 +47480,7 @@ iZq
 bja
 wxQ
 cfc
+dmw
 blA
 blA
 blA
@@ -47415,9 +47499,8 @@ blA
 blA
 blA
 blA
-blA
-blA
-blA
+wVS
+xUV
 kIy
 lOP
 lvI
@@ -47654,6 +47737,7 @@ iZq
 bja
 wxQ
 bYM
+dmw
 blA
 blA
 blA
@@ -47672,9 +47756,8 @@ blA
 blA
 blA
 blA
-blA
-blA
-qNu
+nJf
+wVS
 ckr
 tnj
 uEO
@@ -47911,7 +47994,7 @@ bLD
 ubo
 ksb
 bCx
-blA
+dmw
 blA
 blA
 blA
@@ -47930,8 +48013,8 @@ blA
 blA
 blA
 blA
+dmw
 blA
-qNu
 qWF
 wXB
 bPR
@@ -48168,6 +48251,7 @@ iZq
 bja
 wxQ
 bZy
+dmw
 blA
 blA
 blA
@@ -48186,9 +48270,8 @@ blA
 blA
 blA
 blA
-blA
-blA
-qNu
+srb
+ehi
 cks
 tGe
 vCC
@@ -48425,6 +48508,7 @@ iZq
 bja
 wxQ
 cfc
+dmw
 blA
 blA
 blA
@@ -48443,9 +48527,8 @@ blA
 blA
 blA
 blA
-blA
-blA
-blA
+ehi
+wDA
 bPs
 lOP
 lvI
@@ -48682,6 +48765,10 @@ blt
 lXa
 wxQ
 bYM
+wVS
+wVS
+wVS
+bgX
 blA
 blA
 blA
@@ -48697,12 +48784,8 @@ blA
 blA
 blA
 blA
-blA
-blA
-blA
-blA
-blA
-blA
+dmw
+dmw
 bPp
 lOP
 lvI
@@ -48942,6 +49025,7 @@ bCx
 blA
 blA
 blA
+pgm
 blA
 blA
 blA
@@ -48957,9 +49041,8 @@ blA
 blA
 blA
 blA
-blA
-blA
-blA
+dmw
+dmw
 bPq
 lOP
 lvI
@@ -49199,24 +49282,24 @@ bZy
 blA
 blA
 blA
+wVS
+wVS
+dmw
+blA
+blA
+nJf
+wVS
+wVS
+wVS
+wVS
+iBD
 blA
 blA
 blA
 blA
 blA
-cjW
-cjW
-cjW
-cjW
-cjW
-blA
-blA
-blA
-blA
-blA
-blA
-blA
-blA
+dmw
+wVS
 bPr
 lOP
 lvI

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -16585,6 +16585,14 @@
 	},
 /turf/open/floor/mainship/ai,
 /area/mainship/living/numbertwobunks)
+"qWF" = (
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 1
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "qWS" = (
 /obj/machinery/light{
 	dir = 4
@@ -17789,7 +17797,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "toW" = (
 /turf/open/floor/wood,
@@ -18004,7 +18012,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "tHw" = (
 /obj/effect/landmark/start/job/medicalofficer,
@@ -19729,6 +19737,19 @@
 	dir = 4
 	},
 /area/mainship/shipboard/firing_range)
+"wXB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/hangar)
 "wYp" = (
 /obj/structure/table/mainship,
 /obj/item/circuitboard/airalarm,
@@ -47911,8 +47932,8 @@ blA
 blA
 blA
 qNu
-bPq
-wxQ
+qWF
+wXB
 bPR
 bRE
 cvV

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -675,6 +675,9 @@
 	dir = 1
 	},
 /area/icy_caves/caves/northern)
+"cU" = (
+/turf/open/floor/plating/icefloor/warnplate,
+/area/icy_caves/outpost/LZ1)
 "cW" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice/thin/corner,
@@ -1444,6 +1447,10 @@
 "gB" = (
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/refinery)
+"gC" = (
+/obj/effect/attach_point/electronics/dropship1,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "gF" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -1517,6 +1524,10 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/research)
+"hi" = (
+/obj/effect/attach_point/electronics/dropship1,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ1)
 "hj" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/outpost/outside)
@@ -1690,11 +1701,21 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
+"iC" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "iG" = (
 /turf/open/floor/tile/dark/yellow2{
 	dir = 4
 	},
 /area/icy_caves/outpost/engineering)
+"iI" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 6
+	},
+/area/icy_caves/outpost/LZ2)
 "iJ" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/lowcharge,
@@ -1816,8 +1837,9 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
 "jR" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
 /area/icy_caves/outpost/LZ2)
 "jS" = (
 /obj/machinery/miner/damaged,
@@ -2510,6 +2532,9 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
+"nC" = (
+/turf/open/floor/plating/icefloor/warnplate,
+/area/icy_caves/outpost/LZ2)
 "nD" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark,
@@ -2538,6 +2563,11 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
+"nQ" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 10
+	},
+/area/icy_caves/outpost/LZ2)
 "nS" = (
 /turf/open/floor/plating/dmg1,
 /area/icy_caves/caves/crashed_ship)
@@ -2565,6 +2595,11 @@
 	},
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside/center)
+"ob" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "oc" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -2772,6 +2807,11 @@
 /obj/item/clothing/mask/rebreather,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
+"pz" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 5
+	},
+/area/icy_caves/outpost/LZ1)
 "pB" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -2826,6 +2866,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
+"pZ" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 6
+	},
+/area/icy_caves/outpost/LZ1)
 "qa" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -3878,6 +3923,11 @@
 /obj/structure/bed/roller,
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
+"vw" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 5
+	},
+/area/icy_caves/outpost/LZ2)
 "vx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
@@ -4298,6 +4348,11 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"yL" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ1)
 "yR" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -4406,6 +4461,17 @@
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"zE" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 9
+	},
+/area/icy_caves/outpost/LZ2)
+"zF" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "zG" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
@@ -4534,6 +4600,10 @@
 /obj/machinery/processor,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
+"Ap" = (
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "Ar" = (
 /obj/structure/closet/crate/secure/ammo,
 /obj/item/ammo_magazine/smg/m25,
@@ -4576,6 +4646,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"AA" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ1)
 "AB" = (
 /turf/closed/ice/thin/end{
 	dir = 1
@@ -4765,6 +4839,15 @@
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"BF" = (
+/obj/effect/attach_point/weapon/dropship1{
+	dir = 8;
+	icon_state = "equip_base_l_wing"
+	},
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "BI" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -4829,6 +4912,10 @@
 /turf/closed/ice/thin/end{
 	dir = 8
 	},
+/area/icy_caves/outpost/LZ1)
+"Cc" = (
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "Ci" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -4897,6 +4984,12 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ2)
+"Da" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ1)
 "Dc" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/up,
 /turf/open/floor/tile/dark,
@@ -5018,6 +5111,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"DQ" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "DW" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -5301,6 +5400,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"FR" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ1)
 "FU" = (
 /obj/structure/cargo_container/ch_red,
 /turf/open/floor/plating,
@@ -6595,6 +6700,10 @@
 /obj/docking_port/mobile/crashmode/bigbury,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ2)
+"Oz" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "OA" = (
 /turf/closed/ice/thin/corner{
 	dir = 4
@@ -6712,6 +6821,11 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
+"PB" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ1)
 "PC" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -6916,6 +7030,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"QU" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 9
+	},
+/area/icy_caves/outpost/LZ1)
 "QX" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -7609,8 +7728,9 @@
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/northern)
 "VJ" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
 /area/icy_caves/outpost/LZ1)
 "VK" = (
 /obj/machinery/light{
@@ -7643,6 +7763,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/research)
+"VP" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 10
+	},
+/area/icy_caves/outpost/LZ1)
 "VQ" = (
 /turf/open/floor/tile/dark/red2{
 	dir = 4
@@ -7751,6 +7876,15 @@
 /area/icy_caves/outpost/outside)
 "WK" = (
 /turf/open/floor/mech_bay_recharge_floor,
+/area/icy_caves/outpost/LZ1)
+"WM" = (
+/obj/effect/attach_point/weapon/dropship1{
+	dir = 8;
+	icon_state = "equip_base_l_wing"
+	},
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
 /area/icy_caves/outpost/LZ1)
 "WQ" = (
 /turf/closed/ice/thin/end{
@@ -9526,27 +9660,27 @@ Ww
 Sw
 UE
 WT
-Yn
-Yn
+QU
 VJ
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
 VJ
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
 VJ
-Yn
+VJ
+VJ
+VJ
+WM
+VJ
+VJ
+FR
+VJ
+VJ
+VJ
+VJ
+VJ
+VJ
+VJ
+VJ
+VJ
+VP
 wL
 UE
 UE
@@ -9682,6 +9816,10 @@ Sh
 HC
 UE
 Xa
+yL
+Yn
+AA
+Cc
 Yn
 Yn
 Yn
@@ -9696,13 +9834,9 @@ Yn
 Yn
 Yn
 Yn
+AA
 Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
+cU
 MO
 WD
 UE
@@ -9838,6 +9972,10 @@ yW
 TM
 UE
 Xq
+yL
+Yn
+Yn
+hi
 Yn
 Yn
 Yn
@@ -9854,11 +9992,7 @@ Yn
 Yn
 Yn
 Yn
-Yn
-Yn
-Yn
-Yn
-Yn
+cU
 zM
 UE
 UE
@@ -9994,6 +10128,7 @@ YH
 TM
 uw
 Xs
+yL
 Yn
 Yn
 Yn
@@ -10013,8 +10148,7 @@ Yn
 Yn
 Yn
 Yn
-Yn
-Yn
+cU
 TI
 UE
 UE
@@ -10150,6 +10284,7 @@ YH
 TM
 iJ
 WT
+yL
 Yn
 Yn
 Yn
@@ -10169,8 +10304,7 @@ Yn
 Yn
 Yn
 Yn
-Yn
-Yn
+cU
 wL
 WD
 UE
@@ -10306,7 +10440,7 @@ SJ
 TM
 bU
 Xa
-Yn
+yL
 Yn
 Yn
 Yn
@@ -10326,7 +10460,7 @@ Yn
 Yn
 Yn
 Yn
-Yn
+cU
 MO
 UE
 UE
@@ -10462,6 +10596,7 @@ zb
 Tb
 XW
 Xq
+yL
 Yn
 Yn
 Yn
@@ -10481,8 +10616,7 @@ Yn
 Yn
 Yn
 Yn
-Yn
-Yn
+cU
 zM
 UE
 Uu
@@ -10618,6 +10752,7 @@ Tf
 Ml
 XW
 Xs
+yL
 Yn
 Yn
 Yn
@@ -10637,8 +10772,7 @@ Yn
 Yn
 Yn
 Yn
-Yn
-Yn
+cU
 TI
 UE
 Uu
@@ -10774,6 +10908,10 @@ Tm
 Uu
 Vk
 WT
+yL
+Yn
+Yn
+hi
 Yn
 Yn
 Yn
@@ -10790,11 +10928,7 @@ Yn
 Yn
 Yn
 Yn
-Yn
-Yn
-Yn
-Yn
-Yn
+cU
 wL
 UE
 Uu
@@ -10930,6 +11064,10 @@ TQ
 Uu
 bU
 Xa
+yL
+Yn
+AA
+Cc
 Yn
 Yn
 Yn
@@ -10944,13 +11082,9 @@ Yn
 Yn
 Yn
 Yn
+AA
 Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
+cU
 MO
 UE
 Uu
@@ -11086,27 +11220,27 @@ TQ
 UE
 XW
 Xq
-Yn
-Yn
-VJ
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-VJ
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-VJ
-Yn
+pz
+PB
+PB
+PB
+PB
+PB
+PB
+PB
+PB
+PB
+Da
+PB
+PB
+PB
+PB
+PB
+PB
+PB
+PB
+PB
+pZ
 zM
 UE
 Uu
@@ -29774,27 +29908,27 @@ XH
 oP
 wa
 ih
-tL
-tL
+zE
 jR
-tL
-tL
-tL
-tL
-tL
-tL
-tL
 jR
-tL
-tL
-tL
-tL
-tL
-tL
-tL
-tL
 jR
-tL
+jR
+jR
+jR
+BF
+jR
+jR
+DQ
+jR
+jR
+jR
+jR
+jR
+jR
+jR
+jR
+jR
+nQ
 oy
 oP
 nI
@@ -29930,6 +30064,10 @@ lG
 oP
 wa
 ju
+iC
+tL
+Oz
+Ap
 tL
 tL
 tL
@@ -29944,13 +30082,9 @@ tL
 tL
 tL
 tL
+Oz
 tL
-tL
-tL
-tL
-tL
-tL
-tL
+nC
 oA
 wa
 nI
@@ -30086,6 +30220,10 @@ eY
 oP
 wa
 jv
+iC
+tL
+tL
+gC
 tL
 tL
 tL
@@ -30102,11 +30240,7 @@ tL
 tL
 tL
 tL
-tL
-tL
-tL
-tL
-tL
+nC
 oD
 wa
 oP
@@ -30242,6 +30376,7 @@ lG
 oP
 wa
 jw
+iC
 tL
 tL
 tL
@@ -30261,8 +30396,7 @@ tL
 tL
 tL
 tL
-tL
-tL
+nC
 oE
 wa
 oP
@@ -30398,6 +30532,7 @@ eY
 oP
 wa
 ih
+iC
 tL
 tL
 tL
@@ -30417,8 +30552,7 @@ tL
 tL
 tL
 tL
-tL
-tL
+nC
 oy
 wa
 oP
@@ -30554,7 +30688,7 @@ TW
 oP
 wa
 ju
-tL
+iC
 tL
 tL
 tL
@@ -30574,7 +30708,7 @@ tL
 tL
 tL
 tL
-tL
+nC
 oA
 wa
 oP
@@ -30710,6 +30844,7 @@ TW
 oP
 wa
 jv
+iC
 tL
 tL
 tL
@@ -30729,8 +30864,7 @@ tL
 tL
 tL
 tL
-tL
-tL
+nC
 oD
 wa
 nI
@@ -30866,6 +31000,7 @@ TW
 oP
 wa
 jw
+iC
 tL
 tL
 tL
@@ -30885,8 +31020,7 @@ tL
 tL
 tL
 tL
-tL
-tL
+nC
 oE
 wa
 oP
@@ -31022,6 +31156,10 @@ VU
 oP
 wa
 ih
+iC
+tL
+tL
+gC
 tL
 tL
 tL
@@ -31038,11 +31176,7 @@ tL
 tL
 tL
 tL
-tL
-tL
-tL
-tL
-tL
+nC
 oy
 wa
 oP
@@ -31178,6 +31312,10 @@ bH
 oP
 wa
 ju
+iC
+tL
+Oz
+Ap
 tL
 tL
 tL
@@ -31192,13 +31330,9 @@ tL
 tL
 tL
 tL
+Oz
 tL
-tL
-tL
-tL
-tL
-tL
-tL
+nC
 oA
 wa
 oP
@@ -31334,27 +31468,27 @@ bH
 oP
 wa
 jv
-tL
-tL
-jR
-tL
-tL
-tL
-tL
-tL
-tL
-tL
-jR
-tL
-tL
-tL
-tL
-tL
-tL
-tL
-tL
-jR
-tL
+vw
+ob
+ob
+ob
+ob
+ob
+ob
+ob
+ob
+ob
+zF
+ob
+ob
+ob
+ob
+ob
+ob
+ob
+ob
+ob
+iI
 oD
 oP
 oP


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

OSHA came to inspect every landing zones, and they realized that it was not shiny enough to prevent dumb marines from stepping into landing zones!

Also, holy smokes. +2,205 −1,163? My bad. I went crazy with mapping.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Consistency across shipside and planetside maps' landing zones. Arrow and box tiles in shipside helps marine indicate where Alamo doors are at when Alamo is not in shipside. Outline of Alamo to REALLY show where Alamo will be.

Not even CM SS13 has this, and I remember fondly when I encounter such Alamo LZ design, I was like, "Why doesn't CM have this? This is smart."

Spooky is correct. Mapping is all about finding pretty tiles.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Every shipside maps follow PoS Alamo LZ tiles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
