### PR TITLE
Removes neuro sting from queen, shrike and drone

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -56,7 +56,6 @@
 		/datum/action/xeno_action/activable/psychic_cure/acidic_salve,
 		/datum/action/xeno_action/activable/transfer_plasma/drone,
 		/datum/action/xeno_action/activable/corrosive_acid/drone,
-		/datum/action/xeno_action/activable/neurotox_sting,
 		/datum/action/xeno_action/create_jelly/slow,
 		/datum/action/xeno_action/toggle_pheromones,
 	)

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -60,7 +60,6 @@
 		/datum/action/xeno_action/activable/corrosive_acid/strong,
 		/datum/action/xeno_action/activable/xeno_spit,
 		/datum/action/xeno_action/activable/psychic_cure/acidic_salve/queen,
-		/datum/action/xeno_action/activable/neurotox_sting,
 		/datum/action/xeno_action/toggle_pheromones,
 		/datum/action/xeno_action/toggle_queen_zoom,
 		/datum/action/xeno_action/watch_xeno,

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -52,7 +52,6 @@
 		/datum/action/xeno_action/activable/cocoon,
 		/datum/action/xeno_action/activable/plant_weeds,
 		/datum/action/xeno_action/lay_egg,
-		/datum/action/xeno_action/activable/neurotox_sting,
 		/datum/action/xeno_action/call_of_the_burrowed,
 		/datum/action/xeno_action/activable/secrete_resin,
 		/datum/action/xeno_action/place_acidwell,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Shrike, Queen and Drone don't need the powercreep of getting neurosting, and probably shouldn't have had larva sting in the first place because it was gradual powercreep from defilers kit getting spread around.

## Alternatives
Rework neuros purging properties into a different chemical entirely as neurotoxin is incredibly powercreeped.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Queen shouldn't have direct combat abilities in the first place as it's **literally** part of the chess king design that queen now has, and giving them a direct combat ability literally overrides that.
Shrike doesn't need neurotoxin stun fun button, it has two instant stuns already, who even thought this was a good idea? It didn't need compensation.
Drone didn't need compensation for losing larval sting and encourging and buffing combat drone is against it's caste design in the first place.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Removes neurosting from queen, shrike and drone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
