### PR TITLE
Plasma pistol buff

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1628,7 +1628,7 @@ datum/ammo/bullet/revolver/tp44
 	icon_state = "overchargedlaser"
 	hud_state = "laser_sniper"
 	damage = 40
-	max_range = 7
+	max_range = 14
 	penetration = 5
 	shell_speed = 1.5
 	flags_ammo_behavior = AMMO_ENERGY|AMMO_INCENDIARY|AMMO_EXPLOSIVE
@@ -1642,7 +1642,15 @@ datum/ammo/bullet/revolver/tp44
 	var/fire_color = "green"
 
 /datum/ammo/energy/plasma_pistol/on_hit_turf(turf/T, obj/projectile/proj)
-	T.ignite(heat, burn_damage, fire_color)
+	var/burn_mod = 1
+	if(istype(T, /turf/closed/wall))
+		burn_mod = 3
+	T.ignite(heat, burn_damage * burn_mod, fire_color)
+	for(var/mob/living/mob_caught in T)
+		if(mob_caught.stat == DEAD)
+			continue
+		mob_caught.adjust_fire_stacks(burn_damage)
+		mob_caught.IgniteMob()
 
 /datum/ammo/energy/plasma_pistol/on_hit_mob(mob/M, obj/projectile/proj)
 	var/turf/T = get_turf(M)

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -310,7 +310,10 @@
 	fire_sound = 'sound/weapons/guns/fire/flamethrower3.ogg'
 
 	default_ammo_type = /obj/item/ammo_magazine/flamer_tank/mini
-	allowed_ammo_types = list(/obj/item/ammo_magazine/flamer_tank/mini)
+	allowed_ammo_types = list(
+		/obj/item/ammo_magazine/flamer_tank/mini,
+		/obj/item/ammo_magazine/flamer_tank/backtank,
+	)
 	starting_attachment_types = list(/obj/item/attachable/flamer_nozzle/unremovable/invisible)
 	attachable_allowed = list(
 		/obj/item/attachable/flamer_nozzle/unremovable/invisible,
@@ -321,6 +324,7 @@
 	pixel_shift_x = 15
 	pixel_shift_y = 18
 
+	mob_flame_damage_mod = 1
 	flame_max_range = 4
 
 /obj/item/weapon/gun/flamer/mini_flamer/unremovable

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -310,10 +310,7 @@
 	fire_sound = 'sound/weapons/guns/fire/flamethrower3.ogg'
 
 	default_ammo_type = /obj/item/ammo_magazine/flamer_tank/mini
-	allowed_ammo_types = list(
-		/obj/item/ammo_magazine/flamer_tank/mini,
-		/obj/item/ammo_magazine/flamer_tank/backtank,
-	)
+	allowed_ammo_types = list(/obj/item/ammo_magazine/flamer_tank/mini)
 	starting_attachment_types = list(/obj/item/attachable/flamer_nozzle/unremovable/invisible)
 	attachable_allowed = list(
 		/obj/item/attachable/flamer_nozzle/unremovable/invisible,
@@ -324,7 +321,6 @@
 	pixel_shift_x = 15
 	pixel_shift_y = 18
 
-	mob_flame_damage_mod = 1
 	flame_max_range = 4
 
 /obj/item/weapon/gun/flamer/mini_flamer/unremovable

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -89,6 +89,7 @@
 		/obj/item/attachable/lace,
 		/obj/item/attachable/buildasentry,
 		/obj/item/attachable/shoulder_mount,
+		/obj/item/attachable/scope/marine,
 	)
 
 	muzzleflash_iconstate = "muzzle_flash_laser"
@@ -99,8 +100,6 @@
 	muzzle_flash_color = COLOR_GREEN
 
 	fire_delay = 1.5 SECONDS
-	accuracy_mult = 0.8
-	accuracy_mult_unwielded = 0.35
 	scatter = -1
 	scatter_unwielded = 2
 	recoil = -2


### PR DESCRIPTION
## About The Pull Request
This aims to bring the plasma pistols niche back and give it some QOL

Changed the guns accuracy stats to 1, the shots will not always miss xenos. This was because I didnt quite understand the var when I initially added the gun. Willing to lower it again if its too powerful.

Plasma pistol shots range increase to 14 from 7.
Gives plasma pistol its t47 scope back.

If a turf is hit, any mobs on top of it will be ignited. This is too make it consistent.
If the turf that is hit is a wall, its firestacks will be tripled to give its original role back. Walls gained a ton of flame armor to nerf flamers but it also killed the plasma pistols niche. This will give it back without making the fire oppressive in combat. Flame duration is unchanged.

## Why It's Good For The Game

There was a nerf aimed for flamers that gave walls a fair amount of fire armor. It was aimed for flamers and in the process removed the plasma pistols niche.
This gives its niche back and a few other buffs to make it more worthwhile to use in general.


## Changelog
:cl:
balance: Plasma pistol accuracy increased to 1 from .8 (wielded) and .35 (unwielded)
balance: Plasma pistol gains its t47 scope again
balance: Plasma pistol range increased to 14 from 7
balance: Plasma pistol fire damage tripled if the projectile hits a wall.
qol: Plasma pistol fire will now ignite any mobs on top of it.
/:cl:

