### PR TITLE
Change plasma_cost of Psychic Summon so that young King can use Psychic Summon

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
@@ -131,7 +131,7 @@
 	action_icon_state = "stomp"
 	mechanics_text = "Summons all xenos in a hive to the caller's location, uses all plasma to activate."
 	ability_name = "Psychic summon"
-	plasma_cost = 1100 //uses all an elder kings plasma
+	plasma_cost = 900 //uses all an young kings plasma
 	cooldown_timer = 10 MINUTES
 	keybind_flags = XACT_KEYBIND_USE_ABILITY
 	keybind_signal = COMSIG_XENOABILITY_HIVE_SUMMON

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -88,7 +88,7 @@
 	speed = -0.2
 
 	// *** Plasma *** //
-	plasma_max = 1200
+	plasma_max = 1100
 	plasma_gain = 60
 
 	// *** Health *** //
@@ -115,7 +115,7 @@
 	speed = -0.3
 
 	// *** Plasma *** //
-	plasma_max = 1300
+	plasma_max = 1200
 	plasma_gain = 70
 
 	// *** Health *** //

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -15,7 +15,7 @@
 	speed = 0
 
 	// *** Plasma *** //
-	plasma_max = 1100
+	plasma_max = 900
 	plasma_gain = 40
 
 	// *** Health *** //
@@ -63,7 +63,7 @@
 	speed = -0.1
 
 	// *** Plasma *** //
-	plasma_max = 1200
+	plasma_max = 1000
 	plasma_gain = 50
 
 	// *** Health *** //
@@ -88,7 +88,7 @@
 	speed = -0.2
 
 	// *** Plasma *** //
-	plasma_max = 1300
+	plasma_max = 1200
 	plasma_gain = 60
 
 	// *** Health *** //
@@ -115,7 +115,7 @@
 	speed = -0.3
 
 	// *** Plasma *** //
-	plasma_max = 1400
+	plasma_max = 1300
 	plasma_gain = 70
 
 	// *** Health *** //

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -15,7 +15,7 @@
 	speed = 0
 
 	// *** Plasma *** //
-	plasma_max = 900
+	plasma_max = 1100
 	plasma_gain = 40
 
 	// *** Health *** //
@@ -63,7 +63,7 @@
 	speed = -0.1
 
 	// *** Plasma *** //
-	plasma_max = 1000
+	plasma_max = 1200
 	plasma_gain = 50
 
 	// *** Health *** //
@@ -88,7 +88,7 @@
 	speed = -0.2
 
 	// *** Plasma *** //
-	plasma_max = 1100
+	plasma_max = 1300
 	plasma_gain = 60
 
 	// *** Health *** //
@@ -115,7 +115,7 @@
 	speed = -0.3
 
 	// *** Plasma *** //
-	plasma_max = 1200
+	plasma_max = 1400
 	plasma_gain = 70
 
 	// *** Health *** //


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bravemole forgot that psychic summon is 1,100 plasma, and he didn't change the cost of psychic summon. I'm making this PR to bring awareness to this.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: change plasma_cost on King's psychic summon, meaning he can psychic summon at young
fix: King can use psychic summon from young and mature now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
