### PR TITLE
add milk in soda dispenser

### DIFF
--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -385,6 +385,7 @@
 	req_one_access = list()
 	dispensable_reagents = list(
 		/datum/reagent/water,
+		/datum/reagent/consumable/drink/milk,
 		/datum/reagent/consumable/drink/cold/ice,
 		/datum/reagent/consumable/drink/coffee,
 		/datum/reagent/consumable/drink/milk/cream,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bihexajuline is a chemical that causes extreme pain and fixes bones at cryogenic temperatures. It's the juice that provide the SNAP CRACKLE POP in cryotube.

Milk is required to make this. I'm not sure why, but it does. Maybe bone likes cold milk, not room-temperature milk. Only Sulaco and Theseus have /obj/item/reagent_containers/food/drinks/milk , which hinder PoS and Minerva from producing bihexajuline.

Can also add this in chem dispenser.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: add milk in soda dispenser
balance: marines have access to milk; JUICE UP, BOYS AND GIRLS!
qol: you can finally make Bihexajuline in all shipside maps; if there isn't a soda dispenser nearby medical, I will change that in another PR.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
