### PR TITLE
Queen announcement filter now checks for ascii

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -52,6 +52,9 @@
 		to_chat(xeno, span_warning("That announcement contained a word prohibited in IC chat! Consider reviewing the server rules.\n<span replaceRegex='show_filtered_ic_chat'>\"[input]\"</span>"))
 		SSblackbox.record_feedback(FEEDBACK_TALLY, "ic_blocked_words", 1, lowertext(config.ic_filter_regex.match))
 		return FALSE
+	if(NON_ASCII_CHECK(input))
+		to_chat(usr, span_warning("That announcement contained characters prohibited in IC chat! Consider reviewing the server rules."))
+		return FALSE
 
 	var/queensWord = "<br><h2 class='alert'>The words of the queen reverberate in your head...</h2>"
 	queensWord += "<br>[span_alert("[input]")]<br><br>"


### PR DESCRIPTION
## About The Pull Request
Added `NON_ASCII_CHECK` to `/datum/action/xeno_action/hive_message/action_activate()`

This PR has been fully tested for anti-ascii on a local build with zero (0) runtimes or errors.
![2022-01-04_11-55-52](https://user-images.githubusercontent.com/17747087/148053039-63da919b-63c0-4a6e-a332-6d9cb403cc69.gif)
## Why It's Good For The Game
I don't think admins, and likewise most players, like the idea of queen announcement being turned into an ascii shitposting-fest.

Fixes #9147 
## Changelog
:cl: Vondiech
fix: Hive Message now checks and filters ascii.
/:cl:
