### PR TITLE
T90 rebalance

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -83,7 +83,7 @@
 	caliber = CALIBER_10X20_CASELESS //codex
 	max_shells = 50 //codex
 	flags_equip_slot = ITEM_SLOT_BACK
-	wield_delay = 0.5 SECONDS
+	wield_delay = 0.3 SECONDS
 	force = 20
 	type_of_casings = null
 	default_ammo_type = /obj/item/ammo_magazine/smg/standard_smg
@@ -114,9 +114,11 @@
 	accuracy_mult_unwielded = 0.9
 	scatter = -2
 	fire_delay = 0.15 SECONDS
-	scatter_unwielded = 20
-	aim_slowdown = 0.25
+	scatter_unwielded = 30
+	aim_slowdown = 0.2
 	burst_amount = 0
+	upper_akimbo_accuracy = 5
+	lower_akimbo_accuracy = 3
 
 	placed_overlay_iconstate = "t90"
 

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -117,8 +117,7 @@
 	scatter_unwielded = 30
 	aim_slowdown = 0.2
 	burst_amount = 0
-	upper_akimbo_accuracy = 5
-	lower_akimbo_accuracy = 3
+	akimbo_additional_delay = 0.2
 
 	placed_overlay_iconstate = "t90"
 


### PR DESCRIPTION
Buffs T90 wielded performance
Nerfs T90 akimbo performance and slightly increase one hand scatter

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Buffs the T90's wield time to 0.3 from 0.5 and wield speed penalty to 0.2 from 0.25. These are the same values as the laser carbine.
Reduces the effectiveness of the T90 when used one handed by increased scatter to 30 from 20, and adding 0.2 akimbo additionally delay, on MJP's advice.

This is PR 2/2, with the MR25 readded in a seperate PR to be a less DPS heavy one handed option.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

T90 akimbo spam is pretty gross, as it has extremely low scatter and high DPS. Makes it a more mobile and useful weapon when wielded, comparable to the laser carbine, where it trades off higher DPS and capacity compared to the carbine's ability to use scatter shot and have underbarrel attachments.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: T90 is better wielded, worse one handed and akimbo.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
