### PR TITLE
Research outpost Crash silo fixes.

### DIFF
--- a/_maps/map_files/Research_Outpost/Research_Outpost.dmm
+++ b/_maps/map_files/Research_Outpost/Research_Outpost.dmm
@@ -103,9 +103,8 @@
 /area/outpost/hallway/west)
 "aB" = (
 /obj/effect/landmark/excavation_site_spawner,
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/outpost/science/xenobiology)
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/north)
 "aC" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -293,9 +292,8 @@
 /area/outpost/science/research)
 "bx" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall,
-/area/outpost/science/xenobiology)
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/caves/north_east)
 "bz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -507,7 +505,6 @@
 /turf/open/floor/tile/dark,
 /area/outpost/cargo/security)
 "cE" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 9
 	},
@@ -565,8 +562,10 @@
 /area/outpost/hallway/central)
 "cU" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/outpost/caves/south)
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/outpost/caves/north_east)
 "cV" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/tile/dark/blue2,
@@ -725,9 +724,7 @@
 /turf/open/floor/plating/asteroidfloor,
 /area/outpost/arrivals)
 "dQ" = (
-/obj/effect/decal/cleanable/blood/writing{
-	dir = 1
-	},
+/obj/effect/ai_node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/north_east)
@@ -1162,6 +1159,7 @@
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/north_east)
 "fT" = (
@@ -1255,10 +1253,10 @@
 	},
 /area/outpost/medbay/storage)
 "gn" = (
+/obj/effect/landmark/weed_node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/outpost/caves/north_west)
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/north_east)
 "go" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/tile/dark/purple2,
@@ -1338,8 +1336,10 @@
 /area/outpost/medbay)
 "gH" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/north_west)
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 8
+	},
+/area/outpost/caves/north_east)
 "gJ" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/marking/asteroidwarning{
@@ -1443,7 +1443,6 @@
 /turf/open/floor/tile/dark,
 /area/outpost/brig/wardens_office)
 "he" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 6
 	},
@@ -1485,7 +1484,6 @@
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 1
 	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/north_east)
 "hr" = (
@@ -2035,9 +2033,10 @@
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/hallway/central)
 "jQ" = (
-/obj/effect/landmark/xeno_resin_door,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 4
+	},
 /area/outpost/caves/north_east)
 "jR" = (
 /obj/structure/closet/secure_closet/medical_doctor,
@@ -2251,12 +2250,9 @@
 /turf/open/floor/tile/dark/purple2,
 /area/outpost/science)
 "kM" = (
-/obj/structure/xenoautopsy/tank/hugger,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark/purple2{
-	dir = 8
-	},
-/area/outpost/science/xenobiology)
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/outpost/caves/north_east)
 "kN" = (
 /turf/open/floor/plating/asteroidfloor,
 /area/outpost/yard/south)
@@ -2757,7 +2753,6 @@
 /area/outpost/medbay/storage)
 "mX" = (
 /obj/effect/landmark/xeno_resin_door,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/dmg3,
 /area/outpost/science/xenobiology)
 "mY" = (
@@ -3607,8 +3602,8 @@
 /area/outpost/caves/east)
 "rj" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark,
-/area/outpost/science/xenobiology)
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/north_west)
 "rl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -3968,7 +3963,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/xeno_resin_door,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 1
 	},
@@ -4150,10 +4144,9 @@
 	},
 /area/outpost/hallway/west)
 "tN" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/south_east)
+/area/outpost/caves/north_west)
 "tO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -4330,8 +4323,8 @@
 	},
 /area/outpost/yard/north_east)
 "uP" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/mars/cavetodirt,
 /area/outpost/caves/north_west)
 "uQ" = (
 /obj/effect/landmark/excavation_site_spawner,
@@ -4361,8 +4354,8 @@
 /area/outpost/cargo)
 "uX" = (
 /obj/effect/landmark/excavation_site_spawner,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/north)
+/turf/closed/mineral/bigred,
+/area/outpost/yard/west)
 "uY" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/purple2,
@@ -4916,7 +4909,7 @@
 "xD" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/cavetodirt{
-	dir = 4
+	dir = 9
 	},
 /area/outpost/caves/south)
 "xG" = (
@@ -4943,10 +4936,9 @@
 	},
 /area/outpost/lz1)
 "xN" = (
-/obj/effect/landmark/weed_node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark,
-/area/outpost/science/xenobiology)
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/south)
 "xO" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -5024,6 +5016,7 @@
 "yj" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/effect/ai_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 8
 	},
