### PR TITLE
Soft armor, including Jaegar storage and helmet modules, don't give 100 bio armor

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -38,7 +38,7 @@
 		soft_armor = getArmor(arglist(soft_armor))
 	else if (!soft_armor)
 		// Default bio armor 100 to avoid sentinels getting free damage on sent
-		soft_armor = getArmor(bio = 100)
+		soft_armor = getArmor(bio = 0) // if bio = 100, marines can have at least 150 bio armor, and with M.II Mimir, 190 bio armor. This permits them to tank acid shots and neurotoxin, which was not part of the game when this was made.
 	else if (!istype(soft_armor, /datum/armor))
 		stack_trace("Invalid type [soft_armor.type] found in .soft_armor during /obj Initialize()")
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -38,7 +38,7 @@
 		soft_armor = getArmor(arglist(soft_armor))
 	else if (!soft_armor)
 		// Default bio armor 100 to avoid sentinels getting free damage on sent
-		soft_armor = getArmor(bio = 0) // if bio = 100, marines can have at least 150 bio armor, and with M.II Mimir, 190 bio armor. This permits them to tank acid shots and neurotoxin, which was not part of the game when this was made.
+		soft_armor = getArmor(bio = 100) // This is here so that walls don't die from NEUROTOXIN
 	else if (!istype(soft_armor, /datum/armor))
 		stack_trace("Invalid type [soft_armor.type] found in .soft_armor during /obj Initialize()")
 

--- a/code/modules/clothing/modular_armor/attachments.dm
+++ b/code/modules/clothing/modular_armor/attachments.dm
@@ -3,6 +3,7 @@
 	name = "armor module"
 	desc = "A dis-figured armor module, in its prime this would've been a key item in your modular armor... now its just trash."
 	icon = 'icons/mob/modular/modular_armor.dmi'
+	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0) // This is here to overwrite code over at objs.dm line 41. Marines don't get funny 200+ bio buff anymore.
 
 	slowdown = 0
 

--- a/code/modules/clothing/modular_armor/attachments/storage.dm
+++ b/code/modules/clothing/modular_armor/attachments/storage.dm
@@ -86,6 +86,7 @@
 	name = "General Purpose Storage module"
 	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Certainly not as specialised as any other storage modules, but definitely able to hold some larger things, like binoculars, maps, and motion detectors."
 	icon_state = "mod_general_bag"
+	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	storage =  /obj/item/storage/internal/modular/general
 
 /obj/item/storage/internal/modular/general
@@ -107,6 +108,7 @@
 	name = "Magazine Storage module"
 	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Holds some magazines. Don’t expect to fit specialist munitions or LMG drums in, but you can get some good mileage. Looks like it might slow you down a bit."
 	icon_state = "mod_mag_bag"
+	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	storage =  /obj/item/storage/internal/modular/ammo_mag
 	slowdown = 0.1
 
@@ -135,6 +137,7 @@
 	name = "Engineering Storage module"
 	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Can hold about as much as a tool pouch, and sometimes small spools of things like barbed wire, or an entrenching tool."
 	icon_state = "mod_engineer_bag"
+	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	storage =  /obj/item/storage/internal/modular/engineering
 
 /obj/item/storage/internal/modular/engineering
@@ -176,6 +179,7 @@
 	name = "Medical Storage module"
 	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Can hold a substantial variety of medical supplies and apparatus, but cannot hold as much as a medkit could."
 	icon_state = "mod_medic_bag"
+	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	storage =  /obj/item/storage/internal/modular/medical
 
 /obj/item/storage/internal/modular/medical

--- a/code/modules/clothing/modular_armor/attachments/storage.dm
+++ b/code/modules/clothing/modular_armor/attachments/storage.dm
@@ -86,7 +86,6 @@
 	name = "General Purpose Storage module"
 	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Certainly not as specialised as any other storage modules, but definitely able to hold some larger things, like binoculars, maps, and motion detectors."
 	icon_state = "mod_general_bag"
-	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	storage =  /obj/item/storage/internal/modular/general
 
 /obj/item/storage/internal/modular/general
@@ -108,7 +107,6 @@
 	name = "Magazine Storage module"
 	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Holds some magazines. Don’t expect to fit specialist munitions or LMG drums in, but you can get some good mileage. Looks like it might slow you down a bit."
 	icon_state = "mod_mag_bag"
-	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	storage =  /obj/item/storage/internal/modular/ammo_mag
 	slowdown = 0.1
 
@@ -137,7 +135,6 @@
 	name = "Engineering Storage module"
 	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Can hold about as much as a tool pouch, and sometimes small spools of things like barbed wire, or an entrenching tool."
 	icon_state = "mod_engineer_bag"
-	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	storage =  /obj/item/storage/internal/modular/engineering
 
 /obj/item/storage/internal/modular/engineering
@@ -179,7 +176,6 @@
 	name = "Medical Storage module"
 	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Can hold a substantial variety of medical supplies and apparatus, but cannot hold as much as a medkit could."
 	icon_state = "mod_medic_bag"
-	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	storage =  /obj/item/storage/internal/modular/medical
 
 /obj/item/storage/internal/modular/medical


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. Fixes #9130. Adding ONE LINE CODE gets the fix.

~~I'm still not sure how modules give more bio armor. That is a mystery for another day, so this is just a fix.~~ The mystery is solved. #4096 points to such reason. Also, thanks InterroLouis for the feedback.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

How storage module and helmet modules give 100 bio armor is insane, not to mention on top of M.II Mimir. No more tanking acid shots or neurotoxin. You take it like everyone else.

Cope and seeth, M.II Mimir users.

I have a strong sense that this will make sent pretty oppressive.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: storage modules don't give more armor as intended. Now you can't have 200+ or possibly 300+ bio armor to spawn
balance: marines don't stack bio armor like no tomorrow, so expect the sentinel castes to give you a harder time 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
