### PR TITLE
Give queen command minions

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -70,6 +70,7 @@
 		/datum/action/xeno_action/deevolve,
 		/datum/action/xeno_action/rally_hive,
 		/datum/action/xeno_action/rally_minion,
+		/datum/action/xeno_action/activable/command_minions,
 		/datum/action/xeno_action/set_agressivity,
 	)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Title.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Restricting this ability to hivemind was a bad idea in retrospect. It's locking a fun ability that would suit well queen just to promote playing hivemind. Hivemind will still be better at controlling minions because of its ability to move around the map quickly, but queen should be able to tell minions where to go as well

## Changelog
:cl:
balance: Give queen the command minion ability
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
