### PR TITLE
Put Integrated and Magazine Storage Module in Researcher Content

### DIFF
--- a/code/game/objects/machinery/research.dm
+++ b/code/game/objects/machinery/research.dm
@@ -49,9 +49,11 @@
 				/obj/item/research_product/money/uncommon,
 				/obj/item/implanter/blade,
 				/obj/item/attachable/shoulder_mount,
+				/obj/item/armor_module/storage/ammo_mag,
 			),
 			RES_TIER_RARE = list(
 				/obj/item/research_product/money/rare,
+				/obj/item/armor_module/storage/integrated,
 			),
 		),
 		RES_XENO = list(
@@ -66,10 +68,12 @@
 				/obj/item/research_product/money/uncommon,
 				/obj/item/implanter/chem/blood,
 				/obj/item/attachable/shoulder_mount,
+				/obj/item/armor_module/storage/ammo_mag,
 			),
 			RES_TIER_RARE = list(
 				/obj/item/research_product/money/rare,
 				/obj/item/implanter/cloak,
+				/obj/item/armor_module/storage/integrated,
 			),
 		),
 	)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The two modules that cause storage creep come back AT A COST! Kill a T3 or T4 xenomorph, and you JUST MIGHT get more storage.

Bring them back home.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Put IS and mag modules in researcher content. Kill a T3 or T4 xenomorph, and you JUST MIGHT get more storage!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
