### PR TITLE
Removes M40-T box from reqs vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -555,7 +555,6 @@
 			/obj/item/storage/box/visual/grenade/impact = 2,
 			/obj/item/storage/box/visual/grenade/incendiary = 2,
 			/obj/item/storage/box/visual/grenade/M15 = 2,
-			/obj/item/storage/box/visual/grenade/drain = 1,
 			/obj/item/storage/box/visual/grenade/cloak = 1,
 		),
 		"Ammo Boxes" = list(


### PR DESCRIPTION
## About The Pull Request
Per title.

## Why It's Good For The Game
Tesla already exists, and M40-T smoke has been in a rather questionable spot balance-wise. Drain gas is being reduced in general, in favor of Tesla being kept as a free weapon in vendors.

## Changelog
:cl: Lewdcifer
balance: Drain gas nade box removed from requisitions's vendor.
/:cl: