### PR TITLE
Readd MR25 to vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -32,6 +32,8 @@
 		"SMGs" = list(
 			/obj/item/weapon/gun/smg/standard_smg = -1,
 			/obj/item/ammo_magazine/smg/standard_smg = -1,
+			/obj/item/weapon/gun/smg/m25 = -1,
+			/obj/item/ammo_magazine/smg/m25 = -1,
 			/obj/item/weapon/gun/smg/standard_machinepistol = -1,
 			/obj/item/ammo_magazine/smg/standard_machinepistol = -1,
 		),

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -161,6 +161,9 @@
 		/obj/item/attachable/burstfire_assembly,
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/gyro,
+		/obj/item/attachable/buildasentry,
+		/obj/item/attachable/shoulder_mount,
+		/obj/item/attachable/motiondetector,
 	)
 
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 17,"rail_x" = 14, "rail_y" = 20, "under_x" = 24, "under_y" = 13, "stock_x" = 24, "stock_y" = 16)


### PR DESCRIPTION
## About The Pull Request

Brings back to MR25 to the marine vendor. 
Currently the T90 is pretty spammable akimbo, which is kind of gross due to it's high DPS and managable scatter. The MR25 is a bit more reasonable as a one handed SMG option, due to it's lower rate of fire and slightly worse accuracy/scatter.

T90 rebalance to reduce it's one handed effectiveness and buff it's wielded effectiveness put into another PR for atomisation. This PR is somewhat redundant if that doesn't get merged.

Currently MR25 (among others) has really high scatter due to a bug, but #9273 will fix this, providing a significant improvement to it's current performance.

## Why It's Good For The Game

Akimbo T90 rushing benos is a bit gross, akimbo MR25 will have saner DPS, while being a larger capacity, larger item size alternative to the T19.

## Changelog
:cl:
add: MR25 added to marine vendor

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
