### PR TITLE
Updating the TerraGov Corpsman Vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -955,6 +955,7 @@
 			/obj/item/bodybag/cryobag = 4,
 			/obj/item/healthanalyzer = 4,
 			)
+
 	contraband = list(/obj/item/reagent_containers/blood/OMinus = 1)
 
 /obj/machinery/vending/marine_medic/rebel

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -947,6 +947,7 @@
 			/obj/item/reagent_containers/glass/bottle/medicalnanites = 2,
 		),
 		"Misc" = list(
+			/obj/item/storage/syringe_case = 10,
 			/obj/item/clothing/under/marine/corpsman = 4,
 			/obj/item/storage/backpack/marine/corpsman = 4,
 			/obj/item/storage/backpack/marine/satchel/corpsman = 4,

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -955,6 +955,7 @@
 			/obj/item/bodybag/cryobag = 4,
 			/obj/item/healthanalyzer = 4,
 			)
+	)
 
 	contraband = list(/obj/item/reagent_containers/blood/OMinus = 1)
 

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -916,44 +916,45 @@
 	icon_deny = "marinemed-deny"
 	wrenchable = FALSE
 
-	"Hypospray" = list (
-		/obj/item/reagent_containers/hypospray/advanced/bicaridine = 4,
-		/obj/item/reagent_containers/hypospray/advanced/kelotane = 4,
-		/obj/item/reagent_containers/hypospray/advanced/tramadol = 4,
-		/obj/item/reagent_containers/hypospray/advanced/tricordrazine = 4,
-		/obj/item/reagent_containers/hypospray/advanced/dexalin = 4,
-		/obj/item/reagent_containers/hypospray/advanced/inaprovaline = 4,
-		/obj/item/reagent_containers/hypospray/advanced/peridaxon = 4,
-		/obj/item/reagent_containers/hypospray/advanced/quickclot = 4,
-		/obj/item/clothing/glasses/hud/health = 4,
-		/obj/item/storage/firstaid/regular = 4,
-		/obj/item/storage/firstaid/adv = 8,
-		/obj/item/storage/pouch/medical = 4,
-		/obj/item/storage/pouch/medkit = 4,
+	products = list(
+		"Hypospray" = list (
+			/obj/item/reagent_containers/hypospray/advanced/bicaridine = 4,
+			/obj/item/reagent_containers/hypospray/advanced/kelotane = 4,
+			/obj/item/reagent_containers/hypospray/advanced/tramadol = 4,
+			/obj/item/reagent_containers/hypospray/advanced/tricordrazine = 4,
+			/obj/item/reagent_containers/hypospray/advanced/dexalin = 4,
+			/obj/item/reagent_containers/hypospray/advanced/inaprovaline = 4,
+			/obj/item/reagent_containers/hypospray/advanced/peridaxon = 4,
+			/obj/item/reagent_containers/hypospray/advanced/quickclot = 4,
+			/obj/item/clothing/glasses/hud/health = 4,
+			/obj/item/storage/firstaid/regular = 4,
+			/obj/item/storage/firstaid/adv = 8,
+			/obj/item/storage/pouch/medical = 4,
+			/obj/item/storage/pouch/medkit = 4,
+			),
+		"Reagent Bottle" = list(
+			/obj/item/reagent_containers/glass/bottle/bicaridine = 4,
+			/obj/item/reagent_containers/glass/bottle/kelotane = 4,
+			/obj/item/reagent_containers/glass/bottle/dylovene = 4,
+			/obj/item/reagent_containers/glass/bottle/tramadol = 4,
+			/obj/item/reagent_containers/glass/bottle/inaprovaline = 4,
+			/obj/item/reagent_containers/glass/bottle/sleeptoxin = 2,
+			/obj/item/reagent_containers/glass/bottle/spaceacillin = 4,
+			/obj/item/reagent_containers/glass/bottle/peridaxon = 2,
+			/obj/item/reagent_containers/glass/bottle/dexalin = 4,
+			/obj/item/reagent_containers/glass/bottle/oxycodone = 4,
+			/obj/item/reagent_containers/glass/bottle/polyhexanide = 2,
+			/obj/item/reagent_containers/glass/bottle/medicalnanites = 2,
 		),
-	"Reagent Bottle" = list(
-		/obj/item/reagent_containers/glass/bottle/bicaridine = 4,
-		/obj/item/reagent_containers/glass/bottle/kelotane = 4,
-		/obj/item/reagent_containers/glass/bottle/dylovene = 4,
-		/obj/item/reagent_containers/glass/bottle/tramadol = 4,
-		/obj/item/reagent_containers/glass/bottle/inaprovaline = 4,
-		/obj/item/reagent_containers/glass/bottle/sleeptoxin = 2,
-		/obj/item/reagent_containers/glass/bottle/spaceacillin = 4,
-		/obj/item/reagent_containers/glass/bottle/peridaxon = 2,
-		/obj/item/reagent_containers/glass/bottle/dexalin = 4,
-		/obj/item/reagent_containers/glass/bottle/oxycodone = 4,
-		/obj/item/reagent_containers/glass/bottle/polyhexanide = 2,
-		/obj/item/reagent_containers/glass/bottle/medicalnanites = 2,
-		),
-	"Misc" = list(
-		/obj/item/clothing/under/marine/corpsman = 4,
-		/obj/item/storage/backpack/marine/corpsman = 4,
-		/obj/item/storage/backpack/marine/satchel/corpsman = 4,
-		/obj/item/encryptionkey/med = 4,
-		/obj/item/storage/belt/medical = 6,
-		/obj/item/bodybag/cryobag = 4,
-		/obj/item/healthanalyzer = 4,
-		)
+		"Misc" = list(
+			/obj/item/clothing/under/marine/corpsman = 4,
+			/obj/item/storage/backpack/marine/corpsman = 4,
+			/obj/item/storage/backpack/marine/satchel/corpsman = 4,
+			/obj/item/encryptionkey/med = 4,
+			/obj/item/storage/belt/medical = 6,
+			/obj/item/bodybag/cryobag = 4,
+			/obj/item/healthanalyzer = 4,
+			)
 	contraband = list(/obj/item/reagent_containers/blood/OMinus = 1)
 
 /obj/machinery/vending/marine_medic/rebel

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -908,33 +908,52 @@
 			if(!temp_list.len) break
 
 /obj/machinery/vending/marine_medic
-	name = "\improper TerraGovTech Medic Vendor"
-	desc = "A marine medic equipment vendor"
+	name = "\improper TerraGovTech Corpsman Vendor"
+	desc = "A marine corpsman equipment vendor"
 	product_ads = "They were gonna die anyway.;Let's get space drugged!"
 	req_access = list(ACCESS_MARINE_MEDPREP)
 	icon_state = "marinemed"
 	icon_deny = "marinemed-deny"
 	wrenchable = FALSE
 
-	products = list(
+	"Hypospray" = list (
+		/obj/item/reagent_containers/hypospray/advanced/bicaridine = 4,
+		/obj/item/reagent_containers/hypospray/advanced/kelotane = 4,
+		/obj/item/reagent_containers/hypospray/advanced/tramadol = 4,
+		/obj/item/reagent_containers/hypospray/advanced/tricordrazine = 4,
+		/obj/item/reagent_containers/hypospray/advanced/dexalin = 4,
+		/obj/item/reagent_containers/hypospray/advanced/inaprovaline = 4,
+		/obj/item/reagent_containers/hypospray/advanced/peridaxon = 4,
+		/obj/item/reagent_containers/hypospray/advanced/quickclot = 4,
+		/obj/item/clothing/glasses/hud/health = 4,
+		/obj/item/storage/firstaid/regular = 4,
+		/obj/item/storage/firstaid/adv = 8,
+		/obj/item/storage/pouch/medical = 4,
+		/obj/item/storage/pouch/medkit = 4,
+		),
+	"Reagent Bottle" = list(
+		/obj/item/reagent_containers/glass/bottle/bicaridine = 4,
+		/obj/item/reagent_containers/glass/bottle/kelotane = 4,
+		/obj/item/reagent_containers/glass/bottle/dylovene = 4,
+		/obj/item/reagent_containers/glass/bottle/tramadol = 4,
+		/obj/item/reagent_containers/glass/bottle/inaprovaline = 4,
+		/obj/item/reagent_containers/glass/bottle/sleeptoxin = 2,
+		/obj/item/reagent_containers/glass/bottle/spaceacillin = 4,
+		/obj/item/reagent_containers/glass/bottle/peridaxon = 2,
+		/obj/item/reagent_containers/glass/bottle/dexalin = 4,
+		/obj/item/reagent_containers/glass/bottle/oxycodone = 4,
+		/obj/item/reagent_containers/glass/bottle/polyhexanide = 2,
+		/obj/item/reagent_containers/glass/bottle/medicalnanites = 2,
+		),
+	"Misc" = list(
 		/obj/item/clothing/under/marine/corpsman = 4,
-		/obj/item/clothing/head/modular/marine/m10x = 4,
 		/obj/item/storage/backpack/marine/corpsman = 4,
 		/obj/item/storage/backpack/marine/satchel/corpsman = 4,
 		/obj/item/encryptionkey/med = 4,
 		/obj/item/storage/belt/medical = 6,
 		/obj/item/bodybag/cryobag = 4,
 		/obj/item/healthanalyzer = 4,
-		/obj/item/clothing/glasses/hud/health = 4,
-		/obj/item/storage/firstaid/regular = 4,
-		/obj/item/storage/firstaid/adv = 8,
-		/obj/item/storage/pouch/medical = 4,
-		/obj/item/storage/pouch/medkit = 4,
-		/obj/item/storage/pouch/magazine/large = 4,
-		/obj/item/storage/pouch/magazine/pistol/large = 4,
-		/obj/item/clothing/mask/gas = 4,
-		/obj/item/storage/pouch/pistol = 4,
-	)
+		)
 	contraband = list(/obj/item/reagent_containers/blood/OMinus = 1)
 
 /obj/machinery/vending/marine_medic/rebel

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -917,20 +917,15 @@
 	wrenchable = FALSE
 
 	products = list(
-		"Hypospray" = list (
-			/obj/item/reagent_containers/hypospray/advanced/bicaridine = 4,
-			/obj/item/reagent_containers/hypospray/advanced/kelotane = 4,
-			/obj/item/reagent_containers/hypospray/advanced/tramadol = 4,
-			/obj/item/reagent_containers/hypospray/advanced/tricordrazine = 4,
-			/obj/item/reagent_containers/hypospray/advanced/dexalin = 4,
-			/obj/item/reagent_containers/hypospray/advanced/inaprovaline = 4,
-			/obj/item/reagent_containers/hypospray/advanced/peridaxon = 4,
-			/obj/item/reagent_containers/hypospray/advanced/quickclot = 4,
+		"General" = list (
 			/obj/item/clothing/glasses/hud/health = 4,
 			/obj/item/storage/firstaid/regular = 4,
 			/obj/item/storage/firstaid/adv = 8,
 			/obj/item/storage/pouch/medical = 4,
 			/obj/item/storage/pouch/medkit = 4,
+			/obj/item/storage/syringe_case = 10,
+			/obj/item/bodybag/cryobag = 4,
+			/obj/item/healthanalyzer = 4,
 			),
 		"Reagent Bottle" = list(
 			/obj/item/reagent_containers/glass/bottle/bicaridine = 4,
@@ -946,15 +941,12 @@
 			/obj/item/reagent_containers/glass/bottle/polyhexanide = 2,
 			/obj/item/reagent_containers/glass/bottle/medicalnanites = 2,
 		),
-		"Misc" = list(
-			/obj/item/storage/syringe_case = 10,
+		"Clothing" = list(
 			/obj/item/clothing/under/marine/corpsman = 4,
 			/obj/item/storage/backpack/marine/corpsman = 4,
 			/obj/item/storage/backpack/marine/satchel/corpsman = 4,
 			/obj/item/encryptionkey/med = 4,
 			/obj/item/storage/belt/medical = 6,
-			/obj/item/bodybag/cryobag = 4,
-			/obj/item/healthanalyzer = 4,
 			)
 	)
 

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -926,6 +926,8 @@
 			/obj/item/storage/syringe_case = 10,
 			/obj/item/bodybag/cryobag = 4,
 			/obj/item/healthanalyzer = 4,
+			/obj/item/stack/medical/heal_pack/advanced/bruise_pack = 10,
+			/obj/item/stack/medical/heal_pack/advanced/burn_pack = 10,
 			),
 		"Reagent Bottle" = list(
 			/obj/item/reagent_containers/glass/bottle/bicaridine = 4,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The age old TerraGov Medic Vendor is in dire need of update. Might update it further in light of #9236.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Corpsmen should use corpsman vendor since it's pretty close to them.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
expanded: the TerraGovTech Corpsman Vendor is now ACTUALLY not outdated!
add: reagent bottles in the TerraGovTech Corpsman Vendor
balance: add burn and brute kits in vendor 
del: Remove stuff in TerraGovTech CORPSMAN Vendor; why do you need to get a pistol pouch from there?
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
