### PR TITLE
Wall Nanomed Contraband Removal

### DIFF
--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -275,11 +275,8 @@
 		/obj/item/stack/medical/heal_pack/ointment = 2,
 		/obj/item/healthanalyzer = 1,
 		/obj/item/stack/medical/splint = 1,
-	)
-	contraband = list(
 		/obj/item/reagent_containers/hypospray/autoinjector/combat = 0,
-		/obj/item/reagent_containers/hypospray/autoinjector/hyperzine/expired = 0,
-		/obj/item/reagent_containers/hypospray/autoinjector/synaptizine_expired = 0,
+		/obj/item/reagent_containers/hypospray/autoinjector/synaptizine = 0,
 	)
 
 /obj/machinery/vending/nanomed/Initialize(mapload, ...)
@@ -457,13 +454,13 @@
 	use_power = NO_POWER_USE
 
 /obj/machinery/vending/hydroseeds/nopower
-	use_power = NO_POWER_USE	
+	use_power = NO_POWER_USE
 
 /obj/machinery/vending/dinnerware/nopower
 	use_power = NO_POWER_USE
 
 /obj/machinery/vending/sovietsoda/nopower
-	use_power = NO_POWER_USE	
+	use_power = NO_POWER_USE
 
 /obj/machinery/vending/tool/nopower
 	use_power = NO_POWER_USE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the contraband of wall mounted nanomed and update normal inventory to include removed yet still relevant chems.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Contraband is a leftover mechanic from SS13. Wallmounted Nanomeds are there for marines to get a quick heal/resupply which you can't do unless an engi first repairs power then hacks a nanomed. This hopefully makes both repairing power and using combat injectors more popular

Also removes hyperzine since it no longer exists
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Moved wallnanomed contraband inventory to normal inventory, removed hyperzine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
