### PR TITLE
Delete some hazard signs in Big Red

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -58,12 +58,6 @@
 	dir = 8
 	},
 /area/bigredv2/outside/space_port)
-"aaq" = (
-/obj/structure/sign/safety/hazard{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/bigredv2/outside/space_port)
 "aas" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -422,12 +416,6 @@
 	dir = 8
 	},
 /turf/open/floor/asteroidfloor,
-/area/bigredv2/outside/space_port)
-"abR" = (
-/obj/structure/sign/safety/vent{
-	dir = 1
-	},
-/turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
 "abT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3040,12 +3028,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
-"als" = (
-/obj/structure/sign/safety/hazard{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/bigredv2/outside/space_port)
 "alt" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/red/redtaupecorner{
@@ -3210,11 +3192,6 @@
 	dir = 6
 	},
 /area/bigredv2/outside/nw)
-"amb" = (
-/obj/structure/sign/safety/hazard,
-/obj/structure/cable,
-/turf/open/floor/marking/asteroidwarning,
-/area/bigredv2/outside/space_port)
 "amc" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -33374,7 +33351,7 @@ agQ
 bLG
 bLG
 bLG
-amb
+fYS
 aae
 ktH
 hqP
@@ -36822,7 +36799,7 @@ hqP
 hqP
 bXE
 aae
-aaq
+tOR
 cAN
 aaf
 cAN
@@ -37039,7 +37016,7 @@ hqP
 hqP
 bXE
 aae
-abR
+tOR
 cAN
 tOR
 adL
@@ -39010,7 +38987,7 @@ tOR
 tOR
 tOR
 tOR
-als
+tOR
 adL
 tOR
 tOR


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Hazard signs show where xenomorphs can melt into. Since the Big Red changes, these signs are not needed.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Delete some hazard signs in Big Red
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
