### PR TITLE
Fixes #9097

### DIFF
--- a/code/datums/jobs/job/pmc.dm
+++ b/code/datums/jobs/job/pmc.dm
@@ -29,7 +29,7 @@
 	suit_store = /obj/item/weapon/gun/smg/m25/elite/pmc
 	r_store = /obj/item/storage/pouch/magazine/large/pmc_m25
 	l_store = /obj/item/storage/pouch/firstaid/full
-	back = /obj/item/storage/backpack/satchel
+	back = /obj/item/storage/backpack/lightpack
 
 
 /datum/outfit/job/pmc/standard/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -121,10 +121,10 @@
 	head = /obj/item/clothing/head/helmet/marine/veteran/PMC/sniper
 	mask = /obj/item/clothing/mask/gas/PMC
 	glasses = /obj/item/clothing/glasses/night/m42_night_goggles
-	suit_store = /obj/item/weapon/gun/rifle/sniper/elite
+	suit_store = /obj/item/weapon/gun/rifle/sniper/antimaterial
 	r_store = /obj/item/storage/pouch/magazine/large/pmc_sniper
 	l_store = /obj/item/storage/pouch/firstaid/full
-	back = /obj/item/storage/backpack/satchel
+	back = /obj/item/storage/backpack/lightpack
 
 
 /datum/outfit/job/pmc/sniper/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -169,7 +169,7 @@
 	suit_store = /obj/item/weapon/gun/rifle/m412/elite
 	r_store = /obj/item/storage/pouch/magazine/large/pmc_rifle
 	l_store = /obj/item/storage/pouch/firstaid/full
-	back = /obj/item/storage/backpack/satchel
+	back = /obj/item/storage/backpack/lightpack
 
 
 /datum/outfit/job/pmc/leader/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -304,7 +304,7 @@
 	fill_number = 3
 
 /obj/item/storage/pouch/magazine/large/pmc_sniper
-	fill_type = /obj/item/ammo_magazine/sniper/elite
+	fill_type = /obj/item/ammo_magazine/sniper
 	fill_number = 3
 
 /obj/item/storage/pouch/magazine/large/pmc_rifle


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #9097 by giving them the T-26 anti-material rifle, replacing the Colonial Marines M42C AT sniper. They both do the same job, and the icons for the M42C magazines are missing entirely. I'm not entirely sure if any other roles use the M42C at all, so might look into taking it and it's sprite out entirely down the road.

Replaces all PMC satchels with lightweight combat packs. The smartgunner had one of these but none of the other roles do, and the default satchel jars.

## Why It's Good For The Game

Bugfix and unification of equipment.

## Changelog
:cl:
add: PMC snipers are now issued with the T-26 antimaterial rifle, and lightweight combat backpacks as standard across the entire PMC.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
