### PR TITLE
Miniflamer nerf.

### DIFF
--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -310,7 +310,10 @@
 	fire_sound = 'sound/weapons/guns/fire/flamethrower3.ogg'
 
 	default_ammo_type = /obj/item/ammo_magazine/flamer_tank/mini
-	allowed_ammo_types = list(/obj/item/ammo_magazine/flamer_tank/mini)
+	allowed_ammo_types = list(
+		/obj/item/ammo_magazine/flamer_tank/mini,
+		/obj/item/ammo_magazine/flamer_tank/backtank,
+	)
 	starting_attachment_types = list(/obj/item/attachable/flamer_nozzle/unremovable/invisible)
 	attachable_allowed = list(
 		/obj/item/attachable/flamer_nozzle/unremovable/invisible,
@@ -321,6 +324,7 @@
 	pixel_shift_x = 15
 	pixel_shift_y = 18
 
+	mob_flame_damage_mod = 1
 	flame_max_range = 4
 
 /obj/item/weapon/gun/flamer/mini_flamer/unremovable


### PR DESCRIPTION
## About The Pull Request
Miniflamer now will not do any bonus damage to mobs hit in the initial fire stream.
Miniflamer can now be connected to the backpack fuel tank once more.

## Why It's Good For The Game

I was supposed to nerf the miniflamer when I did the flamer rework, I forgot so here it is. This will aim to make the miniflamer less oppressive damage wise yet still keep its area denial capabilities.
When I refactored guns I accidentally removed the ability to connect the miniflamer to a back tank. This remedies that.

## Changelog
:cl:
balance: Miniflamer now will not do any bonus damage to mobs hit in the initial fire stream.
fix: Miniflamer can now be connected to the backpack fuel tank once more.
/:cl:
