### PR TITLE
Rocket hammer balance pass (nerf)

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -411,6 +411,15 @@
 
 	return ..()
 
+/obj/item/weapon/twohanded/rocketsledge/AltClick(mob/user)
+	if(!can_interact(user) || !ishuman(user) || !(user.l_hand == src || user.r_hand == src))
+		return ..()
+	TOGGLE_BITFIELD(flags_item, NODROP)
+	if(CHECK_BITFIELD(flags_item, NODROP))
+		to_chat(user, span_warning("You tighten the grip around [src]!"))
+		return
+	to_chat(user, span_notice("You loosen the grip around [src]!"))
+
 /obj/item/weapon/twohanded/rocketsledge/unique_action(mob/user)
 	. = ..()
 	if (knockback)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -359,8 +359,6 @@
 	var/stun = 1
 	///weaken value
 	var/weaken = 2
-	///stagger value
-	var/stagger = 2
 	///knockback value
 	var/knockback = 0
 
@@ -427,7 +425,6 @@
 	if (knockback)
 		stun = 1
 		weaken = 2
-		stagger = 2
 		knockback = 0
 		balloon_alert(user, "Selected mode: CRUSH.")
 		playsound(loc, 'sound/machines/switch.ogg', 25)
@@ -435,7 +432,6 @@
 
 	stun = 1
 	weaken = 1
-	stagger = 1
 	knockback = 1
 	balloon_alert(user, "Selected mode: KNOCKBACK.")
 	playsound(loc, 'sound/machines/switch.ogg', 25)
@@ -479,10 +475,7 @@
 		else
 			stun = 1
 
-	if(!M.IsStun() && !M.IsParalyzed()) //Prevent chain stunning.
+	if(!M.IsStun() && !M.IsParalyzed() && !isxenoqueen(M)) //Prevent chain stunning. Queen is protected.
 		M.apply_effects(stun,weaken)
-
-	if(!isxenoqueen(M))
-		M.adjust_stagger(stagger)
 
 	return ..()

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -452,7 +452,7 @@ WEAPONS
 /datum/supply_packs/weapons/rocketsledge
 	name = "Rocket Sledge"
 	contains = list(/obj/item/weapon/twohanded/rocketsledge)
-	cost = 50
+	cost = 60
 
 /*******************************************************************************
 EXPLOSIVES


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Removed stagger so xeno abilities are not interrupted; 
- Made Queen protected from stun because she's the Queen;
- Price increased from 50 to 60 points.

## Why It's Good For The Game

Based on feedback, i'm nerfing it a bit. 

## Changelog
:cl:
balance: rocket hammer balance pass
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
