### PR TITLE
Cache Greyscale Palettes at Round Init

### DIFF
--- a/code/controllers/subsystem/greyscale.dm
+++ b/code/controllers/subsystem/greyscale.dm
@@ -14,6 +14,22 @@ SUBSYSTEM_DEF(greyscale)
 		var/datum/greyscale_config/config = new greyscale_type()
 		configurations["[greyscale_type]"] = config
 
+	for(var/obj/item/armor_module/armor/armor_type AS in subtypesof(/obj/item/armor_module/armor))
+		if(!initial(armor_type.greyscale_config))
+			continue
+		var/obj/item/armor_module/armor/armor = new armor_type()
+		for(var/key in armor.colorable_colors)
+			GetColoredIconByType(armor.greyscale_config, armor.colorable_colors[key])
+		qdel(armor)
+
+	for(var/obj/item/clothing/head/modular/helmet_type AS in subtypesof(/obj/item/clothing/head/modular))
+		if(!initial(helmet_type.greyscale_config))
+			continue
+		var/obj/item/clothing/head/modular/helmet = new helmet_type()
+		for(var/key in helmet.colorable_colors)
+			GetColoredIconByType(helmet.greyscale_config, helmet.colorable_colors[key])
+		qdel(helmet)
+
 	return ..()
 
 /datum/controller/subsystem/greyscale/proc/RefreshConfigsFromFile()

--- a/code/modules/clothing/modular_armor/attachments.dm
+++ b/code/modules/clothing/modular_armor/attachments.dm
@@ -128,14 +128,6 @@
 
 /obj/item/armor_module/armor/Initialize()
 	. = ..()
-	if(greyscale_config && length(SSgreyscale.configurations["[greyscale_config]"].icon_cache) < length(colorable_colors)) //This checks if the current greyscale config has all the colors chached. If not it caches them.
-		for(var/key in colorable_colors)
-			var/color = colorable_colors[key]
-			set_greyscale_colors(color)
-		if(flags_item_map_variant)
-			update_item_sprites()
-		else
-			set_greyscale_colors(initial(greyscale_colors))
 	item_state = initial(icon_state) + "_a"
 	update_icon()
 

--- a/code/modules/clothing/modular_armor/attachments/badges.dm
+++ b/code/modules/clothing/modular_armor/attachments/badges.dm
@@ -8,6 +8,7 @@
 	flags_attach_features = ATTACH_REMOVABLE|ATTACH_APPLY_ON_MOB|ATTACH_NO_HANDS|ATTACH_SAME_ICON
 	colorable_allowed = COLOR_WHEEL_ONLY
 	flags_item_map_variant = NONE
+	colorable_colors = list()
 
 	///List of selectable styles for where the badge is worn.
 	var/list/style_list = list(

--- a/code/modules/clothing/modular_armor/attachments/visors.dm
+++ b/code/modules/clothing/modular_armor/attachments/visors.dm
@@ -7,6 +7,7 @@
 /obj/item/armor_module/armor/visor
 	name = "standard visor"
 	slot = ATTACHMENT_SLOT_VISOR
+	greyscale_config = /datum/greyscale_config/modular_helmet_visor
 	///Initial hex color we use when applying the visor color
 	greyscale_colors = VISOR_PALETTE_GOLD
 	flags_attach_features = ATTACH_SAME_ICON|ATTACH_APPLY_ON_MOB

--- a/code/modules/clothing/modular_armor/modular.dm
+++ b/code/modules/clothing/modular_armor/modular.dm
@@ -363,14 +363,6 @@
 
 /obj/item/clothing/head/modular/Initialize()
 	. = ..()
-	if(greyscale_config && length(SSgreyscale.configurations["[greyscale_config]"].icon_cache) < length(colorable_colors)) //This checks if the current greyscale config has all the colors chached. If not it caches them.
-		for(var/key in colorable_colors)
-			var/color = colorable_colors[key]
-			set_greyscale_colors(color)
-		if(flags_item_map_variant)
-			update_item_sprites()
-		else
-			set_greyscale_colors(initial(greyscale_colors))
 	update_icon() //Update for greyscale.
 
 /obj/item/clothing/head/modular/update_icon()


### PR DESCRIPTION

## About The Pull Request
Makes the greyscale palettes for jaeger armor and helmets cache at round initialization. This is much more performant.


## Why It's Good For The Game
See above


## Changelog
:cl:
code: Makes the greyscale palettes for jaeger armor and helmets cache at round initialization. This is much more performant.
/:cl:


