### PR TITLE
Minor nerf to the Sledgehammer

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -423,15 +423,15 @@
 /obj/item/weapon/twohanded/rocketsledge/unique_action(mob/user)
 	. = ..()
 	if (knockback)
-		stun = 1
-		weaken = 2
+		stun = 0.5
+		weaken = 0.5
 		knockback = 0
 		balloon_alert(user, "Selected mode: CRUSH.")
 		playsound(loc, 'sound/machines/switch.ogg', 25)
 		return
 
-	stun = 1
-	weaken = 1
+	stun = 0
+	weaken = 0
 	knockback = 1
 	balloon_alert(user, "Selected mode: KNOCKBACK.")
 	playsound(loc, 'sound/machines/switch.ogg', 25)


### PR DESCRIPTION
## About The Pull Request
Per title. The changes are as follows;
- Crush Mode: Stun and Weaken durations reduced from 1 and 2 (respectively) to 0.5 both _(half a second)_.
- Knockback Mode: Stun and Weaken removed while in this mode.

## Why It's Good For The Game
Hardstuns are very, _very_ wack.

## Changelog
:cl: Lewdcifer
balance: Sledgehammer nerfs. Crush Mode stun and weaken durations are now 0.5 (half a second), Knockback Mode no longer stuns and weakens.
/:cl: