### PR TITLE
MR-25 changes- Scatter reduced massively and UGL added.

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -159,6 +159,7 @@
 		/obj/item/attachable/heavy_barrel,
 		/obj/item/attachable/scope/mini,
 		/obj/item/attachable/burstfire_assembly,
+		/obj/item/weapon/gun/grenade_launcher/underslung,
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/gyro,
 	)
@@ -167,7 +168,7 @@
 
 	accuracy_mult = 1
 	accuracy_mult_unwielded = 0.9
-	scatter = 20
+	scatter = 0
 	fire_delay = 0.2 SECONDS
 	scatter_unwielded = 30
 	aim_slowdown = 0.15
@@ -201,7 +202,7 @@
 	accuracy_mult_unwielded = 0.95
 	damage_mult = 1.2
 	aim_slowdown = 0.4
-	scatter = 10
+	scatter = 4
 
 /obj/item/weapon/gun/smg/m25/elite/pmc
 	starting_attachment_types = list(/obj/item/attachable/magnetic_harness)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
MR-25 has old scatter assumptions, rather than new scatter assumptions, it has 20 scatter, higher than any other weapon in the game, which is kinda absurd if you think about it though, really other than that I think it's overall fine because it has rifle level fire rate and the ability to mount a UGL can give you some utility.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the MR-25 not awful garbage, and makes it useable.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: MR-25 can mount a UGL, and massive scatter reduction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
