### PR TITLE
Fix BaS Dupe

### DIFF
--- a/code/datums/elements/deployable_item.dm
+++ b/code/datums/elements/deployable_item.dm
@@ -42,7 +42,7 @@
 	var/deploy_location
 	var/new_direction
 	if(user)
-		if(!ishuman(user))
+		if(!ishuman(user) || CHECK_BITFIELD(attached_item.flags_item, NODROP))
 			return
 
 		deploy_location = get_step(user, user.dir)


### PR DESCRIPTION
## About The Pull Request

Fixes a Duplication glitch of the Build a Sentry attachment

## Why It's Good For The Game

Doesn't let someone place infinite Build a Sentries

## Changelog
:cl:
fix: Made it so you couldn't deploy the BaS while it being a no drop
/:cl:
