### PR TITLE
Defenders that are fortified with 100+ bullet armor will have rounds bounce off of them.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -317,6 +317,8 @@
 		X.soft_armor = X.soft_armor.modifyAllRatings(fortifyAB)
 		X.soft_armor = X.soft_armor.setRating(bomb = XENO_BOMB_RESIST_4)
 		last_fortify_bonus = fortifyAB
+		if(X.soft_armor.getRating("bullet") >= 100)
+			X.add_filter("bullet_bounce_outline", 2, outline_filter(1, COLOR_VERY_DARK_LIME_GREEN))
 	else
 		if(!silent)
 			to_chat(X, span_xenowarning("We resume our normal stance."))
@@ -324,6 +326,7 @@
 		X.soft_armor = X.soft_armor.setRating(bomb = XENO_BOMB_RESIST_2)
 		last_fortify_bonus = 0
 		REMOVE_TRAIT(X, TRAIT_IMMOBILE, FORTIFY_TRAIT)
+		X.remove_filter("bullet_bounce_outline")
 	X.fortify = on
 	X.anchored = on
 	playsound(X.loc, 'sound/effects/stonedoor_openclose.ogg', 30, TRUE)

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
@@ -66,3 +66,35 @@
 		to_chat(src, span_warning("You can't do that right now."))
 		return
 	return ..()
+
+/mob/living/carbon/xenomorph/defender/bullet_act(obj/projectile/proj)
+	var/soft_armor_value = soft_armor.getRating("bullet")
+	var/ammo_type = proj.ammo
+	var/shot_from = proj.shot_from
+	. = ..()
+	if(proj.ammo.damage_type != BRUTE || !fortify || soft_armor_value < 100)
+		return
+
+	var/ricochet_angle = 360 - Get_Angle(proj.firer, loc)
+	// Check for the neightbour tile
+	var/rico_dir_check
+	switch(ricochet_angle)
+		if(-INFINITY to 45)
+			rico_dir_check = EAST
+		if(46 to 135)
+			rico_dir_check = ricochet_angle > 90 ? SOUTH : NORTH
+		if(136 to 225)
+			rico_dir_check = ricochet_angle > 180 ? WEST : EAST
+		if(126 to 315)
+			rico_dir_check = ricochet_angle > 270 ? NORTH : SOUTH
+		if(316 to INFINITY)
+			rico_dir_check = WEST
+
+	var/turf/next_turf = get_step(loc, rico_dir_check)
+	if(next_turf.density)
+		ricochet_angle += 180
+
+	var/obj/projectile/new_proj = new(next_turf)
+	new_proj.generate_bullet(ammo_type)
+	new_proj.iff_signal = NONE
+	new_proj.fire_at(null, src, shot_from, new_proj.proj_max_range, new_proj.projectile_speed, ricochet_angle, suppress_light = TRUE)

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
@@ -74,7 +74,8 @@
 	. = ..()
 	if(proj.ammo.damage_type != BRUTE || !fortify || soft_armor_value < 100)
 		return
-
+	if(soft_armor.getRating("bullet") < 100) //This uses the non-cached soft_armor value so it will remove the outline if the hit caused the defender to drop below 100 bullet armor.
+		remove_filter("bullet_bounce_outline")
 	var/ricochet_angle = 360 - Get_Angle(proj.firer, loc)
 	// Check for the neightbour tile
 	var/rico_dir_check


### PR DESCRIPTION

## About The Pull Request
If a Defender is fortified and has 100+ bullet armor, bullets will reflect off of it.
This only counts for projectiles that do brute damage.

Defender is still hit by the projectiles so sunder and ap will still be applied.
Sadar shots de-fortify on hit and thus cannot be reflected.

## Why It's Good For The Game
This can only be achieved through ancient defender with very strong warding pheros.
I figure this will be a funny interaction that will not cause too much problems balance wise.


## Changelog
:cl:
add: If a Defender is fortified and has 100+ bullet armor, bullets will reflect off of it.
/:cl:

