### PR TITLE
Brings back My Icy caves edit but fixes things.

### DIFF
--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -218,7 +218,6 @@
 /obj/item/ammo_magazine/rifle/m16,
 /obj/item/ammo_magazine/rifle/m16,
 /obj/item/ammo_magazine/rifle/m16,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "aS" = (
@@ -262,9 +261,14 @@
 /obj/item/ammo_magazine/rifle/bolt,
 /obj/item/ammo_magazine/rifle/bolt,
 /obj/item/ammo_magazine/rifle/bolt,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
+"aZ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/corner{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "ba" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -372,7 +376,6 @@
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/reagent_containers/glass/beaker/bluespace,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "bt" = (
@@ -683,10 +686,6 @@
 	dir = 4
 	},
 /area/icy_caves/caves/northern)
-"cC" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/end,
-/area/icy_caves/caves/northern)
 "cD" = (
 /obj/item/tool/surgery/circular_saw,
 /turf/open/floor/tile/dark,
@@ -706,20 +705,13 @@
 	},
 /turf/open/shuttle/escapepod/plain,
 /area/icy_caves/caves/northern)
+"cG" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
 "cI" = (
 /turf/closed/ice/thin/single,
 /area/icy_caves/caves/northern)
-"cJ" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/mainship,
-/area/icy_caves/caves/crashed_ship)
-"cK" = (
-/obj/machinery/door/airlock/mainship/generic{
-	dir = 2
-	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/crashed_ship)
 "cL" = (
 /obj/structure/monorail,
 /turf/open/floor/mainship_hull,
@@ -727,10 +719,6 @@
 "cM" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/crashed_ship)
-"cN" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "cO" = (
 /obj/effect/ai_node,
@@ -760,14 +748,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"cX" = (
-/obj/structure/largecrate/supply,
-/obj/machinery/camera/autoname/mainship/dropship_one{
-	dir = 8;
-	pixel_x = 16
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "cY" = (
 /turf/closed/ice/thin/corner{
 	dir = 8
@@ -1145,6 +1125,7 @@
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "Canteen"
 	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "eD" = (
@@ -1528,6 +1509,10 @@
 	dir = 5
 	},
 /area/icy_caves/caves/east)
+"gf" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/single,
+/area/icy_caves/caves/northern)
 "gh" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 9
@@ -1795,6 +1780,10 @@
 /obj/structure/largecrate/supply,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"hC" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside/center)
 "hD" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/floor/plating/ground/ice,
@@ -1921,6 +1910,16 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"iA" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"iB" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/corners{
+	dir = 5
+	},
+/area/icy_caves/caves)
 "iG" = (
 /turf/open/floor/tile/dark/yellow2{
 	dir = 4
@@ -1941,6 +1940,18 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"iO" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/red2{
+	dir = 5
+	},
+/area/icy_caves/outpost/LZ2)
 "iP" = (
 /obj/machinery/door/airlock/multi_tile/mainship/research,
 /turf/open/floor/plating,
@@ -1996,6 +2007,12 @@
 /obj/item/tool/surgery/cautery,
 /obj/item/tool/surgery/retractor,
 /turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"jl" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/corner{
+	dir = 1
+	},
 /area/icy_caves/caves/northern)
 "jo" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -2228,6 +2245,12 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
+"kt" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/corner{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "ku" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/tile/dark,
@@ -2236,6 +2259,10 @@
 /obj/machinery/vending/snack,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"kw" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/straight,
+/area/icy_caves/caves/northern)
 "kx" = (
 /obj/structure/bed/chair,
 /turf/open/floor/tile/dark,
@@ -2274,6 +2301,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark/green2/corner,
 /area/icy_caves/outpost/medbay)
+"kH" = (
+/obj/machinery/miner/damaged/platinum,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/northern)
 "kJ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -2386,6 +2418,10 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
+"ls" = (
+/obj/structure/prop/mainship/hangar_stencil/two,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "lt" = (
@@ -3692,6 +3728,12 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/engineering)
+"rN" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/corner{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "rO" = (
 /obj/machinery/vending/tool,
 /obj/machinery/light{
@@ -3953,6 +3995,11 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/security)
+"sP" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/northern)
 "sQ" = (
 /obj/machinery/light/small,
 /turf/open/floor/freezer,
@@ -4017,6 +4064,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"tj" = (
+/turf/open/floor/tile/dark/red2{
+	dir = 6
+	},
+/area/icy_caves/outpost/LZ2)
 "tk" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
@@ -4114,6 +4166,10 @@
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 4
 	},
+/area/icy_caves/caves/northern)
+"tG" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "tH" = (
 /turf/closed/wall/r_wall,
@@ -4387,6 +4443,10 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
+"uY" = (
+/obj/docking_port/mobile/crashmode/bigbury,
+/turf/closed/ice,
+/area/icy_caves/caves/south)
 "va" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/tile/dark/green2{
@@ -4769,6 +4829,10 @@
 	dir = 1
 	},
 /area/icy_caves/caves/south)
+"xe" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/single,
+/area/icy_caves/caves/northern)
 "xf" = (
 /obj/structure/closet/secure_closet/scientist,
 /turf/open/floor/tile/dark/purple2,
@@ -4858,6 +4922,10 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
+"xB" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/corners,
+/area/icy_caves/caves/northern)
 "xE" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
@@ -4996,6 +5064,12 @@
 "yx" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/engineering)
+"yy" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/end{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "yz" = (
 /obj/structure/bed/chair,
 /turf/open/floor/tile/dark,
@@ -5201,6 +5275,11 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"zI" = (
+/turf/open/floor/tile/dark/brown2{
+	dir = 9
+	},
+/area/icy_caves/outpost/LZ2)
 "zK" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -5386,6 +5465,13 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"Ay" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "AB" = (
 /turf/closed/ice/thin/end{
 	dir = 1
@@ -5564,6 +5650,12 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"Bp" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/end{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
 "Bq" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/prison/kitchen,
@@ -5641,10 +5733,6 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/outside)
-"BM" = (
-/obj/docking_port/stationary/crashmode,
-/turf/closed/wall/r_wall,
-/area/icy_caves/outpost/dorms)
 "BN" = (
 /turf/closed/shuttle/dropship2{
 	icon_state = "52"
@@ -5788,6 +5876,11 @@
 	dir = 10
 	},
 /area/icy_caves/caves/northern)
+"CI" = (
+/turf/open/floor/tile/dark/red2{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "CL" = (
 /obj/machinery/light{
 	dir = 1
@@ -6248,6 +6341,11 @@
 	},
 /turf/open/shuttle/dropship/seven,
 /area/space)
+"Fl" = (
+/turf/open/floor/tile/dark/red2{
+	dir = 10
+	},
+/area/icy_caves/outpost/LZ2)
 "Fm" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -6456,6 +6554,10 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
+"Gr" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/eastWall,
+/area/icy_caves/caves)
 "Gs" = (
 /turf/closed/ice_rock/corners,
 /area/icy_caves/caves/northern)
@@ -6787,6 +6889,17 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"HY" = (
+/obj/structure/cable,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
+"Ia" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
 "Ib" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -7064,6 +7177,12 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"Ju" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "Jv" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -7106,6 +7225,11 @@
 /obj/item/lightstick/anchored,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"JE" = (
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "JF" = (
 /obj/machinery/vending/cola,
 /obj/machinery/light{
@@ -7131,10 +7255,6 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
-"JN" = (
-/obj/docking_port/mobile/crashmode/bigbury,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/refinery)
 "JO" = (
 /obj/machinery/bodyscanner,
 /turf/open/floor/tile/dark/green2,
@@ -7450,6 +7570,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"LB" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/straight{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "LC" = (
 /obj/machinery/light/small,
 /turf/open/floor/wood,
@@ -7504,6 +7630,12 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
+"LM" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/end{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "LO" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -7958,6 +8090,10 @@
 "NW" = (
 /turf/open/shuttle/dropship/seven,
 /area/space)
+"Oa" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/intersection,
+/area/icy_caves/caves/northern)
 "Ob" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark,
@@ -8041,7 +8177,9 @@
 /area/icy_caves/caves/northern)
 "Oy" = (
 /obj/docking_port/mobile/crashmode/bigbury,
-/turf/open/floor/tile/dark,
+/turf/open/floor/tile/dark/red2{
+	dir = 8
+	},
 /area/icy_caves/outpost/LZ2)
 "OA" = (
 /turf/closed/ice/thin/corner{
@@ -8083,14 +8221,6 @@
 "OJ" = (
 /turf/closed/ice/end,
 /area/icy_caves/outpost/outside)
-"OL" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/docking_port/mobile/crashmode/bigbury,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside/center)
 "OO" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -8340,6 +8470,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
+"Qt" = (
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "Qw" = (
 /turf/closed/ice/corner{
 	dir = 4
@@ -8665,10 +8800,6 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"Sc" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/crashed_ship)
 "Se" = (
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 8
@@ -8750,6 +8881,11 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
+"Sz" = (
+/turf/open/floor/tile/dark/brown2{
+	dir = 5
+	},
+/area/icy_caves/outpost/LZ2)
 "SA" = (
 /turf/closed/ice/thin/straight{
 	dir = 4
@@ -8940,6 +9076,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/refinery)
+"TG" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/straight,
+/area/icy_caves/caves/northern)
 "TH" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/ice,
@@ -9236,6 +9376,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"Vh" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Vi" = (
 /obj/structure/table,
 /obj/item/storage/fancy/vials,
@@ -9559,6 +9707,10 @@
 /obj/docking_port/stationary/marine_dropship/lz1,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
+"WN" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/westWall,
+/area/icy_caves/caves)
 "WO" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
@@ -9620,6 +9772,12 @@
 /obj/structure/largecrate/random/case,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"Xe" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/LZ2)
 "Xf" = (
 /obj/effect/landmark/start/job/survivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -9667,6 +9825,11 @@
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"Xm" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Xn" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/cheeseburger,
@@ -9834,6 +9997,10 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/refinery)
+"XV" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/intersection,
+/area/icy_caves/caves/northern)
 "XW" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -15095,7 +15262,7 @@ BZ
 dF
 Gs
 dF
-cX
+hB
 Zl
 Zl
 Zl
@@ -15396,17 +15563,17 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-WF
-Zl
-Zl
-Zl
-ns
-dF
-Gs
-dF
+ll
+ll
+ll
+HY
+iA
+iA
+iA
+Vh
+cG
+xB
+cG
 dF
 Zl
 dF
@@ -15552,7 +15719,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+ll
 WF
 WF
 WF
@@ -15562,7 +15729,7 @@ Wc
 BF
 dF
 Gs
-Gs
+xB
 dF
 Zl
 dF
@@ -15659,7 +15826,7 @@ DY
 sl
 DY
 DY
-JN
+DY
 yK
 DY
 DY
@@ -15708,7 +15875,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+ll
 WF
 Zl
 EU
@@ -15718,7 +15885,7 @@ Bf
 BZ
 dF
 dF
-dF
+cG
 dF
 Bo
 Zl
@@ -15864,17 +16031,17 @@ Yf
 Yf
 Yf
 Yf
-Yf
+ll
 WF
 Zl
-Zl
+WO
 Zl
 Gf
 Zl
-BZ
+Ay
 Zl
 Zl
-dF
+cG
 Zl
 Fj
 Tz
@@ -16020,17 +16187,17 @@ Yf
 Yf
 Yf
 Yf
-Yf
+ll
 WF
 Xh
 Xh
 Zl
 Zl
-Zl
+tG
 HQ
 Xh
 Zl
-EP
+Xm
 Zl
 Zl
 Zl
@@ -16176,7 +16343,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+ll
 WF
 MT
 eD
@@ -16332,7 +16499,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+ll
 WF
 eD
 eD
@@ -16342,7 +16509,7 @@ Zl
 IK
 eD
 PZ
-Zl
+iA
 Zl
 Zl
 Zl
@@ -16488,17 +16655,17 @@ Yf
 Yf
 Yf
 Yf
-Yf
+ll
 WF
 BW
 BW
-Zl
+WO
 Zl
 Zl
 QQ
 BW
 Zl
-EP
+Xm
 di
 Pg
 Zl
@@ -16644,7 +16811,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+ll
 WF
 Yh
 Zl
@@ -16652,9 +16819,9 @@ Fj
 Tz
 Tz
 eP
-Zl
+WO
 FB
-WF
+HY
 WF
 WF
 WF
@@ -16800,7 +16967,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+ll
 WF
 Zl
 Zl
@@ -16810,7 +16977,7 @@ CX
 Zl
 Zl
 Zl
-WF
+HY
 Yf
 Yf
 Gs
@@ -16956,17 +17123,17 @@ Yf
 Yf
 Yf
 Yf
-Yf
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
-WF
+ll
+HY
+HY
+HY
+HY
+HY
+HY
+HY
+HY
+HY
+HY
 Yf
 Yf
 Il
@@ -19258,7 +19425,7 @@ DD
 DD
 DD
 my
-OL
+HA
 li
 YA
 YL
@@ -20648,7 +20815,7 @@ my
 my
 my
 my
-my
+hC
 Iw
 my
 my
@@ -20821,7 +20988,7 @@ li
 HA
 my
 li
-BM
+ND
 Ez
 wZ
 tk
@@ -20876,12 +21043,12 @@ pk
 pk
 pk
 Ho
-yh
-yh
-yh
-yh
-yh
-yh
+SR
+SR
+SR
+SR
+SR
+SR
 bP
 aX
 Zy
@@ -20920,7 +21087,7 @@ xX
 xX
 hv
 ST
-YW
+uY
 YW
 YW
 YW
@@ -21191,7 +21358,7 @@ bZ
 Rh
 XP
 SR
-bC
+SR
 SR
 Io
 Rh
@@ -21501,12 +21668,12 @@ VI
 VI
 Nd
 Ry
-yh
-yh
-yh
-yh
-yh
-cp
+SR
+SR
+SR
+SR
+SR
+Zb
 qT
 Zt
 qT
@@ -25086,20 +25253,20 @@ Yf
 Yf
 Yf
 Yf
-Yf
-qs
-Vb
-lG
-KU
-bT
-SR
-SR
-SR
-bS
-SR
-wo
-ce
-Zy
+ll
+cZ
+ne
+Jh
+cQ
+ct
+yh
+yh
+yh
+xe
+yh
+yy
+LB
+gf
 Zy
 bS
 bS
@@ -25242,7 +25409,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+ll
 Yf
 RN
 Vb
@@ -25255,7 +25422,7 @@ SR
 SR
 ce
 ce
-Zy
+gf
 Zy
 Zy
 bS
@@ -25398,7 +25565,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+ll
 Yf
 qs
 qz
@@ -25411,7 +25578,7 @@ wo
 wo
 ce
 ce
-Zy
+gf
 Zy
 Zy
 Zy
@@ -25554,7 +25721,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+ll
 Yf
 qy
 lX
@@ -25567,7 +25734,7 @@ VI
 VI
 bM
 by
-Zy
+gf
 Zy
 Zy
 Zy
@@ -25710,20 +25877,20 @@ Yf
 Yf
 Yf
 Yf
-re
+Gr
 qy
 lX
 WS
 eY
 SR
-SR
+bC
 SR
 SR
 Sg
 ot
 pk
 Ho
-Zy
+gf
 Zy
 Zy
 Zy
@@ -25850,15 +26017,15 @@ MQ
 MQ
 MQ
 MQ
-cJ
-cJ
-cJ
-cJ
+MQ
+MQ
+MQ
+MQ
 aR
 aY
-cN
+sH
 bs
-cJ
+MQ
 bz
 bD
 Yf
@@ -25866,7 +26033,7 @@ Yf
 Yf
 Yf
 qy
-PD
+rN
 Ho
 Vb
 eY
@@ -25879,7 +26046,7 @@ SR
 Lm
 Ho
 Zy
-Zy
+gf
 Zy
 Zy
 Zy
@@ -26006,15 +26173,15 @@ eJ
 eJ
 eJ
 eJ
-cJ
+MQ
 sH
 sH
 MQ
 sH
 aj
-Sc
+sH
 bt
-cJ
+MQ
 bz
 bD
 Yf
@@ -26022,7 +26189,7 @@ Yf
 Yf
 qy
 PD
-VI
+Oa
 bA
 Ho
 SR
@@ -26035,7 +26202,7 @@ im
 SR
 ok
 pk
-pk
+kw
 pk
 pk
 pk
@@ -26162,7 +26329,7 @@ sH
 kr
 sH
 aJ
-cJ
+MQ
 ay
 sH
 bc
@@ -26170,7 +26337,7 @@ AN
 aQ
 bi
 aN
-cJ
+MQ
 MQ
 bD
 Yf
@@ -26178,7 +26345,7 @@ Yf
 qs
 PD
 VI
-by
+kt
 Sg
 SR
 SR
@@ -26191,7 +26358,7 @@ bl
 SR
 SR
 ok
-pk
+kw
 pk
 pk
 pk
@@ -26318,7 +26485,7 @@ ah
 AN
 ah
 sH
-cK
+bc
 sH
 aN
 MQ
@@ -26326,7 +26493,7 @@ sH
 sH
 sH
 bu
-cJ
+MQ
 bz
 bD
 Yf
@@ -26334,7 +26501,7 @@ Yf
 qy
 ot
 Fu
-Sg
+LM
 SR
 bl
 SR
@@ -26347,7 +26514,7 @@ SR
 bl
 SR
 SR
-cj
+Bp
 Xw
 Xw
 Ir
@@ -26474,7 +26641,7 @@ ad
 aj
 aj
 aN
-cJ
+MQ
 sH
 sH
 MQ
@@ -26482,7 +26649,7 @@ aS
 IO
 sH
 sH
-cJ
+MQ
 bz
 bh
 re
@@ -26490,20 +26657,20 @@ qy
 PD
 VI
 Fu
-SR
-bl
-GH
-SR
-cj
-IC
-bT
-qT
-IC
-Zt
-SR
-bl
-Zb
-SR
+yh
+sP
+kH
+yh
+Bp
+XV
+ct
+aZ
+XV
+cP
+yh
+sP
+cp
+yh
 cj
 Xw
 IC
@@ -26630,15 +26797,15 @@ RN
 al
 ar
 ah
-cJ
-cN
-cN
-cJ
-cJ
-cJ
-cJ
-cJ
-cJ
+MQ
+sH
+sH
+MQ
+MQ
+MQ
+MQ
+MQ
+MQ
 MQ
 PD
 pk
@@ -27968,14 +28135,14 @@ PS
 oP
 kL
 mE
-IT
-IT
-IT
-IT
-IT
-tx
-Ko
-IT
+CI
+CI
+CI
+CI
+CI
+iO
+tj
+CI
 Oy
 kP
 nd
@@ -28126,13 +28293,13 @@ wa
 ka
 IT
 IT
-IT
+ls
 nb
 IT
 vv
 Ko
-IT
-IT
+JE
+zI
 iP
 tL
 tL
@@ -28214,13 +28381,13 @@ bl
 Ry
 KU
 Ir
-IC
-Zt
-SR
-bl
-SR
-SR
-Lm
+XV
+cP
+yh
+sP
+yh
+yh
+jl
 by
 Zy
 Zy
@@ -28287,8 +28454,8 @@ on
 on
 Cm
 Ko
-IT
-IT
+Qt
+Sz
 tL
 tL
 tL
@@ -28370,13 +28537,13 @@ SR
 bl
 SR
 QK
-KU
+cQ
 IC
 rf
 SR
 bl
 SR
-SR
+yh
 bP
 bS
 bS
@@ -28430,7 +28597,7 @@ oP
 CZ
 wa
 kp
-IT
+Fl
 IT
 IT
 IT
@@ -28526,13 +28693,13 @@ SR
 SR
 bl
 Zb
-SR
+yh
 QK
 Xw
 rf
 PI
 PI
-Io
+Ia
 ca
 bS
 bS
@@ -28586,7 +28753,7 @@ wa
 CZ
 nI
 wa
-IT
+tj
 IT
 IT
 td
@@ -28682,7 +28849,7 @@ lG
 SR
 SR
 bl
-SR
+yh
 SR
 SR
 SR
@@ -28838,16 +29005,16 @@ Vb
 lG
 SR
 VU
-bl
+sP
 SR
 SR
 we
 bl
 SR
 yh
-im
-cj
-Xw
+cb
+Bp
+TG
 cP
 qT
 Xw
@@ -28994,13 +29161,13 @@ RN
 Vb
 pq
 eY
-wo
+yy
 wo
 SR
 wo
 wo
 bl
-yh
+SR
 SR
 SR
 bl
@@ -29150,13 +29317,13 @@ Yf
 oW
 oW
 RN
-Lm
+jl
 VI
 pk
 VI
 bM
 Nd
-yh
+SR
 im
 SR
 SR
@@ -29226,7 +29393,7 @@ Ko
 IT
 IT
 IT
-IT
+nf
 IT
 mP
 wa
@@ -29306,13 +29473,13 @@ Yf
 Yf
 Yf
 Yf
-RN
+iB
 Lm
 Ho
 ce
 Zy
 VI
-cC
+Ho
 SR
 bC
 SR
@@ -29379,11 +29546,11 @@ IT
 IT
 vv
 Ko
-IT
-IT
-IT
-IT
-IT
+JE
+JE
+JE
+JE
+JE
 ka
 wa
 wa
@@ -29462,13 +29629,13 @@ Yf
 Yf
 Yf
 Yf
-Yf
+ll
 oW
 RN
 Lm
 pk
 by
-yh
+SR
 SR
 SR
 bl
@@ -29535,11 +29702,11 @@ IT
 on
 vv
 Ko
-td
-IT
-IT
-IT
-IT
+Ju
+Qt
+Qt
+Qt
+Qt
 IT
 wa
 uq
@@ -29618,16 +29785,16 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-oW
-RN
-VU
-VU
-SR
-VU
-VU
+ll
+ll
+ll
+WN
+iB
+zv
+zv
+yh
+zv
+zv
 yh
 SR
 SR
@@ -30634,7 +30801,7 @@ on
 on
 on
 nI
-nI
+Xe
 nI
 oP
 wa
@@ -30777,7 +30944,7 @@ IT
 IT
 oP
 oP
-oP
+ky
 oP
 oP
 wa
@@ -30786,7 +30953,7 @@ Ko
 wa
 oP
 wa
-oP
+ky
 oP
 oP
 oP

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -23,8 +23,9 @@
 /turf/open/floor/plating/dmg1,
 /area/icy_caves/caves/crashed_ship)
 "af" = (
-/turf/closed/wall/r_wall/unmeltable,
-/area/lv624/lazarus/console)
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside)
 "ag" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/effect/landmark/nuke_spawn,
@@ -53,9 +54,11 @@
 /turf/open/floor/plating/dmg1,
 /area/icy_caves/caves/crashed_ship)
 "am" = (
-/obj/machinery/telecomms/relay/preset/telecomms,
-/turf/open/floor/plating/icefloor,
-/area/lv624/lazarus/console)
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "an" = (
 /obj/structure/xenoautopsy/tank/broken,
 /obj/effect/decal/cleanable/blood/xeno,
@@ -66,10 +69,6 @@
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
-"ap" = (
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
 "aq" = (
 /obj/structure/xenoautopsy/tank/broken,
 /turf/open/floor/plating/mainship,
@@ -219,6 +218,7 @@
 /obj/item/ammo_magazine/rifle/m16,
 /obj/item/ammo_magazine/rifle/m16,
 /obj/item/ammo_magazine/rifle/m16,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "aS" = (
@@ -262,6 +262,7 @@
 /obj/item/ammo_magazine/rifle/bolt,
 /obj/item/ammo_magazine/rifle/bolt,
 /obj/item/ammo_magazine/rifle/bolt,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "ba" = (
@@ -371,6 +372,7 @@
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "bt" = (
@@ -528,6 +530,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
+"bW" = (
+/obj/structure/cryofeed/right{
+	name = "\improper coolant feed"
+	},
+/turf/open/floor/podhatch/floor{
+	icon_state = "bcircuitoff"
+	},
+/area/icy_caves/caves/northern)
 "bX" = (
 /turf/closed/ice_rock/singlePart,
 /area/icy_caves/caves)
@@ -570,6 +580,12 @@
 	dir = 8
 	},
 /area/icy_caves/caves/northern)
+"ch" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/floor,
+/area/space)
 "ci" = (
 /turf/closed/ice/thin/junction,
 /area/icy_caves/caves/northern)
@@ -595,6 +611,21 @@
 /turf/closed/ice/thin/straight{
 	dir = 4
 	},
+/area/icy_caves/caves/northern)
+"co" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/mainship/tcomms,
 /area/icy_caves/caves/northern)
 "cp" = (
 /obj/item/lightstick/anchored,
@@ -633,7 +664,7 @@
 /turf/closed/ice/corner{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "cv" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice/thin/junction{
@@ -656,20 +687,42 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice/end,
 /area/icy_caves/caves/northern)
+"cD" = (
+/obj/item/tool/surgery/circular_saw,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"cE" = (
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
+"cF" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/structure/monorail{
+	dir = 5
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
 "cI" = (
 /turf/closed/ice/thin/single,
 /area/icy_caves/caves/northern)
 "cJ" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/junction{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
+/turf/closed/wall/mainship,
+/area/icy_caves/caves/crashed_ship)
 "cK" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/junction{
-	dir = 8
+/obj/machinery/door/airlock/mainship/generic{
+	dir = 2
 	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/crashed_ship)
+"cL" = (
+/obj/structure/monorail,
+/turf/open/floor/mainship_hull,
 /area/icy_caves/caves/northern)
 "cM" = (
 /obj/effect/landmark/xeno_resin_door,
@@ -677,13 +730,14 @@
 /area/icy_caves/caves/crashed_ship)
 "cN" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/corner{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/crashed_ship)
 "cO" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/straight,
+/obj/effect/ai_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
 /area/icy_caves/caves/northern)
 "cP" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -695,15 +749,34 @@
 	dir = 1
 	},
 /area/icy_caves/caves/northern)
+"cV" = (
+/turf/open/floor/tile/white/warningstripe{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
 "cW" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/corner,
-/area/icy_caves/caves/west)
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/space/basic,
+/area/space)
+"cX" = (
+/obj/structure/largecrate/supply,
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "cY" = (
 /turf/closed/ice/thin/corner{
 	dir = 8
 	},
 /area/icy_caves/caves/west)
+"cZ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/southWall,
+/area/icy_caves/caves)
 "da" = (
 /turf/closed/ice/junction,
 /area/icy_caves/caves/west)
@@ -713,31 +786,43 @@
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "dd" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/junction{
-	dir = 1
-	},
-/area/icy_caves/caves/west)
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/green2,
+/area/icy_caves/caves/northern)
 "de" = (
 /turf/closed/ice/thin/junction{
 	dir = 1
 	},
 /area/icy_caves/caves/west)
 "df" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/corner{
+/obj/structure/dropship_piece/two/front/left,
+/turf/open/floor/mainship_hull/dir{
 	dir = 8
 	},
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "dg" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/west)
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/structure/dropship_piece/two/front,
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
 "dh" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 1
 	},
 /area/icy_caves/caves/west)
+"di" = (
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "dj" = (
 /turf/closed/ice,
 /area/icy_caves/caves/west)
@@ -768,6 +853,27 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"ds" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"du" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"dv" = (
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/obj/structure/largecrate/supply/explosives,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "dw" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 4
@@ -782,9 +888,12 @@
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/west)
 "dz" = (
-/obj/machinery/computer/nuke_disk_generator/green,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/south)
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "dA" = (
 /obj/machinery/light,
 /turf/open/floor/plating/ground/ice,
@@ -824,40 +933,35 @@
 	},
 /area/icy_caves/caves/east)
 "dK" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/intersection,
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "dL" = (
-/obj/structure/closet/crate/science,
-/obj/item/stack/sheet/mineral/phoron/medium_stack,
+/obj/effect/ai_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
-"dM" = (
-/obj/machinery/power/apc/drained,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "dN" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "dO" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
-"dP" = (
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "dQ" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "dR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/tile/dark,
@@ -893,13 +997,14 @@
 /turf/closed/ice/thin/end,
 /area/icy_caves/caves/east)
 "dZ" = (
-/obj/machinery/power/port_gen/pacman,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/turf/closed/shuttle/dropship2{
+	icon_state = "24"
+	},
+/area/icy_caves/caves/northern)
 "ea" = (
 /obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "eb" = (
 /turf/closed/ice/end,
 /area/icy_caves/caves/west)
@@ -911,12 +1016,12 @@
 "ed" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "eg" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
 "eh" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -924,13 +1029,13 @@
 /area/icy_caves/caves/west)
 "ei" = (
 /obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
 "ej" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
 "em" = (
 /obj/effect/decal/cleanable/blood,
@@ -987,41 +1092,31 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
 "eu" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/east)
-"ev" = (
-/obj/structure/closet/crate,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick,
-/obj/item/storage/box/lightstick,
-/obj/item/tool/pickaxe/plasmacutter,
-/obj/effect/spawner/random/powercell,
-/obj/item/clothing/glasses/welding,
-/obj/item/explosive/plastique,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/camera{
+	dir = 5
 	},
+/obj/effect/ai_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
+"ev" = (
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "ew" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "ex" = (
-/obj/machinery/door/airlock/mainship/secure/locked/free_access{
-	name = "\improper Mining Storage"
-	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/door/airlock/mainship/secure/locked/free_access,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "ey" = (
 /turf/closed/ice,
 /area/icy_caves/caves/crashed_ship)
@@ -1046,11 +1141,21 @@
 	dir = 9
 	},
 /area/icy_caves/caves/northern)
+"eC" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	name = "Canteen"
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"eD" = (
+/obj/structure/table,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "eF" = (
-/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/ai_node,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/west)
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "eG" = (
 /obj/machinery/light{
 	dir = 8
@@ -1088,33 +1193,29 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
 "eL" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/east)
-"eM" = (
-/obj/structure/closet/crate,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick,
-/obj/item/storage/box/lightstick,
-/obj/item/tool/pickaxe/plasmacutter,
-/obj/effect/spawner/random/powercell,
-/obj/item/explosive/plastique,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/obj/effect/ai_node,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "eN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
+"eO" = (
+/obj/structure/table/reinforced,
+/obj/item/tool/surgery/scalpel/laser3,
+/obj/item/reagent_containers/spray/pepper,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "eP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "eR" = (
 /turf/closed/ice/end{
 	dir = 1
@@ -1122,18 +1223,18 @@
 /area/icy_caves/caves/south)
 "eS" = (
 /obj/machinery/light,
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
 "eT" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "eU" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
 "eV" = (
 /obj/structure/ore_box,
@@ -1187,13 +1288,19 @@
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/fire,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
+"fc" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "fd" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/powercell,
 /obj/effect/spawner/random/powercell,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "fe" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/tech_supply,
@@ -1204,7 +1311,7 @@
 /obj/item/clothing/glasses/welding,
 /obj/machinery/light/small,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "ff" = (
 /obj/structure/rack,
 /obj/structure/rack,
@@ -1212,7 +1319,7 @@
 /obj/effect/spawner/random/toolbox,
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "fg" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/tool,
@@ -1220,7 +1327,7 @@
 /obj/effect/spawner/random/tool,
 /obj/item/storage/belt/utility/full,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "fh" = (
 /turf/closed/ice/thin/junction,
 /area/icy_caves/caves/south)
@@ -1255,10 +1362,20 @@
 	dir = 1
 	},
 /area/icy_caves/caves/east)
-"fs" = (
+"fq" = (
 /obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow/layer1,
+/turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ1)
+"fs" = (
+/obj/structure/barricade/guardrail{
+	dir = 1
+	},
+/obj/structure/dropship_piece/two/front,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "ft" = (
 /turf/closed/ice/thin/junction{
 	dir = 4
@@ -1310,6 +1427,16 @@
 	dir = 9
 	},
 /area/icy_caves/caves/south)
+"fD" = (
+/obj/machinery/power/apc/drained,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "fE" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
@@ -1328,6 +1455,9 @@
 	dir = 1
 	},
 /area/icy_caves/caves/south)
+"fI" = (
+/turf/closed/ice/thin,
+/area/icy_caves/outpost/LZ2)
 "fK" = (
 /turf/closed/ice/thin/corner{
 	dir = 1
@@ -1478,17 +1608,51 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
+"gK" = (
+/obj/structure/monorail,
+/obj/structure/dropship_piece/two/front,
+/turf/open/floor/mainship_hull,
+/area/icy_caves/caves/northern)
 "gL" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/closed/ice_rock/corners,
 /area/icy_caves/caves)
+"gM" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/turf/open/floor/mainship/cargo,
+/area/icy_caves/caves/northern)
 "gN" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
+"gP" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
+"gQ" = (
+/obj/structure/dropship_piece/one/corner/middleright,
+/obj/structure/dropship_piece/two/corner/rearright,
+/turf/open/floor/mainship_hull/dir{
+	dir = 10
+	},
+/area/icy_caves/caves/northern)
 "gS" = (
 /turf/closed/ice/thin/end{
 	dir = 8
@@ -1511,12 +1675,23 @@
 	},
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"gZ" = (
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "hb" = (
 /turf/closed/ice/junction,
 /area/icy_caves/caves/south)
 "hc" = (
 /turf/closed/ice/straight,
 /area/icy_caves/caves/east)
+"hd" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "he" = (
 /turf/closed/ice/junction{
 	dir = 4
@@ -1616,6 +1791,10 @@
 	},
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"hB" = (
+/obj/structure/largecrate/supply,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "hD" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/floor/plating/ground/ice,
@@ -1625,6 +1804,13 @@
 	dir = 8
 	},
 /area/icy_caves/caves/east)
+"hG" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/research_and_development,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "hI" = (
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/ai_node,
@@ -1635,6 +1821,11 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"hM" = (
+/turf/closed/ice_rock/corners{
+	dir = 10
+	},
+/area/icy_caves/caves/northern)
 "hO" = (
 /turf/closed/ice/thin/single,
 /area/icy_caves/caves/east)
@@ -1646,6 +1837,11 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"hT" = (
+/obj/machinery/vending/medical,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "hU" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/ice,
@@ -1653,6 +1849,12 @@
 "hV" = (
 /turf/closed/ice_rock/singlePart,
 /area/icy_caves/caves/south)
+"hW" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "hX" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/effect/ai_node,
@@ -1690,6 +1892,22 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
+"in" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall/unmeltable,
+/area/icy_caves/caves/northern)
+"io" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
+"ip" = (
+/obj/structure/closet/l3closet/janitor,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "iu" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -1700,30 +1918,44 @@
 "ix" = (
 /obj/structure/cable,
 /obj/effect/landmark/excavation_site_spawner,
+/obj/effect/ai_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "iG" = (
 /turf/open/floor/tile/dark/yellow2{
 	dir = 4
 	},
 /area/icy_caves/outpost/engineering)
 "iJ" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/lowcharge,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
+/obj/machinery/computer/intel_computer,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/mining/west)
 "iK" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
+"iN" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"iP" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "iQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
+"iS" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "iT" = (
 /turf/closed/ice/end{
 	dir = 1
@@ -1742,11 +1974,37 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"jc" = (
+/obj/machinery/door/poddoor/mainship/indestructible,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
+"jd" = (
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "je" = (
 /turf/closed/ice/thin/corner{
 	dir = 1
 	},
 /area/icy_caves/outpost/outside)
+"jf" = (
+/obj/item/stool,
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
+"jk" = (
+/obj/structure/table/mainship,
+/obj/item/tool/surgery/cautery,
+/obj/item/tool/surgery/retractor,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"jo" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "jt" = (
 /obj/machinery/floodlight/landing,
 /obj/effect/decal/warning_stripes,
@@ -1778,23 +2036,46 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"jC" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "jE" = (
 /obj/structure/table/reinforced,
 /obj/effect/landmark/dropship_console_spawn_lz1,
 /turf/open/floor/plating/ground/snow,
 /area/lv624/lazarus/console)
+"jF" = (
+/obj/structure/ore_box,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "jH" = (
 /obj/machinery/landinglight/ds1/delaythree{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"jI" = (
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/caves)
 "jJ" = (
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"jK" = (
+/obj/structure/largecrate/supply/medicine,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
+"jL" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "jM" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = /obj/item/storage/backpack/satchel/norm;
@@ -1850,9 +2131,23 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/research)
+"jX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"jY" = (
+/obj/machinery/door/airlock/mainship/security,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "ka" = (
-/obj/structure/fence,
-/turf/open/floor/plating/ground/snow/layer0,
+/obj/machinery/door/airlock/multi_tile/mainship/research,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "kb" = (
 /obj/machinery/landinglight/ds1/delayone{
@@ -1866,9 +2161,18 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"kd" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "ke" = (
 /turf/closed/ice/junction,
 /area/icy_caves/outpost/outside)
+"kf" = (
+/obj/machinery/computer3/server/rack,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "kg" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/mining/east)
@@ -1895,93 +2199,57 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
+"kn" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/structure/dropship_piece/two/front,
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
 "ko" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/largecrate/cow,
-/turf/open/floor/tile/dark,
+/obj/structure/window/framed/colony/reinforced,
+/turf/closed/wall/r_wall,
 /area/icy_caves/outpost/LZ2)
 "kp" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/radio,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
+/obj/machinery/door/airlock/multi_tile/mainship/research,
+/turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ2)
 "kq" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/item/storage/fancy/cigarettes/dromedaryco,
-/obj/item/storage/fancy/cigar,
-/obj/item/tool/lighter,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ2)
 "kr" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "ku" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/largecrate/supply/supplies/water,
+/obj/machinery/vending/dinnerware,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "kv" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"kw" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/largecrate/supply/supplies,
+/obj/machinery/vending/snack,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "kx" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/item/binoculars,
+/obj/structure/bed/chair,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "ky" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/item/big_ammo_box,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ2)
+"kz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside/center)
 "kA" = (
 /obj/machinery/landinglight/ds1/delaytwo{
 	dir = 4
@@ -2022,6 +2290,12 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
+"kL" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/LZ2)
 "kM" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/singlePart{
@@ -2033,24 +2307,19 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
-"kO" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
+"kP" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"kR" = (
+/obj/structure/table/mainship,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "kS" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/structure/largecrate/random/case,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"kT" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/structure/largecrate/supply/ammo/standard_smg,
+/obj/machinery/light,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "kW" = (
@@ -2067,6 +2336,12 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/office)
+"kY" = (
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "lc" = (
 /turf/closed/ice/straight{
 	dir = 4
@@ -2094,50 +2369,35 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "ll" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/prop/mainship/hangar_stencil/two,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"lm" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/corners,
+/area/icy_caves/caves)
 "ln" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/end{
+	dir = 1
 	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/largecrate/supply/supplies,
-/obj/structure/prop/mainship/hangar_stencil/two,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves)
 "lo" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/largecrate/supply/ammo/shotgun,
-/obj/structure/prop/mainship/hangar_stencil/two,
+/obj/structure/table,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "lp" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
+/obj/structure/bed/chair{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "lt" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"lv" = (
+/obj/machinery/door/poddoor/two_tile_ver,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "lx" = (
 /obj/machinery/light{
 	dir = 8
@@ -2147,7 +2407,7 @@
 "lA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "lB" = (
 /obj/structure/table,
 /obj/structure/paper_bin,
@@ -2162,7 +2422,7 @@
 /turf/closed/ice/junction{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "lD" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark/brown2{
@@ -2178,6 +2438,25 @@
 	dir = 5
 	},
 /area/icy_caves/caves)
+"lH" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/mining/west)
+"lJ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark/yellow2{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
+"lL" = (
+/turf/closed/ice/thin/corner{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "lM" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -2189,6 +2468,14 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
+"lO" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "lP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -2201,6 +2488,12 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"lR" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "lS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -2208,6 +2501,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"lV" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside/center)
 "lW" = (
 /turf/closed/ice/thin/end{
 	dir = 1
@@ -2226,8 +2523,17 @@
 /obj/machinery/power/apc/lowcharge{
 	dir = 8
 	},
-/turf/open/floor/tile/dark,
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
 /area/icy_caves/outpost/LZ2)
+"ma" = (
+/obj/structure/dropship_piece/one/corner/middleleft,
+/obj/structure/dropship_piece/two/corner/rearleft,
+/turf/open/floor/mainship_hull/dir{
+	dir = 6
+	},
+/area/icy_caves/caves/northern)
 "mb" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/outpost/LZ1)
@@ -2243,14 +2549,36 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/refinery)
+"mg" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "mh" = (
 /turf/closed/ice/thin/junction{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "mi" = (
-/turf/closed/ice/thin/end,
-/area/icy_caves/outpost/LZ1)
+/turf/closed/wall/r_wall/unmeltable,
+/area/lv624/lazarus/console)
+"mj" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 4;
+	pixel_x = -16
+	},
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern)
 "mk" = (
 /obj/docking_port/stationary/marine_dropship/lz2,
 /turf/open/floor/plating,
@@ -2275,6 +2603,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"mq" = (
+/obj/machinery/miner/damaged/platinum,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "mr" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
@@ -2294,9 +2626,25 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"mu" = (
+/obj/machinery/vending/security,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "mv" = (
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves)
+/turf/closed/ice_rock/corners,
+/area/space)
+"mw" = (
+/obj/structure/bookcase/manuals/research_and_development,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 9
+	},
+/area/icy_caves/caves/northern)
 "mx" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 8
@@ -2306,64 +2654,35 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
 "mz" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/end{
 	dir = 1
 	},
-/obj/structure/largecrate/random/case/small,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/west)
 "mA" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/largecrate/random/barrel/yellow,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/west)
 "mC" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/item/tank/air,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/west)
 "mD" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/corner{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/largecrate/goat,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/west)
 "mE" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/largecrate/random/barrel/green,
-/turf/open/floor/tile/dark,
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ2)
 "mG" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/structure/dispenser,
+/turf/open/floor/tile/dark/yellow2{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/item/storage/backpack,
-/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "mH" = (
 /turf/closed/ice/corner{
@@ -2395,77 +2714,58 @@
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/caves/south)
 "mP" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
+/obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "mQ" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
+	dir = 5
 	},
-/obj/structure/largecrate/random/barrel/white,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/west)
 "mR" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
+"mV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"mY" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
+	dir = 9
+	},
+/area/icy_caves/caves/west)
+"mZ" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
+"nb" = (
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/pizzabox/margherita,
-/obj/item/storage/donut_box,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"mY" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/reagent_scanner/adv,
-/obj/item/storage/firstaid/o2,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"nb" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
-/obj/item/flashlight,
-/obj/structure/prop/mainship/hangar_stencil/two,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "nc" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/machinery/light/small,
-/turf/open/floor/tile/dark,
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/tile/dark/yellow2,
 /area/icy_caves/outpost/LZ2)
 "nd" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/largecrate/random/barrel/white,
-/turf/open/floor/tile/dark,
+/obj/structure/largecrate/random/case/double,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
 "ne" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
+	dir = 10
+	},
+/area/icy_caves/caves)
+"nf" = (
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/reagent_dispensers/watertank,
-/obj/structure/prop/mainship/hangar_stencil/two,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"nf" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/table,
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/crayons,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "ng" = (
@@ -2486,33 +2786,47 @@
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/garage)
 "nl" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/table,
-/obj/item/roller,
-/obj/item/storage/firstaid,
-/obj/structure/prop/mainship/hangar_stencil/two,
-/turf/open/floor/tile/dark,
+/turf/open/floor/tile/dark/yellow2,
 /area/icy_caves/outpost/LZ2)
 "nm" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 6
 	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/largecrate/random/case,
-/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "np" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
+"ns" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "nu" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"nv" = (
+/obj/structure/table,
+/obj/item/corncob,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"nw" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
+"nx" = (
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/mining/west)
 "ny" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/ice_rock/single,
@@ -2521,11 +2835,22 @@
 /obj/docking_port/stationary/crashmode,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
+"nB" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "nD" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
+"nF" = (
+/obj/structure/janitorialcart,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "nH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -2536,6 +2861,10 @@
 "nI" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ2)
+"nK" = (
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "nL" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/outside/center)
@@ -2585,6 +2914,9 @@
 	dir = 10
 	},
 /area/icy_caves/outpost/garage)
+"od" = (
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/mining/west)
 "of" = (
 /turf/closed/ice/thin/end{
 	dir = 4
@@ -2618,6 +2950,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"op" = (
+/obj/structure/prop/mainship/sensor_computer3/sd,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern)
 "or" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/structure/cable,
@@ -2626,6 +2966,10 @@
 "ot" = (
 /turf/closed/ice/junction,
 /area/icy_caves/caves/northern)
+"ov" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall,
+/area/icy_caves/outpost/garage)
 "ow" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside/center)
@@ -2653,6 +2997,9 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"oF" = (
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/caves/east)
 "oI" = (
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
@@ -2665,6 +3012,12 @@
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
+"oM" = (
+/obj/structure/dropship_piece/two/front/right,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "oO" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -2672,10 +3025,35 @@
 "oP" = (
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ2)
+"oQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
+"oR" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 6
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "oS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"oT" = (
+/obj/structure/largecrate/supply/floodlights,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "oU" = (
 /obj/item/tool/pickaxe,
 /obj/structure/rack,
@@ -2688,11 +3066,17 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
+"pa" = (
+/turf/closed/wall,
+/area/icy_caves/outpost/outside)
 "pb" = (
 /turf/closed/ice_rock/corners{
 	dir = 9
 	},
 /area/icy_caves/caves/west)
+"pc" = (
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "pf" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = /obj/item/storage/backpack/satchel/norm;
@@ -2714,6 +3098,12 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"ph" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "pj" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -2722,9 +3112,8 @@
 /turf/closed/ice/straight,
 /area/icy_caves/caves/northern)
 "pl" = (
-/obj/structure/ore_box,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
+/turf/closed/wall/r_wall/unmeltable,
+/area/icy_caves/caves/northern)
 "pm" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/cable,
@@ -2733,7 +3122,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "po" = (
 /turf/open/floor/tile/dark/purple2{
 	dir = 4
@@ -2744,6 +3133,12 @@
 	dir = 1
 	},
 /area/icy_caves/caves)
+"pr" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "ps" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/dmg1,
@@ -2752,8 +3147,14 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/refinery)
+"pu" = (
+/obj/structure/barricade/guardrail{
+	dir = 4
+	},
+/obj/item/clothing/head/warning_cone,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "pw" = (
-/obj/structure/ore_box,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -2796,6 +3197,11 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside)
+"pE" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
 "pF" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/smg/m25,
@@ -2806,18 +3212,52 @@
 /obj/item/ammo_magazine/smg/m25,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"pH" = (
+/turf/closed/ice_rock/corners{
+	dir = 10
+	},
+/area/icy_caves/caves/west)
+"pL" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"pN" = (
+/obj/structure/janitorialcart,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "pO" = (
 /obj/item/ammo_casing,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"pP" = (
+/obj/structure/closet/crate,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick,
+/obj/item/storage/box/lightstick,
+/obj/item/tool/pickaxe/plasmacutter,
+/obj/effect/spawner/random/powercell,
+/obj/item/explosive/plastique,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "pR" = (
 /obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
+"pS" = (
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "pT" = (
 /obj/effect/landmark/fob_sentry,
+/obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "pU" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -2838,10 +3278,15 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
+"pZ" = (
+/obj/item/paper/crumpled/bloody,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "qa" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/space)
 "qb" = (
 /obj/machinery/conveyor{
 	dir = 5
@@ -2863,8 +3308,10 @@
 	},
 /area/icy_caves/outpost/refinery)
 "qe" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow/layer2,
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "qf" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -2872,7 +3319,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "qg" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plating,
@@ -2895,6 +3342,12 @@
 /obj/item/tool/pickaxe,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
+"qk" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
 "ql" = (
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
@@ -2939,6 +3392,13 @@
 	dir = 10
 	},
 /area/icy_caves/outpost/refinery)
+"qu" = (
+/obj/structure/dropship_piece/one/corner/middleleft,
+/obj/structure/dropship_piece/two/corner/rearleft,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "qw" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1
@@ -2959,6 +3419,15 @@
 "qz" = (
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves)
+"qA" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
 "qB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/tile/dark,
@@ -2988,12 +3457,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"qM" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
 "qN" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -3011,6 +3474,9 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"qR" = (
+/turf/closed/ice_rock/northWall,
+/area/icy_caves/caves/west)
 "qS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -3075,6 +3541,11 @@
 "rf" = (
 /turf/closed/ice/thin/end,
 /area/icy_caves/caves/northern)
+"rg" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 5
+	},
+/area/icy_caves/caves/northern)
 "rh" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/machinery/door/airlock/multi_tile/mainship/research{
@@ -3082,6 +3553,13 @@
 	},
 /turf/open/floor/tile/dark/purple2,
 /area/icy_caves/outpost/research)
+"rk" = (
+/obj/structure/table/reinforced,
+/obj/structure/xenoautopsy,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
 "rl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8
@@ -3102,7 +3580,7 @@
 /turf/closed/ice/thin/end{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "rq" = (
 /obj/structure/closet/fireaxecabinet,
 /turf/closed/wall/r_wall,
@@ -3192,6 +3670,10 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/engineering)
+"rI" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleT,
+/area/icy_caves/caves)
 "rJ" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -3281,9 +3763,11 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
 "sb" = (
-/obj/machinery/floodlight/landing,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
+	dir = 9
+	},
+/area/icy_caves/caves)
 "sc" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -3375,9 +3859,9 @@
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
 "ss" = (
-/obj/item/weapon/gun/syringe,
-/turf/open/floor/tile/dark/green2,
-/area/icy_caves/outpost/medbay)
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/LZ2)
 "st" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table,
@@ -3406,6 +3890,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/ai_node,
 /turf/open/floor/tile/dark/brown2{
 	dir = 8
 	},
@@ -3434,10 +3919,10 @@
 	},
 /area/icy_caves/outpost/medbay)
 "sD" = (
-/obj/machinery/landinglight/ds1/delaythree{
+/obj/effect/landmark/fob_sentry_rebel,
+/turf/closed/ice_rock/singleEnd{
 	dir = 8
 	},
-/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "sE" = (
 /obj/machinery/light/small{
@@ -3445,6 +3930,11 @@
 	},
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"sG" = (
+/obj/structure/bed/chair,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "sH" = (
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
@@ -3452,8 +3942,9 @@
 /turf/closed/ice/thin/corner,
 /area/icy_caves/caves/east)
 "sK" = (
-/obj/docking_port/stationary/marine_dropship/lz1,
-/turf/open/floor/plating,
+/obj/machinery/power/apc/lowcharge,
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
 /area/icy_caves/outpost/LZ1)
 "sN" = (
 /obj/structure/table/flipped,
@@ -3479,6 +3970,13 @@
 /obj/item/weapon/gun/rifle/ak47,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"ta" = (
+/obj/effect/decal/cleanable/vomit,
+/obj/machinery/camera{
+	dir = 5
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "tb" = (
 /obj/structure/sink,
 /obj/machinery/light{
@@ -3525,6 +4023,10 @@
 /obj/item/clothing/shoes/laceup,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"tl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside)
 "tm" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -3532,6 +4034,17 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"tn" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
+	dir = 8
+	},
+/area/icy_caves/caves)
+"tp" = (
+/obj/item/lightstick/anchored,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "tq" = (
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/plating/ground/ice,
@@ -3549,12 +4062,27 @@
 	dir = 2
 	},
 /turf/closed/ice/junction,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "tw" = (
-/turf/closed/ice_rock/singleEnd{
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
+"tx" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/blue2{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
+"tA" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside/center)
 "tB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -3582,6 +4110,11 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/engineering)
+"tF" = (
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "tH" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/research)
@@ -3632,6 +4165,11 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"tT" = (
+/obj/structure/table/mainship,
+/obj/machinery/computer/med_data,
+/turf/open/floor/mainship/mono,
+/area/icy_caves/caves/northern)
 "tU" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -3701,6 +4239,15 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
+"ul" = (
+/obj/structure/dropship_piece/two/corner/rearright,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
+"un" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "uo" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -3723,6 +4270,18 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ2)
+"us" = (
+/obj/structure/shuttle/engine/router{
+	dir = 1
+	},
+/obj/structure/dropship_equipment/weapon/heavygun,
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/shuttle/dropship/floor,
+/area/space)
+"uu" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "uv" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/grilledcheese,
@@ -3731,6 +4290,16 @@
 "uw" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
+"ux" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/mass_spectrometer/adv,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/icy_caves/caves/northern)
 "uy" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -3772,11 +4341,15 @@
 /turf/closed/ice/straight{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "uN" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"uO" = (
+/obj/structure/dropship_piece/two/corner/rearleft,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "uP" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -3803,6 +4376,13 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/medbay)
+"uT" = (
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "uX" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -3834,6 +4414,12 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"ve" = (
+/obj/machinery/power/apc/drained{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "vf" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/outpost/outside)
@@ -3864,6 +4450,11 @@
 	dir = 10
 	},
 /area/icy_caves/outpost/engineering)
+"vn" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "25"
+	},
+/area/icy_caves/caves/northern)
 "vo" = (
 /obj/machinery/light{
 	dir = 1
@@ -3884,6 +4475,10 @@
 	dir = 6
 	},
 /area/icy_caves/outpost/garage)
+"vr" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/ice/thin/straight,
+/area/icy_caves/outpost/LZ1)
 "vs" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -3894,6 +4489,23 @@
 /obj/structure/bed/roller,
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
+"vu" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd,
+/area/icy_caves/caves)
+"vv" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
+"vw" = (
+/obj/structure/largecrate/random,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "vx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
@@ -3955,7 +4567,7 @@
 "vR" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/end,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "vS" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/tile/dark,
@@ -3965,7 +4577,7 @@
 	dir = 1
 	},
 /turf/closed/ice/corner,
-/area/icy_caves/caves/east)
+/area/icy_caves/outpost/LZ2)
 "vX" = (
 /obj/item/flashlight,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4000,16 +4612,30 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
+"wf" = (
+/obj/structure/barricade/guardrail{
+	dir = 1
+	},
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "wg" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
+"wh" = (
+/obj/structure/morgue/crematorium,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "wi" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/tile/dark/green2{
 	dir = 4
 	},
 /area/icy_caves/outpost/medbay)
+"wj" = (
+/obj/structure/largecrate/random/barrel/yellow,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "wk" = (
 /turf/open/floor/tile/dark/red2/corner,
 /area/icy_caves/outpost/security)
@@ -4031,6 +4657,17 @@
 /turf/closed/ice/end{
 	dir = 8
 	},
+/area/icy_caves/caves/northern)
+"wq" = (
+/obj/machinery/light,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
+"ws" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "wu" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
@@ -4062,15 +4699,19 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/medbay)
+"wG" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "wH" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/refinery)
 "wL" = (
-/obj/machinery/landinglight/ds1/delaythree{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/turf/open/floor/mech_bay_recharge_floor,
 /area/icy_caves/outpost/LZ1)
 "wM" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -4081,7 +4722,12 @@
 "wN" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
+"wO" = (
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "wP" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -4095,6 +4741,19 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
+"wT" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/space)
 "wW" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
@@ -4152,6 +4811,21 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
+"xo" = (
+/obj/structure/closet/crate,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick,
+/obj/item/storage/box/lightstick,
+/obj/item/tool/pickaxe/plasmacutter,
+/obj/effect/spawner/random/powercell,
+/obj/item/clothing/glasses/welding,
+/obj/item/explosive/plastique,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "xr" = (
 /obj/machinery/mineral/stacking_machine,
 /obj/machinery/conveyor{
@@ -4159,6 +4833,10 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/refinery)
+"xs" = (
+/obj/structure/barricade/guardrail,
+/turf/open/floor/mainship/red/full,
+/area/icy_caves/caves/northern)
 "xu" = (
 /obj/structure/cargo_container/green,
 /turf/open/floor/plating,
@@ -4210,6 +4888,10 @@
 "xR" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"xS" = (
+/obj/machinery/computer3/server,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "xT" = (
 /turf/open/floor/tile/dark/green2/corner{
 	dir = 4
@@ -4222,13 +4904,42 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"xW" = (
+/obj/structure/largecrate/supply/explosives/mortar_flare,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "xX" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/caves/south)
+"xZ" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "ya" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves)
+"yb" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
+"yd" = (
+/obj/structure/monorail,
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/floor/mainship_hull,
+/area/space)
+"ye" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/r_wall,
+/area/icy_caves/outpost/dorms)
 "yg" = (
 /obj/structure/bookcase/manuals,
 /obj/machinery/light{
@@ -4241,6 +4952,12 @@
 "yh" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/northern)
+"yi" = (
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
 /area/icy_caves/caves/northern)
 "yj" = (
 /obj/structure/closet/crate/secure/weapon,
@@ -4265,6 +4982,12 @@
 "yq" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/outpost/LZ2)
+"yv" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "yw" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/machinery/light,
@@ -4273,6 +4996,10 @@
 "yx" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/engineering)
+"yz" = (
+/obj/structure/bed/chair,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "yB" = (
 /turf/closed/ice/thin/junction{
 	dir = 8
@@ -4289,6 +5016,14 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"yF" = (
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/space)
 "yG" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -4297,6 +5032,12 @@
 	dir = 8
 	},
 /area/icy_caves/caves)
+"yH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "yJ" = (
 /obj/structure/closet/crate/construction,
 /obj/item/cell/hyper,
@@ -4333,20 +5074,21 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/garage)
-"yW" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
+"yV" = (
+/obj/effect/spawner/gibspawner/human,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
 	},
-/turf/closed/ice_rock/singlePart{
-	dir = 6
-	},
-/area/icy_caves/outpost/outside)
-"zb" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/closed/ice_rock/fourway,
-/area/icy_caves/outpost/outside)
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"zd" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/LZ2)
+"ze" = (
+/obj/structure/largecrate/random/case/double,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "zh" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -4355,6 +5097,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"zi" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/ice_rock/corners{
+	dir = 9
+	},
+/area/icy_caves/caves)
 "zk" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleT{
@@ -4368,7 +5118,7 @@
 /turf/closed/ice/corner{
 	dir = 8
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "zm" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/drained,
@@ -4394,6 +5144,25 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/garage)
+"zs" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/single,
+/area/icy_caves/caves)
+"zt" = (
+/turf/open/floor/tile/white/warningstripe{
+	dir = 6
+	},
+/area/icy_caves/caves/northern)
+"zu" = (
+/obj/machinery/door/airlock/multi_tile/mainship/secdoor,
+/turf/open/floor/mainship/red/full,
+/area/icy_caves/caves/northern)
+"zv" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd{
+	dir = 4
+	},
+/area/icy_caves/caves)
 "zw" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -4414,6 +5183,9 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/refinery)
+"zB" = (
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "zC" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/tile/dark,
@@ -4442,10 +5214,8 @@
 /turf/closed/ice_rock/singlePart,
 /area/icy_caves/caves)
 "zM" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/obj/machinery/landinglight/ds1/delaytwo,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "zN" = (
 /obj/effect/landmark/excavation_site_spawner,
@@ -4464,9 +5234,9 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
 "zS" = (
-/turf/closed/ice/end{
-	dir = 4
-	},
+/obj/machinery/landinglight/ds1/delaytwo,
+/obj/machinery/floodlight/landing,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "zT" = (
 /obj/machinery/iv_drip,
@@ -4498,6 +5268,12 @@
 	dir = 9
 	},
 /area/icy_caves/outpost/medbay)
+"zZ" = (
+/obj/machinery/door/airlock/mainship/secure/locked/free_access{
+	dir = 2
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Aa" = (
 /obj/item/storage/box/flashbangs,
 /obj/item/storage/box/m94,
@@ -4507,6 +5283,10 @@
 /obj/structure/closet/crate/secure/explosives,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Ab" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "Ad" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -4516,12 +5296,19 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/garage)
-"Ag" = (
-/obj/machinery/landinglight/ds1/delaytwo{
-	dir = 4
+"Ae" = (
+/turf/closed/ice_rock/eastWall,
+/area/icy_caves/caves/northern)
+"Af" = (
+/obj/vehicle/multitile/root/cm_armored/tank{
+	dir = 1;
+	layer = 1
 	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
+/obj/structure/dropship_equipment/weapon/laser_beam_gun,
+/obj/effect/turf_overlay/shuttle/heater,
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/shuttle/dropship/floor,
+/area/space)
 "Ah" = (
 /obj/effect/landmark/corpsespawner/security{
 	corpsebelt = /obj/item/weapon/gun/revolver/cmb;
@@ -4551,6 +5338,12 @@
 /obj/machinery/processor,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
+"Aq" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/snow,
+/area/icy_caves/outpost/LZ1)
 "Ar" = (
 /obj/structure/closet/crate/secure/ammo,
 /obj/item/ammo_magazine/smg/m25,
@@ -4636,23 +5429,25 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/office)
-"AH" = (
-/obj/machinery/landinglight/ds1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
 "AI" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 4
 	},
 /area/icy_caves/outpost/refinery)
+"AJ" = (
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "AK" = (
 /turf/closed/ice/end{
 	dir = 1
 	},
 /area/icy_caves/outpost/outside)
+"AL" = (
+/turf/closed/ice/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "AM" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/cable,
@@ -4665,6 +5460,19 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
+"AQ" = (
+/obj/machinery/disposal,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"AR" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
 "AS" = (
 /obj/machinery/power/geothermal,
 /obj/machinery/light/small{
@@ -4715,6 +5523,10 @@
 	dir = 4
 	},
 /area/icy_caves/caves)
+"Bb" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/caves/west)
 "Bd" = (
 /obj/machinery/door/airlock/multi_tile/mainship/secdoor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4727,6 +5539,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"Bf" = (
+/turf/open/floor/tile/dark/green2{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "Bi" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/prison/kitchen,
@@ -4741,13 +5558,29 @@
 	dir = 1
 	},
 /area/icy_caves/caves/east)
+"Bo" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Bq" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
+"Br" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/shuttle/canterbury)
 "Bs" = (
 /turf/open/floor/podhatch/floor,
 /area/icy_caves/outpost/engineering)
+"Bt" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "Bu" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -4778,6 +5611,23 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
+"BB" = (
+/obj/structure/cryofeed,
+/turf/open/floor/podhatch/floor{
+	icon_state = "bcircuitoff"
+	},
+/area/icy_caves/caves/northern)
+"BD" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/northWall,
+/area/icy_caves/caves)
+"BF" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "BI" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -4795,6 +5645,18 @@
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/dorms)
+"BN" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "52"
+	},
+/area/icy_caves/caves/northern)
+"BO" = (
+/obj/machinery/door/airlock/multi_tile/secure{
+	dir = 2
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "BP" = (
 /turf/closed/ice/junction{
 	dir = 4
@@ -4830,6 +5692,12 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"BW" = (
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "BX" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -4839,10 +5707,25 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "BY" = (
-/turf/closed/ice/thin/end{
-	dir = 8
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 6
 	},
-/area/icy_caves/outpost/LZ1)
+/obj/structure/monorail{
+	dir = 10
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/space)
+"BZ" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Ch" = (
+/obj/machinery/computer3/server/rack,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Ci" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -4856,6 +5739,29 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
+"Cl" = (
+/obj/machinery/camera{
+	dir = 5
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Cm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
+"Cq" = (
+/turf/closed/ice/thin/end{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "Cs" = (
 /obj/item/ammo_casing,
 /turf/open/floor/wood,
@@ -4877,6 +5783,17 @@
 /obj/item/clothing/shoes/rainbow,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"CH" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 10
+	},
+/area/icy_caves/caves/northern)
+"CL" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside)
 "CN" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/south)
@@ -4904,6 +5821,10 @@
 	dir = 9
 	},
 /area/icy_caves/outpost/refinery)
+"CX" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "CZ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -4948,6 +5869,13 @@
 	},
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
+"Dm" = (
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "Dn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -4955,10 +5883,25 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
+"Do" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "Dp" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleEnd{
 	dir = 1
+	},
+/area/icy_caves/caves)
+"Dr" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd{
+	dir = 8
 	},
 /area/icy_caves/caves)
 "Ds" = (
@@ -4988,6 +5931,11 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Dx" = (
+/turf/open/floor/tile/dark/yellow2{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "DB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/singlePart{
@@ -5005,6 +5953,13 @@
 /obj/effect/decal/cleanable/blood/writing,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"DH" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/closed/ice/end{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
 "DJ" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 4
@@ -5020,7 +5975,7 @@
 /turf/closed/ice/thin/corner{
 	dir = 8
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "DM" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 10
@@ -5031,6 +5986,22 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"DS" = (
+/obj/structure/dropship_piece/one/corner/middleright,
+/obj/structure/dropship_piece/two/corner/rearright,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
+"DU" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
+"DV" = (
+/obj/structure/mopbucket,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "DW" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -5041,6 +6012,11 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/garage)
+"DX" = (
+/turf/closed/ice_rock/corners{
+	dir = 9
+	},
+/area/icy_caves/outpost/LZ1)
 "DY" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
@@ -5049,6 +6025,12 @@
 	dir = 6
 	},
 /area/icy_caves/caves/west)
+"Ea" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Eb" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/effect/ai_node,
@@ -5073,6 +6055,14 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"Eh" = (
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/space)
 "Ej" = (
 /obj/structure/table,
 /obj/item/stack/nanopaste,
@@ -5080,6 +6070,11 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/medbay)
+"Ek" = (
+/obj/structure/table/mainship,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "El" = (
 /obj/structure/table/reinforced,
 /obj/effect/landmark/dropship_console_spawn_lz2,
@@ -5090,7 +6085,7 @@
 	dir = 2
 	},
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Ep" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -5116,10 +6111,15 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"Ex" = (
+/obj/effect/decal/cleanable/mucus,
+/obj/structure/table,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "Ey" = (
 /obj/effect/landmark/fob_sentry_rebel,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "Ez" = (
 /obj/structure/bed,
 /turf/open/floor/wood,
@@ -5167,20 +6167,38 @@
 /area/icy_caves/caves/south)
 "EO" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/closed/wall/r_wall,
-/area/icy_caves/outpost/outside)
+/turf/closed/ice/thin/junction,
+/area/icy_caves/outpost/LZ1)
+"EP" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "EQ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/corner{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "ES" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/closed/ice_rock/westWall,
 /area/icy_caves/caves)
+"ET" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside)
+"EU" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"EX" = (
+/obj/structure/largecrate/supply/floodlights,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "EZ" = (
 /obj/item/ammo_casing,
 /obj/structure/cable,
@@ -5219,6 +6237,17 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"Fj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Fk" = (
+/obj/structure/barricade/guardrail,
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "Fm" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -5236,6 +6265,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"Fq" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "Fr" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/purple2{
@@ -5271,9 +6304,18 @@
 	dir = 1
 	},
 /area/icy_caves/caves/northern)
+"Fw" = (
+/turf/open/floor/tile/white/warningstripe{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "Fy" = (
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
+"FB" = (
+/obj/machinery/light,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "FF" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -5317,6 +6359,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"FR" = (
+/turf/closed/shuttle/dropship2/transparent{
+	icon_state = "109"
+	},
+/area/icy_caves/caves/northern)
 "FU" = (
 /obj/structure/cargo_container/ch_red,
 /turf/open/floor/plating,
@@ -5357,6 +6404,24 @@
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Gf" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Gh" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/structure/table/mainship,
+/obj/structure/cable,
+/obj/machinery/computer/nuke_disk_generator/blue,
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern)
+"Gj" = (
+/obj/machinery/computer/operating,
+/obj/structure/table/reinforced,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Gk" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -5374,6 +6439,10 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"Gn" = (
+/obj/structure/largecrate/random/barrel/green,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Go" = (
 /turf/open/floor/tile/dark/purple2/corner{
 	dir = 1
@@ -5387,25 +6456,43 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
+"Gs" = (
+/turf/closed/ice_rock/corners,
+/area/icy_caves/caves/northern)
 "Gu" = (
 /turf/closed/ice,
 /area/icy_caves/outpost/outside)
 "Gw" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/refinery)
+"Gx" = (
+/obj/structure/mopbucket,
+/obj/machinery/power/apc/drained,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "Gz" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleT,
 /area/icy_caves/caves)
-"GC" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow,
-/area/icy_caves/outpost/LZ1)
 "GD" = (
 /turf/open/floor/tile/dark/red2/corner{
 	dir = 1
 	},
 /area/icy_caves/outpost/security)
+"GE" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
+"GF" = (
+/turf/closed/wall,
+/area/icy_caves/caves/west)
+"GG" = (
+/turf/closed/ice/thin/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "GH" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/ice,
@@ -5417,7 +6504,7 @@
 /turf/closed/ice/thin/corner{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "GK" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
@@ -5438,6 +6525,35 @@
 	dir = 4
 	},
 /area/icy_caves/caves)
+"GN" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/space)
+"GO" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ2)
+"GP" = (
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/caves/east)
+"GQ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "GR" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -5452,6 +6568,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"GU" = (
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "GV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -5461,7 +6583,6 @@
 	},
 /area/icy_caves/outpost/medbay)
 "GX" = (
-/obj/machinery/computer/nuke_disk_generator/blue,
 /turf/open/floor/tile/dark/purple2{
 	dir = 9
 	},
@@ -5479,6 +6600,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
+"He" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Hf" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/dorms)
@@ -5498,10 +6623,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
+"Hj" = (
+/obj/structure/table/mainship,
+/obj/machinery/recharger,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "Hl" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "Hm" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -5526,6 +6659,10 @@
 /obj/machinery/light/small,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"Hw" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
 "HA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -5539,10 +6676,13 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "HC" = (
-/turf/closed/ice_rock/singlePart{
+/obj/structure/monorail,
+/obj/structure/lattice,
+/obj/structure/monorail{
 	dir = 4
 	},
-/area/icy_caves/outpost/LZ1)
+/turf/open/floor/mainship_hull,
+/area/space)
 "HE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -5550,6 +6690,11 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
+"HF" = (
+/turf/closed/ice/corner{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "HG" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/south)
@@ -5560,13 +6705,18 @@
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "HJ" = (
 /obj/machinery/vending/MarineMed/Blood,
 /turf/open/floor/tile/dark/green2{
 	dir = 4
 	},
 /area/icy_caves/outpost/medbay)
+"HL" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 6
+	},
+/area/icy_caves/caves/northern)
 "HM" = (
 /obj/item/ammo_casing,
 /turf/open/floor/tile/dark/brown2/corner{
@@ -5581,6 +6731,21 @@
 /obj/item/clothing/head/nun_hood,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"HP" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"HQ" = (
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "HR" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -5597,6 +6762,18 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"HT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"HU" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "HV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/corners{
@@ -5620,12 +6797,33 @@
 "Ie" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"If" = (
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor/mainship/cargo,
+/area/icy_caves/caves/northern)
+"Ig" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
 "Ih" = (
 /obj/structure/cargo_container/green{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Ij" = (
+/obj/structure/largecrate/random/barrel/green,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "Ik" = (
 /obj/structure/table,
 /obj/item/storage/box/flashbangs,
@@ -5634,9 +6832,13 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/security)
+"Il" = (
+/turf/closed/ice_rock/southWall,
+/area/icy_caves/caves/northern)
 "Im" = (
-/turf/open/floor/plating/ground/snow,
-/area/icy_caves/outpost/outside)
+/obj/item/shard,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "In" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -5668,6 +6870,10 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/garage)
+"It" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/outside)
 "Iv" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating,
@@ -5723,12 +6929,23 @@
 	},
 /turf/open/floor/tile/dark/red2,
 /area/icy_caves/outpost/security)
+"II" = (
+/obj/item/paper/crumpled/bloody/csheet,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "IJ" = (
 /obj/machinery/vending/security,
 /turf/open/floor/tile/dark/red2{
 	dir = 9
 	},
 /area/icy_caves/outpost/security)
+"IK" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "IO" = (
 /obj/structure/closet/crate/construction,
 /obj/item/stack/sheet/metal/medium_stack,
@@ -5740,6 +6957,14 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
+"IP" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "IR" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
@@ -5753,10 +6978,23 @@
 "IT" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"IU" = (
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "IX" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"IY" = (
+/obj/item/tool/surgery/hemostat,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"IZ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside)
 "Je" = (
 /turf/closed/ice/thin/end{
 	dir = 8
@@ -5771,6 +7009,12 @@
 "Jg" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/west)
+"Jh" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
+	dir = 5
+	},
+/area/icy_caves/caves)
 "Ji" = (
 /obj/effect/landmark/start/job/survivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -5796,7 +7040,10 @@
 /turf/closed/ice/thin/junction{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
+"Jn" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "Jo" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
@@ -5812,7 +7059,7 @@
 /turf/closed/ice/end{
 	dir = 1
 	},
-/area/icy_caves/caves/east)
+/area/icy_caves/outpost/LZ2)
 "Jq" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/dark,
@@ -5859,6 +7106,13 @@
 /obj/item/lightstick/anchored,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"JF" = (
+/obj/machinery/vending/cola,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "JH" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/pepper,
@@ -5891,6 +7145,16 @@
 	dir = 5
 	},
 /area/icy_caves/caves)
+"JR" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/structure/monorail{
+	dir = 9
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
 "JS" = (
 /obj/structure/closet/crate/freezer/rations,
 /turf/open/floor/tile/dark,
@@ -5901,11 +7165,16 @@
 	dir = 6
 	},
 /area/icy_caves/outpost/medbay)
+"JW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside/center)
 "JX" = (
 /turf/closed/ice/end,
 /area/icy_caves/caves/south)
 "JY" = (
-/turf/closed/ice/thin/single,
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "Ka" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -5918,6 +7187,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/office)
+"Kd" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "Ke" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -5946,8 +7221,8 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "Ko" = (
-/turf/closed/ice_rock/singleEnd,
-/area/icy_caves/outpost/outside)
+/turf/open/floor/tile/dark/blue2,
+/area/icy_caves/outpost/LZ2)
 "Kp" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
@@ -6008,12 +7283,18 @@
 "KJ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "KK" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 1
 	},
 /area/icy_caves/caves/south)
+"KL" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "KM" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 9
@@ -6025,11 +7306,20 @@
 /obj/item/clothing/suit/hgpirate,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"KP" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "54"
+	},
+/area/icy_caves/caves/northern)
 "KS" = (
 /turf/open/floor/tile/dark/red2{
 	dir = 5
 	},
 /area/icy_caves/outpost/security)
+"KT" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall,
+/area/icy_caves/outpost/mining/west)
 "KU" = (
 /turf/closed/ice/thin/corner{
 	dir = 1
@@ -6043,6 +7333,14 @@
 "KZ" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/garage)
+"La" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/white/warningstripe{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "Lb" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/tile/dark,
@@ -6086,12 +7384,31 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
+"Lo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	on = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Lp" = (
+/turf/open/floor/tile/white/warningstripe,
+/area/icy_caves/caves/northern)
 "Lq" = (
 /obj/machinery/power/geothermal,
 /obj/machinery/light/small,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
+"Lr" = (
+/obj/item/shard,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
+"Ls" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Lt" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = null;
@@ -6111,6 +7428,10 @@
 "Lv" = (
 /turf/closed/ice/thin,
 /area/icy_caves/outpost/outside)
+"Lw" = (
+/obj/structure/closet/l3closet/virology,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "Lx" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 10
@@ -6141,6 +7462,13 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"LF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "LH" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
@@ -6172,9 +7500,9 @@
 /area/icy_caves/outpost/garage)
 "LL" = (
 /obj/machinery/landinglight/ds1/delaytwo{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "LO" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -6187,7 +7515,7 @@
 /turf/closed/ice/thin/end{
 	dir = 8
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "LQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -6243,6 +7571,17 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"Me" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
+"Mf" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/red/full,
+/area/icy_caves/caves/northern)
 "Mg" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 5
@@ -6288,10 +7627,15 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
+"Mq" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "Ms" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Mt" = (
 /obj/item/ammo_casing,
 /turf/open/floor/tile/dark/red2{
@@ -6306,12 +7650,34 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"Mv" = (
+/obj/machinery/optable,
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Mw" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
+"Mx" = (
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Mz" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/corner{
 	dir = 4
 	},
 /area/icy_caves/outpost/LZ1)
+"MA" = (
+/obj/structure/barricade/guardrail,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "MB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -6327,6 +7693,11 @@
 	dir = 8
 	},
 /area/icy_caves/caves/south)
+"MH" = (
+/turf/closed/ice/thin/end{
+	dir = 1
+	},
+/area/icy_caves/caves)
 "MJ" = (
 /turf/closed/ice/corner{
 	dir = 1
@@ -6352,10 +7723,10 @@
 	},
 /area/icy_caves/caves/south)
 "MO" = (
-/obj/machinery/landinglight/ds1{
-	dir = 1
+/obj/machinery/landinglight/ds1/delaytwo{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "MP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -6368,6 +7739,11 @@
 /obj/machinery/space_heater,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
+"MT" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/cheeseburger,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "MV" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -6379,6 +7755,21 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"MX" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
+"MY" = (
+/obj/item/reagent_containers/spray/pepper,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 6
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "MZ" = (
 /obj/machinery/door/airlock/mainship/command/free_access{
 	dir = 1;
@@ -6430,10 +7821,10 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "Np" = (
 /turf/closed/ice/intersection,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Nq" = (
 /turf/closed/ice/end{
 	dir = 4
@@ -6447,11 +7838,16 @@
 /obj/structure/cable,
 /obj/effect/landmark/fob_sentry,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Nt" = (
 /obj/item/ammo_magazine/smg/m25,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"Nu" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "Nv" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -6488,6 +7884,12 @@
 	},
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/refinery)
+"NH" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside)
 "NJ" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -6509,6 +7911,13 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"NM" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "NN" = (
 /obj/structure/filingcabinet,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -6540,6 +7949,15 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/outside)
+"NU" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 10
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"NW" = (
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "Ob" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark,
@@ -6548,6 +7966,16 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"Od" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 6
+	},
+/obj/structure/monorail{
+	dir = 10
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
 "Oe" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark/brown2{
@@ -6573,6 +8001,12 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"Oo" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "Os" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -6598,10 +8032,16 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
+"Ox" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern)
 "Oy" = (
 /obj/docking_port/mobile/crashmode/bigbury,
-/turf/open/floor/plating/ground/snow/layer1,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "OA" = (
 /turf/closed/ice/thin/corner{
@@ -6615,7 +8055,7 @@
 "OD" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "OE" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/dark/brown2,
@@ -6636,9 +8076,10 @@
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
 "OI" = (
-/obj/machinery/computer/intel_computer,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/space)
 "OJ" = (
 /turf/closed/ice/end,
 /area/icy_caves/outpost/outside)
@@ -6654,6 +8095,9 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
+"OP" = (
+/turf/open/floor/mainship/red/full,
+/area/icy_caves/caves/northern)
 "OQ" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/kitchen,
@@ -6668,6 +8112,12 @@
 "Pd" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/security)
+"Pg" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Pi" = (
 /turf/closed/ice/corner{
 	dir = 8
@@ -6688,6 +8138,12 @@
 	dir = 8
 	},
 /area/icy_caves/caves/south)
+"Pp" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/tile/white/warningstripe{
+	dir = 5
+	},
+/area/icy_caves/caves/northern)
 "Pq" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 8
@@ -6726,7 +8182,7 @@
 /turf/closed/ice/junction{
 	dir = 8
 	},
-/area/icy_caves/caves/east)
+/area/icy_caves/outpost/LZ2)
 "PD" = (
 /turf/closed/ice/corner{
 	dir = 4
@@ -6751,6 +8207,13 @@
 	dir = 8
 	},
 /area/icy_caves/caves)
+"PN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8;
+	welded = 1
+	},
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "PO" = (
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
@@ -6760,6 +8223,14 @@
 /obj/item/weapon/gun/smg/m25,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"PR" = (
+/turf/closed/ice/junction{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
+"PS" = (
+/turf/closed/ice/thin/corner,
+/area/icy_caves/outpost/LZ2)
 "PT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -6795,6 +8266,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
+"PZ" = (
+/turf/open/floor/tile/dark/green2,
+/area/icy_caves/caves/northern)
 "Qa" = (
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
@@ -6807,12 +8281,24 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"Qe" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "Qf" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/green2{
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
+"Qg" = (
+/obj/structure/prop/mainship/sensor_computer2,
+/obj/structure/cable,
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern)
 "Qh" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 6
@@ -6829,11 +8315,22 @@
 "Qk" = (
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"Qp" = (
-/turf/closed/ice_rock/singleEnd{
+"Qn" = (
+/obj/structure/barricade/guardrail,
+/obj/structure/bed/chair/dropship/passenger{
 	dir = 8
 	},
-/area/icy_caves/outpost/outside)
+/turf/open/shuttle/dropship/seven,
+/area/space)
+"Qo" = (
+/turf/closed/ice_rock/corners{
+	dir = 9
+	},
+/area/icy_caves/caves/northern)
+"Qp" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/blue2,
+/area/icy_caves/outpost/LZ2)
 "Qq" = (
 /turf/closed/ice/corner{
 	dir = 4
@@ -6862,6 +8359,12 @@
 /obj/effect/decal/cleanable/blood/writing,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"QD" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/red/full,
+/area/icy_caves/caves/northern)
 "QF" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating,
@@ -6905,6 +8408,15 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/outside)
+"QQ" = (
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "QR" = (
 /obj/machinery/light,
 /turf/open/floor/tile/dark/brown2,
@@ -7009,6 +8521,15 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"Rt" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Ru" = (
 /obj/structure/table/woodentable,
 /obj/structure/paper_bin,
@@ -7018,6 +8539,18 @@
 "Rv" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves)
+"Rw" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "103"
+	},
+/area/icy_caves/caves/northern)
+"Rx" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/blood,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "Ry" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 8
@@ -7031,8 +8564,13 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
 "RA" = (
-/turf/closed/ice_rock/singleT,
-/area/icy_caves/outpost/outside)
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/mining/west)
 "RB" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/brown2{
@@ -7069,6 +8607,18 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"RL" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
+"RM" = (
+/obj/structure/monorail,
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 4
+	},
+/turf/open/floor/mainship_hull,
+/area/icy_caves/caves/northern)
 "RN" = (
 /turf/closed/ice_rock/corners{
 	dir = 5
@@ -7081,12 +8631,19 @@
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
 "RQ" = (
-/turf/closed/ice_rock/fourway,
-/area/icy_caves/outpost/outside)
+/obj/machinery/door/airlock/multi_tile/mainship/research,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "RS" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/southWall,
 /area/icy_caves/caves)
+"RT" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside/center)
 "RW" = (
 /turf/closed/ice/end{
 	dir = 4
@@ -7112,6 +8669,20 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
+"Se" = (
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
+"Sf" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "Sg" = (
 /turf/closed/ice/end{
 	dir = 4
@@ -7121,8 +8692,16 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/closed/ice_rock/single,
+/turf/closed/ice_rock/singleEnd{
+	dir = 8
+	},
 /area/icy_caves/caves)
+"Si" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
 "Sk" = (
 /obj/machinery/space_heater,
 /turf/open/floor/tile/dark/red2{
@@ -7152,16 +8731,20 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/security)
+"Ss" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "104"
+	},
+/area/icy_caves/caves/northern)
 "Sv" = (
 /turf/closed/ice_rock/singleT{
 	dir = 4
 	},
 /area/icy_caves/caves/south)
 "Sw" = (
-/turf/closed/ice_rock/singleEnd{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ1)
+/obj/machinery/telecomms/relay/preset/telecomms,
+/turf/open/floor/plating/icefloor,
+/area/lv624/lazarus/console)
 "Sy" = (
 /turf/open/floor/tile/dark/green2/corner{
 	dir = 8
@@ -7172,6 +8755,11 @@
 	dir = 4
 	},
 /area/icy_caves/caves/south)
+"SB" = (
+/turf/closed/ice/thin/end{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ1)
 "SD" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 4
@@ -7189,18 +8777,13 @@
 "SI" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
-"SJ" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/closed/ice_rock/singlePart{
-	dir = 4
-	},
-/area/icy_caves/outpost/outside)
 "SM" = (
 /obj/structure/closet/crate/internals,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"SO" = (
+/turf/closed/ice_rock/eastWall,
+/area/icy_caves/caves/west)
 "SP" = (
 /turf/closed/ice_rock/singleT{
 	dir = 1
@@ -7231,6 +8814,12 @@
 	},
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/caves)
+"SY" = (
+/obj/structure/bookcase/manuals/research_and_development,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
 "Tb" = (
 /turf/closed/ice_rock/singleT{
 	dir = 1
@@ -7251,21 +8840,44 @@
 /turf/closed/ice_rock/singleEnd{
 	dir = 8
 	},
+/area/icy_caves/outpost/LZ1)
+"Th" = (
+/obj/structure/barricade/guardrail{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Tj" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside)
 "Tk" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside/center)
+"Tl" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ2)
 "Tm" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/turf/closed/ice/thin/straight,
+/area/icy_caves/outpost/LZ1)
 "Tr" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"Ts" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Tu" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 1
@@ -7279,6 +8891,17 @@
 	dir = 5
 	},
 /area/icy_caves/caves)
+"Tx" = (
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor{
+	name = "\improper Lambda Lab"
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Tz" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "TB" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -7289,6 +8912,22 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"TC" = (
+/obj/structure/barricade/guardrail{
+	dir = 4
+	},
+/obj/structure/xenoautopsy/tank/escaped,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
+"TD" = (
+/obj/machinery/camera{
+	dir = 9
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "TE" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -7297,19 +8936,26 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
+"TF" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/brown2,
+/area/icy_caves/outpost/refinery)
 "TH" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
 "TI" = (
-/obj/machinery/landinglight/ds1/delaytwo{
-	dir = 1
+/obj/machinery/landinglight/ds1/delaythree{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "TJ" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/east)
+"TK" = (
+/turf/open/floor/mainship/red,
+/area/icy_caves/caves/northern)
 "TL" = (
 /obj/structure/cargo_container/gorg{
 	dir = 4
@@ -7319,14 +8965,20 @@
 "TM" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/LZ1)
+"TN" = (
+/obj/effect/spawner/gibspawner/human,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "TQ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "TR" = (
 /obj/structure/table/flipped,
+/obj/machinery/computer/nuke_disk_generator/green,
 /turf/open/floor/tile/dark/red2{
 	dir = 1
 	},
@@ -7334,7 +8986,7 @@
 "TT" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "TU" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/docking_port/mobile/crashmode/bigbury,
@@ -7358,6 +9010,16 @@
 	dir = 6
 	},
 /area/icy_caves/caves)
+"TZ" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 10
+	},
+/obj/structure/monorail{
+	dir = 6
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/space)
 "Ub" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 1
@@ -7383,8 +9045,10 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "Ud" = (
-/obj/machinery/floodlight/landing,
-/turf/open/floor/plating/ground/snow/layer2,
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "Ug" = (
 /obj/machinery/power/apc/drained,
@@ -7398,7 +9062,7 @@
 	dir = 2
 	},
 /turf/closed/ice/intersection,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Uk" = (
 /turf/closed/ice/thin/end,
 /area/icy_caves/caves/south)
@@ -7413,14 +9077,14 @@
 	dir = 1
 	},
 /turf/closed/ice/intersection,
-/area/icy_caves/caves/east)
+/area/icy_caves/outpost/LZ2)
 "Uq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
 	},
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Us" = (
 /turf/closed/ice_rock/singleT{
 	dir = 8
@@ -7493,6 +9157,10 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/security)
+"UR" = (
+/obj/structure/largecrate/supply/medicine/medivend,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "US" = (
 /obj/structure/table,
 /obj/item/clothing/suit/chef/classic,
@@ -7504,6 +9172,10 @@
 /obj/item/clothing/shoes/blue,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"UU" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "UV" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 8
@@ -7524,6 +9196,18 @@
 /obj/item/analyzer,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
+"UZ" = (
+/obj/structure/dropship_piece/two/front,
+/turf/closed/shuttle/dropship2/transparent{
+	icon_state = "109"
+	},
+/area/icy_caves/caves/northern)
+"Va" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
+	dir = 4
+	},
+/area/icy_caves/caves)
 "Vb" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 10
@@ -7533,7 +9217,7 @@
 /turf/closed/ice/thin/junction{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Vd" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/corners,
@@ -7557,6 +9241,10 @@
 /obj/item/storage/fancy/vials,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/research)
+"Vj" = (
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "Vk" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow,
@@ -7565,18 +9253,39 @@
 /obj/structure/table,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"Vq" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/mainship/cargo,
+/area/icy_caves/caves/northern)
 "Vr" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/closed/ice_rock/southWall,
 /area/icy_caves/caves)
+"Vs" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
+"Vt" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 9
+	},
+/area/icy_caves/caves/northern)
 "Vu" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/corner{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "Vx" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -7598,6 +9307,10 @@
 	dir = 4
 	},
 /area/icy_caves/caves/west)
+"VC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/outside/center)
 "VD" = (
 /obj/structure/largecrate/supply/medicine/iv,
 /turf/open/floor/plating,
@@ -7607,14 +9320,26 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "VG" = (
-/turf/closed/ice/thin/junction,
-/area/icy_caves/outpost/outside)
+/obj/structure/barricade/guardrail{
+	dir = 8
+	},
+/obj/structure/xenoautopsy/tank,
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
+"VH" = (
+/obj/machinery/space_heater,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 10
+	},
+/area/icy_caves/outpost/LZ2)
 "VI" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/northern)
 "VJ" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating,
+/obj/machinery/landinglight/ds1{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "VK" = (
 /obj/machinery/light{
@@ -7630,6 +9355,18 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/security)
+"VL" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/turf/open/floor/mainship/cargo,
+/area/icy_caves/caves/northern)
 "VM" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/security)
@@ -7660,6 +9397,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"VS" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
 "VT" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/outpost/LZ1)
@@ -7687,32 +9430,71 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"VZ" = (
+/obj/item/shard,
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "Wa" = (
 /obj/structure/largecrate/supply/explosives,
 /obj/item/explosive/plastique,
 /obj/item/explosive/plastique,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"Wb" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 4
+"Wc" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2;
+	name = "Canteen"
 	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Wd" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "We" = (
 /turf/closed/ice/junction{
 	dir = 1
 	},
 /area/icy_caves/outpost/outside/center)
 "Wg" = (
-/obj/effect/landmark/fob_sentry_rebel,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/obj/structure/barricade/guardrail{
+	dir = 4
+	},
+/obj/structure/xenoautopsy/tank/alien,
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
+"Wi" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Wj" = (
 /turf/closed/ice/thin/end{
 	dir = 4
 	},
 /area/icy_caves/caves/south)
+"Wm" = (
+/turf/open/floor/tile/dark/yellow2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
+"Wp" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Wr" = (
+/obj/machinery/door/airlock/mainship/maint,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Ws" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "Wt" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs,
@@ -7724,7 +9506,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Ww" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -7733,12 +9515,26 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
+"Wx" = (
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/caves/west)
+"Wy" = (
+/turf/open/shuttle/dropship/floor,
+/area/space)
 "WA" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 8
 	},
-/turf/closed/ice/thin/end,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
+"WB" = (
+/obj/machinery/vending/dinnerware,
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "WD" = (
 /turf/open/floor/plating/ground/snow,
 /area/icy_caves/outpost/LZ1)
@@ -7749,12 +9545,28 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"WF" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
+"WG" = (
+/turf/closed/ice_rock/corners,
+/area/icy_caves/caves/west)
 "WI" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside)
 "WK" = (
-/turf/open/floor/mech_bay_recharge_floor,
+/obj/docking_port/stationary/marine_dropship/lz1,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
+"WO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"WP" = (
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "WQ" = (
 /turf/closed/ice/thin/end{
 	dir = 8
@@ -7770,8 +9582,10 @@
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/caves)
 "WT" = (
-/obj/machinery/landinglight/ds1/delaytwo,
-/turf/open/floor/plating,
+/obj/machinery/landinglight/ds1{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "WU" = (
 /obj/structure/closet/cabinet,
@@ -7780,13 +9594,32 @@
 /obj/item/clothing/head/pirate,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"WW" = (
+/turf/open/floor/tile/dark/yellow2{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
+"WX" = (
+/obj/machinery/computer3/laptop,
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "WY" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/medbay)
 "Xa" = (
-/obj/machinery/landinglight/ds1/delayone,
-/turf/open/floor/plating,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/ice/thin/end{
+	dir = 1
+	},
 /area/icy_caves/outpost/LZ1)
+"Xc" = (
+/obj/structure/largecrate/random/case,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "Xf" = (
 /obj/effect/landmark/start/job/survivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -7801,6 +9634,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"Xh" = (
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Xi" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -7842,16 +9681,21 @@
 	},
 /area/icy_caves/caves)
 "Xq" = (
-/obj/machinery/landinglight/ds1,
-/turf/open/floor/plating,
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "Xr" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/dmg3,
 /area/icy_caves/caves/crashed_ship)
 "Xs" = (
-/obj/machinery/landinglight/ds1/delaythree,
-/turf/open/floor/plating,
+/obj/machinery/landinglight/ds1/delaythree{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "Xu" = (
 /turf/closed/ice/end{
@@ -7874,6 +9718,31 @@
 /obj/item/storage/box/visual/grenade/teargas,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Xy" = (
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/shuttle/dropship/floor,
+/area/space)
+"Xz" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"XA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/east)
+"XC" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/outside/center)
+"XD" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "XF" = (
 /turf/closed/ice/corner,
 /area/icy_caves/caves/west)
@@ -7908,6 +9777,13 @@
 "XJ" = (
 /turf/closed/ice_rock/singleEnd,
 /area/icy_caves/caves/west)
+"XL" = (
+/obj/structure/barricade/guardrail{
+	dir = 1
+	},
+/obj/structure/dropship_piece/two/front,
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "XM" = (
 /obj/structure/bed/chair,
 /obj/effect/landmark/corpsespawner/colonist,
@@ -7926,6 +9802,10 @@
 /area/icy_caves/outpost/outside)
 "XP" = (
 /turf/closed/ice_rock/singleEnd,
+/area/icy_caves/caves/northern)
+"XQ" = (
+/obj/machinery/door/poddoor/mainship/indestructible,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "XR" = (
 /obj/structure/closet/crate,
@@ -7948,7 +9828,7 @@
 /turf/closed/ice/thin/junction{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "XU" = (
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 1
@@ -7991,6 +9871,10 @@
 	dir = 1
 	},
 /area/icy_caves/caves)
+"Yh" = (
+/obj/machinery/power/apc/drained,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Yi" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/green2{
@@ -7998,11 +9882,18 @@
 	},
 /area/icy_caves/outpost/medbay)
 "Yj" = (
-/obj/machinery/landinglight/ds1/delaythree{
+/obj/machinery/landinglight/ds1/delaytwo{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/floodlight/landing,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
+"Yk" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Ym" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/swat,
@@ -8025,18 +9916,16 @@
 /turf/closed/ice/thin/junction{
 	dir = 8
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "Yv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Yw" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 8
-	},
+/obj/machinery/landinglight/ds1/delaytwo,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "Yx" = (
@@ -8061,6 +9950,16 @@
 "YA" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/kitchen)
+"YB" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 10
+	},
+/obj/structure/monorail{
+	dir = 6
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
 "YF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -8072,8 +9971,8 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/closed/ice_rock/singleT,
-/area/icy_caves/outpost/outside)
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/LZ1)
 "YI" = (
 /turf/closed/ice/thin/end{
 	dir = 1
@@ -8098,6 +9997,15 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"YP" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "YQ" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/space)
@@ -8113,6 +10021,13 @@
 "YT" = (
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"YV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "YW" = (
 /turf/closed/ice,
 /area/icy_caves/caves/south)
@@ -8178,6 +10093,9 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ1)
+"Zl" = (
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Zm" = (
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ1)
@@ -8248,7 +10166,7 @@
 "ZE" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "ZF" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -8269,10 +10187,11 @@
 /turf/closed/ice/straight,
 /area/icy_caves/caves/south)
 "ZK" = (
-/obj/machinery/landinglight/ds1{
+/obj/machinery/floodlight/landing,
+/obj/machinery/landinglight/ds1/delaytwo{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "ZL" = (
 /obj/machinery/power/apc/drained,
@@ -8289,10 +10208,14 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "ZU" = (
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"ZV" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "ZW" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -8311,6 +10234,12 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
+"ZZ" = (
+/obj/structure/morgue{
+	dir = 2
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 
 (1,1,1) = {"
 YQ
@@ -8470,12 +10399,12 @@ YQ
 "}
 (2,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+mi
+mi
+mi
+mv
+mv
+mv
 Yf
 Yf
 Yf
@@ -8626,6 +10555,12 @@ YQ
 "}
 (3,1,1) = {"
 YQ
+mi
+Sw
+mi
+mv
+mv
+mv
 Yf
 Yf
 Yf
@@ -8653,22 +10588,16 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+WF
+WF
+WF
+WF
+WF
+WF
+dF
+dF
+dF
+dF
 Yf
 Yf
 Yf
@@ -8782,6 +10711,12 @@ YQ
 "}
 (4,1,1) = {"
 YQ
+mi
+mi
+mi
+mv
+mv
+mv
 Yf
 Yf
 Yf
@@ -8809,22 +10744,16 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+WF
+mw
+cE
+ta
+hW
+kY
+Vj
+AJ
+eO
+dF
 Yf
 Yf
 Yf
@@ -8912,25 +10841,25 @@ Zk
 Zm
 UE
 UE
+fq
 Uu
 Uu
-qz
-aG
-pq
-aI
-pq
-eY
-zS
-JY
-JY
-zS
-aG
-pq
-aI
-pq
-eY
-XH
-qz
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
 lX
 Bu
 bD
@@ -8938,6 +10867,12 @@ YQ
 "}
 (5,1,1) = {"
 YQ
+mv
+mv
+mv
+mv
+mv
+mv
 Yf
 Yf
 Yf
@@ -8965,6 +10900,16 @@ Yf
 Yf
 Yf
 Yf
+WF
+SY
+AJ
+AJ
+jf
+Ex
+II
+AJ
+kf
+dF
 Yf
 Yf
 Yf
@@ -9018,43 +10963,27 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+ll
+ll
+ll
+ll
+ll
+ll
+ll
+ll
+ll
+ll
+ll
+ll
+ll
+ll
+ll
+ll
+ll
+ll
+ll
+ll
+ll
 Yf
 Yf
 Yf
@@ -9062,31 +10991,31 @@ qs
 uA
 TW
 qz
-UE
-WD
-Zm
-Zm
-UE
-UE
-UE
-UE
-UE
-UE
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-UE
-UE
-UE
-UE
-UE
-Uu
-Uu
-Uu
+wL
+uw
+Xs
+Xs
+WT
+Ud
+LL
+Xs
+WT
+Ud
+LL
+Xs
+Ud
+Ud
+LL
+Xs
+WT
+Xq
+LL
+Xs
+WT
+Xq
+Yj
+uw
+uw
 Vb
 Ww
 bD
@@ -9094,6 +11023,12 @@ YQ
 "}
 (6,1,1) = {"
 YQ
+mv
+mv
+mv
+mv
+mv
+mv
 Yf
 Yf
 Yf
@@ -9121,6 +11056,16 @@ Yf
 Yf
 Yf
 Yf
+WF
+AR
+VZ
+AJ
+AJ
+Fq
+eL
+AJ
+kf
+dF
 Yf
 Yf
 Yf
@@ -9173,44 +11118,28 @@ Yf
 Yf
 Yf
 Yf
+MH
+ln
 Yf
 Yf
+MH
+MH
+re
 Yf
+MH
+MH
 Yf
 Yf
 Yf
 Yf
 Yf
 Yf
+qy
+qy
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+ll
 Yf
 Yf
 Yf
@@ -9218,31 +11147,31 @@ qs
 ED
 qz
 UM
-WD
-WD
-WD
-GC
-WD
-UE
-WD
-WD
-WD
-UE
-UE
-UM
-fs
-UE
-UE
-UE
-UE
-UE
-WD
-WD
-GC
-UE
-Uu
-Ud
-Uu
+uw
+zM
+Yn
+Yn
+JY
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+JY
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+JY
+Yw
+uw
+uw
 VU
 uc
 bD
@@ -9283,6 +11212,16 @@ Yf
 Yf
 Yf
 Yf
+WF
+rk
+AJ
+WP
+AJ
+AJ
+MY
+gZ
+yH
+dF
 Yf
 Yf
 Yf
@@ -9333,72 +11272,62 @@ Yf
 Yf
 Yf
 Yf
+MH
+YI
+YI
+mz
+ZU
+ZU
+ZU
+GF
+re
+re
+re
+MH
 Yf
 Yf
 Yf
 Yf
+MH
+MH
+qy
+qy
+qy
+MH
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+ll
 Yf
 Yf
 Yf
 qy
 RC
-WD
-UE
-WK
-Yj
-Yj
-AH
-Wb
-Ag
-Yj
-AH
-Wb
-Ag
-Yj
-WK
-Wb
-Ag
-Yj
-AH
-Wb
-Ag
-Yj
-AH
-Wb
-Ag
-WK
-Uu
-Uu
+TM
+uw
+uw
+zM
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yw
+uw
+uw
 qH
 Ww
 bD
@@ -9411,6 +11340,27 @@ Yf
 Yf
 Yf
 Yf
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
 Yf
 Yf
 Yf
@@ -9418,37 +11368,16 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+WF
+ux
+hG
+Rx
+AJ
+AJ
+HU
+AJ
+Lr
+dF
 Yf
 Yf
 Yf
@@ -9500,48 +11429,38 @@ Yf
 Yf
 Yf
 Yf
+ZU
+YI
+mA
+ZU
+Wx
+Wx
+Bb
+WI
+WI
+WI
+WI
+MH
 Yf
 Yf
 Yf
+MH
+MH
+Za
+Za
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qy
-aG
-Ww
-Sw
-UE
-WT
-Yn
-Yn
-VJ
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-VJ
+MH
+ln
+MH
+MH
+DX
+AB
+zi
+TM
+uw
+uw
+zM
 Yn
 Yn
 Yn
@@ -9550,11 +11469,21 @@ Yn
 Yn
 Yn
 Yn
-VJ
 Yn
-wL
-UE
-UE
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yw
+uw
+uw
 XH
 Ne
 Yf
@@ -9567,6 +11496,27 @@ Yf
 Yf
 Yf
 Yf
+WF
+Qg
+mj
+GQ
+yb
+dF
+Ls
+Zl
+EU
+Zl
+Zl
+EU
+Zl
+nK
+Gn
+dF
+EU
+Zl
+LF
+Zl
+WF
 Yf
 Yf
 Yf
@@ -9574,37 +11524,16 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+WF
+EP
+EP
+dF
+AJ
+AJ
+HU
+AJ
+GE
+dF
 Yf
 Yf
 Yf
@@ -9653,40 +11582,41 @@ Yf
 Yf
 Yf
 Yf
+MH
+MH
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-VU
-qz
+ZU
+ZU
+mC
+ZU
+ZU
+ZU
+Bb
+WI
+pa
+Si
+WI
+WI
+MH
+MH
+MH
+MH
+pa
+CL
+tl
+Za
+MH
+MH
+ln
+Uu
+Uu
+DX
+DX
 Sh
-HC
-UE
-Xa
+sK
+bU
+uw
+zM
 Yn
 Yn
 Yn
@@ -9707,10 +11637,9 @@ Yn
 Yn
 Yn
 Yn
-Yn
-MO
-WD
-UE
+Yw
+uw
+uw
 VU
 Ne
 Yf
@@ -9723,57 +11652,57 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-re
-re
-re
-re
-re
-re
+WF
+op
+Ox
+yi
+Dm
+dF
+Zl
+Zl
+Zl
+Zl
+He
+Zl
+Zl
+Zl
+wj
+dF
+Zl
+Zl
+BZ
+Zl
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+Zl
+He
+dF
+EP
+Zl
+YP
+EP
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
 Yf
 Yf
 Yf
@@ -9810,63 +11739,63 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-aK
-VU
-yW
+YI
+ZU
+ZU
+ZU
+mA
+ZU
+ZU
+ZU
+Bb
+WI
+Tj
+SI
+SI
+SI
+SI
+SI
+SI
+SI
+SI
+Za
+Za
+af
+Za
+Za
+ET
+Uu
+Uu
+DX
+Ml
+Tf
 TM
-UE
-Xq
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
+bU
+uw
 zM
-UE
-UE
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yw
+uw
+uw
 bH
 Ne
 Yf
@@ -9874,62 +11803,62 @@ YQ
 "}
 (11,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-af
-af
-af
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
-dy
-dy
-dy
-dy
-dy
-dy
+pl
+pl
+pl
+pl
+pl
+WF
+Gh
+co
+oR
+lO
+iN
+Tz
+Tz
+Tz
+ph
+Tz
+Tz
+Tz
+Tz
+Tz
+kd
+Tz
+Tz
+UU
+Zl
+Xz
+Zl
+Zl
+Cl
+EU
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+cV
+IU
+MX
+Lp
+Zl
+Zl
+Zl
+Zl
+EU
+Zl
+LF
+Zl
+dF
+Zl
+Mx
+NM
+xo
+pP
+dF
 bD
 Yf
 Yf
@@ -9966,39 +11895,40 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qy
-XH
-XH
-YH
+ZU
+gx
+ez
+ZU
+mA
+ZU
+ZU
+ZU
+Bb
+WI
+WI
+Ln
+SI
+SI
+SI
+SI
+SI
+SI
+SI
+Za
+Za
+Za
+Za
+tl
+ET
+Uu
+Uu
+Uu
+Ml
+Tf
 TM
+bU
 uw
-Xs
+zS
 Yn
 Yn
 Yn
@@ -10009,6 +11939,7 @@ Yn
 Yn
 Yn
 Yn
+WK
 Yn
 Yn
 Yn
@@ -10018,11 +11949,9 @@ Yn
 Yn
 Yn
 Yn
-Yn
-Yn
-TI
-UE
-UE
+Yw
+uw
+uw
 bH
 Ne
 Yf
@@ -10030,62 +11959,62 @@ YQ
 "}
 (12,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-af
+pl
+bW
+bW
+bW
+bW
+in
+mu
+yi
+oQ
+yi
+zu
+TK
+Zl
+Zl
+BZ
+Zl
+Zl
+Zl
+Zl
+Zl
+Wp
+Zl
+Zl
+Wd
+Tz
 am
-af
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
-dL
-dZ
+Tz
+Tz
+Tz
+Tz
+TN
+Tz
+Yk
+Zl
+Zl
+Zl
+Zl
+Pp
+Fw
+La
+zt
+Zl
+Zl
+Zl
+He
+Zl
+Zl
+BZ
+Zl
+dF
+Zl
+Zl
 ev
-eM
+Zl
 fb
-dy
+dF
 bD
 Yf
 Yf
@@ -10122,63 +12051,63 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+ZU
+ZU
+ZU
+ZU
+mA
+ZU
 re
 re
 re
-re
-re
-re
-re
-re
-re
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-re
-qy
-qz
-qz
-qz
-YH
-TM
-iJ
-WT
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-wL
-WD
+WI
+WI
+SI
+Ln
+WI
+WI
+WI
+WI
+SI
+Ln
+tl
+Za
+Za
+Za
+Za
+ET
 UE
+fq
+Uu
+Uu
+Aq
+TM
+bU
+uw
+zM
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yw
+uw
+uw
 bH
 Ne
 Yf
@@ -10186,62 +12115,62 @@ YQ
 "}
 (13,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-af
-af
-af
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
-dM
-ap
+pl
+BB
+BB
+BB
+BB
+nw
+Sf
+yi
+wG
+cO
+OP
+TK
+Zl
+Zl
+BZ
+Zl
+dL
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+dz
+Zl
+ev
+He
+Zl
+Zl
+Zl
+dL
+Zl
+Wi
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+iS
+Zl
+Zl
+Zl
+Gf
+Zl
+dL
+Zl
+BZ
+Zl
+zZ
+Zl
+Zl
 ix
 eN
 fd
-dy
+dF
 bD
 Yf
 Yf
@@ -10278,39 +12207,40 @@ Yf
 Yf
 re
 re
-re
-re
-re
-re
-re
-re
+ZU
+ZU
+ZU
+ZU
+mD
+Di
 lG
 lX
 lG
-lX
-lG
-lX
-lG
-re
-re
-re
-re
-re
-Yf
-Yf
-Yf
-Yf
-qs
-VU
-aG
-aH
-TW
-VU
-qz
-SJ
+WI
+WI
+SI
+SI
+WI
+pD
+WI
+WI
+SI
+SI
+Za
+Za
+Za
+Za
+Za
+ET
+Uu
+Uu
+Uu
+Uu
+YH
 TM
 bU
-Xa
+uw
+zM
 Yn
 Yn
 Yn
@@ -10321,7 +12251,6 @@ Yn
 Yn
 Yn
 Yn
-sK
 Yn
 Yn
 Yn
@@ -10332,9 +12261,9 @@ Yn
 Yn
 Yn
 Yn
-MO
-UE
-UE
+Yw
+uw
+uw
 bH
 Ne
 Yf
@@ -10342,62 +12271,62 @@ YQ
 "}
 (14,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
+pl
+bW
+bW
+bW
+bW
+nw
+gP
+yi
+yi
+yi
+EP
+Zl
+Zl
+Zl
+BZ
+Zl
+Zl
+Zl
+Zl
+Zl
+EP
+Zl
+Zl
+BZ
+Zl
+Xz
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+pL
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Wi
+Tz
+un
+Tz
+Tz
+Tz
+Tz
+Tz
+HP
+un
+Hw
 dN
-dP
+Tz
 ew
 eP
 fe
-dy
+dF
 bD
 Yf
 Yf
@@ -10431,66 +12360,66 @@ re
 re
 re
 re
-re
-qy
-lX
-mv
-mv
-mv
-bX
-pq
-lG
-ec
-Vb
-eY
-Vb
-eY
-Vb
-eY
-qz
-qz
-qz
-eY
-re
-re
-re
-re
-re
-qy
-XH
-lX
-aK
-lX
-eY
-Qh
-zb
+ZU
+ZU
+SF
+ZU
+ZU
+ZU
+ZU
+mD
+mQ
+mY
+ne
+sb
+Ig
+tw
+IZ
+IZ
+tw
+tw
+tw
+tw
+SI
+SI
+Za
+Za
+MH
+qs
+WI
+tw
+Uu
+Uu
+Uu
+Ml
+Tf
 Tb
 XW
-Xq
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
+uw
 zM
-UE
-Uu
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yw
+uw
+uw
 XH
 Ne
 Yf
@@ -10498,62 +12427,62 @@ YQ
 "}
 (15,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
+pl
+BB
+BB
+BB
+BB
+WF
+fD
+yi
+Do
+wq
+dF
+Bo
+Zl
+Zl
+BZ
+Zl
+He
+Zl
+Zl
+Zl
+dF
+Zl
+Zl
+BZ
+Zl
+WF
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+BZ
+Pg
+ve
+Zl
+Zl
+Zl
+Zl
+BZ
+Zl
+Zl
+Pg
+TD
+Zl
+Zl
+Zl
+Zl
+Zl
+dF
 dO
 ea
-dQ
+nB
 eT
 ff
-dy
+dF
 bD
 Yf
 Yf
@@ -10586,43 +12515,44 @@ TW
 dj
 Di
 XF
-Di
-XF
-qz
-mv
+DZ
 ZU
 ZU
+SF
+ZU
+gx
 ZU
 ZU
-aG
-eY
+RG
+ec
 fT
 xI
 xI
 xI
+nx
+od
+lH
+nx
 xI
 xI
-xI
-xI
-xI
-xI
-xI
-pq
-aG
-pq
-lG
-lX
-pq
-lG
-XH
-XH
-XH
-qz
-Qp
+KT
+SI
+SI
+WI
+MH
+Yf
+Yf
+MH
+tw
+Uu
+Uu
+sD
+Ml
 Tf
 Ml
 XW
-Xs
+uw
+zM
 Yn
 Yn
 Yn
@@ -10643,10 +12573,9 @@ Yn
 Yn
 Yn
 Yn
-Yn
-TI
-UE
-Uu
+Yw
+uw
+uw
 VU
 Ne
 Yf
@@ -10654,62 +12583,62 @@ YQ
 "}
 (16,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
+pl
+dF
+dF
+dF
+dF
+dF
+wO
+yi
+Hj
+kR
+dF
+Zl
+Zl
+Zl
+ds
+Zl
+Zl
+Zl
+Zl
+FB
+dF
+dv
+hB
+BZ
+Zl
+pE
+WF
+WF
+WF
+ev
+BO
+WF
+VS
+dF
+dF
+dF
+dF
+dF
+Zl
+YP
+dF
+dF
+dF
+dF
+dF
+Wr
+dF
+dF
+dF
+dF
 nD
 ed
-ZW
-dP
+nB
+Zl
 fg
-dy
+dF
 bD
 Yf
 Yf
@@ -10741,44 +12670,56 @@ XH
 qz
 ZU
 gz
-Jg
-Jg
-DK
-ez
-ZU
-ZU
 ZU
 ZU
 ZU
 ez
+SF
 ZU
+ZU
+ZU
+ZU
+ez
+SF
 ZU
 nO
 oI
 wW
-pl
+oI
 pw
-OI
+oI
 pf
 oZ
 oK
-xI
-VU
-lX
-pq
-WS
-eY
-VU
-XH
-aG
-TW
-qz
+KT
+SI
+SI
 WI
-Wg
-Tm
+MH
+Yf
+Yf
+Yf
+ln
+Uu
+Uu
+Uu
+UE
+TQ
 Uu
 Vk
-WT
+uw
+zM
+Yn
+Yn
+JY
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+JY
 Yn
 Yn
 Yn
@@ -10787,22 +12728,10 @@ Yn
 Yn
 Yn
 Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-wL
-UE
-Uu
+JY
+Yw
+uw
+uw
 qH
 Ne
 Yf
@@ -10810,62 +12739,62 @@ YQ
 "}
 (17,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
-dy
-dy
+Gs
+Gs
+Gs
+Gs
+Gs
+dF
+jY
+dF
+EP
+EP
+dF
+pu
+dF
+dF
+dF
+Zl
+VL
+Vq
+Vq
+Vq
+dF
+dF
+dF
+BZ
+Zl
+WF
+Gs
+WF
+hT
+Zl
+Zl
+Zl
+AQ
+dF
+Gs
+Gs
+Gs
+dF
+Zl
+BZ
+dF
+DV
+EX
+jd
+jd
+jd
+dF
+Gs
+Il
+dF
+dF
+dF
 ex
-dy
-dy
-dy
+dF
+dF
+dF
 bh
 Yf
 Yf
@@ -10883,12 +12812,12 @@ eb
 ZU
 ZU
 ZU
+SF
 ZU
 ZU
 ZU
 ZU
-ZU
-ZU
+SF
 ZU
 ZU
 ez
@@ -10897,8 +12826,8 @@ ZU
 ZU
 ZU
 ZU
-gz
-DK
+ZU
+ZU
 ez
 ZU
 dx
@@ -10907,7 +12836,7 @@ gA
 Mg
 ZU
 ZU
-ZU
+SF
 fT
 xI
 oJ
@@ -10918,47 +12847,47 @@ oI
 oI
 oI
 oU
-xI
-eY
-bH
-VU
-XH
-aG
-aI
-TW
-qz
-WI
-WI
-WI
-XO
+KT
+IZ
+IZ
+ln
+ll
+ll
+ll
+cZ
+cZ
+Uu
+Uu
+Uu
+Uu
 TQ
 Uu
 bU
-Xa
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
+uw
+uw
+TI
 MO
-UE
-Uu
+GU
+VJ
+TI
+MO
+GU
+TI
+TI
+MO
+GU
+VJ
+TI
+MO
+GU
+VJ
+TI
+MO
+MO
+MO
+ZK
+uw
+uw
 XH
 Ne
 Yf
@@ -10966,70 +12895,70 @@ YQ
 "}
 (18,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-lX
-TW
+YQ
+YQ
+dF
+dF
+dF
+OP
+OP
+OP
+OP
+Se
+xs
+OP
+Mf
+OP
+dF
+dF
+Se
+Se
+Se
+Se
+Vt
+CH
+dF
+mg
+Zl
+WF
+Gs
+WF
+tT
+Zl
+pZ
+IY
+BZ
+dF
+Gs
+Gs
+Gs
+dF
+Zl
+Wi
+Ts
+ZV
+ZV
+Vs
+Jn
+Jn
+dF
+Gs
+Il
+bI
+XP
 eg
 ZW
 eU
-VU
-lX
-lG
-bD
-Yf
-Yf
-Yf
-qy
-nM
-nM
+dw
+DZ
+Mg
+qR
+WG
+WG
+WG
+pb
+SD
+SD
 ZU
 ZU
 ZU
@@ -11039,12 +12968,12 @@ ZU
 ZU
 ez
 ZU
-ZU
+SF
 Eb
 ZU
 ZU
 gx
-ZU
+SF
 ez
 ZU
 gx
@@ -11075,117 +13004,117 @@ qo
 qO
 oU
 xI
-VU
-XH
-qH
-TW
-qz
+NH
+SI
 WI
+jI
+jI
+jI
 WI
-WI
-WI
-XO
-XO
-XO
+jI
+Uu
+UE
+UE
+UE
 TQ
 UE
 XW
-Xq
-Yn
-Yn
-VJ
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-VJ
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-VJ
-Yn
-zM
-UE
-Uu
+uw
+uw
+uw
+uw
+uw
+uw
+dW
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+dW
+uw
+uw
+uw
+uw
+uw
+uw
+uw
 VU
 Ne
 Yf
 YQ
 "}
 (19,1,1) = {"
-YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-bH
-ZU
-eh
+cW
+qa
+yF
+jL
+Me
+Me
+df
+Rw
+BN
+BN
+pc
+BN
+BN
+BN
+qu
+Rw
+BN
+jc
+jc
+XQ
+XQ
+dZ
+ma
+dF
+dz
+Zl
+WF
+Gs
+WF
+Ch
+Zl
+cD
+Zl
+pL
+dF
+Gs
+Gs
+Gs
+dF
+Lo
+UU
+dF
+nF
+mZ
+PN
+Lw
+Lw
+dF
+Gs
+Il
+bR
+SR
+RL
 ZW
-ZU
-Vb
-aI
-eY
-bD
-Yf
-Yf
-qy
-lX
-WS
-eY
+zB
+Lx
+Ga
+ec
+qR
+WG
+WG
+pb
+DZ
+Rj
+ec
 gx
 ZU
 ZU
@@ -11218,7 +13147,7 @@ Lx
 ec
 ZU
 ZU
-ZU
+gx
 da
 DK
 xI
@@ -11231,116 +13160,116 @@ pX
 oI
 oU
 xI
-eY
-aG
-eY
+SI
+SI
 WI
 WI
 WI
 WI
 WI
 WI
-WI
-XO
-XO
+Uu
+Uu
+UE
+UE
 TQ
 WD
 XW
-WK
-Yw
-Yw
-ZK
-sD
-LL
-Yw
-ZK
-sD
-LL
-Yw
-WK
-sD
-LL
-Yw
-ZK
-sD
-LL
-Yw
-ZK
-sD
-LL
-WK
-UE
-Uu
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
 qH
 Ne
 Yf
 YQ
 "}
 (20,1,1) = {"
-YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-Vb
-TW
-ZU
+cW
+BY
+wT
+Od
+JR
+Od
+dg
+FR
+qk
+wf
+pc
+MA
+TC
+Wg
+Ss
+ul
+Fk
+NW
+XD
+NW
+NW
+fs
+UZ
+Zl
+BZ
+Zl
+WF
+Gs
+WF
+WX
+Zl
+Gf
+Mv
+ns
+dF
+dF
+dF
+dF
+dF
+Zl
+BZ
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+Gs
+Il
+bJ
+XP
+zB
 ZW
-eh
+RL
 ZU
 Di
 XF
-bh
-re
-qy
-aG
-WS
-eY
+pH
+SO
+pb
+RG
+Rj
+ec
 ZU
 ZU
 ZU
@@ -11387,20 +13316,20 @@ qp
 oI
 oK
 xI
+SI
+SI
 XO
-XO
-XO
 WI
 WI
 WI
 WI
 WI
-WI
-AW
-XO
-XO
-TQ
+Uu
+fq
 UE
+UE
+Aq
+Ml
 gI
 UE
 WD
@@ -11411,9 +13340,9 @@ uw
 uw
 uw
 uw
+dW
 uw
 uw
-sb
 dW
 HE
 uw
@@ -11423,79 +13352,79 @@ uw
 uw
 uw
 HB
-WD
-UE
-UM
-Uu
+uw
+uw
+uw
+uw
 XH
 Ne
 Yf
 YQ
 "}
 (21,1,1) = {"
-YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-Di
-eb
+cW
+HC
+yd
+RM
+cL
+RM
+gK
+FR
+pc
+pc
+Bt
+pc
+pc
+MA
+Xy
+Wy
+Wy
+Wy
+ch
+Af
+us
+Wy
+FR
+Zl
+BZ
+Zl
+WF
+Gs
+WF
+xS
+Zl
+IY
+jk
+BZ
+dF
+EX
+jd
+ze
+dF
+Zl
+BZ
+dF
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Il
+PD
+Ho
 ei
 ZW
-ZU
+zB
 Xu
 Jg
 DK
-lX
-pq
-lG
+DZ
+dh
+Mg
 fT
-XH
+dD
 ZU
 ez
 ZU
@@ -11534,12 +13463,12 @@ ZU
 gz
 XF
 xI
-oZ
+iJ
 oI
 wW
 oI
-ig
-wW
+RA
+oI
 oI
 oI
 nO
@@ -11551,12 +13480,12 @@ WI
 WI
 WI
 WI
-WI
-XO
-XO
-XO
-TQ
 Uu
+UE
+UE
+UE
+Tm
+Ml
 Vk
 XW
 bU
@@ -11579,79 +13508,79 @@ uw
 uw
 uw
 uw
-WD
-WD
-UE
-Uu
+uw
+uw
+uw
+uw
 XH
 uy
 Yf
 YQ
 "}
 (22,1,1) = {"
-YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-re
-re
-re
-re
-Yf
-Yf
-re
-re
-qy
-do
-ZU
-ZU
+cW
+TZ
+GN
+YB
+cF
+YB
+kn
+FR
+qA
+wf
+Im
+MA
+VG
+VG
+Rw
+uO
+Qn
+NW
+XD
+yv
+NW
+XL
+UZ
+Zl
+BZ
+Zl
+WF
+Gs
+WF
+Gj
+cD
+eu
+Zl
+ds
+dF
+Ij
+jd
+jd
+Ea
+He
+BZ
+dF
+Ae
+Ae
+Ae
+Gs
+Gs
+Ae
+Ae
+Qo
+ce
+SR
+zB
 ZW
-ZU
+zB
 Xu
 Jg
 eb
-bH
-qz
-XH
-qz
-qz
+hn
+xa
+dD
+xa
+xa
 ez
 ZU
 DZ
@@ -11701,34 +13630,34 @@ xI
 xI
 Za
 SI
-Za
+XO
 XO
 WI
 WI
 WI
 XO
-XO
-XO
-XO
-XO
+UE
+UE
+UE
+UE
 LP
-UE
-UE
-UE
-WD
+VT
+VT
+VT
+VT
 WD
 uw
 vi
 WD
 WD
-WD
-UE
+AB
+AB
 AB
 Nr
 jE
 Zm
 bq
-BY
+Ml
 UE
 UE
 UE
@@ -11736,8 +13665,8 @@ WD
 uw
 uw
 Zm
-WD
-UE
+VT
+Ml
 VU
 VU
 uc
@@ -11745,65 +13674,65 @@ bD
 YQ
 "}
 (23,1,1) = {"
-YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-PD
-pk
-cJ
+cW
+OI
+Eh
+IP
+DU
+DU
+oM
+Ss
+KP
+KP
+pc
+KP
+KP
+KP
+DS
+Ss
+KP
+jc
+jc
+vn
+vn
+vn
+gQ
+dF
+BZ
+Zl
+WF
+Gs
+WF
+ws
+He
+Zl
+ZZ
+Zl
+dF
+dF
+dF
+dF
+dF
+Zl
+BZ
+dF
+bA
 bA
 Nd
-bh
-qy
-bX
-pq
-TW
-da
-eb
-ZU
+hM
+Qo
+cd
+Tu
+XP
+ot
+Ho
+zB
 ZW
-ZU
+zB
 Xu
 Jg
 XF
-XH
+dD
 fi
 gp
 Sn
@@ -11840,11 +13769,11 @@ ZU
 ZU
 lj
 ZU
-ZU
+gx
 EB
 EB
 ez
-ZU
+SF
 XO
 XO
 XO
@@ -11857,43 +13786,43 @@ WI
 WI
 XO
 SI
-Za
 XO
 XO
 XO
 XO
 XO
 XO
-WI
-XO
-lW
+UE
+Uu
+UE
+AB
 Yq
 VT
-Nr
-UE
-UE
+VT
+VT
+VT
 Zm
 uw
 vi
 Zm
 Zm
-WD
-UE
+Ml
+Ml
 AB
 mb
 Nr
-TM
-TM
+JA
+JA
 JA
 fN
-mi
-UE
-Zm
+Ml
+Ml
+VT
 uw
 uw
-Zm
-UE
-aG
+VT
+Ml
+XH
 WS
 WS
 Ww
@@ -11902,60 +13831,60 @@ YQ
 "}
 (24,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-re
-qy
-ce
-PD
-cK
+YQ
+YQ
+dF
+dF
+dF
+OP
+OP
+OP
+xs
+tF
+xs
+OP
+QD
+OP
+dF
+dF
+tF
+lv
+dF
+dF
+rg
+HL
+dF
+mg
+Zl
+WF
+Gs
+WF
+wh
+TD
+Pg
+ZZ
+ve
+dF
+Gs
+Gs
+Ae
+dF
+Zl
+BZ
+dF
+bM
 bM
 Fu
-qz
-lX
-TW
+bS
+bI
+XP
 qT
-cW
-dp
-ZU
-eh
+Zt
+Sg
+SR
+RL
 ZW
-ZU
+zB
 ZU
 dp
 do
@@ -11999,11 +13928,11 @@ Bw
 ZU
 ZU
 cY
-ZU
-ZU
+gx
+SF
 XO
 Za
-Za
+XO
 Za
 Za
 Dn
@@ -12019,10 +13948,10 @@ XO
 XO
 XO
 XO
-WI
-XO
-XO
-XO
+Uu
+UE
+UE
+UE
 TT
 EQ
 XT
@@ -12034,8 +13963,8 @@ HI
 ZE
 ZE
 KJ
-TT
-ZE
+Xa
+Xa
 Vu
 DL
 EO
@@ -12043,13 +13972,13 @@ EO
 rp
 Vu
 vR
-TT
-ZE
+vr
+vr
 Hl
 Hl
-ZE
-TT
-TT
+vr
+vr
+vr
 PL
 PL
 HV
@@ -12063,55 +13992,55 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qy
-VU
-VU
-qz
-ce
-Sg
-yh
+dF
+Wr
+dF
+dF
+Zl
+Th
+Th
+dF
+dF
+dF
+Zl
+gM
+If
+Zl
+dF
+dF
+dF
+dF
+BZ
+Zl
+WF
+Gs
+WF
+dF
+dF
+dF
+dF
+dF
+dF
+Gs
+Qo
+bP
+dF
+Zl
+dz
+dF
+SR
 SR
 Sg
-aG
-eY
+Io
+eB
 qT
 IC
-dd
-ZU
-ZU
-ZU
+cm
+SR
+SR
+zB
 ZW
-ZU
+zB
 eh
 ZU
 dp
@@ -12156,12 +14085,12 @@ fz
 ZU
 ZU
 ja
-ZU
+SF
 XO
 XO
 XO
 oO
-Za
+XO
 Dn
 SI
 Za
@@ -12176,37 +14105,37 @@ Za
 XO
 XO
 XO
-XO
-XO
-XO
-XO
-of
-of
+UE
+UE
+UE
+UE
+SB
+SB
 Ey
-XO
-XO
-SI
-Dn
-Za
-Za
-Im
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-Za
-SI
-SI
-Za
+UE
+UE
+uw
+vi
+Zm
+Zm
+WD
+UE
+UE
+UE
+UE
+UE
+UE
+UE
+UE
+UE
+UE
+Zm
+uw
+uw
+Zm
 Ey
-XO
-XO
+UE
+UE
 qz
 bD
 Yf
@@ -12219,55 +14148,55 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-qy
-lX
-WS
-WS
-TW
-Sg
-SR
-cb
+dF
+Jn
+pN
+dF
+dL
+Zl
+Zl
+LF
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+EU
+pS
+Zl
+Wi
+HT
+WF
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Ae
+Qo
+bI
+Rh
+dF
+Zl
+yV
+dF
+im
 SR
 SR
 SR
 cj
 IC
 cg
-df
-ZU
-ZU
-ZU
-ZW
-ZU
+bT
+SR
+SR
+zB
+jo
+zB
 ZU
 gx
 jb
@@ -12280,14 +14209,14 @@ ZU
 ZU
 ZU
 ZU
-ZU
+SF
 ZU
 ZU
 ZU
 ZU
 gx
 ZU
-ZU
+SF
 ZU
 ZU
 ZU
@@ -12309,7 +14238,7 @@ ZU
 dE
 Sn
 xa
-xa
+dE
 ez
 ZU
 ht
@@ -12332,37 +14261,37 @@ CV
 Za
 Za
 Za
-Za
-Za
-Za
-XO
-XO
-XO
-XO
-Za
-Za
-SI
-Dn
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-SI
-SI
-Za
-Za
-Za
-XO
+Zm
+Zm
+Zm
+UE
+UE
+UE
+UE
+Zm
+Zm
+uw
+vi
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+uw
+uw
+Zm
+Zm
+Zm
+UE
 bF
 Yf
 Yf
@@ -12375,55 +14304,55 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-qy
+dF
+oT
+Jn
+dF
+Bo
+dL
+Zl
+BZ
+Zl
+Zl
+dL
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+dK
+Zl
+WF
+Gs
+Gs
+Gs
+Gs
+Gs
+Ae
+Qo
 PD
 Ho
-Vb
-eY
-XH
+bJ
+eB
+dF
+Zl
+YP
+dF
 SR
-SR
-SR
-yh
 SR
 SR
 im
-bC
+SR
 QK
 SR
-dg
-ZU
-gx
-ZU
+SR
+SR
+im
+zB
 ZW
-ez
+Ws
 ZU
 ZU
 SF
@@ -12436,14 +14365,14 @@ ZU
 ZU
 ZU
 gx
-ZU
+SF
 ZU
 ZU
 ez
 ZU
 ZU
 ZU
-ZU
+SF
 ZU
 ez
 gx
@@ -12474,8 +14403,8 @@ XO
 XO
 np
 Za
-SI
 Ln
+SI
 SI
 SI
 SI
@@ -12485,40 +14414,40 @@ SI
 SI
 SI
 pY
-Al
-vy
 vy
 Al
 vy
-vy
-vy
-vy
-vy
+Nu
+Nu
+Nu
+Nu
+Nu
+Nu
 Nn
-vy
-vy
-Al
-qf
-SI
-SI
-SI
-SI
-SI
-SI
-SI
-Ln
-SI
-SI
-SI
-SI
-SI
-SI
-SI
-Ln
-SI
-SI
-Ln
-XO
+Nu
+Nu
+Mw
+Qe
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+dW
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+dW
+uw
+uw
+dW
+UE
 bD
 Yf
 Yf
@@ -12531,32 +14460,32 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qy
+dF
+Ek
+uu
+dF
+Zl
+Zl
+Zl
+BZ
+Zl
+He
+Zl
+Zl
+Zl
+lR
+lR
+Zl
+Zl
+Zl
+BZ
+Zl
+WF
+Gs
+Gs
+Gs
+Gs
+Qo
 PD
 bA
 VI
@@ -12564,22 +14493,22 @@ Ho
 yh
 SR
 SR
+Zl
+uT
+Zl
 SR
-im
-SR
-yh
 wo
 SR
 SR
 SR
-bl
+SR
 we
-dg
-ZU
-ZU
-ZU
-dQ
-eF
+SR
+SR
+SR
+zB
+ZW
+Ab
 ZU
 ZU
 SF
@@ -12592,7 +14521,7 @@ ZU
 ZU
 ZU
 ZU
-ZU
+SF
 gx
 ZU
 ZU
@@ -12630,7 +14559,7 @@ XO
 XO
 XO
 XO
-qa
+XO
 XO
 XO
 XO
@@ -12644,17 +14573,17 @@ SI
 SI
 SI
 SI
-SI
-SI
-SI
-SI
-SI
-SI
-Dn
-SI
-SI
-SI
-SI
+uw
+uw
+uw
+uw
+uw
+uw
+vi
+uw
+uw
+uw
+uw
 SI
 SI
 SI
@@ -12671,10 +14600,10 @@ SI
 SI
 SI
 SI
-SI
-SI
-SI
-XO
+uw
+uw
+uw
+UE
 bD
 Yf
 Yf
@@ -12687,55 +14616,55 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
+dF
+Gx
+YV
+dF
+Zl
+Zl
+Zl
+Wi
+Tz
+Tz
+Tz
+Tz
+du
+Hw
+Hw
+sG
+Tz
+Tz
+UU
+Zl
+WF
+Gs
+Gs
+Gs
+Il
 PD
 Fu
 ot
 by
-bl
+SR
 yh
 SR
 im
-SR
-bl
-ok
-cO
+Zl
+BZ
+Zl
+pk
 VI
 Nd
 SR
 SR
 SR
 SR
-dg
-gx
-ZU
-ZU
+SR
+im
+SR
+zB
 ZW
-ZU
+zB
 ZU
 ZU
 dx
@@ -12767,7 +14696,7 @@ ZU
 ZU
 ez
 ZU
-ZU
+SF
 ZU
 ZU
 ZU
@@ -12781,7 +14710,7 @@ ZU
 ZU
 YI
 cY
-ZU
+SF
 XO
 XO
 XO
@@ -12805,12 +14734,12 @@ XO
 XO
 XO
 XO
-SI
-Dn
-Za
-Za
-Za
-Za
+uw
+vi
+Zm
+Zm
+Zm
+Zm
 XO
 XO
 XO
@@ -12843,31 +14772,31 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
+dF
+ip
+hd
+Ts
+Tz
+Tz
+Tz
+UU
+Zl
+di
+Pg
+Zl
+KL
+dF
+dF
+yz
+Zl
+Zl
+BZ
+Zl
+WF
+Gs
+Gs
+Gs
+Il
 ce
 ot
 by
@@ -12876,22 +14805,22 @@ SR
 yh
 SR
 wo
-GH
+mq
+BZ
+Zl
 SR
-SR
-yh
 Lm
 by
 SR
 SR
 SR
 SR
-DZ
-Mg
-ZU
-ZU
+bI
+bL
+SR
+zB
 ZW
-ZU
+zB
 ZU
 Xu
 Jg
@@ -12923,21 +14852,21 @@ ZU
 ZU
 kE
 ZU
+SF
+ZU
+ZU
+ZU
+gx
 ZU
 ZU
 ZU
 ZU
-ZU
-ZU
-ZU
-ZU
-ZU
-ZU
-ZU
+SF
+gx
 ez
 ZU
 ZU
-ZU
+SF
 ZU
 XO
 AW
@@ -12999,31 +14928,31 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
+dF
+dF
+dF
+WF
+Zl
+Zl
+Zl
+BZ
+dF
+dF
+dF
+xW
+Zl
+Rt
+fc
+Zl
+Zl
+Zl
+BZ
+He
+WF
+Gs
+Gs
+Gs
+Il
 ce
 ce
 SR
@@ -13032,22 +14961,22 @@ SR
 yh
 PD
 Fu
+Zl
+BZ
+FB
+dF
 SR
-bl
 SR
-yh
-SR
-bl
 im
 SR
-bl
+SR
 Io
-Rj
-Rj
-Mg
-ZU
+Rh
+Rh
+bL
+zB
 ZW
-ZU
+zB
 Xu
 VB
 Jg
@@ -13088,12 +15017,12 @@ ZU
 Qd
 ZU
 ZU
+SF
 ZU
 ZU
 ZU
-ZU
-ZU
-ZU
+gx
+SF
 ZU
 WI
 WI
@@ -13158,28 +15087,28 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qy
+WF
+Zl
+Zl
+Zl
+BZ
+dF
+Gs
+dF
+cX
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+BZ
+FB
+WF
+Gs
+Gs
+Gs
+Qo
 ce
 Sg
 SR
@@ -13188,20 +15117,20 @@ SR
 kl
 bM
 VI
-Nd
+Zl
+BZ
+Zl
 SR
-wo
-yh
-yh
-yh
-yh
-yh
-cN
-cP
-Lx
-Rj
-ec
-ZU
+SR
+SR
+SR
+SR
+qT
+Zt
+bJ
+Rh
+eB
+zB
 ZW
 eS
 dy
@@ -13266,7 +15195,7 @@ Pq
 XU
 DY
 DY
-gB
+TF
 wx
 lB
 lM
@@ -13314,28 +15243,28 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-qz
+WF
+Zl
+Zl
+Zl
+BZ
+dF
+Gs
+dF
+UR
+dL
+Zl
+Zl
+Zl
+Zl
+Zl
+dz
+Zl
+WF
+Gs
+Gs
+Il
+bS
 Sg
 SR
 SR
@@ -13344,9 +15273,9 @@ SR
 cs
 bN
 Lm
-VI
-pk
-VI
+Zl
+BZ
+Zl
 Ho
 SR
 SR
@@ -13354,12 +15283,12 @@ SR
 qT
 bT
 KU
-EB
-dD
-gx
-ZU
+Zt
+Ry
+im
+zB
 ZW
-ZU
+zB
 YI
 ft
 EB
@@ -13470,28 +15399,28 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-VU
+WF
+Zl
+Zl
+Zl
+ns
+dF
+Gs
+dF
+dF
+Zl
+dF
+dF
+Zl
+Zl
+Gf
+BZ
+Zl
+WF
+Gs
+Gs
+Il
+bP
 qT
 rf
 SR
@@ -13500,22 +15429,22 @@ cj
 ct
 cn
 bN
-Sg
-bN
-Sg
-SR
+Zl
+BZ
+Zl
+rf
 SR
 im
 SR
 KU
 Zt
 qT
-de
-ZU
-ZU
-ZU
+cm
+SR
+SR
+zB
 ZW
-ZU
+zB
 ZU
 dE
 de
@@ -13624,30 +15553,30 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-nM
+WF
+WF
+WF
+EP
+Zl
+Wc
+BF
+dF
+Gs
+Gs
+dF
+Zl
+dF
+dF
+Zl
+Zl
+Zl
+BZ
+Zl
+WF
+Gs
+Gs
+Il
+QZ
 KU
 rf
 SR
@@ -13656,9 +15585,9 @@ SR
 cs
 cn
 cn
-bN
-cn
-qT
+Zl
+BZ
+Zl
 rf
 SR
 SR
@@ -13666,12 +15595,12 @@ SR
 Zb
 KU
 IC
-Bw
-EB
-BQ
-ZU
+IC
+Zt
+Zb
+zB
 ZW
-gx
+Ab
 ZU
 YI
 de
@@ -13709,7 +15638,7 @@ ft
 EB
 ZU
 ZU
-ZU
+gx
 Xu
 Jg
 xP
@@ -13780,41 +15709,41 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-qH
-TW
+WF
+Zl
+EU
+Zl
+Bf
+Bf
+BZ
+dF
+dF
+dF
+dF
+Bo
+Zl
+Zl
+Zl
+Zl
+Zl
+BZ
+Zl
+WF
+Gs
+Gs
+Il
+cc
+XP
 SR
 SR
 SR
 cj
 cv
 IC
-IC
-bT
-cn
-KU
+ci
+Zl
+BZ
+Zl
 rf
 SR
 SR
@@ -13822,12 +15751,12 @@ SR
 SR
 SR
 KU
-cY
-dE
-Sn
-ZU
+bT
+KU
+rf
+zB
 ZW
-ZU
+zB
 ZU
 fi
 de
@@ -13936,41 +15865,41 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-qy
-qH
-lG
-bp
+WF
+Zl
+Zl
+Zl
+Gf
+Zl
+BZ
+Zl
+Zl
+dF
+Zl
+Fj
+Tz
+Tz
+Tz
+Tz
+Tz
+UU
+Zl
+WF
+Gs
+Ae
+Qo
+cc
+bL
+im
 SR
-bl
+SR
 cj
 cw
 cm
 ci
-Xw
-Xw
-rf
+Zl
+BZ
+Zl
 SR
 Zb
 SR
@@ -13978,12 +15907,12 @@ SR
 PD
 Nd
 PD
-XF
-Di
-eb
-ZU
+Nd
+PD
+Ho
+zB
 ZW
-ZU
+zB
 YI
 fz
 cY
@@ -14028,7 +15957,7 @@ dp
 gS
 dD
 ZU
-ZU
+gx
 ZU
 dx
 xa
@@ -14092,41 +16021,41 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
+WF
+Xh
+Xh
+Zl
+Zl
+Zl
+HQ
+Xh
+Zl
+EP
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+BZ
+FB
+WF
+Il
 PD
 Nd
-Vb
-eY
+bJ
+eB
 SR
 SR
 bI
 XP
 cx
 QK
-cn
-qT
-Zt
-qT
+dF
+Bo
+BZ
+Zl
 rf
 PI
 PI
@@ -14134,12 +16063,12 @@ PI
 Lm
 VI
 Fu
-da
-DK
-ZU
-ZU
+ot
+by
+SR
+zB
 ZW
-ZU
+zB
 Xu
 xP
 xP
@@ -14248,27 +16177,27 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
+WF
+MT
+eD
+Zl
+dL
+Zl
+nv
+MT
+dd
+eC
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+He
+dz
+Zl
+WF
+Il
 ce
 Lm
 Nd
@@ -14280,9 +16209,9 @@ bI
 Tu
 bL
 ci
-cm
-KU
-bT
+Zl
+BZ
+Zl
 SR
 SR
 SR
@@ -14290,12 +16219,12 @@ SR
 SR
 Sg
 Lm
-DK
-ZU
-ZU
-ZU
+by
+SR
+SR
+zB
 ZW
-ZU
+zB
 ZU
 RG
 fB
@@ -14404,27 +16333,27 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-re
-re
-re
-re
-qy
+WF
+eD
+eD
+Zl
+He
+Zl
+IK
+eD
+PZ
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+BZ
+Zl
+WF
+Qo
 ce
 PD
 by
@@ -14436,9 +16365,9 @@ Rh
 XP
 QZ
 QK
-QK
-SR
-SR
+Zl
+dz
+Zl
 SR
 im
 bl
@@ -14446,12 +16375,12 @@ SR
 SR
 SR
 im
-ZU
-ZU
-ZU
-ZU
+SR
+SR
+SR
+zB
 ZW
-ez
+Ws
 ZU
 RG
 fS
@@ -14483,7 +16412,7 @@ ZU
 ZU
 ZU
 ZU
-ZU
+SF
 ZU
 ZU
 ZU
@@ -14560,26 +16489,26 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-lX
-pq
-TW
-bX
-lG
+WF
+BW
+BW
+Zl
+Zl
+Zl
+QQ
+BW
+Zl
+EP
+di
+Pg
+Zl
+Zl
+Zl
+Zl
+Zl
+BZ
+Zl
+WF
 PD
 by
 Sg
@@ -14592,7 +16521,9 @@ bR
 Io
 Rh
 XP
-im
+WO
+BZ
+Zl
 SR
 SR
 SR
@@ -14602,12 +16533,10 @@ SR
 SR
 SR
 SR
-ZU
-ZU
-ZU
-ZU
+SR
+zB
 rP
-ZU
+zB
 RG
 fB
 Rj
@@ -14639,8 +16568,8 @@ ZU
 gx
 ZU
 ZU
-ZU
-ZU
+SF
+gx
 ZU
 ZU
 ZU
@@ -14716,26 +16645,26 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-bH
-qT
-Ir
-Zt
-XH
+WF
+Yh
+Zl
+Fj
+Tz
+Tz
+eP
+Zl
+FB
+WF
+WF
+WF
+WF
+WF
+Zl
+Zl
+Zl
+BZ
+Zl
+WF
 ot
 Ho
 SR
@@ -14747,10 +16676,10 @@ cc
 Rh
 XP
 Ry
-SR
-SR
-SR
-SR
+Zl
+Zl
+BZ
+Zl
 bN
 SR
 SR
@@ -14758,12 +16687,12 @@ SR
 wo
 SR
 PD
-XF
-ZU
-ZU
-ZU
+Nd
+SR
+SR
+zB
 ZW
-ZU
+zB
 DZ
 Rj
 Rj
@@ -14872,41 +16801,41 @@ Yf
 Yf
 Yf
 Yf
+WF
+Zl
+Zl
+WB
+JF
+CX
+Zl
+Zl
+Zl
+WF
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-qy
-bH
-KU
-IC
-IC
-Zt
-Sg
+Gs
+WF
+Bo
+Zl
+Zl
+BZ
+Zl
+Xz
 SR
 SR
 SR
 SR
 SR
+dF
 Io
 ca
 Ry
 bS
 SR
-im
-SR
-SR
-qT
+WO
+Zl
+BZ
+Zl
 cm
 SR
 SR
@@ -14914,12 +16843,12 @@ ok
 VI
 bA
 VI
-Om
-XF
-ZU
-ZU
+bM
+Nd
+SR
+zB
 ZW
-ZU
+zB
 Lx
 Ga
 Ga
@@ -15010,14 +16939,14 @@ Qa
 Qa
 LO
 vq
-KZ
-XO
-SI
-SI
-Za
-XO
-bD
-Yf
+ov
+It
+IZ
+IZ
+ET
+It
+BD
+ll
 YQ
 "}
 (44,1,1) = {"
@@ -15028,41 +16957,41 @@ Yf
 Yf
 Yf
 Yf
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-lX
-pq
-WS
-TW
-KU
-cg
-bT
-SR
-im
-SR
-bP
-SR
-SR
-SR
-bJ
-XP
-SR
-SR
-SR
-SR
-cj
-IC
+Il
+WF
+LF
+Zl
+Zl
+BZ
+Zl
+Tx
+Zl
+WO
+Zl
+Zl
+Zl
+EU
+Zl
+Zl
+Zl
+Zl
+Zl
+LF
+Zl
+BZ
+WF
 bT
 SR
 SR
@@ -15070,12 +16999,12 @@ ok
 VI
 bM
 by
-Di
-DK
-xa
-ZU
+PD
+by
+bS
+zB
 ZW
-ZU
+zB
 gx
 ZU
 ZU
@@ -15166,14 +17095,14 @@ Is
 Zc
 RJ
 KZ
-KZ
+ov
 XO
 SI
 SI
 Za
 XO
 bD
-Yf
+ll
 YQ
 "}
 (45,1,1) = {"
@@ -15196,29 +17125,29 @@ Yf
 Yf
 Yf
 Yf
-qs
-bH
-lX
-eY
-SR
-SR
-SR
-SR
-SR
-SR
-Io
-eB
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-PD
-Nd
-QK
+Il
+WF
+NU
+Tz
+Tz
+dQ
+Tz
+mV
+Tz
+Tz
+Tz
+Tz
+Tz
+eF
+Tz
+Tz
+Tz
+Tz
+Tz
+HP
+Tz
+jX
+WF
 SR
 im
 SR
@@ -15226,12 +17155,12 @@ SR
 Lm
 Nd
 PD
-DK
-dw
-dw
-ZU
+by
+bP
+bP
+zB
 ZW
-ez
+zB
 ZU
 ZU
 ZU
@@ -15257,9 +17186,9 @@ Lx
 Mg
 dE
 Sn
-ZU
-ZU
-ZU
+SF
+SF
+SF
 dE
 Bw
 Bw
@@ -15322,14 +17251,14 @@ KZ
 KZ
 KZ
 KZ
-WI
+tw
 XO
 SI
 SI
 Za
 XO
 lX
-TW
+vu
 YQ
 "}
 (46,1,1) = {"
@@ -15353,28 +17282,28 @@ Yf
 Yf
 Yf
 qs
-bH
-bH
-SR
-bp
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-bl
-SR
-im
-we
-SR
-SR
-ok
-VI
-VI
-Ho
+WF
+Zl
+Zl
+dL
+Zl
+Zl
+pr
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+WO
+jC
+Zl
+Zl
+DH
+WF
+WF
+WF
 SR
 SR
 SR
@@ -15387,7 +17316,7 @@ Rj
 dy
 ej
 ZW
-ZU
+zB
 fi
 ft
 EB
@@ -15478,14 +17407,14 @@ li
 li
 li
 li
-li
+XC
 li
 my
 my
 DD
-li
+DD
 Vb
-lG
+Jh
 YQ
 "}
 (47,1,1) = {"
@@ -15509,13 +17438,13 @@ Yf
 Yf
 re
 qy
-bH
-XH
-SR
-SR
-SR
-PD
-Nd
+WF
+Xz
+ev
+xZ
+Xz
+WF
+WF
 aX
 bN
 bN
@@ -15541,9 +17470,9 @@ Tu
 dh
 Ga
 dD
-ZU
+zB
 ZW
-ZU
+zB
 dE
 Bw
 fz
@@ -15634,14 +17563,14 @@ my
 my
 my
 my
-my
+tA
 my
 my
 Iw
 DD
-li
-ow
-nM
+kz
+DD
+Va
 YQ
 "}
 (48,1,1) = {"
@@ -15669,7 +17598,7 @@ XH
 SR
 SR
 SR
-PD
+SR
 VI
 VI
 Nd
@@ -15677,7 +17606,7 @@ ci
 IC
 cm
 qT
-rf
+SR
 SR
 cq
 SR
@@ -15697,9 +17626,9 @@ Tu
 dh
 XJ
 ZU
-ZU
+zB
 ZW
-ZU
+zB
 fi
 Bw
 ft
@@ -15790,14 +17719,14 @@ my
 my
 my
 my
+tA
 my
-my
-my
+JW
 my
 DD
-li
-li
-nM
+lV
+DD
+Va
 YQ
 "}
 (49,1,1) = {"
@@ -15853,9 +17782,9 @@ Zt
 dj
 dx
 ZU
-ZU
+zB
 ZW
-BQ
+tp
 dE
 cY
 dE
@@ -15946,14 +17875,14 @@ li
 li
 li
 li
-li
-li
+XC
+DD
 my
 my
 DD
+kz
 DD
-li
-XH
+Dr
 YQ
 "}
 (50,1,1) = {"
@@ -16009,9 +17938,9 @@ QK
 Xu
 Jg
 eb
-ZU
+zB
 ZW
-ZU
+zB
 ZU
 Xu
 xP
@@ -16102,14 +18031,14 @@ ND
 ND
 ND
 ND
-ND
-li
+ye
+kz
 my
 my
 DD
 DD
-li
-qz
+DD
+zs
 YQ
 "}
 (51,1,1) = {"
@@ -16165,9 +18094,9 @@ Ir
 EB
 do
 dj
-ZU
+zB
 ZW
-ZU
+zB
 ZU
 Xu
 xP
@@ -16258,14 +18187,14 @@ Hf
 JC
 wZ
 Ez
-ND
-li
-my
-my
+ye
 DD
-li
-li
-qz
+my
+my
+kz
+DD
+DD
+zs
 YQ
 "}
 (52,1,1) = {"
@@ -16321,9 +18250,9 @@ IC
 de
 do
 ZU
-ZU
+zB
 ZW
-ZU
+zB
 DZ
 Mg
 fT
@@ -16414,14 +18343,14 @@ Zq
 wZ
 wZ
 LC
-ND
-li
+ye
+DD
 my
 my
 DD
-li
-ow
-VU
+DD
+DD
+zv
 YQ
 "}
 (53,1,1) = {"
@@ -16477,9 +18406,9 @@ cg
 ME
 xb
 Yp
-ym
+Td
 gG
-ym
+Td
 EM
 fC
 dC
@@ -16570,14 +18499,14 @@ Hf
 Ze
 wZ
 Ez
-ND
-li
-my
-my
+ye
 DD
-li
-li
-qH
+my
+my
+kz
+DD
+DD
+rI
 YQ
 "}
 (54,1,1) = {"
@@ -16633,9 +18562,9 @@ Tu
 fx
 Qw
 MM
-ym
+Td
 gG
-ym
+Td
 YS
 KK
 Iy
@@ -16661,9 +18590,9 @@ dC
 dC
 hb
 Yp
-ym
-ym
-ym
+ij
+ij
+ij
 YS
 gT
 ZB
@@ -16726,14 +18655,14 @@ Hf
 Hf
 Hf
 Hf
-ND
-li
+ye
+DD
 my
 my
 DD
 DD
 li
-bH
+tn
 YQ
 "}
 (55,1,1) = {"
@@ -16789,9 +18718,9 @@ qT
 Uk
 YK
 ym
-ym
+Td
 gG
-ym
+Td
 ym
 fF
 UL
@@ -16882,14 +18811,14 @@ Hf
 KO
 Cs
 Ez
-ND
-li
-my
-my
-DD
-DD
-li
-bH
+ye
+XC
+tA
+tA
+RT
+RT
+XC
+tn
 YQ
 "}
 (56,1,1) = {"
@@ -16943,11 +18872,11 @@ SR
 qT
 IC
 Uk
-dz
 ym
 ym
+Td
 gG
-ym
+Td
 ym
 ym
 Wj
@@ -17094,7 +19023,7 @@ ci
 rf
 SR
 SR
-SR
+im
 SR
 cn
 QK
@@ -17279,7 +19208,7 @@ ym
 ym
 ym
 ym
-ym
+Be
 ym
 gX
 ym
@@ -17294,7 +19223,7 @@ li
 lx
 li
 li
-li
+VC
 li
 li
 lx
@@ -17315,7 +19244,7 @@ li
 WY
 rB
 se
-ss
+Ai
 sg
 uR
 RK
@@ -17423,7 +19352,7 @@ Td
 Qs
 Td
 Td
-Td
+Qs
 fE
 Td
 Td
@@ -17456,7 +19385,7 @@ my
 my
 my
 my
-my
+JW
 my
 my
 my
@@ -17750,7 +19679,7 @@ Td
 Td
 Td
 Td
-Td
+Qs
 Td
 Td
 Td
@@ -17758,7 +19687,7 @@ Td
 xE
 my
 my
-my
+JW
 my
 my
 my
@@ -17873,7 +19802,7 @@ pk
 Ho
 SR
 SR
-SR
+im
 SR
 SR
 wo
@@ -17891,7 +19820,7 @@ Be
 ym
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -17923,7 +19852,7 @@ li
 li
 li
 li
-li
+VC
 li
 li
 li
@@ -18851,7 +20780,7 @@ Xj
 Je
 ym
 ym
-ym
+Be
 ym
 Wj
 fh
@@ -19165,7 +21094,7 @@ Uk
 ym
 cl
 ym
-ym
+Be
 dT
 Wj
 SA
@@ -19275,7 +21204,7 @@ cc
 eB
 SR
 SR
-SR
+im
 SR
 cj
 Ir
@@ -19791,7 +21720,7 @@ YW
 hb
 Yp
 ym
-ym
+Be
 ym
 ym
 Ps
@@ -20060,7 +21989,7 @@ SR
 bl
 SR
 SR
-SR
+im
 SR
 SR
 SR
@@ -20230,7 +22159,7 @@ Ps
 ym
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -20257,7 +22186,7 @@ YW
 YW
 hb
 JX
-ym
+Be
 ym
 ym
 ym
@@ -20546,7 +22475,7 @@ ST
 ST
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -21026,7 +22955,7 @@ ym
 ym
 gT
 gq
-ym
+Be
 ym
 ym
 fF
@@ -21174,7 +23103,7 @@ ZB
 gq
 ym
 ym
-ym
+Be
 ym
 xb
 MM
@@ -21201,7 +23130,7 @@ JX
 cl
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -21344,7 +23273,7 @@ fx
 ym
 cl
 ym
-ym
+Be
 ym
 ym
 QL
@@ -21362,7 +23291,7 @@ ym
 ym
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -21650,7 +23579,7 @@ ym
 ym
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -21664,7 +23593,7 @@ TH
 ym
 ym
 ym
-ym
+Be
 ym
 ZP
 Ps
@@ -21966,7 +23895,7 @@ Je
 dT
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -22129,7 +24058,7 @@ ym
 Qw
 Yp
 zQ
-ym
+Be
 ym
 YK
 KK
@@ -22296,7 +24225,7 @@ ZB
 fx
 Ps
 ym
-ym
+Be
 ym
 fF
 fW
@@ -22755,7 +24684,7 @@ fp
 TJ
 TV
 YT
-YT
+eK
 JD
 Bn
 xN
@@ -23348,7 +25277,7 @@ YT
 fo
 YT
 YT
-YT
+eK
 YT
 Tr
 dq
@@ -23397,11 +25326,11 @@ XO
 WI
 XO
 XO
-fQ
-gW
-fv
-TV
-fv
+oF
+oF
+oF
+oF
+oF
 TV
 fP
 TJ
@@ -23555,9 +25484,9 @@ Za
 Za
 oO
 XO
-fy
-fp
-dk
+GP
+GP
+oF
 fP
 TJ
 dk
@@ -23921,15 +25850,15 @@ MQ
 MQ
 MQ
 MQ
-MQ
-MQ
-MQ
-MQ
+cJ
+cJ
+cJ
+cJ
 aR
 aY
-sH
+cN
 bs
-MQ
+cJ
 bz
 bD
 Yf
@@ -24077,7 +26006,7 @@ eJ
 eJ
 eJ
 eJ
-MQ
+cJ
 sH
 sH
 MQ
@@ -24085,7 +26014,7 @@ sH
 aj
 Sc
 bt
-MQ
+cJ
 bz
 bD
 Yf
@@ -24121,7 +26050,7 @@ SR
 SR
 wo
 YT
-YT
+eK
 Bz
 YT
 YT
@@ -24173,7 +26102,7 @@ ke
 OJ
 XO
 Za
-XO
+Za
 XO
 of
 of
@@ -24233,7 +26162,7 @@ sH
 kr
 sH
 aJ
-MQ
+cJ
 ay
 sH
 bc
@@ -24241,7 +26170,7 @@ AN
 aQ
 bi
 aN
-MQ
+cJ
 MQ
 bD
 Yf
@@ -24301,7 +26230,7 @@ fy
 lc
 YT
 YT
-YT
+eK
 YT
 YT
 YT
@@ -24327,9 +26256,9 @@ Za
 XO
 xM
 WI
-WI
-XO
-XO
+Za
+Za
+Za
 XO
 XO
 XO
@@ -24389,7 +26318,7 @@ ah
 AN
 ah
 sH
-bc
+cK
 sH
 aN
 MQ
@@ -24397,7 +26326,7 @@ sH
 sH
 sH
 bu
-MQ
+cJ
 bz
 bD
 Yf
@@ -24427,7 +26356,7 @@ Xw
 Xw
 rf
 SR
-SR
+im
 SR
 ok
 VI
@@ -24545,7 +26474,7 @@ ad
 aj
 aj
 aN
-MQ
+cJ
 sH
 sH
 MQ
@@ -24553,7 +26482,7 @@ aS
 IO
 sH
 sH
-MQ
+cJ
 bz
 bh
 re
@@ -24638,18 +26567,18 @@ Za
 XO
 XO
 XO
-XO
+Za
 WI
 XO
 XO
 Za
 XO
+Za
 XO
-XO
-WI
-WI
-WI
-WI
+Za
+Za
+Za
+Za
 Hh
 QO
 vf
@@ -24661,10 +26590,10 @@ qG
 qm
 Ee
 tH
-WI
-WI
-WI
-WI
+nI
+nI
+nI
+nI
 GY
 Gu
 bh
@@ -24701,15 +26630,15 @@ RN
 al
 ar
 ah
-MQ
-sH
-sH
-MQ
-MQ
-MQ
-MQ
-MQ
-MQ
+cJ
+cN
+cN
+cJ
+cJ
+cJ
+cJ
+cJ
+cJ
 MQ
 PD
 pk
@@ -24777,39 +26706,39 @@ XO
 XO
 XO
 km
-WI
-WI
-WI
-XO
-XO
-XO
-XO
-WI
-WI
-WI
-XO
-XO
-Za
-XO
-XO
-XO
-WI
-WI
-WI
-XO
-km
-XO
-XO
-XO
-WI
-WI
-WI
-WI
-WI
-of
-WI
-WI
-XO
+nI
+nI
+nI
+oP
+oP
+oP
+oP
+nI
+nI
+nI
+oP
+oP
+wa
+oP
+oP
+oP
+nI
+wa
+nI
+oP
+GO
+oP
+oP
+oP
+nI
+nI
+nI
+wa
+wa
+Cq
+nI
+nI
+oP
 tH
 Ck
 nH
@@ -24817,10 +26746,10 @@ hh
 vM
 fu
 tH
-WI
-WI
-WI
-WI
+nI
+nI
+nI
+nI
 GZ
 GY
 Gu
@@ -24904,7 +26833,7 @@ YT
 AU
 Bz
 AU
-YT
+eK
 YT
 fR
 gw
@@ -24933,39 +26862,39 @@ XO
 Za
 XO
 XO
-WI
-WI
-XO
-Za
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-WI
-WI
-WI
-WI
-WI
-XO
-Za
-XO
-XO
-WI
+nI
+nI
+oP
+wa
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+wa
+wa
+wa
+wa
+nI
+oP
+wa
+oP
+wa
+nI
 OD
-WI
-WI
-WI
-WI
-XO
-XO
-XO
+nI
+wa
+nI
+nI
+oP
+oP
+oP
 tH
 CC
 jU
@@ -24973,8 +26902,8 @@ UH
 po
 rn
 tH
-WI
-WI
+nI
+nI
 xM
 Gu
 bh
@@ -25089,39 +27018,39 @@ XO
 XO
 XO
 XO
-OO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-Za
-XO
-XO
-XO
-WI
-WI
-WI
-XO
-XO
-XO
-XO
-XO
+Tl
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+wa
+oP
+oP
+oP
+wa
+oP
+oP
+wa
+nI
+wa
+wa
+oP
+oP
+oP
+oP
+oP
 tH
 Mh
 kK
@@ -25129,8 +27058,8 @@ rh
 Mh
 tH
 tH
-WI
-WI
+nI
+nI
 GZ
 GY
 BL
@@ -25245,48 +27174,48 @@ XO
 Za
 Za
 Za
-Za
-Za
-oO
-Za
-Za
-Za
-Za
-XO
-XO
-Za
-Za
-oO
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
+wa
+wa
+uq
+wa
+wa
+wa
+wa
+oP
+oP
+wa
+wa
+uq
+wa
+wa
+wa
+wa
+wa
+wa
+wa
+wa
 Uq
-SI
-SI
-SI
-XO
-XO
-XO
-XO
-np
-SI
-SI
-SI
-SI
-SI
-SI
-FV
-SI
-XO
-XO
-XO
-WI
-WI
+IT
+IT
+IT
+oP
+oP
+wa
+wa
+sT
+IT
+IT
+IT
+IT
+IT
+IT
+io
+IT
+oP
+oP
+oP
+nI
+nI
 AK
 KV
 xM
@@ -25401,49 +27330,49 @@ vy
 vy
 vy
 vy
-vy
-vy
-vy
-vy
-vy
-vy
-vy
-vy
-vy
-vy
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
 Ns
-vy
-vy
-vy
-vy
-vy
-vy
-vy
-vy
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
 Yv
 Ow
-vy
-vy
-vy
-vy
-vy
-vy
-vy
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
 Ns
-vy
-vy
-vy
-vy
-vy
-vy
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
 qf
-SI
-Za
-Za
-Za
-XO
-XO
-WI
+td
+wa
+wa
+wa
+oP
+oP
+nI
 BL
 xM
 bD
@@ -25513,7 +27442,7 @@ SR
 SR
 SR
 SR
-SR
+im
 SR
 SR
 SR
@@ -25527,7 +27456,7 @@ AU
 AU
 dI
 eI
-AU
+XA
 AU
 AU
 YT
@@ -25557,11 +27486,11 @@ YT
 XO
 np
 Za
-Za
-Za
-oO
-Za
-Za
+wa
+wa
+uq
+wa
+wa
 lA
 lA
 wN
@@ -25593,12 +27522,12 @@ wN
 wN
 wN
 lA
-XO
-XO
-XO
-Za
-XO
-XO
+oP
+oP
+oP
+wa
+oP
+oP
 AK
 KV
 xM
@@ -25713,50 +27642,50 @@ fo
 WI
 XO
 XO
-XO
-XO
-XO
-Za
-lW
+oP
+oP
+oP
+wa
+CP
 Jm
-jO
-Hh
+PS
+OA
 mh
-hj
-mI
-Za
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-Dn
-SI
-XO
-XO
-XO
-XO
-XO
-WI
-WI
-WI
-Hh
+yq
+nW
+wa
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+at
+IT
+oP
+oP
+oP
+oP
+oP
+nI
+nI
+nI
+OA
 mh
 mh
 mh
-jO
-XO
+PS
+oP
 iK
-XO
-XO
-Lv
-XO
-Za
-XO
-WI
-WI
+oP
+oP
+fI
+oP
+wa
+oP
+nI
+nI
 BL
 xM
 Yf
@@ -25869,49 +27798,49 @@ Tc
 WI
 XO
 XO
-XO
-XO
-XO
-Za
+oP
+oP
+oP
+wa
 pR
 GI
 Vc
-VG
-vf
+qC
+wv
 mh
-mI
-oP
-wa
-CP
-on
 nW
-wa
-wa
-oP
+on
+on
+on
+on
+on
+on
+ss
+mE
 at
-IT
-oP
-wa
-wa
-oP
-wa
+Kd
+mE
+ss
+on
+on
+on
 CP
 yq
 yq
-QO
-QO
-QO
-wm
-of
-XO
+yB
+yB
+yB
+lL
+Cq
+oP
 iK
-XO
-WI
-Lv
-XO
-Za
-XO
-XO
+oP
+nI
+fI
+oP
+wa
+oP
+oP
 AK
 NT
 xM
@@ -26025,48 +27954,48 @@ gt
 fZ
 XO
 WI
-XO
-Lv
-Za
-Za
-WI
+oP
+fI
+wa
+wa
+nI
 Wu
 oP
-Zx
-je
-vf
-jO
+WQ
+GG
+wv
+PS
 oP
-wa
-oP
-oP
-oP
-oP
-oP
-wa
-at
+kL
+mE
 IT
-wa
+IT
+IT
+IT
+IT
+tx
+Ko
+IT
 Oy
+kP
+nd
+Oo
+tL
+tL
+jF
+fI
+fI
+fI
+fI
+WQ
 oP
-oP
-wa
-oP
-nI
-nI
-Lv
-Lv
-Lv
-Lv
-Zx
-XO
 iK
-XO
-XO
-Lv
-XO
-XO
-XO
+oP
+oP
+fI
+oP
+oP
+oP
 AK
 zy
 NT
@@ -26181,49 +28110,49 @@ oW
 RN
 WI
 WI
-WI
-XO
-XO
-Za
-XO
+nI
+oP
+oP
+wa
+oP
 Wu
 CP
-vf
-jO
-je
-wm
+on
+wa
+wa
+wa
 oP
 wa
 ka
-ka
-ka
-ka
-oP
-wa
-at
 IT
+IT
+IT
+nb
+IT
+vv
+Ko
+IT
+IT
+iP
+tL
+tL
+tL
+tL
+jF
+fI
+fI
+fI
+OA
+wv
+nI
+En
 wa
 oP
-ka
-ka
-ka
-ka
+oP
+oP
 wa
+oP
 nI
-Lv
-Lv
-Lv
-Hh
-vf
-jO
-En
-Za
-XO
-XO
-XO
-Za
-XO
-WI
 GZ
 KV
 bF
@@ -26337,48 +28266,48 @@ Yf
 qs
 WI
 WI
-WI
-XO
-XO
-Za
-XO
-Wu
-oP
-je
-vf
-jO
-Zx
 nI
 oP
-ka
-ko
-mP
-ll
-wa
-wa
-at
-IT
+oP
 wa
 oP
-mz
-mP
-nb
-ka
+Wu
+oP
+ko
 wa
 wa
-Lv
-Lv
-Hh
-vf
-vf
-QO
-WA
+wa
+nI
+oP
+IT
+IT
+IT
+IT
+on
+on
+Cm
+Ko
+IT
+IT
+tL
+tL
+tL
+tL
+tL
+tL
+fI
+fI
+OA
+zd
+nI
+nI
+En
 pT
-XO
-Za
-XO
-XO
-WI
+oP
+wa
+oP
+oP
+nI
 lX
 lG
 Gu
@@ -26493,47 +28422,47 @@ Yf
 qs
 WI
 WI
-XO
-Lv
-XO
-XO
-XO
-qM
-wa
 oP
-je
-QO
-wm
-nI
+fI
+oP
+oP
+oP
+CZ
 wa
-on
 kp
 IT
 IT
 IT
 IT
-at
+IT
+mP
 IT
 IT
-IT
-IT
-IT
-nc
+kS
 on
-oP
-oP
-tw
-PK
-je
-QO
-wm
+on
+vv
+Ko
+IT
+IT
+mP
+tL
+tL
+on
+on
+on
+on
+on
+GG
+nI
+nI
 oP
 En
-Za
-Za
-XO
-XO
-WI
+wa
+wa
+oP
+oP
+nI
 lX
 WS
 eY
@@ -26633,7 +28562,7 @@ YT
 YT
 YT
 YT
-YT
+eK
 YT
 YT
 YT
@@ -26649,46 +28578,46 @@ Yf
 qs
 WI
 WI
-XO
-XO
-np
-XO
-Za
-qM
-nI
-nI
-nI
-nI
-nI
-qe
 oP
-ka
-kq
-kO
-lm
+oP
+sT
+oP
 wa
-oP
-at
+CZ
+nI
+wa
 IT
-wa
-wa
-mA
-mQ
+IT
+IT
+td
+IT
+on
+IT
+IT
+IT
+IT
+nf
+vv
+Ko
+IT
+IT
+on
+tL
 nd
-ka
+on
 oP
 wa
-tw
-RQ
-Ko
+wa
+wa
+wa
 nI
 oP
 oP
-iK
-XO
-XO
-XO
-WI
+Br
+oP
+oP
+oP
+nI
 lX
 WS
 eY
@@ -26772,7 +28701,7 @@ XP
 Sg
 SR
 SR
-SR
+im
 YT
 dq
 YT
@@ -26805,45 +28734,45 @@ Yf
 qs
 WI
 XO
-XO
-XO
-XO
-XO
-XO
+oP
+oP
+oP
+oP
+oP
 ZS
 oP
+ko
 oP
 oP
 oP
-oP
-oP
-wa
-ka
-ka
-ka
-ka
-oP
-oP
-at
 IT
-oP
-oP
-ka
-ka
-ka
-ka
+IT
+on
+IT
+IT
+IT
+IT
+IT
+vv
+Ko
+IT
+IT
+on
+tL
+vw
+on
 wa
 oP
+nI
+nI
+wa
 oP
-RA
-Ko
+nI
 oP
-Hh
-mI
 iK
-XO
-XO
-WI
+oP
+oP
+nI
 lX
 WS
 eY
@@ -26968,36 +28897,36 @@ pq
 TW
 CZ
 oP
-wa
+on
+kq
 oP
 oP
-oP
-sT
-oP
-oP
-oP
-oP
-oP
-oP
-wa
-at
 td
-wa
-oP
-oP
-oP
-oP
-oP
-oP
-wa
-sT
+IT
+on
+on
+on
+on
+on
+on
+vv
 Qp
+IT
+IT
+on
+jK
+Xc
+on
 oP
-oP
-of
 wa
+nI
+nI
+oP
+oP
+nI
+nI
 En
-XO
+oP
 aG
 pq
 WS
@@ -27124,34 +29053,34 @@ hc
 he
 vV
 oP
-oP
-oP
-wa
+on
 oP
 wa
 oP
-ka
-ka
-ka
-ka
-wa
-oP
-at
 IT
-oP
-oP
-ka
-ka
-ka
-ka
+IT
+on
+mR
+IT
+nf
+IT
+on
+vv
+Ko
+IT
+IT
+on
+on
+on
+on
 wa
 wa
-oP
+nI
 oP
 oP
 wa
-wa
-wa
+nI
+nI
 En
 BL
 aG
@@ -27280,32 +29209,32 @@ gc
 gt
 Up
 TV
-nI
+on
 oP
 oP
 wa
-wa
-oP
-ka
-ku
-kS
-ln
-wa
-wa
-at
 IT
-wa
-wa
-mC
-mP
-ne
+IT
+on
+ku
+IT
+IT
+IT
 ka
+vv
+Ko
+IT
+IT
+IT
+IT
+IT
+mP
 wa
 wa
-wa
-wa
-wa
-wa
+nI
+nI
+nI
+nI
 oP
 oP
 cu
@@ -27393,7 +29322,7 @@ QK
 SR
 SR
 SR
-SR
+im
 SR
 SR
 Zy
@@ -27437,33 +29366,33 @@ gc
 PC
 TJ
 TV
-nI
+on
 oP
 oP
-wa
-oP
+IT
+kS
 on
 kv
 IT
+qe
+IT
+IT
+vv
+Ko
 IT
 IT
 IT
-at
 IT
 IT
-IT
-IT
-IT
-nc
-on
+ka
 wa
 wa
-wa
-wa
+nI
+nI
 oP
 wa
 oP
-KE
+HF
 Uj
 OJ
 bF
@@ -27594,32 +29523,32 @@ Jp
 gt
 TJ
 TV
-nI
+on
 oP
-oP
-wa
-ka
-kw
-kO
-lm
-oP
-wa
-at
+IT
+IT
+on
+kx
+lo
+lo
+IT
+on
+vv
+Ko
+td
+IT
+IT
+IT
+IT
 IT
 wa
-oP
-mD
-mR
-nf
-ka
-wa
-wa
+uq
 oP
 oP
 oP
-wa
+uq
 oP
-GZ
+AL
 Uj
 GY
 bD
@@ -27751,23 +29680,23 @@ gc
 gt
 TJ
 TV
-oP
-oP
-wa
-ka
-ka
-ka
-ka
-oP
-wa
-at
-td
-wa
-oP
-ka
-ka
-ka
-ka
+on
+IT
+IT
+on
+kx
+lo
+lo
+IT
+on
+vv
+Qp
+IT
+IT
+IT
+IT
+IT
+mP
 wa
 oP
 oP
@@ -27908,22 +29837,22 @@ gc
 TJ
 TJ
 fZ
-oP
-wa
-oP
-oP
-oP
-oP
-oP
-oP
-at
 IT
-wa
-wa
-oP
-oP
-oP
-oP
+IT
+on
+IT
+lp
+IT
+kS
+on
+Cm
+Ko
+on
+on
+on
+on
+on
+on
 oP
 oP
 nI
@@ -27931,7 +29860,7 @@ nI
 nI
 wa
 oP
-AK
+iT
 lC
 xM
 bD
@@ -28064,22 +29993,22 @@ gc
 TJ
 TJ
 fZ
-oP
-wa
-ka
-ka
-ka
-ka
-wa
-oP
-at
 IT
-oP
-oP
+IT
 ka
-ka
-ka
-ka
+IT
+IT
+qe
+IT
+on
+vv
+Ko
+on
+WA
+Dx
+Dx
+VH
+on
 oP
 nI
 WQ
@@ -28174,13 +30103,13 @@ pk
 by
 aX
 bH
-cQ
-dK
-cP
-eu
-eu
-eu
-eu
+KU
+IC
+Zt
+YT
+YT
+YT
+YT
 YT
 lc
 bD
@@ -28219,31 +30148,31 @@ qy
 qy
 fp
 dk
-nI
-oP
-wa
-ka
-kx
-kT
-lo
-oP
-wa
-at
+on
 IT
-wa
-wa
-mE
-mY
-nl
+IT
+IT
+kx
+lo
+lo
+IT
 ka
+vv
+Ko
+RQ
+IT
+IT
+IT
+nl
+on
 oP
-OA
+wa
 wv
 yB
 nW
 wa
 oP
-AK
+iT
 lC
 xM
 bD
@@ -28375,31 +30304,31 @@ aG
 nI
 nI
 nI
-oP
-oP
-wa
+ky
+IT
+IT
 on
-kv
+IT
+lo
+lo
 IT
 IT
-IT
-IT
-at
-IT
-IT
+vv
+Ko
+Wm
 IT
 IT
 IT
 nc
 on
 oP
-qC
+wa
 wv
 nW
 oP
 wa
 oP
-KE
+HF
 Uj
 NT
 bD
@@ -28532,30 +30461,30 @@ nI
 nI
 oP
 wa
-wa
-wa
-ka
-ky
-kO
-lp
-oP
-wa
-at
 IT
-wa
-oP
+IT
+on
+IT
+nb
+lp
+IT
+on
+vv
+Ko
+on
+WW
 mG
-kO
+lJ
 nm
-ka
-CP
-yB
+on
+on
+on
 yB
 nW
-wa
-wa
-AK
-NT
+on
+on
+iT
+PR
 tv
 KV
 bD
@@ -28646,7 +30575,7 @@ RN
 VU
 VU
 YT
-eL
+eK
 YT
 nM
 bH
@@ -28688,29 +30617,29 @@ nI
 oP
 oP
 wa
-wa
-oP
-ka
-ka
-ka
-ka
-oP
-wa
-at
 IT
-wa
-oP
-ka
-ka
-ka
-ka
+IT
+on
+on
+on
+on
+on
+on
+vv
+Ko
+on
+on
+on
+on
+on
+on
 nI
 nI
 nI
 oP
 wa
 oP
-KE
+HF
 Np
 zl
 bF
@@ -28844,16 +30773,16 @@ nI
 oP
 wa
 wa
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-wa
-at
 IT
+IT
+oP
+oP
+oP
+oP
+oP
+wa
+tx
+Ko
 wa
 oP
 wa
@@ -28866,8 +30795,8 @@ oP
 oP
 wa
 oP
-GZ
-KV
+AL
+mH
 kW
 Yf
 Yf
@@ -29000,8 +30929,8 @@ oP
 oP
 wa
 wa
-sT
-oP
+td
+IT
 oP
 oP
 oP
@@ -29009,7 +30938,7 @@ oP
 wa
 lP
 lZ
-td
+Qp
 IT
 wa
 wa
@@ -29156,8 +31085,8 @@ oP
 oP
 wa
 wa
-oP
-oP
+IT
+IT
 oP
 IT
 IT

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -22,10 +22,6 @@
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/plating/dmg1,
 /area/icy_caves/caves/crashed_ship)
-"af" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
 "ag" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/effect/landmark/nuke_spawn,
@@ -263,12 +259,6 @@
 /obj/item/ammo_magazine/rifle/bolt,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
-"aZ" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/corner{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "ba" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -631,10 +621,9 @@
 /turf/open/floor/mainship/tcomms,
 /area/icy_caves/caves/northern)
 "cp" = (
-/obj/item/lightstick/anchored,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/northern)
+/turf/closed/ice_rock/corners,
+/area/icy_caves/caves)
 "cq" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating/ground/ice,
@@ -649,15 +638,15 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "cs" = (
+/obj/structure/cable,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/end{
-	dir = 8
-	},
+/turf/closed/wall/r_wall,
 /area/icy_caves/caves/northern)
 "ct" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/corner{
-	dir = 8
+/obj/effect/ai_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
 	},
 /area/icy_caves/caves/northern)
 "cu" = (
@@ -670,21 +659,34 @@
 /area/icy_caves/outpost/LZ2)
 "cv" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/junction{
-	dir = 8
-	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "cw" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/junction{
-	dir = 4
-	},
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "cx" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/end{
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"cy" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/LZ2)
+"cz" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside)
+"cC" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "cD" = (
 /obj/item/tool/surgery/circular_saw,
@@ -706,11 +708,27 @@
 /turf/open/shuttle/escapepod/plain,
 /area/icy_caves/caves/northern)
 "cG" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/red2{
+	dir = 5
+	},
+/area/icy_caves/outpost/LZ2)
+"cI" = (
+/turf/closed/ice/thin/single,
+/area/icy_caves/caves/northern)
+"cJ" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/northern)
-"cI" = (
-/turf/closed/ice/thin/single,
+"cK" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/corners,
 /area/icy_caves/caves/northern)
 "cL" = (
 /obj/structure/monorail,
@@ -720,12 +738,14 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/crashed_ship)
-"cO" = (
+"cN" = (
 /obj/effect/ai_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
+/turf/open/floor/tile/dark/green2,
+/area/icy_caves/caves/northern)
+"cO" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "cP" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -748,15 +768,18 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"cX" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "cY" = (
 /turf/closed/ice/thin/corner{
 	dir = 8
 	},
 /area/icy_caves/caves/west)
-"cZ" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/southWall,
-/area/icy_caves/caves)
 "da" = (
 /turf/closed/ice/junction,
 /area/icy_caves/caves/west)
@@ -766,8 +789,12 @@
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "dd" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
 /obj/effect/ai_node,
-/turf/open/floor/tile/dark/green2,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "de" = (
 /turf/closed/ice/thin/junction{
@@ -868,7 +895,7 @@
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/west)
 "dz" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
 	},
 /obj/effect/ai_node,
@@ -913,13 +940,9 @@
 	},
 /area/icy_caves/caves/east)
 "dK" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/eastWall,
+/area/icy_caves/caves)
 "dL" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
@@ -936,11 +959,10 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "dQ" = (
-/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/corner{
 	dir = 4
 	},
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "dR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
@@ -1072,11 +1094,8 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
 "eu" = (
-/obj/machinery/camera{
-	dir = 5
-	},
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/intersection,
 /area/icy_caves/caves/northern)
 "ev" = (
 /obj/structure/cable,
@@ -1133,9 +1152,10 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "eF" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/corner{
+	dir = 8
+	},
 /area/icy_caves/caves/northern)
 "eG" = (
 /obj/machinery/light{
@@ -1174,8 +1194,10 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
 "eL" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/purple/whitepurplefull,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/end{
+	dir = 4
+	},
 /area/icy_caves/caves/northern)
 "eN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -1509,10 +1531,6 @@
 	dir = 5
 	},
 /area/icy_caves/caves/east)
-"gf" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/single,
-/area/icy_caves/caves/northern)
 "gh" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 9
@@ -1693,6 +1711,9 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/research)
+"hi" = (
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/caves/east)
 "hj" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/outpost/outside)
@@ -1780,10 +1801,6 @@
 /obj/structure/largecrate/supply,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"hC" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside/center)
 "hD" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/floor/plating/ground/ice,
@@ -1818,6 +1835,15 @@
 "hO" = (
 /turf/closed/ice/thin/single,
 /area/icy_caves/caves/east)
+"hP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "hQ" = (
 /obj/machinery/space_heater,
 /turf/open/floor/tile/dark/blue2,
@@ -1910,16 +1936,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"iA" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"iB" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/corners{
-	dir = 5
-	},
-/area/icy_caves/caves)
 "iG" = (
 /turf/open/floor/tile/dark/yellow2{
 	dir = 4
@@ -1940,22 +1956,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"iO" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 8
-	},
-/turf/open/floor/tile/dark/red2{
-	dir = 5
-	},
-/area/icy_caves/outpost/LZ2)
-"iP" = (
-/obj/machinery/door/airlock/multi_tile/mainship/research,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
 "iQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -1963,14 +1963,19 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
 "iS" = (
-/obj/machinery/atmospherics/pipe/manifold/green/hidden,
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/southWall,
+/area/icy_caves/caves)
 "iT" = (
 /turf/closed/ice/end{
 	dir = 1
 	},
+/area/icy_caves/outpost/LZ2)
+"iV" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "iZ" = (
 /turf/open/floor/tile/dark/brown2,
@@ -2008,20 +2013,11 @@
 /obj/item/tool/surgery/retractor,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"jl" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/corner{
-	dir = 1
-	},
-/area/icy_caves/caves/northern)
 "jo" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
 /obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/northern)
 "jt" = (
 /obj/machinery/floodlight/landing,
 /obj/effect/decal/warning_stripes,
@@ -2062,10 +2058,6 @@
 /obj/effect/landmark/dropship_console_spawn_lz1,
 /turf/open/floor/plating/ground/snow,
 /area/lv624/lazarus/console)
-"jF" = (
-/obj/structure/ore_box,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
 "jH" = (
 /obj/machinery/landinglight/ds1/delaythree{
 	dir = 4
@@ -2079,10 +2071,6 @@
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
-"jK" = (
-/obj/structure/largecrate/supply/medicine,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
 "jL" = (
@@ -2148,6 +2136,10 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/research)
+"jW" = (
+/obj/structure/ore_box,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "jX" = (
 /obj/machinery/light{
 	dir = 4
@@ -2228,29 +2220,26 @@
 /turf/open/shuttle/escapepod/plain,
 /area/icy_caves/caves/northern)
 "ko" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/closed/wall/r_wall,
-/area/icy_caves/outpost/LZ2)
-"kp" = (
-/obj/machinery/door/airlock/multi_tile/mainship/research,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/LZ2)
-"kq" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
+	dir = 10
 	},
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves)
+"kp" = (
+/obj/machinery/miner/damaged/platinum,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/northern)
+"kq" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
+	dir = 5
+	},
+/area/icy_caves/caves)
 "kr" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
-"kt" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/corner{
-	dir = 8
-	},
-/area/icy_caves/caves/northern)
 "ku" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/tile/dark,
@@ -2259,24 +2248,16 @@
 /obj/machinery/vending/snack,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"kw" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/straight,
-/area/icy_caves/caves/northern)
 "kx" = (
 /obj/structure/bed/chair,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "ky" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/end{
+	dir = 1
 	},
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/LZ2)
-"kz" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside/center)
+/area/icy_caves/caves/northern)
 "kA" = (
 /obj/machinery/landinglight/ds1/delaytwo{
 	dir = 4
@@ -2301,11 +2282,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark/green2/corner,
 /area/icy_caves/outpost/medbay)
-"kH" = (
-/obj/machinery/miner/damaged/platinum,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/northern)
 "kJ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -2323,11 +2299,11 @@
 	},
 /area/icy_caves/outpost/research)
 "kL" = (
-/obj/machinery/light{
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/corner{
 	dir = 8
 	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/northern)
 "kM" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/singlePart{
@@ -2339,10 +2315,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
-"kP" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
 "kR" = (
 /obj/structure/table/mainship,
 /turf/open/floor/prison{
@@ -2351,9 +2323,9 @@
 	},
 /area/icy_caves/caves/northern)
 "kS" = (
-/obj/machinery/light,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/intersection,
+/area/icy_caves/caves/northern)
 "kW" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -2401,15 +2373,18 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "ll" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/corners,
-/area/icy_caves/caves)
+/obj/machinery/camera{
+	dir = 5
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "ln" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/end{
-	dir = 1
+/turf/closed/ice/thin/corner{
+	dir = 4
 	},
-/area/icy_caves/caves)
+/area/icy_caves/caves/northern)
 "lo" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark,
@@ -2418,10 +2393,6 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"ls" = (
-/obj/structure/prop/mainship/hangar_stencil/two,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "lt" = (
@@ -2480,14 +2451,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/mining/west)
-"lJ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/tile/dark/yellow2{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ2)
 "lL" = (
 /turf/closed/ice/thin/corner{
 	dir = 8
@@ -2537,10 +2500,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"lV" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside/center)
 "lW" = (
 /turf/closed/ice/thin/end{
 	dir = 1
@@ -2690,29 +2649,31 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
 "mz" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/end{
-	dir = 1
-	},
-/area/icy_caves/caves/west)
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "mA" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/west)
+/turf/closed/ice/end{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "mC" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/west)
-"mD" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice/corner{
-	dir = 4
+	dir = 1
 	},
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "mE" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/plating/ground/snow/layer1,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/corners{
+	dir = 5
+	},
+/area/icy_caves/caves)
+"mF" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/tile/dark/yellow2,
 /area/icy_caves/outpost/LZ2)
 "mG" = (
 /obj/structure/dispenser,
@@ -2750,59 +2711,56 @@
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/caves/south)
 "mP" = (
-/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "mQ" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singlePart{
-	dir = 5
-	},
-/area/icy_caves/caves/west)
-"mR" = (
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/turf/closed/ice_rock/single,
+/area/icy_caves/caves/northern)
 "mV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"mX" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/r_wall,
+/area/icy_caves/outpost/dorms)
 "mY" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singlePart{
-	dir = 9
-	},
-/area/icy_caves/caves/west)
+/turf/closed/ice_rock/westWall,
+/area/icy_caves/caves)
 "mZ" = (
 /obj/effect/decal/cleanable/blood/xtracks,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/northern)
 "nb" = (
-/obj/machinery/light{
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/straight{
 	dir = 4
 	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/northern)
 "nc" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
-/turf/open/floor/tile/dark/yellow2,
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
 /area/icy_caves/outpost/LZ2)
 "nd" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
 "ne" = (
+/obj/item/lightstick/anchored,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singlePart{
-	dir = 10
-	},
-/area/icy_caves/caves)
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/northern)
 "nf" = (
-/obj/machinery/light{
-	dir = 8
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
 	},
-/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "ng" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -2994,6 +2952,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/tcomms,
 /area/icy_caves/caves/northern)
+"oq" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "or" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/structure/cable,
@@ -3002,10 +2966,6 @@
 "ot" = (
 /turf/closed/ice/junction,
 /area/icy_caves/caves/northern)
-"ov" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall,
-/area/icy_caves/outpost/garage)
 "ow" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside/center)
@@ -3033,9 +2993,6 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
-"oF" = (
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/caves/east)
 "oI" = (
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
@@ -3054,6 +3011,10 @@
 	dir = 4
 	},
 /area/icy_caves/caves/northern)
+"oN" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside/center)
 "oO" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -3344,11 +3305,9 @@
 	},
 /area/icy_caves/outpost/refinery)
 "qe" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/single,
+/area/icy_caves/caves/northern)
 "qf" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -3493,6 +3452,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"qL" = (
+/turf/open/floor/tile/dark/yellow2{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "qN" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -3602,6 +3566,11 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
+"rm" = (
+/turf/open/floor/tile/dark/brown2{
+	dir = 5
+	},
+/area/icy_caves/outpost/LZ2)
 "rn" = (
 /obj/structure/closet/crate/science,
 /turf/open/floor/tile/dark/purple2{
@@ -3647,6 +3616,10 @@
 /obj/item/tool/kitchen/knife,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
+"rw" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/brown2,
+/area/icy_caves/outpost/refinery)
 "rx" = (
 /obj/structure/table,
 /obj/item/reagent_containers/dropper,
@@ -3706,10 +3679,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/engineering)
-"rI" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singleT,
-/area/icy_caves/caves)
 "rJ" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -3728,12 +3697,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/engineering)
-"rN" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/corner{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "rO" = (
 /obj/machinery/vending/tool,
 /obj/machinery/light{
@@ -3806,10 +3769,8 @@
 /area/icy_caves/outpost/medbay)
 "sb" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singlePart{
-	dir = 9
-	},
-/area/icy_caves/caves)
+/turf/closed/ice/straight,
+/area/icy_caves/caves/northern)
 "sc" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -3901,9 +3862,11 @@
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
 "ss" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/LZ2)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd{
+	dir = 4
+	},
+/area/icy_caves/caves)
 "st" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table,
@@ -3988,6 +3951,12 @@
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/LZ1)
+"sM" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside)
 "sN" = (
 /obj/structure/table/flipped,
 /obj/item/flashlight,
@@ -3995,11 +3964,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/security)
-"sP" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/northern)
 "sQ" = (
 /obj/machinery/light/small,
 /turf/open/floor/freezer,
@@ -4064,21 +4028,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
-"tj" = (
-/turf/open/floor/tile/dark/red2{
-	dir = 6
-	},
-/area/icy_caves/outpost/LZ2)
 "tk" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
 /obj/item/clothing/shoes/laceup,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"tl" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
 "tm" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -4086,12 +4041,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
-"tn" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singlePart{
-	dir = 8
-	},
-/area/icy_caves/caves)
 "tp" = (
 /obj/item/lightstick/anchored,
 /obj/effect/ai_node,
@@ -4117,24 +4066,14 @@
 /area/icy_caves/outpost/LZ2)
 "tw" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
-"tx" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 8
-	},
-/turf/open/floor/tile/dark/blue2{
+/turf/closed/ice_rock/singleEnd{
 	dir = 1
 	},
-/area/icy_caves/outpost/LZ2)
-"tA" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside/center)
+/area/icy_caves/caves/northern)
+"tx" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "tB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -4168,9 +4107,11 @@
 	},
 /area/icy_caves/caves/northern)
 "tG" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "tH" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/research)
@@ -4183,6 +4124,10 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
+"tJ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall,
+/area/icy_caves/outpost/mining/west)
 "tK" = (
 /obj/item/ammo_casing,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4443,10 +4388,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
-"uY" = (
-/obj/docking_port/mobile/crashmode/bigbury,
-/turf/closed/ice,
-/area/icy_caves/caves/south)
 "va" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/tile/dark/green2{
@@ -4549,23 +4490,11 @@
 /obj/structure/bed/roller,
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
-"vu" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singleEnd,
-/area/icy_caves/caves)
 "vv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 8
-	},
-/turf/open/floor/tile/dark/blue2{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
-"vw" = (
-/obj/structure/largecrate/random,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
+/obj/machinery/atmospherics/pipe/manifold/green/hidden,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "vx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
@@ -4742,6 +4671,10 @@
 "wv" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/outpost/LZ2)
+"ww" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/northWall,
+/area/icy_caves/caves)
 "wx" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -4759,6 +4692,10 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/medbay)
+"wE" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside/center)
 "wG" = (
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/prison{
@@ -4801,6 +4738,10 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
+"wQ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/single,
+/area/icy_caves/caves)
 "wT" = (
 /obj/structure/lattice,
 /obj/structure/monorail{
@@ -4829,10 +4770,6 @@
 	dir = 1
 	},
 /area/icy_caves/caves/south)
-"xe" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/single,
-/area/icy_caves/caves/northern)
 "xf" = (
 /obj/structure/closet/secure_closet/scientist,
 /turf/open/floor/tile/dark/purple2,
@@ -4901,6 +4838,10 @@
 /obj/structure/barricade/guardrail,
 /turf/open/floor/mainship/red/full,
 /area/icy_caves/caves/northern)
+"xt" = (
+/obj/structure/largecrate/supply/medicine,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "xu" = (
 /obj/structure/cargo_container/green,
 /turf/open/floor/plating,
@@ -4914,6 +4855,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"xx" = (
+/turf/open/floor/tile/dark/yellow2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "xA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -4922,10 +4868,6 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
-"xB" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/corners,
-/area/icy_caves/caves/northern)
 "xE" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
@@ -5004,10 +4946,6 @@
 	},
 /turf/open/floor/mainship_hull,
 /area/space)
-"ye" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall,
-/area/icy_caves/outpost/dorms)
 "yg" = (
 /obj/structure/bookcase/manuals,
 /obj/machinery/light{
@@ -5033,6 +4971,12 @@
 /obj/item/weapon/gun/smg/m25,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"yk" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "yl" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/tile/dark/blue2{
@@ -5064,12 +5008,6 @@
 "yx" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/engineering)
-"yy" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/end{
-	dir = 8
-	},
-/area/icy_caves/caves/northern)
 "yz" = (
 /obj/structure/bed/chair,
 /turf/open/floor/tile/dark,
@@ -5155,10 +5093,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"zd" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/LZ2)
+"yZ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside)
 "ze" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating/mainship,
@@ -5218,10 +5156,18 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/garage)
-"zs" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/single,
-/area/icy_caves/caves)
+"zq" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "zt" = (
 /turf/open/floor/tile/white/warningstripe{
 	dir = 6
@@ -5231,12 +5177,6 @@
 /obj/machinery/door/airlock/multi_tile/mainship/secdoor,
 /turf/open/floor/mainship/red/full,
 /area/icy_caves/caves/northern)
-"zv" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singleEnd{
-	dir = 4
-	},
-/area/icy_caves/caves)
 "zw" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -5268,6 +5208,12 @@
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"zF" = (
+/obj/machinery/space_heater,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 10
+	},
+/area/icy_caves/outpost/LZ2)
 "zG" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
@@ -5275,11 +5221,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"zI" = (
-/turf/open/floor/tile/dark/brown2{
-	dir = 9
-	},
-/area/icy_caves/outpost/LZ2)
 "zK" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -5466,12 +5407,9 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "Ay" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd,
+/area/icy_caves/caves)
 "AB" = (
 /turf/closed/ice/thin/end{
 	dir = 1
@@ -5613,6 +5551,10 @@
 /obj/structure/fence,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/caves/west)
+"Bc" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleT,
+/area/icy_caves/caves)
 "Bd" = (
 /obj/machinery/door/airlock/multi_tile/mainship/secdoor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -5650,22 +5592,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"Bp" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/end{
-	dir = 1
-	},
-/area/icy_caves/caves/northern)
 "Bq" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"Br" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/shuttle/canterbury)
 "Bs" = (
 /turf/open/floor/podhatch/floor,
 /area/icy_caves/outpost/engineering)
@@ -5709,10 +5639,6 @@
 	icon_state = "bcircuitoff"
 	},
 /area/icy_caves/caves/northern)
-"BD" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/northWall,
-/area/icy_caves/caves)
 "BF" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -5728,11 +5654,19 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"BK" = (
+/obj/structure/prop/mainship/hangar_stencil/two,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "BL" = (
 /turf/closed/ice/end{
 	dir = 8
 	},
 /area/icy_caves/outpost/outside)
+"BM" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/straight,
+/area/icy_caves/caves/northern)
 "BN" = (
 /turf/closed/shuttle/dropship2{
 	icon_state = "52"
@@ -5834,17 +5768,17 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "Cm" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 8
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/tile/dark/blue2{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
+"Co" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
 "Cq" = (
 /turf/closed/ice/thin/end{
 	dir = 4
@@ -5876,17 +5810,6 @@
 	dir = 10
 	},
 /area/icy_caves/caves/northern)
-"CI" = (
-/turf/open/floor/tile/dark/red2{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ2)
-"CL" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
 "CN" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/south)
@@ -5991,12 +5914,6 @@
 	dir = 1
 	},
 /area/icy_caves/caves)
-"Dr" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singleEnd{
-	dir = 8
-	},
-/area/icy_caves/caves)
 "Ds" = (
 /obj/structure/table,
 /obj/item/storage/surgical_tray,
@@ -6024,11 +5941,6 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"Dx" = (
-/turf/open/floor/tile/dark/yellow2{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ2)
 "DB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/singlePart{
@@ -6079,6 +5991,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"DO" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/LZ2)
 "DS" = (
 /obj/structure/dropship_piece/one/corner/middleright,
 /obj/structure/dropship_piece/two/corner/rearright,
@@ -6173,6 +6091,10 @@
 /obj/effect/landmark/dropship_console_spawn_lz2,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/console)
+"Em" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall,
+/area/icy_caves/outpost/garage)
 "En" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -6278,10 +6200,6 @@
 	},
 /turf/closed/ice_rock/westWall,
 /area/icy_caves/caves)
-"ET" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
 "EU" = (
 /obj/machinery/light{
 	dir = 8
@@ -6341,11 +6259,6 @@
 	},
 /turf/open/shuttle/dropship/seven,
 /area/space)
-"Fl" = (
-/turf/open/floor/tile/dark/red2{
-	dir = 10
-	},
-/area/icy_caves/outpost/LZ2)
 "Fm" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -6527,6 +6440,14 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/office)
+"Gl" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/mining/west)
 "Gm" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -6554,10 +6475,6 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
-"Gr" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/eastWall,
-/area/icy_caves/caves)
 "Gs" = (
 /turf/closed/ice_rock/corners,
 /area/icy_caves/caves/northern)
@@ -6644,9 +6561,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ2)
-"GP" = (
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/caves/east)
 "GQ" = (
 /obj/machinery/light{
 	dir = 8
@@ -6765,6 +6679,10 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/northern)
+"Hx" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/outside/center)
 "HA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -6889,17 +6807,6 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"HY" = (
-/obj/structure/cable,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall,
-/area/icy_caves/caves/northern)
-"Ia" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singleEnd{
-	dir = 1
-	},
-/area/icy_caves/caves/northern)
 "Ib" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -6921,18 +6828,21 @@
 /turf/open/floor/mainship/cargo,
 /area/icy_caves/caves/northern)
 "Ig" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/obj/docking_port/mobile/crashmode/bigbury,
+/turf/closed/ice,
+/area/icy_caves/caves/south)
 "Ih" = (
 /obj/structure/cargo_container/green{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Ii" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/end{
+	dir = 1
+	},
+/area/icy_caves/caves)
 "Ij" = (
 /obj/structure/largecrate/random/barrel/green,
 /turf/open/floor/plating/mainship,
@@ -6970,6 +6880,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"Iq" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside/center)
 "Ir" = (
 /turf/closed/ice/thin/junction{
 	dir = 4
@@ -6983,10 +6897,6 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/garage)
-"It" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
 "Iv" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating,
@@ -7105,9 +7015,9 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "IZ" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/obj/structure/window/framed/colony/reinforced,
+/turf/closed/wall/r_wall,
+/area/icy_caves/outpost/LZ2)
 "Je" = (
 /turf/closed/ice/thin/end{
 	dir = 8
@@ -7122,12 +7032,6 @@
 "Jg" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/west)
-"Jh" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singlePart{
-	dir = 5
-	},
-/area/icy_caves/caves)
 "Ji" = (
 /obj/effect/landmark/start/job/survivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -7177,12 +7081,12 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
-"Ju" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark/brown2{
+"Js" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
 	dir = 4
 	},
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves)
 "Jv" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -7225,11 +7129,6 @@
 /obj/item/lightstick/anchored,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
-"JE" = (
-/turf/open/floor/tile/dark/brown2{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ2)
 "JF" = (
 /obj/machinery/vending/cola,
 /obj/machinery/light{
@@ -7255,6 +7154,10 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
+"JN" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/LZ2)
 "JO" = (
 /obj/machinery/bodyscanner,
 /turf/open/floor/tile/dark/green2,
@@ -7308,10 +7211,9 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/office)
 "Kd" = (
-/obj/machinery/door/airlock/multi_tile/mainship/research{
-	dir = 1
+/turf/open/floor/tile/dark/red2{
+	dir = 10
 	},
-/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "Ke" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -7341,7 +7243,9 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "Ko" = (
-/turf/open/floor/tile/dark/blue2,
+/turf/open/floor/tile/dark/red2{
+	dir = 6
+	},
 /area/icy_caves/outpost/LZ2)
 "Kp" = (
 /turf/open/floor/tile/dark,
@@ -7351,6 +7255,10 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/garage)
+"Kt" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/blue2,
+/area/icy_caves/outpost/LZ2)
 "Ku" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/item/reagent_containers/hypospray/autoinjector/tricordrazine,
@@ -7371,6 +7279,12 @@
 /obj/machinery/space_heater,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"Kz" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "KA" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/machinery/light{
@@ -7436,10 +7350,6 @@
 	dir = 5
 	},
 /area/icy_caves/outpost/security)
-"KT" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall,
-/area/icy_caves/outpost/mining/west)
 "KU" = (
 /turf/closed/ice/thin/corner{
 	dir = 1
@@ -7571,11 +7481,10 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
 "LB" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/straight{
-	dir = 4
+/turf/open/floor/tile/dark/brown2{
+	dir = 9
 	},
-/area/icy_caves/caves/northern)
+/area/icy_caves/outpost/LZ2)
 "LC" = (
 /obj/machinery/light/small,
 /turf/open/floor/wood,
@@ -7630,12 +7539,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
-"LM" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/end{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "LO" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -7696,6 +7599,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"LY" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "LZ" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -7764,6 +7671,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"Mr" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd{
+	dir = 8
+	},
+/area/icy_caves/caves)
 "Ms" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/tile/dark,
@@ -8090,10 +8003,6 @@
 "NW" = (
 /turf/open/shuttle/dropship/seven,
 /area/space)
-"Oa" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/intersection,
-/area/icy_caves/caves/northern)
 "Ob" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark,
@@ -8137,12 +8046,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
-"Oo" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
 "Os" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -8221,6 +8124,16 @@
 "OJ" = (
 /turf/closed/ice/end,
 /area/icy_caves/outpost/outside)
+"OL" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ2)
+"OM" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside/center)
 "OO" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -8239,6 +8152,18 @@
 /obj/structure/cargo_container/gorg,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Pc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "Pd" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/security)
@@ -8292,6 +8217,10 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/refinery)
+"Pv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside)
 "Pz" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -8458,8 +8387,10 @@
 	},
 /area/icy_caves/caves/northern)
 "Qp" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark/blue2,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ2)
 "Qq" = (
 /turf/closed/ice/corner{
@@ -8470,11 +8401,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
-"Qt" = (
-/turf/open/floor/tile/dark/brown2{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ2)
 "Qw" = (
 /turf/closed/ice/corner{
 	dir = 4
@@ -8543,6 +8469,12 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/outside)
+"QP" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "QQ" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -8570,6 +8502,9 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"QW" = (
+/turf/open/floor/tile/dark/blue2,
+/area/icy_caves/outpost/LZ2)
 "QX" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -8699,13 +8634,11 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
 "RA" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/LZ2)
 "RB" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/brown2{
@@ -8766,19 +8699,16 @@
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
 "RQ" = (
-/obj/machinery/door/airlock/multi_tile/mainship/research,
-/turf/open/floor/tile/dark/yellow2{
-	dir = 1
-	},
+/obj/machinery/light,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "RS" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/southWall,
 /area/icy_caves/caves)
-"RT" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside/center)
+"RU" = (
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/caves/east)
 "RW" = (
 /turf/closed/ice/end{
 	dir = 4
@@ -8800,6 +8730,16 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"Sb" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
+	dir = 8
+	},
+/area/icy_caves/caves)
+"Sc" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ2)
 "Se" = (
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 8
@@ -8862,6 +8802,10 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/security)
+"Sq" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/outside)
 "Ss" = (
 /turf/closed/shuttle/dropship2{
 	icon_state = "104"
@@ -8881,11 +8825,6 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
-"Sz" = (
-/turf/open/floor/tile/dark/brown2{
-	dir = 5
-	},
-/area/icy_caves/outpost/LZ2)
 "SA" = (
 /turf/closed/ice/thin/straight{
 	dir = 4
@@ -9072,14 +9011,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
-"TF" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark/brown2,
-/area/icy_caves/outpost/refinery)
-"TG" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/straight,
-/area/icy_caves/caves/northern)
 "TH" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/ice,
@@ -9212,6 +9143,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"Uo" = (
+/obj/structure/largecrate/random/case,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "Up" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -9233,6 +9168,10 @@
 "Uu" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ1)
+"Uy" = (
+/obj/structure/largecrate/random,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "Uz" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/wood,
@@ -9321,6 +9260,14 @@
 	dir = 8
 	},
 /area/icy_caves/caves/east)
+"UW" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark/yellow2{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "UY" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/black,
@@ -9342,12 +9289,6 @@
 	icon_state = "109"
 	},
 /area/icy_caves/caves/northern)
-"Va" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singlePart{
-	dir = 4
-	},
-/area/icy_caves/caves)
 "Vb" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 10
@@ -9376,14 +9317,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"Vh" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Vi" = (
 /obj/structure/table,
 /obj/item/storage/fancy/vials,
@@ -9401,6 +9334,10 @@
 /obj/structure/table,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"Vp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside/center)
 "Vq" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -9474,12 +9411,6 @@
 /obj/structure/xenoautopsy/tank,
 /turf/open/shuttle/dropship/seven,
 /area/icy_caves/caves/northern)
-"VH" = (
-/obj/machinery/space_heater,
-/turf/open/floor/tile/dark/yellow2{
-	dir = 10
-	},
-/area/icy_caves/outpost/LZ2)
 "VI" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/northern)
@@ -9627,9 +9558,8 @@
 	},
 /area/icy_caves/caves/south)
 "Wm" = (
-/turf/open/floor/tile/dark/yellow2{
-	dir = 1
-	},
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "Wp" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
@@ -9670,8 +9600,7 @@
 /turf/open/shuttle/dropship/floor,
 /area/space)
 "WA" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/tile/dark/yellow2{
+/turf/open/floor/tile/dark/red2{
 	dir = 8
 	},
 /area/icy_caves/outpost/LZ2)
@@ -9707,10 +9636,6 @@
 /obj/docking_port/stationary/marine_dropship/lz1,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
-"WN" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/westWall,
-/area/icy_caves/caves)
 "WO" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
@@ -9747,9 +9672,8 @@
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
 "WW" = (
-/turf/open/floor/tile/dark/yellow2{
-	dir = 4
-	},
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "WX" = (
 /obj/machinery/computer3/laptop,
@@ -9768,15 +9692,9 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/LZ1)
-"Xc" = (
-/obj/structure/largecrate/random/case,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
-"Xe" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/snow/layer2,
+"Xb" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ2)
 "Xf" = (
 /obj/effect/landmark/start/job/survivor,
@@ -9825,11 +9743,6 @@
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"Xm" = (
-/obj/structure/window/framed/colony/reinforced,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Xn" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/cheeseburger,
@@ -9896,10 +9809,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
-"XC" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside/center)
 "XD" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -9997,10 +9906,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/refinery)
-"XV" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/intersection,
-/area/icy_caves/caves/northern)
 "XW" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -10061,6 +9966,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"Yl" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside)
 "Ym" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/swat,
@@ -10330,6 +10239,12 @@
 "ZB" = (
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/caves/south)
+"ZD" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "ZE" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -10365,6 +10280,15 @@
 /obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
+"ZM" = (
+/turf/open/floor/tile/dark/yellow2{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
+"ZN" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "ZP" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 4
@@ -11130,27 +11054,27 @@ Yf
 Yf
 Yf
 Yf
-ll
-ll
-ll
-ll
-ll
-ll
-ll
-ll
-ll
-ll
-ll
-ll
-ll
-ll
-ll
-ll
-ll
-ll
-ll
-ll
-ll
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+cp
+cp
+cp
+cp
+cp
+cp
+cp
+cp
+cp
 Yf
 Yf
 Yf
@@ -11229,7 +11153,7 @@ VZ
 AJ
 AJ
 Fq
-eL
+tx
 AJ
 kf
 dF
@@ -11286,7 +11210,7 @@ Yf
 Yf
 Yf
 MH
-ln
+MH
 Yf
 Yf
 MH
@@ -11298,7 +11222,7 @@ MH
 Yf
 Yf
 Yf
-Yf
+cp
 Yf
 Yf
 qy
@@ -11306,7 +11230,7 @@ qy
 Yf
 Yf
 Yf
-ll
+cp
 Yf
 Yf
 Yf
@@ -11442,7 +11366,7 @@ Yf
 MH
 YI
 YI
-mz
+YI
 ZU
 ZU
 ZU
@@ -11454,7 +11378,7 @@ MH
 Yf
 Yf
 Yf
-Yf
+cp
 MH
 MH
 qy
@@ -11462,7 +11386,7 @@ qy
 qy
 MH
 Yf
-ll
+cp
 Yf
 Yf
 Yf
@@ -11598,7 +11522,7 @@ Yf
 Yf
 ZU
 YI
-mA
+ZU
 ZU
 Wx
 Wx
@@ -11610,7 +11534,7 @@ WI
 MH
 Yf
 Yf
-Yf
+cp
 MH
 MH
 Za
@@ -11618,7 +11542,7 @@ Za
 Yf
 Yf
 MH
-ln
+Ii
 MH
 MH
 DX
@@ -11754,7 +11678,7 @@ MH
 Yf
 ZU
 ZU
-mC
+ZU
 ZU
 ZU
 ZU
@@ -11766,15 +11690,15 @@ WI
 WI
 MH
 MH
-MH
+Ii
 MH
 pa
-CL
-tl
+sM
+Pv
 Za
 MH
 MH
-ln
+Ii
 Uu
 Uu
 DX
@@ -11910,7 +11834,7 @@ YI
 ZU
 ZU
 ZU
-mA
+ZU
 ZU
 ZU
 ZU
@@ -11922,15 +11846,15 @@ SI
 SI
 SI
 SI
+Yl
 SI
 SI
-SI
 Za
 Za
-af
+cz
 Za
 Za
-ET
+yZ
 Uu
 Uu
 DX
@@ -12066,7 +11990,7 @@ ZU
 gx
 ez
 ZU
-mA
+ZU
 ZU
 ZU
 ZU
@@ -12078,15 +12002,15 @@ SI
 SI
 SI
 SI
+Yl
 SI
 SI
-SI
 Za
 Za
 Za
 Za
-tl
-ET
+Pv
+yZ
 Uu
 Uu
 Uu
@@ -12222,7 +12146,7 @@ ZU
 ZU
 ZU
 ZU
-mA
+ZU
 ZU
 re
 re
@@ -12234,15 +12158,15 @@ Ln
 WI
 WI
 WI
-WI
+Co
 SI
 Ln
-tl
+Pv
 Za
 Za
 Za
 Za
-ET
+yZ
 UE
 fq
 Uu
@@ -12291,7 +12215,7 @@ nw
 Sf
 yi
 wG
-cO
+ct
 OP
 TK
 Zl
@@ -12305,7 +12229,7 @@ Zl
 Zl
 Zl
 Zl
-dz
+cX
 Zl
 ev
 He
@@ -12321,7 +12245,7 @@ Tz
 Tz
 Tz
 Tz
-iS
+vv
 Zl
 Zl
 Zl
@@ -12378,7 +12302,7 @@ ZU
 ZU
 ZU
 ZU
-mD
+Di
 Di
 lG
 lX
@@ -12390,7 +12314,7 @@ SI
 WI
 pD
 WI
-WI
+Co
 SI
 SI
 Za
@@ -12398,7 +12322,7 @@ Za
 Za
 Za
 Za
-ET
+yZ
 Uu
 Uu
 Uu
@@ -12534,19 +12458,19 @@ ZU
 ZU
 ZU
 ZU
-mD
-mQ
-mY
-ne
-sb
-Ig
-tw
-IZ
-IZ
-tw
-tw
-tw
-tw
+Di
+Mg
+ec
+Vb
+eY
+WI
+WI
+SI
+SI
+WI
+WI
+WI
+Co
 SI
 SI
 Za
@@ -12554,7 +12478,7 @@ Za
 MH
 qs
 WI
-tw
+Co
 Uu
 Uu
 Uu
@@ -12702,7 +12626,7 @@ lH
 nx
 xI
 xI
-KT
+tJ
 SI
 SI
 WI
@@ -12710,7 +12634,7 @@ MH
 Yf
 Yf
 MH
-tw
+Co
 Uu
 Uu
 sD
@@ -12858,7 +12782,7 @@ oI
 pf
 oZ
 oK
-KT
+tJ
 SI
 SI
 WI
@@ -12866,7 +12790,7 @@ MH
 Yf
 Yf
 Yf
-ln
+Ii
 Uu
 Uu
 Uu
@@ -13014,15 +12938,15 @@ oI
 oI
 oI
 oU
-KT
-IZ
-IZ
-ln
-ll
-ll
-ll
-cZ
-cZ
+tJ
+Yl
+Yl
+Ii
+cp
+cp
+cp
+iS
+iS
 Uu
 Uu
 Uu
@@ -13241,7 +13165,7 @@ XQ
 dZ
 ma
 dF
-dz
+cX
 Zl
 WF
 Gs
@@ -13634,7 +13558,7 @@ iJ
 oI
 wW
 oI
-RA
+Gl
 oI
 oI
 oI
@@ -13716,7 +13640,7 @@ Gs
 WF
 Gj
 cD
-eu
+ll
 Zl
 ds
 dF
@@ -14193,7 +14117,7 @@ Qo
 bP
 dF
 Zl
-dz
+cX
 dF
 SR
 SR
@@ -14362,7 +14286,7 @@ bT
 SR
 SR
 zB
-jo
+Cm
 zB
 ZU
 gx
@@ -14489,7 +14413,7 @@ Zl
 Zl
 Zl
 Zl
-dK
+dd
 Zl
 WF
 Gs
@@ -14657,7 +14581,7 @@ PD
 bA
 VI
 Ho
-yh
+SR
 SR
 SR
 Zl
@@ -14813,7 +14737,7 @@ Fu
 ot
 by
 SR
-yh
+SR
 SR
 im
 Zl
@@ -14969,7 +14893,7 @@ ot
 by
 hX
 SR
-yh
+SR
 SR
 wo
 mq
@@ -15125,7 +15049,7 @@ ce
 SR
 im
 SR
-yh
+SR
 PD
 Fu
 Zl
@@ -15279,9 +15203,9 @@ Qo
 ce
 Sg
 SR
-bC
 SR
-kl
+SR
+ok
 bM
 VI
 Zl
@@ -15362,7 +15286,7 @@ Pq
 XU
 DY
 DY
-TF
+rw
 wx
 lB
 lM
@@ -15425,7 +15349,7 @@ Zl
 Zl
 Zl
 Zl
-dz
+cX
 Zl
 WF
 Gs
@@ -15437,7 +15361,7 @@ SR
 SR
 im
 SR
-cs
+bN
 bN
 Lm
 Zl
@@ -15563,17 +15487,17 @@ Yf
 Yf
 Yf
 Yf
-ll
-ll
-ll
-HY
-iA
-iA
-iA
-Vh
-cG
-xB
-cG
+cp
+cp
+cp
+cs
+cv
+cv
+cv
+cx
+cJ
+cK
+cJ
 dF
 Zl
 dF
@@ -15593,7 +15517,7 @@ rf
 SR
 SR
 cj
-ct
+bT
 cn
 bN
 Zl
@@ -15719,7 +15643,7 @@ Yf
 Yf
 Yf
 Yf
-ll
+cp
 WF
 WF
 WF
@@ -15729,7 +15653,7 @@ Wc
 BF
 dF
 Gs
-xB
+cK
 dF
 Zl
 dF
@@ -15749,7 +15673,7 @@ rf
 SR
 Zb
 SR
-cs
+bN
 cn
 cn
 Zl
@@ -15875,7 +15799,7 @@ Yf
 Yf
 Yf
 Yf
-ll
+cp
 WF
 Zl
 EU
@@ -15885,7 +15809,7 @@ Bf
 BZ
 dF
 dF
-cG
+cJ
 dF
 Bo
 Zl
@@ -15905,7 +15829,7 @@ SR
 SR
 SR
 cj
-cv
+cg
 IC
 ci
 Zl
@@ -16031,17 +15955,17 @@ Yf
 Yf
 Yf
 Yf
-ll
+cp
 WF
 Zl
 WO
 Zl
 Gf
 Zl
-Ay
+cC
 Zl
 Zl
-cG
+cJ
 Zl
 Fj
 Tz
@@ -16061,7 +15985,7 @@ im
 SR
 SR
 cj
-cw
+Ir
 cm
 ci
 Zl
@@ -16187,17 +16111,17 @@ Yf
 Yf
 Yf
 Yf
-ll
+cp
 WF
 Xh
 Xh
 Zl
 Zl
-tG
+cw
 HQ
 Xh
 Zl
-Xm
+cO
 Zl
 Zl
 Zl
@@ -16217,7 +16141,7 @@ SR
 SR
 bI
 XP
-cx
+QK
 QK
 dF
 Bo
@@ -16343,7 +16267,7 @@ Yf
 Yf
 Yf
 Yf
-ll
+cp
 WF
 MT
 eD
@@ -16352,7 +16276,7 @@ dL
 Zl
 nv
 MT
-dd
+cN
 eC
 Zl
 Zl
@@ -16361,16 +16285,16 @@ Zl
 Zl
 Zl
 He
-dz
+cX
 Zl
 WF
 Il
 ce
 Lm
 Nd
-yh
-yh
-yh
+SR
+SR
+SR
 bR
 bI
 Tu
@@ -16499,7 +16423,7 @@ Yf
 Yf
 Yf
 Yf
-ll
+cp
 WF
 eD
 eD
@@ -16509,7 +16433,7 @@ Zl
 IK
 eD
 PZ
-iA
+cv
 Zl
 Zl
 Zl
@@ -16533,7 +16457,7 @@ XP
 QZ
 QK
 Zl
-dz
+cX
 Zl
 SR
 im
@@ -16655,7 +16579,7 @@ Yf
 Yf
 Yf
 Yf
-ll
+cp
 WF
 BW
 BW
@@ -16665,7 +16589,7 @@ Zl
 QQ
 BW
 Zl
-Xm
+cO
 di
 Pg
 Zl
@@ -16811,7 +16735,7 @@ Yf
 Yf
 Yf
 Yf
-ll
+cp
 WF
 Yh
 Zl
@@ -16821,7 +16745,7 @@ Tz
 eP
 WO
 FB
-HY
+cs
 WF
 WF
 WF
@@ -16967,7 +16891,7 @@ Yf
 Yf
 Yf
 Yf
-ll
+cp
 WF
 Zl
 Zl
@@ -16977,7 +16901,7 @@ CX
 Zl
 Zl
 Zl
-HY
+cs
 Yf
 Yf
 Gs
@@ -17106,14 +17030,14 @@ Qa
 Qa
 LO
 vq
-ov
-It
-IZ
-IZ
-ET
-It
-BD
-ll
+Em
+Sq
+Yl
+Yl
+yZ
+Sq
+ww
+cp
 YQ
 "}
 (44,1,1) = {"
@@ -17123,17 +17047,17 @@ Yf
 Yf
 Yf
 Yf
-ll
-HY
-HY
-HY
-HY
-HY
-HY
-HY
-HY
-HY
-HY
+cp
+cs
+cs
+cs
+cs
+cs
+cs
+cs
+cs
+cs
+cs
 Yf
 Yf
 Il
@@ -17262,14 +17186,14 @@ Is
 Zc
 RJ
 KZ
-ov
+Em
 XO
 SI
 SI
 Za
 XO
 bD
-ll
+cp
 YQ
 "}
 (45,1,1) = {"
@@ -17297,7 +17221,7 @@ WF
 NU
 Tz
 Tz
-dQ
+dz
 Tz
 mV
 Tz
@@ -17305,7 +17229,7 @@ Tz
 Tz
 Tz
 Tz
-eF
+mz
 Tz
 Tz
 Tz
@@ -17418,14 +17342,14 @@ KZ
 KZ
 KZ
 KZ
-tw
+Co
 XO
 SI
 SI
 Za
 XO
 lX
-vu
+Ay
 YQ
 "}
 (46,1,1) = {"
@@ -17574,14 +17498,14 @@ li
 li
 li
 li
-XC
+Hx
 li
 my
 my
 DD
 DD
 Vb
-Jh
+kq
 YQ
 "}
 (47,1,1) = {"
@@ -17730,14 +17654,14 @@ my
 my
 my
 my
-tA
+wE
 my
 my
 Iw
 DD
-kz
+Vp
 DD
-Va
+Js
 YQ
 "}
 (48,1,1) = {"
@@ -17886,14 +17810,14 @@ my
 my
 my
 my
-tA
+wE
 my
 JW
 my
 DD
-lV
+Iq
 DD
-Va
+Js
 YQ
 "}
 (49,1,1) = {"
@@ -18042,14 +17966,14 @@ li
 li
 li
 li
-XC
+Hx
 DD
 my
 my
 DD
-kz
+Vp
 DD
-Dr
+Mr
 YQ
 "}
 (50,1,1) = {"
@@ -18198,14 +18122,14 @@ ND
 ND
 ND
 ND
-ye
-kz
+mX
+Vp
 my
 my
 DD
 DD
 DD
-zs
+wQ
 YQ
 "}
 (51,1,1) = {"
@@ -18354,14 +18278,14 @@ Hf
 JC
 wZ
 Ez
-ye
+mX
 DD
 my
 my
-kz
+Vp
 DD
 DD
-zs
+wQ
 YQ
 "}
 (52,1,1) = {"
@@ -18510,14 +18434,14 @@ Zq
 wZ
 wZ
 LC
-ye
+mX
 DD
 my
 my
 DD
 DD
 DD
-zv
+ss
 YQ
 "}
 (53,1,1) = {"
@@ -18666,14 +18590,14 @@ Hf
 Ze
 wZ
 Ez
-ye
+mX
 DD
 my
 my
-kz
+Vp
 DD
 DD
-rI
+Bc
 YQ
 "}
 (54,1,1) = {"
@@ -18822,14 +18746,14 @@ Hf
 Hf
 Hf
 Hf
-ye
+mX
 DD
 my
 my
 DD
 DD
 li
-tn
+Sb
 YQ
 "}
 (55,1,1) = {"
@@ -18978,14 +18902,14 @@ Hf
 KO
 Cs
 Ez
-ye
-XC
-tA
-tA
-RT
-RT
-XC
-tn
+mX
+Hx
+wE
+wE
+OM
+OM
+Hx
+Sb
 YQ
 "}
 (56,1,1) = {"
@@ -20815,7 +20739,7 @@ my
 my
 my
 my
-hC
+oN
 Iw
 my
 my
@@ -21087,7 +21011,7 @@ xX
 xX
 hv
 ST
-uY
+Ig
 YW
 YW
 YW
@@ -25253,20 +25177,20 @@ Yf
 Yf
 Yf
 Yf
-ll
-cZ
-ne
-Jh
+cp
+iS
+ko
+kq
 cQ
-ct
+kL
 yh
 yh
 yh
-xe
+mQ
 yh
-yy
-LB
-gf
+mA
+nb
+qe
 Zy
 bS
 bS
@@ -25409,7 +25333,7 @@ Yf
 Yf
 Yf
 Yf
-ll
+cp
 Yf
 RN
 Vb
@@ -25422,7 +25346,7 @@ SR
 SR
 ce
 ce
-gf
+qe
 Zy
 Zy
 bS
@@ -25493,11 +25417,11 @@ XO
 WI
 XO
 XO
-oF
-oF
-oF
-oF
-oF
+RU
+RU
+RU
+RU
+RU
 TV
 fP
 TJ
@@ -25565,7 +25489,7 @@ Yf
 Yf
 Yf
 Yf
-ll
+cp
 Yf
 qs
 qz
@@ -25578,7 +25502,7 @@ wo
 wo
 ce
 ce
-gf
+qe
 Zy
 Zy
 Zy
@@ -25651,9 +25575,9 @@ Za
 Za
 oO
 XO
-GP
-GP
-oF
+hi
+hi
+RU
 fP
 TJ
 dk
@@ -25721,7 +25645,7 @@ Yf
 Yf
 Yf
 Yf
-ll
+cp
 Yf
 qy
 lX
@@ -25734,7 +25658,7 @@ VI
 VI
 bM
 by
-gf
+qe
 Zy
 Zy
 Zy
@@ -25877,7 +25801,7 @@ Yf
 Yf
 Yf
 Yf
-Gr
+dK
 qy
 lX
 WS
@@ -25890,7 +25814,7 @@ Sg
 ot
 pk
 Ho
-gf
+qe
 Zy
 Zy
 Zy
@@ -26033,7 +25957,7 @@ Yf
 Yf
 Yf
 qy
-rN
+dQ
 Ho
 Vb
 eY
@@ -26046,7 +25970,7 @@ SR
 Lm
 Ho
 Zy
-gf
+qe
 Zy
 Zy
 Zy
@@ -26189,7 +26113,7 @@ Yf
 Yf
 qy
 PD
-Oa
+eu
 bA
 Ho
 SR
@@ -26202,7 +26126,7 @@ im
 SR
 ok
 pk
-kw
+sb
 pk
 pk
 pk
@@ -26345,7 +26269,7 @@ Yf
 qs
 PD
 VI
-kt
+eF
 Sg
 SR
 SR
@@ -26358,7 +26282,7 @@ bl
 SR
 SR
 ok
-kw
+sb
 pk
 pk
 pk
@@ -26501,7 +26425,7 @@ Yf
 qy
 ot
 Fu
-LM
+eL
 SR
 bl
 SR
@@ -26514,7 +26438,7 @@ SR
 bl
 SR
 SR
-Bp
+ky
 Xw
 Xw
 Ir
@@ -26658,18 +26582,18 @@ PD
 VI
 Fu
 yh
-sP
-kH
+jo
+kp
 yh
-Bp
-XV
-ct
-aZ
-XV
+ky
+kS
+kL
+ln
+kS
 cP
 yh
-sP
-cp
+jo
+ne
 yh
 cj
 Xw
@@ -27982,12 +27906,12 @@ on
 on
 on
 on
-ss
-mE
+Xb
+Sc
 at
-Kd
-mE
-ss
+Kz
+Sc
+Xb
 on
 on
 on
@@ -28133,23 +28057,23 @@ GG
 wv
 PS
 oP
-kL
-mE
-CI
-CI
-CI
-CI
-CI
-iO
-tj
-CI
+RA
+Sc
+WA
+WA
+WA
+WA
+WA
+cG
+Ko
+WA
 Oy
-kP
+ZN
 nd
-Oo
+oq
 tL
 tL
-jF
+jW
 fI
 fI
 fI
@@ -28293,19 +28217,19 @@ wa
 ka
 IT
 IT
-ls
-nb
+BK
+ZD
 IT
-vv
-Ko
-JE
-zI
-iP
+hP
+QW
+nc
+LB
+LY
 tL
 tL
 tL
 tL
-jF
+jW
 fI
 fI
 fI
@@ -28381,13 +28305,13 @@ bl
 Ry
 KU
 Ir
-XV
+kS
 cP
 yh
-sP
+jo
 yh
 yh
-jl
+mC
 by
 Zy
 Zy
@@ -28440,7 +28364,7 @@ wa
 oP
 Wu
 oP
-ko
+IZ
 wa
 wa
 wa
@@ -28452,10 +28376,10 @@ IT
 IT
 on
 on
-Cm
-Ko
-Qt
-Sz
+Pc
+QW
+nf
+rm
 tL
 tL
 tL
@@ -28465,7 +28389,7 @@ tL
 fI
 fI
 OA
-zd
+cy
 nI
 nI
 En
@@ -28596,23 +28520,23 @@ oP
 oP
 CZ
 wa
-kp
-Fl
+JN
+Kd
 IT
 IT
 IT
 IT
-mP
+Wm
 IT
 IT
-kS
+RQ
 on
 on
-vv
-Ko
+hP
+QW
 IT
 IT
-mP
+Wm
 tL
 tL
 on
@@ -28699,7 +28623,7 @@ Xw
 rf
 PI
 PI
-Ia
+tw
 ca
 bS
 bS
@@ -28753,7 +28677,7 @@ wa
 CZ
 nI
 wa
-tj
+Ko
 IT
 IT
 td
@@ -28763,9 +28687,9 @@ IT
 IT
 IT
 IT
-nf
-vv
-Ko
+mP
+hP
+QW
 IT
 IT
 on
@@ -28780,7 +28704,7 @@ wa
 nI
 oP
 oP
-Br
+iK
 oP
 oP
 oP
@@ -28908,7 +28832,7 @@ oP
 oP
 ZS
 oP
-ko
+IZ
 oP
 oP
 oP
@@ -28920,13 +28844,13 @@ IT
 IT
 IT
 IT
-vv
-Ko
+hP
+QW
 IT
 IT
 on
 tL
-vw
+Uy
 on
 wa
 oP
@@ -29005,7 +28929,7 @@ Vb
 lG
 SR
 VU
-sP
+jo
 SR
 SR
 we
@@ -29013,8 +28937,8 @@ bl
 SR
 yh
 cb
-Bp
-TG
+ky
+BM
 cP
 qT
 Xw
@@ -29065,7 +28989,7 @@ TW
 CZ
 oP
 on
-kq
+OL
 oP
 oP
 td
@@ -29076,13 +29000,13 @@ on
 on
 on
 on
-vv
-Qp
+hP
+Kt
 IT
 IT
 on
-jK
-Xc
+xt
+Uo
 on
 oP
 wa
@@ -29161,7 +29085,7 @@ RN
 Vb
 pq
 eY
-yy
+mA
 wo
 SR
 wo
@@ -29227,13 +29151,13 @@ oP
 IT
 IT
 on
-mR
+WW
 IT
-nf
+mP
 IT
 on
-vv
-Ko
+hP
+QW
 IT
 IT
 on
@@ -29317,7 +29241,7 @@ Yf
 oW
 oW
 RN
-jl
+mC
 VI
 pk
 VI
@@ -29388,14 +29312,14 @@ IT
 IT
 IT
 ka
-vv
-Ko
+hP
+QW
 IT
 IT
-IT
-nf
 IT
 mP
+IT
+Wm
 wa
 wa
 nI
@@ -29473,7 +29397,7 @@ Yf
 Yf
 Yf
 Yf
-iB
+mE
 Lm
 Ho
 ce
@@ -29537,20 +29461,20 @@ on
 oP
 oP
 IT
-kS
+RQ
 on
 kv
 IT
-qe
+iV
 IT
 IT
-vv
-Ko
-JE
-JE
-JE
-JE
-JE
+hP
+QW
+nc
+nc
+nc
+nc
+nc
 ka
 wa
 wa
@@ -29629,7 +29553,7 @@ Yf
 Yf
 Yf
 Yf
-ll
+cp
 oW
 RN
 Lm
@@ -29700,13 +29624,13 @@ lo
 lo
 IT
 on
-vv
-Ko
-Ju
-Qt
-Qt
-Qt
-Qt
+hP
+QW
+QP
+nf
+nf
+nf
+nf
 IT
 wa
 uq
@@ -29785,16 +29709,16 @@ Yf
 Yf
 Yf
 Yf
-ll
-ll
-ll
-WN
-iB
-zv
-zv
+cp
+cp
+cp
+mY
+mE
+ss
+ss
 yh
-zv
-zv
+ss
+ss
 yh
 SR
 SR
@@ -29856,14 +29780,14 @@ lo
 lo
 IT
 on
-vv
-Qp
+hP
+Kt
 IT
 IT
 IT
 IT
 IT
-mP
+Wm
 wa
 oP
 oP
@@ -30010,10 +29934,10 @@ on
 IT
 lp
 IT
-kS
+RQ
 on
-Cm
-Ko
+Pc
+QW
 on
 on
 on
@@ -30165,16 +30089,16 @@ IT
 ka
 IT
 IT
-qe
+iV
 IT
 on
-vv
-Ko
+hP
+QW
 on
-WA
-Dx
-Dx
-VH
+tG
+qL
+qL
+zF
 on
 oP
 nI
@@ -30324,9 +30248,9 @@ lo
 lo
 IT
 ka
-vv
-Ko
-RQ
+hP
+QW
+yk
 IT
 IT
 IT
@@ -30471,7 +30395,7 @@ aG
 nI
 nI
 nI
-ky
+Qp
 IT
 IT
 on
@@ -30480,13 +30404,13 @@ lo
 lo
 IT
 IT
-vv
-Ko
-Wm
+hP
+QW
+xx
 IT
 IT
 IT
-nc
+mF
 on
 oP
 wa
@@ -30632,16 +30556,16 @@ IT
 IT
 on
 IT
-nb
+ZD
 lp
 IT
 on
-vv
-Ko
+hP
+QW
 on
-WW
+ZM
 mG
-lJ
+UW
 nm
 on
 on
@@ -30792,8 +30716,8 @@ on
 on
 on
 on
-vv
-Ko
+hP
+QW
 on
 on
 on
@@ -30801,7 +30725,7 @@ on
 on
 on
 nI
-Xe
+DO
 nI
 oP
 wa
@@ -30944,16 +30868,16 @@ IT
 IT
 oP
 oP
-ky
+Qp
 oP
 oP
 wa
-tx
-Ko
+zq
+QW
 wa
 oP
 wa
-ky
+Qp
 oP
 oP
 oP
@@ -31105,7 +31029,7 @@ oP
 wa
 lP
 lZ
-Qp
+Kt
 IT
 wa
 wa

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -757,11 +757,6 @@
 	dir = 1
 	},
 /area/icy_caves/caves/northern)
-"cV" = (
-/turf/open/floor/tile/white/warningstripe{
-	dir = 1
-	},
-/area/icy_caves/caves/northern)
 "cW" = (
 /obj/machinery/door/poddoor/mainship/indestructible{
 	dir = 2
@@ -1884,6 +1879,10 @@
 	dir = 5
 	},
 /area/icy_caves/outpost/office)
+"ie" = (
+/obj/effect/landmark/fob_sentry_rebel,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/LZ1)
 "ig" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -3923,12 +3922,6 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
-"sD" = (
-/obj/effect/landmark/fob_sentry_rebel,
-/turf/closed/ice_rock/singleEnd{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ1)
 "sE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -5168,11 +5161,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/LZ2)
-"zt" = (
-/turf/open/floor/tile/white/warningstripe{
-	dir = 6
-	},
-/area/icy_caves/caves/northern)
 "zu" = (
 /obj/machinery/door/airlock/multi_tile/mainship/secdoor,
 /turf/open/floor/mainship/red/full,
@@ -6315,11 +6303,6 @@
 	dir = 1
 	},
 /area/icy_caves/caves/northern)
-"Fw" = (
-/turf/open/floor/tile/white/warningstripe{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "Fy" = (
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
@@ -7001,11 +6984,6 @@
 "IT" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"IU" = (
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "IX" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark,
@@ -7363,14 +7341,6 @@
 "KZ" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/garage)
-"La" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/white/warningstripe{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "Lb" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/tile/dark,
@@ -7419,9 +7389,6 @@
 	on = 1
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Lp" = (
-/turf/open/floor/tile/white/warningstripe,
 /area/icy_caves/caves/northern)
 "Lq" = (
 /obj/machinery/power/geothermal,
@@ -7800,14 +7767,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
-"MX" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "MY" = (
 /obj/item/reagent_containers/spray/pepper,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -8195,9 +8154,7 @@
 /area/icy_caves/caves/south)
 "Pp" = (
 /obj/effect/decal/cleanable/blood/xtracks,
-/turf/open/floor/tile/white/warningstripe{
-	dir = 5
-	},
+/turf/open/floor/tile/purple/whitepurplefull,
 /area/icy_caves/caves/northern)
 "Pq" = (
 /turf/open/floor/tile/dark/brown2{
@@ -11931,10 +11888,10 @@ Zl
 Zl
 Zl
 Zl
-cV
-IU
-MX
-Lp
+AJ
+AJ
+HU
+AJ
 Zl
 Zl
 Zl
@@ -12088,9 +12045,9 @@ Zl
 Zl
 Zl
 Pp
-Fw
-La
-zt
+AJ
+HU
+AJ
 Zl
 Zl
 Zl
@@ -12637,7 +12594,7 @@ MH
 Co
 Uu
 Uu
-sD
+Ml
 Ml
 Tf
 Ml
@@ -12792,7 +12749,7 @@ Yf
 Yf
 Ii
 Uu
-Uu
+ie
 Uu
 UE
 TQ


### PR DESCRIPTION
## About The Pull Request

I have been getting some dm's to bring back my icy caves edit, so here it is with fixes and some changes.

## Why It's Good For The Game

Swaps around Crash disk locations, move some stupid silo spots in Crash and changes them up to make it a bit more challenging for marines as they dominate this map whilst not giving Xenos free handouts either. LZ2 is redone sorta. Lz1 has been tinkered with and northwest caves have a new area, 

## Changelog
:cl:
balance: LZ2 semi redone to make it more appealing for marines
balance: some LZ1 changes
balance: moved crash disk locations
balance: removed some silos like that one in the nuke disk area and replaced them elsewhere
balance: caves have been fully pre wedded as they should
add: new area northeast of caves transit station (not pre wedded)

/:cl:

Pictures

(1)
![image](https://user-images.githubusercontent.com/64131993/148223147-f4ee20f1-2f33-4b8f-b515-fadacc446414.png)


(2)
![image](https://user-images.githubusercontent.com/64131993/148223217-fd9c4d22-7447-4f9e-b2bf-b2de9a9607b6.png)


(3)
![image](https://user-images.githubusercontent.com/64131993/148223313-26535a3b-87b1-4cb1-a74e-549729a7343c.png)


(4)
![image](https://user-images.githubusercontent.com/64131993/148224044-0a97d4f5-0c4e-4b57-b179-c20ab8334ea8.png)
