### PR TITLE
SMG rebalance

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -32,6 +32,8 @@
 		"SMGs" = list(
 			/obj/item/weapon/gun/smg/standard_smg = -1,
 			/obj/item/ammo_magazine/smg/standard_smg = -1,
+			/obj/item/weapon/gun/smg/m25 = -1,
+			/obj/item/ammo_magazine/smg/m25 = -1,
 			/obj/item/weapon/gun/smg/standard_machinepistol = -1,
 			/obj/item/ammo_magazine/smg/standard_machinepistol = -1,
 		),

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -83,7 +83,7 @@
 	caliber = CALIBER_10X20_CASELESS //codex
 	max_shells = 50 //codex
 	flags_equip_slot = ITEM_SLOT_BACK
-	wield_delay = 0.5 SECONDS
+	wield_delay = 0.3 SECONDS
 	force = 20
 	type_of_casings = null
 	default_ammo_type = /obj/item/ammo_magazine/smg/standard_smg
@@ -114,9 +114,11 @@
 	accuracy_mult_unwielded = 0.9
 	scatter = -2
 	fire_delay = 0.15 SECONDS
-	scatter_unwielded = 20
-	aim_slowdown = 0.25
+	scatter_unwielded = 30
+	aim_slowdown = 0.20
 	burst_amount = 0
+	upper_akimbo_accuracy = 5
+	lower_akimbo_accuracy = 3
 
 	placed_overlay_iconstate = "t90"
 
@@ -160,6 +162,9 @@
 		/obj/item/attachable/scope/mini,
 		/obj/item/attachable/burstfire_assembly,
 		/obj/item/attachable/magnetic_harness,
+		/obj/item/attachable/motiondetector,
+		/obj/item/attachable/buildasentry,
+		/obj/item/attachable/shoulder_mount,
 		/obj/item/attachable/gyro,
 	)
 


### PR DESCRIPTION
## About The Pull Request
Tweaks the T90 to make it less effective one handed and in particular akimbo, with higher scatter. Improves its wielded performance by reducing it's wield time to 0.3 from 0.5 and reducing it's slowdown to 0.2 from 0.25.
These are the same stats as the laser carbine for comparison, which trades off a lower capacity and rate of fire for scatter shot and underbarrel weapon options.

Also brings back to MR25 to the marine vendor, as a more balanced one handed option due to it's lower rate of fire, accuracy and higher scatter. Adds a few attachment options it was missing for QOL as well.
Currently this gun has really high scatter due to a bug, but #9273 will fix this, providing a significant improvement.

First PR in years, no bully.

## Why It's Good For The Game

Akimbo T90 rushing benos is a bit gross, akimbo MR25 will have saner DPS, while being a larger capacity, larger item size alternative to the T19.
Makes the T90 a more mobile and useful weapon when wielded, putting it in line with the laser carbine which has fairly comparable stats.

## Changelog
:cl:
balance: Rebalance the T90 for better wielded performance but worse one handed and akimbo performance
add: Add MR25 back to marinevendors, intended to be a more balanced one handed SMG option
/:cl: