### PR TITLE
Icy caves 2.0

### DIFF
--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -97,6 +97,7 @@
 	name = "Shaft Miner"
 	},
 /obj/structure/cable,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
 "av" = (
@@ -1829,10 +1830,8 @@
 /area/icy_caves/caves/south)
 "hL" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/end{
-	dir = 1
-	},
-/area/icy_caves/caves)
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/west)
 "hM" = (
 /turf/closed/ice_rock/corners{
 	dir = 10
@@ -2008,9 +2007,10 @@
 /turf/open/floor/tile/purple/whitepurplefull,
 /area/icy_caves/caves/northern)
 "jh" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside/center)
+/obj/effect/ai_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/west)
 "jk" = (
 /obj/structure/table/mainship,
 /obj/item/tool/surgery/cautery,
@@ -2456,9 +2456,11 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/mining/west)
 "lK" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/end{
+	dir = 8
+	},
+/area/icy_caves/caves/west)
 "lL" = (
 /turf/closed/ice/thin/corner{
 	dir = 8
@@ -2873,6 +2875,11 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
+"nQ" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside/center)
 "nS" = (
 /turf/open/floor/plating/dmg1,
 /area/icy_caves/caves/crashed_ship)
@@ -3006,6 +3013,7 @@
 "oJ" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
 "oK" = (
@@ -3265,6 +3273,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
+"pV" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside/center)
 "pW" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/tile/dark/yellow2{
@@ -3918,6 +3930,11 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
+"sC" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/mining/west)
 "sD" = (
 /obj/effect/landmark/fob_sentry_rebel,
 /turf/closed/ice_rock/singleEnd{
@@ -3970,6 +3987,11 @@
 /area/icy_caves/outpost/LZ2)
 "sV" = (
 /obj/structure/rack,
+/obj/item/ammo_magazine/rifle/ak47,
+/obj/item/ammo_magazine/rifle/ak47,
+/obj/item/ammo_magazine/rifle/ak47,
+/obj/item/ammo_magazine/rifle/ak47,
+/obj/item/weapon/gun/rifle/ak47,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
 "ta" = (
@@ -4034,8 +4056,8 @@
 /area/icy_caves/outpost/engineering)
 "to" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall,
-/area/icy_caves/outpost/garage)
+/turf/closed/ice_rock/singleT,
+/area/icy_caves/caves/west)
 "tp" = (
 /obj/item/lightstick/anchored,
 /obj/effect/ai_node,
@@ -4926,6 +4948,10 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/medbay)
+"xU" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
 "xV" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
@@ -5007,6 +5033,11 @@
 "yq" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/outpost/LZ2)
+"yr" = (
+/turf/closed/ice_rock/singlePart{
+	dir = 10
+	},
+/area/icy_caves/outpost/outside/center)
 "yv" = (
 /obj/machinery/light{
 	dir = 4
@@ -5329,9 +5360,11 @@
 /turf/open/shuttle/dropship/floor,
 /area/space)
 "Ag" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
+	dir = 5
+	},
+/area/icy_caves/caves/west)
 "Ah" = (
 /obj/effect/landmark/corpsespawner/security{
 	corpsebelt = /obj/item/weapon/gun/revolver/cmb;
@@ -5404,8 +5437,10 @@
 /area/icy_caves/outpost/garage)
 "Aw" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall,
-/area/icy_caves/outpost/dorms)
+/turf/closed/ice/thin/end{
+	dir = 1
+	},
+/area/icy_caves/caves)
 "Ax" = (
 /obj/structure/table,
 /obj/machinery/light/built{
@@ -6203,6 +6238,10 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/LZ1)
+"ER" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall,
+/area/icy_caves/outpost/mining/west)
 "ES" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -6491,6 +6530,10 @@
 "Gs" = (
 /turf/closed/ice_rock/corners,
 /area/icy_caves/caves/northern)
+"Gt" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/single,
+/area/icy_caves/caves/west)
 "Gu" = (
 /turf/closed/ice,
 /area/icy_caves/outpost/outside)
@@ -6503,9 +6546,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northern)
 "Gy" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/west)
 "Gz" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleT,
@@ -9077,9 +9120,10 @@
 	},
 /area/icy_caves/outpost/security)
 "TS" = (
+/obj/effect/landmark/xeno_resin_door,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall,
-/area/icy_caves/outpost/mining/west)
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/west)
 "TT" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -11061,15 +11105,15 @@ Yf
 Yf
 Yf
 Yf
-cp
-cp
-cp
-cp
-cp
-cp
-cp
-cp
-cp
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
 Yf
 Yf
 Yf
@@ -11199,25 +11243,25 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-MH
-MH
-Yf
-Yf
-MH
-MH
-re
-Yf
-MH
-MH
-Yf
-Yf
-Yf
 cp
+cp
+cp
+cp
+cp
+Aw
+Aw
+cp
+cp
+Aw
+Aw
+dK
+Yf
+MH
+MH
+Yf
+Yf
+Yf
+Yf
 Yf
 Yf
 qy
@@ -11225,7 +11269,7 @@ qy
 Yf
 Yf
 Yf
-cp
+Yf
 Yf
 Yf
 Yf
@@ -11355,7 +11399,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+cp
 Yf
 Yf
 MH
@@ -11366,14 +11410,14 @@ ZU
 ZU
 ZU
 GF
-re
+dK
 re
 re
 MH
 Yf
 Yf
 Yf
-cp
+Yf
 MH
 MH
 qy
@@ -11381,7 +11425,7 @@ qy
 qy
 MH
 Yf
-cp
+Yf
 Yf
 Yf
 Yf
@@ -11511,7 +11555,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -11522,14 +11566,14 @@ ZU
 Wx
 Wx
 Bb
-WI
+xU
 WI
 WI
 WI
 MH
 Yf
 Yf
-cp
+Yf
 MH
 MH
 Za
@@ -11537,7 +11581,7 @@ Za
 Yf
 Yf
 MH
-hL
+MH
 MH
 MH
 DX
@@ -11667,7 +11711,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+cp
 MH
 MH
 Yf
@@ -11678,22 +11722,22 @@ ZU
 ZU
 ZU
 Bb
-WI
+xU
 pa
 Si
 WI
 WI
 MH
 MH
-hL
+MH
 MH
 pa
 Mb
-lK
+Za
 Za
 MH
 MH
-hL
+MH
 Uu
 Uu
 DX
@@ -11823,33 +11867,33 @@ Yf
 Yf
 Yf
 Yf
-Yf
+cp
 Yf
 YI
 ZU
 ZU
 ZU
-ZU
+Gy
 ZU
 ZU
 ZU
 Bb
-WI
+xU
 Tj
 SI
 SI
 SI
 SI
 SI
-Pe
 SI
 SI
+SI
 Za
 Za
-Ag
 Za
 Za
-za
+Za
+Za
 Uu
 Uu
 DX
@@ -11979,7 +12023,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+cp
 Yf
 ZU
 gx
@@ -11990,22 +12034,22 @@ ZU
 ZU
 ZU
 Bb
-WI
+xU
 WI
 Ln
 SI
 SI
 SI
 SI
-Pe
 SI
 SI
+SI
 Za
 Za
 Za
 Za
-lK
-za
+Za
+Za
 Uu
 Uu
 Uu
@@ -12135,8 +12179,8 @@ Yf
 Yf
 Yf
 Yf
+cp
 Yf
-Yf
 ZU
 ZU
 ZU
@@ -12146,22 +12190,22 @@ ZU
 re
 re
 re
-WI
+xU
 WI
 SI
 Ln
 WI
 WI
 WI
-Gy
+WI
 SI
 Ln
-lK
 Za
 Za
 Za
 Za
-za
+Za
+Za
 UE
 fq
 Uu
@@ -12291,7 +12335,7 @@ Yf
 Yf
 Yf
 Yf
-re
+dK
 re
 ZU
 ZU
@@ -12302,14 +12346,14 @@ Di
 lG
 lX
 lG
-WI
+xU
 WI
 SI
 SI
 WI
 pD
 WI
-Gy
+WI
 SI
 SI
 Za
@@ -12317,7 +12361,7 @@ Za
 Za
 Za
 Za
-za
+Za
 Uu
 Uu
 Uu
@@ -12447,7 +12491,7 @@ re
 re
 re
 ZU
-ZU
+hL
 SF
 ZU
 ZU
@@ -12458,14 +12502,14 @@ Mg
 ec
 Vb
 eY
-WI
+xU
 WI
 SI
 SI
 WI
 WI
 WI
-Gy
+WI
 SI
 SI
 Za
@@ -12473,7 +12517,7 @@ Za
 MH
 qs
 WI
-Gy
+WI
 Uu
 Uu
 Uu
@@ -12603,7 +12647,7 @@ Di
 XF
 DZ
 ZU
-ZU
+hL
 SF
 ZU
 gx
@@ -12614,14 +12658,14 @@ ec
 fT
 xI
 xI
-xI
+ER
 nx
 od
 lH
 nx
 xI
 xI
-TS
+xI
 SI
 SI
 WI
@@ -12629,7 +12673,7 @@ MH
 Yf
 Yf
 MH
-Gy
+WI
 Uu
 Uu
 sD
@@ -12759,7 +12803,7 @@ gz
 ZU
 ZU
 ZU
-ez
+jh
 SF
 ZU
 ZU
@@ -12770,14 +12814,14 @@ SF
 ZU
 nO
 oI
-wW
+sC
 oI
 pw
 oI
 pf
 oZ
 oK
-TS
+xI
 SI
 SI
 WI
@@ -12785,7 +12829,7 @@ MH
 Yf
 Yf
 Yf
-hL
+MH
 Uu
 Uu
 Uu
@@ -12915,16 +12959,16 @@ ZU
 ZU
 ZU
 ez
-ZU
-dx
-ZU
-gA
-Mg
-ZU
-ZU
-SF
-fT
-xI
+hL
+lK
+hL
+to
+Ag
+hL
+hL
+TS
+Gt
+ER
 oJ
 au
 xn
@@ -12933,15 +12977,15 @@ oI
 oI
 oI
 oU
-TS
-Pe
-Pe
-hL
-cp
-cp
-cp
-iS
-iS
+xI
+SI
+SI
+MH
+Yf
+Yf
+Yf
+qs
+qs
 Uu
 Uu
 Uu
@@ -13717,12 +13761,12 @@ xI
 Za
 SI
 XO
-XO
+lW
+lW
 WI
 WI
-WI
-XO
-UE
+lW
+AB
 UE
 UE
 UE
@@ -13873,11 +13917,11 @@ WI
 XO
 SI
 XO
+lW
 XO
 XO
 XO
-XO
-XO
+lW
 UE
 Uu
 UE
@@ -14028,9 +14072,9 @@ XO
 XO
 XO
 SI
-Za
-XO
-XO
+lW
+lW
+lW
 XO
 XO
 XO
@@ -14652,8 +14696,8 @@ XO
 XO
 XO
 Za
-Za
-Za
+lW
+lW
 Za
 SI
 SI
@@ -14809,7 +14853,7 @@ XO
 XO
 XO
 XO
-Za
+lW
 Za
 SI
 SI
@@ -15419,7 +15463,7 @@ Jg
 XF
 DZ
 Ga
-XJ
+ZU
 ZU
 gz
 Om
@@ -15732,7 +15776,7 @@ XF
 gA
 XJ
 ZU
-Xu
+ZU
 XF
 xa
 SD
@@ -15886,9 +15930,9 @@ Jg
 XF
 dp
 gA
-XJ
 ZU
-Xu
+ZU
+ZU
 DK
 RG
 Rj
@@ -16352,8 +16396,8 @@ gx
 ZU
 ZU
 ZU
-lj
-Sn
+ZU
+ZU
 ZU
 dx
 dx
@@ -16508,7 +16552,7 @@ dw
 ZU
 ZU
 ZU
-gn
+ZU
 ZU
 ZU
 do
@@ -17025,8 +17069,8 @@ Qa
 Qa
 LO
 vq
-to
-TF
+KZ
+XO
 Pe
 Pe
 za
@@ -17181,12 +17225,12 @@ Is
 Zc
 RJ
 KZ
-to
+KZ
 XO
+Pe
 SI
-SI
-Za
-XO
+Ll
+Ll
 bD
 cp
 YQ
@@ -17337,12 +17381,12 @@ KZ
 KZ
 KZ
 KZ
-Gy
+WI
 XO
+Pe
 SI
-SI
-Za
-XO
+Ll
+Ll
 lX
 kQ
 YQ
@@ -17493,9 +17537,9 @@ li
 li
 li
 li
-cR
 li
-my
+li
+zz
 my
 DD
 DD
@@ -17649,9 +17693,9 @@ my
 my
 my
 my
+my
+my
 zz
-my
-my
 Iw
 DD
 iX
@@ -17805,13 +17849,13 @@ my
 my
 my
 my
-zz
 my
-JW
+my
+nQ
 my
 DD
-jh
 DD
+pV
 wI
 YQ
 "}
@@ -17961,9 +18005,9 @@ li
 li
 li
 li
-cR
+li
 DD
-my
+zz
 my
 DD
 iX
@@ -18117,9 +18161,9 @@ ND
 ND
 ND
 ND
-Aw
-iX
-my
+ND
+DD
+zz
 my
 DD
 DD
@@ -18273,9 +18317,9 @@ Hf
 JC
 wZ
 Ez
-Aw
+ND
 DD
-my
+zz
 my
 iX
 DD
@@ -18429,9 +18473,9 @@ Zq
 wZ
 wZ
 LC
-Aw
+ND
 DD
-my
+zz
 my
 DD
 DD
@@ -18585,9 +18629,9 @@ Hf
 Ze
 wZ
 Ez
-Aw
+ND
 DD
-my
+zz
 my
 iX
 DD
@@ -18741,9 +18785,9 @@ Hf
 Hf
 Hf
 Hf
-Aw
+ND
 DD
-my
+zz
 my
 DD
 DD
@@ -18897,8 +18941,8 @@ Hf
 KO
 Cs
 Ez
-Aw
-cR
+ND
+li
 zz
 zz
 Kr
@@ -19213,8 +19257,8 @@ ND
 li
 my
 my
-DD
-li
+yr
+yr
 li
 bH
 YQ
@@ -19369,8 +19413,8 @@ ND
 li
 my
 my
-DD
-li
+yr
+yr
 ow
 XH
 YQ
@@ -19527,7 +19571,7 @@ xE
 my
 DD
 li
-ow
+yr
 qz
 YQ
 "}
@@ -20535,8 +20579,8 @@ Us
 Us
 fC
 Je
-fh
-UL
+ym
+Be
 ym
 ym
 Xj
@@ -20691,8 +20735,8 @@ YS
 YS
 YS
 fh
-fY
-hv
+ym
+ym
 Xj
 Xj
 ST
@@ -20847,8 +20891,8 @@ YS
 YS
 Vz
 fY
-xX
-hv
+ym
+ym
 ST
 xb
 MM
@@ -21002,9 +21046,9 @@ dC
 YS
 YS
 fh
-xX
-xX
-hv
+ym
+ym
+ym
 ST
 Ig
 YW
@@ -21158,8 +21202,8 @@ YS
 YS
 YS
 fh
-xX
-xX
+ym
+ym
 ME
 ST
 YW
@@ -21313,9 +21357,9 @@ YS
 YS
 YS
 Vz
-hm
-xX
-xX
+ym
+Be
+ym
 Uk
 ST
 YW
@@ -21469,9 +21513,9 @@ YS
 YS
 hf
 fh
-fY
-xX
-xX
+ym
+ym
+ym
 Uk
 ST
 YW
@@ -21625,8 +21669,8 @@ YS
 YS
 hf
 fh
-xX
-xX
+ym
+ym
 xX
 UL
 ST
@@ -21780,9 +21824,9 @@ Iy
 gq
 YS
 ym
-fh
-fW
-xX
+ym
+ym
+ym
 xX
 hv
 ST
@@ -21936,9 +21980,9 @@ Iy
 fC
 ym
 ym
-fH
-hm
-fW
+ym
+ym
+ym
 fW
 hv
 ST
@@ -22093,7 +22137,7 @@ ym
 ym
 ym
 ym
-Wj
+ym
 SA
 fh
 ME

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -22,9 +22,6 @@
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/plating/dmg1,
 /area/icy_caves/caves/crashed_ship)
-"af" = (
-/turf/closed/wall/r_wall/unmeltable,
-/area/lv624/lazarus/console)
 "ag" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/effect/landmark/nuke_spawn,
@@ -53,9 +50,11 @@
 /turf/open/floor/plating/dmg1,
 /area/icy_caves/caves/crashed_ship)
 "am" = (
-/obj/machinery/telecomms/relay/preset/telecomms,
-/turf/open/floor/plating/icefloor,
-/area/lv624/lazarus/console)
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "an" = (
 /obj/structure/xenoautopsy/tank/broken,
 /obj/effect/decal/cleanable/blood/xeno,
@@ -524,6 +523,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
+"bW" = (
+/obj/structure/cryofeed/right{
+	name = "\improper coolant feed"
+	},
+/turf/open/floor/podhatch/floor{
+	icon_state = "bcircuitoff"
+	},
+/area/icy_caves/caves/northern)
 "bX" = (
 /turf/closed/ice_rock/singlePart,
 /area/icy_caves/caves)
@@ -566,6 +573,12 @@
 	dir = 8
 	},
 /area/icy_caves/caves/northern)
+"ch" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/floor,
+/area/space)
 "ci" = (
 /turf/closed/ice/thin/junction,
 /area/icy_caves/caves/northern)
@@ -593,16 +606,24 @@
 	},
 /area/icy_caves/caves/northern)
 "co" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
-/turf/open/floor/tile/dark,
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/mainship/tcomms,
 /area/icy_caves/caves/northern)
 "cp" = (
-/obj/item/lightstick/anchored,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/northern)
+/turf/closed/ice_rock/corners,
+/area/icy_caves/caves)
 "cq" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating/ground/ice,
@@ -616,10 +637,16 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"ct" = (
+"cs" = (
+/obj/structure/cable,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/corner{
-	dir = 8
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
+"ct" = (
+/obj/effect/ai_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
 	},
 /area/icy_caves/caves/northern)
 "cu" = (
@@ -630,46 +657,81 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/LZ2)
-"cD" = (
+"cv" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singlePart{
-	dir = 10
-	},
-/area/icy_caves/caves)
-"cE" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/end{
-	dir = 8
-	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"cG" = (
-/obj/structure/cable,
+"cw" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"cx" = (
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 8
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/tile/dark/blue2{
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"cy" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research,
+/turf/open/floor/tile/dark/yellow2{
 	dir = 1
 	},
 /area/icy_caves/outpost/LZ2)
+"cC" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"cD" = (
+/obj/item/tool/surgery/circular_saw,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"cE" = (
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
+"cF" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/structure/monorail{
+	dir = 5
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
 "cI" = (
 /turf/closed/ice/thin/single,
+/area/icy_caves/caves/northern)
+"cJ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
+"cK" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/corners,
+/area/icy_caves/caves/northern)
+"cL" = (
+/obj/structure/monorail,
+/turf/open/floor/mainship_hull,
 /area/icy_caves/caves/northern)
 "cM" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/crashed_ship)
 "cN" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/corner{
-	dir = 4
-	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/green2,
 /area/icy_caves/caves/northern)
 "cO" = (
+/obj/structure/window/framed/colony/reinforced,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/straight,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "cP" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -681,29 +743,26 @@
 	dir = 1
 	},
 /area/icy_caves/caves/northern)
-"cS" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
-"cT" = (
-/obj/effect/decal/cleanable/blood,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
-"cU" = (
-/obj/machinery/landinglight/ds1/delaytwo{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
+"cR" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/outside/center)
 "cV" = (
-/obj/machinery/atmospherics/pipe/manifold/green/hidden{
-	dir = 8
+/turf/open/floor/tile/white/warningstripe{
+	dir = 1
 	},
+/area/icy_caves/caves/northern)
+"cW" = (
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/space/basic,
+/area/space)
+"cX" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "cY" = (
@@ -719,16 +778,48 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
+"dd" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "de" = (
 /turf/closed/ice/thin/junction{
 	dir = 1
 	},
 /area/icy_caves/caves/west)
+"df" = (
+/obj/structure/dropship_piece/two/front/left,
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
+"dg" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/structure/dropship_piece/two/front,
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
 "dh" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 1
 	},
 /area/icy_caves/caves/west)
+"di" = (
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "dj" = (
 /turf/closed/ice,
 /area/icy_caves/caves/west)
@@ -759,11 +850,25 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
-"dt" = (
-/obj/effect/landmark/weed_node,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
+"ds" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8
 	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"du" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"dv" = (
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/obj/structure/largecrate/supply/explosives,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "dw" = (
@@ -779,6 +884,13 @@
 "dy" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/west)
+"dz" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "dA" = (
 /obj/machinery/light,
 /turf/open/floor/plating/ground/ice,
@@ -819,7 +931,11 @@
 /area/icy_caves/caves/east)
 "dK" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/intersection,
+/turf/closed/ice_rock/eastWall,
+/area/icy_caves/caves)
+"dL" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "dN" = (
 /obj/machinery/light/small{
@@ -832,17 +948,12 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"dP" = (
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
 "dQ" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/corner{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "dR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/tile/dark,
@@ -877,10 +988,15 @@
 "dY" = (
 /turf/closed/ice/thin/end,
 /area/icy_caves/caves/east)
+"dZ" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "24"
+	},
+/area/icy_caves/caves/northern)
 "ea" = (
 /obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "eb" = (
 /turf/closed/ice/end,
 /area/icy_caves/caves/west)
@@ -891,18 +1007,6 @@
 /area/icy_caves/caves/west)
 "ed" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
-"ee" = (
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor{
-	name = "\improper Lambda Lab"
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"ef" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "eg" = (
@@ -915,12 +1019,20 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"ei" = (
+/obj/effect/landmark/corpsespawner/pmc,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "ej" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
+"el" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/tile/dark/yellow2,
+/area/icy_caves/outpost/LZ2)
 "em" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark,
@@ -975,6 +1087,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"eu" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/intersection,
+/area/icy_caves/caves/northern)
 "ev" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
@@ -1019,19 +1135,22 @@
 	},
 /area/icy_caves/caves/northern)
 "eC" = (
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 5
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	name = "Canteen"
 	},
-/obj/structure/monorail{
-	dir = 9
-	},
-/turf/open/shuttle/escapepod/plain,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"eD" = (
+/obj/structure/table,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "eF" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/corner{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "eG" = (
 /obj/machinery/light{
 	dir = 8
@@ -1068,8 +1187,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
-"eM" = (
-/turf/open/floor/tile/dark,
+"eL" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/end{
+	dir = 4
+	},
 /area/icy_caves/caves/northern)
 "eN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -1078,12 +1200,13 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "eO" = (
-/obj/structure/barricade/guardrail{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/item/tool/surgery/scalpel/laser3,
+/obj/item/reagent_containers/spray/pepper,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 8
 	},
-/obj/structure/dropship_piece/two/front,
-/turf/open/shuttle/dropship/seven,
-/area/space)
+/area/icy_caves/caves/northern)
 "eP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -1163,6 +1286,12 @@
 /obj/item/storage/firstaid/fire,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"fc" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "fd" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/powercell,
@@ -1230,6 +1359,20 @@
 	dir = 1
 	},
 /area/icy_caves/caves/east)
+"fq" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/LZ1)
+"fs" = (
+/obj/structure/barricade/guardrail{
+	dir = 1
+	},
+/obj/structure/dropship_piece/two/front,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "ft" = (
 /turf/closed/ice/thin/junction{
 	dir = 4
@@ -1282,11 +1425,15 @@
 	},
 /area/icy_caves/caves/south)
 "fD" = (
-/obj/machinery/door/airlock/multi_tile/mainship/research,
-/turf/open/floor/tile/dark/yellow2{
+/obj/machinery/power/apc/drained,
+/obj/machinery/light{
 	dir = 1
 	},
-/area/icy_caves/outpost/LZ2)
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "fE" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
@@ -1305,6 +1452,9 @@
 	dir = 1
 	},
 /area/icy_caves/caves/south)
+"fI" = (
+/turf/closed/ice/thin,
+/area/icy_caves/outpost/LZ2)
 "fK" = (
 /turf/closed/ice/thin/corner{
 	dir = 1
@@ -1315,17 +1465,15 @@
 	dir = 4
 	},
 /area/icy_caves/caves/east)
+"fM" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/LZ2)
 "fN" = (
 /turf/closed/ice/thin/junction{
 	dir = 4
 	},
 /area/icy_caves/outpost/LZ1)
-"fO" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/straight{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "fP" = (
 /turf/closed/ice/junction,
 /area/icy_caves/caves/east)
@@ -1347,25 +1495,10 @@
 "fT" = (
 /turf/closed/ice/single,
 /area/icy_caves/caves/west)
-"fU" = (
-/turf/closed/shuttle/dropship2{
-	icon_state = "25"
-	},
-/area/icy_caves/caves/northern)
-"fV" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "fW" = (
 /turf/closed/ice/thin/junction{
 	dir = 4
 	},
-/area/icy_caves/caves/south)
-"fX" = (
-/obj/docking_port/mobile/crashmode/bigbury,
-/turf/closed/ice,
 /area/icy_caves/caves/south)
 "fY" = (
 /turf/closed/ice/thin/junction{
@@ -1381,10 +1514,6 @@
 	},
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
-"gb" = (
-/obj/machinery/computer3/server,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "gc" = (
 /turf/closed/ice/end{
 	dir = 1
@@ -1400,39 +1529,19 @@
 	dir = 5
 	},
 /area/icy_caves/caves/east)
-"gf" = (
-/obj/structure/table/mainship,
-/obj/machinery/computer/med_data,
-/turf/open/floor/mainship/mono,
-/area/icy_caves/caves/northern)
 "gh" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 9
 	},
 /area/icy_caves/caves/east)
-"gi" = (
-/obj/effect/decal/cleanable/vomit,
-/obj/machinery/camera{
-	dir = 5
-	},
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
 "gk" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/caves/east)
-"gm" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall,
-/area/icy_caves/outpost/mining/west)
 "gn" = (
 /turf/closed/ice/thin/end{
 	dir = 4
 	},
 /area/icy_caves/caves/west)
-"go" = (
-/obj/machinery/door/airlock/multi_tile/mainship/secdoor,
-/turf/open/floor/mainship/red/full,
-/area/icy_caves/caves/northern)
 "gp" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/caves/west)
@@ -1457,11 +1566,6 @@
 	dir = 4
 	},
 /area/icy_caves/caves/east)
-"gv" = (
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
-	},
-/area/space)
 "gw" = (
 /turf/closed/ice_rock/singleT{
 	dir = 1
@@ -1487,11 +1591,11 @@
 "gB" = (
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/refinery)
-"gD" = (
-/turf/closed/ice_rock/corners{
-	dir = 9
+"gE" = (
+/turf/open/floor/tile/dark/yellow2{
+	dir = 4
 	},
-/area/icy_caves/caves/northern)
+/area/icy_caves/outpost/LZ2)
 "gF" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -1505,28 +1609,15 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
-"gH" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "gI" = (
 /obj/machinery/floodlight/landing,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
-"gJ" = (
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/LZ2)
 "gK" = (
-/turf/closed/shuttle/dropship2{
-	icon_state = "52"
-	},
+/obj/structure/monorail,
+/obj/structure/dropship_piece/two/front,
+/turf/open/floor/mainship_hull,
 /area/icy_caves/caves/northern)
 "gL" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -1534,16 +1625,40 @@
 	},
 /turf/closed/ice_rock/corners,
 /area/icy_caves/caves)
+"gM" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/turf/open/floor/mainship/cargo,
+/area/icy_caves/caves/northern)
 "gN" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
-"gQ" = (
-/turf/open/floor/mainship_hull/dir{
-	dir = 8
+"gP" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
 	},
-/area/space)
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
+"gQ" = (
+/obj/structure/dropship_piece/one/corner/middleright,
+/obj/structure/dropship_piece/two/corner/rearright,
+/turf/open/floor/mainship_hull/dir{
+	dir = 10
+	},
+/area/icy_caves/caves/northern)
 "gS" = (
 /turf/closed/ice/thin/end{
 	dir = 8
@@ -1554,10 +1669,6 @@
 	dir = 6
 	},
 /area/icy_caves/caves/south)
-"gU" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/closed/wall/r_wall,
-/area/icy_caves/outpost/LZ2)
 "gV" = (
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves/east)
@@ -1570,12 +1681,23 @@
 	},
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"gZ" = (
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "hb" = (
 /turf/closed/ice/junction,
 /area/icy_caves/caves/south)
 "hc" = (
 /turf/closed/ice/straight,
 /area/icy_caves/caves/east)
+"hd" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "he" = (
 /turf/closed/ice/junction{
 	dir = 4
@@ -1675,10 +1797,10 @@
 	},
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
-"hC" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+"hB" = (
+/obj/structure/largecrate/supply,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "hD" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/floor/plating/ground/ice,
@@ -1688,13 +1810,13 @@
 	dir = 8
 	},
 /area/icy_caves/caves/east)
-"hF" = (
-/turf/closed/ice/thin/corner,
-/area/icy_caves/outpost/LZ2)
-"hH" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/westWall,
-/area/icy_caves/caves)
+"hG" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/research_and_development,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "hI" = (
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/ai_node,
@@ -1706,11 +1828,15 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
 "hL" = (
-/obj/machinery/door/airlock/multi_tile/secure{
-	dir = 2
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/end{
+	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
+/area/icy_caves/caves)
+"hM" = (
+/turf/closed/ice_rock/corners{
+	dir = 10
+	},
 /area/icy_caves/caves/northern)
 "hO" = (
 /turf/closed/ice/thin/single,
@@ -1723,18 +1849,11 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
-"hS" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/end{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "hT" = (
-/obj/machinery/landinglight/ds1/delaytwo{
-	dir = 4
-	},
+/obj/machinery/vending/medical,
+/obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/caves/northern)
 "hU" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/ice,
@@ -1743,25 +1862,15 @@
 /turf/closed/ice_rock/singlePart,
 /area/icy_caves/caves/south)
 "hW" = (
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
+/turf/open/floor/tile/purple/whitepurplefull,
 /area/icy_caves/caves/northern)
 "hX" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/northern)
-"hZ" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"ia" = (
-/obj/structure/cryofeed,
-/turf/open/floor/podhatch/floor{
-	icon_state = "bcircuitoff"
-	},
 /area/icy_caves/caves/northern)
 "ib" = (
 /obj/machinery/light{
@@ -1772,13 +1881,6 @@
 	dir = 5
 	},
 /area/icy_caves/outpost/office)
-"if" = (
-/obj/machinery/landinglight/ds1/delaytwo{
-	dir = 4
-	},
-/obj/machinery/floodlight/landing,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "ig" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -1798,36 +1900,26 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
-"ik" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/northWall,
-/area/icy_caves/caves)
-"il" = (
-/obj/machinery/atmospherics/pipe/manifold/green/hidden,
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "im" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
-"io" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/obj/machinery/atmospherics/pipe/manifold/green/hidden{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
+"in" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall/unmeltable,
 /area/icy_caves/caves/northern)
-"ip" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside/center)
-"it" = (
-/obj/machinery/light{
-	dir = 8
+"io" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
 	},
-/turf/open/floor/plating/ground/snow/layer1,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"ip" = (
+/obj/structure/closet/l3closet/janitor,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "iu" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -1841,65 +1933,50 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"iz" = (
-/obj/machinery/landinglight/ds1{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
-"iB" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singleT,
-/area/icy_caves/caves)
-"iF" = (
-/turf/closed/ice_rock/corners,
-/area/space)
 "iG" = (
 /turf/open/floor/tile/dark/yellow2{
 	dir = 4
 	},
 /area/icy_caves/outpost/engineering)
+"iJ" = (
+/obj/machinery/computer/intel_computer,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/mining/west)
 "iK" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ2)
-"iM" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 2
-	},
-/obj/structure/cable,
+"iN" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"iP" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
+"iO" = (
+/turf/open/floor/tile/dark/yellow2{
+	dir = 8
 	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/outpost/LZ2)
 "iQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
+"iS" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/southWall,
+/area/icy_caves/caves)
 "iT" = (
 /turf/closed/ice/end{
 	dir = 1
 	},
 /area/icy_caves/outpost/LZ2)
-"iV" = (
-/obj/item/tool/surgery/hemostat,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"iY" = (
-/obj/machinery/door/airlock/multi_tile/mainship/research{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+"iX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside/center)
 "iZ" = (
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/garage)
@@ -1914,45 +1991,36 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
 "jc" = (
-/turf/closed/shuttle/dropship2{
-	icon_state = "24"
-	},
+/obj/machinery/door/poddoor/mainship/indestructible,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
+"jd" = (
+/turf/open/floor/plating/mainship,
 /area/icy_caves/caves/northern)
 "je" = (
 /turf/closed/ice/thin/corner{
 	dir = 1
 	},
 /area/icy_caves/outpost/outside)
-"jg" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/closed/ice_rock/corners{
-	dir = 9
-	},
-/area/icy_caves/caves)
-"jh" = (
-/obj/effect/decal/cleanable/blood/xtracks,
+"jf" = (
+/obj/item/stool,
+/obj/effect/decal/cleanable/vomit,
 /turf/open/floor/tile/purple/whitepurplefull,
 /area/icy_caves/caves/northern)
+"jh" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside/center)
 "jk" = (
-/turf/open/floor/tile/dark/red2{
-	dir = 6
-	},
-/area/icy_caves/outpost/LZ2)
-"jn" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 6
-	},
-/turf/open/floor/mainship/cargo,
+/obj/structure/table/mainship,
+/obj/item/tool/surgery/cautery,
+/obj/item/tool/surgery/retractor,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "jo" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
+/obj/effect/ai_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
 "jt" = (
 /obj/machinery/floodlight/landing,
@@ -1986,12 +2054,7 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
 "jC" = (
-/obj/machinery/vending/medical,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"jD" = (
-/obj/machinery/door/poddoor/mainship/indestructible,
+/obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "jE" = (
@@ -2006,19 +2069,22 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
 "jI" = (
-/obj/structure/monorail,
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 4
-	},
-/turf/open/floor/mainship_hull,
-/area/icy_caves/caves/northern)
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/caves)
 "jJ" = (
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"jL" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "jM" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = /obj/item/storage/backpack/satchel/norm;
@@ -2051,6 +2117,10 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"jR" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "jS" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -2071,24 +2141,21 @@
 	},
 /area/icy_caves/outpost/research)
 "jX" = (
-/obj/structure/barricade/guardrail{
-	dir = 8
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/xenoautopsy/tank,
-/turf/open/shuttle/dropship/seven,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "jY" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singleEnd{
-	dir = 8
-	},
-/area/icy_caves/caves)
-"jZ" = (
-/obj/effect/decal/cleanable/blood/gibs/limb,
-/turf/open/floor/tile/purple/whitepurplefull,
+/obj/machinery/door/airlock/mainship/security,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "ka" = (
-/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/door/airlock/multi_tile/mainship/research,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "kb" = (
@@ -2103,9 +2170,18 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"kd" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "ke" = (
 /turf/closed/ice/junction,
 /area/icy_caves/outpost/outside)
+"kf" = (
+/obj/machinery/computer3/server/rack,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "kg" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/mining/east)
@@ -2122,12 +2198,6 @@
 "kj" = (
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/refinery)
-"kk" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/mining/west)
 "kl" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice/end{
@@ -2138,14 +2208,38 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
+"kn" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/structure/dropship_piece/two/front,
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
+"ko" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
+	dir = 10
+	},
+/area/icy_caves/caves)
+"kp" = (
+/obj/machinery/miner/damaged/platinum,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/northern)
+"kq" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
+	dir = 5
+	},
+/area/icy_caves/caves)
 "kr" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
-"kt" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "ku" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/tile/dark,
@@ -2154,10 +2248,16 @@
 /obj/machinery/vending/snack,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"kw" = (
+"kx" = (
 /obj/structure/bed/chair,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"ky" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/end{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
 "kA" = (
 /obj/machinery/landinglight/ds1/delaytwo{
 	dir = 4
@@ -2199,10 +2299,11 @@
 	},
 /area/icy_caves/outpost/research)
 "kL" = (
-/turf/closed/ice/thin/end{
-	dir = 4
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/corner{
+	dir = 8
 	},
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/northern)
 "kM" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/singlePart{
@@ -2214,17 +2315,20 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
-"kO" = (
-/obj/machinery/light{
-	dir = 1
+"kQ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd,
+/area/icy_caves/caves)
+"kR" = (
+/obj/structure/table/mainship,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
 	},
-/turf/open/floor/tile/dark/yellow2{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ2)
-"kU" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"kS" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/intersection,
 /area/icy_caves/caves/northern)
 "kW" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -2240,24 +2344,17 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/office)
+"kY" = (
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "lc" = (
 /turf/closed/ice/straight{
 	dir = 4
 	},
 /area/icy_caves/caves/east)
-"le" = (
-/obj/structure/bed/chair,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"lf" = (
-/obj/structure/bed/chair/comfy{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "lg" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -2279,7 +2376,20 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"lm" = (
+"ll" = (
+/obj/machinery/camera{
+	dir = 5
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"ln" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/corner{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
+"lo" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
@@ -2293,31 +2403,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
-"lu" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/closed/wall/r_wall,
-/area/icy_caves/caves/northern)
 "lv" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
-"lw" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
+/obj/machinery/door/poddoor/two_tile_ver,
+/turf/open/floor/mainship/cargo/arrow{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 8
-	},
-/turf/open/floor/tile/dark/blue2{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/northern)
 "lx" = (
 /obj/machinery/light{
 	dir = 8
@@ -2359,27 +2450,18 @@
 	},
 /area/icy_caves/caves)
 "lH" = (
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 9
-	},
-/obj/structure/monorail{
-	dir = 5
-	},
-/obj/machinery/door/poddoor/mainship/indestructible{
-	dir = 2
-	},
-/turf/open/shuttle/escapepod/plain,
-/area/space)
-"lI" = (
-/obj/structure/bookcase/manuals/research_and_development,
-/turf/open/floor/tile/purple/whitepurple{
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1
 	},
-/area/icy_caves/caves/northern)
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/mining/west)
+"lK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside)
 "lL" = (
-/turf/open/floor/tile/dark/red2{
-	dir = 10
+/turf/closed/ice/thin/corner{
+	dir = 8
 	},
 /area/icy_caves/outpost/LZ2)
 "lM" = (
@@ -2393,6 +2475,14 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
+"lO" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "lP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -2406,15 +2496,11 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "lR" = (
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 6
+/obj/structure/bed/chair{
+	dir = 8
 	},
-/obj/structure/monorail{
-	dir = 10
-	},
-/turf/open/shuttle/escapepod/plain,
-/area/space)
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "lS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -2422,14 +2508,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"lT" = (
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
-/area/icy_caves/caves/northern)
-"lV" = (
-/turf/open/shuttle/dropship/floor,
-/area/space)
 "lW" = (
 /turf/closed/ice/thin/end{
 	dir = 1
@@ -2440,10 +2518,6 @@
 	dir = 6
 	},
 /area/icy_caves/caves)
-"lY" = (
-/obj/machinery/landinglight/ds1/delaytwo,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "lZ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -2456,24 +2530,16 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/LZ2)
+"ma" = (
+/obj/structure/dropship_piece/one/corner/middleleft,
+/obj/structure/dropship_piece/two/corner/rearleft,
+/turf/open/floor/mainship_hull/dir{
+	dir = 6
+	},
+/area/icy_caves/caves/northern)
 "mb" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/outpost/LZ1)
-"mc" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 6
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/mainship/tcomms,
-/area/icy_caves/caves/northern)
 "md" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/tile/dark,
@@ -2486,13 +2552,13 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/refinery)
-"mf" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/single,
-/area/icy_caves/caves)
 "mg" = (
-/obj/structure/window/framed/colony/reinforced,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "mh" = (
@@ -2500,11 +2566,21 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/LZ2)
+"mi" = (
+/turf/closed/wall/r_wall/unmeltable,
+/area/lv624/lazarus/console)
 "mj" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/end{
+/obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 4;
+	pixel_x = -16
+	},
+/turf/open/floor/mainship/tcomms,
 /area/icy_caves/caves/northern)
 "mk" = (
 /obj/docking_port/stationary/marine_dropship/lz2,
@@ -2530,6 +2606,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"mq" = (
+/obj/machinery/miner/damaged/platinum,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "mr" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
@@ -2549,9 +2629,23 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"mu" = (
+/obj/machinery/vending/security,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
+"mv" = (
+/turf/closed/ice_rock/corners,
+/area/space)
 "mw" = (
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
+/obj/structure/bookcase/manuals/research_and_development,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 9
 	},
 /area/icy_caves/caves/northern)
 "mx" = (
@@ -2562,6 +2656,29 @@
 "my" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"mz" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"mA" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/end{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
+"mC" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/corner{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
+"mE" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/corners{
+	dir = 5
+	},
+/area/icy_caves/caves)
 "mG" = (
 /obj/structure/dispenser,
 /turf/open/floor/tile/dark/yellow2{
@@ -2576,10 +2693,6 @@
 "mI" = (
 /turf/closed/ice/thin/end,
 /area/icy_caves/outpost/outside)
-"mJ" = (
-/obj/item/paper/crumpled/bloody,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "mK" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -2607,25 +2720,29 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"mW" = (
-/obj/item/shard,
-/obj/effect/decal/cleanable/blood/xtracks,
-/turf/open/floor/tile/purple/whitepurplefull,
+"mQ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/single,
 /area/icy_caves/caves/northern)
+"mV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"mY" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/westWall,
+/area/icy_caves/caves)
 "mZ" = (
-/obj/machinery/computer3/server/rack,
-/turf/open/floor/tile/purple/whitepurplefull,
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/plating/mainship,
 /area/icy_caves/caves/northern)
-"na" = (
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 10
+"nb" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/straight{
+	dir = 4
 	},
-/obj/structure/monorail{
-	dir = 6
-	},
-/turf/open/shuttle/escapepod/plain,
-/area/space)
+/area/icy_caves/caves/northern)
 "nc" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 8
@@ -2635,6 +2752,11 @@
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"ne" = (
+/obj/item/lightstick/anchored,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/northern)
 "nf" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 4
@@ -2648,16 +2770,6 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
-"nh" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"ni" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	on = 1
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "nj" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
@@ -2680,31 +2792,35 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
-"nq" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/closed/ice/end{
-	dir = 1
+"ns" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
 	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "nu" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"nw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 8;
-	welded = 1
+"nv" = (
+/obj/structure/table,
+/obj/item/corncob,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
 	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"nw" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/northern)
 "nx" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/tile/dark/yellow2{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ2)
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/mining/west)
 "ny" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/ice_rock/single,
@@ -2715,14 +2831,19 @@
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ2)
 "nB" = (
-/obj/machinery/door/poddoor/two_tile_ver,
-/turf/open/floor/mainship/cargo/arrow{
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "nD" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"nF" = (
+/obj/structure/janitorialcart,
+/turf/open/floor/plating/mainship,
 /area/icy_caves/caves/northern)
 "nH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -2734,15 +2855,8 @@
 "nI" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ2)
-"nJ" = (
-/obj/machinery/miner/damaged/platinum,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/northern)
 "nK" = (
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
+/obj/structure/largecrate/random/secure,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "nL" = (
@@ -2762,11 +2876,6 @@
 "nS" = (
 /turf/open/floor/plating/dmg1,
 /area/icy_caves/caves/crashed_ship)
-"nT" = (
-/obj/structure/table/mainship,
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern)
 "nU" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -2785,16 +2894,6 @@
 /obj/docking_port/mobile/crashmode/bigbury,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
-"nY" = (
-/obj/structure/barricade/guardrail{
-	dir = 1
-	},
-/obj/structure/dropship_piece/two/front,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/shuttle/dropship/seven,
-/area/space)
 "nZ" = (
 /obj/machinery/light{
 	dir = 4
@@ -2809,13 +2908,9 @@
 	dir = 10
 	},
 /area/icy_caves/outpost/garage)
-"oe" = (
-/obj/effect/spawner/gibspawner/human,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+"od" = (
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/mining/west)
 "of" = (
 /turf/closed/ice/thin/end{
 	dir = 4
@@ -2824,12 +2919,6 @@
 "oh" = (
 /turf/open/floor/plating/dmg3,
 /area/icy_caves/caves/crashed_ship)
-"oi" = (
-/obj/structure/bed/chair/comfy{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "oj" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -2856,12 +2945,12 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
 "op" = (
-/turf/open/floor/tile/dark/green2,
-/area/icy_caves/caves/northern)
-"oq" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/tile/dark,
+/obj/structure/prop/mainship/sensor_computer3/sd,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/tcomms,
 /area/icy_caves/caves/northern)
 "or" = (
 /obj/effect/landmark/corpsespawner/colonist,
@@ -2869,26 +2958,17 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
 "os" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
 	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "ot" = (
 /turf/closed/ice/junction,
 /area/icy_caves/caves/northern)
-"ou" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"ov" = (
-/obj/machinery/landinglight/ds1/delaythree{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "ow" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside/center)
@@ -2905,14 +2985,9 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
 "oC" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/LZ2)
 "oD" = (
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 1
@@ -2925,11 +3000,6 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
-"oG" = (
-/turf/closed/shuttle/dropship2{
-	icon_state = "104"
-	},
-/area/icy_caves/caves/northern)
 "oI" = (
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
@@ -2943,10 +3013,11 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
 "oM" = (
-/turf/closed/ice/thin/end{
-	dir = 1
+/obj/structure/dropship_piece/two/front/right,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
 	},
-/area/icy_caves/caves)
+/area/icy_caves/caves/northern)
 "oO" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -2954,25 +3025,40 @@
 "oP" = (
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ2)
+"oQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
+"oR" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 6
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "oS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
 "oT" = (
+/obj/structure/largecrate/supply/floodlights,
 /obj/machinery/light{
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/mainship/red/full,
+/turf/open/floor/plating/mainship,
 /area/icy_caves/caves/northern)
 "oU" = (
 /obj/item/tool/pickaxe,
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
-"oV" = (
-/obj/structure/largecrate/random/barrel/green,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
 "oW" = (
 /turf/closed/ice_rock/westWall,
 /area/icy_caves/caves)
@@ -2980,11 +3066,17 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
+"pa" = (
+/turf/closed/wall,
+/area/icy_caves/outpost/outside)
 "pb" = (
 /turf/closed/ice_rock/corners{
 	dir = 9
 	},
 /area/icy_caves/caves/west)
+"pc" = (
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "pf" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = /obj/item/storage/backpack/satchel/norm;
@@ -3006,11 +3098,11 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"pi" = (
-/obj/structure/dropship_piece/two/front/right,
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
+"ph" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 8
 	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "pj" = (
 /obj/effect/decal/cleanable/blood,
@@ -3018,6 +3110,9 @@
 /area/icy_caves/outpost/mining/west)
 "pk" = (
 /turf/closed/ice/straight,
+/area/icy_caves/caves/northern)
+"pl" = (
+/turf/closed/wall/r_wall/unmeltable,
 /area/icy_caves/caves/northern)
 "pm" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -3028,13 +3123,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"pn" = (
-/obj/structure/table/reinforced,
-/obj/structure/xenoautopsy,
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 1
-	},
-/area/icy_caves/caves/northern)
 "po" = (
 /turf/open/floor/tile/dark/purple2{
 	dir = 4
@@ -3046,10 +3134,9 @@
 	},
 /area/icy_caves/caves)
 "pr" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/effect/ai_node,
+/obj/structure/window/framed/colony/reinforced,
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "ps" = (
@@ -3060,6 +3147,13 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/refinery)
+"pu" = (
+/obj/structure/barricade/guardrail{
+	dir = 4
+	},
+/obj/item/clothing/head/warning_cone,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "pw" = (
 /obj/machinery/light{
 	dir = 8
@@ -3103,6 +3197,11 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside)
+"pE" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
 "pF" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/smg/m25,
@@ -3113,18 +3212,47 @@
 /obj/item/ammo_magazine/smg/m25,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"pH" = (
+/turf/closed/ice_rock/corners{
+	dir = 10
+	},
+/area/icy_caves/caves/west)
 "pL" = (
-/obj/structure/largecrate/supply/explosives/mortar_flare,
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
 /turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"pN" = (
+/obj/structure/janitorialcart,
+/turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northern)
 "pO" = (
 /obj/item/ammo_casing,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"pP" = (
+/obj/structure/closet/crate,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick,
+/obj/item/storage/box/lightstick,
+/obj/item/tool/pickaxe/plasmacutter,
+/obj/effect/spawner/random/powercell,
+/obj/item/explosive/plastique,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "pR" = (
 /obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ2)
+"pS" = (
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "pT" = (
 /obj/effect/landmark/fob_sentry,
 /obj/effect/ai_node,
@@ -3137,10 +3265,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
-"pV" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
+"pW" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "pX" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -3154,6 +3284,15 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
+"pZ" = (
+/obj/item/paper/crumpled/bloody,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"qa" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/space)
 "qb" = (
 /obj/machinery/conveyor{
 	dir = 5
@@ -3175,16 +3314,16 @@
 	},
 /area/icy_caves/outpost/refinery)
 "qe" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/LZ2)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/single,
+/area/icy_caves/caves/northern)
 "qf" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/LZ2)
 "qg" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plating,
@@ -3207,6 +3346,12 @@
 /obj/item/tool/pickaxe,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
+"qk" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
 "ql" = (
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
@@ -3252,11 +3397,11 @@
 	},
 /area/icy_caves/outpost/refinery)
 "qu" = (
-/obj/machinery/camera/autoname/mainship/dropship_one{
-	dir = 8;
-	pixel_x = 16
+/obj/structure/dropship_piece/one/corner/middleleft,
+/obj/structure/dropship_piece/two/corner/rearleft,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
 	},
-/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "qw" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
@@ -3278,6 +3423,15 @@
 "qz" = (
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves)
+"qA" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
 "qB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/tile/dark,
@@ -3298,13 +3452,6 @@
 "qH" = (
 /turf/closed/ice_rock/singleT,
 /area/icy_caves/caves)
-"qI" = (
-/obj/structure/dropship_piece/one/corner/middleright,
-/obj/structure/dropship_piece/two/corner/rearright,
-/turf/open/floor/mainship_hull/dir{
-	dir = 10
-	},
-/area/icy_caves/caves/northern)
 "qJ" = (
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/dark,
@@ -3331,6 +3478,9 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"qR" = (
+/turf/closed/ice_rock/northWall,
+/area/icy_caves/caves/west)
 "qS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -3342,16 +3492,6 @@
 	dir = 4
 	},
 /area/icy_caves/caves/northern)
-"qU" = (
-/obj/item/tool/surgery/circular_saw,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"qV" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
 "qW" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/landmark/start/job/survivor,
@@ -3405,6 +3545,11 @@
 "rf" = (
 /turf/closed/ice/thin/end,
 /area/icy_caves/caves/northern)
+"rg" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 5
+	},
+/area/icy_caves/caves/northern)
 "rh" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/machinery/door/airlock/multi_tile/mainship/research{
@@ -3412,25 +3557,19 @@
 	},
 /turf/open/floor/tile/dark/purple2,
 /area/icy_caves/outpost/research)
-"rj" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/single,
-/area/icy_caves/caves/northern)
 "rk" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside/center)
+/obj/structure/table/reinforced,
+/obj/structure/xenoautopsy,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
 "rl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
-"rm" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/cheeseburger,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "rn" = (
 /obj/structure/closet/crate/science,
 /turf/open/floor/tile/dark/purple2{
@@ -3535,15 +3674,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/engineering)
-"rI" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
 "rJ" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -3562,11 +3692,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/engineering)
-"rN" = (
-/obj/structure/prop/mainship/sensor_computer2,
-/obj/structure/cable,
-/turf/open/floor/mainship/tcomms,
-/area/icy_caves/caves/northern)
 "rO" = (
 /obj/machinery/vending/tool,
 /obj/machinery/light{
@@ -3590,14 +3715,6 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/research)
-"rR" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
 "rS" = (
 /obj/structure/table,
 /obj/item/tool/pickaxe/plasmacutter,
@@ -3638,15 +3755,6 @@
 	},
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/garage)
-"rZ" = (
-/obj/structure/bookcase/manuals/research_and_development,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 9
-	},
-/area/icy_caves/caves/northern)
 "sa" = (
 /obj/machinery/door/airlock/mainship/medical/free_access,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -3654,6 +3762,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"sb" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/straight,
+/area/icy_caves/caves/northern)
 "sc" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -3745,10 +3857,11 @@
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
 "ss" = (
-/turf/closed/shuttle/dropship2{
-	icon_state = "103"
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd{
+	dir = 4
 	},
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves)
 "st" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table,
@@ -3805,19 +3918,25 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
-"sB" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
+"sD" = (
+/obj/effect/landmark/fob_sentry_rebel,
+/turf/closed/ice_rock/singleEnd{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ1)
 "sE" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"sF" = (
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/caves/east)
 "sG" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall/unmeltable,
+/obj/structure/bed/chair,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "sH" = (
 /turf/open/floor/plating/mainship,
@@ -3826,8 +3945,9 @@
 /turf/closed/ice/thin/corner,
 /area/icy_caves/caves/east)
 "sK" = (
-/obj/docking_port/stationary/marine_dropship/lz1,
-/turf/open/floor/plating,
+/obj/machinery/power/apc/lowcharge,
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
 /area/icy_caves/outpost/LZ1)
 "sN" = (
 /obj/structure/table/flipped,
@@ -3840,31 +3960,24 @@
 /obj/machinery/light/small,
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
+"sR" = (
+/obj/structure/largecrate/random/case,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "sT" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ2)
 "sV" = (
 /obj/structure/rack,
-/obj/item/ammo_magazine/rifle/ak47,
-/obj/item/ammo_magazine/rifle/ak47,
-/obj/item/ammo_magazine/rifle/ak47,
-/obj/item/ammo_magazine/rifle/ak47,
-/obj/item/weapon/gun/rifle/ak47,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
-"sY" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singlePart{
-	dir = 8
-	},
-/area/icy_caves/caves)
-"sZ" = (
-/turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern)
 "ta" = (
-/obj/structure/mopbucket,
-/turf/open/floor/plating/mainship,
+/obj/effect/decal/cleanable/vomit,
+/obj/machinery/camera{
+	dir = 5
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
 /area/icy_caves/caves/northern)
 "tb" = (
 /obj/structure/sink,
@@ -3919,6 +4032,15 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"to" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall,
+/area/icy_caves/outpost/garage)
+"tp" = (
+/obj/item/lightstick/anchored,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "tq" = (
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/plating/ground/ice,
@@ -3931,25 +4053,21 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
-"tt" = (
-/turf/open/floor/mainship/red,
-/area/icy_caves/caves/northern)
 "tv" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
 /turf/closed/ice/junction,
 /area/icy_caves/outpost/LZ2)
-"tz" = (
-/obj/structure/janitorialcart,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
-"tA" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
+"tw" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd{
+	dir = 1
 	},
-/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"tx" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/purple/whitepurplefull,
 /area/icy_caves/caves/northern)
 "tB" = (
 /obj/structure/cable,
@@ -3978,6 +4096,15 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/engineering)
+"tF" = (
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
+"tG" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleT,
+/area/icy_caves/caves)
 "tH" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/research)
@@ -4020,11 +4147,6 @@
 	dir = 5
 	},
 /area/icy_caves/outpost/garage)
-"tP" = (
-/obj/structure/mopbucket,
-/obj/machinery/power/apc/drained,
-/turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern)
 "tQ" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/plating,
@@ -4033,16 +4155,10 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
-"tS" = (
-/obj/structure/largecrate/random/barrel/yellow,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "tT" = (
-/obj/machinery/light,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
+/obj/structure/table/mainship,
+/obj/machinery/computer/med_data,
+/turf/open/floor/mainship/mono,
 /area/icy_caves/caves/northern)
 "tU" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -4052,13 +4168,6 @@
 	dir = 10
 	},
 /area/icy_caves/outpost/garage)
-"tV" = (
-/obj/structure/largecrate/random/secure,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
 "tW" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4093,6 +4202,12 @@
 	dir = 4
 	},
 /area/icy_caves/caves)
+"ud" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "ue" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -4106,11 +4221,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"ug" = (
-/turf/open/floor/tile/dark/green2{
-	dir = 8
-	},
-/area/icy_caves/caves/northern)
 "uh" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/green2/corner{
@@ -4125,21 +4235,15 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
-"uk" = (
-/turf/closed/ice_rock/eastWall,
-/area/icy_caves/caves/northern)
 "ul" = (
-/obj/machinery/door/airlock/mainship/security,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"um" = (
-/obj/machinery/door/airlock/mainship/maint,
-/turf/open/floor/tile/dark,
+/obj/structure/dropship_piece/two/corner/rearright,
+/turf/open/shuttle/dropship/floor,
 /area/icy_caves/caves/northern)
 "un" = (
-/obj/effect/landmark/weed_node,
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/east)
+/area/icy_caves/caves/northern)
 "uo" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -4163,15 +4267,17 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ2)
 "us" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singleEnd{
-	dir = 4
+/obj/structure/shuttle/engine/router{
+	dir = 1
 	},
-/area/icy_caves/caves)
-"ut" = (
-/obj/structure/largecrate/random,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
+/obj/structure/dropship_equipment/weapon/heavygun,
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/shuttle/dropship/floor,
+/area/space)
+"uu" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "uv" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/grilledcheese,
@@ -4180,6 +4286,16 @@
 "uw" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
+"ux" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/mass_spectrometer/adv,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/icy_caves/caves/northern)
 "uy" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -4188,16 +4304,18 @@
 	dir = 10
 	},
 /area/icy_caves/caves)
-"uz" = (
-/obj/item/shard,
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
 "uA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
 /turf/closed/ice_rock/singlePart{
 	dir = 6
+	},
+/area/icy_caves/caves)
+"uB" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd{
+	dir = 8
 	},
 /area/icy_caves/caves)
 "uC" = (
@@ -4212,22 +4330,6 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"uE" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"uF" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 5
-	},
-/turf/open/floor/mainship/cargo,
-/area/icy_caves/caves/northern)
 "uH" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/tile/dark/green2{
@@ -4246,6 +4348,10 @@
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"uO" = (
+/obj/structure/dropship_piece/two/corner/rearleft,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "uP" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -4272,38 +4378,22 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/medbay)
-"uS" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/shuttle/dropship/seven,
-/area/space)
 "uT" = (
-/obj/structure/window/framed/colony/reinforced,
+/obj/effect/landmark/weed_node,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"uU" = (
-/obj/machinery/light{
+"uW" = (
+/turf/open/floor/tile/dark/yellow2{
 	dir = 1
 	},
-/turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ2)
-"uW" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/straight,
-/area/icy_caves/caves/northern)
 "uX" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
-"uY" = (
-/turf/closed/ice/junction{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "va" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/tile/dark/green2{
@@ -4331,6 +4421,12 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"ve" = (
+/obj/machinery/power/apc/drained{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "vf" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/outpost/outside)
@@ -4352,9 +4448,9 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "vk" = (
-/obj/structure/window/framed/colony,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/mining/west)
+/obj/structure/ore_box,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "vl" = (
 /obj/structure/curtain/medical,
 /turf/open/floor/tile/dark,
@@ -4365,6 +4461,11 @@
 	dir = 10
 	},
 /area/icy_caves/outpost/engineering)
+"vn" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "25"
+	},
+/area/icy_caves/caves/northern)
 "vo" = (
 /obj/machinery/light{
 	dir = 1
@@ -4385,6 +4486,10 @@
 	dir = 6
 	},
 /area/icy_caves/outpost/garage)
+"vr" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/ice/thin/straight,
+/area/icy_caves/outpost/LZ1)
 "vs" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -4395,6 +4500,11 @@
 /obj/structure/bed/roller,
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
+"vv" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "vx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
@@ -4425,25 +4535,21 @@
 /obj/structure/bed/chair/comfy,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"vC" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "vE" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
+"vF" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
+	dir = 8
+	},
+/area/icy_caves/caves)
 "vI" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"vK" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
 "vL" = (
 /obj/effect/decal/cleanable/blood/gibs/robot,
 /turf/open/floor/tile/dark/brown2/corner,
@@ -4452,10 +4558,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/research)
-"vN" = (
-/obj/structure/janitorialcart,
-/turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern)
 "vP" = (
 /obj/structure/powerloader_wreckage,
 /turf/open/floor/tile/dark/brown2{
@@ -4515,16 +4617,30 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
+"wf" = (
+/obj/structure/barricade/guardrail{
+	dir = 1
+	},
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "wg" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
+"wh" = (
+/obj/structure/morgue/crematorium,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "wi" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/tile/dark/green2{
 	dir = 4
 	},
 /area/icy_caves/outpost/medbay)
+"wj" = (
+/obj/structure/largecrate/random/barrel/yellow,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "wk" = (
 /turf/open/floor/tile/dark/red2/corner,
 /area/icy_caves/outpost/security)
@@ -4547,14 +4663,29 @@
 	dir = 8
 	},
 /area/icy_caves/caves/northern)
-"wp" = (
-/obj/machinery/door/airlock/multi_tile/mainship/research,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/LZ2)
-"wr" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/intersection,
+"wq" = (
+/obj/machinery/light,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
 /area/icy_caves/caves/northern)
+"ws" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"wt" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/red2{
+	dir = 5
+	},
+/area/icy_caves/outpost/LZ2)
 "wu" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
@@ -4568,21 +4699,10 @@
 "wv" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/outpost/LZ2)
-"ww" = (
-/obj/item/shard,
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "wx" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/refinery)
-"wy" = (
-/turf/open/floor/tile/dark/yellow2{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ2)
 "wz" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -4596,33 +4716,26 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/medbay)
-"wF" = (
-/obj/structure/table/mainship,
+"wG" = (
+/obj/effect/spawner/gibspawner/human,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean2"
 	},
 /area/icy_caves/caves/northern)
-"wG" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "wH" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/refinery)
-"wJ" = (
-/obj/effect/decal/warning_stripes/thin{
+"wI" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
 	dir = 4
 	},
-/obj/structure/table/mainship,
-/obj/structure/cable,
-/obj/machinery/computer/nuke_disk_generator/blue,
-/turf/open/floor/mainship/tcomms,
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves)
+"wL" = (
+/turf/open/floor/mech_bay_recharge_floor,
+/area/icy_caves/outpost/LZ1)
 "wM" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
@@ -4634,9 +4747,8 @@
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ2)
 "wO" = (
-/obj/structure/dropship_piece/two/front/left,
-/turf/open/floor/mainship_hull/dir{
-	dir = 8
+/turf/open/floor/mainship/red{
+	dir = 4
 	},
 /area/icy_caves/caves/northern)
 "wP" = (
@@ -4652,41 +4764,23 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
-"wQ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"wS" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 8
-	},
-/turf/open/floor/tile/dark/red2{
+"wT" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
 	dir = 5
 	},
-/area/icy_caves/outpost/LZ2)
-"wT" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
+/obj/structure/monorail{
 	dir = 9
 	},
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/space)
 "wW" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
-"wX" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/icy_caves/caves/northern)
 "wZ" = (
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
@@ -4698,19 +4792,6 @@
 	dir = 1
 	},
 /area/icy_caves/caves/south)
-"xc" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/southWall,
-/area/icy_caves/caves)
-"xe" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 8
-	},
-/turf/open/floor/tile/dark/blue2{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "xf" = (
 /obj/structure/closet/secure_closet/scientist,
 /turf/open/floor/tile/dark/purple2,
@@ -4726,6 +4807,12 @@
 /obj/structure/curtain/medical,
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
+"xj" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "xk" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -4754,24 +4841,20 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
 "xo" = (
-/turf/open/floor/tile/dark/brown2{
-	dir = 9
-	},
-/area/icy_caves/outpost/LZ2)
-"xp" = (
-/obj/structure/monorail,
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 4
-	},
-/turf/open/floor/mainship_hull,
-/area/space)
-"xq" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/closet/crate,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick,
+/obj/item/storage/box/lightstick,
+/obj/item/tool/pickaxe/plasmacutter,
+/obj/effect/spawner/random/powercell,
+/obj/item/clothing/glasses/welding,
+/obj/item/explosive/plastique,
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/caves/northern)
 "xr" = (
 /obj/machinery/mineral/stacking_machine,
 /obj/machinery/conveyor{
@@ -4780,10 +4863,8 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/refinery)
 "xs" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/tile/purple/whitepurplefull,
+/obj/structure/barricade/guardrail,
+/turf/open/floor/mainship/red/full,
 /area/icy_caves/caves/northern)
 "xu" = (
 /obj/structure/cargo_container/green,
@@ -4798,11 +4879,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
-"xy" = (
-/turf/closed/ice/thin/end{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ1)
 "xA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -4825,15 +4901,6 @@
 /obj/structure/prop/mainship/hangar_stencil,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
-"xK" = (
-/turf/open/floor/tile/dark/yellow2{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ2)
-"xL" = (
-/obj/structure/fence,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/caves/west)
 "xM" = (
 /turf/closed/ice/straight{
 	dir = 4
@@ -4850,6 +4917,10 @@
 "xR" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"xS" = (
+/obj/machinery/computer3/server,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "xT" = (
 /turf/open/floor/tile/dark/green2/corner{
 	dir = 4
@@ -4862,29 +4933,38 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"xW" = (
+/obj/structure/largecrate/supply/explosives/mortar_flare,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "xX" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/caves/south)
+"xZ" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "ya" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves)
 "yb" = (
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/mining/west)
-"ye" = (
-/obj/structure/window/framed/colony/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"yf" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mainship_hull/dir{
-	dir = 8
+/obj/structure/filingcabinet,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
 	},
 /area/icy_caves/caves/northern)
+"yd" = (
+/obj/structure/monorail,
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/floor/mainship_hull,
+/area/space)
 "yg" = (
 /obj/structure/bookcase/manuals,
 /obj/machinery/light{
@@ -4898,20 +4978,18 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
+"yi" = (
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "yj" = (
 /obj/structure/closet/crate/secure/weapon,
 /obj/item/weapon/gun/smg/m25,
 /obj/item/weapon/gun/smg/m25,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"yk" = (
-/obj/structure/table,
-/obj/item/corncob,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "yl" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/tile/dark/blue2{
@@ -4930,9 +5008,11 @@
 /turf/closed/ice/thin/straight,
 /area/icy_caves/outpost/LZ2)
 "yv" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "yw" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/machinery/light,
@@ -4941,6 +5021,10 @@
 "yx" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/engineering)
+"yz" = (
+/obj/structure/bed/chair,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "yB" = (
 /turf/closed/ice/thin/junction{
 	dir = 8
@@ -4957,6 +5041,14 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"yF" = (
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/space)
 "yG" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -4965,6 +5057,12 @@
 	dir = 8
 	},
 /area/icy_caves/caves)
+"yH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "yJ" = (
 /obj/structure/closet/crate/construction,
 /obj/item/cell/hyper,
@@ -4982,21 +5080,6 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
-"yL" = (
-/obj/machinery/landinglight/ds1/delaytwo,
-/obj/machinery/floodlight/landing,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
-"yP" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/end{
-	dir = 1
-	},
-/area/icy_caves/caves)
-"yQ" = (
-/obj/structure/largecrate/random/secure,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/garage)
 "yR" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -5005,15 +5088,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
-"yS" = (
-/obj/structure/cable,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall,
-/area/icy_caves/caves/northern)
-"yT" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside/center)
 "yU" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
@@ -5025,26 +5099,21 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/garage)
-"yW" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
+"yV" = (
+/obj/effect/spawner/gibspawner/human,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
 	},
-/turf/closed/ice_rock/singleEnd{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ1)
-"yY" = (
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"za" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/outside)
-"zd" = (
-/obj/structure/closet/l3closet/virology,
-/turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern)
 "ze" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
+/obj/structure/largecrate/random/case/double,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "zh" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -5053,6 +5122,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"zi" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/ice_rock/corners{
+	dir = 9
+	},
+/area/icy_caves/caves)
 "zk" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleT{
@@ -5093,12 +5170,13 @@
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/garage)
 "zt" = (
-/obj/structure/table/mainship,
-/obj/machinery/recharger,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
+/turf/open/floor/tile/white/warningstripe{
+	dir = 6
 	},
+/area/icy_caves/caves/northern)
+"zu" = (
+/obj/machinery/door/airlock/multi_tile/mainship/secdoor,
+/turf/open/floor/mainship/red/full,
 /area/icy_caves/caves/northern)
 "zw" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -5117,15 +5195,16 @@
 	},
 /area/icy_caves/outpost/outside)
 "zz" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/obj/effect/ai_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/outside/center)
 "zA" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/refinery)
+"zB" = (
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "zC" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/tile/dark,
@@ -5141,13 +5220,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"zI" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	on = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern)
 "zK" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -5160,6 +5232,10 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singlePart,
 /area/icy_caves/caves)
+"zM" = (
+/obj/machinery/landinglight/ds1/delaytwo,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "zN" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
@@ -5176,13 +5252,11 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
-"zR" = (
-/obj/structure/monorail,
-/obj/machinery/door/poddoor/mainship/indestructible{
-	dir = 2
-	},
-/turf/open/floor/mainship_hull,
-/area/space)
+"zS" = (
+/obj/machinery/landinglight/ds1/delaytwo,
+/obj/machinery/floodlight/landing,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "zT" = (
 /obj/machinery/iv_drip,
 /obj/machinery/power/apc/drained{
@@ -5213,6 +5287,12 @@
 	dir = 9
 	},
 /area/icy_caves/outpost/medbay)
+"zZ" = (
+/obj/machinery/door/airlock/mainship/secure/locked/free_access{
+	dir = 2
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Aa" = (
 /obj/item/storage/box/flashbangs,
 /obj/item/storage/box/m94,
@@ -5223,13 +5303,9 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "Ab" = (
-/turf/open/shuttle/dropship/seven,
-/area/space)
-"Ac" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/northern)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "Ad" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -5239,14 +5315,23 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/garage)
-"Af" = (
-/obj/machinery/camera/autoname/mainship/dropship_one{
-	dir = 8;
-	pixel_x = 16
-	},
-/obj/structure/largecrate/supply/explosives,
-/turf/open/floor/tile/dark,
+"Ae" = (
+/turf/closed/ice_rock/eastWall,
 /area/icy_caves/caves/northern)
+"Af" = (
+/obj/vehicle/multitile/root/cm_armored/tank{
+	dir = 1;
+	layer = 1
+	},
+/obj/structure/dropship_equipment/weapon/laser_beam_gun,
+/obj/effect/turf_overlay/shuttle/heater,
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/shuttle/dropship/floor,
+/area/space)
+"Ag" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside)
 "Ah" = (
 /obj/effect/landmark/corpsespawner/security{
 	corpsebelt = /obj/item/weapon/gun/revolver/cmb;
@@ -5259,10 +5344,6 @@
 "Ai" = (
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
-"Aj" = (
-/obj/structure/barricade/guardrail,
-/turf/open/floor/mainship/red/full,
-/area/icy_caves/caves/northern)
 "Ak" = (
 /obj/machinery/sleeper,
 /turf/open/floor/tile/dark/green2{
@@ -5280,10 +5361,12 @@
 /obj/machinery/processor,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"An" = (
-/obj/machinery/light,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+"Aq" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/snow,
+/area/icy_caves/outpost/LZ1)
 "Ar" = (
 /obj/structure/closet/crate/secure/ammo,
 /obj/item/ammo_magazine/smg/m25,
@@ -5319,6 +5402,10 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
+"Aw" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/r_wall,
+/area/icy_caves/outpost/dorms)
 "Ax" = (
 /obj/structure/table,
 /obj/machinery/light/built{
@@ -5326,10 +5413,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"AA" = (
-/obj/machinery/camera/autoname/lz_camera,
+"Az" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research,
 /turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/LZ2)
 "AB" = (
 /turf/closed/ice/thin/end{
 	dir = 1
@@ -5379,11 +5466,19 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/refinery)
+"AJ" = (
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "AK" = (
 /turf/closed/ice/end{
 	dir = 1
 	},
 /area/icy_caves/outpost/outside)
+"AL" = (
+/turf/closed/ice/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "AM" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/cable,
@@ -5397,14 +5492,17 @@
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "AQ" = (
-/obj/machinery/landinglight/ds1{
-	dir = 8
+/obj/machinery/disposal,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/caves/northern)
 "AR" = (
-/obj/machinery/light,
-/turf/open/floor/tile/dark,
+/obj/structure/table/reinforced,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 1
+	},
 /area/icy_caves/caves/northern)
 "AS" = (
 /obj/machinery/power/geothermal,
@@ -5456,6 +5554,10 @@
 	dir = 4
 	},
 /area/icy_caves/caves)
+"Bb" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/caves/west)
 "Bd" = (
 /obj/machinery/door/airlock/multi_tile/mainship/secdoor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -5468,6 +5570,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"Bf" = (
+/turf/open/floor/tile/dark/green2{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "Bi" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/prison/kitchen,
@@ -5483,17 +5590,10 @@
 	},
 /area/icy_caves/caves/east)
 "Bo" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Bp" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
 /area/icy_caves/caves/northern)
 "Bq" = (
 /obj/machinery/vending/dinnerware,
@@ -5503,8 +5603,9 @@
 /turf/open/floor/podhatch/floor,
 /area/icy_caves/outpost/engineering)
 "Bt" = (
-/turf/closed/wall,
-/area/icy_caves/outpost/outside)
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "Bu" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -5513,12 +5614,6 @@
 	dir = 4
 	},
 /area/icy_caves/caves)
-"Bv" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Bw" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/caves/west)
@@ -5541,10 +5636,18 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
-"BH" = (
-/turf/open/floor/tile/purple/whitepurplecorner{
-	dir = 1
+"BB" = (
+/obj/structure/cryofeed,
+/turf/open/floor/podhatch/floor{
+	icon_state = "bcircuitoff"
 	},
+/area/icy_caves/caves/northern)
+"BF" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "BI" = (
 /obj/machinery/power/apc/drained,
@@ -5554,31 +5657,27 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
-"BJ" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
-"BK" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark/brown2{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ2)
 "BL" = (
 /turf/closed/ice/end{
 	dir = 8
 	},
 /area/icy_caves/outpost/outside)
-"BO" = (
-/obj/machinery/light{
-	dir = 8
+"BM" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/straight,
+/area/icy_caves/caves/northern)
+"BN" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "52"
 	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/northern)
+"BO" = (
+/obj/machinery/door/airlock/multi_tile/secure{
+	dir = 2
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "BP" = (
 /turf/closed/ice/junction{
 	dir = 4
@@ -5603,15 +5702,6 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/engineering)
-"BT" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 6
-	},
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
 "BU" = (
 /obj/structure/closet/crate/science,
 /obj/item/clothing/glasses/science,
@@ -5623,6 +5713,12 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"BW" = (
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "BX" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -5631,39 +5727,30 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"BZ" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
-"Ca" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 5
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Ce" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/mainship/tcomms,
-/area/icy_caves/caves/northern)
-"Cg" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside/center)
-"Ch" = (
+"BY" = (
 /obj/structure/lattice,
 /obj/structure/monorail{
-	dir = 9
+	dir = 6
 	},
 /obj/structure/monorail{
+	dir = 10
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/space)
+"BZ" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Cc" = (
+/turf/open/floor/tile/dark/brown2{
 	dir = 5
 	},
-/obj/structure/dropship_piece/two/front,
-/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/outpost/LZ2)
+"Ch" = (
+/obj/machinery/computer3/server/rack,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "Ci" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -5672,16 +5759,31 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
-"Cj" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Ck" = (
 /obj/machinery/science/analyser,
 /turf/open/floor/tile/dark/purple2{
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
+"Cl" = (
+/obj/machinery/camera{
+	dir = 5
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Cm" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
+"Cq" = (
+/turf/closed/ice/thin/end{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "Cs" = (
 /obj/item/ammo_casing,
 /turf/open/floor/wood,
@@ -5691,32 +5793,20 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
-"Cy" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
+"CA" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/blood/xtracks,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
-"CB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1
-	},
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/mining/west)
 "CC" = (
 /obj/machinery/space_heater,
 /turf/open/floor/tile/dark/purple2{
 	dir = 5
 	},
 /area/icy_caves/outpost/research)
-"CE" = (
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "CF" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
@@ -5724,53 +5814,29 @@
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
 "CH" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
-"CI" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 9
+/turf/open/floor/mainship_hull/dir{
+	dir = 10
 	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"CK" = (
-/obj/effect/decal/cleanable/mucus,
-/obj/structure/table,
-/turf/open/floor/tile/purple/whitepurplefull,
 /area/icy_caves/caves/northern)
 "CN" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/south)
-"CO" = (
-/obj/structure/bed/chair/comfy{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "CP" = (
 /turf/closed/ice/thin/end{
 	dir = 1
 	},
-/area/icy_caves/outpost/LZ2)
-"CR" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ2)
 "CS" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 6
 	},
 /area/icy_caves/caves/east)
-"CU" = (
-/obj/machinery/door/poddoor/mainship/indestructible{
-	dir = 2
+"CT" = (
+/obj/structure/bed/chair{
+	dir = 4
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "CV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -5785,8 +5851,8 @@
 	dir = 9
 	},
 /area/icy_caves/outpost/refinery)
-"CY" = (
-/obj/structure/largecrate/random/secure,
+"CX" = (
+/obj/machinery/vending/cigarette,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "CZ" = (
@@ -5811,10 +5877,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"Dh" = (
-/obj/machinery/power/apc/drained,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Di" = (
 /turf/closed/ice/corner{
 	dir = 4
@@ -5838,9 +5900,7 @@
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
 "Dm" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
+/obj/structure/largecrate/random/secure,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean2"
@@ -5853,16 +5913,21 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
+"Do" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "Dp" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleEnd{
 	dir = 1
 	},
 /area/icy_caves/caves)
-"Dq" = (
-/obj/structure/dropship_piece/two/corner/rearleft,
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
 "Ds" = (
 /obj/structure/table,
 /obj/item/storage/surgical_tray,
@@ -5890,21 +5955,12 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"DA" = (
-/obj/machinery/door/airlock/multi_tile/mainship/research,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
 "DB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/singlePart{
 	dir = 1
 	},
 /area/icy_caves/caves)
-"DC" = (
-/turf/open/floor/mainship_hull/dir{
-	dir = 9
-	},
-/area/icy_caves/caves/northern)
 "DD" = (
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/outside/center)
@@ -5917,15 +5973,10 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "DH" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/LZ2)
-"DI" = (
-/obj/structure/dropship_piece/two/front,
-/turf/closed/shuttle/dropship2/transparent{
-	icon_state = "109"
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/closed/ice/end{
+	dir = 1
 	},
 /area/icy_caves/caves/northern)
 "DJ" = (
@@ -5955,28 +6006,26 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "DO" = (
-/obj/structure/morgue/crematorium,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"DS" = (
-/obj/structure/closet/crate,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick,
-/obj/item/storage/box/lightstick,
-/obj/item/tool/pickaxe/plasmacutter,
-/obj/effect/spawner/random/powercell,
-/obj/item/clothing/glasses/welding,
-/obj/item/explosive/plastique,
-/obj/machinery/light/small{
-	dir = 8
+/turf/open/floor/tile/dark/brown2{
+	dir = 9
 	},
-/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
+"DS" = (
+/obj/structure/dropship_piece/one/corner/middleright,
+/obj/structure/dropship_piece/two/corner/rearright,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
 /area/icy_caves/caves/northern)
-"DT" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/LZ1)
+"DU" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
+"DV" = (
+/obj/structure/mopbucket,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "DW" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -5988,13 +6037,10 @@
 	},
 /area/icy_caves/outpost/garage)
 "DX" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
+/turf/closed/ice_rock/corners{
+	dir = 9
 	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/outpost/LZ1)
 "DY" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
@@ -6004,9 +6050,11 @@
 	},
 /area/icy_caves/caves/west)
 "Ea" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/eastWall,
-/area/icy_caves/caves)
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Eb" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/effect/ai_node,
@@ -6031,12 +6079,14 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"Eg" = (
-/obj/machinery/light{
-	dir = 8
+"Eh" = (
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
 	},
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/space)
 "Ej" = (
 /obj/structure/table,
 /obj/item/stack/nanopaste,
@@ -6044,6 +6094,11 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/medbay)
+"Ek" = (
+/obj/structure/table/mainship,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "El" = (
 /obj/structure/table/reinforced,
 /obj/effect/landmark/dropship_console_spawn_lz2,
@@ -6059,10 +6114,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
-"Eq" = (
-/obj/structure/closet/l3closet/janitor,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
 "Er" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/snow/layer2,
@@ -6085,6 +6136,8 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
 "Ex" = (
+/obj/effect/decal/cleanable/mucus,
+/obj/structure/table,
 /turf/open/floor/tile/purple/whitepurplefull,
 /area/icy_caves/caves/northern)
 "Ey" = (
@@ -6131,14 +6184,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
-"EL" = (
-/obj/machinery/vending/dinnerware,
-/obj/machinery/camera/autoname/mainship/dropship_one{
-	dir = 8;
-	pixel_x = 16
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "EM" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 10
@@ -6148,6 +6193,10 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/junction,
 /area/icy_caves/outpost/LZ1)
+"EP" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "EQ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/corner{
@@ -6160,27 +6209,16 @@
 	},
 /turf/closed/ice_rock/westWall,
 /area/icy_caves/caves)
-"ET" = (
-/obj/structure/largecrate/random/case/double,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
 "EU" = (
-/obj/structure/cryofeed/right{
-	name = "\improper coolant feed"
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/podhatch/floor{
-	icon_state = "bcircuitoff"
-	},
-/area/icy_caves/caves/northern)
-"EV" = (
-/obj/structure/bed/chair,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"EW" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singleEnd,
-/area/icy_caves/caves)
+"EX" = (
+/obj/structure/largecrate/supply/floodlights,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "EZ" = (
 /obj/item/ammo_casing,
 /obj/structure/cable,
@@ -6219,10 +6257,17 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
-"Fk" = (
-/obj/structure/dropship_piece/two/corner/rearright,
-/turf/open/shuttle/dropship/floor,
+"Fj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"Fk" = (
+/obj/structure/barricade/guardrail,
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "Fm" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -6240,6 +6285,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"Fq" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "Fr" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/purple2{
@@ -6275,27 +6324,18 @@
 	dir = 1
 	},
 /area/icy_caves/caves/northern)
-"Fx" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+"Fw" = (
+/turf/open/floor/tile/white/warningstripe{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "Fy" = (
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
-"FA" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside/center)
-"FC" = (
-/obj/vehicle/multitile/root/cm_armored/tank{
-	dir = 1;
-	layer = 1
-	},
-/obj/structure/dropship_equipment/weapon/laser_beam_gun,
-/obj/effect/turf_overlay/shuttle/heater,
-/obj/structure/dropship_equipment/weapon/rocket_pod,
-/turf/open/shuttle/dropship/floor,
-/area/space)
+"FB" = (
+/obj/machinery/light,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "FF" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -6323,13 +6363,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"FM" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "FN" = (
 /obj/structure/sink{
 	dir = 4
@@ -6346,9 +6379,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
-"FT" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
+"FR" = (
+/turf/closed/shuttle/dropship2/transparent{
+	icon_state = "109"
+	},
 /area/icy_caves/caves/northern)
 "FU" = (
 /obj/structure/cargo_container/ch_red,
@@ -6390,11 +6424,24 @@
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"Gg" = (
-/turf/open/floor/tile/dark/red2{
-	dir = 8
+"Gf" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Gh" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
 	},
-/area/icy_caves/outpost/LZ2)
+/obj/structure/table/mainship,
+/obj/structure/cable,
+/obj/machinery/computer/nuke_disk_generator/blue,
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern)
+"Gj" = (
+/obj/machinery/computer/operating,
+/obj/structure/table/reinforced,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Gk" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -6413,9 +6460,9 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
 "Gn" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
-/turf/open/floor/tile/dark/yellow2,
-/area/icy_caves/outpost/LZ2)
+/obj/structure/largecrate/random/barrel/green,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Go" = (
 /turf/open/floor/tile/dark/purple2/corner{
 	dir = 1
@@ -6430,16 +6477,19 @@
 	},
 /area/icy_caves/outpost/medbay)
 "Gr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
-"Gt" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
+"Gs" = (
+/turf/closed/ice_rock/corners,
 /area/icy_caves/caves/northern)
 "Gu" = (
 /turf/closed/ice,
@@ -6447,27 +6497,44 @@
 "Gw" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/refinery)
+"Gx" = (
+/obj/structure/mopbucket,
+/obj/machinery/power/apc/drained,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
+"Gy" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
 "Gz" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleT,
 /area/icy_caves/caves)
+"GC" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "GD" = (
 /turf/open/floor/tile/dark/red2/corner{
 	dir = 1
 	},
 /area/icy_caves/outpost/security)
 "GE" = (
-/obj/machinery/power/apc/drained{
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/tile/purple/whitepurplefull,
 /area/icy_caves/caves/northern)
 "GF" = (
-/obj/machinery/landinglight/ds1/delaythree{
-	dir = 8
+/turf/closed/wall,
+/area/icy_caves/caves/west)
+"GG" = (
+/turf/closed/ice/thin/corner{
+	dir = 1
 	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/LZ2)
 "GH" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/ice,
@@ -6500,6 +6567,32 @@
 	dir = 4
 	},
 /area/icy_caves/caves)
+"GN" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/space)
+"GO" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ2)
+"GQ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "GR" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -6514,16 +6607,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"GT" = (
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 6
+"GU" = (
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 8
 	},
-/obj/structure/monorail{
-	dir = 10
-	},
-/turf/open/shuttle/escapepod/plain,
-/area/icy_caves/caves/northern)
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "GV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -6550,11 +6639,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
-"Hb" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
+"Hc" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/blue2,
 /area/icy_caves/outpost/LZ2)
+"He" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Hf" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/dorms)
@@ -6574,6 +6666,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
+"Hj" = (
+/obj/structure/table/mainship,
+/obj/machinery/recharger,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "Hl" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/dark,
@@ -6591,15 +6691,6 @@
 "Hq" = (
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/caves/east)
-"Hr" = (
-/turf/closed/wall/r_wall/unmeltable,
-/area/icy_caves/caves/northern)
-"Hs" = (
-/turf/closed/ice_rock/northWall,
-/area/icy_caves/caves/west)
-"Ht" = (
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
 "Hu" = (
 /obj/structure/closet/crate/science,
 /turf/open/floor/tile/dark/purple2{
@@ -6612,12 +6703,15 @@
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
 "Hw" = (
-/obj/machinery/vending/cola,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
+"Hx" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/outpost/LZ2)
 "HA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -6631,10 +6725,13 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "HC" = (
-/obj/machinery/power/apc/lowcharge,
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/icy_caves/outpost/LZ1)
+/obj/structure/monorail,
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 4
+	},
+/turf/open/floor/mainship_hull,
+/area/space)
 "HE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -6643,13 +6740,16 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "HF" = (
-/turf/open/floor/mainship_hull/dir{
-	dir = 8
+/turf/closed/ice/corner{
+	dir = 4
 	},
-/area/icy_caves/caves/northern)
+/area/icy_caves/outpost/LZ2)
 "HG" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/south)
+"HH" = (
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/caves/east)
 "HI" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -6664,17 +6764,10 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/medbay)
-"HK" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/corners{
-	dir = 5
-	},
-/area/icy_caves/caves)
 "HL" = (
-/obj/machinery/camera{
-	dir = 9
+/turf/open/floor/mainship_hull/dir{
+	dir = 6
 	},
-/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "HM" = (
 /obj/item/ammo_casing,
@@ -6690,8 +6783,19 @@
 /obj/item/clothing/head/nun_hood,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"HP" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "HQ" = (
-/obj/structure/window/framed/colony/reinforced,
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "HR" = (
@@ -6710,6 +6814,18 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"HT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"HU" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "HV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/corners{
@@ -6723,21 +6839,6 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"HY" = (
-/obj/machinery/door/poddoor/mainship/indestructible{
-	dir = 2
-	},
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
-	},
-/area/space)
-"Ia" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 2;
-	name = "Canteen"
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Ib" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -6745,26 +6846,33 @@
 /obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"Id" = (
-/obj/structure/cargo_container/gorg,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/garage)
 "Ie" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
-"Ig" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/blood,
-/turf/open/floor/tile/purple/whitepurple{
+"If" = (
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor/mainship/cargo,
 /area/icy_caves/caves/northern)
+"Ig" = (
+/obj/docking_port/mobile/crashmode/bigbury,
+/turf/closed/ice,
+/area/icy_caves/caves/south)
 "Ih" = (
 /obj/structure/cargo_container/green{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Ij" = (
+/obj/structure/largecrate/random/barrel/green,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "Ik" = (
 /obj/structure/table,
 /obj/item/storage/box/flashbangs,
@@ -6774,9 +6882,11 @@
 	},
 /area/icy_caves/outpost/security)
 "Il" = (
-/turf/closed/shuttle/dropship2/transparent{
-	icon_state = "109"
-	},
+/turf/closed/ice_rock/southWall,
+/area/icy_caves/caves/northern)
+"Im" = (
+/obj/item/shard,
+/turf/open/shuttle/dropship/floor,
 /area/icy_caves/caves/northern)
 "In" = (
 /obj/effect/decal/cleanable/blood/xeno,
@@ -6809,10 +6919,6 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/garage)
-"Iu" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
 "Iv" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating,
@@ -6838,6 +6944,12 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"IB" = (
+/obj/machinery/space_heater,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 10
+	},
+/area/icy_caves/outpost/LZ2)
 "IC" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/caves/northern)
@@ -6850,13 +6962,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
-"IE" = (
-/obj/structure/barricade/guardrail,
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 4
-	},
-/turf/open/shuttle/dropship/seven,
-/area/space)
 "IG" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -6876,23 +6981,22 @@
 /turf/open/floor/tile/dark/red2,
 /area/icy_caves/outpost/security)
 "II" = (
-/obj/structure/shuttle/engine/router{
-	dir = 1
-	},
-/obj/structure/dropship_equipment/weapon/heavygun,
-/obj/structure/dropship_equipment/weapon/rocket_pod,
-/turf/open/shuttle/dropship/floor,
-/area/space)
+/obj/item/paper/crumpled/bloody/csheet,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "IJ" = (
 /obj/machinery/vending/security,
 /turf/open/floor/tile/dark/red2{
 	dir = 9
 	},
 /area/icy_caves/outpost/security)
-"IM" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/LZ2)
+"IK" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "IO" = (
 /obj/structure/closet/crate/construction,
 /obj/item/stack/sheet/metal/medium_stack,
@@ -6905,10 +7009,11 @@
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "IP" = (
-/obj/effect/spawner/gibspawner/human,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
 	},
 /area/icy_caves/caves/northern)
 "IR" = (
@@ -6924,38 +7029,23 @@
 "IT" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"IV" = (
-/obj/structure/closet/crate,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick,
-/obj/item/storage/box/lightstick,
-/obj/item/tool/pickaxe/plasmacutter,
-/obj/effect/spawner/random/powercell,
-/obj/item/explosive/plastique,
-/turf/open/floor/tile/dark,
+"IU" = (
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 4
+	},
 /area/icy_caves/caves/northern)
 "IX" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
 "IY" = (
-/obj/structure/window/framed/colony/reinforced,
-/obj/structure/cable,
+/obj/item/tool/surgery/hemostat,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "IZ" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/research_and_development,
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
-"Jd" = (
-/obj/machinery/optable,
-/obj/effect/decal/cleanable/blood/xtracks,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/obj/structure/window/framed/colony/reinforced,
+/turf/closed/wall/r_wall,
+/area/icy_caves/outpost/LZ2)
 "Je" = (
 /turf/closed/ice/thin/end{
 	dir = 8
@@ -6970,12 +7060,6 @@
 "Jg" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/west)
-"Jh" = (
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 4
-	},
-/turf/open/shuttle/dropship/seven,
-/area/icy_caves/caves/northern)
 "Ji" = (
 /obj/effect/landmark/start/job/survivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -7002,6 +7086,9 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/LZ2)
+"Jn" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "Jo" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
@@ -7022,10 +7109,6 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
-"Jr" = (
-/obj/effect/decal/cleanable/vomit,
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
 "Jv" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -7033,12 +7116,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"Jw" = (
-/obj/machinery/door/airlock/mainship/secure/locked/free_access{
-	dir = 2
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Jx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8
@@ -7074,6 +7151,13 @@
 /obj/item/lightstick/anchored,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"JF" = (
+/obj/machinery/vending/cola,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "JH" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/pepper,
@@ -7083,24 +7167,19 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/security)
-"JI" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/corners,
-/area/icy_caves/caves/northern)
 "JJ" = (
 /turf/closed/ice/end{
 	dir = 1
 	},
 /area/icy_caves/outpost/outside/center)
-"JL" = (
-/turf/open/floor/mainship_hull/dir{
-	dir = 10
-	},
-/area/icy_caves/caves/northern)
 "JM" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
+"JN" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/LZ2)
 "JO" = (
 /obj/machinery/bodyscanner,
 /turf/open/floor/tile/dark/green2,
@@ -7111,11 +7190,15 @@
 	dir = 5
 	},
 /area/icy_caves/caves)
-"JQ" = (
-/obj/structure/barricade/guardrail{
-	dir = 8
+"JR" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 5
 	},
-/turf/open/floor/tile/dark,
+/obj/structure/monorail{
+	dir = 9
+	},
+/turf/open/shuttle/escapepod/plain,
 /area/icy_caves/caves/northern)
 "JS" = (
 /obj/structure/closet/crate/freezer/rations,
@@ -7127,24 +7210,16 @@
 	dir = 6
 	},
 /area/icy_caves/outpost/medbay)
-"JU" = (
-/obj/item/reagent_containers/spray/pepper,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 6
-	},
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
-"JV" = (
-/obj/effect/ai_node,
+"JW" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/outpost/outside/center)
 "JX" = (
 /turf/closed/ice/end,
 /area/icy_caves/caves/south)
-"JZ" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
+"JY" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "Ka" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -7157,6 +7232,11 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/office)
+"Kd" = (
+/turf/open/floor/tile/dark/red2{
+	dir = 10
+	},
+/area/icy_caves/outpost/LZ2)
 "Ke" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -7184,15 +7264,18 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"Ko" = (
+/turf/open/floor/tile/dark/red2{
+	dir = 6
+	},
+/area/icy_caves/outpost/LZ2)
 "Kp" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
 "Kr" = (
-/obj/machinery/atmospherics/pipe/manifold/green/hidden{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside/center)
 "Ks" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 8
@@ -7218,11 +7301,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"Kz" = (
-/turf/closed/ice/thin/corner{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "KA" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/machinery/light{
@@ -7241,13 +7319,6 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/outside)
-"KF" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "KH" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -7268,6 +7339,12 @@
 	dir = 1
 	},
 /area/icy_caves/caves/south)
+"KL" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "KM" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 9
@@ -7279,10 +7356,9 @@
 /obj/item/clothing/suit/hgpirate,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"KQ" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/corner{
-	dir = 1
+"KP" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "54"
 	},
 /area/icy_caves/caves/northern)
 "KS" = (
@@ -7290,16 +7366,6 @@
 	dir = 5
 	},
 /area/icy_caves/outpost/security)
-"KT" = (
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 9
-	},
-/obj/structure/monorail{
-	dir = 5
-	},
-/turf/open/shuttle/escapepod/plain,
-/area/icy_caves/caves/northern)
 "KU" = (
 /turf/closed/ice/thin/corner{
 	dir = 1
@@ -7313,6 +7379,14 @@
 "KZ" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/garage)
+"La" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/white/warningstripe{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "Lb" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/tile/dark,
@@ -7336,9 +7410,6 @@
 /obj/item/storage/box/flashbangs,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
-"Li" = (
-/turf/open/floor/mainship/red/full,
-/area/icy_caves/caves/northern)
 "Lj" = (
 /obj/machinery/light{
 	dir = 8
@@ -7359,16 +7430,31 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
+"Lo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	on = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Lp" = (
+/turf/open/floor/tile/white/warningstripe,
+/area/icy_caves/caves/northern)
 "Lq" = (
 /obj/machinery/power/geothermal,
 /obj/machinery/light/small,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
+"Lr" = (
+/obj/item/shard,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "Ls" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/machinery/vending/coffee,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/caves/northern)
 "Lt" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = null;
@@ -7388,6 +7474,10 @@
 "Lv" = (
 /turf/closed/ice/thin,
 /area/icy_caves/outpost/outside)
+"Lw" = (
+/obj/structure/closet/l3closet/virology,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "Lx" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 10
@@ -7418,12 +7508,13 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
-"LE" = (
-/obj/machinery/light{
-	dir = 1
+"LF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
 	},
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "LH" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
@@ -7438,13 +7529,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
-"LJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	on = 1
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "LK" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -7460,10 +7544,16 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/garage)
+"LL" = (
+/obj/machinery/landinglight/ds1/delaytwo{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "LN" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall,
-/area/icy_caves/outpost/garage)
+/obj/structure/prop/mainship/hangar_stencil/two,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "LO" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -7495,10 +7585,6 @@
 	dir = 10
 	},
 /area/icy_caves/outpost/security)
-"LS" = (
-/obj/structure/prop/mainship/hangar_stencil/two,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
 "LT" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -7535,25 +7621,22 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
-"Ma" = (
-/obj/structure/barricade/guardrail,
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
-"Md" = (
-/turf/closed/ice_rock/corners{
-	dir = 10
+"Mb" = (
+/obj/machinery/light{
+	dir = 1
 	},
-/area/icy_caves/caves/northern)
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside)
 "Me" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "Mf" = (
-/obj/structure/monorail,
-/turf/open/floor/mainship_hull,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/red/full,
 /area/icy_caves/caves/northern)
 "Mg" = (
 /turf/closed/ice_rock/singlePart{
@@ -7601,19 +7684,10 @@
 	},
 /area/icy_caves/caves)
 "Mq" = (
-/obj/structure/barricade/guardrail{
-	dir = 4
-	},
-/obj/structure/xenoautopsy/tank/escaped,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/shuttle/dropship/seven,
-/area/icy_caves/caves/northern)
-"Mr" = (
-/obj/structure/largecrate/random/barrel/green,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/outpost/LZ2)
 "Ms" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/tile/dark,
@@ -7632,16 +7706,24 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"Mv" = (
+/obj/machinery/optable,
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Mw" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
+"Mx" = (
+/obj/machinery/power/apc/drained{
 	dir = 4
 	},
-/turf/open/shuttle/dropship/floor,
-/area/space)
-"Mx" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark/blue2,
-/area/icy_caves/outpost/LZ2)
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Mz" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/corner{
@@ -7649,10 +7731,8 @@
 	},
 /area/icy_caves/outpost/LZ1)
 "MA" = (
-/obj/structure/window/framed/colony/reinforced,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
+/obj/structure/barricade/guardrail,
+/turf/open/shuttle/dropship/floor,
 /area/icy_caves/caves/northern)
 "MB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -7660,6 +7740,10 @@
 	},
 /turf/closed/ice_rock/singleEnd,
 /area/icy_caves/caves)
+"MC" = (
+/obj/structure/largecrate/random,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "MD" = (
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/tile/dark/green2,
@@ -7670,17 +7754,10 @@
 	},
 /area/icy_caves/caves/south)
 "MH" = (
-/obj/structure/largecrate/supply/medicine,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
-"MI" = (
-/obj/structure/prop/mainship/sensor_computer3/sd,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 6
+/turf/closed/ice/thin/end{
+	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/mainship/tcomms,
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves)
 "MJ" = (
 /turf/closed/ice/corner{
 	dir = 1
@@ -7706,7 +7783,6 @@
 	},
 /area/icy_caves/caves/south)
 "MO" = (
-/obj/machinery/floodlight/landing,
 /obj/machinery/landinglight/ds1/delaytwo{
 	dir = 8
 	},
@@ -7724,15 +7800,8 @@
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
 "MT" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
-"MU" = (
-/obj/machinery/computer3/laptop,
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/cheeseburger,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "MV" = (
@@ -7747,9 +7816,19 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
 "MX" = (
-/obj/effect/spawner/gibspawner/human,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
+"MY" = (
+/obj/item/reagent_containers/spray/pepper,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 6
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
 /area/icy_caves/caves/northern)
 "MZ" = (
 /obj/machinery/door/airlock/mainship/command/free_access{
@@ -7759,9 +7838,10 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
-"Nb" = (
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/caves/west)
+"Na" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/northWall,
+/area/icy_caves/caves)
 "Nc" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -7799,12 +7879,6 @@
 /obj/item/clothing/under/lawyer/blue,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"Nm" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/corner{
-	dir = 8
-	},
-/area/icy_caves/caves/northern)
 "Nn" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -7812,12 +7886,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
-"No" = (
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Np" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/outpost/LZ2)
@@ -7839,6 +7907,11 @@
 /obj/item/ammo_magazine/smg/m25,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"Nu" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "Nv" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -7875,18 +7948,12 @@
 	},
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/refinery)
-"NF" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/corners,
-/area/icy_caves/caves)
-"NG" = (
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/caves)
-"NI" = (
-/turf/open/floor/mainship/red{
-	dir = 4
+"NH" = (
+/obj/machinery/light{
+	dir = 1
 	},
-/area/icy_caves/caves/northern)
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside)
 "NJ" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -7908,6 +7975,13 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"NM" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "NN" = (
 /obj/structure/filingcabinet,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -7927,11 +8001,6 @@
 /obj/item/explosive/plastique,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"NR" = (
-/obj/structure/window/framed/colony/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
 "NS" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/structure/closet/cabinet,
@@ -7945,27 +8014,14 @@
 	},
 /area/icy_caves/outpost/outside)
 "NU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 10
 	},
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "NW" = (
-/obj/machinery/door/poddoor/mainship/indestructible,
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
-"NY" = (
-/turf/closed/shuttle/dropship2{
-	icon_state = "54"
-	},
-/area/icy_caves/caves/northern)
-"NZ" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/single,
-/area/icy_caves/caves/northern)
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "Ob" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark,
@@ -7975,13 +8031,14 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
 "Od" = (
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 8
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 6
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/structure/monorail{
+	dir = 10
 	},
-/turf/open/shuttle/dropship/seven,
+/turf/open/shuttle/escapepod/plain,
 /area/icy_caves/caves/northern)
 "Oe" = (
 /obj/structure/table,
@@ -7994,8 +8051,13 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/outside)
 "Og" = (
-/turf/closed/ice_rock/southWall,
-/area/icy_caves/caves/northern)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark/yellow2{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "Oh" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -8003,17 +8065,17 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
 "Ok" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 8
 	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Ol" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singlePart{
-	dir = 5
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
 	},
-/area/icy_caves/caves)
+/area/icy_caves/outpost/LZ2)
 "Om" = (
 /turf/closed/ice/junction{
 	dir = 8
@@ -8031,10 +8093,6 @@
 	dir = 9
 	},
 /area/icy_caves/outpost/garage)
-"Ot" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Ou" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
@@ -8053,15 +8111,17 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"Ox" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern)
 "Oy" = (
 /obj/docking_port/mobile/crashmode/bigbury,
 /turf/open/floor/tile/dark/red2{
 	dir = 8
 	},
-/area/icy_caves/outpost/LZ2)
-"Oz" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
 "OA" = (
 /turf/closed/ice/thin/corner{
@@ -8096,90 +8156,60 @@
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
 "OI" = (
-/obj/machinery/computer/intel_computer,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/space)
 "OJ" = (
 /turf/closed/ice/end,
 /area/icy_caves/outpost/outside)
-"ON" = (
-/obj/structure/monorail,
-/obj/structure/dropship_piece/two/front,
-/turf/open/floor/mainship_hull,
-/area/icy_caves/caves/northern)
+"OL" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ2)
 "OO" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
 "OP" = (
-/obj/effect/landmark/fob_sentry_rebel,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/LZ1)
+/turf/open/floor/mainship/red/full,
+/area/icy_caves/caves/northern)
 "OQ" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"OR" = (
-/turf/closed/ice_rock/corners,
-/area/icy_caves/caves/northern)
-"OS" = (
-/obj/machinery/door/poddoor/mainship/indestructible{
-	dir = 2
-	},
-/turf/open/floor/mainship_hull/dir{
-	dir = 8
-	},
-/area/space)
-"OU" = (
-/obj/structure/bed/chair/comfy{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "OW" = (
 /turf/closed/ice,
 /area/icy_caves/caves/east)
-"OX" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/corner{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
-"OY" = (
-/obj/machinery/camera{
-	dir = 5
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+"OZ" = (
+/obj/structure/cargo_container/gorg,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/garage)
 "Pd" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/security)
+"Pe" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside)
 "Pg" = (
-/turf/closed/ice_rock/corners,
-/area/icy_caves/caves/west)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Pi" = (
 /turf/closed/ice/corner{
 	dir = 8
 	},
 /area/icy_caves/outpost/outside/center)
-"Pj" = (
-/obj/structure/dropship_piece/one/corner/middleright,
-/obj/structure/dropship_piece/two/corner/rearright,
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "Pl" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /obj/item/ammo_casing,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"Pm" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
 "Pn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/ai_node,
@@ -8190,6 +8220,12 @@
 	dir = 8
 	},
 /area/icy_caves/caves/south)
+"Pp" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/tile/white/warningstripe{
+	dir = 5
+	},
+/area/icy_caves/caves/northern)
 "Pq" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 8
@@ -8208,10 +8244,6 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/refinery)
-"Px" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
 "Pz" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -8238,22 +8270,9 @@
 	dir = 4
 	},
 /area/icy_caves/caves/northern)
-"PE" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall,
-/area/icy_caves/outpost/dorms)
-"PG" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"PH" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 1
-	},
-/area/icy_caves/caves/northern)
+"PF" = (
+/turf/open/floor/tile/dark/blue2,
+/area/icy_caves/outpost/LZ2)
 "PI" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
@@ -8274,9 +8293,12 @@
 	},
 /area/icy_caves/caves)
 "PN" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark/brown2,
-/area/icy_caves/outpost/refinery)
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8;
+	welded = 1
+	},
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "PO" = (
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
@@ -8286,6 +8308,14 @@
 /obj/item/weapon/gun/smg/m25,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"PR" = (
+/turf/closed/ice/junction{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
+"PS" = (
+/turf/closed/ice/thin/corner,
+/area/icy_caves/outpost/LZ2)
 "PT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -8309,10 +8339,6 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/security)
-"PW" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/LZ2)
 "PX" = (
 /obj/structure/table/woodentable,
 /obj/item/flashlight/lamp,
@@ -8326,8 +8352,7 @@
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
 "PZ" = (
-/obj/machinery/computer3/server/rack,
-/turf/open/floor/tile/dark,
+/turf/open/floor/tile/dark/green2,
 /area/icy_caves/caves/northern)
 "Qa" = (
 /turf/open/floor/plating,
@@ -8341,12 +8366,24 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"Qe" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "Qf" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/green2{
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
+"Qg" = (
+/obj/structure/prop/mainship/sensor_computer2,
+/obj/structure/cable,
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern)
 "Qh" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 6
@@ -8363,13 +8400,24 @@
 "Qk" = (
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"Ql" = (
-/obj/structure/largecrate/supply/floodlights,
-/obj/machinery/light{
-	dir = 1
+"Qn" = (
+/obj/structure/barricade/guardrail,
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 8
 	},
-/turf/open/floor/plating/mainship,
+/turf/open/shuttle/dropship/seven,
+/area/space)
+"Qo" = (
+/turf/closed/ice_rock/corners{
+	dir = 9
+	},
 /area/icy_caves/caves/northern)
+"Qp" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ2)
 "Qq" = (
 /turf/closed/ice/corner{
 	dir = 4
@@ -8384,19 +8432,6 @@
 	dir = 4
 	},
 /area/icy_caves/caves/south)
-"Qy" = (
-/obj/item/lightstick/anchored,
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
-"Qz" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "QA" = (
 /obj/structure/largecrate/supply/medicine,
 /turf/open/floor/plating,
@@ -8411,6 +8446,12 @@
 /obj/effect/decal/cleanable/blood/writing,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"QD" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/red/full,
+/area/icy_caves/caves/northern)
 "QF" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating,
@@ -8450,29 +8491,23 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "QN" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
-	},
-/turf/open/floor/mainship/cargo,
-/area/icy_caves/caves/northern)
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "QO" = (
 /turf/closed/ice/thin/junction{
 	dir = 8
 	},
 /area/icy_caves/outpost/outside)
-"QP" = (
-/obj/structure/barricade/guardrail,
-/obj/structure/bed/chair/dropship/passenger{
+"QQ" = (
+/obj/structure/bed/chair/comfy{
 	dir = 8
 	},
-/turf/open/shuttle/dropship/seven,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "QR" = (
 /obj/machinery/light,
 /turf/open/floor/tile/dark/brown2,
@@ -8491,10 +8526,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"QW" = (
-/obj/structure/ore_box,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
 "QX" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -8510,22 +8541,12 @@
 	dir = 4
 	},
 /area/icy_caves/caves/northern)
-"Ra" = (
-/obj/structure/table,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Rb" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
 	},
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
-"Re" = (
-/obj/machinery/door/poddoor/mainship/indestructible{
-	dir = 2
-	},
-/turf/open/shuttle/dropship/floor,
-/area/space)
 "Rf" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/dark,
@@ -8565,13 +8586,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"Rn" = (
-/obj/structure/dropship_piece/one/corner/middleleft,
-/obj/structure/dropship_piece/two/corner/rearleft,
-/turf/open/floor/mainship_hull/dir{
-	dir = 6
-	},
-/area/icy_caves/caves/northern)
 "Ro" = (
 /obj/structure/table,
 /obj/item/clothing/head/chefhat,
@@ -8598,19 +8612,15 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
-"Rs" = (
-/obj/structure/barricade/guardrail{
+"Rt" = (
+/obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/item/clothing/head/warning_cone,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Rt" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/LZ2)
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Ru" = (
 /obj/structure/table/woodentable,
 /obj/structure/paper_bin,
@@ -8621,10 +8631,17 @@
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves)
 "Rw" = (
-/turf/closed/ice/corner{
-	dir = 1
+/turf/closed/shuttle/dropship2{
+	icon_state = "103"
 	},
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/northern)
+"Rx" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/blood,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "Ry" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 8
@@ -8637,6 +8654,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"RA" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/LZ2)
 "RB" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/brown2{
@@ -8651,9 +8674,11 @@
 	dir = 4
 	},
 /area/icy_caves/caves)
-"RE" = (
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/tile/dark,
+"RF" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ2)
 "RG" = (
 /turf/closed/ice_rock/singleEnd{
@@ -8678,30 +8703,32 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
 "RL" = (
-/turf/open/floor/mainship_hull/dir{
-	dir = 6
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
+"RM" = (
+/obj/structure/monorail,
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 4
 	},
+/turf/open/floor/mainship_hull,
 /area/icy_caves/caves/northern)
 "RN" = (
 /turf/closed/ice_rock/corners{
 	dir = 5
 	},
 /area/icy_caves/caves)
-"RO" = (
-/turf/open/floor/tile/dark/blue2,
-/area/icy_caves/outpost/LZ2)
 "RP" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
 /obj/item/clothing/shoes/leather,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"RR" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/shuttle/dropship/seven,
-/area/space)
+"RQ" = (
+/obj/machinery/light,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "RS" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/southWall,
@@ -8718,6 +8745,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"RY" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/brown2,
+/area/icy_caves/outpost/refinery)
 "RZ" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark,
@@ -8727,32 +8758,23 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"Sb" = (
-/obj/structure/bed/chair{
+"Sc" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ2)
+"Se" = (
+/turf/open/floor/mainship/cargo/arrow{
 	dir = 8
 	},
-/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"Sd" = (
-/obj/machinery/power/apc/drained,
-/obj/machinery/light{
+"Sf" = (
+/obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean2"
 	},
-/area/icy_caves/caves/northern)
-"Se" = (
-/obj/effect/ai_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
-"Sf" = (
-/obj/structure/largecrate/supply/floodlights,
-/turf/open/floor/plating/mainship,
 /area/icy_caves/caves/northern)
 "Sg" = (
 /turf/closed/ice/end{
@@ -8769,10 +8791,10 @@
 /area/icy_caves/caves)
 "Si" = (
 /obj/machinery/light{
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
 "Sk" = (
 /obj/machinery/space_heater,
 /turf/open/floor/tile/dark/red2{
@@ -8802,19 +8824,20 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/security)
-"Sq" = (
-/obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor/tile/dark,
+"Ss" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "104"
+	},
 /area/icy_caves/caves/northern)
 "Sv" = (
 /turf/closed/ice_rock/singleT{
 	dir = 4
 	},
 /area/icy_caves/caves/south)
-"Sx" = (
-/obj/structure/largecrate/supply/medicine/medivend,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+"Sw" = (
+/obj/machinery/telecomms/relay/preset/telecomms,
+/turf/open/floor/plating/icefloor,
+/area/lv624/lazarus/console)
 "Sy" = (
 /turf/open/floor/tile/dark/green2/corner{
 	dir = 8
@@ -8825,6 +8848,11 @@
 	dir = 4
 	},
 /area/icy_caves/caves/south)
+"SB" = (
+/turf/closed/ice/thin/end{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ1)
 "SD" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 4
@@ -8842,36 +8870,13 @@
 "SI" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
-"SJ" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/LZ1)
-"SK" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/obj/machinery/camera/autoname/mainship/dropship_one{
-	dir = 4;
-	pixel_x = -16
-	},
-/turf/open/floor/mainship/tcomms,
-/area/icy_caves/caves/northern)
-"SL" = (
-/obj/structure/barricade/guardrail{
-	dir = 4
-	},
-/obj/structure/xenoautopsy/tank/alien,
-/turf/open/shuttle/dropship/seven,
-/area/icy_caves/caves/northern)
 "SM" = (
 /obj/structure/closet/crate/internals,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"SO" = (
+/turf/closed/ice_rock/eastWall,
+/area/icy_caves/caves/west)
 "SP" = (
 /turf/closed/ice_rock/singleT{
 	dir = 1
@@ -8879,10 +8884,6 @@
 /area/icy_caves/caves/south)
 "SR" = (
 /turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/northern)
-"SS" = (
-/obj/item/paper/crumpled/bloody/csheet,
-/turf/open/floor/tile/purple/whitepurplefull,
 /area/icy_caves/caves/northern)
 "ST" = (
 /turf/closed/ice/straight{
@@ -8906,12 +8907,10 @@
 	},
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/caves)
-"SZ" = (
-/obj/structure/table/reinforced,
-/obj/item/tool/surgery/scalpel/laser3,
-/obj/item/reagent_containers/spray/pepper,
-/turf/open/floor/tile/purple/whitepurplecorner{
-	dir = 8
+"SY" = (
+/obj/structure/bookcase/manuals/research_and_development,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 1
 	},
 /area/icy_caves/caves/northern)
 "Tb" = (
@@ -8927,52 +8926,51 @@
 "Td" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
-"Te" = (
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/caves/east)
-"Tg" = (
-/turf/open/floor/tile/dark/yellow2{
-	dir = 1
+"Tf" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
 	},
-/area/icy_caves/outpost/LZ2)
-"Ti" = (
-/turf/closed/ice/corner{
-	dir = 4
+/turf/closed/ice_rock/singleEnd{
+	dir = 8
 	},
-/area/icy_caves/outpost/LZ2)
-"Tj" = (
-/obj/effect/spawner/gibspawner/human,
-/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/outpost/LZ1)
+"Th" = (
+/obj/structure/barricade/guardrail{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"Tj" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
 "Tk" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside/center)
 "Tl" = (
-/obj/machinery/disposal,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ2)
 "Tm" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/open/floor/plating/ground/snow/layer1,
+/turf/closed/ice/thin/straight,
 /area/icy_caves/outpost/LZ1)
-"To" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Tr" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"Ts" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Tu" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 1
@@ -8986,21 +8984,17 @@
 	dir = 5
 	},
 /area/icy_caves/caves)
-"Tw" = (
-/turf/open/floor/tile/dark/brown2{
-	dir = 5
-	},
-/area/icy_caves/outpost/LZ2)
-"Tz" = (
-/obj/machinery/light/small{
-	dir = 8
+"Tx" = (
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor{
+	name = "\improper Lambda Lab"
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"TA" = (
-/turf/closed/wall,
-/area/icy_caves/caves/west)
+"Tz" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "TB" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -9011,6 +9005,22 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"TC" = (
+/obj/structure/barricade/guardrail{
+	dir = 4
+	},
+/obj/structure/xenoautopsy/tank/escaped,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
+"TD" = (
+/obj/machinery/camera{
+	dir = 9
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "TE" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -9020,27 +9030,44 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
 "TF" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/caves/east)
-"TG" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside/center)
+/area/icy_caves/outpost/outside)
 "TH" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"TI" = (
+/obj/machinery/landinglight/ds1/delaythree{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "TJ" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/east)
+"TK" = (
+/turf/open/floor/mainship/red,
+/area/icy_caves/caves/northern)
+"TL" = (
+/obj/structure/cargo_container/gorg{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/icy_caves/outpost/garage)
 "TM" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/LZ1)
+"TN" = (
+/obj/effect/spawner/gibspawner/human,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "TQ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/closed/ice/thin/straight,
+/turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ1)
 "TR" = (
 /obj/structure/table/flipped,
@@ -9049,9 +9076,13 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/security)
+"TS" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall,
+/area/icy_caves/outpost/mining/west)
 "TT" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/closed/ice/thin/straight,
+/turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ1)
 "TU" = (
 /obj/effect/decal/warning_stripes/thin,
@@ -9077,9 +9108,15 @@
 	},
 /area/icy_caves/caves)
 "TZ" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 10
+	},
+/obj/structure/monorail{
+	dir = 6
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/space)
 "Ub" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 1
@@ -9104,6 +9141,12 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Ud" = (
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "Ug" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -9139,9 +9182,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"Ur" = (
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
 "Us" = (
 /turf/closed/ice_rock/singleT{
 	dir = 8
@@ -9149,22 +9189,6 @@
 /area/icy_caves/caves/south)
 "Uu" = (
 /turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/LZ1)
-"Uw" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/LZ1)
-"Ux" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Uy" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "Uz" = (
 /obj/effect/decal/cleanable/blood/xeno,
@@ -9231,14 +9255,8 @@
 	},
 /area/icy_caves/outpost/security)
 "UR" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 10
-	},
-/turf/open/floor/mainship/cargo,
+/obj/structure/largecrate/supply/medicine/medivend,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "US" = (
 /obj/structure/table,
@@ -9251,21 +9269,15 @@
 /obj/item/clothing/shoes/blue,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"UU" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "UV" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 8
 	},
 /area/icy_caves/caves/east)
-"UX" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/mass_spectrometer/adv,
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 5
-	},
-/area/icy_caves/caves/northern)
 "UY" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/black,
@@ -9282,9 +9294,11 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
 "UZ" = (
-/obj/machinery/door/airlock/multi_tile/mainship/research,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
+/obj/structure/dropship_piece/two/front,
+/turf/closed/shuttle/dropship2/transparent{
+	icon_state = "109"
+	},
+/area/icy_caves/caves/northern)
 "Vb" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 10
@@ -9313,60 +9327,60 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"Vh" = (
-/obj/machinery/vending/security,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
+"Vg" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside/center)
 "Vi" = (
 /obj/structure/table,
 /obj/item/storage/fancy/vials,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/research)
+"Vj" = (
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "Vk" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow,
 /area/icy_caves/outpost/LZ1)
-"Vl" = (
-/obj/structure/dropship_piece/one/corner/middleleft,
-/obj/structure/dropship_piece/two/corner/rearleft,
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
-"Vm" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mainship/red/full,
-/area/icy_caves/caves/northern)
 "Vo" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"Vp" = (
-/obj/structure/largecrate/random/case,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
+"Vq" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/mainship/cargo,
+/area/icy_caves/caves/northern)
 "Vr" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/closed/ice_rock/southWall,
 /area/icy_caves/caves)
+"Vs" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
+"Vt" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 9
+	},
+/area/icy_caves/caves/northern)
 "Vu" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/corner{
 	dir = 1
 	},
 /area/icy_caves/outpost/LZ1)
-"Vv" = (
-/turf/open/floor/mainship_hull/dir{
-	dir = 5
-	},
-/area/icy_caves/caves/northern)
 "Vx" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -9378,47 +9392,48 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/garage)
-"Vy" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singlePart{
-	dir = 4
-	},
-/area/icy_caves/caves)
 "Vz" = (
 /turf/closed/ice/thin/corner{
 	dir = 4
 	},
 /area/icy_caves/caves/south)
 "VA" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall,
-/area/icy_caves/caves/northern)
+/obj/structure/largecrate/supply/medicine,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "VB" = (
 /turf/closed/ice/junction{
 	dir = 4
 	},
 /area/icy_caves/caves/west)
 "VC" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside/center)
 "VD" = (
 /obj/structure/largecrate/supply/medicine/iv,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "VE" = (
-/obj/structure/cargo_container/gorg{
-	dir = 4
-	},
+/obj/structure/largecrate/random/secure,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"VH" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/LZ1)
+"VG" = (
+/obj/structure/barricade/guardrail{
+	dir = 8
+	},
+/obj/structure/xenoautopsy/tank,
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
 "VI" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/northern)
+"VJ" = (
+/obj/machinery/landinglight/ds1{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "VK" = (
 /obj/machinery/light{
 	dir = 8
@@ -9434,9 +9449,16 @@
 	},
 /area/icy_caves/outpost/security)
 "VL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/turf/open/floor/mainship/cargo,
 /area/icy_caves/caves/northern)
 "VM" = (
 /turf/closed/wall/r_wall,
@@ -9468,6 +9490,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"VS" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
 "VT" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/outpost/LZ1)
@@ -9496,9 +9524,9 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
 "VZ" = (
-/obj/machinery/computer/operating,
-/obj/structure/table/reinforced,
-/turf/open/floor/tile/dark,
+/obj/item/shard,
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/tile/purple/whitepurplefull,
 /area/icy_caves/caves/northern)
 "Wa" = (
 /obj/structure/largecrate/supply/explosives,
@@ -9506,22 +9534,59 @@
 /obj/item/explosive/plastique,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Wc" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2;
+	name = "Canteen"
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Wd" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "We" = (
 /turf/closed/ice/junction{
 	dir = 1
 	},
 /area/icy_caves/outpost/outside/center)
+"Wg" = (
+/obj/structure/barricade/guardrail{
+	dir = 4
+	},
+/obj/structure/xenoautopsy/tank/alien,
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
+"Wi" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Wj" = (
 /turf/closed/ice/thin/end{
 	dir = 4
 	},
 /area/icy_caves/caves/south)
-"Ws" = (
-/obj/structure/table/mainship,
-/obj/item/tool/surgery/cautery,
-/obj/item/tool/surgery/retractor,
+"Wm" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
+"Wp" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"Wr" = (
+/obj/machinery/door/airlock/mainship/maint,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Ws" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "Wt" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs,
@@ -9534,12 +9599,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ2)
-"Wv" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singleEnd{
-	dir = 1
-	},
-/area/icy_caves/caves/northern)
 "Ww" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -9548,18 +9607,24 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
-"Wz" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "Canteen"
+"Wx" = (
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/caves/west)
+"Wy" = (
+/turf/open/shuttle/dropship/floor,
+/area/space)
+"WA" = (
+/turf/open/floor/tile/dark/red2{
+	dir = 8
 	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/outpost/LZ2)
 "WB" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 10
+/obj/machinery/vending/dinnerware,
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "WD" = (
 /turf/open/floor/plating/ground/snow,
@@ -9571,23 +9636,27 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"WF" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
+"WG" = (
+/turf/closed/ice_rock/corners,
+/area/icy_caves/caves/west)
 "WI" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside)
-"WJ" = (
-/obj/machinery/light{
-	dir = 8
-	},
+"WK" = (
+/obj/docking_port/stationary/marine_dropship/lz1,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ1)
+"WO" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"WK" = (
-/turf/open/floor/mech_bay_recharge_floor,
-/area/icy_caves/outpost/LZ1)
-"WN" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 10
-	},
-/turf/open/floor/tile/dark,
+"WP" = (
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/tile/purple/whitepurplefull,
 /area/icy_caves/caves/northern)
 "WQ" = (
 /turf/closed/ice/thin/end{
@@ -9604,8 +9673,10 @@
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/caves)
 "WT" = (
-/obj/machinery/landinglight/ds1/delaytwo,
-/turf/open/floor/plating,
+/obj/machinery/landinglight/ds1{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "WU" = (
 /obj/structure/closet/cabinet,
@@ -9614,25 +9685,31 @@
 /obj/item/clothing/head/pirate,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"WW" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
+"WX" = (
+/obj/machinery/computer3/laptop,
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "WY" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/medbay)
-"WZ" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 5
+"Xa" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/ice/thin/end{
+	dir = 1
 	},
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
-"Xd" = (
-/obj/machinery/miner/damaged/platinum,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/outpost/LZ1)
 "Xe" = (
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/icy_caves/caves/northern)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/single,
+/area/icy_caves/caves)
 "Xf" = (
 /obj/effect/landmark/start/job/survivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -9648,7 +9725,9 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
 "Xh" = (
-/obj/structure/largecrate/supply,
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "Xi" = (
@@ -9691,13 +9770,23 @@
 	dir = 6
 	},
 /area/icy_caves/caves)
-"Xp" = (
-/turf/closed/ice/thin,
-/area/icy_caves/outpost/LZ2)
+"Xq" = (
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "Xr" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/dmg3,
 /area/icy_caves/caves/crashed_ship)
+"Xs" = (
+/obj/machinery/landinglight/ds1/delaythree{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "Xu" = (
 /turf/closed/ice/end{
 	dir = 1
@@ -9720,30 +9809,26 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "Xy" = (
-/obj/machinery/power/apc/drained{
-	dir = 4
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
 	},
+/turf/open/shuttle/dropship/floor,
+/area/space)
+"Xz" = (
+/obj/structure/window/framed/colony/reinforced,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"Xz" = (
-/obj/effect/spawner/gibspawner/human,
+"XA" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"XB" = (
-/obj/structure/bed/chair{
+/area/icy_caves/caves/east)
+"XD" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"XC" = (
-/obj/item/stool,
-/obj/effect/decal/cleanable/vomit,
-/turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern)
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "XF" = (
 /turf/closed/ice/corner,
 /area/icy_caves/caves/west)
@@ -9778,18 +9863,12 @@
 "XJ" = (
 /turf/closed/ice_rock/singleEnd,
 /area/icy_caves/caves/west)
-"XK" = (
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 5
+"XL" = (
+/obj/structure/barricade/guardrail{
+	dir = 1
 	},
-/obj/structure/monorail{
-	dir = 9
-	},
-/obj/machinery/door/poddoor/mainship/indestructible{
-	dir = 2
-	},
-/turf/open/shuttle/escapepod/plain,
+/obj/structure/dropship_piece/two/front,
+/turf/open/shuttle/dropship/seven,
 /area/space)
 "XM" = (
 /obj/structure/bed/chair,
@@ -9809,6 +9888,10 @@
 /area/icy_caves/outpost/outside)
 "XP" = (
 /turf/closed/ice_rock/singleEnd,
+/area/icy_caves/caves/northern)
+"XQ" = (
+/obj/machinery/door/poddoor/mainship/indestructible,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "XR" = (
 /obj/structure/closet/crate,
@@ -9841,15 +9924,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ1)
-"XX" = (
-/turf/closed/ice_rock/eastWall,
-/area/icy_caves/caves/west)
-"XY" = (
-/obj/structure/barricade/guardrail{
-	dir = 1
-	},
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
 "XZ" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 4
@@ -9883,23 +9957,29 @@
 	dir = 1
 	},
 /area/icy_caves/caves)
+"Yh" = (
+/obj/machinery/power/apc/drained,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Yi" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/green2{
 	dir = 4
 	},
 /area/icy_caves/outpost/medbay)
-"Yk" = (
-/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+"Yj" = (
+/obj/machinery/landinglight/ds1/delaytwo{
 	dir = 4
 	},
-/obj/effect/ai_node,
+/obj/machinery/floodlight/landing,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
+"Yk" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"Yl" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside/center)
 "Ym" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/swat,
@@ -9912,12 +9992,6 @@
 "Yn" = (
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
-"Yo" = (
-/obj/structure/morgue{
-	dir = 2
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Yp" = (
 /turf/closed/ice/corner,
 /area/icy_caves/caves/south)
@@ -9929,11 +10003,6 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/LZ1)
-"Yr" = (
-/turf/closed/ice_rock/corners{
-	dir = 10
-	},
-/area/icy_caves/caves/west)
 "Yv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -9941,6 +10010,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"Yw" = (
+/obj/machinery/landinglight/ds1/delaytwo,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ1)
 "Yx" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -9963,6 +10036,16 @@
 "YA" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/kitchen)
+"YB" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 10
+	},
+/obj/structure/monorail{
+	dir = 6
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
 "YF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -9970,29 +10053,17 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
-"YG" = (
-/obj/machinery/camera{
-	dir = 5
-	},
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "YH" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/open/floor/plating/ground/snow,
+/turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ1)
 "YI" = (
 /turf/closed/ice/thin/end{
 	dir = 1
 	},
 /area/icy_caves/caves/west)
-"YJ" = (
-/turf/closed/ice/thin/corner{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ2)
 "YK" = (
 /turf/closed/ice/end{
 	dir = 4
@@ -10002,24 +10073,6 @@
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"YM" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
-"YN" = (
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 5
-	},
-/obj/structure/monorail{
-	dir = 9
-	},
-/obj/structure/dropship_piece/two/front,
-/turf/open/shuttle/escapepod/plain,
-/area/icy_caves/caves/northern)
 "YO" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -10030,6 +10083,15 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"YP" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "YQ" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/space)
@@ -10046,10 +10108,11 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
 "YV" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
 	},
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northern)
 "YW" = (
 /turf/closed/ice,
@@ -10117,9 +10180,6 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ1)
 "Zl" = (
-/obj/machinery/atmospherics/pipe/manifold/green/hidden{
-	dir = 4
-	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "Zm" = (
@@ -10152,10 +10212,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/security)
-"Zs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Zt" = (
 /turf/closed/ice/thin/corner,
 /area/icy_caves/caves/northern)
@@ -10193,16 +10249,9 @@
 "ZB" = (
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/caves/south)
-"ZC" = (
-/turf/closed/ice_rock/corners{
-	dir = 9
-	},
-/area/icy_caves/outpost/LZ1)
 "ZE" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/closed/ice/thin/end{
-	dir = 1
-	},
+/turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ1)
 "ZF" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -10223,44 +10272,23 @@
 "ZI" = (
 /turf/closed/ice/straight,
 /area/icy_caves/caves/south)
-"ZJ" = (
-/obj/machinery/atmospherics/pipe/manifold/green/hidden,
+"ZK" = (
+/obj/machinery/floodlight/landing,
+/obj/machinery/landinglight/ds1/delaytwo{
+	dir = 8
+	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
+/area/icy_caves/outpost/LZ1)
 "ZL" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"ZM" = (
-/obj/structure/lattice,
-/obj/structure/monorail{
-	dir = 10
-	},
-/obj/structure/monorail{
-	dir = 6
-	},
-/turf/open/shuttle/escapepod/plain,
-/area/icy_caves/caves/northern)
-"ZN" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark/green2,
-/area/icy_caves/caves/northern)
-"ZO" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern)
 "ZP" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 4
 	},
 /area/icy_caves/caves/south)
-"ZR" = (
-/obj/machinery/space_heater,
-/turf/open/floor/tile/dark/yellow2{
-	dir = 10
-	},
-/area/icy_caves/outpost/LZ2)
 "ZS" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -10270,6 +10298,10 @@
 "ZU" = (
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"ZV" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "ZW" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -10288,6 +10320,12 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
+"ZZ" = (
+/obj/structure/morgue{
+	dir = 2
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 
 (1,1,1) = {"
 YQ
@@ -10447,12 +10485,12 @@ YQ
 "}
 (2,1,1) = {"
 YQ
-af
-af
-af
-iF
-iF
-iF
+mi
+mi
+mi
+mv
+mv
+mv
 Yf
 Yf
 Yf
@@ -10603,12 +10641,12 @@ YQ
 "}
 (3,1,1) = {"
 YQ
-af
-am
-af
-iF
-iF
-iF
+mi
+Sw
+mi
+mv
+mv
+mv
 Yf
 Yf
 Yf
@@ -10636,12 +10674,12 @@ Yf
 Yf
 Yf
 Yf
-jo
-jo
-jo
-jo
-jo
-jo
+WF
+WF
+WF
+WF
+WF
+WF
 dF
 dF
 dF
@@ -10759,12 +10797,12 @@ YQ
 "}
 (4,1,1) = {"
 YQ
-af
-af
-af
-iF
-iF
-iF
+mi
+mi
+mi
+mv
+mv
+mv
 Yf
 Yf
 Yf
@@ -10792,15 +10830,15 @@ Yf
 Yf
 Yf
 Yf
-jo
-rZ
-BH
-gi
-Si
-GE
-jZ
-Ex
-SZ
+WF
+mw
+cE
+ta
+hW
+kY
+Vj
+AJ
+eO
 dF
 Yf
 Yf
@@ -10889,7 +10927,7 @@ Zk
 Zm
 UE
 UE
-DT
+fq
 Uu
 Uu
 Uu
@@ -10915,12 +10953,12 @@ YQ
 "}
 (5,1,1) = {"
 YQ
-iF
-iF
-iF
-iF
-iF
-iF
+mv
+mv
+mv
+mv
+mv
+mv
 Yf
 Yf
 Yf
@@ -10948,15 +10986,15 @@ Yf
 Yf
 Yf
 Yf
-jo
-lI
+WF
+SY
+AJ
+AJ
+jf
 Ex
-Ex
-XC
-CK
-SS
-Ex
-mZ
+II
+AJ
+kf
 dF
 Yf
 Yf
@@ -11023,15 +11061,15 @@ Yf
 Yf
 Yf
 Yf
-NF
-NF
-NF
-NF
-NF
-NF
-NF
-NF
-NF
+cp
+cp
+cp
+cp
+cp
+cp
+cp
+cp
+cp
 Yf
 Yf
 Yf
@@ -11039,29 +11077,29 @@ qs
 uA
 TW
 qz
-WK
+wL
 uw
-ov
-ov
-iz
-Uy
-hT
-ov
-iz
-Uy
-hT
-ov
-Uy
-Uy
-hT
-ov
-iz
-YM
-hT
-ov
-iz
-YM
-if
+Xs
+Xs
+WT
+Ud
+LL
+Xs
+WT
+Ud
+LL
+Xs
+Ud
+Ud
+LL
+Xs
+WT
+Xq
+LL
+Xs
+WT
+Xq
+Yj
 uw
 uw
 Vb
@@ -11071,12 +11109,12 @@ YQ
 "}
 (6,1,1) = {"
 YQ
-iF
-iF
-iF
-iF
-iF
-iF
+mv
+mv
+mv
+mv
+mv
+mv
 Yf
 Yf
 Yf
@@ -11104,15 +11142,15 @@ Yf
 Yf
 Yf
 Yf
-jo
-PH
-mW
-Ex
-Ex
-Tj
-Iu
-Ex
-mZ
+WF
+AR
+VZ
+AJ
+AJ
+Fq
+tx
+AJ
+kf
 dF
 Yf
 Yf
@@ -11166,20 +11204,20 @@ Yf
 Yf
 Yf
 Yf
-oM
-oM
+MH
+MH
 Yf
 Yf
-oM
-oM
+MH
+MH
 re
 Yf
-oM
-oM
+MH
+MH
 Yf
 Yf
 Yf
-NF
+cp
 Yf
 Yf
 qy
@@ -11187,7 +11225,7 @@ qy
 Yf
 Yf
 Yf
-NF
+cp
 Yf
 Yf
 Yf
@@ -11196,18 +11234,10 @@ ED
 qz
 UM
 uw
-lY
+zM
 Yn
 Yn
-AA
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-AA
+JY
 Yn
 Yn
 Yn
@@ -11215,9 +11245,17 @@ Yn
 Yn
 Yn
 Yn
+JY
 Yn
-AA
-WT
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+JY
+Yw
 uw
 uw
 VU
@@ -11260,15 +11298,15 @@ Yf
 Yf
 Yf
 Yf
-jo
-pn
-Ex
-Jr
-Ex
-Ex
-JU
-cT
-CB
+WF
+rk
+AJ
+WP
+AJ
+AJ
+MY
+gZ
+yH
 dF
 Yf
 Yf
@@ -11320,30 +11358,30 @@ Yf
 Yf
 Yf
 Yf
-oM
+MH
 YI
 YI
 YI
 ZU
 ZU
 ZU
-TA
+GF
 re
 re
 re
-oM
+MH
 Yf
 Yf
 Yf
-NF
-oM
-oM
+cp
+MH
+MH
 qy
 qy
 qy
-oM
+MH
 Yf
-NF
+cp
 Yf
 Yf
 Yf
@@ -11352,7 +11390,7 @@ RC
 TM
 uw
 uw
-lY
+zM
 Yn
 Yn
 Yn
@@ -11373,7 +11411,7 @@ Yn
 Yn
 Yn
 Yn
-WT
+Yw
 uw
 uw
 qH
@@ -11388,27 +11426,27 @@ Yf
 Yf
 Yf
 Yf
-jo
-jo
-jo
-jo
-jo
-jo
-jo
-jo
-jo
-jo
-jo
-jo
-jo
-jo
-jo
-jo
-jo
-jo
-jo
-jo
-jo
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
 Yf
 Yf
 Yf
@@ -11416,15 +11454,15 @@ Yf
 Yf
 Yf
 Yf
-jo
-UX
-IZ
-Ig
-Ex
-Ex
-vK
-Ex
-ww
+WF
+ux
+hG
+Rx
+AJ
+AJ
+HU
+AJ
+Lr
 dF
 Yf
 Yf
@@ -11481,34 +11519,34 @@ ZU
 YI
 ZU
 ZU
-Nb
-Nb
-xL
+Wx
+Wx
+Bb
 WI
 WI
 WI
 WI
-oM
+MH
 Yf
 Yf
-NF
-oM
-oM
+cp
+MH
+MH
 Za
 Za
 Yf
 Yf
-oM
-yP
-oM
-oM
-ZC
+MH
+hL
+MH
+MH
+DX
 AB
-jg
+zi
 TM
 uw
 uw
-lY
+zM
 Yn
 Yn
 Yn
@@ -11529,7 +11567,7 @@ Yn
 Yn
 Yn
 Yn
-WT
+Yw
 uw
 uw
 XH
@@ -11544,27 +11582,27 @@ Yf
 Yf
 Yf
 Yf
-jo
-rN
-SK
-lv
-BZ
+WF
+Qg
+mj
+GQ
+yb
 dF
-Ot
-eM
-WJ
-eM
-eM
-WJ
-eM
-CY
-Mr
+Ls
+Zl
+EU
+Zl
+Zl
+EU
+Zl
+nK
+Gn
 dF
-WJ
-eM
-LJ
-eM
-jo
+EU
+Zl
+LF
+Zl
+WF
 Yf
 Yf
 Yf
@@ -11572,15 +11610,15 @@ Yf
 Yf
 Yf
 Yf
-jo
-HQ
-HQ
+WF
+EP
+EP
 dF
-Ex
-Ex
-vK
-Ex
-xs
+AJ
+AJ
+HU
+AJ
+GE
 dF
 Yf
 Yf
@@ -11630,8 +11668,8 @@ Yf
 Yf
 Yf
 Yf
-oM
-oM
+MH
+MH
 Yf
 ZU
 ZU
@@ -11639,32 +11677,32 @@ ZU
 ZU
 ZU
 ZU
-xL
+Bb
 WI
-Bt
-LE
+pa
+Si
 WI
 WI
-oM
-oM
-yP
-oM
-Bt
-Gr
-ze
+MH
+MH
+hL
+MH
+pa
+Mb
+lK
 Za
-oM
-oM
-yP
+MH
+MH
+hL
 Uu
 Uu
-ZC
-ZC
+DX
+DX
 Sh
-HC
+sK
 bU
 uw
-lY
+zM
 Yn
 Yn
 Yn
@@ -11685,7 +11723,7 @@ Yn
 Yn
 Yn
 Yn
-WT
+Yw
 uw
 uw
 VU
@@ -11700,42 +11738,42 @@ Yf
 Yf
 Yf
 Yf
-jo
-MI
-Ce
-Xe
-tV
+WF
+op
+Ox
+yi
+Dm
 dF
-eM
-eM
-eM
-eM
-nh
-eM
-eM
-eM
-tS
+Zl
+Zl
+Zl
+Zl
+He
+Zl
+Zl
+Zl
+wj
 dF
-eM
-eM
-ou
-eM
-jo
-jo
-jo
-jo
-jo
-jo
-jo
-jo
-jo
-eM
-nh
+Zl
+Zl
+BZ
+Zl
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+Zl
+He
 dF
-HQ
-eM
-gH
-HQ
+EP
+Zl
+YP
+EP
 dF
 dF
 dF
@@ -11795,32 +11833,32 @@ ZU
 ZU
 ZU
 ZU
-xL
+Bb
 WI
-Eg
+Tj
 SI
 SI
 SI
 SI
 SI
-Ls
+Pe
 SI
 SI
 Za
 Za
-MT
+Ag
 Za
 Za
-yY
+za
 Uu
 Uu
-ZC
+DX
 Ml
-yW
+Tf
 TM
 bU
 uw
-lY
+zM
 Yn
 Yn
 Yn
@@ -11841,7 +11879,7 @@ Yn
 Yn
 Yn
 Yn
-WT
+Yw
 uw
 uw
 bH
@@ -11851,61 +11889,61 @@ YQ
 "}
 (11,1,1) = {"
 YQ
-Hr
-Hr
-Hr
-Hr
-Hr
-jo
-wJ
-mc
-BT
-cS
-ye
-FT
-FT
-FT
-cV
-FT
-FT
-FT
-FT
-FT
-oq
-FT
-FT
-ZJ
-eM
-IY
-eM
-eM
-OY
-WJ
-eM
-eM
-eM
-eM
-eM
-eM
-eM
-Ex
-Ex
-vK
-Ex
-eM
-eM
-eM
-eM
-WJ
-eM
-LJ
-eM
-dF
-eM
-Xy
+pl
+pl
+pl
+pl
+pl
+WF
+Gh
+co
+oR
+lO
+iN
 Tz
-DS
-IV
+Tz
+Tz
+ph
+Tz
+Tz
+Tz
+Tz
+Tz
+kd
+Tz
+Tz
+UU
+Zl
+Xz
+Zl
+Zl
+Cl
+EU
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+cV
+IU
+MX
+Lp
+Zl
+Zl
+Zl
+Zl
+EU
+Zl
+LF
+Zl
+dF
+Zl
+Mx
+NM
+xo
+pP
 dF
 bD
 Yf
@@ -11951,7 +11989,7 @@ ZU
 ZU
 ZU
 ZU
-xL
+Bb
 WI
 WI
 Ln
@@ -11959,24 +11997,24 @@ SI
 SI
 SI
 SI
-Ls
+Pe
 SI
 SI
 Za
 Za
 Za
 Za
-ze
-yY
+lK
+za
 Uu
 Uu
 Uu
 Ml
-yW
+Tf
 TM
 bU
 uw
-yL
+zS
 Yn
 Yn
 Yn
@@ -11987,7 +12025,7 @@ Yn
 Yn
 Yn
 Yn
-sK
+WK
 Yn
 Yn
 Yn
@@ -11997,7 +12035,7 @@ Yn
 Yn
 Yn
 Yn
-WT
+Yw
 uw
 uw
 bH
@@ -12007,60 +12045,60 @@ YQ
 "}
 (12,1,1) = {"
 YQ
-Hr
-EU
-EU
-EU
-EU
-sG
-Vh
-Xe
-NU
-Xe
-go
-tt
-eM
-eM
-ou
-eM
-eM
-eM
-eM
-eM
-TZ
-eM
-eM
-io
-FT
-Gt
-FT
-FT
-FT
-FT
-MX
-FT
-Ca
-eM
-eM
-eM
-eM
-jh
-Ex
-vK
-Ex
-eM
-eM
-eM
-nh
-eM
-eM
-ou
-eM
+pl
+bW
+bW
+bW
+bW
+in
+mu
+yi
+oQ
+yi
+zu
+TK
+Zl
+Zl
+BZ
+Zl
+Zl
+Zl
+Zl
+Zl
+Wp
+Zl
+Zl
+Wd
+Tz
+am
+Tz
+Tz
+Tz
+Tz
+TN
+Tz
+Yk
+Zl
+Zl
+Zl
+Zl
+Pp
+Fw
+La
+zt
+Zl
+Zl
+Zl
+He
+Zl
+Zl
+BZ
+Zl
 dF
-eM
-eM
+Zl
+Zl
 ev
-eM
+Zl
 fb
 dF
 bD
@@ -12115,24 +12153,24 @@ Ln
 WI
 WI
 WI
-Fx
+Gy
 SI
 Ln
-ze
+lK
 Za
 Za
 Za
 Za
-yY
+za
 UE
-DT
+fq
 Uu
 Uu
-YH
+Aq
 TM
 bU
 uw
-lY
+zM
 Yn
 Yn
 Yn
@@ -12153,7 +12191,7 @@ Yn
 Yn
 Yn
 Yn
-WT
+Yw
 uw
 uw
 bH
@@ -12163,58 +12201,58 @@ YQ
 "}
 (13,1,1) = {"
 YQ
-Hr
-ia
-ia
-ia
-ia
-NR
-rI
-Xe
-IP
-Se
-Li
-tt
-eM
-eM
-ou
-eM
-JV
-eM
-eM
-eM
-eM
-eM
-eM
-pr
-eM
+pl
+BB
+BB
+BB
+BB
+nw
+Sf
+yi
+wG
+ct
+OP
+TK
+Zl
+Zl
+BZ
+Zl
+dL
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+cX
+Zl
 ev
-nh
-eM
-eM
-eM
-JV
-eM
-Kr
-FT
-FT
-FT
-FT
-FT
-FT
-il
-eM
-eM
-eM
-Xz
-eM
-JV
-eM
-ou
-eM
-Jw
-eM
-eM
+He
+Zl
+Zl
+Zl
+dL
+Zl
+Wi
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+vv
+Zl
+Zl
+Zl
+Gf
+Zl
+dL
+Zl
+BZ
+Zl
+zZ
+Zl
+Zl
 ix
 eN
 fd
@@ -12271,7 +12309,7 @@ SI
 WI
 pD
 WI
-Fx
+Gy
 SI
 SI
 Za
@@ -12279,16 +12317,16 @@ Za
 Za
 Za
 Za
-yY
+za
 Uu
 Uu
 Uu
 Uu
-SJ
+YH
 TM
 bU
 uw
-lY
+zM
 Yn
 Yn
 Yn
@@ -12309,7 +12347,7 @@ Yn
 Yn
 Yn
 Yn
-WT
+Yw
 uw
 uw
 bH
@@ -12319,58 +12357,58 @@ YQ
 "}
 (14,1,1) = {"
 YQ
-Hr
-EU
-EU
-EU
-EU
-NR
-Cy
-Xe
-Xe
-Xe
-HQ
-eM
-eM
-eM
-ou
-eM
-eM
-eM
-eM
-eM
-HQ
-eM
-eM
-ou
-eM
-IY
-eM
-eM
-eM
-eM
-eM
-eM
-tA
-eM
-eM
-eM
-eM
-eM
-eM
-Kr
-FT
-hZ
-FT
-FT
-FT
-FT
-FT
+pl
+bW
+bW
+bW
+bW
+nw
+gP
+yi
+yi
+yi
+EP
 Zl
-hZ
-lu
+Zl
+Zl
+BZ
+Zl
+Zl
+Zl
+Zl
+Zl
+EP
+Zl
+Zl
+BZ
+Zl
+Xz
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+pL
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Wi
+Tz
+un
+Tz
+Tz
+Tz
+Tz
+Tz
+HP
+un
+Hw
 dN
-FT
+Tz
 ew
 eP
 fe
@@ -12427,24 +12465,24 @@ SI
 WI
 WI
 WI
-Fx
+Gy
 SI
 SI
 Za
 Za
-oM
+MH
 qs
 WI
-Fx
+Gy
 Uu
 Uu
 Uu
 Ml
-yW
+Tf
 Tb
 XW
 uw
-lY
+zM
 Yn
 Yn
 Yn
@@ -12465,7 +12503,7 @@ Yn
 Yn
 Yn
 Yn
-WT
+Yw
 uw
 uw
 XH
@@ -12475,59 +12513,59 @@ YQ
 "}
 (15,1,1) = {"
 YQ
-Hr
-ia
-ia
-ia
-ia
-jo
-Sd
-Xe
-Dm
-tT
+pl
+BB
+BB
+BB
+BB
+WF
+fD
+yi
+Do
+wq
 dF
-YV
-eM
-eM
-ou
-eM
-nh
-eM
-eM
-eM
+Bo
+Zl
+Zl
+BZ
+Zl
+He
+Zl
+Zl
+Zl
 dF
-eM
-eM
-ou
-eM
-jo
-eM
-eM
-eM
-eM
-eM
-eM
-ou
-PG
-nK
-eM
-eM
-eM
-eM
-ou
-eM
-eM
-PG
-HL
-eM
-eM
-eM
-eM
-eM
+Zl
+Zl
+BZ
+Zl
+WF
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+BZ
+Pg
+ve
+Zl
+Zl
+Zl
+Zl
+BZ
+Zl
+Zl
+Pg
+TD
+Zl
+Zl
+Zl
+Zl
+Zl
 dF
 dO
-Sq
-wG
+ea
+nB
 eT
 ff
 dF
@@ -12577,30 +12615,30 @@ fT
 xI
 xI
 xI
-vk
-yb
-kk
-vk
+nx
+od
+lH
+nx
 xI
 xI
-gm
+TS
 SI
 SI
 WI
-oM
+MH
 Yf
 Yf
-oM
-Fx
+MH
+Gy
 Uu
 Uu
+sD
 Ml
-Ml
-yW
+Tf
 Ml
 XW
 uw
-lY
+zM
 Yn
 Yn
 Yn
@@ -12621,7 +12659,7 @@ Yn
 Yn
 Yn
 Yn
-WT
+Yw
 uw
 uw
 VU
@@ -12631,60 +12669,60 @@ YQ
 "}
 (16,1,1) = {"
 YQ
-Hr
+pl
 dF
 dF
 dF
 dF
 dF
-NI
-Xe
-zt
-wF
+wO
+yi
+Hj
+kR
 dF
-eM
-eM
-eM
-Ok
-eM
-eM
-eM
-eM
-AR
+Zl
+Zl
+Zl
+ds
+Zl
+Zl
+Zl
+Zl
+FB
 dF
-Af
-Xh
-ou
-eM
-wX
-jo
-jo
-jo
+dv
+hB
+BZ
+Zl
+pE
+WF
+WF
+WF
 ev
-hL
-jo
-Bp
+BO
+WF
+VS
 dF
 dF
 dF
 dF
 dF
-eM
-gH
+Zl
+YP
 dF
 dF
 dF
 dF
 dF
-um
+Wr
 dF
 dF
 dF
 dF
 nD
-kt
-wG
-eM
+ed
+nB
+Zl
 fg
 dF
 bD
@@ -12739,35 +12777,27 @@ oI
 pf
 oZ
 oK
-gm
+TS
 SI
 SI
 WI
-oM
+MH
 Yf
 Yf
 Yf
-yP
+hL
 Uu
-OP
+Uu
 Uu
 UE
-Tm
+TQ
 Uu
 Vk
 uw
-lY
+zM
 Yn
 Yn
-AA
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-AA
+JY
 Yn
 Yn
 Yn
@@ -12775,9 +12805,17 @@ Yn
 Yn
 Yn
 Yn
+JY
 Yn
-AA
-WT
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+JY
+Yw
 uw
 uw
 qH
@@ -12787,55 +12825,55 @@ YQ
 "}
 (17,1,1) = {"
 YQ
-OR
-OR
-OR
-OR
-OR
+Gs
+Gs
+Gs
+Gs
+Gs
 dF
-ul
+jY
 dF
-HQ
-HQ
+EP
+EP
 dF
-Rs
-dF
-dF
-dF
-eM
-QN
-UR
-UR
-UR
+pu
 dF
 dF
 dF
-ou
-eM
-jo
-OR
-jo
-jC
-eM
-eM
-eM
-Tl
+Zl
+VL
+Vq
+Vq
+Vq
 dF
-OR
-OR
-OR
 dF
-eM
-ou
 dF
-ta
-Sf
-Ht
-Ht
-Ht
+BZ
+Zl
+WF
+Gs
+WF
+hT
+Zl
+Zl
+Zl
+AQ
 dF
-OR
-Og
+Gs
+Gs
+Gs
+dF
+Zl
+BZ
+dF
+DV
+EX
+jd
+jd
+jd
+dF
+Gs
+Il
 dF
 dF
 dF
@@ -12895,45 +12933,45 @@ oI
 oI
 oI
 oU
-gm
-Ls
-Ls
-yP
-NF
-NF
-NF
-xc
-xc
+TS
+Pe
+Pe
+hL
+cp
+cp
+cp
+iS
+iS
 Uu
 Uu
 Uu
 Uu
-Tm
+TQ
 Uu
 bU
 uw
 uw
-GF
-cU
-fV
-AQ
-GF
-cU
-fV
-GF
-GF
-cU
-fV
-AQ
-GF
-cU
-fV
-AQ
-GF
-cU
-cU
-cU
+TI
 MO
+GU
+VJ
+TI
+MO
+GU
+TI
+TI
+MO
+GU
+VJ
+TI
+MO
+GU
+VJ
+TI
+MO
+MO
+MO
+ZK
 uw
 uw
 XH
@@ -12948,50 +12986,50 @@ YQ
 dF
 dF
 dF
-Li
-Li
-Li
-Li
-lT
-Aj
-Li
-oT
-Li
+OP
+OP
+OP
+OP
+Se
+xs
+OP
+Mf
+OP
 dF
 dF
-lT
-lT
-lT
-lT
-DC
-JL
+Se
+Se
+Se
+Se
+Vt
+CH
 dF
-oC
-eM
-jo
-OR
-jo
-gf
-eM
-mJ
-iV
-ou
+mg
+Zl
+WF
+Gs
+WF
+tT
+Zl
+pZ
+IY
+BZ
 dF
-OR
-OR
-OR
+Gs
+Gs
+Gs
 dF
-eM
-Kr
-Me
-pV
-pV
-WZ
-sZ
-sZ
+Zl
+Wi
+Ts
+ZV
+ZV
+Vs
+Jn
+Jn
 dF
-OR
-Og
+Gs
+Il
 bI
 XP
 eg
@@ -13000,10 +13038,10 @@ eU
 dw
 DZ
 Mg
-Hs
-Pg
-Pg
-Pg
+qR
+WG
+WG
+WG
 pb
 SD
 SD
@@ -13052,19 +13090,19 @@ qo
 qO
 oU
 xI
-xq
+NH
 SI
 WI
-NG
-NG
-NG
+jI
+jI
+jI
 WI
-NG
+jI
 Uu
 UE
 UE
 UE
-Tm
+TQ
 UE
 XW
 uw
@@ -13098,67 +13136,67 @@ Yf
 YQ
 "}
 (19,1,1) = {"
-CU
-gQ
-OS
-yf
-HF
-HF
-wO
-ss
-gK
-gK
-Ur
-gK
-gK
-gK
-Vl
-ss
-gK
-NW
-NW
-jD
-jD
+cW
+qa
+yF
+jL
+Me
+Me
+df
+Rw
+BN
+BN
+pc
+BN
+BN
+BN
+qu
+Rw
+BN
 jc
-Rn
+jc
+XQ
+XQ
+dZ
+ma
 dF
-pr
-eM
-jo
-OR
-jo
-PZ
-eM
-qU
-eM
-tA
+cX
+Zl
+WF
+Gs
+WF
+Ch
+Zl
+cD
+Zl
+pL
 dF
-OR
-OR
-OR
+Gs
+Gs
+Gs
 dF
-ni
-ZJ
+Lo
+UU
 dF
-tz
-ZO
-nw
-zd
-zd
+nF
+mZ
+PN
+Lw
+Lw
 dF
-OR
-Og
+Gs
+Il
 bR
 SR
-ed
+RL
 ZW
-dP
+zB
 Lx
 Ga
 ec
-Hs
-Pg
-Pg
+qR
+WG
+WG
 pb
 DZ
 Rj
@@ -13220,7 +13258,7 @@ Uu
 Uu
 UE
 UE
-Tm
+TQ
 WD
 XW
 uw
@@ -13254,47 +13292,47 @@ Yf
 YQ
 "}
 (20,1,1) = {"
-CU
-lR
-XK
-GT
-eC
-GT
-YN
-Il
-Jh
-XY
-Ur
-Ma
-Mq
-SL
-oG
+cW
+BY
+wT
+Od
+JR
+Od
+dg
+FR
+qk
+wf
+pc
+MA
+TC
+Wg
+Ss
+ul
 Fk
-IE
-Ab
-uS
-Ab
-Ab
-nY
-DI
-eM
-ou
-eM
-jo
-OR
-jo
-MU
-eM
-Xz
-Jd
-iP
+NW
+XD
+NW
+NW
+fs
+UZ
+Zl
+BZ
+Zl
+WF
+Gs
+WF
+WX
+Zl
+Gf
+Mv
+ns
 dF
 dF
 dF
 dF
 dF
-eM
-ou
+Zl
+BZ
 dF
 dF
 dF
@@ -13302,18 +13340,18 @@ dF
 dF
 dF
 dF
-OR
-Og
+Gs
+Il
 bJ
 XP
-dP
+zB
 ZW
-ed
+RL
 ZU
 Di
 XF
-Yr
-XX
+pH
+SO
 pb
 RG
 Rj
@@ -13373,10 +13411,10 @@ WI
 WI
 WI
 Uu
-DT
+fq
 UE
 UE
-YH
+Aq
 Ml
 gI
 UE
@@ -13410,61 +13448,61 @@ Yf
 YQ
 "}
 (21,1,1) = {"
-CU
-xp
-zR
-jI
-Mf
-jI
-ON
+cW
+HC
+yd
+RM
+cL
+RM
+gK
+FR
+pc
+pc
+Bt
+pc
+pc
+MA
+Xy
+Wy
+Wy
+Wy
+ch
+Af
+us
+Wy
+FR
+Zl
+BZ
+Zl
+WF
+Gs
+WF
+xS
+Zl
+IY
+jk
+BZ
+dF
+EX
+jd
+ze
+dF
+Zl
+BZ
+dF
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
 Il
-Ur
-Ur
-Px
-Ur
-Ur
-Ma
-Re
-lV
-lV
-lV
-Mw
-FC
-II
-lV
-Il
-eM
-ou
-eM
-jo
-OR
-jo
-gb
-eM
-iV
-Ws
-ou
-dF
-Sf
-Ht
-ET
-dF
-eM
-ou
-dF
-OR
-OR
-OR
-OR
-OR
-OR
-OR
-Og
 PD
 Ho
-ea
+ei
 ZW
-dP
+zB
 Xu
 Jg
 DK
@@ -13511,11 +13549,11 @@ ZU
 gz
 XF
 xI
-OI
+iJ
 oI
 wW
 oI
-BJ
+CA
 oI
 oI
 oI
@@ -13532,7 +13570,7 @@ Uu
 UE
 UE
 UE
-TQ
+Tm
 Ml
 Vk
 XW
@@ -13566,61 +13604,61 @@ Yf
 YQ
 "}
 (22,1,1) = {"
-CU
-na
-lH
-ZM
-KT
-ZM
-Ch
-Il
-Od
-XY
-uz
-Ma
-jX
-jX
-ss
-Dq
-QP
-Ab
-uS
-RR
-Ab
-eO
-DI
-eM
-ou
-eM
-jo
-OR
-jo
-VZ
-qU
-YG
-eM
-Ok
+cW
+TZ
+GN
+YB
+cF
+YB
+kn
+FR
+qA
+wf
+Im
+MA
+VG
+VG
+Rw
+uO
+Qn
+NW
+XD
+yv
+NW
+XL
+UZ
+Zl
+BZ
+Zl
+WF
+Gs
+WF
+Gj
+cD
+ll
+Zl
+ds
 dF
-oV
-Ht
-Ht
-os
-nh
-ou
+Ij
+jd
+jd
+Ea
+He
+BZ
 dF
-uk
-uk
-uk
-OR
-OR
-uk
-uk
-gD
+Ae
+Ae
+Ae
+Gs
+Gs
+Ae
+Ae
+Qo
 ce
 SR
-dP
+zB
 ZW
-dP
+zB
 Xu
 Jg
 eb
@@ -13722,61 +13760,61 @@ bD
 YQ
 "}
 (23,1,1) = {"
-CU
-gv
-HY
-Qz
-mw
-mw
-pi
-oG
-NY
-NY
-Ur
-NY
-NY
-NY
-Pj
-oG
-NY
-NW
-NW
-fU
-fU
-fU
-qI
+cW
+OI
+Eh
+IP
+DU
+DU
+oM
+Ss
+KP
+KP
+pc
+KP
+KP
+KP
+DS
+Ss
+KP
+jc
+jc
+vn
+vn
+vn
+gQ
 dF
-ou
-eM
-jo
-OR
-jo
-uE
-nh
-eM
-Yo
-eM
-dF
-dF
+BZ
+Zl
+WF
+Gs
+WF
+ws
+He
+Zl
+ZZ
+Zl
 dF
 dF
 dF
-eM
-ou
+dF
+dF
+Zl
+BZ
 dF
 bA
 bA
 Nd
-Md
-gD
+hM
+Qo
 cd
 Tu
 XP
 ot
 Ho
-dP
+zB
 ZW
-dP
+zB
 Xu
 Jg
 XF
@@ -13884,41 +13922,41 @@ YQ
 dF
 dF
 dF
-Li
-Li
-Li
-Aj
-hW
-Aj
-Li
-Vm
-Li
+OP
+OP
+OP
+xs
+tF
+xs
+OP
+QD
+OP
 dF
 dF
-hW
-nB
+tF
+lv
 dF
 dF
-Vv
-RL
-dF
-oC
-eM
-jo
-OR
-jo
-DO
+rg
 HL
-PG
-Yo
-nK
 dF
-OR
-OR
-uk
+mg
+Zl
+WF
+Gs
+WF
+wh
+TD
+Pg
+ZZ
+ve
 dF
-eM
-ou
+Gs
+Gs
+Ae
+dF
+Zl
+BZ
 dF
 bM
 bM
@@ -13930,9 +13968,9 @@ qT
 Zt
 Sg
 SR
-ed
+RL
 ZW
-dP
+zB
 ZU
 dp
 do
@@ -14000,19 +14038,19 @@ Uu
 UE
 UE
 UE
-Uw
+TT
 EQ
 XT
-Uw
-Uw
-VH
+TT
+TT
+ZE
 Hl
 HI
-VH
-VH
+ZE
+ZE
 KJ
-ZE
-ZE
+Xa
+Xa
 Vu
 DL
 EO
@@ -14020,13 +14058,13 @@ EO
 rp
 Vu
 vR
-TT
-TT
+vr
+vr
 Hl
 Hl
-TT
-TT
-TT
+vr
+vr
+vr
 PL
 PL
 HV
@@ -14041,40 +14079,40 @@ Yf
 Yf
 Yf
 dF
-um
+Wr
 dF
 dF
-eM
-JQ
-JQ
-dF
-dF
-dF
-eM
-uF
-jn
-eM
+Zl
+Th
+Th
 dF
 dF
 dF
-dF
-ou
-eM
-jo
-OR
-jo
+Zl
+gM
+If
+Zl
 dF
 dF
 dF
 dF
+BZ
+Zl
+WF
+Gs
+WF
 dF
 dF
-OR
-gD
+dF
+dF
+dF
+dF
+Gs
+Qo
 bP
 dF
-eM
-pr
+Zl
+cX
 dF
 SR
 SR
@@ -14086,9 +14124,9 @@ IC
 cm
 SR
 SR
-dP
+zB
 ZW
-dP
+zB
 eh
 ZU
 dp
@@ -14157,8 +14195,8 @@ UE
 UE
 UE
 UE
-xy
-xy
+SB
+SB
 Ey
 UE
 UE
@@ -14197,40 +14235,40 @@ Yf
 Yf
 Yf
 dF
-sZ
-vN
+Jn
+pN
 dF
-JV
-eM
-eM
-LJ
-eM
-eM
-eM
-eM
-eM
-eM
-eM
-WJ
-No
-eM
-Kr
-co
-jo
-OR
-OR
-OR
-OR
-OR
-OR
-OR
-uk
-gD
+dL
+Zl
+Zl
+LF
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+EU
+pS
+Zl
+Wi
+HT
+WF
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Ae
+Qo
 bI
 Rh
 dF
-eM
-oe
+Zl
+yV
 dF
 im
 SR
@@ -14242,9 +14280,9 @@ cg
 bT
 SR
 SR
-dP
-dQ
-dP
+zB
+Cm
+zB
 ZU
 gx
 jb
@@ -14353,40 +14391,40 @@ Yf
 Yf
 Yf
 dF
-Ql
-sZ
+oT
+Jn
 dF
-YV
-JV
-eM
-ou
-eM
-eM
-JV
-eM
-eM
-eM
-eM
-eM
-eM
-eM
-To
-eM
-jo
-OR
-OR
-OR
-OR
-OR
-uk
-gD
+Bo
+dL
+Zl
+BZ
+Zl
+Zl
+dL
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+dd
+Zl
+WF
+Gs
+Gs
+Gs
+Gs
+Gs
+Ae
+Qo
 PD
 Ho
 bJ
 eB
 dF
-eM
-gH
+Zl
+YP
 dF
 SR
 SR
@@ -14398,9 +14436,9 @@ SR
 SR
 SR
 im
-dP
+zB
 ZW
-CH
+Ws
 ZU
 ZU
 SF
@@ -14465,17 +14503,17 @@ pY
 vy
 Al
 vy
-JZ
-JZ
-JZ
-JZ
-JZ
-JZ
+Nu
+Nu
+Nu
+Nu
+Nu
+Nu
 Nn
-JZ
-JZ
-zz
-qf
+Nu
+Nu
+Mw
+Qe
 uw
 uw
 uw
@@ -14509,31 +14547,31 @@ Yf
 Yf
 Yf
 dF
-nT
-yv
+Ek
+uu
 dF
-eM
-eM
-eM
-ou
-eM
-nh
-eM
-eM
-eM
-Sb
-Sb
-eM
-eM
-eM
-ou
-eM
-jo
-OR
-OR
-OR
-OR
-gD
+Zl
+Zl
+Zl
+BZ
+Zl
+He
+Zl
+Zl
+Zl
+lR
+lR
+Zl
+Zl
+Zl
+BZ
+Zl
+WF
+Gs
+Gs
+Gs
+Gs
+Qo
 PD
 bA
 VI
@@ -14541,9 +14579,9 @@ Ho
 SR
 SR
 SR
-eM
-dt
-eM
+Zl
+uT
+Zl
 SR
 wo
 SR
@@ -14554,9 +14592,9 @@ we
 SR
 SR
 SR
-dP
+zB
 ZW
-eF
+Ab
 ZU
 ZU
 SF
@@ -14665,30 +14703,30 @@ Yf
 Yf
 Yf
 dF
-tP
-zI
+Gx
+YV
 dF
-eM
-eM
-eM
-Kr
-FT
-FT
-FT
-FT
-KF
-lu
-lu
-EV
-FT
-FT
-ZJ
-eM
-jo
-OR
-OR
-OR
-Og
+Zl
+Zl
+Zl
+Wi
+Tz
+Tz
+Tz
+Tz
+du
+Hw
+Hw
+sG
+Tz
+Tz
+UU
+Zl
+WF
+Gs
+Gs
+Gs
+Il
 PD
 Fu
 ot
@@ -14697,9 +14735,9 @@ SR
 SR
 SR
 im
-eM
-ou
-eM
+Zl
+BZ
+Zl
 pk
 VI
 Nd
@@ -14710,9 +14748,9 @@ SR
 SR
 im
 SR
-dP
+zB
 ZW
-dP
+zB
 ZU
 ZU
 dx
@@ -14821,30 +14859,30 @@ Yf
 Yf
 Yf
 dF
-Eq
-WB
-Me
-FT
-FT
-FT
-ZJ
-eM
-qu
-PG
-eM
-Bv
+ip
+hd
+Ts
+Tz
+Tz
+Tz
+UU
+Zl
+di
+Pg
+Zl
+KL
 dF
 dF
-le
-eM
-eM
-ou
-eM
-jo
-OR
-OR
-OR
-Og
+yz
+Zl
+Zl
+BZ
+Zl
+WF
+Gs
+Gs
+Gs
+Il
 ce
 ot
 by
@@ -14853,9 +14891,9 @@ SR
 SR
 SR
 wo
-Xd
-ou
-eM
+mq
+BZ
+Zl
 SR
 Lm
 by
@@ -14866,9 +14904,9 @@ SR
 bI
 bL
 SR
-dP
+zB
 ZW
-dP
+zB
 ZU
 Xu
 Jg
@@ -14979,28 +15017,28 @@ Yf
 dF
 dF
 dF
-jo
-eM
-eM
-eM
-ou
+WF
+Zl
+Zl
+Zl
+BZ
 dF
 dF
 dF
-pL
-eM
-XB
-Ux
-eM
-eM
-eM
-ou
-nh
-jo
-OR
-OR
-OR
-Og
+xW
+Zl
+Rt
+fc
+Zl
+Zl
+Zl
+BZ
+He
+WF
+Gs
+Gs
+Gs
+Il
 ce
 ce
 SR
@@ -15009,9 +15047,9 @@ SR
 SR
 PD
 Fu
-eM
-ou
-AR
+Zl
+BZ
+FB
 dF
 SR
 SR
@@ -15022,9 +15060,9 @@ Io
 Rh
 Rh
 bL
-dP
+zB
 ZW
-dP
+zB
 Xu
 VB
 Jg
@@ -15135,28 +15173,28 @@ Yf
 Yf
 Yf
 Yf
-jo
-eM
-eM
-eM
-ou
+WF
+Zl
+Zl
+Zl
+BZ
 dF
-OR
+Gs
 dF
-Xh
-eM
-eM
-eM
-eM
-eM
-eM
-ou
-AR
-jo
-OR
-OR
-OR
-gD
+hB
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+BZ
+FB
+WF
+Gs
+Gs
+Gs
+Qo
 ce
 Sg
 SR
@@ -15165,9 +15203,9 @@ SR
 ok
 bM
 VI
-eM
-ou
-eM
+Zl
+BZ
+Zl
 SR
 SR
 SR
@@ -15178,7 +15216,7 @@ Zt
 bJ
 Rh
 eB
-dP
+zB
 ZW
 eS
 dy
@@ -15243,7 +15281,7 @@ Pq
 XU
 DY
 DY
-PN
+RY
 wx
 lB
 lM
@@ -15291,27 +15329,27 @@ Yf
 Yf
 Yf
 Yf
-jo
-eM
-eM
-eM
-ou
+WF
+Zl
+Zl
+Zl
+BZ
 dF
-OR
+Gs
 dF
-Sx
-JV
-eM
-eM
-eM
-eM
-eM
-pr
-eM
-jo
-OR
-OR
-Og
+UR
+dL
+Zl
+Zl
+Zl
+Zl
+Zl
+cX
+Zl
+WF
+Gs
+Gs
+Il
 bS
 Sg
 SR
@@ -15321,9 +15359,9 @@ SR
 bN
 bN
 Lm
-eM
-ou
-eM
+Zl
+BZ
+Zl
 Ho
 SR
 SR
@@ -15334,9 +15372,9 @@ KU
 Zt
 Ry
 im
-dP
+zB
 ZW
-dP
+zB
 YI
 ft
 EB
@@ -15444,30 +15482,30 @@ Yf
 Yf
 Yf
 Yf
-NF
-NF
-NF
-yS
-vC
-vC
-vC
-DX
-VA
-JI
-VA
+cp
+cp
+cp
+cs
+cv
+cv
+cv
+cx
+cJ
+cK
+cJ
 dF
-eM
+Zl
 dF
 dF
-eM
-eM
-Xz
-ou
-eM
-jo
-OR
-OR
-Og
+Zl
+Zl
+Gf
+BZ
+Zl
+WF
+Gs
+Gs
+Il
 bP
 qT
 rf
@@ -15477,9 +15515,9 @@ cj
 bT
 cn
 bN
-eM
-ou
-eM
+Zl
+BZ
+Zl
 rf
 SR
 im
@@ -15490,9 +15528,9 @@ qT
 cm
 SR
 SR
-dP
+zB
 ZW
-dP
+zB
 ZU
 dE
 de
@@ -15600,30 +15638,30 @@ Yf
 Yf
 Yf
 Yf
-NF
-jo
-jo
-jo
-HQ
-eM
-Ia
-uT
+cp
+WF
+WF
+WF
+EP
+Zl
+Wc
+BF
 dF
-OR
-JI
+Gs
+cK
 dF
-eM
+Zl
 dF
 dF
-eM
-eM
-eM
-ou
-eM
-jo
-OR
-OR
-Og
+Zl
+Zl
+Zl
+BZ
+Zl
+WF
+Gs
+Gs
+Il
 QZ
 KU
 rf
@@ -15633,9 +15671,9 @@ SR
 bN
 cn
 cn
-eM
-ou
-eM
+Zl
+BZ
+Zl
 rf
 SR
 SR
@@ -15646,9 +15684,9 @@ IC
 IC
 Zt
 Zb
-dP
+zB
 ZW
-eF
+Ab
 ZU
 YI
 de
@@ -15756,30 +15794,30 @@ Yf
 Yf
 Yf
 Yf
-NF
-jo
-eM
-WJ
-eM
-ug
-ug
-ou
+cp
+WF
+Zl
+EU
+Zl
+Bf
+Bf
+BZ
 dF
 dF
-VA
+cJ
 dF
-YV
-eM
-eM
-eM
-eM
-eM
-ou
-eM
-jo
-OR
-OR
-Og
+Bo
+Zl
+Zl
+Zl
+Zl
+Zl
+BZ
+Zl
+WF
+Gs
+Gs
+Il
 cc
 XP
 SR
@@ -15789,9 +15827,9 @@ cj
 cg
 IC
 ci
-eM
-ou
-eM
+Zl
+BZ
+Zl
 rf
 SR
 SR
@@ -15802,9 +15840,9 @@ KU
 bT
 KU
 rf
-dP
+zB
 ZW
-dP
+zB
 ZU
 fi
 de
@@ -15912,30 +15950,30 @@ Yf
 Yf
 Yf
 Yf
-NF
-jo
-eM
-wQ
-eM
-Xz
-eM
-Bo
-eM
-eM
-VA
-eM
-Zs
-FT
-FT
-FT
-FT
-FT
-ZJ
-eM
-jo
-OR
-uk
-gD
+cp
+WF
+Zl
+WO
+Zl
+Gf
+Zl
+cC
+Zl
+Zl
+cJ
+Zl
+Fj
+Tz
+Tz
+Tz
+Tz
+Tz
+UU
+Zl
+WF
+Gs
+Ae
+Qo
 cc
 bL
 im
@@ -15945,9 +15983,9 @@ cj
 Ir
 cm
 ci
-eM
-ou
-eM
+Zl
+BZ
+Zl
 SR
 Zb
 SR
@@ -15958,9 +15996,9 @@ PD
 Nd
 PD
 Ho
-dP
+zB
 ZW
-dP
+zB
 YI
 fz
 cY
@@ -16068,28 +16106,28 @@ Yf
 Yf
 Yf
 Yf
-NF
-jo
-OU
-OU
-eM
-eM
-Cj
-CO
-OU
-eM
-mg
-eM
-eM
-eM
-eM
-eM
-eM
-eM
-ou
-AR
-jo
-Og
+cp
+WF
+Xh
+Xh
+Zl
+Zl
+cw
+HQ
+Xh
+Zl
+cO
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+BZ
+FB
+WF
+Il
 PD
 Nd
 bJ
@@ -16101,9 +16139,9 @@ XP
 QK
 QK
 dF
-YV
-ou
-eM
+Bo
+BZ
+Zl
 rf
 PI
 PI
@@ -16114,9 +16152,9 @@ Fu
 ot
 by
 SR
-dP
+zB
 ZW
-dP
+zB
 Xu
 xP
 xP
@@ -16224,28 +16262,28 @@ Yf
 Yf
 Yf
 Yf
-NF
-jo
-rm
-Ra
-eM
-JV
-eM
-yk
-rm
-ZN
-Wz
-eM
-eM
-eM
-eM
-eM
-eM
-nh
-pr
-eM
-jo
-Og
+cp
+WF
+MT
+eD
+Zl
+dL
+Zl
+nv
+MT
+cN
+eC
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+He
+cX
+Zl
+WF
+Il
 ce
 Lm
 Nd
@@ -16257,9 +16295,9 @@ bI
 Tu
 bL
 ci
-eM
-ou
-eM
+Zl
+BZ
+Zl
 SR
 SR
 SR
@@ -16270,9 +16308,9 @@ Lm
 by
 SR
 SR
-dP
+zB
 ZW
-dP
+zB
 ZU
 RG
 fB
@@ -16380,28 +16418,28 @@ Yf
 Yf
 Yf
 Yf
-NF
-jo
-Ra
-Ra
-eM
-nh
-eM
-FM
-Ra
-op
-vC
-eM
-eM
-eM
-eM
-eM
-eM
-eM
-ou
-eM
-jo
-gD
+cp
+WF
+eD
+eD
+Zl
+He
+Zl
+IK
+eD
+PZ
+cv
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+BZ
+Zl
+WF
+Qo
 ce
 PD
 by
@@ -16413,9 +16451,9 @@ Rh
 XP
 QZ
 QK
-eM
-pr
-eM
+Zl
+cX
+Zl
 SR
 im
 bl
@@ -16426,9 +16464,9 @@ im
 SR
 SR
 SR
-dP
+zB
 ZW
-CH
+Ws
 ZU
 RG
 fS
@@ -16511,7 +16549,7 @@ Dk
 Aa
 Qa
 bE
-Id
+OZ
 Dk
 Nc
 XR
@@ -16536,27 +16574,27 @@ Yf
 Yf
 Yf
 Yf
-NF
-jo
-oi
-oi
-wQ
-eM
-eM
-lf
-oi
-eM
-mg
-qu
-PG
-eM
-eM
-eM
-eM
-eM
-ou
-eM
-jo
+cp
+WF
+BW
+BW
+WO
+Zl
+Zl
+QQ
+BW
+Zl
+cO
+di
+Pg
+Zl
+Zl
+Zl
+Zl
+Zl
+BZ
+Zl
+WF
 PD
 by
 Sg
@@ -16569,9 +16607,9 @@ bR
 Io
 Rh
 XP
-wQ
-ou
-eM
+WO
+BZ
+Zl
 SR
 SR
 SR
@@ -16582,9 +16620,9 @@ SR
 SR
 SR
 SR
-dP
+zB
 rP
-dP
+zB
 RG
 fB
 Rj
@@ -16667,8 +16705,8 @@ xu
 Ar
 yj
 bE
+TL
 VE
-yQ
 Nc
 tQ
 LO
@@ -16692,27 +16730,27 @@ Yf
 Yf
 Yf
 Yf
-NF
-jo
-Dh
-eM
-Zs
-FT
-FT
+cp
+WF
+Yh
+Zl
+Fj
+Tz
+Tz
 eP
-wQ
-AR
-yS
-jo
-jo
-jo
-jo
-eM
-eM
-eM
-ou
-eM
-jo
+WO
+FB
+cs
+WF
+WF
+WF
+WF
+Zl
+Zl
+Zl
+BZ
+Zl
+WF
 ot
 Ho
 SR
@@ -16724,10 +16762,10 @@ cc
 Rh
 XP
 Ry
-eM
-eM
-ou
-eM
+Zl
+Zl
+BZ
+Zl
 bN
 SR
 SR
@@ -16738,9 +16776,9 @@ PD
 Nd
 SR
 SR
-dP
+zB
 ZW
-dP
+zB
 DZ
 Rj
 Rj
@@ -16848,27 +16886,27 @@ Yf
 Yf
 Yf
 Yf
-NF
-jo
-eM
-eM
-EL
-Hw
-kU
-eM
-eM
-eM
-yS
+cp
+WF
+Zl
+Zl
+WB
+JF
+CX
+Zl
+Zl
+Zl
+cs
 Yf
 Yf
-OR
-jo
-YV
-eM
-eM
-ou
-eM
-IY
+Gs
+WF
+Bo
+Zl
+Zl
+BZ
+Zl
+Xz
 SR
 SR
 SR
@@ -16880,10 +16918,10 @@ ca
 Ry
 bS
 SR
-wQ
-eM
-ou
-eM
+WO
+Zl
+BZ
+Zl
 cm
 SR
 SR
@@ -16894,9 +16932,9 @@ VI
 bM
 Nd
 SR
-dP
+zB
 ZW
-dP
+zB
 Lx
 Ga
 Ga
@@ -16987,14 +17025,14 @@ Qa
 Qa
 LO
 vq
-LN
-hC
-Ls
-Ls
-yY
-hC
-ik
-NF
+to
+TF
+Pe
+Pe
+za
+TF
+Na
+cp
 YQ
 "}
 (44,1,1) = {"
@@ -17004,42 +17042,42 @@ Yf
 Yf
 Yf
 Yf
-NF
-yS
-yS
-yS
-yS
-yS
-yS
-yS
-yS
-yS
-yS
+cp
+cs
+cs
+cs
+cs
+cs
+cs
+cs
+cs
+cs
+cs
 Yf
 Yf
-Og
-jo
-LJ
-eM
-eM
-ou
-eM
-ee
-eM
-wQ
-eM
-eM
-eM
-WJ
-eM
-eM
-eM
-eM
-eM
-LJ
-eM
-ou
-jo
+Il
+WF
+LF
+Zl
+Zl
+BZ
+Zl
+Tx
+Zl
+WO
+Zl
+Zl
+Zl
+EU
+Zl
+Zl
+Zl
+Zl
+Zl
+LF
+Zl
+BZ
+WF
 bT
 SR
 SR
@@ -17050,9 +17088,9 @@ by
 PD
 by
 bS
-dP
+zB
 ZW
-dP
+zB
 gx
 ZU
 ZU
@@ -17143,14 +17181,14 @@ Is
 Zc
 RJ
 KZ
-LN
+to
 XO
 SI
 SI
 Za
 XO
 bD
-NF
+cp
 YQ
 "}
 (45,1,1) = {"
@@ -17173,29 +17211,29 @@ Yf
 Yf
 Yf
 Yf
-Og
-jo
-WN
-FT
-FT
-Yk
-FT
-VL
-FT
-FT
-FT
-FT
-FT
-ef
-FT
-FT
-FT
-FT
-FT
-Zl
-FT
-wT
-jo
+Il
+WF
+NU
+Tz
+Tz
+dz
+Tz
+mV
+Tz
+Tz
+Tz
+Tz
+Tz
+mz
+Tz
+Tz
+Tz
+Tz
+Tz
+HP
+Tz
+jX
+WF
 SR
 im
 SR
@@ -17206,9 +17244,9 @@ PD
 by
 bP
 bP
-dP
+zB
 ZW
-dP
+zB
 ZU
 ZU
 ZU
@@ -17299,14 +17337,14 @@ KZ
 KZ
 KZ
 KZ
-Fx
+Gy
 XO
 SI
 SI
 Za
 XO
 lX
-EW
+kQ
 YQ
 "}
 (46,1,1) = {"
@@ -17330,28 +17368,28 @@ Yf
 Yf
 Yf
 qs
-jo
-eM
-eM
-JV
-eM
-eM
-MA
-eM
-eM
-eM
-eM
-eM
-eM
-eM
-wQ
-CE
-eM
-eM
-nq
-jo
-jo
-jo
+WF
+Zl
+Zl
+dL
+Zl
+Zl
+pr
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+WO
+jC
+Zl
+Zl
+DH
+WF
+WF
+WF
 SR
 SR
 SR
@@ -17364,7 +17402,7 @@ Rj
 dy
 ej
 ZW
-dP
+zB
 fi
 ft
 EB
@@ -17455,14 +17493,14 @@ li
 li
 li
 li
-rk
+cR
 li
 my
 my
 DD
 DD
 Vb
-Ol
+kq
 YQ
 "}
 (47,1,1) = {"
@@ -17486,13 +17524,13 @@ Yf
 Yf
 re
 qy
-jo
-IY
+WF
+Xz
 ev
-iM
-IY
-jo
-jo
+xZ
+Xz
+WF
+WF
 aX
 bN
 bN
@@ -17518,9 +17556,9 @@ Tu
 dh
 Ga
 dD
-dP
+zB
 ZW
-dP
+zB
 dE
 Bw
 fz
@@ -17611,14 +17649,14 @@ my
 my
 my
 my
-VC
+zz
 my
 my
 Iw
 DD
-ip
+iX
 DD
-Vy
+wI
 YQ
 "}
 (48,1,1) = {"
@@ -17674,9 +17712,9 @@ Tu
 dh
 XJ
 ZU
-dP
+zB
 ZW
-dP
+zB
 fi
 Bw
 ft
@@ -17767,14 +17805,14 @@ my
 my
 my
 my
-VC
+zz
 my
-yT
+JW
 my
 DD
-TG
+jh
 DD
-Vy
+wI
 YQ
 "}
 (49,1,1) = {"
@@ -17830,9 +17868,9 @@ Zt
 dj
 dx
 ZU
-dP
+zB
 ZW
-Qy
+tp
 dE
 cY
 dE
@@ -17923,14 +17961,14 @@ li
 li
 li
 li
-rk
+cR
 DD
 my
 my
 DD
-ip
+iX
 DD
-jY
+uB
 YQ
 "}
 (50,1,1) = {"
@@ -17986,9 +18024,9 @@ QK
 Xu
 Jg
 eb
-dP
+zB
 ZW
-dP
+zB
 ZU
 Xu
 xP
@@ -18079,14 +18117,14 @@ ND
 ND
 ND
 ND
-PE
-ip
+Aw
+iX
 my
 my
 DD
 DD
 DD
-mf
+Xe
 YQ
 "}
 (51,1,1) = {"
@@ -18142,9 +18180,9 @@ Ir
 EB
 do
 dj
-dP
+zB
 ZW
-dP
+zB
 ZU
 Xu
 xP
@@ -18235,14 +18273,14 @@ Hf
 JC
 wZ
 Ez
-PE
+Aw
 DD
 my
 my
-ip
+iX
 DD
 DD
-mf
+Xe
 YQ
 "}
 (52,1,1) = {"
@@ -18298,9 +18336,9 @@ IC
 de
 do
 ZU
-dP
+zB
 ZW
-dP
+zB
 DZ
 Mg
 fT
@@ -18391,14 +18429,14 @@ Zq
 wZ
 wZ
 LC
-PE
+Aw
 DD
 my
 my
 DD
 DD
 DD
-us
+ss
 YQ
 "}
 (53,1,1) = {"
@@ -18547,14 +18585,14 @@ Hf
 Ze
 wZ
 Ez
-PE
+Aw
 DD
 my
 my
-ip
+iX
 DD
 DD
-iB
+tG
 YQ
 "}
 (54,1,1) = {"
@@ -18703,14 +18741,14 @@ Hf
 Hf
 Hf
 Hf
-PE
+Aw
 DD
 my
 my
 DD
 DD
 li
-sY
+vF
 YQ
 "}
 (55,1,1) = {"
@@ -18859,14 +18897,14 @@ Hf
 KO
 Cs
 Ez
-PE
-rk
-VC
-VC
-FA
-FA
-rk
-sY
+Aw
+cR
+zz
+zz
+Kr
+Kr
+cR
+vF
 YQ
 "}
 (56,1,1) = {"
@@ -19271,7 +19309,7 @@ li
 lx
 li
 li
-Yl
+VC
 li
 li
 lx
@@ -19433,7 +19471,7 @@ my
 my
 my
 my
-yT
+JW
 my
 my
 my
@@ -19735,7 +19773,7 @@ Td
 xE
 my
 my
-yT
+JW
 my
 my
 my
@@ -19900,7 +19938,7 @@ li
 li
 li
 li
-Yl
+VC
 li
 li
 li
@@ -20696,7 +20734,7 @@ my
 my
 my
 my
-Cg
+Vg
 Iw
 my
 my
@@ -20968,7 +21006,7 @@ xX
 xX
 hv
 ST
-fX
+Ig
 YW
 YW
 YW
@@ -25134,20 +25172,20 @@ Yf
 Yf
 Yf
 Yf
-NF
-xc
-cD
-Ol
+cp
+iS
+ko
+kq
 cQ
-ct
+kL
 yh
 yh
 yh
-rj
+mQ
 yh
-cE
-fO
-NZ
+mA
+nb
+qe
 Zy
 bS
 bS
@@ -25290,7 +25328,7 @@ Yf
 Yf
 Yf
 Yf
-NF
+cp
 Yf
 RN
 Vb
@@ -25303,7 +25341,7 @@ SR
 SR
 ce
 ce
-NZ
+qe
 Zy
 Zy
 bS
@@ -25374,11 +25412,11 @@ XO
 WI
 XO
 XO
-TF
-TF
-TF
-TF
-TF
+HH
+HH
+HH
+HH
+HH
 TV
 fP
 TJ
@@ -25446,7 +25484,7 @@ Yf
 Yf
 Yf
 Yf
-NF
+cp
 Yf
 qs
 qz
@@ -25459,7 +25497,7 @@ wo
 wo
 ce
 ce
-NZ
+qe
 Zy
 Zy
 Zy
@@ -25532,9 +25570,9 @@ Za
 Za
 oO
 XO
-Te
-Te
-TF
+sF
+sF
+HH
 fP
 TJ
 dk
@@ -25602,7 +25640,7 @@ Yf
 Yf
 Yf
 Yf
-NF
+cp
 Yf
 qy
 lX
@@ -25615,7 +25653,7 @@ VI
 VI
 bM
 by
-NZ
+qe
 Zy
 Zy
 Zy
@@ -25758,7 +25796,7 @@ Yf
 Yf
 Yf
 Yf
-Ea
+dK
 qy
 lX
 WS
@@ -25771,7 +25809,7 @@ Sg
 ot
 pk
 Ho
-NZ
+qe
 Zy
 Zy
 Zy
@@ -25914,7 +25952,7 @@ Yf
 Yf
 Yf
 qy
-OX
+dQ
 Ho
 Vb
 eY
@@ -25927,7 +25965,7 @@ SR
 Lm
 Ho
 Zy
-NZ
+qe
 Zy
 Zy
 Zy
@@ -26070,7 +26108,7 @@ Yf
 Yf
 qy
 PD
-wr
+eu
 bA
 Ho
 SR
@@ -26083,7 +26121,7 @@ im
 SR
 ok
 pk
-cO
+sb
 pk
 pk
 pk
@@ -26226,7 +26264,7 @@ Yf
 qs
 PD
 VI
-Nm
+eF
 Sg
 SR
 SR
@@ -26239,7 +26277,7 @@ bl
 SR
 SR
 ok
-cO
+sb
 pk
 pk
 pk
@@ -26382,7 +26420,7 @@ Yf
 qy
 ot
 Fu
-hS
+eL
 SR
 bl
 SR
@@ -26395,7 +26433,7 @@ SR
 bl
 SR
 SR
-mj
+ky
 Xw
 Xw
 Ir
@@ -26539,18 +26577,18 @@ PD
 VI
 Fu
 yh
-Ac
-nJ
+jo
+kp
 yh
-mj
-dK
-ct
-cN
-dK
+ky
+kS
+kL
+ln
+kS
 cP
 yh
-Ac
-cp
+jo
+ne
 yh
 cj
 Xw
@@ -26774,7 +26812,7 @@ nI
 wa
 nI
 oP
-CR
+GO
 oP
 oP
 oP
@@ -26783,7 +26821,7 @@ nI
 nI
 wa
 wa
-kL
+Cq
 nI
 nI
 oP
@@ -27066,7 +27104,7 @@ XO
 XO
 XO
 XO
-gJ
+Tl
 oP
 oP
 oP
@@ -27257,7 +27295,7 @@ IT
 IT
 IT
 IT
-rR
+io
 IT
 oP
 oP
@@ -27378,42 +27416,42 @@ vy
 vy
 vy
 vy
-Hb
-Hb
-Hb
-Hb
-Hb
-Hb
-Hb
-Hb
-Hb
-Hb
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
 Ns
-Hb
-Hb
-Hb
-Hb
-Hb
-Hb
-Hb
-Hb
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
 Yv
 Ow
-Hb
-Hb
-Hb
-Hb
-Hb
-Hb
-Hb
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
 Ns
-Hb
-Hb
-Hb
-Hb
-Hb
-Hb
-CI
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+qf
 td
 wa
 wa
@@ -27504,7 +27542,7 @@ AU
 AU
 dI
 eI
-un
+XA
 AU
 AU
 YT
@@ -27696,7 +27734,7 @@ oP
 wa
 CP
 Jm
-hF
+PS
 OA
 mh
 yq
@@ -27723,12 +27761,12 @@ OA
 mh
 mh
 mh
-hF
+PS
 oP
 iK
 oP
 oP
-Xp
+fI
 oP
 wa
 oP
@@ -27863,12 +27901,12 @@ on
 on
 on
 on
-IM
-PW
+fM
+Sc
 at
-iY
-PW
-IM
+GC
+Sc
+fM
 on
 on
 on
@@ -27878,13 +27916,13 @@ yq
 yB
 yB
 yB
-YJ
-kL
+lL
+Cq
 oP
 iK
 oP
 nI
-Xp
+fI
 oP
 wa
 oP
@@ -28003,44 +28041,44 @@ fZ
 XO
 WI
 oP
-Xp
+fI
 wa
 wa
 nI
 Wu
 oP
 WQ
-Kz
+GG
 wv
-hF
+PS
 oP
-DH
-PW
-Gg
-Gg
-Gg
-Gg
-Gg
-wS
-jk
-Gg
+RA
+Sc
+WA
+WA
+WA
+WA
+WA
+wt
+Ko
+WA
 Oy
-sB
+QN
 nd
-BO
+ud
 tL
 tL
-QW
-Xp
-Xp
-Xp
-Xp
+vk
+fI
+fI
+fI
+fI
 WQ
 oP
 iK
 oP
 oP
-Xp
+fI
 oP
 oP
 oP
@@ -28171,25 +28209,25 @@ wa
 wa
 oP
 wa
-DA
+ka
 IT
 IT
-LS
-Pm
+LN
+Hx
 IT
-xe
-RO
+os
+PF
 nc
-xo
-UZ
+DO
+Az
 tL
 tL
 tL
 tL
-QW
-Xp
-Xp
-Xp
+vk
+fI
+fI
+fI
 OA
 wv
 nI
@@ -28262,13 +28300,13 @@ bl
 Ry
 KU
 Ir
-dK
+kS
 cP
 yh
-Ac
+jo
 yh
 yh
-KQ
+mC
 by
 Zy
 Zy
@@ -28321,7 +28359,7 @@ wa
 oP
 Wu
 oP
-gU
+IZ
 wa
 wa
 wa
@@ -28333,20 +28371,20 @@ IT
 IT
 on
 on
-cG
-RO
+Gr
+PF
 nf
-Tw
+Cc
 tL
 tL
 tL
 tL
 tL
 tL
-Xp
-Xp
+fI
+fI
 OA
-qe
+oC
 nI
 nI
 En
@@ -28471,29 +28509,29 @@ qs
 WI
 WI
 oP
-Xp
+fI
 oP
 oP
 oP
 CZ
 wa
-wp
-lL
+JN
+Kd
 IT
 IT
 IT
 IT
-ka
+Wm
 IT
 IT
-An
+RQ
 on
 on
-xe
-RO
+os
+PF
 IT
 IT
-ka
+Wm
 tL
 tL
 on
@@ -28501,7 +28539,7 @@ on
 on
 on
 on
-Kz
+GG
 nI
 nI
 oP
@@ -28580,7 +28618,7 @@ Xw
 rf
 PI
 PI
-Wv
+tw
 ca
 bS
 bS
@@ -28634,7 +28672,7 @@ wa
 CZ
 nI
 wa
-jk
+Ko
 IT
 IT
 td
@@ -28645,8 +28683,8 @@ IT
 IT
 IT
 mP
-xe
-RO
+os
+PF
 IT
 IT
 on
@@ -28789,7 +28827,7 @@ oP
 oP
 ZS
 oP
-gU
+IZ
 oP
 oP
 oP
@@ -28801,13 +28839,13 @@ IT
 IT
 IT
 IT
-xe
-RO
+os
+PF
 IT
 IT
 on
 tL
-ut
+MC
 on
 wa
 oP
@@ -28886,7 +28924,7 @@ Vb
 lG
 SR
 VU
-Ac
+jo
 SR
 SR
 we
@@ -28894,8 +28932,8 @@ bl
 SR
 yh
 cb
-mj
-uW
+ky
+BM
 cP
 qT
 Xw
@@ -28946,7 +28984,7 @@ TW
 CZ
 oP
 on
-uU
+OL
 oP
 oP
 td
@@ -28957,13 +28995,13 @@ on
 on
 on
 on
-xe
-Mx
+os
+Hc
 IT
 IT
 on
-MH
-Vp
+VA
+sR
 on
 oP
 wa
@@ -29042,7 +29080,7 @@ RN
 Vb
 pq
 eY
-cE
+mA
 wo
 SR
 wo
@@ -29108,13 +29146,13 @@ oP
 IT
 IT
 on
-RE
+WW
 IT
 mP
 IT
 on
-xe
-RO
+os
+PF
 IT
 IT
 on
@@ -29198,7 +29236,7 @@ Yf
 oW
 oW
 RN
-KQ
+mC
 VI
 pk
 VI
@@ -29268,15 +29306,15 @@ ku
 IT
 IT
 IT
-DA
-xe
-RO
+ka
+os
+PF
 IT
 IT
 IT
 mP
 IT
-ka
+Wm
 wa
 wa
 nI
@@ -29354,7 +29392,7 @@ Yf
 Yf
 Yf
 Yf
-HK
+mE
 Lm
 Ho
 ce
@@ -29418,21 +29456,21 @@ on
 oP
 oP
 IT
-An
+RQ
 on
 kv
 IT
-qV
+CT
 IT
 IT
-xe
-RO
+os
+PF
 nc
 nc
 nc
 nc
 nc
-DA
+ka
 wa
 wa
 nI
@@ -29440,7 +29478,7 @@ nI
 oP
 wa
 oP
-Ti
+HF
 Uj
 OJ
 bF
@@ -29510,7 +29548,7 @@ Yf
 Yf
 Yf
 Yf
-NF
+cp
 oW
 RN
 Lm
@@ -29576,14 +29614,14 @@ oP
 IT
 IT
 on
-kw
-lm
-lm
+kx
+lo
+lo
 IT
 on
-xe
-RO
-BK
+os
+PF
+xj
 nf
 nf
 nf
@@ -29596,7 +29634,7 @@ oP
 oP
 uq
 oP
-Rw
+AL
 Uj
 GY
 bD
@@ -29666,16 +29704,16 @@ Yf
 Yf
 Yf
 Yf
-NF
-NF
-NF
-hH
-HK
-us
-us
+cp
+cp
+cp
+mY
+mE
+ss
+ss
 yh
-us
-us
+ss
+ss
 yh
 SR
 SR
@@ -29732,19 +29770,19 @@ on
 IT
 IT
 on
-kw
-lm
-lm
+kx
+lo
+lo
 IT
 on
-xe
-Mx
+os
+Hc
 IT
 IT
 IT
 IT
 IT
-ka
+Wm
 wa
 oP
 oP
@@ -29891,10 +29929,10 @@ on
 IT
 lp
 IT
-An
+RQ
 on
-cG
-RO
+Gr
+PF
 on
 on
 on
@@ -30043,19 +30081,19 @@ TJ
 fZ
 IT
 IT
-DA
+ka
 IT
 IT
-qV
+CT
 IT
 on
-xe
-RO
+os
+PF
 on
-nx
-xK
-xK
-ZR
+pW
+iO
+iO
+IB
 on
 oP
 nI
@@ -30200,14 +30238,14 @@ on
 IT
 IT
 IT
-kw
-lm
-lm
+kx
+lo
+lo
 IT
-DA
-xe
-RO
-fD
+ka
+os
+PF
+cy
 IT
 IT
 IT
@@ -30352,22 +30390,22 @@ aG
 nI
 nI
 nI
-it
+Qp
 IT
 IT
 on
 IT
-lm
-lm
+lo
+lo
 IT
 IT
-xe
-RO
-Tg
+os
+PF
+uW
 IT
 IT
 IT
-Gn
+el
 on
 oP
 wa
@@ -30376,7 +30414,7 @@ nW
 oP
 wa
 oP
-Ti
+HF
 Uj
 NT
 bD
@@ -30513,16 +30551,16 @@ IT
 IT
 on
 IT
-Pm
+Hx
 lp
 IT
 on
-xe
-RO
+os
+PF
 on
-wy
+gE
 mG
-kO
+Og
 nm
 on
 on
@@ -30532,7 +30570,7 @@ nW
 on
 on
 iT
-uY
+PR
 tv
 KV
 bD
@@ -30673,8 +30711,8 @@ on
 on
 on
 on
-xe
-RO
+os
+PF
 on
 on
 on
@@ -30682,12 +30720,12 @@ on
 on
 on
 nI
-Rt
+RF
 nI
 oP
 wa
 oP
-Ti
+HF
 Np
 zl
 bF
@@ -30825,16 +30863,16 @@ IT
 IT
 oP
 oP
-it
+Qp
 oP
 oP
 wa
-lw
-RO
+Ok
+PF
 wa
 oP
 wa
-it
+Qp
 oP
 oP
 oP
@@ -30843,7 +30881,7 @@ oP
 oP
 wa
 oP
-Rw
+AL
 mH
 kW
 Yf
@@ -30986,7 +31024,7 @@ oP
 wa
 lP
 lZ
-Mx
+Hc
 IT
 wa
 wa
@@ -31758,7 +31796,7 @@ wa
 ih
 tL
 tL
-Oz
+jR
 tL
 tL
 tL
@@ -31766,7 +31804,7 @@ tL
 tL
 tL
 tL
-Oz
+jR
 tL
 tL
 tL
@@ -31775,7 +31813,7 @@ tL
 tL
 tL
 tL
-Oz
+jR
 tL
 oy
 oP
@@ -33318,7 +33356,7 @@ wa
 jv
 tL
 tL
-Oz
+jR
 tL
 tL
 tL
@@ -33326,7 +33364,7 @@ tL
 tL
 tL
 tL
-Oz
+jR
 tL
 tL
 tL
@@ -33335,7 +33373,7 @@ tL
 tL
 tL
 tL
-Oz
+jR
 tL
 oD
 oP

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -66,10 +66,6 @@
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
-"ap" = (
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
 "aq" = (
 /obj/structure/xenoautopsy/tank/broken,
 /turf/open/floor/plating/mainship,
@@ -208,14 +204,26 @@
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "aR" = (
-/obj/structure/largecrate/lisa,
+/obj/structure/closet/crate/weapon,
+/obj/item/weapon/energy/sword,
+/obj/item/weapon/gun/rifle/m16,
+/obj/item/ammo_magazine/rifle/m16,
+/obj/item/ammo_magazine/rifle/m16,
+/obj/item/ammo_magazine/rifle/m16,
+/obj/item/ammo_magazine/rifle/m16,
+/obj/item/ammo_magazine/rifle/m16,
+/obj/item/ammo_magazine/rifle/m16,
+/obj/item/ammo_magazine/rifle/m16,
+/obj/item/ammo_magazine/rifle/m16,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "aS" = (
-/obj/structure/closet/crate/freezer/rations,
-/obj/item/storage/box/MRE,
-/obj/item/storage/box/MRE,
-/obj/item/storage/box/MRE,
+/obj/structure/closet/crate/explosives,
+/obj/item/storage/box/visual/grenade/frag,
+/obj/item/explosive/plastique,
+/obj/item/explosive/plastique,
+/obj/item/explosive/plastique,
+/obj/item/explosive/plastique,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "aT" = (
@@ -240,15 +248,18 @@
 /turf/closed/ice,
 /area/icy_caves/caves/northern)
 "aY" = (
-/obj/structure/closet/crate/radiation,
+/obj/structure/closet/crate/ammo,
+/obj/item/ammo_magazine/rifle/bolt,
+/obj/item/ammo_magazine/rifle/bolt,
+/obj/item/ammo_magazine/rifle/bolt,
+/obj/item/ammo_magazine/rifle/bolt,
+/obj/item/ammo_magazine/rifle/bolt,
+/obj/item/ammo_magazine/rifle/bolt,
+/obj/item/ammo_magazine/rifle/bolt,
+/obj/item/ammo_magazine/rifle/bolt,
+/obj/item/ammo_magazine/rifle/bolt,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
-"aZ" = (
-/obj/structure/mirror{
-	dir = 8
-	},
-/turf/open/floor/freezer,
-/area/icy_caves/outpost/dorms)
 "ba" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -329,11 +340,11 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
 "bq" = (
+/obj/structure/rack,
 /obj/item/tool/shovel,
 /obj/item/tool/shovel,
 /obj/item/tool/shovel,
 /obj/item/tool/shovel,
-/obj/structure/rack/nometal,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ1)
 "br" = (
@@ -345,9 +356,14 @@
 	},
 /area/icy_caves/outpost/refinery)
 "bs" = (
+/obj/structure/closet/crate/medical,
 /obj/item/defibrillator,
 /obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
 /obj/item/storage/firstaid/fire,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/reagent_containers/glass/beaker/bluespace,
@@ -576,6 +592,12 @@
 	dir = 4
 	},
 /area/icy_caves/caves/northern)
+"co" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "cp" = (
 /obj/item/lightstick/anchored,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -594,12 +616,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"cs" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/end{
-	dir = 8
-	},
-/area/icy_caves/caves/northern)
 "ct" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice/thin/corner{
@@ -613,43 +629,33 @@
 /turf/closed/ice/corner{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
-"cv" = (
+/area/icy_caves/outpost/LZ2)
+"cD" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/junction{
+/turf/closed/ice_rock/singlePart{
+	dir = 10
+	},
+/area/icy_caves/caves)
+"cE" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/end{
 	dir = 8
 	},
 /area/icy_caves/caves/northern)
-"cw" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/junction{
-	dir = 4
+"cG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
 	},
-/area/icy_caves/caves/northern)
-"cx" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/end{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/area/icy_caves/caves/northern)
-"cC" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/end,
-/area/icy_caves/caves/northern)
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "cI" = (
 /turf/closed/ice/thin/single,
-/area/icy_caves/caves/northern)
-"cJ" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/junction{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
-"cK" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/junction{
-	dir = 8
-	},
 /area/icy_caves/caves/northern)
 "cM" = (
 /obj/effect/landmark/xeno_resin_door,
@@ -675,13 +681,31 @@
 	dir = 1
 	},
 /area/icy_caves/caves/northern)
+"cS" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
+"cT" = (
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "cU" = (
-/turf/open/floor/plating/icefloor/warnplate,
+/obj/machinery/landinglight/ds1/delaytwo{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
-"cW" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/corner,
-/area/icy_caves/caves/west)
+"cV" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "cY" = (
 /turf/closed/ice/thin/corner{
 	dir = 8
@@ -695,26 +719,10 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
-"dd" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/junction{
-	dir = 1
-	},
-/area/icy_caves/caves/west)
 "de" = (
 /turf/closed/ice/thin/junction{
 	dir = 1
 	},
-/area/icy_caves/caves/west)
-"df" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/corner{
-	dir = 8
-	},
-/area/icy_caves/caves/west)
-"dg" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
 "dh" = (
 /turf/closed/ice_rock/singlePart{
@@ -751,6 +759,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"dt" = (
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "dw" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 4
@@ -764,10 +779,6 @@
 "dy" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/west)
-"dz" = (
-/obj/machinery/computer/nuke_disk_generator/green,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/south)
 "dA" = (
 /obj/machinery/light,
 /turf/open/floor/plating/ground/ice,
@@ -810,26 +821,17 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/caves/northern)
-"dL" = (
-/obj/structure/closet/crate/science,
-/obj/item/stack/sheet/mineral/phoron/medium_stack,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
-"dM" = (
-/obj/machinery/power/apc/drained,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
 "dN" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "dO" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "dP" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
@@ -875,10 +877,6 @@
 "dY" = (
 /turf/closed/ice/thin/end,
 /area/icy_caves/caves/east)
-"dZ" = (
-/obj/machinery/power/port_gen/pacman,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
 "ea" = (
 /obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor/tile/dark,
@@ -895,30 +893,34 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
+"ee" = (
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor{
+	name = "\improper Lambda Lab"
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"ef" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "eg" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
 "eh" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/west)
-"ei" = (
-/obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
 "ej" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
-"el" = (
-/obj/item/clothing/suit/radiation,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/crashed_ship)
 "em" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark,
@@ -938,11 +940,11 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
 "eo" = (
+/obj/item/tool/pickaxe/plasmacutter,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
 	},
 /obj/effect/ai_node,
-/obj/item/tool/pickaxe,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
 "ep" = (
@@ -973,42 +975,25 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
-"eu" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/east)
 "ev" = (
-/obj/structure/closet/crate,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick,
-/obj/item/storage/box/lightstick,
-/obj/effect/spawner/random/powercell,
-/obj/item/clothing/glasses/welding,
-/obj/item/explosive/plastique,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/item/tool/pickaxe,
+/obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "ew" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "ex" = (
-/obj/machinery/door/airlock/mainship/secure/locked/free_access{
-	name = "\improper Mining Storage"
-	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/door/airlock/mainship/secure/locked/free_access,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "ey" = (
 /turf/closed/ice,
 /area/icy_caves/caves/crashed_ship)
@@ -1033,10 +1018,19 @@
 	dir = 9
 	},
 /area/icy_caves/caves/northern)
+"eC" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/structure/monorail{
+	dir = 9
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
 "eF" = (
 /obj/effect/landmark/weed_node,
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
 "eG" = (
 /obj/machinery/light{
@@ -1074,34 +1068,28 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
-"eL" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/east)
 "eM" = (
-/obj/structure/closet/crate,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick,
-/obj/item/storage/box/lightstick,
-/obj/effect/spawner/random/powercell,
-/obj/item/explosive/plastique,
-/obj/item/tool/pickaxe,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "eN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
+"eO" = (
+/obj/structure/barricade/guardrail{
+	dir = 1
+	},
+/obj/structure/dropship_piece/two/front,
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "eP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "eR" = (
 /turf/closed/ice/end{
 	dir = 1
@@ -1109,18 +1097,18 @@
 /area/icy_caves/caves/south)
 "eS" = (
 /obj/machinery/light,
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
 "eT" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "eU" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
 "eV" = (
 /obj/structure/ore_box,
@@ -1152,11 +1140,11 @@
 	},
 /area/icy_caves/caves)
 "eZ" = (
+/obj/item/tool/pickaxe/plasmacutter,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/item/tool/pickaxe,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
 "fa" = (
@@ -1174,13 +1162,13 @@
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/fire,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "fd" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/powercell,
 /obj/effect/spawner/random/powercell,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "fe" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/tech_supply,
@@ -1191,7 +1179,7 @@
 /obj/item/clothing/glasses/welding,
 /obj/machinery/light/small,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "ff" = (
 /obj/structure/rack,
 /obj/structure/rack,
@@ -1199,7 +1187,7 @@
 /obj/effect/spawner/random/toolbox,
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "fg" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/tool,
@@ -1207,7 +1195,7 @@
 /obj/effect/spawner/random/tool,
 /obj/item/storage/belt/utility/full,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "fh" = (
 /turf/closed/ice/thin/junction,
 /area/icy_caves/caves/south)
@@ -1242,10 +1230,6 @@
 	dir = 1
 	},
 /area/icy_caves/caves/east)
-"fs" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/LZ1)
 "ft" = (
 /turf/closed/ice/thin/junction{
 	dir = 4
@@ -1297,6 +1281,12 @@
 	dir = 9
 	},
 /area/icy_caves/caves/south)
+"fD" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "fE" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
@@ -1330,6 +1320,12 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/LZ1)
+"fO" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/straight{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "fP" = (
 /turf/closed/ice/junction,
 /area/icy_caves/caves/east)
@@ -1351,10 +1347,25 @@
 "fT" = (
 /turf/closed/ice/single,
 /area/icy_caves/caves/west)
+"fU" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "25"
+	},
+/area/icy_caves/caves/northern)
+"fV" = (
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "fW" = (
 /turf/closed/ice/thin/junction{
 	dir = 4
 	},
+/area/icy_caves/caves/south)
+"fX" = (
+/obj/docking_port/mobile/crashmode/bigbury,
+/turf/closed/ice,
 /area/icy_caves/caves/south)
 "fY" = (
 /turf/closed/ice/thin/junction{
@@ -1370,6 +1381,10 @@
 	},
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
+"gb" = (
+/obj/machinery/computer3/server,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "gc" = (
 /turf/closed/ice/end{
 	dir = 1
@@ -1385,19 +1400,39 @@
 	dir = 5
 	},
 /area/icy_caves/caves/east)
+"gf" = (
+/obj/structure/table/mainship,
+/obj/machinery/computer/med_data,
+/turf/open/floor/mainship/mono,
+/area/icy_caves/caves/northern)
 "gh" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 9
 	},
 /area/icy_caves/caves/east)
+"gi" = (
+/obj/effect/decal/cleanable/vomit,
+/obj/machinery/camera{
+	dir = 5
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "gk" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/caves/east)
+"gm" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall,
+/area/icy_caves/outpost/mining/west)
 "gn" = (
 /turf/closed/ice/thin/end{
 	dir = 4
 	},
 /area/icy_caves/caves/west)
+"go" = (
+/obj/machinery/door/airlock/multi_tile/mainship/secdoor,
+/turf/open/floor/mainship/red/full,
+/area/icy_caves/caves/northern)
 "gp" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/caves/west)
@@ -1422,6 +1457,11 @@
 	dir = 4
 	},
 /area/icy_caves/caves/east)
+"gv" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/space)
 "gw" = (
 /turf/closed/ice_rock/singleT{
 	dir = 1
@@ -1447,10 +1487,11 @@
 "gB" = (
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/refinery)
-"gC" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
+"gD" = (
+/turf/closed/ice_rock/corners{
+	dir = 9
+	},
+/area/icy_caves/caves/northern)
 "gF" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -1464,11 +1505,29 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
+"gH" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "gI" = (
 /obj/machinery/floodlight/landing,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
+"gJ" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ2)
+"gK" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "52"
+	},
+/area/icy_caves/caves/northern)
 "gL" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -1480,6 +1539,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
+"gQ" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/space)
 "gS" = (
 /turf/closed/ice/thin/end{
 	dir = 8
@@ -1490,6 +1554,10 @@
 	dir = 6
 	},
 /area/icy_caves/caves/south)
+"gU" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/closed/wall/r_wall,
+/area/icy_caves/outpost/LZ2)
 "gV" = (
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves/east)
@@ -1524,10 +1592,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/research)
-"hi" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
 "hj" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/outpost/outside)
@@ -1611,10 +1675,10 @@
 	},
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
-"hB" = (
-/obj/item/clothing/head/radiation,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/crashed_ship)
+"hC" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/outside)
 "hD" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/floor/plating/ground/ice,
@@ -1624,6 +1688,13 @@
 	dir = 8
 	},
 /area/icy_caves/caves/east)
+"hF" = (
+/turf/closed/ice/thin/corner,
+/area/icy_caves/outpost/LZ2)
+"hH" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/westWall,
+/area/icy_caves/caves)
 "hI" = (
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/ai_node,
@@ -1634,6 +1705,13 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"hL" = (
+/obj/machinery/door/airlock/multi_tile/secure{
+	dir = 2
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "hO" = (
 /turf/closed/ice/thin/single,
 /area/icy_caves/caves/east)
@@ -1645,6 +1723,18 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"hS" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/end{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
+"hT" = (
+/obj/machinery/landinglight/ds1/delaytwo{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "hU" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/ice,
@@ -1652,10 +1742,26 @@
 "hV" = (
 /turf/closed/ice_rock/singlePart,
 /area/icy_caves/caves/south)
+"hW" = (
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "hX" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/northern)
+"hZ" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"ia" = (
+/obj/structure/cryofeed,
+/turf/open/floor/podhatch/floor{
+	icon_state = "bcircuitoff"
+	},
 /area/icy_caves/caves/northern)
 "ib" = (
 /obj/machinery/light{
@@ -1666,6 +1772,13 @@
 	dir = 5
 	},
 /area/icy_caves/outpost/office)
+"if" = (
+/obj/machinery/landinglight/ds1/delaytwo{
+	dir = 4
+	},
+/obj/machinery/floodlight/landing,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "ig" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -1685,10 +1798,36 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"ik" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/northWall,
+/area/icy_caves/caves)
+"il" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "im" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
+"io" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"ip" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside/center)
+"it" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ2)
 "iu" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -1699,34 +1838,47 @@
 "ix" = (
 /obj/structure/cable,
 /obj/effect/landmark/excavation_site_spawner,
+/obj/effect/ai_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
-"iC" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 1
+/area/icy_caves/caves/northern)
+"iz" = (
+/obj/machinery/landinglight/ds1{
+	dir = 4
 	},
-/area/icy_caves/outpost/LZ2)
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
+"iB" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleT,
+/area/icy_caves/caves)
+"iF" = (
+/turf/closed/ice_rock/corners,
+/area/space)
 "iG" = (
 /turf/open/floor/tile/dark/yellow2{
 	dir = 4
 	},
 /area/icy_caves/outpost/engineering)
-"iI" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 6
-	},
-/area/icy_caves/outpost/LZ2)
-"iJ" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/lowcharge,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "iK" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
+"iM" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"iP" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "iQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -1737,6 +1889,16 @@
 /turf/closed/ice/end{
 	dir = 1
 	},
+/area/icy_caves/outpost/LZ2)
+"iV" = (
+/obj/item/tool/surgery/hemostat,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"iY" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "iZ" = (
 /turf/open/floor/tile/dark/brown2,
@@ -1751,11 +1913,47 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"jc" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "24"
+	},
+/area/icy_caves/caves/northern)
 "je" = (
 /turf/closed/ice/thin/corner{
 	dir = 1
 	},
 /area/icy_caves/outpost/outside)
+"jg" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/ice_rock/corners{
+	dir = 9
+	},
+/area/icy_caves/caves)
+"jh" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
+"jk" = (
+/turf/open/floor/tile/dark/red2{
+	dir = 6
+	},
+/area/icy_caves/outpost/LZ2)
+"jn" = (
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor/mainship/cargo,
+/area/icy_caves/caves/northern)
+"jo" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
 "jt" = (
 /obj/machinery/floodlight/landing,
 /obj/effect/decal/warning_stripes,
@@ -1780,13 +1978,22 @@
 /turf/closed/ice/thin/single,
 /area/icy_caves/caves/west)
 "jA" = (
-/obj/item/tool/pickaxe,
+/obj/item/tool/pickaxe/plasmacutter,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
 "jB" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"jC" = (
+/obj/machinery/vending/medical,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"jD" = (
+/obj/machinery/door/poddoor/mainship/indestructible,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "jE" = (
 /obj/structure/table/reinforced,
 /obj/effect/landmark/dropship_console_spawn_lz1,
@@ -1798,6 +2005,14 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"jI" = (
+/obj/structure/monorail,
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 4
+	},
+/turf/open/floor/mainship_hull,
+/area/icy_caves/caves/northern)
 "jJ" = (
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 8
@@ -1816,7 +2031,7 @@
 	name = "Shaft Miner"
 	},
 /obj/effect/decal/cleanable/blood,
-/obj/item/tool/pickaxe,
+/obj/item/tool/pickaxe/plasmacutter,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
 "jN" = (
@@ -1835,11 +2050,6 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
-"jR" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
 /area/icy_caves/outpost/LZ2)
 "jS" = (
 /obj/machinery/miner/damaged,
@@ -1860,9 +2070,26 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/research)
+"jX" = (
+/obj/structure/barricade/guardrail{
+	dir = 8
+	},
+/obj/structure/xenoautopsy/tank,
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
+"jY" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd{
+	dir = 8
+	},
+/area/icy_caves/caves)
+"jZ" = (
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "ka" = (
-/obj/structure/fence,
-/turf/open/floor/plating/ground/snow/layer0,
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "kb" = (
 /obj/machinery/landinglight/ds1/delayone{
@@ -1895,6 +2122,12 @@
 "kj" = (
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/refinery)
+"kk" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/mining/west)
 "kl" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice/end{
@@ -1905,91 +2138,24 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
-"ko" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/largecrate/cow,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"kp" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/radio,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"kq" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/storage/fancy/cigarettes/dromedaryco,
-/obj/item/storage/fancy/cigar,
-/obj/item/tool/lighter,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
 "kr" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
+"kt" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "ku" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/largecrate/supply/supplies/water,
+/obj/machinery/vending/dinnerware,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "kv" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/vending/snack,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "kw" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/largecrate/supply/supplies,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"kx" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/item/binoculars,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"ky" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/item/big_ammo_box,
+/obj/structure/bed/chair,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "kA" = (
@@ -2032,6 +2198,11 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
+"kL" = (
+/turf/closed/ice/thin/end{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "kM" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/singlePart{
@@ -2044,25 +2215,17 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
 "kO" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark/yellow2{
 	dir = 4
 	},
-/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"kS" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/structure/largecrate/random/case,
+"kU" = (
+/obj/machinery/vending/cigarette,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"kT" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/structure/largecrate/supply/ammo/standard_smg,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/northern)
 "kW" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -2082,6 +2245,19 @@
 	dir = 4
 	},
 /area/icy_caves/caves/east)
+"le" = (
+/obj/structure/bed/chair,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"lf" = (
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "lg" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -2103,51 +2279,45 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"ll" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/prop/mainship/hangar_stencil/two,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
 "lm" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"ln" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/largecrate/supply/supplies,
-/obj/structure/prop/mainship/hangar_stencil/two,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"lo" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/largecrate/supply/ammo/shotgun,
-/obj/structure/prop/mainship/hangar_stencil/two,
+/obj/structure/table,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "lp" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
+/obj/structure/bed/chair{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "lt" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"lu" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
+"lv" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
+"lw" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "lx" = (
 /obj/machinery/light{
 	dir = 8
@@ -2157,7 +2327,7 @@
 "lA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "lB" = (
 /obj/structure/table,
 /obj/structure/paper_bin,
@@ -2172,7 +2342,7 @@
 /turf/closed/ice/junction{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "lD" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark/brown2{
@@ -2188,6 +2358,30 @@
 	dir = 5
 	},
 /area/icy_caves/caves)
+"lH" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/space)
+"lI" = (
+/obj/structure/bookcase/manuals/research_and_development,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
+"lL" = (
+/turf/open/floor/tile/dark/red2{
+	dir = 10
+	},
+/area/icy_caves/outpost/LZ2)
 "lM" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -2211,6 +2405,16 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"lR" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 6
+	},
+/obj/structure/monorail{
+	dir = 10
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/space)
 "lS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -2218,6 +2422,14 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"lT" = (
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
+"lV" = (
+/turf/open/shuttle/dropship/floor,
+/area/space)
 "lW" = (
 /turf/closed/ice/thin/end{
 	dir = 1
@@ -2228,6 +2440,10 @@
 	dir = 6
 	},
 /area/icy_caves/caves)
+"lY" = (
+/obj/machinery/landinglight/ds1/delaytwo,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "lZ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -2236,11 +2452,28 @@
 /obj/machinery/power/apc/lowcharge{
 	dir = 8
 	},
-/turf/open/floor/tile/dark,
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
 /area/icy_caves/outpost/LZ2)
 "mb" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/outpost/LZ1)
+"mc" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern)
 "md" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/tile/dark,
@@ -2253,14 +2486,26 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/refinery)
+"mf" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/single,
+/area/icy_caves/caves)
+"mg" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "mh" = (
 /turf/closed/ice/thin/junction{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
-"mi" = (
-/turf/closed/ice/thin/end,
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/LZ2)
+"mj" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/end{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
 "mk" = (
 /obj/docking_port/stationary/marine_dropship/lz2,
 /turf/open/floor/plating,
@@ -2304,9 +2549,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"mv" = (
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves)
+"mw" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "mx" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 8
@@ -2315,65 +2562,11 @@
 "my" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"mz" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/largecrate/random/case/small,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"mA" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/largecrate/random/barrel/yellow,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"mC" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/item/tank/air,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"mD" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/largecrate/goat,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"mE" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/largecrate/random/barrel/green,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
 "mG" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/structure/dispenser,
+/turf/open/floor/tile/dark/yellow2{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/item/storage/backpack,
-/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "mH" = (
 /turf/closed/ice/corner{
@@ -2383,6 +2576,10 @@
 "mI" = (
 /turf/closed/ice/thin/end,
 /area/icy_caves/outpost/outside)
+"mJ" = (
+/obj/item/paper/crumpled/bloody,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "mK" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -2405,78 +2602,43 @@
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/caves/south)
 "mP" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"mQ" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
+"mW" = (
+/obj/item/shard,
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
+"mZ" = (
+/obj/machinery/computer3/server/rack,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
+"na" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 10
 	},
-/obj/structure/largecrate/random/barrel/white,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"mR" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
+/obj/structure/monorail{
+	dir = 6
 	},
-/obj/structure/table,
-/obj/item/pizzabox/margherita,
-/obj/item/storage/donut_box,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"mY" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/reagent_scanner/adv,
-/obj/item/storage/firstaid/o2,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"nb" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
-/obj/item/flashlight,
-/obj/structure/prop/mainship/hangar_stencil/two,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/turf/open/shuttle/escapepod/plain,
+/area/space)
 "nc" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/machinery/light/small,
-/turf/open/floor/tile/dark,
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
 /area/icy_caves/outpost/LZ2)
 "nd" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/largecrate/random/barrel/white,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"ne" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/reagent_dispensers/watertank,
-/obj/structure/prop/mainship/hangar_stencil/two,
-/turf/open/floor/tile/dark,
+/obj/structure/largecrate/random/case/double,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
 "nf" = (
-/obj/effect/decal/warning_stripes/thin{
+/turf/open/floor/tile/dark/brown2{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/table,
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/crayons,
-/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "ng" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -2486,6 +2648,16 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
+"nh" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"ni" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	on = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "nj" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
@@ -2496,33 +2668,43 @@
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/garage)
 "nl" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/table,
-/obj/item/roller,
-/obj/item/storage/firstaid,
-/obj/structure/prop/mainship/hangar_stencil/two,
-/turf/open/floor/tile/dark,
+/turf/open/floor/tile/dark/yellow2,
 /area/icy_caves/outpost/LZ2)
 "nm" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 6
 	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/largecrate/random/case,
-/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "np" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
+"nq" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/closed/ice/end{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
 "nu" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"nw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8;
+	welded = 1
+	},
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
+"nx" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "ny" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/ice_rock/single,
@@ -2531,14 +2713,17 @@
 /obj/docking_port/stationary/crashmode,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
-"nC" = (
-/turf/open/floor/plating/icefloor/warnplate,
 /area/icy_caves/outpost/LZ2)
+"nB" = (
+/obj/machinery/door/poddoor/two_tile_ver,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "nD" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "nH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -2549,6 +2734,17 @@
 "nI" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ2)
+"nJ" = (
+/obj/machinery/miner/damaged/platinum,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/northern)
+"nK" = (
+/obj/machinery/power/apc/drained{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "nL" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/outside/center)
@@ -2563,14 +2759,14 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
-"nQ" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 10
-	},
-/area/icy_caves/outpost/LZ2)
 "nS" = (
 /turf/open/floor/plating/dmg1,
 /area/icy_caves/caves/crashed_ship)
+"nT" = (
+/obj/structure/table/mainship,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "nU" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -2589,17 +2785,22 @@
 /obj/docking_port/mobile/crashmode/bigbury,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"nY" = (
+/obj/structure/barricade/guardrail{
+	dir = 1
+	},
+/obj/structure/dropship_piece/two/front,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "nZ" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside/center)
-"ob" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ2)
 "oc" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -2608,6 +2809,13 @@
 	dir = 10
 	},
 /area/icy_caves/outpost/garage)
+"oe" = (
+/obj/effect/spawner/gibspawner/human,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "of" = (
 /turf/closed/ice/thin/end{
 	dir = 4
@@ -2616,6 +2824,12 @@
 "oh" = (
 /turf/open/floor/plating/dmg3,
 /area/icy_caves/caves/crashed_ship)
+"oi" = (
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "oj" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -2641,14 +2855,40 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"op" = (
+/turf/open/floor/tile/dark/green2,
+/area/icy_caves/caves/northern)
+"oq" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "or" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"os" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "ot" = (
 /turf/closed/ice/junction,
 /area/icy_caves/caves/northern)
+"ou" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"ov" = (
+/obj/machinery/landinglight/ds1/delaythree{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "ow" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside/center)
@@ -2664,6 +2904,15 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"oC" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "oD" = (
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 1
@@ -2676,6 +2925,11 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"oG" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "104"
+	},
+/area/icy_caves/caves/northern)
 "oI" = (
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
@@ -2688,6 +2942,11 @@
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
+"oM" = (
+/turf/closed/ice/thin/end{
+	dir = 1
+	},
+/area/icy_caves/caves)
 "oO" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -2699,11 +2958,21 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"oT" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/red/full,
+/area/icy_caves/caves/northern)
 "oU" = (
 /obj/item/tool/pickaxe,
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
+"oV" = (
+/obj/structure/largecrate/random/barrel/green,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "oW" = (
 /turf/closed/ice_rock/westWall,
 /area/icy_caves/caves)
@@ -2737,6 +3006,12 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"pi" = (
+/obj/structure/dropship_piece/two/front/right,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "pj" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -2744,10 +3019,6 @@
 "pk" = (
 /turf/closed/ice/straight,
 /area/icy_caves/caves/northern)
-"pl" = (
-/obj/structure/ore_box,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
 "pm" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/cable,
@@ -2756,7 +3027,14 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
+"pn" = (
+/obj/structure/table/reinforced,
+/obj/structure/xenoautopsy,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
 "po" = (
 /turf/open/floor/tile/dark/purple2{
 	dir = 4
@@ -2767,6 +3045,13 @@
 	dir = 1
 	},
 /area/icy_caves/caves)
+"pr" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "ps" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/dmg1,
@@ -2776,7 +3061,6 @@
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/refinery)
 "pw" = (
-/obj/structure/ore_box,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -2807,11 +3091,6 @@
 /obj/item/clothing/mask/rebreather,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
-"pz" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 5
-	},
-/area/icy_caves/outpost/LZ1)
 "pB" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -2834,6 +3113,10 @@
 /obj/item/ammo_magazine/smg/m25,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"pL" = (
+/obj/structure/largecrate/supply/explosives/mortar_flare,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "pO" = (
 /obj/item/ammo_casing,
 /turf/open/floor/tile/dark,
@@ -2841,11 +3124,12 @@
 "pR" = (
 /obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "pT" = (
 /obj/effect/landmark/fob_sentry,
+/obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "pU" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -2853,6 +3137,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
+"pV" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "pX" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -2865,15 +3153,6 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
-"pZ" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 6
-	},
-/area/icy_caves/outpost/LZ1)
-"qa" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
 "qb" = (
 /obj/machinery/conveyor{
@@ -2905,7 +3184,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "qg" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plating,
@@ -2916,7 +3195,7 @@
 /area/icy_caves/outpost/mining/east)
 "qi" = (
 /obj/item/tool/pickaxe,
-/obj/structure/rack/nometal,
+/obj/structure/rack,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
 "qj" = (
@@ -2924,8 +3203,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/rack,
 /obj/item/tool/pickaxe,
-/obj/structure/rack/nometal,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
 "ql" = (
@@ -2972,6 +3251,13 @@
 	dir = 10
 	},
 /area/icy_caves/outpost/refinery)
+"qu" = (
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "qw" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1
@@ -3012,6 +3298,13 @@
 "qH" = (
 /turf/closed/ice_rock/singleT,
 /area/icy_caves/caves)
+"qI" = (
+/obj/structure/dropship_piece/one/corner/middleright,
+/obj/structure/dropship_piece/two/corner/rearright,
+/turf/open/floor/mainship_hull/dir{
+	dir = 10
+	},
+/area/icy_caves/caves/northern)
 "qJ" = (
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/dark,
@@ -3021,12 +3314,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"qM" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
 "qN" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -3055,6 +3342,16 @@
 	dir = 4
 	},
 /area/icy_caves/caves/northern)
+"qU" = (
+/obj/item/tool/surgery/circular_saw,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"qV" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "qW" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/landmark/start/job/survivor,
@@ -3115,12 +3412,25 @@
 	},
 /turf/open/floor/tile/dark/purple2,
 /area/icy_caves/outpost/research)
+"rj" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/single,
+/area/icy_caves/caves/northern)
+"rk" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/outside/center)
 "rl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
+"rm" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/cheeseburger,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "rn" = (
 /obj/structure/closet/crate/science,
 /turf/open/floor/tile/dark/purple2{
@@ -3135,7 +3445,7 @@
 /turf/closed/ice/thin/end{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "rq" = (
 /obj/structure/closet/fireaxecabinet,
 /turf/closed/wall/r_wall,
@@ -3225,6 +3535,15 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/engineering)
+"rI" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "rJ" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -3243,6 +3562,11 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/engineering)
+"rN" = (
+/obj/structure/prop/mainship/sensor_computer2,
+/obj/structure/cable,
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern)
 "rO" = (
 /obj/machinery/vending/tool,
 /obj/machinery/light{
@@ -3266,13 +3590,21 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/research)
+"rR" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "rS" = (
 /obj/structure/table,
+/obj/item/tool/pickaxe/plasmacutter,
 /obj/effect/spawner/random/powercell,
 /obj/item/clothing/head/welding,
 /obj/item/clothing/glasses/welding,
 /obj/item/explosive/plastique,
-/obj/effect/spawner/random/powercell,
 /turf/open/floor/tile/dark/yellow2{
 	dir = 1
 	},
@@ -3306,6 +3638,15 @@
 	},
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/garage)
+"rZ" = (
+/obj/structure/bookcase/manuals/research_and_development,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 9
+	},
+/area/icy_caves/caves/northern)
 "sa" = (
 /obj/machinery/door/airlock/mainship/medical/free_access,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -3313,10 +3654,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
-"sb" = (
-/obj/machinery/floodlight/landing,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "sc" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -3407,6 +3744,11 @@
 /obj/effect/landmark/corpsespawner/doctor,
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
+"ss" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "103"
+	},
+/area/icy_caves/caves/northern)
 "st" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table,
@@ -3435,6 +3777,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/ai_node,
 /turf/open/floor/tile/dark/brown2{
 	dir = 8
 	},
@@ -3462,18 +3805,20 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
-"sD" = (
-/obj/machinery/landinglight/ds1/delaythree{
-	dir = 8
-	},
+"sB" = (
+/obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/LZ2)
 "sE" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"sG" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall/unmeltable,
+/area/icy_caves/caves/northern)
 "sH" = (
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
@@ -3501,13 +3846,26 @@
 /area/icy_caves/outpost/LZ2)
 "sV" = (
 /obj/structure/rack,
-/obj/item/ammo_magazine/rifle/mpi_km,
-/obj/item/ammo_magazine/rifle/mpi_km,
-/obj/item/ammo_magazine/rifle/mpi_km,
-/obj/item/ammo_magazine/rifle/mpi_km,
-/obj/item/weapon/gun/rifle/mpi_km,
+/obj/item/ammo_magazine/rifle/ak47,
+/obj/item/ammo_magazine/rifle/ak47,
+/obj/item/ammo_magazine/rifle/ak47,
+/obj/item/ammo_magazine/rifle/ak47,
+/obj/item/weapon/gun/rifle/ak47,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"sY" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
+	dir = 8
+	},
+/area/icy_caves/caves)
+"sZ" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
+"ta" = (
+/obj/structure/mopbucket,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "tb" = (
 /obj/structure/sink,
 /obj/machinery/light{
@@ -3573,17 +3931,26 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
+"tt" = (
+/turf/open/floor/mainship/red,
+/area/icy_caves/caves/northern)
 "tv" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
 /turf/closed/ice/junction,
-/area/icy_caves/outpost/outside)
-"tw" = (
-/turf/closed/ice_rock/singleEnd{
-	dir = 1
+/area/icy_caves/outpost/LZ2)
+"tz" = (
+/obj/structure/janitorialcart,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
+"tA" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "tB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -3592,8 +3959,8 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
 "tC" = (
+/obj/structure/rack,
 /obj/structure/largecrate/random/case/small,
-/obj/structure/rack/nometal,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "tD" = (
@@ -3653,6 +4020,11 @@
 	dir = 5
 	},
 /area/icy_caves/outpost/garage)
+"tP" = (
+/obj/structure/mopbucket,
+/obj/machinery/power/apc/drained,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "tQ" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/plating,
@@ -3661,6 +4033,17 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"tS" = (
+/obj/structure/largecrate/random/barrel/yellow,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"tT" = (
+/obj/machinery/light,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "tU" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -3669,6 +4052,13 @@
 	dir = 10
 	},
 /area/icy_caves/outpost/garage)
+"tV" = (
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "tW" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -3716,6 +4106,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"ug" = (
+/turf/open/floor/tile/dark/green2{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "uh" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/green2/corner{
@@ -3730,6 +4125,21 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
+"uk" = (
+/turf/closed/ice_rock/eastWall,
+/area/icy_caves/caves/northern)
+"ul" = (
+/obj/machinery/door/airlock/mainship/security,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"um" = (
+/obj/machinery/door/airlock/mainship/maint,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"un" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/east)
 "uo" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -3752,6 +4162,16 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ2)
+"us" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd{
+	dir = 4
+	},
+/area/icy_caves/caves)
+"ut" = (
+/obj/structure/largecrate/random,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "uv" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/grilledcheese,
@@ -3768,6 +4188,10 @@
 	dir = 10
 	},
 /area/icy_caves/caves)
+"uz" = (
+/obj/item/shard,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "uA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -3788,6 +4212,22 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"uE" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"uF" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/turf/open/floor/mainship/cargo,
+/area/icy_caves/caves/northern)
 "uH" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/tile/dark/green2{
@@ -3801,7 +4241,7 @@
 /turf/closed/ice/straight{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "uN" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark,
@@ -3832,10 +4272,38 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/medbay)
+"uS" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
+"uT" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"uU" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ2)
+"uW" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/straight,
+/area/icy_caves/caves/northern)
 "uX" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
+"uY" = (
+/turf/closed/ice/junction{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "va" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/tile/dark/green2{
@@ -3883,6 +4351,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"vk" = (
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/mining/west)
 "vl" = (
 /obj/structure/curtain/medical,
 /turf/open/floor/tile/dark,
@@ -3923,11 +4395,6 @@
 /obj/structure/bed/roller,
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
-"vw" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 5
-	},
-/area/icy_caves/outpost/LZ2)
 "vx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
@@ -3958,6 +4425,10 @@
 /obj/structure/bed/chair/comfy,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"vC" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "vE" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/plating,
@@ -3967,6 +4438,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"vK" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "vL" = (
 /obj/effect/decal/cleanable/blood/gibs/robot,
 /turf/open/floor/tile/dark/brown2/corner,
@@ -3975,6 +4452,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/research)
+"vN" = (
+/obj/structure/janitorialcart,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "vP" = (
 /obj/structure/powerloader_wreckage,
 /turf/open/floor/tile/dark/brown2{
@@ -3989,7 +4470,7 @@
 "vR" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/end,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "vS" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/tile/dark,
@@ -3999,7 +4480,7 @@
 	dir = 1
 	},
 /turf/closed/ice/corner,
-/area/icy_caves/caves/east)
+/area/icy_caves/outpost/LZ2)
 "vX" = (
 /obj/item/flashlight,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4066,6 +4547,14 @@
 	dir = 8
 	},
 /area/icy_caves/caves/northern)
+"wp" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/LZ2)
+"wr" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/intersection,
+/area/icy_caves/caves/northern)
 "wu" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
@@ -4079,10 +4568,21 @@
 "wv" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/outpost/LZ2)
+"ww" = (
+/obj/item/shard,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "wx" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/refinery)
+"wy" = (
+/turf/open/floor/tile/dark/yellow2{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "wz" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -4096,16 +4596,33 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/medbay)
+"wF" = (
+/obj/structure/table/mainship,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
+"wG" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "wH" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/refinery)
-"wL" = (
-/obj/machinery/landinglight/ds1/delaythree{
-	dir = 1
+"wJ" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
+/obj/structure/table/mainship,
+/obj/structure/cable,
+/obj/machinery/computer/nuke_disk_generator/blue,
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern)
 "wM" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
@@ -4115,7 +4632,13 @@
 "wN" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
+"wO" = (
+/obj/structure/dropship_piece/two/front/left,
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "wP" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -4129,10 +4652,41 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
+"wQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"wS" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/red2{
+	dir = 5
+	},
+/area/icy_caves/outpost/LZ2)
+"wT" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "wW" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
+"wX" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
 "wZ" = (
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
@@ -4144,6 +4698,19 @@
 	dir = 1
 	},
 /area/icy_caves/caves/south)
+"xc" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/southWall,
+/area/icy_caves/caves)
+"xe" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "xf" = (
 /obj/structure/closet/secure_closet/scientist,
 /turf/open/floor/tile/dark/purple2,
@@ -4186,6 +4753,25 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
+"xo" = (
+/turf/open/floor/tile/dark/brown2{
+	dir = 9
+	},
+/area/icy_caves/outpost/LZ2)
+"xp" = (
+/obj/structure/monorail,
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 4
+	},
+/turf/open/floor/mainship_hull,
+/area/space)
+"xq" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside)
 "xr" = (
 /obj/machinery/mineral/stacking_machine,
 /obj/machinery/conveyor{
@@ -4193,6 +4779,12 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/refinery)
+"xs" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "xu" = (
 /obj/structure/cargo_container/green,
 /turf/open/floor/plating,
@@ -4206,6 +4798,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"xy" = (
+/turf/closed/ice/thin/end{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ1)
 "xA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -4228,6 +4825,15 @@
 /obj/structure/prop/mainship/hangar_stencil,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
+"xK" = (
+/turf/open/floor/tile/dark/yellow2{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
+"xL" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/caves/west)
 "xM" = (
 /turf/closed/ice/straight{
 	dir = 4
@@ -4263,6 +4869,22 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves)
+"yb" = (
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/mining/west)
+"ye" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"yf" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "yg" = (
 /obj/structure/bookcase/manuals,
 /obj/machinery/light{
@@ -4282,6 +4904,14 @@
 /obj/item/weapon/gun/smg/m25,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"yk" = (
+/obj/structure/table,
+/obj/item/corncob,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "yl" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/tile/dark/blue2{
@@ -4299,6 +4929,10 @@
 "yq" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/outpost/LZ2)
+"yv" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "yw" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/machinery/light,
@@ -4349,10 +4983,20 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
 "yL" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/machinery/landinglight/ds1/delaytwo,
+/obj/machinery/floodlight/landing,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
+"yP" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/end{
 	dir = 1
 	},
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/caves)
+"yQ" = (
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/garage)
 "yR" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -4361,6 +5005,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"yS" = (
+/obj/structure/cable,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
+"yT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside/center)
 "yU" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
@@ -4376,15 +5029,21 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/closed/ice_rock/singlePart{
-	dir = 6
+/turf/closed/ice_rock/singleEnd{
+	dir = 8
 	},
+/area/icy_caves/outpost/LZ1)
+"yY" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/outside)
-"zb" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/closed/ice_rock/fourway,
+"zd" = (
+/obj/structure/closet/l3closet/virology,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
+"ze" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/outside)
 "zh" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -4407,7 +5066,7 @@
 /turf/closed/ice/corner{
 	dir = 8
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "zm" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/drained,
@@ -4433,6 +5092,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/garage)
+"zt" = (
+/obj/structure/table/mainship,
+/obj/machinery/recharger,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "zw" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -4449,6 +5116,12 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/outside)
+"zz" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "zA" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating,
@@ -4461,17 +5134,6 @@
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"zE" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 9
-	},
-/area/icy_caves/outpost/LZ2)
-"zF" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ2)
 "zG" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
@@ -4479,6 +5141,13 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"zI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "zK" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -4491,12 +5160,6 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singlePart,
 /area/icy_caves/caves)
-"zM" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
 "zN" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
@@ -4513,11 +5176,13 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
-"zS" = (
-/turf/closed/ice/end{
-	dir = 4
+"zR" = (
+/obj/structure/monorail,
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
 	},
-/area/icy_caves/outpost/LZ1)
+/turf/open/floor/mainship_hull,
+/area/space)
 "zT" = (
 /obj/machinery/iv_drip,
 /obj/machinery/power/apc/drained{
@@ -4552,10 +5217,19 @@
 /obj/item/storage/box/flashbangs,
 /obj/item/storage/box/m94,
 /obj/item/storage/box/m94,
-/obj/structure/closet/crate/secure/phoron,
-/obj/item/stack/sheet/mineral/phoron,
+/obj/item/explosive/plastique,
+/obj/item/explosive/plastique,
+/obj/structure/closet/crate/secure/explosives,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Ab" = (
+/turf/open/shuttle/dropship/seven,
+/area/space)
+"Ac" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/northern)
 "Ad" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -4565,12 +5239,14 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/garage)
-"Ag" = (
-/obj/machinery/landinglight/ds1/delaytwo{
-	dir = 4
+"Af" = (
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
 	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
+/obj/structure/largecrate/supply/explosives,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Ah" = (
 /obj/effect/landmark/corpsespawner/security{
 	corpsebelt = /obj/item/weapon/gun/revolver/cmb;
@@ -4583,6 +5259,10 @@
 "Ai" = (
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
+"Aj" = (
+/obj/structure/barricade/guardrail,
+/turf/open/floor/mainship/red/full,
+/area/icy_caves/caves/northern)
 "Ak" = (
 /obj/machinery/sleeper,
 /turf/open/floor/tile/dark/green2{
@@ -4600,9 +5280,9 @@
 /obj/machinery/processor,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"Ap" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating,
+"An" = (
+/obj/machinery/light,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "Ar" = (
 /obj/structure/closet/crate/secure/ammo,
@@ -4693,12 +5373,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/office)
-"AH" = (
-/obj/machinery/landinglight/ds1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
 "AI" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/tile/dark/brown2/corner{
@@ -4722,6 +5396,16 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
+"AQ" = (
+/obj/machinery/landinglight/ds1{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
+"AR" = (
+/obj/machinery/light,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "AS" = (
 /obj/machinery/power/geothermal,
 /obj/machinery/light/small{
@@ -4798,6 +5482,19 @@
 	dir = 1
 	},
 /area/icy_caves/caves/east)
+"Bo" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Bp" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
 "Bq" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/prison/kitchen,
@@ -4805,6 +5502,9 @@
 "Bs" = (
 /turf/open/floor/podhatch/floor,
 /area/icy_caves/outpost/engineering)
+"Bt" = (
+/turf/closed/wall,
+/area/icy_caves/outpost/outside)
 "Bu" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -4813,6 +5513,12 @@
 	dir = 4
 	},
 /area/icy_caves/caves)
+"Bv" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Bw" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/caves/west)
@@ -4835,19 +5541,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
-"BD" = (
-/obj/structure/largecrate/random/secure,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/garage)
-"BF" = (
-/obj/effect/attach_point/weapon/dropship1{
-	dir = 8;
-	icon_state = "equip_base_l_wing"
+"BH" = (
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 1
 	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/northern)
 "BI" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -4856,15 +5554,31 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"BJ" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/mining/west)
+"BK" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "BL" = (
 /turf/closed/ice/end{
 	dir = 8
 	},
 /area/icy_caves/outpost/outside)
-"BM" = (
-/obj/docking_port/stationary/crashmode,
-/turf/closed/wall/r_wall,
-/area/icy_caves/outpost/dorms)
+"BO" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "BP" = (
 /turf/closed/ice/junction{
 	dir = 4
@@ -4889,6 +5603,15 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/engineering)
+"BT" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 6
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "BU" = (
 /obj/structure/closet/crate/science,
 /obj/item/clothing/glasses/science,
@@ -4908,15 +5631,40 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"BY" = (
-/turf/closed/ice/thin/end{
-	dir = 8
+"BZ" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
 	},
-/area/icy_caves/outpost/LZ1)
-"Cc" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/caves/northern)
+"Ca" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Ce" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern)
+"Cg" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside/center)
+"Ch" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/structure/dropship_piece/two/front,
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
 "Ci" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -4924,6 +5672,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"Cj" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Ck" = (
 /obj/machinery/science/analyser,
 /turf/open/floor/tile/dark/purple2{
@@ -4939,31 +5691,86 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
+"Cy" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
+"CB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "CC" = (
 /obj/machinery/space_heater,
 /turf/open/floor/tile/dark/purple2{
 	dir = 5
 	},
 /area/icy_caves/outpost/research)
+"CE" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "CF" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
 /obj/item/clothing/shoes/rainbow,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"CH" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
+"CI" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
+"CK" = (
+/obj/effect/decal/cleanable/mucus,
+/obj/structure/table,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "CN" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/south)
+"CO" = (
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "CP" = (
 /turf/closed/ice/thin/end{
 	dir = 1
 	},
+/area/icy_caves/outpost/LZ2)
+"CR" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ2)
 "CS" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 6
 	},
 /area/icy_caves/caves/east)
+"CU" = (
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/space/basic,
+/area/space)
 "CV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -4978,18 +5785,16 @@
 	dir = 9
 	},
 /area/icy_caves/outpost/refinery)
+"CY" = (
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "CZ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ2)
-"Da" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ1)
 "Dc" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/up,
 /turf/open/floor/tile/dark,
@@ -5006,6 +5811,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"Dh" = (
+/obj/machinery/power/apc/drained,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Di" = (
 /turf/closed/ice/corner{
 	dir = 4
@@ -5019,7 +5828,7 @@
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
 "Dk" = (
-/obj/structure/rack/nometal,
+/obj/structure/rack,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "Dl" = (
@@ -5028,6 +5837,15 @@
 	},
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
+"Dm" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "Dn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -5041,6 +5859,10 @@
 	dir = 1
 	},
 /area/icy_caves/caves)
+"Dq" = (
+/obj/structure/dropship_piece/two/corner/rearleft,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "Ds" = (
 /obj/structure/table,
 /obj/item/storage/surgical_tray,
@@ -5068,12 +5890,21 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"DA" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "DB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/singlePart{
 	dir = 1
 	},
 /area/icy_caves/caves)
+"DC" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 9
+	},
+/area/icy_caves/caves/northern)
 "DD" = (
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/outside/center)
@@ -5085,6 +5916,18 @@
 /obj/effect/decal/cleanable/blood/writing,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"DH" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/LZ2)
+"DI" = (
+/obj/structure/dropship_piece/two/front,
+/turf/closed/shuttle/dropship2/transparent{
+	icon_state = "109"
+	},
+/area/icy_caves/caves/northern)
 "DJ" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 4
@@ -5100,7 +5943,7 @@
 /turf/closed/ice/thin/corner{
 	dir = 8
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "DM" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 10
@@ -5111,12 +5954,29 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"DQ" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating/icefloor/warnplate{
+"DO" = (
+/obj/structure/morgue/crematorium,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"DS" = (
+/obj/structure/closet/crate,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick,
+/obj/item/storage/box/lightstick,
+/obj/item/tool/pickaxe/plasmacutter,
+/obj/effect/spawner/random/powercell,
+/obj/item/clothing/glasses/welding,
+/obj/item/explosive/plastique,
+/obj/machinery/light/small{
 	dir = 8
 	},
-/area/icy_caves/outpost/LZ2)
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"DT" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/LZ1)
 "DW" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -5127,6 +5987,14 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/garage)
+"DX" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "DY" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
@@ -5135,6 +6003,10 @@
 	dir = 6
 	},
 /area/icy_caves/caves/west)
+"Ea" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/eastWall,
+/area/icy_caves/caves)
 "Eb" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/effect/ai_node,
@@ -5159,6 +6031,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"Eg" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
 "Ej" = (
 /obj/structure/table,
 /obj/item/stack/nanopaste,
@@ -5176,11 +6054,15 @@
 	dir = 2
 	},
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Ep" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
+"Eq" = (
+/obj/structure/closet/l3closet/janitor,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "Er" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/snow/layer2,
@@ -5202,10 +6084,13 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"Ex" = (
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "Ey" = (
 /obj/effect/landmark/fob_sentry_rebel,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "Ez" = (
 /obj/structure/bed,
 /turf/open/floor/wood,
@@ -5246,6 +6131,14 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"EL" = (
+/obj/machinery/vending/dinnerware,
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "EM" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 10
@@ -5253,19 +6146,40 @@
 /area/icy_caves/caves/south)
 "EO" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/closed/wall/r_wall,
-/area/icy_caves/outpost/outside)
+/turf/closed/ice/thin/junction,
+/area/icy_caves/outpost/LZ1)
 "EQ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/corner{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "ES" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/closed/ice_rock/westWall,
+/area/icy_caves/caves)
+"ET" = (
+/obj/structure/largecrate/random/case/double,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
+"EU" = (
+/obj/structure/cryofeed/right{
+	name = "\improper coolant feed"
+	},
+/turf/open/floor/podhatch/floor{
+	icon_state = "bcircuitoff"
+	},
+/area/icy_caves/caves/northern)
+"EV" = (
+/obj/structure/bed/chair,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"EW" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd,
 /area/icy_caves/caves)
 "EZ" = (
 /obj/item/ammo_casing,
@@ -5305,6 +6219,10 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"Fk" = (
+/obj/structure/dropship_piece/two/corner/rearright,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "Fm" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -5357,9 +6275,27 @@
 	dir = 1
 	},
 /area/icy_caves/caves/northern)
+"Fx" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
 "Fy" = (
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
+"FA" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside/center)
+"FC" = (
+/obj/vehicle/multitile/root/cm_armored/tank{
+	dir = 1;
+	layer = 1
+	},
+/obj/structure/dropship_equipment/weapon/laser_beam_gun,
+/obj/effect/turf_overlay/shuttle/heater,
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/shuttle/dropship/floor,
+/area/space)
 "FF" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -5387,9 +6323,19 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"FM" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "FN" = (
 /obj/structure/sink{
 	dir = 4
+	},
+/obj/structure/mirror{
+	pixel_x = 24
 	},
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
@@ -5400,12 +6346,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
-"FR" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ1)
+"FT" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "FU" = (
 /obj/structure/cargo_container/ch_red,
 /turf/open/floor/plating,
@@ -5446,6 +6390,11 @@
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Gg" = (
+/turf/open/floor/tile/dark/red2{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "Gk" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -5463,6 +6412,10 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"Gn" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/tile/dark/yellow2,
+/area/icy_caves/outpost/LZ2)
 "Go" = (
 /turf/open/floor/tile/dark/purple2/corner{
 	dir = 1
@@ -5476,6 +6429,18 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
+"Gr" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside)
+"Gt" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Gu" = (
 /turf/closed/ice,
 /area/icy_caves/outpost/outside)
@@ -5486,15 +6451,23 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleT,
 /area/icy_caves/caves)
-"GC" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow,
-/area/icy_caves/outpost/LZ1)
 "GD" = (
 /turf/open/floor/tile/dark/red2/corner{
 	dir = 1
 	},
 /area/icy_caves/outpost/security)
+"GE" = (
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
+"GF" = (
+/obj/machinery/landinglight/ds1/delaythree{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "GH" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/ice,
@@ -5506,7 +6479,7 @@
 /turf/closed/ice/thin/corner{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "GK" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
@@ -5541,6 +6514,16 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"GT" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 6
+	},
+/obj/structure/monorail{
+	dir = 10
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
 "GV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -5550,7 +6533,6 @@
 	},
 /area/icy_caves/outpost/medbay)
 "GX" = (
-/obj/machinery/computer/nuke_disk_generator/blue,
 /turf/open/floor/tile/dark/purple2{
 	dir = 9
 	},
@@ -5568,6 +6550,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
+"Hb" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "Hf" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/dorms)
@@ -5590,7 +6577,7 @@
 "Hl" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "Hm" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -5604,6 +6591,15 @@
 "Hq" = (
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/caves/east)
+"Hr" = (
+/turf/closed/wall/r_wall/unmeltable,
+/area/icy_caves/caves/northern)
+"Hs" = (
+/turf/closed/ice_rock/northWall,
+/area/icy_caves/caves/west)
+"Ht" = (
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "Hu" = (
 /obj/structure/closet/crate/science,
 /turf/open/floor/tile/dark/purple2{
@@ -5615,6 +6611,13 @@
 /obj/machinery/light/small,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"Hw" = (
+/obj/machinery/vending/cola,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "HA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -5628,9 +6631,9 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "HC" = (
-/turf/closed/ice_rock/singlePart{
-	dir = 4
-	},
+/obj/machinery/power/apc/lowcharge,
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
 /area/icy_caves/outpost/LZ1)
 "HE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -5639,6 +6642,11 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
+"HF" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "HG" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/south)
@@ -5649,13 +6657,25 @@
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "HJ" = (
 /obj/machinery/vending/MarineMed/Blood,
 /turf/open/floor/tile/dark/green2{
 	dir = 4
 	},
 /area/icy_caves/outpost/medbay)
+"HK" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/corners{
+	dir = 5
+	},
+/area/icy_caves/caves)
+"HL" = (
+/obj/machinery/camera{
+	dir = 9
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "HM" = (
 /obj/item/ammo_casing,
 /turf/open/floor/tile/dark/brown2/corner{
@@ -5670,6 +6690,10 @@
 /obj/item/clothing/head/nun_hood,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"HQ" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "HR" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -5699,6 +6723,21 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"HY" = (
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/space)
+"Ia" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2;
+	name = "Canteen"
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Ib" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -5713,6 +6752,13 @@
 "Ie" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"Ig" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/blood,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "Ih" = (
 /obj/structure/cargo_container/green{
 	dir = 1
@@ -5727,9 +6773,11 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/security)
-"Im" = (
-/turf/open/floor/plating/ground/snow,
-/area/icy_caves/outpost/outside)
+"Il" = (
+/turf/closed/shuttle/dropship2/transparent{
+	icon_state = "109"
+	},
+/area/icy_caves/caves/northern)
 "In" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -5761,6 +6809,10 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/garage)
+"Iu" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "Iv" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating,
@@ -5798,6 +6850,13 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
+"IE" = (
+/obj/structure/barricade/guardrail,
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "IG" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -5816,24 +6875,42 @@
 	},
 /turf/open/floor/tile/dark/red2,
 /area/icy_caves/outpost/security)
+"II" = (
+/obj/structure/shuttle/engine/router{
+	dir = 1
+	},
+/obj/structure/dropship_equipment/weapon/heavygun,
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/shuttle/dropship/floor,
+/area/space)
 "IJ" = (
 /obj/machinery/vending/security,
 /turf/open/floor/tile/dark/red2{
 	dir = 9
 	},
 /area/icy_caves/outpost/security)
+"IM" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/LZ2)
 "IO" = (
+/obj/structure/closet/crate/construction,
+/obj/item/stack/sheet/metal/medium_stack,
+/obj/item/stack/sheet/plasteel/medium_stack,
+/obj/item/stack/sandbags_empty{
+	amount = 25
+	},
+/obj/item/stack/barbed_wire/half_stack,
 /obj/effect/landmark/excavation_site_spawner,
-/obj/structure/closet/crate/hydroponics,
-/obj/item/seeds/tomatoseed{
-	pixel_y = -5
-	},
-/obj/item/seeds/potatoseed{
-	pixel_x = -5
-	},
-/obj/item/seeds/sunflowerseed,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
+"IP" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "IR" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
@@ -5847,10 +6924,38 @@
 "IT" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"IV" = (
+/obj/structure/closet/crate,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick,
+/obj/item/storage/box/lightstick,
+/obj/item/tool/pickaxe/plasmacutter,
+/obj/effect/spawner/random/powercell,
+/obj/item/explosive/plastique,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "IX" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"IY" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"IZ" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/research_and_development,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
+"Jd" = (
+/obj/machinery/optable,
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Je" = (
 /turf/closed/ice/thin/end{
 	dir = 8
@@ -5865,6 +6970,12 @@
 "Jg" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/west)
+"Jh" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
 "Ji" = (
 /obj/effect/landmark/start/job/survivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -5890,7 +7001,7 @@
 /turf/closed/ice/thin/junction{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Jo" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
@@ -5906,11 +7017,15 @@
 /turf/closed/ice/end{
 	dir = 1
 	},
-/area/icy_caves/caves/east)
+/area/icy_caves/outpost/LZ2)
 "Jq" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"Jr" = (
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "Jv" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -5918,6 +7033,12 @@
 /obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
+"Jw" = (
+/obj/machinery/door/airlock/mainship/secure/locked/free_access{
+	dir = 2
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Jx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8
@@ -5962,19 +7083,24 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/security)
+"JI" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/corners,
+/area/icy_caves/caves/northern)
 "JJ" = (
 /turf/closed/ice/end{
 	dir = 1
 	},
 /area/icy_caves/outpost/outside/center)
+"JL" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 10
+	},
+/area/icy_caves/caves/northern)
 "JM" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
-"JN" = (
-/obj/docking_port/mobile/crashmode/bigbury,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/refinery)
 "JO" = (
 /obj/machinery/bodyscanner,
 /turf/open/floor/tile/dark/green2,
@@ -5985,6 +7111,12 @@
 	dir = 5
 	},
 /area/icy_caves/caves)
+"JQ" = (
+/obj/structure/barricade/guardrail{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "JS" = (
 /obj/structure/closet/crate/freezer/rations,
 /turf/open/floor/tile/dark,
@@ -5995,11 +7127,24 @@
 	dir = 6
 	},
 /area/icy_caves/outpost/medbay)
+"JU" = (
+/obj/item/reagent_containers/spray/pepper,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 6
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
+"JV" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "JX" = (
 /turf/closed/ice/end,
 /area/icy_caves/caves/south)
-"JY" = (
-/turf/closed/ice/thin/single,
+"JZ" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "Ka" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -6012,10 +7157,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/office)
-"Kc" = (
-/obj/structure/rack/nometal,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/garage)
 "Ke" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -6043,12 +7184,15 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"Ko" = (
-/turf/closed/ice_rock/singleEnd,
-/area/icy_caves/outpost/outside)
 "Kp" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"Kr" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Ks" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 8
@@ -6074,6 +7218,11 @@
 /obj/machinery/space_heater,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"Kz" = (
+/turf/closed/ice/thin/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "KA" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/machinery/light{
@@ -6092,6 +7241,13 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/outside)
+"KF" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "KH" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -6106,7 +7262,7 @@
 "KJ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "KK" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 1
@@ -6120,14 +7276,30 @@
 "KO" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/structure/closet/cabinet,
-/obj/item/clothing/under/colonist,
+/obj/item/clothing/suit/hgpirate,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"KQ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/corner{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
 "KS" = (
 /turf/open/floor/tile/dark/red2{
 	dir = 5
 	},
 /area/icy_caves/outpost/security)
+"KT" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/structure/monorail{
+	dir = 5
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
 "KU" = (
 /turf/closed/ice/thin/corner{
 	dir = 1
@@ -6164,6 +7336,9 @@
 /obj/item/storage/box/flashbangs,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"Li" = (
+/turf/open/floor/mainship/red/full,
+/area/icy_caves/caves/northern)
 "Lj" = (
 /obj/machinery/light{
 	dir = 8
@@ -6190,6 +7365,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
+"Ls" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside)
 "Lt" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = null;
@@ -6239,6 +7418,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"LE" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
 "LH" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
@@ -6253,6 +7438,13 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"LJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "LK" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -6268,12 +7460,10 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/garage)
-"LL" = (
-/obj/machinery/landinglight/ds1/delaytwo{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
+"LN" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall,
+/area/icy_caves/outpost/garage)
 "LO" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -6285,7 +7475,7 @@
 /turf/closed/ice/thin/end{
 	dir = 8
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "LQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -6305,6 +7495,10 @@
 	dir = 10
 	},
 /area/icy_caves/outpost/security)
+"LS" = (
+/obj/structure/prop/mainship/hangar_stencil/two,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "LT" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -6341,6 +7535,26 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"Ma" = (
+/obj/structure/barricade/guardrail,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
+"Md" = (
+/turf/closed/ice_rock/corners{
+	dir = 10
+	},
+/area/icy_caves/caves/northern)
+"Me" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Mf" = (
+/obj/structure/monorail,
+/turf/open/floor/mainship_hull,
+/area/icy_caves/caves/northern)
 "Mg" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 5
@@ -6386,10 +7600,24 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
+"Mq" = (
+/obj/structure/barricade/guardrail{
+	dir = 4
+	},
+/obj/structure/xenoautopsy/tank/escaped,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
+"Mr" = (
+/obj/structure/largecrate/random/barrel/green,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Ms" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Mt" = (
 /obj/item/ammo_casing,
 /turf/open/floor/tile/dark/red2{
@@ -6404,12 +7632,28 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"Mw" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/floor,
+/area/space)
+"Mx" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/blue2,
+/area/icy_caves/outpost/LZ2)
 "Mz" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/corner{
 	dir = 4
 	},
 /area/icy_caves/outpost/LZ1)
+"MA" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "MB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -6425,6 +7669,18 @@
 	dir = 8
 	},
 /area/icy_caves/caves/south)
+"MH" = (
+/obj/structure/largecrate/supply/medicine,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
+"MI" = (
+/obj/structure/prop/mainship/sensor_computer3/sd,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern)
 "MJ" = (
 /turf/closed/ice/corner{
 	dir = 1
@@ -6450,10 +7706,11 @@
 	},
 /area/icy_caves/caves/south)
 "MO" = (
-/obj/machinery/landinglight/ds1{
-	dir = 1
+/obj/machinery/floodlight/landing,
+/obj/machinery/landinglight/ds1/delaytwo{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "MP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -6466,6 +7723,18 @@
 /obj/machinery/space_heater,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
+"MT" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside)
+"MU" = (
+/obj/machinery/computer3/laptop,
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "MV" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -6477,6 +7746,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"MX" = (
+/obj/effect/spawner/gibspawner/human,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "MZ" = (
 /obj/machinery/door/airlock/mainship/command/free_access{
 	dir = 1;
@@ -6485,6 +7759,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
+"Nb" = (
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/caves/west)
 "Nc" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -6522,16 +7799,28 @@
 /obj/item/clothing/under/lawyer/blue,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"Nm" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/corner{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "Nn" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
+"No" = (
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Np" = (
 /turf/closed/ice/intersection,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Nq" = (
 /turf/closed/ice/end{
 	dir = 4
@@ -6545,7 +7834,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/fob_sentry,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Nt" = (
 /obj/item/ammo_magazine/smg/m25,
 /turf/open/floor/tile/dark,
@@ -6586,6 +7875,18 @@
 	},
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/refinery)
+"NF" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/corners,
+/area/icy_caves/caves)
+"NG" = (
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/caves)
+"NI" = (
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "NJ" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -6620,11 +7921,17 @@
 /obj/item/storage/box/lightstick/red,
 /obj/item/storage/box/lightstick,
 /obj/item/storage/box/lightstick,
+/obj/item/tool/pickaxe/plasmacutter,
 /obj/effect/spawner/random/powercell,
 /obj/item/clothing/glasses/welding,
-/obj/item/newspaper,
+/obj/item/explosive/plastique,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"NR" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "NS" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/structure/closet/cabinet,
@@ -6637,6 +7944,28 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/outside)
+"NU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
+"NW" = (
+/obj/machinery/door/poddoor/mainship/indestructible,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
+"NY" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "54"
+	},
+/area/icy_caves/caves/northern)
+"NZ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/single,
+/area/icy_caves/caves/northern)
 "Ob" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark,
@@ -6645,6 +7974,15 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"Od" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
 "Oe" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark/brown2{
@@ -6655,12 +7993,27 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/outside)
+"Og" = (
+/turf/closed/ice_rock/southWall,
+/area/icy_caves/caves/northern)
 "Oh" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"Ok" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Ol" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
+	dir = 5
+	},
+/area/icy_caves/caves)
 "Om" = (
 /turf/closed/ice/junction{
 	dir = 8
@@ -6678,6 +8031,10 @@
 	dir = 9
 	},
 /area/icy_caves/outpost/garage)
+"Ot" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Ou" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
@@ -6695,10 +8052,12 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Oy" = (
 /obj/docking_port/mobile/crashmode/bigbury,
-/turf/open/floor/plating/ground/snow/layer1,
+/turf/open/floor/tile/dark/red2{
+	dir = 8
+	},
 /area/icy_caves/outpost/LZ2)
 "Oz" = (
 /obj/machinery/camera/autoname/lz_camera,
@@ -6716,7 +8075,7 @@
 "OD" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "OE" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/dark/brown2,
@@ -6743,43 +8102,84 @@
 "OJ" = (
 /turf/closed/ice/end,
 /area/icy_caves/outpost/outside)
-"OL" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/docking_port/mobile/crashmode/bigbury,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside/center)
+"ON" = (
+/obj/structure/monorail,
+/obj/structure/dropship_piece/two/front,
+/turf/open/floor/mainship_hull,
+/area/icy_caves/caves/northern)
 "OO" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
+"OP" = (
+/obj/effect/landmark/fob_sentry_rebel,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/LZ1)
 "OQ" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
+"OR" = (
+/turf/closed/ice_rock/corners,
+/area/icy_caves/caves/northern)
+"OS" = (
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/space)
+"OU" = (
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "OW" = (
 /turf/closed/ice,
 /area/icy_caves/caves/east)
-"OZ" = (
-/obj/item/tool/pickaxe,
-/obj/structure/rack/nometal,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
+"OX" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/corner{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
+"OY" = (
+/obj/machinery/camera{
+	dir = 5
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Pd" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/security)
+"Pg" = (
+/turf/closed/ice_rock/corners,
+/area/icy_caves/caves/west)
 "Pi" = (
 /turf/closed/ice/corner{
 	dir = 8
 	},
 /area/icy_caves/outpost/outside/center)
+"Pj" = (
+/obj/structure/dropship_piece/one/corner/middleright,
+/obj/structure/dropship_piece/two/corner/rearright,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "Pl" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /obj/item/ammo_casing,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"Pm" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "Pn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/ai_node,
@@ -6808,6 +8208,10 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/refinery)
+"Px" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "Pz" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -6821,11 +8225,6 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
-"PB" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ1)
 "PC" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -6833,10 +8232,26 @@
 /turf/closed/ice/junction{
 	dir = 8
 	},
-/area/icy_caves/caves/east)
+/area/icy_caves/outpost/LZ2)
 "PD" = (
 /turf/closed/ice/corner{
 	dir = 4
+	},
+/area/icy_caves/caves/northern)
+"PE" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/r_wall,
+/area/icy_caves/outpost/dorms)
+"PG" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"PH" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 1
 	},
 /area/icy_caves/caves/northern)
 "PI" = (
@@ -6858,6 +8273,10 @@
 	dir = 8
 	},
 /area/icy_caves/caves)
+"PN" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/brown2,
+/area/icy_caves/outpost/refinery)
 "PO" = (
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
@@ -6890,6 +8309,10 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/security)
+"PW" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ2)
 "PX" = (
 /obj/structure/table/woodentable,
 /obj/item/flashlight/lamp,
@@ -6902,6 +8325,10 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
+"PZ" = (
+/obj/machinery/computer3/server/rack,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Qa" = (
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
@@ -6936,11 +8363,13 @@
 "Qk" = (
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"Qp" = (
-/turf/closed/ice_rock/singleEnd{
-	dir = 8
+"Ql" = (
+/obj/structure/largecrate/supply/floodlights,
+/obj/machinery/light{
+	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "Qq" = (
 /turf/closed/ice/corner{
 	dir = 4
@@ -6955,6 +8384,19 @@
 	dir = 4
 	},
 /area/icy_caves/caves/south)
+"Qy" = (
+/obj/item/lightstick/anchored,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
+"Qz" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "QA" = (
 /obj/structure/largecrate/supply/medicine,
 /turf/open/floor/plating,
@@ -7003,15 +8445,34 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
 "QM" = (
+/obj/structure/rack,
 /obj/structure/largecrate/random/case,
-/obj/structure/rack/nometal,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"QN" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/turf/open/floor/mainship/cargo,
+/area/icy_caves/caves/northern)
 "QO" = (
 /turf/closed/ice/thin/junction{
 	dir = 8
 	},
 /area/icy_caves/outpost/outside)
+"QP" = (
+/obj/structure/barricade/guardrail,
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 8
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "QR" = (
 /obj/machinery/light,
 /turf/open/floor/tile/dark/brown2,
@@ -7030,11 +8491,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"QU" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 9
-	},
-/area/icy_caves/outpost/LZ1)
+"QW" = (
+/obj/structure/ore_box,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "QX" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -7050,12 +8510,22 @@
 	dir = 4
 	},
 /area/icy_caves/caves/northern)
+"Ra" = (
+/obj/structure/table,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Rb" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
 	},
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
+"Re" = (
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/shuttle/dropship/floor,
+/area/space)
 "Rf" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/dark,
@@ -7095,6 +8565,13 @@
 /obj/machinery/space_heater,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
+"Rn" = (
+/obj/structure/dropship_piece/one/corner/middleleft,
+/obj/structure/dropship_piece/two/corner/rearleft,
+/turf/open/floor/mainship_hull/dir{
+	dir = 6
+	},
+/area/icy_caves/caves/northern)
 "Ro" = (
 /obj/structure/table,
 /obj/item/clothing/head/chefhat,
@@ -7121,6 +8598,19 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"Rs" = (
+/obj/structure/barricade/guardrail{
+	dir = 4
+	},
+/obj/item/clothing/head/warning_cone,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Rt" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/LZ2)
 "Ru" = (
 /obj/structure/table/woodentable,
 /obj/structure/paper_bin,
@@ -7130,6 +8620,11 @@
 "Rv" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves)
+"Rw" = (
+/turf/closed/ice/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "Ry" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 8
@@ -7142,9 +8637,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
-"RA" = (
-/turf/closed/ice_rock/singleT,
-/area/icy_caves/outpost/outside)
 "RB" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/brown2{
@@ -7159,6 +8651,10 @@
 	dir = 4
 	},
 /area/icy_caves/caves)
+"RE" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "RG" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 1
@@ -7181,20 +8677,31 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"RL" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 6
+	},
+/area/icy_caves/caves/northern)
 "RN" = (
 /turf/closed/ice_rock/corners{
 	dir = 5
 	},
 /area/icy_caves/caves)
+"RO" = (
+/turf/open/floor/tile/dark/blue2,
+/area/icy_caves/outpost/LZ2)
 "RP" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
 /obj/item/clothing/shoes/leather,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"RQ" = (
-/turf/closed/ice_rock/fourway,
-/area/icy_caves/outpost/outside)
+"RR" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "RS" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/southWall,
@@ -7220,10 +8727,33 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"Sc" = (
-/obj/effect/landmark/xeno_silo_spawn,
+"Sb" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Sd" = (
+/obj/machinery/power/apc/drained,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
+"Se" = (
+/obj/effect/ai_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
+"Sf" = (
+/obj/structure/largecrate/supply/floodlights,
 /turf/open/floor/plating/mainship,
-/area/icy_caves/caves/crashed_ship)
+/area/icy_caves/caves/northern)
 "Sg" = (
 /turf/closed/ice/end{
 	dir = 4
@@ -7233,8 +8763,16 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/closed/ice_rock/single,
+/turf/closed/ice_rock/singleEnd{
+	dir = 8
+	},
 /area/icy_caves/caves)
+"Si" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "Sk" = (
 /obj/machinery/space_heater,
 /turf/open/floor/tile/dark/red2{
@@ -7264,16 +8802,19 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/security)
+"Sq" = (
+/obj/effect/landmark/corpsespawner/pmc,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Sv" = (
 /turf/closed/ice_rock/singleT{
 	dir = 4
 	},
 /area/icy_caves/caves/south)
-"Sw" = (
-/turf/closed/ice_rock/singleEnd{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ1)
+"Sx" = (
+/obj/structure/largecrate/supply/medicine/medivend,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Sy" = (
 /turf/open/floor/tile/dark/green2/corner{
 	dir = 8
@@ -7305,10 +8846,28 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/closed/ice_rock/singlePart{
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/LZ1)
+"SK" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 4;
+	pixel_x = -16
+	},
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern)
+"SL" = (
+/obj/structure/barricade/guardrail{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/obj/structure/xenoautopsy/tank/alien,
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
 "SM" = (
 /obj/structure/closet/crate/internals,
 /turf/open/floor/plating,
@@ -7320,6 +8879,10 @@
 /area/icy_caves/caves/south)
 "SR" = (
 /turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/northern)
+"SS" = (
+/obj/item/paper/crumpled/bloody/csheet,
+/turf/open/floor/tile/purple/whitepurplefull,
 /area/icy_caves/caves/northern)
 "ST" = (
 /turf/closed/ice/straight{
@@ -7343,6 +8906,14 @@
 	},
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/caves)
+"SZ" = (
+/obj/structure/table/reinforced,
+/obj/item/tool/surgery/scalpel/laser3,
+/obj/item/reagent_containers/spray/pepper,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "Tb" = (
 /turf/closed/ice_rock/singleT{
 	dir = 1
@@ -7356,24 +8927,48 @@
 "Td" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
-"Tf" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
+"Te" = (
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/caves/east)
+"Tg" = (
+/turf/open/floor/tile/dark/yellow2{
+	dir = 1
 	},
-/turf/closed/ice_rock/singleEnd{
-	dir = 8
+/area/icy_caves/outpost/LZ2)
+"Ti" = (
+/turf/closed/ice/corner{
+	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
+"Tj" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "Tk" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside/center)
+"Tl" = (
+/obj/machinery/disposal,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Tm" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ1)
+"To" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Tr" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
@@ -7391,6 +8986,21 @@
 	dir = 5
 	},
 /area/icy_caves/caves)
+"Tw" = (
+/turf/open/floor/tile/dark/brown2{
+	dir = 5
+	},
+/area/icy_caves/outpost/LZ2)
+"Tz" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"TA" = (
+/turf/closed/wall,
+/area/icy_caves/caves/west)
 "TB" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -7409,26 +9019,20 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
+"TF" = (
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/caves/east)
+"TG" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside/center)
 "TH" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
-"TI" = (
-/obj/machinery/landinglight/ds1/delaytwo{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
 "TJ" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/east)
-"TL" = (
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/fire,
-/obj/structure/closet/crate/secure/surgery,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/garage)
 "TM" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/LZ1)
@@ -7436,18 +9040,19 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/turf/closed/ice/thin/straight,
+/area/icy_caves/outpost/LZ1)
 "TR" = (
 /obj/structure/table/flipped,
+/obj/machinery/computer/nuke_disk_generator/green,
 /turf/open/floor/tile/dark/red2{
 	dir = 1
 	},
 /area/icy_caves/outpost/security)
 "TT" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/turf/closed/ice/thin/straight,
+/area/icy_caves/outpost/LZ1)
 "TU" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/docking_port/mobile/crashmode/bigbury,
@@ -7471,6 +9076,10 @@
 	dir = 6
 	},
 /area/icy_caves/caves)
+"TZ" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Ub" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 1
@@ -7495,10 +9104,6 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"Ud" = (
-/obj/machinery/floodlight/landing,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/LZ1)
 "Ug" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -7511,7 +9116,7 @@
 	dir = 2
 	},
 /turf/closed/ice/intersection,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Uk" = (
 /turf/closed/ice/thin/end,
 /area/icy_caves/caves/south)
@@ -7526,14 +9131,17 @@
 	dir = 1
 	},
 /turf/closed/ice/intersection,
-/area/icy_caves/caves/east)
+/area/icy_caves/outpost/LZ2)
 "Uq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
 	},
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
+"Ur" = (
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "Us" = (
 /turf/closed/ice_rock/singleT{
 	dir = 8
@@ -7541,6 +9149,22 @@
 /area/icy_caves/caves/south)
 "Uu" = (
 /turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/LZ1)
+"Uw" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ1)
+"Ux" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Uy" = (
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "Uz" = (
 /obj/effect/decal/cleanable/blood/xeno,
@@ -7606,6 +9230,16 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/security)
+"UR" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/mainship/cargo,
+/area/icy_caves/caves/northern)
 "US" = (
 /obj/structure/table,
 /obj/item/clothing/suit/chef/classic,
@@ -7622,6 +9256,16 @@
 	dir = 8
 	},
 /area/icy_caves/caves/east)
+"UX" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/mass_spectrometer/adv,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/icy_caves/caves/northern)
 "UY" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/black,
@@ -7637,6 +9281,10 @@
 /obj/item/analyzer,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
+"UZ" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "Vb" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 10
@@ -7646,7 +9294,7 @@
 /turf/closed/ice/thin/junction{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Vd" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/corners,
@@ -7665,6 +9313,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"Vh" = (
+/obj/machinery/vending/security,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "Vi" = (
 /obj/structure/table,
 /obj/item/storage/fancy/vials,
@@ -7674,10 +9329,27 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow,
 /area/icy_caves/outpost/LZ1)
+"Vl" = (
+/obj/structure/dropship_piece/one/corner/middleleft,
+/obj/structure/dropship_piece/two/corner/rearleft,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
+"Vm" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/red/full,
+/area/icy_caves/caves/northern)
 "Vo" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"Vp" = (
+/obj/structure/largecrate/random/case,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "Vr" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -7689,7 +9361,12 @@
 /turf/closed/ice/thin/corner{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
+"Vv" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 5
+	},
+/area/icy_caves/caves/northern)
 "Vx" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -7701,16 +9378,30 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/garage)
+"Vy" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
+	dir = 4
+	},
+/area/icy_caves/caves)
 "Vz" = (
 /turf/closed/ice/thin/corner{
 	dir = 4
 	},
 /area/icy_caves/caves/south)
+"VA" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
 "VB" = (
 /turf/closed/ice/junction{
 	dir = 4
 	},
 /area/icy_caves/caves/west)
+"VC" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside/center)
 "VD" = (
 /obj/structure/largecrate/supply/medicine/iv,
 /turf/open/floor/plating,
@@ -7721,17 +9412,13 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"VG" = (
-/turf/closed/ice/thin/junction,
-/area/icy_caves/outpost/outside)
+"VH" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/LZ1)
 "VI" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/northern)
-"VJ" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ1)
 "VK" = (
 /obj/machinery/light{
 	dir = 8
@@ -7746,6 +9433,11 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/security)
+"VL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "VM" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/security)
@@ -7763,11 +9455,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/research)
-"VP" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 10
-	},
-/area/icy_caves/outpost/LZ1)
 "VQ" = (
 /turf/open/floor/tile/dark/red2{
 	dir = 4
@@ -7776,7 +9463,6 @@
 "VR" = (
 /obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	locked = 1;
 	name = "\improper Underground Security Armory"
 	},
 /obj/structure/cable,
@@ -7809,32 +9495,33 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"VZ" = (
+/obj/machinery/computer/operating,
+/obj/structure/table/reinforced,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Wa" = (
+/obj/structure/largecrate/supply/explosives,
 /obj/item/explosive/plastique,
 /obj/item/explosive/plastique,
-/obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"Wb" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
 "We" = (
 /turf/closed/ice/junction{
 	dir = 1
 	},
 /area/icy_caves/outpost/outside/center)
-"Wg" = (
-/obj/effect/landmark/fob_sentry_rebel,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
 "Wj" = (
 /turf/closed/ice/thin/end{
 	dir = 4
 	},
 /area/icy_caves/caves/south)
+"Ws" = (
+/obj/structure/table/mainship,
+/obj/item/tool/surgery/cautery,
+/obj/item/tool/surgery/retractor,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Wt" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs,
@@ -7846,7 +9533,13 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
+"Wv" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
 "Ww" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -7855,12 +9548,19 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
-"WA" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
+"Wz" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	name = "Canteen"
 	},
-/turf/closed/ice/thin/end,
-/area/icy_caves/outpost/outside)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"WB" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "WD" = (
 /turf/open/floor/plating/ground/snow,
 /area/icy_caves/outpost/LZ1)
@@ -7874,18 +9574,21 @@
 "WI" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside)
+"WJ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "WK" = (
 /turf/open/floor/mech_bay_recharge_floor,
 /area/icy_caves/outpost/LZ1)
-"WM" = (
-/obj/effect/attach_point/weapon/dropship1{
-	dir = 8;
-	icon_state = "equip_base_l_wing"
+"WN" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 10
 	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ1)
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "WQ" = (
 /turf/closed/ice/thin/end{
 	dir = 8
@@ -7914,10 +9617,22 @@
 "WY" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/medbay)
-"Xa" = (
-/obj/machinery/landinglight/ds1/delayone,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
+"WZ" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
+"Xd" = (
+/obj/machinery/miner/damaged/platinum,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Xe" = (
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "Xf" = (
 /obj/effect/landmark/start/job/survivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -7932,6 +9647,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"Xh" = (
+/obj/structure/largecrate/supply,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Xi" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -7972,18 +9691,13 @@
 	dir = 6
 	},
 /area/icy_caves/caves)
-"Xq" = (
-/obj/machinery/landinglight/ds1,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
+"Xp" = (
+/turf/closed/ice/thin,
+/area/icy_caves/outpost/LZ2)
 "Xr" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/dmg3,
 /area/icy_caves/caves/crashed_ship)
-"Xs" = (
-/obj/machinery/landinglight/ds1/delaythree,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
 "Xu" = (
 /turf/closed/ice/end{
 	dir = 1
@@ -7999,11 +9713,37 @@
 /turf/closed/ice/thin/straight,
 /area/icy_caves/caves/northern)
 "Xx" = (
-/obj/structure/closet/crate/internals,
-/obj/item/storage/box/MRE,
-/obj/item/storage/box/MRE,
+/obj/structure/closet/crate/explosives,
+/obj/item/storage/box/m94,
+/obj/item/storage/box/m94,
+/obj/item/storage/box/visual/grenade/teargas,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Xy" = (
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Xz" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"XB" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"XC" = (
+/obj/item/stool,
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "XF" = (
 /turf/closed/ice/corner,
 /area/icy_caves/caves/west)
@@ -8038,6 +9778,19 @@
 "XJ" = (
 /turf/closed/ice_rock/singleEnd,
 /area/icy_caves/caves/west)
+"XK" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/space)
 "XM" = (
 /obj/structure/bed/chair,
 /obj/effect/landmark/corpsespawner/colonist,
@@ -8063,9 +9816,9 @@
 /obj/item/storage/box/lightstick/red,
 /obj/item/storage/box/lightstick,
 /obj/item/storage/box/lightstick,
+/obj/item/tool/pickaxe/plasmacutter,
 /obj/effect/spawner/random/powercell,
-/obj/item/weapon/gun/pistol/holdout,
-/obj/item/stack/sheet/mineral/phoron,
+/obj/item/explosive/plastique,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "XS" = (
@@ -8078,7 +9831,7 @@
 /turf/closed/ice/thin/junction{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "XU" = (
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 1
@@ -8088,6 +9841,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ1)
+"XX" = (
+/turf/closed/ice_rock/eastWall,
+/area/icy_caves/caves/west)
+"XY" = (
+/obj/structure/barricade/guardrail{
+	dir = 1
+	},
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "XZ" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 4
@@ -8127,12 +9889,17 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/medbay)
-"Yj" = (
-/obj/machinery/landinglight/ds1/delaythree{
+"Yk" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Yl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/outside/center)
 "Ym" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/swat,
@@ -8145,6 +9912,12 @@
 "Yn" = (
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
+"Yo" = (
+/obj/structure/morgue{
+	dir = 2
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Yp" = (
 /turf/closed/ice/corner,
 /area/icy_caves/caves/south)
@@ -8155,20 +9928,19 @@
 /turf/closed/ice/thin/junction{
 	dir = 8
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
+"Yr" = (
+/turf/closed/ice_rock/corners{
+	dir = 10
+	},
+/area/icy_caves/caves/west)
 "Yv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
-"Yw" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/outpost/LZ2)
 "Yx" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -8198,17 +9970,29 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"YG" = (
+/obj/machinery/camera{
+	dir = 5
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "YH" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/closed/ice_rock/singleT,
-/area/icy_caves/outpost/outside)
+/turf/open/floor/plating/ground/snow,
+/area/icy_caves/outpost/LZ1)
 "YI" = (
 /turf/closed/ice/thin/end{
 	dir = 1
 	},
 /area/icy_caves/caves/west)
+"YJ" = (
+/turf/closed/ice/thin/corner{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "YK" = (
 /turf/closed/ice/end{
 	dir = 4
@@ -8218,6 +10002,24 @@
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
+"YM" = (
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
+"YN" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/structure/dropship_piece/two/front,
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
 "YO" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -8243,6 +10045,12 @@
 "YT" = (
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"YV" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "YW" = (
 /turf/closed/ice,
 /area/icy_caves/caves/south)
@@ -8298,15 +10106,22 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "Zk" = (
-/obj/machinery/button/door/open_only/landing_zone{
-	pixel_x = -5
-	},
+/obj/machinery/button/door/open_only/landing_zone,
 /obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ1)
+"Zl" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Zm" = (
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ1)
@@ -8337,6 +10152,10 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/security)
+"Zs" = (
+/obj/machinery/atmospherics/components/unary/vent_pump,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Zt" = (
 /turf/closed/ice/thin/corner,
 /area/icy_caves/caves/northern)
@@ -8374,10 +10193,17 @@
 "ZB" = (
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/caves/south)
+"ZC" = (
+/turf/closed/ice_rock/corners{
+	dir = 9
+	},
+/area/icy_caves/outpost/LZ1)
 "ZE" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
+/turf/closed/ice/thin/end{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ1)
 "ZF" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -8397,28 +10223,50 @@
 "ZI" = (
 /turf/closed/ice/straight,
 /area/icy_caves/caves/south)
-"ZK" = (
-/obj/machinery/landinglight/ds1{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
+"ZJ" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "ZL" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
+"ZM" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 10
+	},
+/obj/structure/monorail{
+	dir = 6
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
+"ZN" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/green2,
+/area/icy_caves/caves/northern)
+"ZO" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "ZP" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 4
 	},
 /area/icy_caves/caves/south)
+"ZR" = (
+/obj/machinery/space_heater,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 10
+	},
+/area/icy_caves/outpost/LZ2)
 "ZS" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "ZU" = (
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
@@ -8599,12 +10447,12 @@ YQ
 "}
 (2,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+af
+af
+af
+iF
+iF
+iF
 Yf
 Yf
 Yf
@@ -8755,6 +10603,12 @@ YQ
 "}
 (3,1,1) = {"
 YQ
+af
+am
+af
+iF
+iF
+iF
 Yf
 Yf
 Yf
@@ -8782,22 +10636,16 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+jo
+jo
+jo
+jo
+jo
+jo
+dF
+dF
+dF
+dF
 Yf
 Yf
 Yf
@@ -8911,6 +10759,12 @@ YQ
 "}
 (4,1,1) = {"
 YQ
+af
+af
+af
+iF
+iF
+iF
 Yf
 Yf
 Yf
@@ -8938,22 +10792,16 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+jo
+rZ
+BH
+gi
+Si
+GE
+jZ
+Ex
+SZ
+dF
 Yf
 Yf
 Yf
@@ -9041,25 +10889,25 @@ Zk
 Zm
 UE
 UE
+DT
 Uu
 Uu
-qz
-aG
-pq
-aI
-pq
-eY
-zS
-JY
-JY
-zS
-aG
-pq
-aI
-pq
-eY
-XH
-qz
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
 lX
 Bu
 bD
@@ -9067,6 +10915,12 @@ YQ
 "}
 (5,1,1) = {"
 YQ
+iF
+iF
+iF
+iF
+iF
+iF
 Yf
 Yf
 Yf
@@ -9094,6 +10948,16 @@ Yf
 Yf
 Yf
 Yf
+jo
+lI
+Ex
+Ex
+XC
+CK
+SS
+Ex
+mZ
+dF
 Yf
 Yf
 Yf
@@ -9159,31 +11023,15 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+NF
+NF
+NF
+NF
+NF
+NF
+NF
+NF
+NF
 Yf
 Yf
 Yf
@@ -9191,31 +11039,31 @@ qs
 uA
 TW
 qz
-UE
-WD
-Zm
-Zm
-UE
-UE
-UE
-UE
-UE
-UE
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-UE
-UE
-UE
-UE
-UE
-Uu
-Uu
-Uu
+WK
+uw
+ov
+ov
+iz
+Uy
+hT
+ov
+iz
+Uy
+hT
+ov
+Uy
+Uy
+hT
+ov
+iz
+YM
+hT
+ov
+iz
+YM
+if
+uw
+uw
 Vb
 Ww
 bD
@@ -9223,6 +11071,12 @@ YQ
 "}
 (6,1,1) = {"
 YQ
+iF
+iF
+iF
+iF
+iF
+iF
 Yf
 Yf
 Yf
@@ -9250,6 +11104,16 @@ Yf
 Yf
 Yf
 Yf
+jo
+PH
+mW
+Ex
+Ex
+Tj
+Iu
+Ex
+mZ
+dF
 Yf
 Yf
 Yf
@@ -9302,44 +11166,28 @@ Yf
 Yf
 Yf
 Yf
+oM
+oM
 Yf
 Yf
+oM
+oM
+re
 Yf
+oM
+oM
 Yf
 Yf
 Yf
+NF
 Yf
 Yf
+qy
+qy
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+NF
 Yf
 Yf
 Yf
@@ -9347,31 +11195,31 @@ qs
 ED
 qz
 UM
-WD
-WD
-WD
-GC
-WD
-UE
-WD
-WD
-WD
-UE
-UE
-UM
-fs
-UE
-UE
-UE
-UE
-UE
-WD
-WD
-GC
-UE
-Uu
-Ud
-Uu
+uw
+lY
+Yn
+Yn
+AA
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+AA
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+AA
+WT
+uw
+uw
 VU
 uc
 bD
@@ -9412,6 +11260,16 @@ Yf
 Yf
 Yf
 Yf
+jo
+pn
+Ex
+Jr
+Ex
+Ex
+JU
+cT
+CB
+dF
 Yf
 Yf
 Yf
@@ -9462,72 +11320,62 @@ Yf
 Yf
 Yf
 Yf
+oM
+YI
+YI
+YI
+ZU
+ZU
+ZU
+TA
+re
+re
+re
+oM
 Yf
 Yf
 Yf
+NF
+oM
+oM
+qy
+qy
+qy
+oM
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+NF
 Yf
 Yf
 Yf
 qy
 RC
-WD
-UE
-WK
-Yj
-Yj
-AH
-Wb
-Ag
-Yj
-AH
-Wb
-Ag
-Yj
-WK
-Wb
-Ag
-Yj
-AH
-Wb
-Ag
-Yj
-AH
-Wb
-Ag
-WK
-Uu
-Uu
+TM
+uw
+uw
+lY
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+WT
+uw
+uw
 qH
 Ww
 bD
@@ -9540,6 +11388,27 @@ Yf
 Yf
 Yf
 Yf
+jo
+jo
+jo
+jo
+jo
+jo
+jo
+jo
+jo
+jo
+jo
+jo
+jo
+jo
+jo
+jo
+jo
+jo
+jo
+jo
+jo
 Yf
 Yf
 Yf
@@ -9547,37 +11416,16 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+jo
+UX
+IZ
+Ig
+Ex
+Ex
+vK
+Ex
+ww
+dF
 Yf
 Yf
 Yf
@@ -9629,61 +11477,61 @@ Yf
 Yf
 Yf
 Yf
+ZU
+YI
+ZU
+ZU
+Nb
+Nb
+xL
+WI
+WI
+WI
+WI
+oM
 Yf
 Yf
+NF
+oM
+oM
+Za
+Za
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qy
-aG
-Ww
-Sw
-UE
+oM
+yP
+oM
+oM
+ZC
+AB
+jg
+TM
+uw
+uw
+lY
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
 WT
-QU
-VJ
-VJ
-VJ
-VJ
-VJ
-VJ
-WM
-VJ
-VJ
-FR
-VJ
-VJ
-VJ
-VJ
-VJ
-VJ
-VJ
-VJ
-VJ
-VP
-wL
-UE
-UE
+uw
+uw
 XH
 Ne
 Yf
@@ -9696,6 +11544,27 @@ Yf
 Yf
 Yf
 Yf
+jo
+rN
+SK
+lv
+BZ
+dF
+Ot
+eM
+WJ
+eM
+eM
+WJ
+eM
+CY
+Mr
+dF
+WJ
+eM
+LJ
+eM
+jo
 Yf
 Yf
 Yf
@@ -9703,37 +11572,16 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+jo
+HQ
+HQ
+dF
+Ex
+Ex
+vK
+Ex
+xs
+dF
 Yf
 Yf
 Yf
@@ -9782,44 +11630,41 @@ Yf
 Yf
 Yf
 Yf
+oM
+oM
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-VU
-qz
+ZU
+ZU
+ZU
+ZU
+ZU
+ZU
+xL
+WI
+Bt
+LE
+WI
+WI
+oM
+oM
+yP
+oM
+Bt
+Gr
+ze
+Za
+oM
+oM
+yP
+Uu
+Uu
+ZC
+ZC
 Sh
 HC
-UE
-Xa
-yL
-Yn
-AA
-Cc
+bU
+uw
+lY
 Yn
 Yn
 Yn
@@ -9834,12 +11679,15 @@ Yn
 Yn
 Yn
 Yn
-AA
 Yn
-cU
-MO
-WD
-UE
+Yn
+Yn
+Yn
+Yn
+Yn
+WT
+uw
+uw
 VU
 Ne
 Yf
@@ -9852,57 +11700,57 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-re
-re
-re
-re
-re
-re
+jo
+MI
+Ce
+Xe
+tV
+dF
+eM
+eM
+eM
+eM
+nh
+eM
+eM
+eM
+tS
+dF
+eM
+eM
+ou
+eM
+jo
+jo
+jo
+jo
+jo
+jo
+jo
+jo
+jo
+eM
+nh
+dF
+HQ
+eM
+gH
+HQ
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
 Yf
 Yf
 Yf
@@ -9939,43 +11787,40 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-aK
-VU
+YI
+ZU
+ZU
+ZU
+ZU
+ZU
+ZU
+ZU
+xL
+WI
+Eg
+SI
+SI
+SI
+SI
+SI
+Ls
+SI
+SI
+Za
+Za
+MT
+Za
+Za
+yY
+Uu
+Uu
+ZC
+Ml
 yW
 TM
-UE
-Xq
-yL
-Yn
-Yn
-hi
+bU
+uw
+lY
 Yn
 Yn
 Yn
@@ -9992,10 +11837,13 @@ Yn
 Yn
 Yn
 Yn
-cU
-zM
-UE
-UE
+Yn
+Yn
+Yn
+Yn
+WT
+uw
+uw
 bH
 Ne
 Yf
@@ -10003,62 +11851,62 @@ YQ
 "}
 (11,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-af
-af
-af
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
-dy
-dy
-dy
-dy
-dy
-dy
+Hr
+Hr
+Hr
+Hr
+Hr
+jo
+wJ
+mc
+BT
+cS
+ye
+FT
+FT
+FT
+cV
+FT
+FT
+FT
+FT
+FT
+oq
+FT
+FT
+ZJ
+eM
+IY
+eM
+eM
+OY
+WJ
+eM
+eM
+eM
+eM
+eM
+eM
+eM
+Ex
+Ex
+vK
+Ex
+eM
+eM
+eM
+eM
+WJ
+eM
+LJ
+eM
+dF
+eM
+Xy
+Tz
+DS
+IV
+dF
 bD
 Yf
 Yf
@@ -10095,39 +11943,39 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qy
-XH
-XH
-YH
+ZU
+gx
+ez
+ZU
+ZU
+ZU
+ZU
+ZU
+xL
+WI
+WI
+Ln
+SI
+SI
+SI
+SI
+Ls
+SI
+SI
+Za
+Za
+Za
+Za
+ze
+yY
+Uu
+Uu
+Uu
+Ml
+yW
 TM
+bU
 uw
-Xs
 yL
 Yn
 Yn
@@ -10139,6 +11987,7 @@ Yn
 Yn
 Yn
 Yn
+sK
 Yn
 Yn
 Yn
@@ -10148,10 +11997,9 @@ Yn
 Yn
 Yn
 Yn
-cU
-TI
-UE
-UE
+WT
+uw
+uw
 bH
 Ne
 Yf
@@ -10159,62 +12007,62 @@ YQ
 "}
 (12,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-af
-am
-af
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
-dL
-dZ
+Hr
+EU
+EU
+EU
+EU
+sG
+Vh
+Xe
+NU
+Xe
+go
+tt
+eM
+eM
+ou
+eM
+eM
+eM
+eM
+eM
+TZ
+eM
+eM
+io
+FT
+Gt
+FT
+FT
+FT
+FT
+MX
+FT
+Ca
+eM
+eM
+eM
+eM
+jh
+Ex
+vK
+Ex
+eM
+eM
+eM
+nh
+eM
+eM
+ou
+eM
+dF
+eM
+eM
 ev
 eM
 fb
-dy
+dF
 bD
 Yf
 Yf
@@ -10251,63 +12099,63 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+ZU
+ZU
+ZU
+ZU
+ZU
+ZU
 re
 re
 re
-re
-re
-re
-re
-re
-re
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-re
-qy
-qz
-qz
-qz
+WI
+WI
+SI
+Ln
+WI
+WI
+WI
+Fx
+SI
+Ln
+ze
+Za
+Za
+Za
+Za
+yY
+UE
+DT
+Uu
+Uu
 YH
 TM
-iJ
+bU
+uw
+lY
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
 WT
-yL
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-cU
-wL
-WD
-UE
+uw
+uw
 bH
 Ne
 Yf
@@ -10315,62 +12163,62 @@ YQ
 "}
 (13,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-af
-af
-af
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
-dM
-ap
+Hr
+ia
+ia
+ia
+ia
+NR
+rI
+Xe
+IP
+Se
+Li
+tt
+eM
+eM
+ou
+eM
+JV
+eM
+eM
+eM
+eM
+eM
+eM
+pr
+eM
+ev
+nh
+eM
+eM
+eM
+JV
+eM
+Kr
+FT
+FT
+FT
+FT
+FT
+FT
+il
+eM
+eM
+eM
+Xz
+eM
+JV
+eM
+ou
+eM
+Jw
+eM
+eM
 ix
 eN
 fd
-dy
+dF
 bD
 Yf
 Yf
@@ -10407,40 +12255,40 @@ Yf
 Yf
 re
 re
-re
-re
-re
-re
-re
-re
+ZU
+ZU
+ZU
+ZU
+Di
+Di
 lG
 lX
 lG
-lX
-lG
-lX
-lG
-re
-re
-re
-re
-re
-Yf
-Yf
-Yf
-Yf
-qs
-VU
-aG
-aH
-TW
-VU
-qz
+WI
+WI
+SI
+SI
+WI
+pD
+WI
+Fx
+SI
+SI
+Za
+Za
+Za
+Za
+Za
+yY
+Uu
+Uu
+Uu
+Uu
 SJ
 TM
 bU
-Xa
-yL
+uw
+lY
 Yn
 Yn
 Yn
@@ -10450,7 +12298,6 @@ Yn
 Yn
 Yn
 Yn
-sK
 Yn
 Yn
 Yn
@@ -10460,10 +12307,11 @@ Yn
 Yn
 Yn
 Yn
-cU
-MO
-UE
-UE
+Yn
+Yn
+WT
+uw
+uw
 bH
 Ne
 Yf
@@ -10471,62 +12319,62 @@ YQ
 "}
 (14,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
+Hr
+EU
+EU
+EU
+EU
+NR
+Cy
+Xe
+Xe
+Xe
+HQ
+eM
+eM
+eM
+ou
+eM
+eM
+eM
+eM
+eM
+HQ
+eM
+eM
+ou
+eM
+IY
+eM
+eM
+eM
+eM
+eM
+eM
+tA
+eM
+eM
+eM
+eM
+eM
+eM
+Kr
+FT
+hZ
+FT
+FT
+FT
+FT
+FT
+Zl
+hZ
+lu
 dN
-dP
+FT
 ew
 eP
 fe
-dy
+dF
 bD
 Yf
 Yf
@@ -10560,43 +12408,43 @@ re
 re
 re
 re
-re
-qy
-lX
-mv
-mv
-mv
-bX
-pq
-lG
+ZU
+ZU
+SF
+ZU
+ZU
+ZU
+ZU
+Di
+Mg
 ec
 Vb
 eY
-Vb
-eY
-Vb
-eY
-qz
-qz
-qz
-eY
-re
-re
-re
-re
-re
-qy
-XH
-lX
-aK
-lX
-eY
-Qh
-zb
+WI
+WI
+SI
+SI
+WI
+WI
+WI
+Fx
+SI
+SI
+Za
+Za
+oM
+qs
+WI
+Fx
+Uu
+Uu
+Uu
+Ml
+yW
 Tb
 XW
-Xq
-yL
+uw
+lY
 Yn
 Yn
 Yn
@@ -10616,10 +12464,10 @@ Yn
 Yn
 Yn
 Yn
-cU
-zM
-UE
-Uu
+Yn
+WT
+uw
+uw
 XH
 Ne
 Yf
@@ -10627,62 +12475,62 @@ YQ
 "}
 (15,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
+Hr
+ia
+ia
+ia
+ia
+jo
+Sd
+Xe
+Dm
+tT
+dF
+YV
+eM
+eM
+ou
+eM
+nh
+eM
+eM
+eM
+dF
+eM
+eM
+ou
+eM
+jo
+eM
+eM
+eM
+eM
+eM
+eM
+ou
+PG
+nK
+eM
+eM
+eM
+eM
+ou
+eM
+eM
+PG
+HL
+eM
+eM
+eM
+eM
+eM
+dF
 dO
-ea
-dQ
+Sq
+wG
 eT
 ff
-dy
+dF
 bD
 Yf
 Yf
@@ -10715,44 +12563,44 @@ TW
 dj
 Di
 XF
-Di
-XF
-qz
-mv
+DZ
 ZU
 ZU
+SF
+ZU
+gx
 ZU
 ZU
-aG
-eY
+RG
+ec
 fT
 xI
 xI
 xI
+vk
+yb
+kk
+vk
 xI
 xI
-xI
-xI
-xI
-xI
-xI
-pq
-aG
-pq
-lG
-lX
-pq
-lG
-XH
-XH
-XH
-qz
-Qp
-Tf
+gm
+SI
+SI
+WI
+oM
+Yf
+Yf
+oM
+Fx
+Uu
+Uu
+Ml
+Ml
+yW
 Ml
 XW
-Xs
-yL
+uw
+lY
 Yn
 Yn
 Yn
@@ -10772,10 +12620,10 @@ Yn
 Yn
 Yn
 Yn
-cU
-TI
-UE
-Uu
+Yn
+WT
+uw
+uw
 VU
 Ne
 Yf
@@ -10783,62 +12631,62 @@ YQ
 "}
 (16,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
+Hr
+dF
+dF
+dF
+dF
+dF
+NI
+Xe
+zt
+wF
+dF
+eM
+eM
+eM
+Ok
+eM
+eM
+eM
+eM
+AR
+dF
+Af
+Xh
+ou
+eM
+wX
+jo
+jo
+jo
+ev
+hL
+jo
+Bp
+dF
+dF
+dF
+dF
+dF
+eM
+gH
+dF
+dF
+dF
+dF
+dF
+um
+dF
+dF
+dF
+dF
 nD
-ed
-ZW
-dP
+kt
+wG
+eM
 fg
-dy
+dF
 bD
 Yf
 Yf
@@ -10870,68 +12718,68 @@ XH
 qz
 ZU
 gz
-Jg
-Jg
-DK
-ez
-ZU
-ZU
 ZU
 ZU
 ZU
 ez
+SF
 ZU
+ZU
+ZU
+ZU
+ez
+SF
 ZU
 nO
 oI
 wW
-pl
+oI
 pw
-OI
+oI
 pf
 oZ
 oK
-xI
-VU
-lX
-pq
-WS
-eY
-VU
-XH
-aG
-TW
-qz
+gm
+SI
+SI
 WI
-Wg
+oM
+Yf
+Yf
+Yf
+yP
+Uu
+OP
+Uu
+UE
 Tm
 Uu
 Vk
+uw
+lY
+Yn
+Yn
+AA
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+AA
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+AA
 WT
-yL
-Yn
-Yn
-hi
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-cU
-wL
-UE
-Uu
+uw
+uw
 qH
 Ne
 Yf
@@ -10939,62 +12787,62 @@ YQ
 "}
 (17,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
-dy
-dy
+OR
+OR
+OR
+OR
+OR
+dF
+ul
+dF
+HQ
+HQ
+dF
+Rs
+dF
+dF
+dF
+eM
+QN
+UR
+UR
+UR
+dF
+dF
+dF
+ou
+eM
+jo
+OR
+jo
+jC
+eM
+eM
+eM
+Tl
+dF
+OR
+OR
+OR
+dF
+eM
+ou
+dF
+ta
+Sf
+Ht
+Ht
+Ht
+dF
+OR
+Og
+dF
+dF
+dF
 ex
-dy
-dy
-dy
+dF
+dF
+dF
 bh
 Yf
 Yf
@@ -11012,12 +12860,12 @@ eb
 ZU
 ZU
 ZU
+SF
 ZU
 ZU
 ZU
 ZU
-ZU
-ZU
+SF
 ZU
 ZU
 ez
@@ -11026,8 +12874,8 @@ ZU
 ZU
 ZU
 ZU
-gz
-DK
+ZU
+ZU
 ez
 ZU
 dx
@@ -11036,7 +12884,7 @@ gA
 Mg
 ZU
 ZU
-ZU
+SF
 fT
 xI
 oJ
@@ -11046,48 +12894,48 @@ oI
 oI
 oI
 oI
-OZ
-xI
-eY
-bH
-VU
-XH
-aG
-aI
-TW
-qz
-WI
-WI
-WI
-XO
-TQ
+oU
+gm
+Ls
+Ls
+yP
+NF
+NF
+NF
+xc
+xc
+Uu
+Uu
+Uu
+Uu
+Tm
 Uu
 bU
-Xa
-yL
-Yn
-AA
-Cc
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-AA
-Yn
+uw
+uw
+GF
+cU
+fV
+AQ
+GF
+cU
+fV
+GF
+GF
+cU
+fV
+AQ
+GF
+cU
+fV
+AQ
+GF
+cU
+cU
 cU
 MO
-UE
-Uu
+uw
+uw
 XH
 Ne
 Yf
@@ -11095,70 +12943,70 @@ YQ
 "}
 (18,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-lX
-TW
+YQ
+YQ
+dF
+dF
+dF
+Li
+Li
+Li
+Li
+lT
+Aj
+Li
+oT
+Li
+dF
+dF
+lT
+lT
+lT
+lT
+DC
+JL
+dF
+oC
+eM
+jo
+OR
+jo
+gf
+eM
+mJ
+iV
+ou
+dF
+OR
+OR
+OR
+dF
+eM
+Kr
+Me
+pV
+pV
+WZ
+sZ
+sZ
+dF
+OR
+Og
+bI
+XP
 eg
 ZW
 eU
-VU
-lX
-lG
-bD
-Yf
-Yf
-Yf
-qy
-nM
-nM
+dw
+DZ
+Mg
+Hs
+Pg
+Pg
+Pg
+pb
+SD
+SD
 ZU
 ZU
 ZU
@@ -11168,12 +13016,12 @@ ZU
 ZU
 ez
 ZU
-ZU
+SF
 Eb
 ZU
 ZU
 gx
-ZU
+SF
 ez
 ZU
 gx
@@ -11204,117 +13052,117 @@ qo
 qO
 oU
 xI
-VU
-XH
-qH
-TW
-qz
+xq
+SI
 WI
+NG
+NG
+NG
 WI
-WI
-WI
-XO
-XO
-XO
-TQ
+NG
+Uu
+UE
+UE
+UE
+Tm
 UE
 XW
-Xq
-pz
-PB
-PB
-PB
-PB
-PB
-PB
-PB
-PB
-PB
-Da
-PB
-PB
-PB
-PB
-PB
-PB
-PB
-PB
-PB
-pZ
-zM
-UE
-Uu
+uw
+uw
+uw
+uw
+uw
+uw
+dW
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+dW
+uw
+uw
+uw
+uw
+uw
+uw
+uw
 VU
 Ne
 Yf
 YQ
 "}
 (19,1,1) = {"
-YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-bH
-ZU
-eh
+CU
+gQ
+OS
+yf
+HF
+HF
+wO
+ss
+gK
+gK
+Ur
+gK
+gK
+gK
+Vl
+ss
+gK
+NW
+NW
+jD
+jD
+jc
+Rn
+dF
+pr
+eM
+jo
+OR
+jo
+PZ
+eM
+qU
+eM
+tA
+dF
+OR
+OR
+OR
+dF
+ni
+ZJ
+dF
+tz
+ZO
+nw
+zd
+zd
+dF
+OR
+Og
+bR
+SR
+ed
 ZW
-ZU
-Vb
-aI
-eY
-bD
-Yf
-Yf
-qy
-lX
-WS
-eY
+dP
+Lx
+Ga
+ec
+Hs
+Pg
+Pg
+pb
+DZ
+Rj
+ec
 gx
 ZU
 ZU
@@ -11347,7 +13195,7 @@ Lx
 ec
 ZU
 ZU
-ZU
+gx
 da
 DK
 xI
@@ -11360,116 +13208,116 @@ pX
 oI
 oU
 xI
-eY
-aG
-eY
+SI
+SI
 WI
 WI
 WI
 WI
 WI
 WI
-WI
-XO
-XO
-TQ
+Uu
+Uu
+UE
+UE
+Tm
 WD
 XW
-WK
-Yw
-Yw
-ZK
-sD
-LL
-Yw
-ZK
-sD
-LL
-Yw
-WK
-sD
-LL
-Yw
-ZK
-sD
-LL
-Yw
-ZK
-sD
-LL
-WK
-UE
-Uu
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
 qH
 Ne
 Yf
 YQ
 "}
 (20,1,1) = {"
-YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-Vb
-TW
-ZU
+CU
+lR
+XK
+GT
+eC
+GT
+YN
+Il
+Jh
+XY
+Ur
+Ma
+Mq
+SL
+oG
+Fk
+IE
+Ab
+uS
+Ab
+Ab
+nY
+DI
+eM
+ou
+eM
+jo
+OR
+jo
+MU
+eM
+Xz
+Jd
+iP
+dF
+dF
+dF
+dF
+dF
+eM
+ou
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+OR
+Og
+bJ
+XP
+dP
 ZW
-eh
+ed
 ZU
 Di
 XF
-bh
-re
-qy
-aG
-WS
-eY
+Yr
+XX
+pb
+RG
+Rj
+ec
 ZU
 ZU
 ZU
@@ -11516,20 +13364,20 @@ qp
 oI
 oK
 xI
+SI
+SI
 XO
-XO
-XO
 WI
 WI
 WI
 WI
 WI
-WI
-AW
-XO
-XO
-TQ
+Uu
+DT
 UE
+UE
+YH
+Ml
 gI
 UE
 WD
@@ -11540,9 +13388,9 @@ uw
 uw
 uw
 uw
+dW
 uw
 uw
-sb
 dW
 HE
 uw
@@ -11552,79 +13400,79 @@ uw
 uw
 uw
 HB
-WD
-UE
-UM
-Uu
+uw
+uw
+uw
+uw
 XH
 Ne
 Yf
 YQ
 "}
 (21,1,1) = {"
-YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-Di
-eb
-ei
+CU
+xp
+zR
+jI
+Mf
+jI
+ON
+Il
+Ur
+Ur
+Px
+Ur
+Ur
+Ma
+Re
+lV
+lV
+lV
+Mw
+FC
+II
+lV
+Il
+eM
+ou
+eM
+jo
+OR
+jo
+gb
+eM
+iV
+Ws
+ou
+dF
+Sf
+Ht
+ET
+dF
+eM
+ou
+dF
+OR
+OR
+OR
+OR
+OR
+OR
+OR
+Og
+PD
+Ho
+ea
 ZW
-ZU
+dP
 Xu
 Jg
 DK
-lX
-pq
-lG
+DZ
+dh
+Mg
 fT
-XH
+dD
 ZU
 ez
 ZU
@@ -11663,12 +13511,12 @@ ZU
 gz
 XF
 xI
-oZ
+OI
 oI
 wW
 oI
-ig
-wW
+BJ
+oI
 oI
 oI
 nO
@@ -11680,12 +13528,12 @@ WI
 WI
 WI
 WI
-WI
-XO
-XO
-XO
-TQ
 Uu
+UE
+UE
+UE
+TQ
+Ml
 Vk
 XW
 bU
@@ -11708,79 +13556,79 @@ uw
 uw
 uw
 uw
-WD
-WD
-UE
-Uu
+uw
+uw
+uw
+uw
 XH
 uy
 Yf
 YQ
 "}
 (22,1,1) = {"
-YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-re
-re
-re
-re
-Yf
-Yf
-re
-re
-qy
-do
-ZU
-ZU
+CU
+na
+lH
+ZM
+KT
+ZM
+Ch
+Il
+Od
+XY
+uz
+Ma
+jX
+jX
+ss
+Dq
+QP
+Ab
+uS
+RR
+Ab
+eO
+DI
+eM
+ou
+eM
+jo
+OR
+jo
+VZ
+qU
+YG
+eM
+Ok
+dF
+oV
+Ht
+Ht
+os
+nh
+ou
+dF
+uk
+uk
+uk
+OR
+OR
+uk
+uk
+gD
+ce
+SR
+dP
 ZW
-ZU
+dP
 Xu
 Jg
 eb
-bH
-qz
-XH
-qz
-qz
+hn
+xa
+dD
+xa
+xa
 ez
 ZU
 DZ
@@ -11830,34 +13678,34 @@ xI
 xI
 Za
 SI
-Za
+XO
 XO
 WI
 WI
 WI
 XO
-XO
-XO
-XO
-XO
+UE
+UE
+UE
+UE
 LP
-UE
-UE
-UE
-WD
+VT
+VT
+VT
+VT
 WD
 uw
 vi
 WD
 WD
-WD
-UE
+AB
+AB
 AB
 Nr
 jE
 Zm
 bq
-BY
+Ml
 UE
 UE
 UE
@@ -11865,8 +13713,8 @@ WD
 uw
 uw
 Zm
-WD
-UE
+VT
+Ml
 VU
 VU
 uc
@@ -11874,65 +13722,65 @@ bD
 YQ
 "}
 (23,1,1) = {"
-YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-PD
-pk
-cJ
+CU
+gv
+HY
+Qz
+mw
+mw
+pi
+oG
+NY
+NY
+Ur
+NY
+NY
+NY
+Pj
+oG
+NY
+NW
+NW
+fU
+fU
+fU
+qI
+dF
+ou
+eM
+jo
+OR
+jo
+uE
+nh
+eM
+Yo
+eM
+dF
+dF
+dF
+dF
+dF
+eM
+ou
+dF
+bA
 bA
 Nd
-bh
-qy
-bX
-pq
-TW
-da
-eb
-ZU
+Md
+gD
+cd
+Tu
+XP
+ot
+Ho
+dP
 ZW
-ZU
+dP
 Xu
 Jg
 XF
-XH
+dD
 fi
 gp
 Sn
@@ -11969,11 +13817,11 @@ ZU
 ZU
 lj
 ZU
-ZU
+gx
 EB
 EB
 ez
-ZU
+SF
 XO
 XO
 XO
@@ -11986,43 +13834,43 @@ WI
 WI
 XO
 SI
-Za
 XO
 XO
 XO
 XO
 XO
 XO
-WI
-XO
-lW
+UE
+Uu
+UE
+AB
 Yq
 VT
-Nr
-UE
-UE
+VT
+VT
+VT
 Zm
 uw
 vi
 Zm
 Zm
-WD
-UE
+Ml
+Ml
 AB
 mb
 Nr
-TM
-TM
+JA
+JA
 JA
 fN
-mi
-UE
-Zm
+Ml
+Ml
+VT
 uw
 uw
-Zm
-UE
-aG
+VT
+Ml
+XH
 WS
 WS
 Ww
@@ -12031,60 +13879,60 @@ YQ
 "}
 (24,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-re
-qy
-ce
-PD
-cK
+YQ
+YQ
+dF
+dF
+dF
+Li
+Li
+Li
+Aj
+hW
+Aj
+Li
+Vm
+Li
+dF
+dF
+hW
+nB
+dF
+dF
+Vv
+RL
+dF
+oC
+eM
+jo
+OR
+jo
+DO
+HL
+PG
+Yo
+nK
+dF
+OR
+OR
+uk
+dF
+eM
+ou
+dF
+bM
 bM
 Fu
-qz
-lX
-TW
+bS
+bI
+XP
 qT
-cW
-dp
-ZU
-eh
+Zt
+Sg
+SR
+ed
 ZW
-ZU
+dP
 ZU
 dp
 do
@@ -12128,11 +13976,11 @@ Bw
 ZU
 ZU
 cY
-ZU
-ZU
+gx
+SF
 XO
 Za
-Za
+XO
 Za
 Za
 Dn
@@ -12148,22 +13996,22 @@ XO
 XO
 XO
 XO
-WI
-XO
-XO
-XO
-TT
+Uu
+UE
+UE
+UE
+Uw
 EQ
 XT
-TT
-TT
-ZE
+Uw
+Uw
+VH
 Hl
 HI
-ZE
-ZE
+VH
+VH
 KJ
-TT
+ZE
 ZE
 Vu
 DL
@@ -12173,10 +14021,10 @@ rp
 Vu
 vR
 TT
-ZE
+TT
 Hl
 Hl
-ZE
+TT
 TT
 TT
 PL
@@ -12192,55 +14040,55 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qy
-VU
-VU
-qz
-ce
-Sg
-yh
+dF
+um
+dF
+dF
+eM
+JQ
+JQ
+dF
+dF
+dF
+eM
+uF
+jn
+eM
+dF
+dF
+dF
+dF
+ou
+eM
+jo
+OR
+jo
+dF
+dF
+dF
+dF
+dF
+dF
+OR
+gD
+bP
+dF
+eM
+pr
+dF
+SR
 SR
 Sg
-aG
-eY
+Io
+eB
 qT
 IC
-dd
-ZU
-ZU
-ZU
+cm
+SR
+SR
+dP
 ZW
-ZU
+dP
 eh
 ZU
 dp
@@ -12285,12 +14133,12 @@ fz
 ZU
 ZU
 ja
-ZU
+SF
 XO
 XO
 XO
 oO
-Za
+XO
 Dn
 SI
 Za
@@ -12305,37 +14153,37 @@ Za
 XO
 XO
 XO
-XO
-XO
-XO
-XO
-of
-of
+UE
+UE
+UE
+UE
+xy
+xy
 Ey
-XO
-XO
-SI
-Dn
-Za
-Za
-Im
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-Za
-SI
-SI
-Za
+UE
+UE
+uw
+vi
+Zm
+Zm
+WD
+UE
+UE
+UE
+UE
+UE
+UE
+UE
+UE
+UE
+UE
+Zm
+uw
+uw
+Zm
 Ey
-XO
-XO
+UE
+UE
 qz
 bD
 Yf
@@ -12348,55 +14196,55 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-qy
-lX
-WS
-WS
-TW
-Sg
-SR
-cb
+dF
+sZ
+vN
+dF
+JV
+eM
+eM
+LJ
+eM
+eM
+eM
+eM
+eM
+eM
+eM
+WJ
+No
+eM
+Kr
+co
+jo
+OR
+OR
+OR
+OR
+OR
+OR
+OR
+uk
+gD
+bI
+Rh
+dF
+eM
+oe
+dF
+im
 SR
 SR
 SR
 cj
 IC
 cg
-df
-ZU
-ZU
-ZU
-ZW
-ZU
+bT
+SR
+SR
+dP
+dQ
+dP
 ZU
 gx
 jb
@@ -12409,14 +14257,14 @@ ZU
 ZU
 ZU
 ZU
-ZU
+SF
 ZU
 ZU
 ZU
 ZU
 gx
 ZU
-ZU
+SF
 ZU
 ZU
 ZU
@@ -12438,7 +14286,7 @@ ZU
 dE
 Sn
 xa
-xa
+dE
 ez
 ZU
 ht
@@ -12461,37 +14309,37 @@ CV
 Za
 Za
 Za
-Za
-Za
-Za
-XO
-XO
-XO
-XO
-Za
-Za
-SI
-Dn
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-SI
-SI
-Za
-Za
-Za
-XO
+Zm
+Zm
+Zm
+UE
+UE
+UE
+UE
+Zm
+Zm
+uw
+vi
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+uw
+uw
+Zm
+Zm
+Zm
+UE
 bF
 Yf
 Yf
@@ -12504,55 +14352,55 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-qy
+dF
+Ql
+sZ
+dF
+YV
+JV
+eM
+ou
+eM
+eM
+JV
+eM
+eM
+eM
+eM
+eM
+eM
+eM
+To
+eM
+jo
+OR
+OR
+OR
+OR
+OR
+uk
+gD
 PD
 Ho
-Vb
-eY
-XH
+bJ
+eB
+dF
+eM
+gH
+dF
 SR
-SR
-SR
-yh
 SR
 SR
 im
-bC
+SR
 QK
 SR
-dg
-ZU
-gx
-ZU
+SR
+SR
+im
+dP
 ZW
-ez
+CH
 ZU
 ZU
 SF
@@ -12565,14 +14413,14 @@ ZU
 ZU
 ZU
 gx
-ZU
+SF
 ZU
 ZU
 ez
 ZU
 ZU
 ZU
-ZU
+SF
 ZU
 ez
 gx
@@ -12603,8 +14451,8 @@ XO
 XO
 np
 Za
-SI
 Ln
+SI
 SI
 SI
 SI
@@ -12614,40 +14462,40 @@ SI
 SI
 SI
 pY
-Al
-vy
 vy
 Al
 vy
-vy
-vy
-vy
-vy
+JZ
+JZ
+JZ
+JZ
+JZ
+JZ
 Nn
-vy
-vy
-Al
+JZ
+JZ
+zz
 qf
-SI
-SI
-SI
-SI
-SI
-SI
-SI
-Ln
-SI
-SI
-SI
-SI
-SI
-SI
-SI
-Ln
-SI
-SI
-Ln
-XO
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+dW
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+dW
+uw
+uw
+dW
+UE
 bD
 Yf
 Yf
@@ -12660,54 +14508,54 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qy
+dF
+nT
+yv
+dF
+eM
+eM
+eM
+ou
+eM
+nh
+eM
+eM
+eM
+Sb
+Sb
+eM
+eM
+eM
+ou
+eM
+jo
+OR
+OR
+OR
+OR
+gD
 PD
 bA
 VI
 Ho
-yh
 SR
 SR
 SR
-im
+eM
+dt
+eM
 SR
-yh
 wo
 SR
 SR
 SR
-bl
+SR
 we
-dg
-ZU
-ZU
-ZU
-dQ
+SR
+SR
+SR
+dP
+ZW
 eF
 ZU
 ZU
@@ -12721,7 +14569,7 @@ ZU
 ZU
 ZU
 ZU
-ZU
+SF
 gx
 ZU
 ZU
@@ -12759,7 +14607,7 @@ XO
 XO
 XO
 XO
-qa
+XO
 XO
 XO
 XO
@@ -12773,17 +14621,17 @@ SI
 SI
 SI
 SI
-SI
-SI
-SI
-SI
-SI
-SI
-Dn
-SI
-SI
-SI
-SI
+uw
+uw
+uw
+uw
+uw
+uw
+vi
+uw
+uw
+uw
+uw
 SI
 SI
 SI
@@ -12800,10 +14648,10 @@ SI
 SI
 SI
 SI
-SI
-SI
-SI
-XO
+uw
+uw
+uw
+UE
 bD
 Yf
 Yf
@@ -12816,55 +14664,55 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
+dF
+tP
+zI
+dF
+eM
+eM
+eM
+Kr
+FT
+FT
+FT
+FT
+KF
+lu
+lu
+EV
+FT
+FT
+ZJ
+eM
+jo
+OR
+OR
+OR
+Og
 PD
 Fu
 ot
 by
-bl
-yh
+SR
+SR
 SR
 im
-SR
-bl
-ok
-cO
+eM
+ou
+eM
+pk
 VI
 Nd
 SR
 SR
 SR
 SR
-dg
-gx
-ZU
-ZU
+SR
+im
+SR
+dP
 ZW
-ZU
+dP
 ZU
 ZU
 dx
@@ -12896,7 +14744,7 @@ ZU
 ZU
 ez
 ZU
-ZU
+SF
 ZU
 ZU
 ZU
@@ -12910,7 +14758,7 @@ ZU
 ZU
 YI
 cY
-ZU
+SF
 XO
 XO
 XO
@@ -12934,12 +14782,12 @@ XO
 XO
 XO
 XO
-SI
-Dn
-Za
-Za
-Za
-Za
+uw
+vi
+Zm
+Zm
+Zm
+Zm
 XO
 XO
 XO
@@ -12972,55 +14820,55 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
+dF
+Eq
+WB
+Me
+FT
+FT
+FT
+ZJ
+eM
+qu
+PG
+eM
+Bv
+dF
+dF
+le
+eM
+eM
+ou
+eM
+jo
+OR
+OR
+OR
+Og
 ce
 ot
 by
 hX
 SR
-yh
+SR
 SR
 wo
-GH
+Xd
+ou
+eM
 SR
-SR
-yh
 Lm
 by
 SR
 SR
 SR
 SR
-DZ
-Mg
-ZU
-ZU
+bI
+bL
+SR
+dP
 ZW
-ZU
+dP
 ZU
 Xu
 Jg
@@ -13052,21 +14900,21 @@ ZU
 ZU
 kE
 ZU
+SF
+ZU
+ZU
+ZU
+gx
 ZU
 ZU
 ZU
 ZU
-ZU
-ZU
-ZU
-ZU
-ZU
-ZU
-ZU
+SF
+gx
 ez
 ZU
 ZU
-ZU
+SF
 ZU
 XO
 AW
@@ -13128,55 +14976,55 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
+dF
+dF
+dF
+jo
+eM
+eM
+eM
+ou
+dF
+dF
+dF
+pL
+eM
+XB
+Ux
+eM
+eM
+eM
+ou
+nh
+jo
+OR
+OR
+OR
+Og
 ce
 ce
 SR
 im
 SR
-yh
+SR
 PD
 Fu
+eM
+ou
+AR
+dF
 SR
-bl
 SR
-yh
-SR
-bl
 im
 SR
-bl
+SR
 Io
-Rj
-Rj
-Mg
-ZU
+Rh
+Rh
+bL
+dP
 ZW
-ZU
+dP
 Xu
 VB
 Jg
@@ -13217,12 +15065,12 @@ ZU
 Qd
 ZU
 ZU
+SF
 ZU
 ZU
 ZU
-ZU
-ZU
-ZU
+gx
+SF
 ZU
 WI
 WI
@@ -13287,50 +15135,50 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qy
+jo
+eM
+eM
+eM
+ou
+dF
+OR
+dF
+Xh
+eM
+eM
+eM
+eM
+eM
+eM
+ou
+AR
+jo
+OR
+OR
+OR
+gD
 ce
 Sg
 SR
-bC
 SR
-kl
+SR
+ok
 bM
 VI
-Nd
+eM
+ou
+eM
 SR
-wo
-yh
-yh
-yh
-yh
-yh
-cN
-cP
-Lx
-Rj
-ec
-ZU
+SR
+SR
+SR
+SR
+qT
+Zt
+bJ
+Rh
+eB
+dP
 ZW
 eS
 dy
@@ -13395,7 +15243,7 @@ Pq
 XU
 DY
 DY
-gB
+PN
 wx
 lB
 lM
@@ -13410,7 +15258,7 @@ XO
 WI
 KZ
 Lu
-TL
+Sm
 tQ
 tQ
 Sm
@@ -13443,39 +15291,39 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-qz
+jo
+eM
+eM
+eM
+ou
+dF
+OR
+dF
+Sx
+JV
+eM
+eM
+eM
+eM
+eM
+pr
+eM
+jo
+OR
+OR
+Og
+bS
 Sg
 SR
 SR
 im
 SR
-cs
+bN
 bN
 Lm
-VI
-pk
-VI
+eM
+ou
+eM
 Ho
 SR
 SR
@@ -13483,12 +15331,12 @@ SR
 qT
 bT
 KU
-EB
-dD
-gx
-ZU
+Zt
+Ry
+im
+dP
 ZW
-ZU
+dP
 YI
 ft
 EB
@@ -13596,55 +15444,55 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-VU
+NF
+NF
+NF
+yS
+vC
+vC
+vC
+DX
+VA
+JI
+VA
+dF
+eM
+dF
+dF
+eM
+eM
+Xz
+ou
+eM
+jo
+OR
+OR
+Og
+bP
 qT
 rf
 SR
 SR
 cj
-ct
+bT
 cn
 bN
-Sg
-bN
-Sg
-SR
+eM
+ou
+eM
+rf
 SR
 im
 SR
 KU
 Zt
 qT
-de
-ZU
-ZU
-ZU
+cm
+SR
+SR
+dP
 ZW
-ZU
+dP
 ZU
 dE
 de
@@ -13752,42 +15600,42 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-nM
+NF
+jo
+jo
+jo
+HQ
+eM
+Ia
+uT
+dF
+OR
+JI
+dF
+eM
+dF
+dF
+eM
+eM
+eM
+ou
+eM
+jo
+OR
+OR
+Og
+QZ
 KU
 rf
 SR
 Zb
 SR
-cs
-cn
-cn
 bN
 cn
-qT
+cn
+eM
+ou
+eM
 rf
 SR
 SR
@@ -13795,12 +15643,12 @@ SR
 Zb
 KU
 IC
-Bw
-EB
-BQ
-ZU
+IC
+Zt
+Zb
+dP
 ZW
-gx
+eF
 ZU
 YI
 de
@@ -13838,7 +15686,7 @@ ft
 EB
 ZU
 ZU
-ZU
+gx
 Xu
 Jg
 xP
@@ -13859,7 +15707,7 @@ DY
 sl
 DY
 DY
-JN
+DY
 yK
 DY
 DY
@@ -13908,42 +15756,42 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-qH
-TW
+NF
+jo
+eM
+WJ
+eM
+ug
+ug
+ou
+dF
+dF
+VA
+dF
+YV
+eM
+eM
+eM
+eM
+eM
+ou
+eM
+jo
+OR
+OR
+Og
+cc
+XP
 SR
 SR
 SR
 cj
-cv
+cg
 IC
-IC
-bT
-cn
-KU
+ci
+eM
+ou
+eM
 rf
 SR
 SR
@@ -13951,12 +15799,12 @@ SR
 SR
 SR
 KU
-cY
-dE
-Sn
-ZU
+bT
+KU
+rf
+dP
 ZW
-ZU
+dP
 ZU
 fi
 de
@@ -14064,42 +15912,42 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-qy
-qH
-lG
-bp
+NF
+jo
+eM
+wQ
+eM
+Xz
+eM
+Bo
+eM
+eM
+VA
+eM
+Zs
+FT
+FT
+FT
+FT
+FT
+ZJ
+eM
+jo
+OR
+uk
+gD
+cc
+bL
+im
 SR
-bl
+SR
 cj
-cw
+Ir
 cm
 ci
-Xw
-Xw
-rf
+eM
+ou
+eM
 SR
 Zb
 SR
@@ -14107,12 +15955,12 @@ SR
 PD
 Nd
 PD
-XF
-Di
-eb
-ZU
+Nd
+PD
+Ho
+dP
 ZW
-ZU
+dP
 YI
 fz
 cY
@@ -14157,7 +16005,7 @@ dp
 gS
 dD
 ZU
-ZU
+gx
 ZU
 dx
 xa
@@ -14220,42 +16068,42 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
+NF
+jo
+OU
+OU
+eM
+eM
+Cj
+CO
+OU
+eM
+mg
+eM
+eM
+eM
+eM
+eM
+eM
+eM
+ou
+AR
+jo
+Og
 PD
 Nd
-Vb
-eY
+bJ
+eB
 SR
 SR
 bI
 XP
-cx
 QK
-cn
-qT
-Zt
-qT
+QK
+dF
+YV
+ou
+eM
 rf
 PI
 PI
@@ -14263,12 +16111,12 @@ PI
 Lm
 VI
 Fu
-da
-DK
-ZU
-ZU
+ot
+by
+SR
+dP
 ZW
-ZU
+dP
 Xu
 xP
 xP
@@ -14376,42 +16224,42 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
+NF
+jo
+rm
+Ra
+eM
+JV
+eM
+yk
+rm
+ZN
+Wz
+eM
+eM
+eM
+eM
+eM
+eM
+nh
+pr
+eM
+jo
+Og
 ce
 Lm
 Nd
-yh
-yh
-yh
+SR
+SR
+SR
 bR
 bI
 Tu
 bL
 ci
-cm
-KU
-bT
+eM
+ou
+eM
 SR
 SR
 SR
@@ -14419,12 +16267,12 @@ SR
 SR
 Sg
 Lm
-DK
-ZU
-ZU
-ZU
+by
+SR
+SR
+dP
 ZW
-ZU
+dP
 ZU
 RG
 fB
@@ -14532,28 +16380,28 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-re
-re
-re
-re
-qy
+NF
+jo
+Ra
+Ra
+eM
+nh
+eM
+FM
+Ra
+op
+vC
+eM
+eM
+eM
+eM
+eM
+eM
+eM
+ou
+eM
+jo
+gD
 ce
 PD
 by
@@ -14565,9 +16413,9 @@ Rh
 XP
 QZ
 QK
-QK
-SR
-SR
+eM
+pr
+eM
 SR
 im
 bl
@@ -14575,12 +16423,12 @@ SR
 SR
 SR
 im
-ZU
-ZU
-ZU
-ZU
+SR
+SR
+SR
+dP
 ZW
-ez
+CH
 ZU
 RG
 fS
@@ -14612,7 +16460,7 @@ ZU
 ZU
 ZU
 ZU
-ZU
+SF
 ZU
 ZU
 ZU
@@ -14663,8 +16511,8 @@ Dk
 Aa
 Qa
 bE
-Qa
 Id
+Dk
 Nc
 XR
 tQ
@@ -14688,27 +16536,27 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-lX
-pq
-TW
-bX
-lG
+NF
+jo
+oi
+oi
+wQ
+eM
+eM
+lf
+oi
+eM
+mg
+qu
+PG
+eM
+eM
+eM
+eM
+eM
+ou
+eM
+jo
 PD
 by
 Sg
@@ -14721,7 +16569,9 @@ bR
 Io
 Rh
 XP
-im
+wQ
+ou
+eM
 SR
 SR
 SR
@@ -14731,12 +16581,10 @@ SR
 SR
 SR
 SR
-ZU
-ZU
-ZU
-ZU
+SR
+dP
 rP
-ZU
+dP
 RG
 fB
 Rj
@@ -14768,8 +16616,8 @@ ZU
 gx
 ZU
 ZU
-ZU
-ZU
+SF
+gx
 ZU
 ZU
 ZU
@@ -14819,8 +16667,8 @@ xu
 Ar
 yj
 bE
-SM
 VE
+yQ
 Nc
 tQ
 LO
@@ -14844,27 +16692,27 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-bH
-qT
-Ir
-Zt
-XH
+NF
+jo
+Dh
+eM
+Zs
+FT
+FT
+eP
+wQ
+AR
+yS
+jo
+jo
+jo
+jo
+eM
+eM
+eM
+ou
+eM
+jo
 ot
 Ho
 SR
@@ -14876,10 +16724,10 @@ cc
 Rh
 XP
 Ry
-SR
-SR
-SR
-SR
+eM
+eM
+ou
+eM
 bN
 SR
 SR
@@ -14887,12 +16735,12 @@ SR
 wo
 SR
 PD
-XF
-ZU
-ZU
-ZU
+Nd
+SR
+SR
+dP
 ZW
-ZU
+dP
 DZ
 Rj
 Rj
@@ -15000,42 +16848,42 @@ Yf
 Yf
 Yf
 Yf
+NF
+jo
+eM
+eM
+EL
+Hw
+kU
+eM
+eM
+eM
+yS
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-qy
-bH
-KU
-IC
-IC
-Zt
-Sg
+OR
+jo
+YV
+eM
+eM
+ou
+eM
+IY
 SR
 SR
 SR
 SR
 SR
+dF
 Io
 ca
 Ry
 bS
 SR
-im
-SR
-SR
-qT
+wQ
+eM
+ou
+eM
 cm
 SR
 SR
@@ -15043,12 +16891,12 @@ ok
 VI
 bA
 VI
-Om
-XF
-ZU
-ZU
+bM
+Nd
+SR
+dP
 ZW
-ZU
+dP
 Lx
 Ga
 Ga
@@ -15139,14 +16987,14 @@ Qa
 Qa
 LO
 vq
-KZ
-XO
-SI
-SI
-Za
-XO
-bD
-Yf
+LN
+hC
+Ls
+Ls
+yY
+hC
+ik
+NF
 YQ
 "}
 (44,1,1) = {"
@@ -15156,42 +17004,42 @@ Yf
 Yf
 Yf
 Yf
+NF
+yS
+yS
+yS
+yS
+yS
+yS
+yS
+yS
+yS
+yS
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-lX
-pq
-WS
-TW
-KU
-cg
-bT
-SR
-im
-SR
-bP
-SR
-SR
-SR
-bJ
-XP
-SR
-SR
-SR
-SR
-cj
-IC
+Og
+jo
+LJ
+eM
+eM
+ou
+eM
+ee
+eM
+wQ
+eM
+eM
+eM
+WJ
+eM
+eM
+eM
+eM
+eM
+LJ
+eM
+ou
+jo
 bT
 SR
 SR
@@ -15199,12 +17047,12 @@ ok
 VI
 bM
 by
-Di
-DK
-xa
-ZU
+PD
+by
+bS
+dP
 ZW
-ZU
+dP
 gx
 ZU
 ZU
@@ -15295,14 +17143,14 @@ Is
 Zc
 RJ
 KZ
-KZ
+LN
 XO
 SI
 SI
 Za
 XO
 bD
-Yf
+NF
 YQ
 "}
 (45,1,1) = {"
@@ -15325,29 +17173,29 @@ Yf
 Yf
 Yf
 Yf
-qs
-bH
-lX
-eY
-SR
-SR
-SR
-SR
-SR
-SR
-Io
-eB
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-PD
-Nd
-QK
+Og
+jo
+WN
+FT
+FT
+Yk
+FT
+VL
+FT
+FT
+FT
+FT
+FT
+ef
+FT
+FT
+FT
+FT
+FT
+Zl
+FT
+wT
+jo
 SR
 im
 SR
@@ -15355,12 +17203,12 @@ SR
 Lm
 Nd
 PD
-DK
-dw
-dw
-ZU
+by
+bP
+bP
+dP
 ZW
-ez
+dP
 ZU
 ZU
 ZU
@@ -15386,9 +17234,9 @@ Lx
 Mg
 dE
 Sn
-ZU
-ZU
-ZU
+SF
+SF
+SF
 dE
 Bw
 Bw
@@ -15443,22 +17291,22 @@ KZ
 KZ
 KZ
 tI
-BD
-Kc
+xR
+xR
 iZ
 KZ
 KZ
 KZ
 KZ
 KZ
-WI
+Fx
 XO
 SI
 SI
 Za
 XO
 lX
-TW
+EW
 YQ
 "}
 (46,1,1) = {"
@@ -15482,28 +17330,28 @@ Yf
 Yf
 Yf
 qs
-bH
-bH
-SR
-bp
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-bl
-SR
-im
-we
-SR
-SR
-ok
-VI
-VI
-Ho
+jo
+eM
+eM
+JV
+eM
+eM
+MA
+eM
+eM
+eM
+eM
+eM
+eM
+eM
+wQ
+CE
+eM
+eM
+nq
+jo
+jo
+jo
 SR
 SR
 SR
@@ -15516,7 +17364,7 @@ Rj
 dy
 ej
 ZW
-ZU
+dP
 fi
 ft
 EB
@@ -15607,14 +17455,14 @@ li
 li
 li
 li
-li
+rk
 li
 my
 my
 DD
-li
+DD
 Vb
-lG
+Ol
 YQ
 "}
 (47,1,1) = {"
@@ -15638,13 +17486,13 @@ Yf
 Yf
 re
 qy
-bH
-XH
-SR
-SR
-SR
-PD
-Nd
+jo
+IY
+ev
+iM
+IY
+jo
+jo
 aX
 bN
 bN
@@ -15670,9 +17518,9 @@ Tu
 dh
 Ga
 dD
-ZU
+dP
 ZW
-ZU
+dP
 dE
 Bw
 fz
@@ -15763,14 +17611,14 @@ my
 my
 my
 my
-my
+VC
 my
 my
 Iw
 DD
-li
-ow
-nM
+ip
+DD
+Vy
 YQ
 "}
 (48,1,1) = {"
@@ -15798,7 +17646,7 @@ XH
 SR
 SR
 SR
-PD
+SR
 VI
 VI
 Nd
@@ -15806,7 +17654,7 @@ ci
 IC
 cm
 qT
-rf
+SR
 SR
 cq
 SR
@@ -15826,9 +17674,9 @@ Tu
 dh
 XJ
 ZU
-ZU
+dP
 ZW
-ZU
+dP
 fi
 Bw
 ft
@@ -15919,14 +17767,14 @@ my
 my
 my
 my
+VC
 my
-my
-my
+yT
 my
 DD
-li
-li
-nM
+TG
+DD
+Vy
 YQ
 "}
 (49,1,1) = {"
@@ -15982,9 +17830,9 @@ Zt
 dj
 dx
 ZU
-ZU
+dP
 ZW
-BQ
+Qy
 dE
 cY
 dE
@@ -16075,14 +17923,14 @@ li
 li
 li
 li
-li
-li
+rk
+DD
 my
 my
 DD
+ip
 DD
-li
-XH
+jY
 YQ
 "}
 (50,1,1) = {"
@@ -16138,9 +17986,9 @@ QK
 Xu
 Jg
 eb
-ZU
+dP
 ZW
-ZU
+dP
 ZU
 Xu
 xP
@@ -16231,14 +18079,14 @@ ND
 ND
 ND
 ND
-ND
-li
+PE
+ip
 my
 my
 DD
 DD
-li
-qz
+DD
+mf
 YQ
 "}
 (51,1,1) = {"
@@ -16294,9 +18142,9 @@ Ir
 EB
 do
 dj
-ZU
+dP
 ZW
-ZU
+dP
 ZU
 Xu
 xP
@@ -16387,14 +18235,14 @@ Hf
 JC
 wZ
 Ez
-ND
-li
-my
-my
+PE
 DD
-li
-li
-qz
+my
+my
+ip
+DD
+DD
+mf
 YQ
 "}
 (52,1,1) = {"
@@ -16450,9 +18298,9 @@ IC
 de
 do
 ZU
-ZU
+dP
 ZW
-ZU
+dP
 DZ
 Mg
 fT
@@ -16543,14 +18391,14 @@ Zq
 wZ
 wZ
 LC
-ND
-li
+PE
+DD
 my
 my
 DD
-li
-ow
-VU
+DD
+DD
+us
 YQ
 "}
 (53,1,1) = {"
@@ -16606,9 +18454,9 @@ cg
 ME
 xb
 Yp
-ym
+Td
 gG
-ym
+Td
 EM
 fC
 dC
@@ -16699,14 +18547,14 @@ Hf
 Ze
 wZ
 Ez
-ND
-li
-my
-my
+PE
 DD
-li
-li
-qH
+my
+my
+ip
+DD
+DD
+iB
 YQ
 "}
 (54,1,1) = {"
@@ -16762,9 +18610,9 @@ Tu
 fx
 Qw
 MM
-ym
+Td
 gG
-ym
+Td
 YS
 KK
 Iy
@@ -16790,9 +18638,9 @@ dC
 dC
 hb
 Yp
-ym
-ym
-ym
+ij
+ij
+ij
 YS
 gT
 ZB
@@ -16855,14 +18703,14 @@ Hf
 Hf
 Hf
 Hf
-ND
-li
+PE
+DD
 my
 my
 DD
 DD
 li
-bH
+sY
 YQ
 "}
 (55,1,1) = {"
@@ -16918,9 +18766,9 @@ qT
 Uk
 YK
 ym
-ym
+Td
 gG
-ym
+Td
 ym
 fF
 UL
@@ -17011,14 +18859,14 @@ Hf
 KO
 Cs
 Ez
-ND
-li
-my
-my
-DD
-DD
-li
-bH
+PE
+rk
+VC
+VC
+FA
+FA
+rk
+sY
 YQ
 "}
 (56,1,1) = {"
@@ -17072,11 +18920,11 @@ SR
 qT
 IC
 Uk
-dz
 ym
 ym
+Td
 gG
-ym
+Td
 ym
 ym
 Wj
@@ -17223,7 +19071,7 @@ ci
 rf
 SR
 SR
-SR
+im
 SR
 cn
 QK
@@ -17408,7 +19256,7 @@ ym
 ym
 ym
 ym
-ym
+Be
 ym
 gX
 ym
@@ -17423,7 +19271,7 @@ li
 lx
 li
 li
-li
+Yl
 li
 li
 lx
@@ -17458,7 +19306,7 @@ DD
 DD
 DD
 my
-OL
+HA
 li
 YA
 YL
@@ -17552,7 +19400,7 @@ Td
 Qs
 Td
 Td
-Td
+Qs
 fE
 Td
 Td
@@ -17585,7 +19433,7 @@ my
 my
 my
 my
-my
+yT
 my
 my
 my
@@ -17879,7 +19727,7 @@ Td
 Td
 Td
 Td
-Td
+Qs
 Td
 Td
 Td
@@ -17887,7 +19735,7 @@ Td
 xE
 my
 my
-my
+yT
 my
 my
 my
@@ -18002,7 +19850,7 @@ pk
 Ho
 SR
 SR
-SR
+im
 SR
 SR
 wo
@@ -18020,7 +19868,7 @@ Be
 ym
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -18052,7 +19900,7 @@ li
 li
 li
 li
-li
+Yl
 li
 li
 li
@@ -18848,7 +20696,7 @@ my
 my
 my
 my
-my
+Cg
 Iw
 my
 my
@@ -18980,7 +20828,7 @@ Xj
 Je
 ym
 ym
-ym
+Be
 ym
 Wj
 fh
@@ -19021,7 +20869,7 @@ li
 HA
 my
 li
-BM
+ND
 Ez
 wZ
 tk
@@ -19076,12 +20924,12 @@ pk
 pk
 pk
 Ho
-yh
-yh
-yh
-yh
-yh
-yh
+SR
+SR
+SR
+SR
+SR
+SR
 bP
 aX
 Zy
@@ -19120,7 +20968,7 @@ xX
 xX
 hv
 ST
-YW
+fX
 YW
 YW
 YW
@@ -19294,7 +21142,7 @@ Uk
 ym
 cl
 ym
-ym
+Be
 dT
 Wj
 SA
@@ -19391,7 +21239,7 @@ bZ
 Rh
 XP
 SR
-bC
+SR
 SR
 Io
 Rh
@@ -19404,7 +21252,7 @@ cc
 eB
 SR
 SR
-SR
+im
 SR
 cj
 Ir
@@ -19661,7 +21509,7 @@ tg
 tg
 Hf
 Dl
-aZ
+Fy
 FN
 ND
 li
@@ -19701,12 +21549,12 @@ VI
 VI
 Nd
 Ry
-yh
-yh
-yh
-yh
-yh
-cp
+SR
+SR
+SR
+SR
+SR
+Zb
 qT
 Zt
 qT
@@ -19920,7 +21768,7 @@ YW
 hb
 Yp
 ym
-ym
+Be
 ym
 ym
 Ps
@@ -20189,7 +22037,7 @@ SR
 bl
 SR
 SR
-SR
+im
 SR
 SR
 SR
@@ -20285,7 +22133,7 @@ tg
 Ky
 Hf
 Dl
-aZ
+Fy
 FN
 ND
 li
@@ -20359,7 +22207,7 @@ Ps
 ym
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -20386,7 +22234,7 @@ YW
 YW
 hb
 JX
-ym
+Be
 ym
 ym
 ym
@@ -20675,7 +22523,7 @@ ST
 ST
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -21155,7 +23003,7 @@ ym
 ym
 gT
 gq
-ym
+Be
 ym
 ym
 fF
@@ -21303,7 +23151,7 @@ ZB
 gq
 ym
 ym
-ym
+Be
 ym
 xb
 MM
@@ -21330,7 +23178,7 @@ JX
 cl
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -21473,7 +23321,7 @@ fx
 ym
 cl
 ym
-ym
+Be
 ym
 ym
 QL
@@ -21491,7 +23339,7 @@ ym
 ym
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -21779,7 +23627,7 @@ ym
 ym
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -21793,7 +23641,7 @@ TH
 ym
 ym
 ym
-ym
+Be
 ym
 ZP
 Ps
@@ -22095,7 +23943,7 @@ Je
 dT
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -22258,7 +24106,7 @@ ym
 Qw
 Yp
 zQ
-ym
+Be
 ym
 YK
 KK
@@ -22425,7 +24273,7 @@ ZB
 fx
 Ps
 ym
-ym
+Be
 ym
 fF
 fW
@@ -22884,7 +24732,7 @@ fp
 TJ
 TV
 YT
-YT
+eK
 JD
 Bn
 xN
@@ -23286,20 +25134,20 @@ Yf
 Yf
 Yf
 Yf
-Yf
-qs
-Vb
-lG
-KU
-bT
-SR
-SR
-SR
-bS
-SR
-wo
-ce
-Zy
+NF
+xc
+cD
+Ol
+cQ
+ct
+yh
+yh
+yh
+rj
+yh
+cE
+fO
+NZ
 Zy
 bS
 bS
@@ -23442,7 +25290,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+NF
 Yf
 RN
 Vb
@@ -23455,7 +25303,7 @@ SR
 SR
 ce
 ce
-Zy
+NZ
 Zy
 Zy
 bS
@@ -23477,7 +25325,7 @@ YT
 fo
 YT
 YT
-YT
+eK
 YT
 Tr
 dq
@@ -23526,11 +25374,11 @@ XO
 WI
 XO
 XO
-fQ
-gW
-fv
-TV
-fv
+TF
+TF
+TF
+TF
+TF
 TV
 fP
 TJ
@@ -23598,7 +25446,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+NF
 Yf
 qs
 qz
@@ -23611,7 +25459,7 @@ wo
 wo
 ce
 ce
-Zy
+NZ
 Zy
 Zy
 Zy
@@ -23684,9 +25532,9 @@ Za
 Za
 oO
 XO
-fy
-fp
-dk
+Te
+Te
+TF
 fP
 TJ
 dk
@@ -23754,7 +25602,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+NF
 Yf
 qy
 lX
@@ -23767,7 +25615,7 @@ VI
 VI
 bM
 by
-Zy
+NZ
 Zy
 Zy
 Zy
@@ -23910,20 +25758,20 @@ Yf
 Yf
 Yf
 Yf
-re
+Ea
 qy
 lX
 WS
 eY
 SR
-SR
+bC
 SR
 SR
 Sg
 ot
 pk
 Ho
-Zy
+NZ
 Zy
 Zy
 Zy
@@ -24066,7 +25914,7 @@ Yf
 Yf
 Yf
 qy
-PD
+OX
 Ho
 Vb
 eY
@@ -24079,7 +25927,7 @@ SR
 Lm
 Ho
 Zy
-Zy
+NZ
 Zy
 Zy
 Zy
@@ -24208,11 +26056,11 @@ eJ
 eJ
 MQ
 sH
-hB
+sH
 MQ
 sH
 aj
-Sc
+sH
 bt
 MQ
 bz
@@ -24222,7 +26070,7 @@ Yf
 Yf
 qy
 PD
-VI
+wr
 bA
 Ho
 SR
@@ -24235,7 +26083,7 @@ im
 SR
 ok
 pk
-pk
+cO
 pk
 pk
 pk
@@ -24250,7 +26098,7 @@ SR
 SR
 wo
 YT
-YT
+eK
 Bz
 YT
 YT
@@ -24302,7 +26150,7 @@ ke
 OJ
 XO
 Za
-XO
+Za
 XO
 of
 of
@@ -24378,7 +26226,7 @@ Yf
 qs
 PD
 VI
-by
+Nm
 Sg
 SR
 SR
@@ -24391,7 +26239,7 @@ bl
 SR
 SR
 ok
-pk
+cO
 pk
 pk
 pk
@@ -24430,7 +26278,7 @@ fy
 lc
 YT
 YT
-YT
+eK
 YT
 YT
 YT
@@ -24456,9 +26304,9 @@ Za
 XO
 xM
 WI
-WI
-XO
-XO
+Za
+Za
+Za
 XO
 XO
 XO
@@ -24534,7 +26382,7 @@ Yf
 qy
 ot
 Fu
-Sg
+hS
 SR
 bl
 SR
@@ -24547,7 +26395,7 @@ SR
 bl
 SR
 SR
-cj
+mj
 Xw
 Xw
 Ir
@@ -24556,7 +26404,7 @@ Xw
 Xw
 rf
 SR
-SR
+im
 SR
 ok
 VI
@@ -24680,7 +26528,7 @@ sH
 MQ
 aS
 IO
-el
+sH
 sH
 MQ
 bz
@@ -24690,20 +26538,20 @@ qy
 PD
 VI
 Fu
-SR
-bl
-GH
-SR
-cj
-IC
-bT
-qT
-IC
-Zt
-SR
-bl
-Zb
-SR
+yh
+Ac
+nJ
+yh
+mj
+dK
+ct
+cN
+dK
+cP
+yh
+Ac
+cp
+yh
 cj
 Xw
 IC
@@ -24767,18 +26615,18 @@ Za
 XO
 XO
 XO
-XO
+Za
 WI
 XO
 XO
 Za
 XO
+Za
 XO
-XO
-WI
-WI
-WI
-WI
+Za
+Za
+Za
+Za
 Hh
 QO
 vf
@@ -24790,10 +26638,10 @@ qG
 qm
 Ee
 tH
-WI
-WI
-WI
-WI
+nI
+nI
+nI
+nI
 GY
 Gu
 bh
@@ -24906,39 +26754,39 @@ XO
 XO
 XO
 km
-WI
-WI
-WI
-XO
-XO
-XO
-XO
-WI
-WI
-WI
-XO
-XO
-Za
-XO
-XO
-XO
-WI
-WI
-WI
-XO
-km
-XO
-XO
-XO
-WI
-WI
-WI
-WI
-WI
-of
-WI
-WI
-XO
+nI
+nI
+nI
+oP
+oP
+oP
+oP
+nI
+nI
+nI
+oP
+oP
+wa
+oP
+oP
+oP
+nI
+wa
+nI
+oP
+CR
+oP
+oP
+oP
+nI
+nI
+nI
+wa
+wa
+kL
+nI
+nI
+oP
 tH
 Ck
 nH
@@ -24946,10 +26794,10 @@ hh
 vM
 fu
 tH
-WI
-WI
-WI
-WI
+nI
+nI
+nI
+nI
 GZ
 GY
 Gu
@@ -25033,7 +26881,7 @@ YT
 AU
 Bz
 AU
-YT
+eK
 YT
 fR
 gw
@@ -25062,39 +26910,39 @@ XO
 Za
 XO
 XO
-WI
-WI
-XO
-Za
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-WI
-WI
-WI
-WI
-WI
-XO
-Za
-XO
-XO
-WI
+nI
+nI
+oP
+wa
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+wa
+wa
+wa
+wa
+nI
+oP
+wa
+oP
+wa
+nI
 OD
-WI
-WI
-WI
-WI
-XO
-XO
-XO
+nI
+wa
+nI
+nI
+oP
+oP
+oP
 tH
 CC
 jU
@@ -25102,8 +26950,8 @@ UH
 po
 rn
 tH
-WI
-WI
+nI
+nI
 xM
 Gu
 bh
@@ -25218,39 +27066,39 @@ XO
 XO
 XO
 XO
-OO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-Za
-XO
-XO
-XO
-WI
-WI
-WI
-XO
-XO
-XO
-XO
-XO
+gJ
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+wa
+oP
+oP
+oP
+wa
+oP
+oP
+wa
+nI
+wa
+wa
+oP
+oP
+oP
+oP
+oP
 tH
 Mh
 kK
@@ -25258,8 +27106,8 @@ rh
 Mh
 tH
 tH
-WI
-WI
+nI
+nI
 GZ
 GY
 BL
@@ -25374,48 +27222,48 @@ XO
 Za
 Za
 Za
-Za
-Za
-oO
-Za
-Za
-Za
-Za
-XO
-XO
-Za
-Za
-oO
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
+wa
+wa
+uq
+wa
+wa
+wa
+wa
+oP
+oP
+wa
+wa
+uq
+wa
+wa
+wa
+wa
+wa
+wa
+wa
+wa
 Uq
-SI
-SI
-SI
-XO
-XO
-XO
-XO
-np
-SI
-SI
-SI
-SI
-SI
-SI
-FV
-SI
-XO
-XO
-XO
-WI
-WI
+IT
+IT
+IT
+oP
+oP
+wa
+wa
+sT
+IT
+IT
+IT
+IT
+IT
+IT
+rR
+IT
+oP
+oP
+oP
+nI
+nI
 AK
 KV
 xM
@@ -25530,49 +27378,49 @@ vy
 vy
 vy
 vy
-vy
-vy
-vy
-vy
-vy
-vy
-vy
-vy
-vy
-vy
+Hb
+Hb
+Hb
+Hb
+Hb
+Hb
+Hb
+Hb
+Hb
+Hb
 Ns
-vy
-vy
-vy
-vy
-vy
-vy
-vy
-vy
+Hb
+Hb
+Hb
+Hb
+Hb
+Hb
+Hb
+Hb
 Yv
 Ow
-vy
-vy
-vy
-vy
-vy
-vy
-vy
+Hb
+Hb
+Hb
+Hb
+Hb
+Hb
+Hb
 Ns
-vy
-vy
-vy
-vy
-vy
-vy
-qf
-SI
-Za
-Za
-Za
-XO
-XO
-WI
+Hb
+Hb
+Hb
+Hb
+Hb
+Hb
+CI
+td
+wa
+wa
+wa
+oP
+oP
+nI
 BL
 xM
 bD
@@ -25642,7 +27490,7 @@ SR
 SR
 SR
 SR
-SR
+im
 SR
 SR
 SR
@@ -25656,7 +27504,7 @@ AU
 AU
 dI
 eI
-AU
+un
 AU
 AU
 YT
@@ -25686,11 +27534,11 @@ YT
 XO
 np
 Za
-Za
-Za
-oO
-Za
-Za
+wa
+wa
+uq
+wa
+wa
 lA
 lA
 wN
@@ -25722,12 +27570,12 @@ wN
 wN
 wN
 lA
-XO
-XO
-XO
-Za
-XO
-XO
+oP
+oP
+oP
+wa
+oP
+oP
 AK
 KV
 xM
@@ -25842,50 +27690,50 @@ fo
 WI
 XO
 XO
-XO
-XO
-XO
-Za
-lW
+oP
+oP
+oP
+wa
+CP
 Jm
-jO
-Hh
+hF
+OA
 mh
-hj
-mI
-Za
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-Dn
-SI
-XO
-XO
-XO
-XO
-XO
-WI
-WI
-WI
-Hh
+yq
+nW
+wa
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+at
+IT
+oP
+oP
+oP
+oP
+oP
+nI
+nI
+nI
+OA
 mh
 mh
 mh
-jO
-XO
+hF
+oP
 iK
-XO
-XO
-Lv
-XO
-Za
-XO
-WI
-WI
+oP
+oP
+Xp
+oP
+wa
+oP
+nI
+nI
 BL
 xM
 Yf
@@ -25998,49 +27846,49 @@ Tc
 WI
 XO
 XO
-XO
-XO
-XO
-Za
+oP
+oP
+oP
+wa
 pR
 GI
 Vc
-VG
-vf
+qC
+wv
 mh
-mI
-oP
-wa
-CP
-on
 nW
-wa
-wa
-oP
+on
+on
+on
+on
+on
+on
+IM
+PW
 at
-IT
-oP
-wa
-wa
-oP
-wa
+iY
+PW
+IM
+on
+on
+on
 CP
 yq
 yq
-QO
-QO
-QO
-wm
-of
-XO
+yB
+yB
+yB
+YJ
+kL
+oP
 iK
-XO
-WI
-Lv
-XO
-Za
-XO
-XO
+oP
+nI
+Xp
+oP
+wa
+oP
+oP
 AK
 NT
 xM
@@ -26154,48 +28002,48 @@ gt
 fZ
 XO
 WI
-XO
-Lv
-Za
-Za
-WI
+oP
+Xp
+wa
+wa
+nI
 Wu
 oP
-Zx
-je
-vf
-jO
+WQ
+Kz
+wv
+hF
 oP
-wa
-oP
-oP
-oP
-oP
-oP
-wa
-at
-IT
-wa
+DH
+PW
+Gg
+Gg
+Gg
+Gg
+Gg
+wS
+jk
+Gg
 Oy
+sB
+nd
+BO
+tL
+tL
+QW
+Xp
+Xp
+Xp
+Xp
+WQ
 oP
-oP
-wa
-oP
-nI
-nI
-Lv
-Lv
-Lv
-Lv
-Zx
-XO
 iK
-XO
-XO
-Lv
-XO
-XO
-XO
+oP
+oP
+Xp
+oP
+oP
+oP
 AK
 zy
 NT
@@ -26310,49 +28158,49 @@ oW
 RN
 WI
 WI
-WI
-XO
-XO
-Za
-XO
+nI
+oP
+oP
+wa
+oP
 Wu
 CP
-vf
-jO
-je
-wm
+on
+wa
+wa
+wa
 oP
 wa
-ka
-ka
-ka
-ka
-oP
-wa
-at
+DA
 IT
+IT
+LS
+Pm
+IT
+xe
+RO
+nc
+xo
+UZ
+tL
+tL
+tL
+tL
+QW
+Xp
+Xp
+Xp
+OA
+wv
+nI
+En
 wa
 oP
-ka
-ka
-ka
-ka
+oP
+oP
 wa
+oP
 nI
-Lv
-Lv
-Lv
-Hh
-vf
-jO
-En
-Za
-XO
-XO
-XO
-Za
-XO
-WI
 GZ
 KV
 bF
@@ -26414,13 +28262,13 @@ bl
 Ry
 KU
 Ir
-IC
-Zt
-SR
-bl
-SR
-SR
-Lm
+dK
+cP
+yh
+Ac
+yh
+yh
+KQ
 by
 Zy
 Zy
@@ -26466,48 +28314,48 @@ Yf
 qs
 WI
 WI
-WI
-XO
-XO
-Za
-XO
-Wu
-oP
-je
-vf
-jO
-Zx
 nI
 oP
-ka
-ko
-mP
-ll
-wa
-wa
-at
-IT
+oP
 wa
 oP
-mz
-mP
-nb
-ka
+Wu
+oP
+gU
 wa
 wa
-Lv
-Lv
-Hh
-vf
-vf
-QO
-WA
+wa
+nI
+oP
+IT
+IT
+IT
+IT
+on
+on
+cG
+RO
+nf
+Tw
+tL
+tL
+tL
+tL
+tL
+tL
+Xp
+Xp
+OA
+qe
+nI
+nI
+En
 pT
-XO
-Za
-XO
-XO
-WI
+oP
+wa
+oP
+oP
+nI
 lX
 lG
 Gu
@@ -26570,13 +28418,13 @@ SR
 bl
 SR
 QK
-KU
+cQ
 IC
 rf
 SR
 bl
 SR
-SR
+yh
 bP
 bS
 bS
@@ -26622,47 +28470,47 @@ Yf
 qs
 WI
 WI
-XO
-Lv
-XO
-XO
-XO
-qM
-wa
 oP
-je
-QO
-wm
+Xp
+oP
+oP
+oP
+CZ
+wa
+wp
+lL
+IT
+IT
+IT
+IT
+ka
+IT
+IT
+An
+on
+on
+xe
+RO
+IT
+IT
+ka
+tL
+tL
+on
+on
+on
+on
+on
+Kz
 nI
-wa
-on
-kp
-IT
-IT
-IT
-IT
-at
-IT
-IT
-IT
-IT
-IT
-nc
-on
-oP
-oP
-tw
-PK
-je
-QO
-wm
+nI
 oP
 En
-Za
-Za
-XO
-XO
-WI
+wa
+wa
+oP
+oP
+nI
 lX
 WS
 eY
@@ -26726,13 +28574,13 @@ SR
 SR
 bl
 Zb
-SR
+yh
 QK
 Xw
 rf
 PI
 PI
-Io
+Wv
 ca
 bS
 bS
@@ -26762,7 +28610,7 @@ YT
 YT
 YT
 YT
-YT
+eK
 YT
 YT
 YT
@@ -26778,46 +28626,46 @@ Yf
 qs
 WI
 WI
-XO
-XO
-np
-XO
-Za
-qM
-nI
-nI
-nI
-nI
-nI
-qe
 oP
-ka
-kq
-kO
-lm
+oP
+sT
+oP
 wa
-oP
-at
+CZ
+nI
+wa
+jk
 IT
-wa
-wa
-mA
-mQ
+IT
+td
+IT
+on
+IT
+IT
+IT
+IT
+mP
+xe
+RO
+IT
+IT
+on
+tL
 nd
-ka
+on
 oP
 wa
-tw
-RQ
-Ko
+wa
+wa
+wa
 nI
 oP
 oP
 iK
-XO
-XO
-XO
-WI
+oP
+oP
+oP
+nI
 lX
 WS
 eY
@@ -26882,7 +28730,7 @@ lG
 SR
 SR
 bl
-SR
+yh
 SR
 SR
 SR
@@ -26901,7 +28749,7 @@ XP
 Sg
 SR
 SR
-SR
+im
 YT
 dq
 YT
@@ -26934,45 +28782,45 @@ Yf
 qs
 WI
 XO
-XO
-XO
-XO
-XO
-XO
+oP
+oP
+oP
+oP
+oP
 ZS
 oP
+gU
 oP
 oP
 oP
-oP
-oP
-wa
-ka
-ka
-ka
-ka
-oP
-oP
-at
 IT
-oP
-oP
-ka
-ka
-ka
-ka
+IT
+on
+IT
+IT
+IT
+IT
+IT
+xe
+RO
+IT
+IT
+on
+tL
+ut
+on
 wa
 oP
+nI
+nI
+wa
 oP
-RA
-Ko
+nI
 oP
-Hh
-mI
 iK
-XO
-XO
-WI
+oP
+oP
+nI
 lX
 WS
 eY
@@ -27038,16 +28886,16 @@ Vb
 lG
 SR
 VU
-bl
+Ac
 SR
 SR
 we
 bl
 SR
 yh
-im
-cj
-Xw
+cb
+mj
+uW
 cP
 qT
 Xw
@@ -27097,36 +28945,36 @@ pq
 TW
 CZ
 oP
-wa
+on
+uU
 oP
 oP
-oP
-sT
-oP
-oP
-oP
-oP
-oP
-oP
-wa
-at
 td
+IT
+on
+on
+on
+on
+on
+on
+xe
+Mx
+IT
+IT
+on
+MH
+Vp
+on
+oP
 wa
+nI
+nI
 oP
 oP
-oP
-oP
-oP
-oP
-wa
-sT
-Qp
-oP
-oP
-of
-wa
+nI
+nI
 En
-XO
+oP
 aG
 pq
 WS
@@ -27194,13 +29042,13 @@ RN
 Vb
 pq
 eY
-wo
+cE
 wo
 SR
 wo
 wo
 bl
-yh
+SR
 SR
 SR
 bl
@@ -27253,34 +29101,34 @@ hc
 he
 vV
 oP
-oP
-oP
-wa
+on
 oP
 wa
 oP
-ka
-ka
-ka
-ka
-wa
-oP
-at
 IT
-oP
-oP
-ka
-ka
-ka
-ka
+IT
+on
+RE
+IT
+mP
+IT
+on
+xe
+RO
+IT
+IT
+on
+on
+on
+on
 wa
 wa
-oP
+nI
 oP
 oP
 wa
-wa
-wa
+nI
+nI
 En
 BL
 aG
@@ -27350,13 +29198,13 @@ Yf
 oW
 oW
 RN
-Lm
+KQ
 VI
 pk
 VI
 bM
 Nd
-yh
+SR
 im
 SR
 SR
@@ -27409,32 +29257,32 @@ gc
 gt
 Up
 TV
-nI
+on
 oP
 oP
 wa
-wa
-oP
-ka
-ku
-kS
-ln
-wa
-wa
-at
 IT
-wa
-wa
-mC
+IT
+on
+ku
+IT
+IT
+IT
+DA
+xe
+RO
+IT
+IT
+IT
 mP
-ne
+IT
 ka
 wa
 wa
-wa
-wa
-wa
-wa
+nI
+nI
+nI
+nI
 oP
 oP
 cu
@@ -27506,13 +29354,13 @@ Yf
 Yf
 Yf
 Yf
-RN
+HK
 Lm
 Ho
 ce
 Zy
 VI
-cC
+Ho
 SR
 bC
 SR
@@ -27522,7 +29370,7 @@ QK
 SR
 SR
 SR
-SR
+im
 SR
 SR
 Zy
@@ -27566,33 +29414,33 @@ gc
 PC
 TJ
 TV
-nI
+on
 oP
 oP
-wa
-oP
+IT
+An
 on
 kv
 IT
+qV
 IT
 IT
-IT
-at
-IT
-IT
-IT
-IT
-IT
+xe
+RO
 nc
-on
+nc
+nc
+nc
+nc
+DA
 wa
 wa
-wa
-wa
+nI
+nI
 oP
 wa
 oP
-KE
+Ti
 Uj
 OJ
 bF
@@ -27662,13 +29510,13 @@ Yf
 Yf
 Yf
 Yf
-Yf
+NF
 oW
 RN
 Lm
 pk
 by
-yh
+SR
 SR
 SR
 bl
@@ -27723,32 +29571,32 @@ Jp
 gt
 TJ
 TV
-nI
+on
 oP
-oP
-wa
-ka
+IT
+IT
+on
 kw
-kO
 lm
-oP
-wa
-at
+lm
+IT
+on
+xe
+RO
+BK
+nf
+nf
+nf
+nf
 IT
 wa
-oP
-mD
-mR
-nf
-ka
-wa
-wa
+uq
 oP
 oP
 oP
-wa
+uq
 oP
-GZ
+Rw
 Uj
 GY
 bD
@@ -27818,16 +29666,16 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-oW
-RN
-VU
-VU
-SR
-VU
-VU
+NF
+NF
+NF
+hH
+HK
+us
+us
+yh
+us
+us
 yh
 SR
 SR
@@ -27880,22 +29728,22 @@ gc
 gt
 TJ
 TV
-oP
-oP
-wa
-ka
-ka
-ka
-ka
-oP
-wa
-at
-td
-wa
-oP
-ka
-ka
-ka
+on
+IT
+IT
+on
+kw
+lm
+lm
+IT
+on
+xe
+Mx
+IT
+IT
+IT
+IT
+IT
 ka
 wa
 oP
@@ -28037,22 +29885,22 @@ gc
 TJ
 TJ
 fZ
-oP
-wa
-oP
-oP
-oP
-oP
-oP
-oP
-at
 IT
-wa
-wa
-oP
-oP
-oP
-oP
+IT
+on
+IT
+lp
+IT
+An
+on
+cG
+RO
+on
+on
+on
+on
+on
+on
 oP
 oP
 nI
@@ -28060,7 +29908,7 @@ nI
 nI
 wa
 oP
-AK
+iT
 lC
 xM
 bD
@@ -28193,22 +30041,22 @@ gc
 TJ
 TJ
 fZ
-oP
-wa
-ka
-ka
-ka
-ka
-wa
-oP
-at
 IT
-oP
-oP
-ka
-ka
-ka
-ka
+IT
+DA
+IT
+IT
+qV
+IT
+on
+xe
+RO
+on
+nx
+xK
+xK
+ZR
+on
 oP
 nI
 WQ
@@ -28303,13 +30151,13 @@ pk
 by
 aX
 bH
-cQ
-dK
-cP
-eu
-eu
-eu
-eu
+KU
+IC
+Zt
+YT
+YT
+YT
+YT
 YT
 lc
 bD
@@ -28348,31 +30196,31 @@ qy
 qy
 fp
 dk
-nI
-oP
-wa
-ka
-kx
-kT
-lo
-oP
-wa
-at
+on
 IT
-wa
-wa
-mE
-mY
+IT
+IT
+kw
+lm
+lm
+IT
+DA
+xe
+RO
+fD
+IT
+IT
+IT
 nl
-ka
+on
 oP
-OA
+wa
 wv
 yB
 nW
 wa
 oP
-AK
+iT
 lC
 xM
 bD
@@ -28504,31 +30352,31 @@ aG
 nI
 nI
 nI
-oP
+it
+IT
+IT
+on
+IT
+lm
+lm
+IT
+IT
+xe
+RO
+Tg
+IT
+IT
+IT
+Gn
+on
 oP
 wa
-on
-kv
-IT
-IT
-IT
-IT
-at
-IT
-IT
-IT
-IT
-IT
-nc
-on
-oP
-qC
 wv
 nW
 oP
 wa
 oP
-KE
+Ti
 Uj
 NT
 bD
@@ -28661,30 +30509,30 @@ nI
 nI
 oP
 wa
-wa
-wa
-ka
-ky
-kO
-lp
-oP
-wa
-at
 IT
-wa
-oP
+IT
+on
+IT
+Pm
+lp
+IT
+on
+xe
+RO
+on
+wy
 mG
 kO
 nm
-ka
-CP
-yB
+on
+on
+on
 yB
 nW
-wa
-wa
-AK
-NT
+on
+on
+iT
+uY
 tv
 KV
 bD
@@ -28775,7 +30623,7 @@ RN
 VU
 VU
 YT
-eL
+eK
 YT
 nM
 bH
@@ -28817,29 +30665,29 @@ nI
 oP
 oP
 wa
-wa
-oP
-ka
-ka
-ka
-ka
-oP
-wa
-at
 IT
+IT
+on
+on
+on
+on
+on
+on
+xe
+RO
+on
+on
+on
+on
+on
+on
+nI
+Rt
+nI
+oP
 wa
 oP
-ka
-ka
-ka
-ka
-nI
-nI
-nI
-oP
-wa
-oP
-KE
+Ti
 Np
 zl
 bF
@@ -28973,30 +30821,30 @@ nI
 oP
 wa
 wa
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-wa
-at
 IT
-wa
-oP
-wa
+IT
 oP
 oP
-oP
-oP
-oP
+it
 oP
 oP
 wa
+lw
+RO
+wa
 oP
-GZ
-KV
+wa
+it
+oP
+oP
+oP
+oP
+oP
+oP
+wa
+oP
+Rw
+mH
 kW
 Yf
 Yf
@@ -29129,8 +30977,8 @@ oP
 oP
 wa
 wa
-sT
-oP
+td
+IT
 oP
 oP
 oP
@@ -29138,7 +30986,7 @@ oP
 wa
 lP
 lZ
-td
+Mx
 IT
 wa
 wa
@@ -29285,8 +31133,8 @@ oP
 oP
 wa
 wa
-oP
-oP
+IT
+IT
 oP
 IT
 IT
@@ -29908,27 +31756,27 @@ XH
 oP
 wa
 ih
-zE
-jR
-jR
-jR
-jR
-jR
-jR
-BF
-jR
-jR
-DQ
-jR
-jR
-jR
-jR
-jR
-jR
-jR
-jR
-jR
-nQ
+tL
+tL
+Oz
+tL
+tL
+tL
+tL
+tL
+tL
+tL
+Oz
+tL
+tL
+tL
+tL
+tL
+tL
+tL
+tL
+Oz
+tL
 oy
 oP
 nI
@@ -30064,10 +31912,6 @@ lG
 oP
 wa
 ju
-iC
-tL
-Oz
-Ap
 tL
 tL
 tL
@@ -30082,9 +31926,13 @@ tL
 tL
 tL
 tL
-Oz
 tL
-nC
+tL
+tL
+tL
+tL
+tL
+tL
 oA
 wa
 nI
@@ -30220,10 +32068,6 @@ eY
 oP
 wa
 jv
-iC
-tL
-tL
-gC
 tL
 tL
 tL
@@ -30240,7 +32084,11 @@ tL
 tL
 tL
 tL
-nC
+tL
+tL
+tL
+tL
+tL
 oD
 wa
 oP
@@ -30376,7 +32224,6 @@ lG
 oP
 wa
 jw
-iC
 tL
 tL
 tL
@@ -30396,7 +32243,8 @@ tL
 tL
 tL
 tL
-nC
+tL
+tL
 oE
 wa
 oP
@@ -30532,7 +32380,6 @@ eY
 oP
 wa
 ih
-iC
 tL
 tL
 tL
@@ -30552,7 +32399,8 @@ tL
 tL
 tL
 tL
-nC
+tL
+tL
 oy
 wa
 oP
@@ -30688,7 +32536,7 @@ TW
 oP
 wa
 ju
-iC
+tL
 tL
 tL
 tL
@@ -30708,7 +32556,7 @@ tL
 tL
 tL
 tL
-nC
+tL
 oA
 wa
 oP
@@ -30844,7 +32692,6 @@ TW
 oP
 wa
 jv
-iC
 tL
 tL
 tL
@@ -30864,7 +32711,8 @@ tL
 tL
 tL
 tL
-nC
+tL
+tL
 oD
 wa
 nI
@@ -31000,7 +32848,6 @@ TW
 oP
 wa
 jw
-iC
 tL
 tL
 tL
@@ -31020,7 +32867,8 @@ tL
 tL
 tL
 tL
-nC
+tL
+tL
 oE
 wa
 oP
@@ -31156,10 +33004,6 @@ VU
 oP
 wa
 ih
-iC
-tL
-tL
-gC
 tL
 tL
 tL
@@ -31176,7 +33020,11 @@ tL
 tL
 tL
 tL
-nC
+tL
+tL
+tL
+tL
+tL
 oy
 wa
 oP
@@ -31312,10 +33160,6 @@ bH
 oP
 wa
 ju
-iC
-tL
-Oz
-Ap
 tL
 tL
 tL
@@ -31330,9 +33174,13 @@ tL
 tL
 tL
 tL
-Oz
 tL
-nC
+tL
+tL
+tL
+tL
+tL
+tL
 oA
 wa
 oP
@@ -31468,27 +33316,27 @@ bH
 oP
 wa
 jv
-vw
-ob
-ob
-ob
-ob
-ob
-ob
-ob
-ob
-ob
-zF
-ob
-ob
-ob
-ob
-ob
-ob
-ob
-ob
-ob
-iI
+tL
+tL
+Oz
+tL
+tL
+tL
+tL
+tL
+tL
+tL
+Oz
+tL
+tL
+tL
+tL
+tL
+tL
+tL
+tL
+Oz
+tL
 oD
 oP
 oP

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -1538,6 +1538,10 @@
 "gk" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/caves/east)
+"gm" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
 "gn" = (
 /turf/closed/ice/thin/end{
 	dir = 4
@@ -2875,11 +2879,6 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
-"nQ" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside/center)
 "nS" = (
 /turf/open/floor/plating/dmg1,
 /area/icy_caves/caves/crashed_ship)
@@ -3273,10 +3272,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
-"pV" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside/center)
 "pW" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/tile/dark/yellow2{
@@ -3690,6 +3685,11 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside/center)
+"rK" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside/center)
 "rL" = (
 /obj/structure/table,
 /obj/item/cell/high/empty,
@@ -3930,11 +3930,6 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
-"sC" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
 "sD" = (
 /obj/effect/landmark/fob_sentry_rebel,
 /turf/closed/ice_rock/singleEnd{
@@ -3987,11 +3982,6 @@
 /area/icy_caves/outpost/LZ2)
 "sV" = (
 /obj/structure/rack,
-/obj/item/ammo_magazine/rifle/ak47,
-/obj/item/ammo_magazine/rifle/ak47,
-/obj/item/ammo_magazine/rifle/ak47,
-/obj/item/ammo_magazine/rifle/ak47,
-/obj/item/weapon/gun/rifle/ak47,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
 "ta" = (
@@ -4738,6 +4728,11 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/medbay)
+"wD" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/mining/west)
 "wG" = (
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/prison{
@@ -4948,10 +4943,6 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/medbay)
-"xU" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
 "xV" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
@@ -5033,11 +5024,6 @@
 "yq" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/outpost/LZ2)
-"yr" = (
-/turf/closed/ice_rock/singlePart{
-	dir = 10
-	},
-/area/icy_caves/outpost/outside/center)
 "yv" = (
 /obj/machinery/light{
 	dir = 4
@@ -5842,6 +5828,10 @@
 	dir = 5
 	},
 /area/icy_caves/outpost/research)
+"CD" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall,
+/area/icy_caves/outpost/mining/west)
 "CF" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
@@ -6238,10 +6228,6 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/LZ1)
-"ER" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall,
-/area/icy_caves/outpost/mining/west)
 "ES" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -6423,6 +6409,11 @@
 	icon_state = "109"
 	},
 /area/icy_caves/caves/northern)
+"FS" = (
+/turf/closed/ice_rock/singlePart{
+	dir = 10
+	},
+/area/icy_caves/outpost/outside/center)
 "FU" = (
 /obj/structure/cargo_container/ch_red,
 /turf/open/floor/plating,
@@ -6530,10 +6521,6 @@
 "Gs" = (
 /turf/closed/ice_rock/corners,
 /area/icy_caves/caves/northern)
-"Gt" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/single,
-/area/icy_caves/caves/west)
 "Gu" = (
 /turf/closed/ice,
 /area/icy_caves/outpost/outside)
@@ -7801,6 +7788,10 @@
 	dir = 1
 	},
 /area/icy_caves/caves)
+"MI" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside/center)
 "MJ" = (
 /turf/closed/ice/corner{
 	dir = 1
@@ -8772,6 +8763,10 @@
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"RR" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/single,
+/area/icy_caves/caves/west)
 "RS" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/southWall,
@@ -11566,7 +11561,7 @@ ZU
 Wx
 Wx
 Bb
-xU
+gm
 WI
 WI
 WI
@@ -11722,7 +11717,7 @@ ZU
 ZU
 ZU
 Bb
-xU
+gm
 pa
 Si
 WI
@@ -11878,7 +11873,7 @@ ZU
 ZU
 ZU
 Bb
-xU
+gm
 Tj
 SI
 SI
@@ -12034,7 +12029,7 @@ ZU
 ZU
 ZU
 Bb
-xU
+gm
 WI
 Ln
 SI
@@ -12190,7 +12185,7 @@ ZU
 re
 re
 re
-xU
+gm
 WI
 SI
 Ln
@@ -12346,7 +12341,7 @@ Di
 lG
 lX
 lG
-xU
+gm
 WI
 SI
 SI
@@ -12502,7 +12497,7 @@ Mg
 ec
 Vb
 eY
-xU
+gm
 WI
 SI
 SI
@@ -12658,7 +12653,7 @@ ec
 fT
 xI
 xI
-ER
+CD
 nx
 od
 lH
@@ -12814,7 +12809,7 @@ SF
 ZU
 nO
 oI
-sC
+wD
 oI
 pw
 oI
@@ -12967,8 +12962,8 @@ Ag
 hL
 hL
 TS
-Gt
-ER
+RR
+CD
 oJ
 au
 xn
@@ -17851,11 +17846,11 @@ my
 my
 my
 my
-nQ
+rK
 my
 DD
 DD
-pV
+MI
 wI
 YQ
 "}
@@ -19257,8 +19252,8 @@ ND
 li
 my
 my
-yr
-yr
+FS
+FS
 li
 bH
 YQ
@@ -19413,8 +19408,8 @@ ND
 li
 my
 my
-yr
-yr
+FS
+FS
 ow
 XH
 YQ
@@ -19571,7 +19566,7 @@ xE
 my
 DD
 li
-yr
+FS
 qz
 YQ
 "}

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -6891,10 +6891,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"Iq" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside/center)
 "Ir" = (
 /turf/closed/ice/thin/junction{
 	dir = 4
@@ -9320,10 +9316,6 @@
 /obj/structure/table,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"Vp" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside/center)
 "Vq" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -17648,7 +17640,7 @@ my
 my
 Iw
 DD
-Vp
+DD
 DD
 nM
 YQ
@@ -17801,10 +17793,10 @@ my
 my
 my
 my
-JW
+my
 my
 DD
-Iq
+DD
 DD
 nM
 YQ
@@ -17960,7 +17952,7 @@ DD
 my
 my
 DD
-Vp
+DD
 DD
 XH
 YQ
@@ -18112,7 +18104,7 @@ ND
 ND
 ND
 ND
-Vp
+DD
 my
 my
 DD
@@ -18271,7 +18263,7 @@ ND
 DD
 my
 my
-Vp
+DD
 DD
 DD
 qz
@@ -18583,7 +18575,7 @@ ND
 DD
 my
 my
-Vp
+DD
 DD
 DD
 qH

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -97,7 +97,6 @@
 	name = "Shaft Miner"
 	},
 /obj/structure/cable,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
 "av" = (
@@ -675,10 +674,12 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "cy" = (
-/obj/machinery/door/airlock/multi_tile/mainship/research,
-/turf/open/floor/tile/dark/yellow2{
-	dir = 1
-	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/LZ2)
+"cz" = (
+/obj/structure/grille,
+/turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ2)
 "cC" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -706,6 +707,18 @@
 	},
 /turf/open/shuttle/escapepod/plain,
 /area/icy_caves/caves/northern)
+"cG" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/red2{
+	dir = 5
+	},
+/area/icy_caves/outpost/LZ2)
 "cI" = (
 /turf/closed/ice/thin/single,
 /area/icy_caves/caves/northern)
@@ -741,15 +754,6 @@
 "cQ" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice/thin/corner{
-	dir = 1
-	},
-/area/icy_caves/caves/northern)
-"cR" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside/center)
-"cV" = (
-/turf/open/floor/tile/white/warningstripe{
 	dir = 1
 	},
 /area/icy_caves/caves/northern)
@@ -1030,10 +1034,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
-"el" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
-/turf/open/floor/tile/dark/yellow2,
-/area/icy_caves/outpost/LZ2)
 "em" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark,
@@ -1466,10 +1466,6 @@
 	dir = 4
 	},
 /area/icy_caves/caves/east)
-"fM" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/LZ2)
 "fN" = (
 /turf/closed/ice/thin/junction{
 	dir = 4
@@ -1538,10 +1534,6 @@
 "gk" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/caves/east)
-"gm" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
 "gn" = (
 /turf/closed/ice/thin/end{
 	dir = 4
@@ -1596,11 +1588,6 @@
 "gB" = (
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/refinery)
-"gE" = (
-/turf/open/floor/tile/dark/yellow2{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ2)
 "gF" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -1674,6 +1661,12 @@
 	dir = 6
 	},
 /area/icy_caves/caves/south)
+"gU" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd{
+	dir = 8
+	},
+/area/icy_caves/caves)
 "gV" = (
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves/east)
@@ -1719,6 +1712,9 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/research)
+"hi" = (
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/caves/east)
 "hj" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/outpost/outside)
@@ -1815,6 +1811,10 @@
 	dir = 8
 	},
 /area/icy_caves/caves/east)
+"hF" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice,
+/area/icy_caves/caves)
 "hG" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/research_and_development,
@@ -1832,10 +1832,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
-"hL" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/west)
 "hM" = (
 /turf/closed/ice_rock/corners{
 	dir = 10
@@ -1844,6 +1840,15 @@
 "hO" = (
 /turf/closed/ice/thin/single,
 /area/icy_caves/caves/east)
+"hP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "hQ" = (
 /obj/machinery/space_heater,
 /turf/open/floor/tile/dark/blue2,
@@ -1932,7 +1937,6 @@
 /area/icy_caves/outpost/outside/center)
 "ix" = (
 /obj/structure/cable,
-/obj/effect/landmark/excavation_site_spawner,
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
@@ -1956,11 +1960,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"iO" = (
-/turf/open/floor/tile/dark/yellow2{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ2)
 "iQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -1976,10 +1975,12 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/LZ2)
-"iX" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside/center)
+"iV" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "iZ" = (
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/garage)
@@ -2010,11 +2011,6 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/open/floor/tile/purple/whitepurplefull,
 /area/icy_caves/caves/northern)
-"jh" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/west)
 "jk" = (
 /obj/structure/table/mainship,
 /obj/item/tool/surgery/cautery,
@@ -2144,6 +2140,10 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/research)
+"jW" = (
+/obj/structure/ore_box,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "jX" = (
 /obj/machinery/light{
 	dir = 4
@@ -2319,10 +2319,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
-"kQ" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singleEnd,
-/area/icy_caves/caves)
 "kR" = (
 /obj/structure/table/mainship,
 /turf/open/floor/prison{
@@ -2459,12 +2455,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/mining/west)
-"lK" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/end{
-	dir = 8
-	},
-/area/icy_caves/caves/west)
 "lL" = (
 /turf/closed/ice/thin/corner{
 	dir = 8
@@ -2685,6 +2675,10 @@
 	dir = 5
 	},
 /area/icy_caves/caves)
+"mF" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/tile/dark/yellow2,
+/area/icy_caves/outpost/LZ2)
 "mG" = (
 /obj/structure/dispenser,
 /turf/open/floor/tile/dark/yellow2{
@@ -2735,6 +2729,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"mX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
 "mY" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice_rock/westWall,
@@ -2958,20 +2958,17 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/tcomms,
 /area/icy_caves/caves/northern)
+"oq" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "or" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"os" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 8
-	},
-/turf/open/floor/tile/dark/blue2{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "ot" = (
 /turf/closed/ice/junction,
 /area/icy_caves/caves/northern)
@@ -2989,10 +2986,6 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
-"oC" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ2)
 "oD" = (
 /obj/machinery/landinglight/ds1/delayone{
@@ -3012,7 +3005,6 @@
 "oJ" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
 "oK" = (
@@ -3025,6 +3017,10 @@
 	dir = 4
 	},
 /area/icy_caves/caves/northern)
+"oN" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside/center)
 "oO" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -3272,12 +3268,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
-"pW" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/tile/dark/yellow2{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ2)
 "pX" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -3446,6 +3436,9 @@
 "qC" = (
 /turf/closed/ice/thin/junction,
 /area/icy_caves/outpost/LZ2)
+"qE" = (
+/turf/closed/ice_rock/single,
+/area/icy_caves/outpost/outside/center)
 "qF" = (
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/tile/dark/brown2{
@@ -3468,6 +3461,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"qL" = (
+/turf/open/floor/tile/dark/yellow2{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "qN" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -3478,8 +3476,10 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
 "qP" = (
-/obj/machinery/mineral/processing_unit,
-/turf/open/floor/plating,
+/obj/machinery/conveyor{
+	id = "lower_garbage"
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
 "qQ" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -3577,6 +3577,11 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
+"rm" = (
+/turf/open/floor/tile/dark/brown2{
+	dir = 5
+	},
+/area/icy_caves/outpost/LZ2)
 "rn" = (
 /obj/structure/closet/crate/science,
 /turf/open/floor/tile/dark/purple2{
@@ -3622,6 +3627,10 @@
 /obj/item/tool/kitchen/knife,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
+"rw" = (
+/obj/structure/grille,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/mining/west)
 "rx" = (
 /obj/structure/table,
 /obj/item/reagent_containers/dropper,
@@ -3684,11 +3693,6 @@
 "rJ" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside/center)
-"rK" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
 "rL" = (
 /obj/structure/table,
@@ -3902,7 +3906,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/ai_node,
 /turf/open/floor/tile/dark/brown2{
 	dir = 8
 	},
@@ -3930,21 +3933,12 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
-"sD" = (
-/obj/effect/landmark/fob_sentry_rebel,
-/turf/closed/ice_rock/singleEnd{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ1)
 "sE" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"sF" = (
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/caves/east)
 "sG" = (
 /obj/structure/bed/chair,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -3961,6 +3955,10 @@
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/LZ1)
+"sM" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/refinery)
 "sN" = (
 /obj/structure/table/flipped,
 /obj/item/flashlight,
@@ -3972,10 +3970,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
-"sR" = (
-/obj/structure/largecrate/random/case,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
 "sT" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -4044,10 +4038,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
-"to" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singleT,
-/area/icy_caves/caves/west)
 "tp" = (
 /obj/item/lightstick/anchored,
 /obj/effect/ai_node,
@@ -4114,9 +4104,11 @@
 	},
 /area/icy_caves/caves/northern)
 "tG" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singleT,
-/area/icy_caves/caves)
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "tH" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/research)
@@ -4129,6 +4121,11 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
+"tJ" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/refinery)
 "tK" = (
 /obj/item/ammo_casing,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4214,12 +4211,6 @@
 	dir = 4
 	},
 /area/icy_caves/caves)
-"ud" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
 "ue" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -4324,12 +4315,6 @@
 	dir = 6
 	},
 /area/icy_caves/caves)
-"uB" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singleEnd{
-	dir = 8
-	},
-/area/icy_caves/caves)
 "uC" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/table,
@@ -4397,11 +4382,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"uW" = (
-/turf/open/floor/tile/dark/yellow2{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "uX" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -4459,10 +4439,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"vk" = (
-/obj/structure/ore_box,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
 "vl" = (
 /obj/structure/curtain/medical,
 /turf/open/floor/tile/dark,
@@ -4551,12 +4527,6 @@
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
-"vF" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singlePart{
-	dir = 8
-	},
-/area/icy_caves/caves)
 "vI" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -4595,6 +4565,12 @@
 	},
 /turf/closed/ice/corner,
 /area/icy_caves/outpost/LZ2)
+"vW" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/straight{
+	dir = 4
+	},
+/area/icy_caves/caves)
 "vX" = (
 /obj/item/flashlight,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4686,18 +4662,6 @@
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"wt" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 8
-	},
-/turf/open/floor/tile/dark/red2{
-	dir = 5
-	},
-/area/icy_caves/outpost/LZ2)
 "wu" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
@@ -4711,6 +4675,10 @@
 "wv" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/outpost/LZ2)
+"ww" = (
+/obj/structure/grille,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/refinery)
 "wx" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -4728,11 +4696,10 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/medbay)
-"wD" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
+"wE" = (
+/obj/docking_port/mobile/crashmode/bigbury,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/refinery)
 "wG" = (
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/prison{
@@ -4744,12 +4711,6 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/refinery)
-"wI" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singlePart{
-	dir = 4
-	},
-/area/icy_caves/caves)
 "wL" = (
 /turf/open/floor/mech_bay_recharge_floor,
 /area/icy_caves/outpost/LZ1)
@@ -4781,6 +4742,10 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
+"wQ" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/brown2,
+/area/icy_caves/outpost/refinery)
 "wT" = (
 /obj/structure/lattice,
 /obj/structure/monorail{
@@ -4809,6 +4774,10 @@
 	dir = 1
 	},
 /area/icy_caves/caves/south)
+"xe" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/caves)
 "xf" = (
 /obj/structure/closet/secure_closet/scientist,
 /turf/open/floor/tile/dark/purple2,
@@ -4824,12 +4793,6 @@
 /obj/structure/curtain/medical,
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
-"xj" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark/brown2{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ2)
 "xk" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -4853,10 +4816,9 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
 "xn" = (
-/obj/structure/cable,
 /obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ1)
 "xo" = (
 /obj/structure/closet/crate,
 /obj/item/storage/box/lightstick/red,
@@ -4883,6 +4845,10 @@
 /obj/structure/barricade/guardrail,
 /turf/open/floor/mainship/red/full,
 /area/icy_caves/caves/northern)
+"xt" = (
+/obj/structure/largecrate/supply/medicine,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "xu" = (
 /obj/structure/cargo_container/green,
 /turf/open/floor/plating,
@@ -4896,6 +4862,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"xx" = (
+/turf/open/floor/tile/dark/yellow2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "xA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -5007,6 +4978,12 @@
 /obj/item/weapon/gun/smg/m25,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"yk" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "yl" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/tile/dark/blue2{
@@ -5123,10 +5100,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"za" = (
+"yZ" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
+/turf/closed/ice_rock/fourway,
+/area/icy_caves/caves)
 "ze" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating/mainship,
@@ -5186,11 +5163,18 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/garage)
-"zt" = (
-/turf/open/floor/tile/white/warningstripe{
-	dir = 6
+"zq" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
 	},
-/area/icy_caves/caves/northern)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "zu" = (
 /obj/machinery/door/airlock/multi_tile/mainship/secdoor,
 /turf/open/floor/mainship/red/full,
@@ -5207,14 +5191,11 @@
 /turf/open/floor/tile/dark/purple2,
 /area/icy_caves/outpost/research)
 "zy" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice/junction{
 	dir = 4
 	},
 /area/icy_caves/outpost/outside)
-"zz" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside/center)
 "zA" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating,
@@ -5230,6 +5211,12 @@
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"zF" = (
+/obj/machinery/space_heater,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 10
+	},
+/area/icy_caves/outpost/LZ2)
 "zG" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
@@ -5257,6 +5244,10 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"zO" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/caves)
 "zP" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
@@ -5345,12 +5336,6 @@
 /obj/structure/dropship_equipment/weapon/rocket_pod,
 /turf/open/shuttle/dropship/floor,
 /area/space)
-"Ag" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singlePart{
-	dir = 5
-	},
-/area/icy_caves/caves/west)
 "Ah" = (
 /obj/effect/landmark/corpsespawner/security{
 	corpsebelt = /obj/item/weapon/gun/revolver/cmb;
@@ -5421,12 +5406,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
-"Aw" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/end{
-	dir = 1
-	},
-/area/icy_caves/caves)
 "Ax" = (
 /obj/structure/table,
 /obj/machinery/light/built{
@@ -5434,10 +5413,12 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"Az" = (
-/obj/machinery/door/airlock/multi_tile/mainship/research,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
+"Ay" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/corners{
+	dir = 6
+	},
+/area/icy_caves/caves)
 "AB" = (
 /turf/closed/ice/thin/end{
 	dir = 1
@@ -5579,6 +5560,10 @@
 /obj/structure/fence,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/caves/west)
+"Bc" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/northWall,
+/area/icy_caves/caves)
 "Bd" = (
 /obj/machinery/door/airlock/multi_tile/mainship/secdoor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -5678,6 +5663,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"BK" = (
+/obj/structure/prop/mainship/hangar_stencil/two,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "BL" = (
 /turf/closed/ice/end{
 	dir = 8
@@ -5764,11 +5753,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"Cc" = (
-/turf/open/floor/tile/dark/brown2{
-	dir = 5
-	},
-/area/icy_caves/outpost/LZ2)
 "Ch" = (
 /obj/machinery/computer3/server/rack,
 /turf/open/floor/tile/dark,
@@ -5800,6 +5784,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
+"Co" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/corners{
+	dir = 10
+	},
+/area/icy_caves/caves)
 "Cq" = (
 /turf/closed/ice/thin/end{
 	dir = 4
@@ -5814,24 +5804,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
-"CA" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
 "CC" = (
 /obj/machinery/space_heater,
 /turf/open/floor/tile/dark/purple2{
 	dir = 5
 	},
 /area/icy_caves/outpost/research)
-"CD" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall,
-/area/icy_caves/outpost/mining/west)
 "CF" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
@@ -5856,12 +5834,6 @@
 	dir = 6
 	},
 /area/icy_caves/caves/east)
-"CT" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
 "CV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -6031,9 +6003,10 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "DO" = (
-/turf/open/floor/tile/dark/brown2{
-	dir = 9
+/obj/machinery/light{
+	dir = 8
 	},
+/turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ2)
 "DS" = (
 /obj/structure/dropship_piece/one/corner/middleright,
@@ -6129,6 +6102,10 @@
 /obj/effect/landmark/dropship_console_spawn_lz2,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/console)
+"Em" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice,
+/area/icy_caves/outpost/outside)
 "En" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -6182,6 +6159,11 @@
 	},
 /turf/closed/ice_rock/singlePart{
 	dir = 8
+	},
+/area/icy_caves/caves)
+"EE" = (
+/turf/closed/ice/straight{
+	dir = 4
 	},
 /area/icy_caves/caves)
 "EH" = (
@@ -6349,11 +6331,6 @@
 	dir = 1
 	},
 /area/icy_caves/caves/northern)
-"Fw" = (
-/turf/open/floor/tile/white/warningstripe{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "Fy" = (
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
@@ -6361,6 +6338,12 @@
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"FD" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/end{
+	dir = 4
+	},
+/area/icy_caves/outpost/outside)
 "FF" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -6409,11 +6392,6 @@
 	icon_state = "109"
 	},
 /area/icy_caves/caves/northern)
-"FS" = (
-/turf/closed/ice_rock/singlePart{
-	dir = 10
-	},
-/area/icy_caves/outpost/outside/center)
 "FU" = (
 /obj/structure/cargo_container/ch_red,
 /turf/open/floor/plating,
@@ -6479,6 +6457,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/office)
+"Gl" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/LZ2)
 "Gm" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -6506,18 +6488,6 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
-"Gr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/tile/dark/blue2{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "Gs" = (
 /turf/closed/ice_rock/corners,
 /area/icy_caves/caves/northern)
@@ -6532,20 +6502,10 @@
 /obj/machinery/power/apc/drained,
 /turf/open/floor/plating/plating_catwalk,
 /area/icy_caves/caves/northern)
-"Gy" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/west)
 "Gz" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleT,
 /area/icy_caves/caves)
-"GC" = (
-/obj/machinery/door/airlock/multi_tile/mainship/research{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
 "GD" = (
 /turf/open/floor/tile/dark/red2/corner{
 	dir = 1
@@ -6669,10 +6629,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
-"Hc" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark/blue2,
-/area/icy_caves/outpost/LZ2)
 "He" = (
 /obj/effect/decal/cleanable/blood/xtracks,
 /turf/open/floor/tile/dark,
@@ -6737,11 +6693,9 @@
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/northern)
 "Hx" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/outside)
 "HA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -6777,9 +6731,6 @@
 "HG" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/south)
-"HH" = (
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/caves/east)
 "HI" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -6899,6 +6850,10 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Ii" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside)
 "Ij" = (
 /obj/structure/largecrate/random/barrel/green,
 /turf/open/floor/plating/mainship,
@@ -6935,6 +6890,10 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside/center)
+"Iq" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/outside/center)
 "Ir" = (
 /turf/closed/ice/thin/junction{
@@ -6974,12 +6933,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"IB" = (
-/obj/machinery/space_heater,
-/turf/open/floor/tile/dark/yellow2{
-	dir = 10
-	},
-/area/icy_caves/outpost/LZ2)
 "IC" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/caves/northern)
@@ -6992,6 +6945,12 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
+"IF" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/junction{
+	dir = 1
+	},
+/area/icy_caves/caves)
 "IG" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -7059,11 +7018,6 @@
 "IT" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"IU" = (
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "IX" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark,
@@ -7139,6 +7093,12 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"Js" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/end{
+	dir = 1
+	},
+/area/icy_caves/outpost/outside)
 "Jv" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -7302,15 +7262,15 @@
 "Kp" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
-"Kr" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside/center)
 "Ks" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 8
 	},
 /area/icy_caves/outpost/garage)
+"Kt" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/blue2,
+/area/icy_caves/outpost/LZ2)
 "Ku" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/item/reagent_containers/hypospray/autoinjector/tricordrazine,
@@ -7331,6 +7291,12 @@
 /obj/machinery/space_heater,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"Kz" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "KA" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/machinery/light{
@@ -7409,14 +7375,6 @@
 "KZ" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/garage)
-"La" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/white/warningstripe{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "Lb" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/tile/dark,
@@ -7465,9 +7423,6 @@
 	on = 1
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Lp" = (
-/turf/open/floor/tile/white/warningstripe,
 /area/icy_caves/caves/northern)
 "Lq" = (
 /obj/machinery/power/geothermal,
@@ -7526,6 +7481,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"LB" = (
+/turf/open/floor/tile/dark/brown2{
+	dir = 9
+	},
+/area/icy_caves/outpost/LZ2)
 "LC" = (
 /obj/machinery/light/small,
 /turf/open/floor/wood,
@@ -7580,10 +7540,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
-"LN" = (
-/obj/structure/prop/mainship/hangar_stencil/two,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
 "LO" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -7644,6 +7600,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"LY" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "LZ" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -7651,12 +7611,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
-"Mb" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
 "Me" = (
 /turf/open/floor/mainship_hull/dir{
 	dir = 8
@@ -7718,6 +7672,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"Mr" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/single,
+/area/icy_caves/caves)
 "Ms" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/tile/dark,
@@ -7770,10 +7728,6 @@
 	},
 /turf/closed/ice_rock/singleEnd,
 /area/icy_caves/caves)
-"MC" = (
-/obj/structure/largecrate/random,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
 "MD" = (
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/tile/dark/green2,
@@ -7788,10 +7742,6 @@
 	dir = 1
 	},
 /area/icy_caves/caves)
-"MI" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside/center)
 "MJ" = (
 /turf/closed/ice/corner{
 	dir = 1
@@ -7849,14 +7799,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
-"MX" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "MY" = (
 /obj/item/reagent_containers/spray/pepper,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -7872,10 +7814,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
-"Na" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/northWall,
-/area/icy_caves/caves)
 "Nc" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -8084,32 +8022,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/outside)
-"Og" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/tile/dark/yellow2{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ2)
 "Oh" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
-"Ok" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 8
-	},
-/turf/open/floor/tile/dark/blue2{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "Om" = (
 /turf/closed/ice/junction{
 	dir = 8
@@ -8203,6 +8121,10 @@
 	},
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ2)
+"OM" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd,
+/area/icy_caves/caves)
 "OO" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -8221,13 +8143,21 @@
 /obj/structure/cargo_container/gorg,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Pc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "Pd" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/security)
-"Pe" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
 "Pg" = (
 /obj/machinery/light{
 	dir = 4
@@ -8256,9 +8186,7 @@
 /area/icy_caves/caves/south)
 "Pp" = (
 /obj/effect/decal/cleanable/blood/xtracks,
-/turf/open/floor/tile/white/warningstripe{
-	dir = 5
-	},
+/turf/open/floor/tile/purple/whitepurplefull,
 /area/icy_caves/caves/northern)
 "Pq" = (
 /turf/open/floor/tile/dark/brown2{
@@ -8278,6 +8206,11 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/refinery)
+"Pv" = (
+/turf/closed/ice/junction{
+	dir = 1
+	},
+/area/icy_caves/caves)
 "Pz" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -8304,9 +8237,6 @@
 	dir = 4
 	},
 /area/icy_caves/caves/northern)
-"PF" = (
-/turf/open/floor/tile/dark/blue2,
-/area/icy_caves/outpost/LZ2)
 "PI" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
@@ -8524,15 +8454,14 @@
 /obj/structure/largecrate/random/case,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"QN" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
 "QO" = (
 /turf/closed/ice/thin/junction{
 	dir = 8
 	},
 /area/icy_caves/outpost/outside)
+"QP" = (
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/caves)
 "QQ" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -8560,6 +8489,9 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"QW" = (
+/turf/open/floor/tile/dark/blue2,
+/area/icy_caves/outpost/LZ2)
 "QX" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -8708,12 +8640,6 @@
 	dir = 4
 	},
 /area/icy_caves/caves)
-"RF" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/LZ2)
 "RG" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 1
@@ -8763,14 +8689,13 @@
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"RR" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/single,
-/area/icy_caves/caves/west)
 "RS" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/southWall,
 /area/icy_caves/caves)
+"RU" = (
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/caves/east)
 "RW" = (
 /turf/closed/ice/end{
 	dir = 4
@@ -8783,10 +8708,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
-"RY" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark/brown2,
-/area/icy_caves/outpost/refinery)
 "RZ" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark,
@@ -8796,6 +8717,12 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"Sb" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/junction{
+	dir = 1
+	},
+/area/icy_caves/outpost/outside)
 "Sc" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -8862,6 +8789,9 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/security)
+"Sq" = (
+/turf/closed/ice,
+/area/icy_caves/caves)
 "Ss" = (
 /turf/closed/shuttle/dropship2{
 	icon_state = "104"
@@ -9067,10 +8997,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
-"TF" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
 "TH" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/ice,
@@ -9114,11 +9040,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/security)
-"TS" = (
-/obj/effect/landmark/xeno_resin_door,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/west)
 "TT" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -9208,6 +9129,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"Uo" = (
+/obj/structure/largecrate/random/case,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "Up" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -9229,6 +9154,10 @@
 "Uu" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ1)
+"Uy" = (
+/obj/structure/largecrate/random,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "Uz" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/wood,
@@ -9317,6 +9246,14 @@
 	dir = 8
 	},
 /area/icy_caves/caves/east)
+"UW" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark/yellow2{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "UY" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/black,
@@ -9366,10 +9303,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"Vg" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside/center)
 "Vi" = (
 /obj/structure/table,
 /obj/item/storage/fancy/vials,
@@ -9387,6 +9320,10 @@
 /obj/structure/table,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"Vp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside/center)
 "Vq" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -9436,10 +9373,6 @@
 	dir = 4
 	},
 /area/icy_caves/caves/south)
-"VA" = (
-/obj/structure/largecrate/supply/medicine,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
 "VB" = (
 /turf/closed/ice/junction{
 	dir = 4
@@ -9614,6 +9547,10 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"Wo" = (
+/obj/effect/landmark/fob_sentry_rebel,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/LZ1)
 "Wp" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
 /turf/open/floor/tile/dark,
@@ -9745,10 +9682,10 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/LZ1)
-"Xe" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/single,
-/area/icy_caves/caves)
+"Xb" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/LZ2)
 "Xf" = (
 /obj/effect/landmark/start/job/survivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -10019,6 +9956,9 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"Yl" = (
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/caves)
 "Ym" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/swat,
@@ -10288,6 +10228,12 @@
 "ZB" = (
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/caves/south)
+"ZD" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "ZE" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -10323,6 +10269,15 @@
 /obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
+"ZM" = (
+/turf/open/floor/tile/dark/yellow2{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
+"ZN" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "ZP" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 4
@@ -11238,18 +11193,18 @@ Yf
 Yf
 Yf
 Yf
-cp
-cp
-cp
-cp
-cp
-Aw
-Aw
-cp
-cp
-Aw
-Aw
-dK
+Yf
+Yf
+Yf
+Yf
+Yf
+MH
+MH
+Yf
+Yf
+MH
+MH
+re
 Yf
 MH
 MH
@@ -11394,7 +11349,7 @@ Yf
 Yf
 Yf
 Yf
-cp
+Yf
 Yf
 Yf
 MH
@@ -11405,7 +11360,7 @@ ZU
 ZU
 ZU
 GF
-dK
+re
 re
 re
 MH
@@ -11550,7 +11505,7 @@ Yf
 Yf
 Yf
 Yf
-cp
+Yf
 Yf
 Yf
 Yf
@@ -11561,7 +11516,7 @@ ZU
 Wx
 Wx
 Bb
-gm
+WI
 WI
 WI
 WI
@@ -11571,8 +11526,8 @@ Yf
 Yf
 MH
 MH
-Za
-Za
+WI
+WI
 Yf
 Yf
 MH
@@ -11706,18 +11661,18 @@ Yf
 Yf
 Yf
 Yf
-cp
+Yf
 MH
 MH
 Yf
 ZU
 ZU
-ZU
+gx
 ZU
 ZU
 ZU
 Bb
-gm
+WI
 pa
 Si
 WI
@@ -11727,9 +11682,9 @@ MH
 MH
 MH
 pa
-Mb
-Za
-Za
+Si
+WI
+WI
 MH
 MH
 MH
@@ -11862,18 +11817,18 @@ Yf
 Yf
 Yf
 Yf
-cp
+Yf
 Yf
 YI
 ZU
 ZU
 ZU
-Gy
+ZU
 ZU
 ZU
 ZU
 Bb
-gm
+WI
 Tj
 SI
 SI
@@ -11883,12 +11838,12 @@ SI
 SI
 SI
 SI
-Za
-Za
-Za
-Za
-Za
-Za
+WI
+WI
+WI
+WI
+WI
+WI
 Uu
 Uu
 DX
@@ -11965,10 +11920,10 @@ Zl
 Zl
 Zl
 Zl
-cV
-IU
-MX
-Lp
+AJ
+AJ
+HU
+AJ
 Zl
 Zl
 Zl
@@ -12018,7 +11973,7 @@ Yf
 Yf
 Yf
 Yf
-cp
+Yf
 Yf
 ZU
 gx
@@ -12029,8 +11984,9 @@ ZU
 ZU
 ZU
 Bb
-gm
 WI
+WI
+SI
 Ln
 SI
 SI
@@ -12038,13 +11994,12 @@ SI
 SI
 SI
 SI
-SI
-Za
-Za
-Za
-Za
-Za
-Za
+AW
+WI
+XO
+XO
+XO
+AW
 Uu
 Uu
 Uu
@@ -12122,9 +12077,9 @@ Zl
 Zl
 Zl
 Pp
-Fw
-La
-zt
+AJ
+HU
+AJ
 Zl
 Zl
 Zl
@@ -12174,7 +12129,7 @@ Yf
 Yf
 Yf
 Yf
-cp
+Yf
 Yf
 ZU
 ZU
@@ -12185,24 +12140,24 @@ ZU
 re
 re
 re
-gm
-WI
-SI
-Ln
-WI
-WI
 WI
 WI
 SI
-Ln
-Za
-Za
-Za
-Za
-Za
-Za
-UE
-fq
+SI
+WI
+WI
+WI
+WI
+SI
+SI
+WI
+WI
+WI
+WI
+WI
+WI
+xn
+Uu
 Uu
 Uu
 Aq
@@ -12256,7 +12211,7 @@ Zl
 Zl
 BZ
 Zl
-dL
+Zl
 Zl
 Zl
 Zl
@@ -12330,7 +12285,7 @@ Yf
 Yf
 Yf
 Yf
-dK
+re
 re
 ZU
 ZU
@@ -12341,7 +12296,7 @@ Di
 lG
 lX
 lG
-gm
+WI
 WI
 SI
 SI
@@ -12351,12 +12306,12 @@ WI
 WI
 SI
 SI
-Za
-Za
-Za
-Za
-Za
-Za
+WI
+WI
+WI
+WI
+WI
+WI
 Uu
 Uu
 Uu
@@ -12486,7 +12441,7 @@ re
 re
 re
 ZU
-hL
+ZU
 SF
 ZU
 ZU
@@ -12497,7 +12452,7 @@ Mg
 ec
 Vb
 eY
-gm
+mX
 WI
 SI
 SI
@@ -12507,8 +12462,8 @@ WI
 WI
 SI
 SI
-Za
-Za
+WI
+WI
 MH
 qs
 WI
@@ -12642,7 +12597,7 @@ Di
 XF
 DZ
 ZU
-hL
+ZU
 SF
 ZU
 gx
@@ -12653,7 +12608,7 @@ ec
 fT
 xI
 xI
-CD
+xI
 nx
 od
 lH
@@ -12671,7 +12626,7 @@ MH
 WI
 Uu
 Uu
-sD
+Ml
 Ml
 Tf
 Ml
@@ -12798,7 +12753,7 @@ gz
 ZU
 ZU
 ZU
-jh
+ez
 SF
 ZU
 ZU
@@ -12809,8 +12764,8 @@ SF
 ZU
 nO
 oI
-wD
 oI
+wW
 pw
 oI
 pf
@@ -12826,7 +12781,7 @@ Yf
 Yf
 MH
 Uu
-Uu
+Wo
 Uu
 UE
 TQ
@@ -12954,19 +12909,19 @@ ZU
 ZU
 ZU
 ez
-hL
-lK
-hL
-to
-Ag
-hL
-hL
-TS
-RR
-CD
+ZU
+dx
+ZU
+gA
+Mg
+ZU
+ZU
+SF
+fT
+xI
 oJ
 au
-xn
+ax
 oI
 oI
 oI
@@ -13199,7 +13154,7 @@ XQ
 dZ
 ma
 dF
-cX
+BZ
 Zl
 WF
 Gs
@@ -13450,7 +13405,7 @@ WI
 WI
 WI
 Uu
-fq
+Uu
 UE
 UE
 Aq
@@ -13592,8 +13547,8 @@ iJ
 oI
 wW
 oI
-CA
-oI
+ig
+wW
 oI
 oI
 nO
@@ -13605,7 +13560,7 @@ WI
 WI
 WI
 WI
-Uu
+fq
 UE
 UE
 UE
@@ -13746,7 +13701,7 @@ do
 xI
 xI
 xI
-xI
+rw
 pB
 ig
 qw
@@ -13756,12 +13711,12 @@ xI
 Za
 SI
 XO
-lW
-lW
+XO
 WI
 WI
-lW
-AB
+WI
+np
+UE
 UE
 UE
 UE
@@ -13912,11 +13867,11 @@ WI
 XO
 SI
 XO
-lW
 XO
 XO
 XO
-lW
+XO
+XO
 UE
 Uu
 UE
@@ -14067,9 +14022,9 @@ XO
 XO
 XO
 SI
-lW
-lW
-lW
+Za
+XO
+XO
 XO
 XO
 XO
@@ -14439,7 +14394,7 @@ Zl
 BZ
 Zl
 Zl
-dL
+Zl
 Zl
 Zl
 Zl
@@ -14528,9 +14483,9 @@ XO
 XO
 np
 Za
+SI
+SI
 Ln
-SI
-SI
 SI
 SI
 SI
@@ -14540,7 +14495,7 @@ SI
 SI
 pY
 vy
-Al
+vy
 vy
 Nu
 Nu
@@ -14691,8 +14646,8 @@ XO
 XO
 XO
 Za
-lW
-lW
+Za
+Za
 Za
 SI
 SI
@@ -14848,7 +14803,7 @@ XO
 XO
 XO
 XO
-lW
+Za
 Za
 SI
 SI
@@ -15154,7 +15109,7 @@ WI
 Gw
 Gw
 Gw
-Gw
+sM
 Gw
 Gw
 Gw
@@ -15164,7 +15119,7 @@ Gw
 Ri
 DY
 DY
-gB
+wQ
 Gw
 lD
 me
@@ -15320,7 +15275,7 @@ Pq
 XU
 DY
 DY
-RY
+gB
 wx
 lB
 lM
@@ -15458,7 +15413,7 @@ Jg
 XF
 DZ
 Ga
-ZU
+XJ
 ZU
 gz
 Om
@@ -15622,7 +15577,7 @@ SD
 Gw
 qc
 DY
-qQ
+tJ
 RZ
 DY
 qc
@@ -15763,7 +15718,7 @@ ft
 EB
 ZU
 ZU
-gx
+ZU
 Xu
 Jg
 xP
@@ -15771,7 +15726,7 @@ XF
 gA
 XJ
 ZU
-ZU
+Xu
 XF
 xa
 SD
@@ -15784,7 +15739,7 @@ DY
 sl
 DY
 DY
-DY
+wE
 yK
 DY
 DY
@@ -15925,9 +15880,9 @@ Jg
 XF
 dp
 gA
+XJ
 ZU
-ZU
-ZU
+Xu
 DK
 RG
 Rj
@@ -16246,7 +16201,7 @@ SD
 Gw
 Ub
 gB
-Gw
+ww
 Gw
 Gw
 Ub
@@ -16391,8 +16346,8 @@ gx
 ZU
 ZU
 ZU
-ZU
-ZU
+lj
+Sn
 ZU
 dx
 dx
@@ -16547,7 +16502,7 @@ dw
 ZU
 ZU
 ZU
-ZU
+gn
 ZU
 ZU
 do
@@ -17066,12 +17021,12 @@ LO
 vq
 KZ
 XO
-Pe
-Pe
-za
-TF
-Na
-cp
+SI
+SI
+Za
+XO
+bD
+Yf
 YQ
 "}
 (44,1,1) = {"
@@ -17222,12 +17177,12 @@ RJ
 KZ
 KZ
 XO
-Pe
 SI
-Ll
-Ll
+SI
+Za
+XO
 bD
-cp
+Yf
 YQ
 "}
 (45,1,1) = {"
@@ -17378,12 +17333,12 @@ KZ
 KZ
 WI
 XO
-Pe
 SI
-Ll
-Ll
+SI
+Za
+XO
 lX
-kQ
+TW
 YQ
 "}
 (46,1,1) = {"
@@ -17534,12 +17489,12 @@ li
 li
 li
 li
-zz
+my
 my
 DD
 DD
 Vb
-kq
+lG
 YQ
 "}
 (47,1,1) = {"
@@ -17690,12 +17645,12 @@ my
 my
 my
 my
-zz
+my
 Iw
 DD
-iX
+Vp
 DD
-wI
+nM
 YQ
 "}
 (48,1,1) = {"
@@ -17846,12 +17801,12 @@ my
 my
 my
 my
-rK
+JW
 my
 DD
+Iq
 DD
-MI
-wI
+nM
 YQ
 "}
 (49,1,1) = {"
@@ -18002,12 +17957,12 @@ li
 li
 li
 DD
-zz
+my
 my
 DD
-iX
+Vp
 DD
-uB
+XH
 YQ
 "}
 (50,1,1) = {"
@@ -18157,13 +18112,13 @@ ND
 ND
 ND
 ND
-DD
-zz
+Vp
+my
 my
 DD
 DD
 DD
-Xe
+qz
 YQ
 "}
 (51,1,1) = {"
@@ -18314,12 +18269,12 @@ wZ
 Ez
 ND
 DD
-zz
 my
-iX
+my
+Vp
 DD
 DD
-Xe
+qz
 YQ
 "}
 (52,1,1) = {"
@@ -18470,12 +18425,12 @@ wZ
 LC
 ND
 DD
-zz
+my
 my
 DD
 DD
 DD
-ss
+VU
 YQ
 "}
 (53,1,1) = {"
@@ -18626,12 +18581,12 @@ wZ
 Ez
 ND
 DD
-zz
 my
-iX
+my
+Vp
 DD
 DD
-tG
+qH
 YQ
 "}
 (54,1,1) = {"
@@ -18782,12 +18737,12 @@ Hf
 Hf
 ND
 DD
-zz
+my
 my
 DD
 DD
 li
-vF
+bH
 YQ
 "}
 (55,1,1) = {"
@@ -18938,12 +18893,12 @@ Cs
 Ez
 ND
 li
-zz
-zz
-Kr
-Kr
-cR
-vF
+my
+my
+DD
+DD
+li
+bH
 YQ
 "}
 (56,1,1) = {"
@@ -19252,8 +19207,8 @@ ND
 li
 my
 my
-FS
-FS
+DD
+li
 li
 bH
 YQ
@@ -19408,8 +19363,8 @@ ND
 li
 my
 my
-FS
-FS
+DD
+li
 ow
 XH
 YQ
@@ -19566,7 +19521,7 @@ xE
 my
 DD
 li
-FS
+ow
 qz
 YQ
 "}
@@ -20574,8 +20529,8 @@ Us
 Us
 fC
 Je
-ym
-Be
+fh
+UL
 ym
 ym
 Xj
@@ -20730,8 +20685,8 @@ YS
 YS
 YS
 fh
-ym
-ym
+fY
+hv
 Xj
 Xj
 ST
@@ -20773,7 +20728,7 @@ my
 my
 my
 my
-Vg
+oN
 Iw
 my
 my
@@ -20886,8 +20841,8 @@ YS
 YS
 Vz
 fY
-ym
-ym
+xX
+hv
 ST
 xb
 MM
@@ -21041,9 +20996,9 @@ dC
 YS
 YS
 fh
-ym
-ym
-ym
+xX
+xX
+hv
 ST
 Ig
 YW
@@ -21197,8 +21152,8 @@ YS
 YS
 YS
 fh
-ym
-ym
+xX
+xX
 ME
 ST
 YW
@@ -21352,9 +21307,9 @@ YS
 YS
 YS
 Vz
-ym
-Be
-ym
+hm
+xX
+xX
 Uk
 ST
 YW
@@ -21508,9 +21463,9 @@ YS
 YS
 hf
 fh
-ym
-ym
-ym
+fY
+xX
+xX
 Uk
 ST
 YW
@@ -21664,8 +21619,8 @@ YS
 YS
 hf
 fh
-ym
-ym
+xX
+xX
 xX
 UL
 ST
@@ -21819,9 +21774,9 @@ Iy
 gq
 YS
 ym
-ym
-ym
-ym
+fh
+fW
+xX
 xX
 hv
 ST
@@ -21975,9 +21930,9 @@ Iy
 fC
 ym
 ym
-ym
-ym
-ym
+fH
+hm
+fW
 fW
 hv
 ST
@@ -22132,7 +22087,7 @@ ym
 ym
 ym
 ym
-ym
+Wj
 SA
 fh
 ME
@@ -24079,7 +24034,7 @@ VM
 VM
 VM
 VM
-li
+qE
 li
 li
 li
@@ -24233,9 +24188,9 @@ VQ
 Sk
 VM
 li
-li
-li
-DD
+qE
+qE
+qE
 DD
 DD
 DD
@@ -24546,9 +24501,9 @@ li
 li
 li
 li
-li
-qz
-lX
+DD
+Yl
+Yl
 TW
 XH
 XH
@@ -24702,9 +24657,9 @@ DD
 DD
 li
 qz
-VU
-VU
-XH
+Yl
+Yl
+Yl
 VU
 bF
 oW
@@ -24856,12 +24811,12 @@ ow
 ow
 VU
 aG
-TW
-aG
-aI
-aI
-pq
-eY
+Sq
+Sq
+Yl
+Yl
+Yl
+EE
 bD
 Yf
 Yf
@@ -25011,13 +24966,13 @@ VU
 aG
 bX
 aI
-pq
-TW
-bF
-oW
-oW
-oW
-oW
+Pv
+Pv
+Sq
+Yl
+Yl
+Yl
+EE
 Yf
 Yf
 Yf
@@ -25159,21 +25114,21 @@ ow
 ow
 ow
 ow
-bF
-qz
-VU
-VU
-XH
-VU
-bF
-oW
-oW
-oW
-Yf
-Yf
-Yf
-Yf
-Yf
+Ay
+Mr
+ss
+ss
+gU
+ss
+Ay
+IF
+IF
+hF
+hF
+zO
+zO
+vW
+EE
 Yf
 Yf
 Yf
@@ -25315,21 +25270,21 @@ li
 ow
 ow
 ow
-qz
+Mr
 VU
 VU
 aI
 pq
 eY
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+Pv
+Pv
+Sq
+Sq
+Yl
+Yl
+Yl
+vW
+Pv
 Yf
 Yf
 Yf
@@ -25451,11 +25406,11 @@ XO
 WI
 XO
 XO
-HH
-HH
-HH
-HH
-HH
+RU
+RU
+RU
+RU
+RU
 TV
 fP
 TJ
@@ -25471,21 +25426,21 @@ li
 ow
 VU
 VU
-qz
+Mr
 qH
 WS
 oW
 oW
 oW
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+Pv
+Sq
+Sq
+Yl
+Yl
+Yl
+Yl
+vW
+Pv
 Yf
 Yf
 Yf
@@ -25609,9 +25564,9 @@ Za
 Za
 oO
 XO
-sF
-sF
-HH
+hi
+hi
+RU
 fP
 TJ
 dk
@@ -25626,21 +25581,21 @@ tH
 qz
 VU
 qH
-WS
-TW
+yZ
+OM
 XH
 Vb
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+Sq
+Sq
+Yl
+Yl
+Yl
+Yl
+Yl
+EE
+vW
 Yf
 Yf
 Yf
@@ -25782,21 +25737,21 @@ tH
 aG
 eY
 XH
-Vb
+ko
 TW
 bF
-oW
+Pv
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+Sq
+Sq
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+EE
+cp
 Yf
 Yf
 Yf
@@ -25938,21 +25893,21 @@ tH
 lX
 lG
 qz
-bF
+Ay
 oW
+Pv
+Pv
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+Sq
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+EE
+IF
 Yf
 Yf
 Yf
@@ -26094,21 +26049,21 @@ tH
 Vb
 WS
 lG
-bD
+Bc
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+Sq
+Sq
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+EE
+IF
 Yf
 Yf
 Yf
@@ -26250,21 +26205,21 @@ tH
 qz
 Vb
 eY
-bD
+Bc
+Pv
+Sq
+Sq
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+Yl
+Yl
+Yl
+xe
+Yl
+Yl
+Yl
+EE
+Pv
+IF
 Yf
 Yf
 Yf
@@ -26406,21 +26361,21 @@ tH
 KE
 GY
 Gu
-bh
+Co
 re
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+Sq
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+EE
+Pv
+cp
 Yf
 Yf
 Yf
@@ -26562,21 +26517,21 @@ tH
 Nq
 GZ
 GY
+Em
 Gu
-Gu
-bh
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+EE
+EE
+Pv
+cp
 Yf
 Yf
 Yf
@@ -26718,21 +26673,21 @@ tH
 nI
 nI
 nI
-nI
-GY
-Gu
-bh
+Gl
+Za
+Za
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+EE
+Pv
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -26873,22 +26828,22 @@ fu
 tH
 nI
 nI
-nI
-nI
-GZ
-GY
-Gu
+wa
+Gl
+Za
+Za
+Za
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
 Yf
+EE
+Pv
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -27028,23 +26983,23 @@ po
 rn
 tH
 nI
-nI
-xM
-Gu
-bh
+wa
+Za
+Hx
+QP
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+EE
+Pv
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -27185,22 +27140,22 @@ tH
 tH
 nI
 nI
-GZ
-GY
-BL
-bD
+XO
+Ii
+Za
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yf
+EE
+EE
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -27341,22 +27296,22 @@ oP
 oP
 nI
 nI
-AK
-KV
-xM
-bD
+XO
+Ii
+Za
+QP
+Yl
+Yl
+Yl
+Yf
+EE
+EE
+EE
 Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -27497,22 +27452,22 @@ wa
 wa
 oP
 oP
-nI
-BL
-xM
-bD
+oP
+Ii
+Za
+QP
+Yl
+Yl
+Yl
+EE
+Pv
+Pv
+Pv
 Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -27653,22 +27608,22 @@ oP
 wa
 oP
 oP
-AK
-KV
-xM
-bD
+Za
+Ii
+Za
+Yl
+Yl
+Yf
+EE
+Pv
+Pv
 Yf
 Yf
 Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -27810,9 +27765,13 @@ oP
 wa
 oP
 nI
-nI
+Gl
 BL
 xM
+EE
+Pv
+Pv
+Pv
 Yf
 Yf
 Yf
@@ -27820,11 +27779,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -27934,18 +27889,18 @@ qC
 wv
 mh
 nW
+cz
 on
 on
 on
 on
 on
-on
-fM
+Xb
 Sc
 at
-GC
+Kz
 Sc
-fM
+Xb
 on
 on
 on
@@ -27966,9 +27921,11 @@ oP
 wa
 oP
 oP
-AK
+Js
 NT
 xM
+Pv
+Pv
 Yf
 Yf
 Yf
@@ -27978,9 +27935,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -28098,16 +28053,16 @@ WA
 WA
 WA
 WA
-wt
+cG
 Ko
 WA
 Oy
-QN
+ZN
 nd
-ud
+oq
 tL
 tL
-vk
+jW
 fI
 fI
 fI
@@ -28123,20 +28078,20 @@ oP
 oP
 AK
 zy
-NT
-Nq
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+Sb
+FD
+cp
+cp
+cp
+cp
+cp
+cp
+cp
+cp
+cp
+cp
+cp
+cp
 Yf
 Yf
 Yf
@@ -28246,24 +28201,24 @@ on
 wa
 wa
 wa
-oP
+sT
 wa
 ka
 IT
 IT
-LN
-Hx
+BK
+ZD
 IT
-os
-PF
+hP
+Kt
 nc
-DO
-Az
+LB
+LY
 tL
 tL
 tL
 tL
-vk
+jW
 fI
 fI
 fI
@@ -28410,10 +28365,10 @@ IT
 IT
 on
 on
-Gr
-PF
+Pc
+QW
 nf
-Cc
+rm
 tL
 tL
 tL
@@ -28423,7 +28378,7 @@ tL
 fI
 fI
 OA
-oC
+cy
 nI
 nI
 En
@@ -28566,8 +28521,8 @@ IT
 RQ
 on
 on
-os
-PF
+hP
+QW
 IT
 IT
 Wm
@@ -28722,8 +28677,8 @@ IT
 IT
 IT
 mP
-os
-PF
+hP
+QW
 IT
 IT
 on
@@ -28878,13 +28833,13 @@ IT
 IT
 IT
 IT
-os
-PF
+hP
+QW
 IT
 IT
 on
 tL
-MC
+Uy
 on
 wa
 oP
@@ -29026,21 +28981,21 @@ on
 OL
 oP
 oP
-td
-IT
-on
-on
-on
-on
-on
-on
-os
-Hc
 IT
 IT
 on
-VA
-sR
+on
+on
+on
+on
+on
+hP
+QW
+IT
+IT
+on
+xt
+Uo
 on
 oP
 wa
@@ -29190,8 +29145,8 @@ IT
 mP
 IT
 on
-os
-PF
+hP
+QW
 IT
 IT
 on
@@ -29346,8 +29301,8 @@ IT
 IT
 IT
 ka
-os
-PF
+hP
+QW
 IT
 IT
 IT
@@ -29499,11 +29454,11 @@ RQ
 on
 kv
 IT
-CT
+iV
 IT
 IT
-os
-PF
+hP
+QW
 nc
 nc
 nc
@@ -29658,9 +29613,9 @@ lo
 lo
 IT
 on
-os
-PF
-xj
+hP
+Kt
+nf
 nf
 nf
 nf
@@ -29814,8 +29769,8 @@ lo
 lo
 IT
 on
-os
-Hc
+hP
+QW
 IT
 IT
 IT
@@ -29970,8 +29925,8 @@ lp
 IT
 RQ
 on
-Gr
-PF
+Pc
+QW
 on
 on
 on
@@ -30118,21 +30073,21 @@ gc
 TJ
 TJ
 fZ
-IT
+td
 IT
 ka
 IT
 IT
-CT
+iV
 IT
 on
-os
-PF
+hP
+QW
 on
-pW
-iO
-iO
-IB
+tG
+qL
+qL
+zF
 on
 oP
 nI
@@ -30282,9 +30237,9 @@ lo
 lo
 IT
 ka
-os
-PF
-cy
+hP
+QW
+yk
 IT
 IT
 IT
@@ -30438,13 +30393,13 @@ lo
 lo
 IT
 IT
-os
-PF
-uW
+hP
+QW
+xx
 IT
 IT
 IT
-el
+mF
 on
 oP
 wa
@@ -30590,16 +30545,16 @@ IT
 IT
 on
 IT
-Hx
+ZD
 lp
 IT
 on
-os
-PF
+hP
+QW
 on
-gE
+ZM
 mG
-Og
+UW
 nm
 on
 on
@@ -30607,7 +30562,7 @@ on
 yB
 nW
 on
-on
+cz
 iT
 PR
 tv
@@ -30750,8 +30705,8 @@ on
 on
 on
 on
-os
-PF
+hP
+QW
 on
 on
 on
@@ -30759,7 +30714,7 @@ on
 on
 on
 nI
-RF
+DO
 nI
 oP
 wa
@@ -30906,8 +30861,8 @@ Qp
 oP
 oP
 wa
-Ok
-PF
+zq
+QW
 wa
 oP
 wa
@@ -31063,7 +31018,7 @@ oP
 wa
 lP
 lZ
-Hc
+Kt
 IT
 wa
 wa
@@ -31072,10 +31027,10 @@ oP
 oP
 oP
 nI
-sT
+oP
 oP
 wa
-oP
+sT
 qz
 bF
 XN


### PR DESCRIPTION
## About The Pull Request

I have been getting some dm's to bring back my icy caves edit, so here it is with fixes and some changes.

## Why It's Good For The Game

Swaps around Crash disk locations, move some stupid silo spots in Crash and changes them up to make it a bit more challenging for marines as they dominate this map whilst not giving Xenos free handouts either. LZ2 is redone sorta. Lz1 has been tinkered with and northwest caves have a new area, 

## Changelog
:cl:
balance: LZ2 semi redone to make it more appealing for marines
balance: some LZ1 changes
balance: moved crash disk locations
balance: removed some silos like that one in the nuke disk area and replaced them elsewhere
balance: caves have been fully pre wedded as they should
add: new area northeast of caves transit station (not pre wedded)

/:cl:

**Updated pictures**

(1)
![image](https://user-images.githubusercontent.com/64131993/148223147-f4ee20f1-2f33-4b8f-b515-fadacc446414.png)


(2)
![image](https://user-images.githubusercontent.com/64131993/149647666-f0db1f9e-ebe8-420c-88ec-754d18c164ce.png)


(3)
![image](https://user-images.githubusercontent.com/64131993/149647640-712bbaee-0376-4c9b-89a7-e346e3a49d2d.png)


(4)
![image](https://user-images.githubusercontent.com/64131993/149647609-b2081493-50fb-4001-bbc2-e1e3fcb26e31.png)

(5)
![image](https://user-images.githubusercontent.com/64131993/149647623-e6a6004a-916c-46f3-9fd1-02ac64621c99.png)

