### PR TITLE
Xeno health hud buff 2.0

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -317,7 +317,7 @@
 
 #define HEALTH_RATIO_PAIN_HUD 1
 #define PAIN_RATIO_PAIN_HUD 0.25
-#define STAMINA_RATIO_PAIN_HUD 0.5
+#define STAMINA_RATIO_PAIN_HUD 0.25
 
 
 /mob/proc/med_pain_set_perceived_health()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Time to bring back #8599 from the dead.

This PR changes STAMINA_RATIO_PAIN_HUB from 0.5 to 0.25.

From Bravemole, 
"Pain hud is actually (unlike what you are saying) 25% pain 100% health, 50% stamina. Pain IS an important information because it slows down you a lot, and cause stagger."

Xenomorphs see health bar based off of such variables, and it's time to make xenomorphs' life a little easier.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Xenomorphs see marine's health bar, xenomorphs make choices off of marine's health bar.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: xenomorphs' pain hub on marines are less reliant on stamina damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
