### PR TITLE
Increases cost of Tanglefoot CAS rockets

### DIFF
--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -366,6 +366,12 @@
 	icon_state = "minirocket_smoke"
 	point_cost = 25
 
+/obj/structure/ship_ammo/minirocket/tangle
+	name = "Tanglefoot mini rocket stack"
+	desc = "A pack of laser guided mini rockets loaded with plasma-draining Tanglefoot gas."
+	icon_state = "minirocket_tfoot"
+	point_cost = 150
+	
 /obj/structure/ship_ammo/minirocket/smoke/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(2)
 	explosion(impact, 0, 0, 2, 2, throw_range = 0)// Smaller explosion

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -376,12 +376,6 @@
 	S.set_up(7, impact)// Large radius, but dissipates quickly
 	S.start()
 
-/obj/structure/ship_ammo/minirocket/tangle
-	name = "Tanglefoot mini rocket stack"
-	desc = "A pack of laser guided mini rockets loaded with plasma-draining Tanglefoot gas."
-	icon_state = "minirocket_tfoot"
-	point_cost = 50
-
 /obj/structure/ship_ammo/minirocket/tangle/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(2)
 	explosion(impact, 0, 0, 2, 2, throw_range = 0)// Smaller explosion


### PR DESCRIPTION
## About The Pull Request
Per title.

## Why It's Good For The Game
50 points is a very laughable cost. Also, drain gas is being reduced/nerfed in favor of Tesla being kept as a free weapon.

## Changelog
:cl: Lewdcifer
balance: CAS tanglefoot rocket cost 50 > 150.
/:cl: