### PR TITLE
OOC Color rights fix

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -53,7 +53,7 @@
 
 	var/display_colour
 	var/display_class = "colorooc"
-	if(holder?.rank && !holder.fakekey && check_rights(R_COLOR, FALSE))
+	if(holder?.rank && !holder.fakekey)
 		switch(holder.rank.name)
 			if("Host")
 				display_class = "hostooc"
@@ -87,7 +87,7 @@
 				display_class = "otherooc"
 
 
-		if(CONFIG_GET(flag/allow_admin_ooccolor))
+		if(CONFIG_GET(flag/allow_admin_ooccolor) && check_rights(R_COLOR, FALSE))
 			display_colour = prefs.ooccolor
 
 	for(var/client/C AS in GLOB.clients)

--- a/code/modules/admin/holder.dm
+++ b/code/modules/admin/holder.dm
@@ -266,7 +266,6 @@ GLOBAL_PROTECT(admin_verbs_default)
 	/datum/admins/proc/pref_ff_attack_logs,
 	/datum/admins/proc/pref_end_attack_logs,
 	/datum/admins/proc/pref_debug_logs,
-	/datum/admins/proc/set_ooc_color_self,
 	/datum/admins/proc/admin_ghost,
 	/datum/admins/proc/invisimin,
 	/datum/admins/proc/stealth_mode,
@@ -455,7 +454,7 @@ GLOBAL_PROTECT(admin_verbs_permissions)
 
 /world/proc/AVcolor()
 	return list(
-
+		/datum/admins/proc/set_ooc_color_self,
 	)
 GLOBAL_LIST_INIT(admin_verbs_color, world.AVcolor())
 GLOBAL_PROTECT(admin_verbs_color)

--- a/code/modules/admin/preferences_verbs.dm
+++ b/code/modules/admin/preferences_verbs.dm
@@ -53,7 +53,7 @@
 	set category = "Preferences"
 	set name = "OOC Text Color"
 
-	if(!check_rights(R_FUN))
+	if(!check_rights(R_COLOR))
 		return
 
 	var/new_ooccolor = input(src, "Please select your OOC colour", "OOC colour") as color|null


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes admin color dependent of R_COLOR Perms, and removes its need for showing the color for any staff(useless)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Closes #9212 
![image](https://user-images.githubusercontent.com/29824735/148706936-db3e65f2-9414-4a2a-af55-52d104e261c6.png)


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: now roles with rights to color changing will have access to change their color and show it as opposed to all showing but only changing with rights to  R_FUN
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
