### PR TITLE
Removes bumpattack from vali related tools

### DIFF
--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -67,6 +67,14 @@
 	. = ..()
 	AddComponent(/datum/component/harvester)
 
+/obj/item/weapon/claymore/harvester/equipped(mob/user, slot)
+	. = ..()
+	toggle_item_bump_attack(user, TRUE)
+
+/obj/item/weapon/claymore/harvester/dropped(mob/user)
+	. = ..()
+	toggle_item_bump_attack(user, FALSE)
+
 /obj/item/weapon/claymore/harvester/get_mechanics_info()
 	. = ..()
 	. += jointext(codex_info, "<br>")

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -67,14 +67,6 @@
 	. = ..()
 	AddComponent(/datum/component/harvester)
 
-/obj/item/weapon/claymore/harvester/equipped(mob/user, slot)
-	. = ..()
-	toggle_item_bump_attack(user, TRUE)
-
-/obj/item/weapon/claymore/harvester/dropped(mob/user)
-	. = ..()
-	toggle_item_bump_attack(user, FALSE)
-
 /obj/item/weapon/claymore/harvester/get_mechanics_info()
 	. = ..()
 	. += jointext(codex_info, "<br>")

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -273,14 +273,6 @@
 	. = ..()
 	AddComponent(/datum/component/harvester)
 
-/obj/item/weapon/twohanded/spear/tactical/harvester/equipped(mob/user, slot)
-	. = ..()
-	toggle_item_bump_attack(user, TRUE)
-
-/obj/item/weapon/twohanded/spear/tactical/harvester/dropped(mob/user)
-	. = ..()
-	toggle_item_bump_attack(user, FALSE)
-
 /obj/item/weapon/twohanded/spear/tactical/tacticool
 	name = "M-23 TACTICOOL spear"
 	icon = 'icons/Marine/gun64.dmi'


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Vali related tools lose bump, spear and machete.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Vali bump is honestly not that great of an idea, spear atleast, shouldn't have it. I might just only remove spear bump. But I feel like marine bump other than machete is a bad idea, it gives machete some level of reason to be used over the spear or machete or vali spear etc.. 
I feel like spear should lose it, but I think Vali melee in general shouldn't have bump. I like the idea of a high risk high difficulty playstyle that vali should have.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: vali tools like spear and sword no longer have bump attack.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