@@ -5072,9 +5065,10 @@
 	},
 /area/outpost/hallway/northern)
 "ys" = (
+/obj/effect/ai_node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/dmg2,
-/area/outpost/science/xenobiology)
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/south)
 "yw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -5299,7 +5293,6 @@
 	},
 /area/outpost/hallway/south_west)
 "zF" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 4
@@ -5547,9 +5540,10 @@
 	},
 /area/outpost/caves/north_west)
 "AW" = (
+/obj/effect/landmark/weed_node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/outpost/caves/south_east)
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/south)
 "AY" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -5610,9 +5604,10 @@
 	},
 /area/outpost/hallway/central)
 "Bn" = (
+/obj/effect/ai_node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/south)
+/area/outpost/caves/south_east)
 "Bo" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -5807,7 +5802,6 @@
 /area/outpost/caves/east)
 "Ct" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/tile/dark,
 /area/outpost/science/xenobiology)
 "Cu" = (
@@ -5946,11 +5940,10 @@
 /turf/open/floor/tile/dark,
 /area/outpost/science)
 "Dk" = (
+/obj/effect/landmark/weed_node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/mars/cavetodirt{
-	dir = 5
-	},
-/area/outpost/caves/north_west)
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/south_east)
 "Dl" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -5961,8 +5954,8 @@
 /area/outpost/engineering)
 "Dm" = (
 /obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/tile/dark,
-/area/outpost/science/xenobiology)
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/south)
 "Dn" = (
 /obj/machinery/landinglight/ds2/delaythree{
 	dir = 4
@@ -6155,7 +6148,6 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/bigred,
 /area/outpost/caves/south_east)
 "Em" = (
@@ -7206,9 +7198,9 @@
 /turf/open/floor/tile/dark2,
 /area/outpost/cargo)
 "JA" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/outpost/caves/north_west)
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/south_east)
 "JB" = (
 /turf/open/floor/plating/asteroidwarning{
 	dir = 8
@@ -7601,12 +7593,6 @@
 	dir = 4
 	},
 /area/outpost/lz1)
-"Lo" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/mars/cavetodirt{
-	dir = 10
-	},
-/area/outpost/caves/south_east)
 "Ls" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/outpost/caves/east)
@@ -7845,12 +7831,6 @@
 	dir = 4
 	},
 /area/outpost/arrivals)
-"Mt" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/mars/cavetodirt{
-	dir = 1
-	},
-/area/outpost/caves/south)
 "Mu" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/brown2{
@@ -7871,10 +7851,6 @@
 	dir = 5
 	},
 /area/outpost/engineering/security)
-"MA" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/south)
 "MB" = (
 /obj/structure/cable,
 /obj/machinery/light/small,
@@ -9073,9 +9049,6 @@
 /area/outpost/brig/armoury)
 "RU" = (
 /obj/effect/landmark/xeno_resin_door,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 1
 	},
@@ -9264,7 +9237,6 @@
 /area/outpost/medbay/security)
 "SR" = (
 /obj/effect/landmark/xeno_resin_door,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/south_east)
 "SU" = (
@@ -9302,7 +9274,6 @@
 /area/outpost/medbay)
 "Ta" = (
 /obj/effect/landmark/xeno_resin_door,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/dmg1,
 /area/outpost/science/xenobiology)
 "Tb" = (
@@ -9624,7 +9595,6 @@
 /turf/closed/mineral/bigred,
 /area/outpost/caves/west)
 "UA" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 4
@@ -9879,10 +9849,6 @@
 	dir = 9
 	},
 /area/outpost/science/research)
-"VP" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall,
-/area/outpost/science/xenobiology)
 "VQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -9915,11 +9881,6 @@
 	dir = 1
 	},
 /area/outpost/caves/west)
-"VZ" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/bigred,
-/area/outpost/caves/north_west)
 "Wb" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 8
@@ -10190,12 +10151,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/hallway/south_west)
-"Xq" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/mars/cavetodirt{
-	dir = 9
-	},
-/area/outpost/caves/south)
 "Xt" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -10478,10 +10433,6 @@
 	dir = 10
 	},
 /area/outpost/cargo/security)
-"YO" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/south_east)
 "YP" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark/blue2{
@@ -10524,10 +10475,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/hallway/east)
-"YZ" = (
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/outpost/caves/south)
 "Zb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/landinglight/ds2/delayone,
@@ -19203,8 +19150,8 @@ wY
 wY
 wY
 wY
-wY
-JA
+WU
+FZ
 FZ
 uK
 Cp
@@ -19460,9 +19407,9 @@ wY
 Cp
 Cp
 Cp
-Xc
+uP
 FZ
-JA
+FZ
 FZ
 uw
 Cp
@@ -19715,12 +19662,12 @@ wY
 ge
 Vr
 Cp
-Cp
+tN
 mo
 Cp
-Xc
+uP
 FZ
-JA
+FZ
 FZ
 hx
 Cp
@@ -19972,13 +19919,13 @@ wY
 wY
 Cp
 Cp
-uP
 Cp
 Cp
 Cp
+Cp
+wY
 WU
-WU
-JA
+FZ
 uK
 Cp
 Cp
@@ -20235,8 +20182,8 @@ Cp
 wY
 wY
 wY
-wY
-wY
+WU
+WU
 Cp
 GI
 Cp
@@ -21001,9 +20948,9 @@ WU
 WU
 WU
 wY
-Cp
-Cp
-WU
+rj
+rj
+wY
 wY
 WU
 WU
@@ -21258,11 +21205,11 @@ WU
 WU
 WU
 WU
-VZ
+WU
 Cp
 Cp
 WU
-wY
+WU
 WU
 WU
 WU
@@ -21516,11 +21463,11 @@ WU
 WU
 WU
 WU
-gH
 Cp
 Cp
 Cp
-wY
+Cp
+WU
 WU
 WU
 WU
@@ -21774,11 +21721,11 @@ WU
 FZ
 FZ
 FZ
-Dk
+Ny
 sB
 sB
 KY
-gH
+Cp
 WU
 WU
 WU
@@ -22032,10 +21979,10 @@ FZ
 FZ
 uQ
 FZ
-JA
-JA
-gn
-Dk
+FZ
+FZ
+dU
+Ny
 UA
 sB
 Cp
@@ -25681,7 +25628,7 @@ Jb
 Jb
 qD
 pT
-SH
+uX
 SH
 QY
 IG
@@ -27444,7 +27391,7 @@ XD
 uU
 uU
 uU
-uX
+uU
 Fy
 gb
 Fy
@@ -28469,7 +28416,7 @@ Fy
 gb
 Fy
 uU
-uU
+aB
 Pb
 Fy
 Fy
@@ -31119,15 +31066,15 @@ Zc
 hK
 hK
 hK
-Zc
-Zc
-Zc
-Zc
-Zc
-Zc
-Zc
-Zc
-Zc
+gP
+gP
+gP
+gP
+gP
+gP
+gP
+gP
+gP
 Zc
 Zc
 Zc
@@ -31377,6 +31324,7 @@ Zc
 Zc
 wy
 wy
+gP
 Zc
 Zc
 Zc
@@ -31384,8 +31332,7 @@ Zc
 Zc
 Zc
 Zc
-Zc
-Zc
+gP
 Zc
 Zc
 Zc
@@ -31635,6 +31582,7 @@ Cy
 Zc
 PR
 PR
+gP
 Zc
 Zc
 Zc
@@ -31642,8 +31590,7 @@ Zc
 Zc
 Zc
 Zc
-Zc
-Zc
+gP
 Zc
 Zc
 Zc
@@ -31893,15 +31840,15 @@ Cy
 my
 Ml
 Mr
+xD
+hK
+zz
+nP
+hK
+Dm
 Zc
 Zc
-Zc
-Zc
-Zc
-Zc
-Zc
-Zc
-Zc
+gP
 Zc
 Zc
 Zc
@@ -32091,7 +32038,7 @@ Fy
 Fy
 Fy
 Fy
-uX
+uU
 uU
 Co
 OR
@@ -32150,16 +32097,16 @@ Cy
 Cy
 my
 Mr
-Mr
+Uv
+xN
+hK
+hK
+hK
+hK
+hK
 Zc
 Zc
-Zc
-Zc
-Zc
-Zc
-Zc
-Zc
-Zc
+gP
 Zc
 Zc
 Zc
@@ -32408,16 +32355,16 @@ tm
 tm
 Mr
 Mr
-Xq
-gP
-gP
-gP
-gP
-gP
+wM
+xN
+hK
+hK
+hK
+hK
+hK
 Zc
 Zc
-Zc
-Zc
+gP
 Zc
 Zc
 Zc
@@ -32666,16 +32613,16 @@ Mr
 Mr
 Mr
 Mr
-Mt
-hK
+wM
+xN
 nP
 hK
-MA
+hK
+hK
+hK
+Zc
+Zc
 gP
-Zc
-Zc
-Zc
-Zc
 Zc
 Zc
 Zc
@@ -32924,16 +32871,16 @@ Zc
 Mr
 Mr
 WG
-Bn
-PS
+hK
+ys
 hK
 hK
 hK
+hK
+Zc
+Zc
+Zc
 gP
-Zc
-Zc
-Zc
-Zc
 Zc
 Zc
 Zc
@@ -33182,16 +33129,16 @@ Zc
 Zc
 Mr
 wM
-Bn
 hK
-hK
-hK
-nP
+xN
+xN
+xN
+AW
 gP
-Zc
-Zc
-Zc
-Zc
+gP
+gP
+gP
+gP
 Zc
 Zc
 Zc
@@ -33440,12 +33387,12 @@ Zc
 Zc
 Zc
 hK
-Bn
 hK
 hK
 hK
 hK
-gP
+hK
+Zc
 Zc
 Zc
 Zc
@@ -33698,12 +33645,12 @@ Zc
 Zc
 Zc
 hK
-Bn
 hK
 hK
 hK
 hK
-Bn
+hK
+hK
 Zc
 Zc
 Zc
@@ -33883,14 +33830,14 @@ Fy
 Fy
 Fy
 Fy
-VP
-VP
-VP
-VP
-VP
-VP
-VP
-VP
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 Je
 Je
 mA
@@ -33956,12 +33903,12 @@ Zc
 Zc
 Zc
 hK
-Bn
-Bn
+hK
+hK
 hK
 wy
 bA
-xD
+wy
 Zc
 Zc
 Zc
@@ -34141,14 +34088,14 @@ Fy
 Fy
 Fy
 Fy
-VP
+Je
 Rl
 Rl
 Rl
 ro
 sb
 iY
-kM
+iY
 fc
 Je
 IY
@@ -34217,9 +34164,9 @@ hK
 hK
 zF
 he
-cU
-cU
-cU
+Mr
+Mr
+Mr
 Mr
 CP
 Zc
@@ -34399,14 +34346,14 @@ Fy
 Fy
 Fy
 Fy
-VP
+Je
 Rl
 aK
 Rl
 lk
 Dv
 bh
-rj
+Rl
 aO
 Je
 IY
@@ -34657,14 +34604,14 @@ Fy
 Fy
 Fy
 Fy
-VP
+Je
 gz
 Rl
 Rl
 ro
 Dv
 Rl
-rj
+Rl
 id
 Je
 Je
@@ -34736,7 +34683,7 @@ xv
 Zc
 Zc
 Mr
-YZ
+Mr
 Uv
 hK
 hK
@@ -34915,9 +34862,9 @@ Fy
 Fy
 Fy
 Fy
-VP
+Je
 Rl
-aB
+bh
 Rl
 ro
 Dv
@@ -35173,14 +35120,14 @@ cg
 cg
 cg
 cg
-VP
+Je
 Rl
-Dm
+Rl
 Rl
 ro
 Dv
 bh
-xN
+wP
 uY
 ll
 jh
@@ -35431,14 +35378,14 @@ cg
 cg
 cg
 cg
-VP
+Je
 gz
 wP
 Rl
 ro
 cC
 qH
-rj
+Rl
 nn
 Je
 Je
@@ -35689,14 +35636,14 @@ cg
 cg
 cg
 cg
-VP
+Je
 Rl
 Rl
 Rl
 ro
 eG
 Rl
-rj
+Rl
 uY
 Je
 Af
@@ -35947,14 +35894,14 @@ cg
 cg
 cg
 cg
-VP
+Je
 Rl
 Rl
 Rl
 ro
 fp
 Na
-ys
+Na
 Zq
 Je
 RL
@@ -36205,12 +36152,12 @@ cg
 cg
 cg
 cg
-VP
-VP
-VP
-VP
-VP
-bx
+Je
+Je
+Je
+Je
+Je
+Je
 Ta
 mX
 Je
@@ -38014,20 +37961,20 @@ cg
 cg
 cg
 cg
-cg
-Af
-Jh
-cg
-cg
-cg
-cg
-cg
-dE
-Yx
-Yx
-mM
+Cx
+bx
+cU
+Cx
+Cx
+Cx
+Cx
+Cx
+dQ
+DB
+DB
+gH
 yj
-Yx
+DB
 TP
 Yx
 kG
@@ -38272,7 +38219,7 @@ cg
 cg
 cg
 cg
-cg
+Cx
 tp
 se
 se
@@ -38285,7 +38232,7 @@ Yx
 Yx
 tg
 Yx
-Yx
+DB
 Yx
 cg
 cg
@@ -38530,7 +38477,7 @@ cg
 cg
 cg
 cg
-cg
+Cx
 se
 bk
 se
@@ -38543,7 +38490,7 @@ Yx
 Yx
 Yx
 Yx
-cg
+Cx
 cg
 cg
 cg
@@ -38788,7 +38735,7 @@ cg
 cg
 cg
 cg
-cg
+Cx
 cg
 se
 se
@@ -38801,7 +38748,7 @@ TP
 Yx
 Yx
 Yx
-cg
+Cx
 cg
 cg
 cg
@@ -39046,20 +38993,20 @@ cg
 cg
 cg
 cg
+Cx
 cg
 cg
-Cx
-Cx
-Cx
-jQ
-jQ
-Cx
-Cx
-Cx
+cg
+cg
+qO
+qO
+cg
+cg
+cg
 Yx
 ZB
 Yx
-Yx
+DB
 cg
 cg
 cg
@@ -39304,20 +39251,20 @@ cg
 cg
 cg
 cg
-cg
-cg
 Cx
+cg
+cg
 Yo
 Yo
 WB
 WB
 Yo
 Yo
-Cx
-Cx
+cg
+cg
 se
 Ud
-Yx
+DB
 cg
 cg
 cg
@@ -39572,10 +39519,10 @@ WB
 Yx
 Yo
 Yo
-Cx
+cg
 se
 Ud
-Yx
+DB
 Yx
 Yx
 cg
@@ -39644,15 +39591,15 @@ Dl
 Sw
 UT
 UT
-UT
-LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
+cE
+Hm
+Hm
+Hm
+Hm
+Hm
+Hm
+Hm
+Hm
 LU
 LU
 LU
@@ -39830,10 +39777,10 @@ qa
 WB
 Yx
 Yo
-Cx
-Cx
+cg
+cg
 Yx
-Yx
+DB
 Yx
 Yx
 Yx
@@ -39902,14 +39849,14 @@ Sw
 Sw
 eu
 eu
-LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
+Hm
+Hm
+Hm
+Hm
+Hm
+Hm
+Hm
+Hm
 LU
 LU
 LU
@@ -40089,9 +40036,9 @@ WB
 WB
 Yo
 Yo
+cg
+cg
 Cx
-cg
-cg
 Yx
 Yx
 SD
@@ -40147,24 +40094,24 @@ UT
 UT
 RU
 SR
-Yb
-Yb
-Yb
-Yb
-Yb
-Yb
-Lo
-AW
-AW
+LU
+LU
+LU
+LU
+LU
+LU
+jk
+UT
+UT
 cE
 Hm
 Hm
 Hm
 LU
-LU
-LU
-LU
-LU
+Hm
+Hm
+Hm
+Hm
 LU
 LU
 LU
@@ -40347,9 +40294,9 @@ WB
 WB
 WB
 WB
-jQ
+qO
 Yx
-Yx
+DB
 FW
 xI
 Vk
@@ -40414,15 +40361,15 @@ NC
 Hm
 eu
 eu
-sI
+Hm
 Hm
 NC
 Hm
 LU
 LU
-LU
-LU
-LU
+Hm
+Hm
+Hm
 LU
 LU
 LU
@@ -40606,7 +40553,7 @@ vl
 ov
 ov
 hp
-dQ
+xI
 fS
 Ao
 jc
@@ -40661,27 +40608,27 @@ Mk
 Mk
 Qw
 Qw
-tN
+np
 np
 NC
 Hm
 Hm
 Hm
 Hm
-NC
-Vi
-Hm
-Hm
+Bn
+Dk
 sI
-LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
+sI
+sI
+sI
+sI
+sI
+sI
+sI
+Hm
+Hm
+Hm
+Hm
 LU
 LU
 LU
@@ -40864,8 +40811,8 @@ za
 WB
 Yx
 Yo
-Cx
-Yx
+cg
+DB
 Yx
 cg
 cg
@@ -40919,26 +40866,26 @@ hY
 hY
 KR
 LU
-Yb
+LU
 np
 np
 TD
 Hm
 Hm
-YO
+sI
+sI
 Hm
 Hm
 Hm
-Yb
-Yb
-LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
+Hm
+Hm
+Hm
+Vi
+Hm
+sI
+Hm
+Hm
+Hm
 LU
 LU
 LU
@@ -41122,8 +41069,8 @@ WB
 Yx
 Yo
 Yo
-Cx
-Yx
+cg
+DB
 Yx
 cg
 cg
@@ -41177,25 +41124,25 @@ hY
 hY
 KR
 LU
-Yb
-Yb
-Yb
+LU
+LU
+LU
 El
-Yb
+LU
+Vi
+sI
+Hm
 Vi
 Hm
 Hm
-Yb
-Yb
-Yb
-LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
+Vi
+Hm
+Hm
+Hm
+Hm
+sI
+Hm
+Hm
 LU
 LU
 LU
@@ -41379,9 +41326,9 @@ EV
 WB
 Yx
 Yo
-DB
-Cx
 Yx
+cg
+DB
 Yx
 cg
 cg
@@ -41439,20 +41386,20 @@ KR
 KR
 KR
 eF
-Yb
+LU
+Hm
+sI
 Hm
 Hm
-Yb
-Yb
-LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
+Hm
+Hm
+Hm
+Hm
+Hm
+Hm
+Hm
+sI
+Hm
 LU
 LU
 LU
@@ -41637,9 +41584,9 @@ XF
 WB
 WB
 Yo
-Cx
 cg
-Yx
+cg
+DB
 TP
 Yx
 cg
@@ -41697,20 +41644,20 @@ hY
 KR
 KR
 eF
+LU
+LU
 Yb
-Yb
-Yb
-Yb
-LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
+Hm
+Hm
+Vi
+Hm
+Hm
+Hm
+Vi
+Hm
+Hm
+sI
+Hm
 LU
 LU
 LU
@@ -41895,9 +41842,9 @@ WB
 cj
 WB
 qO
-DB
-TP
 Yx
+TP
+DB
 Yx
 Yx
 cg
@@ -41957,17 +41904,17 @@ KR
 eF
 LU
 LU
+Yb
+Hm
+Hm
+Hm
+Hm
+JA
+qU
+Hm
+Hm
 LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
+Yb
 LU
 LU
 LU
@@ -42153,9 +42100,9 @@ WB
 WB
 qa
 qO
-DB
 Yx
-ZB
+Yx
+jQ
 ZB
 Yx
 Yx
@@ -42215,17 +42162,17 @@ KR
 eF
 LU
 LU
+Yb
+LU
+LU
+Hm
+Vi
+Hm
 LU
 LU
 LU
 LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
+Yb
 LU
 LU
 LU
@@ -42411,9 +42358,9 @@ Yo
 WB
 WB
 Yo
-Cx
 cg
-se
+cg
+kM
 se
 Ud
 Yx
@@ -42473,17 +42420,17 @@ KR
 eF
 LU
 LU
+Yb
+LU
+LU
+Hm
+Hm
+Hm
 LU
 LU
 LU
 LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
+Yb
 LU
 LU
 LU
@@ -42666,12 +42613,12 @@ Yx
 Yx
 Yx
 Yo
-jQ
-jQ
+qO
+qO
 bT
+cg
+cg
 Cx
-cg
-cg
 cg
 cg
 cg
@@ -42731,17 +42678,17 @@ KR
 eF
 LU
 LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
-LU
+Yb
+Yb
+Yb
+Yb
+Yb
+Yb
+Yb
+Yb
+Yb
+Yb
+Yb
 LU
 LU
 LU
@@ -42924,12 +42871,12 @@ Yo
 Yo
 Yo
 Yo
+Yx
+Yx
+Yx
+Yx
+Yx
 DB
-Yx
-Yx
-Yx
-Yx
-Yx
 cg
 cg
 cg
@@ -43183,11 +43130,11 @@ Cx
 Cx
 Cx
 DB
-Yx
-TP
-Yx
-Yx
-Yx
+DB
+gn
+DB
+DB
+DB
 BP
 Yx
 Yx


### PR DESCRIPTION
## About The Pull Request

Fixes silo camping.

## Why It's Good For The Game

Moves silos and gives them more room so not only aren't they really up close to disks, they got more room to.

## Changelog
:cl:
balance: slight changes to map around silos
balance: deleted some silos and moved some
/:cl:

1
![image](https://user-images.githubusercontent.com/64131993/148215074-d59e999b-542c-42c2-a71c-161b22bacc30.png)

2
![image](https://user-images.githubusercontent.com/64131993/148215140-8438fad0-eb66-4012-b064-4bfd5a03411e.png)

3
![image](https://user-images.githubusercontent.com/64131993/148215183-e60b00db-2b65-46c1-99cb-65b5cb71cac6.png)

