### PR TITLE
Grenade boxes don't chain grenade

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1075,6 +1075,7 @@
 	max_w_class = 3
 	storage_slots = 25
 	max_storage_space = 50
+	flags_atom = PREVENT_CONTENTS_EXPLOSION //These ones should be safe, since they're supposed to be put in FOB
 	can_hold = list(
 		/obj/item/explosive/grenade,
 	)


### PR DESCRIPTION
## About The Pull Request

Adds the PREVENT_CONTENTS_EXPLOSION flag to grenade boxes. If a grenade blows near a grenade box, the grenades inside won't blow

## Why It's Good For The Game

Chain grenades are pretty funny, let's be honest, but they're extremely devastating
Brave said he wouldn't remove chain grenades but he would accept a PR which made grenade _boxes_ not explode
This makes the game more fun while pleasing people who like chain grenades

## Changelog
:cl:
balance: Explosions no longer blow grenades inside grenade boxes. The FOB is safe once more
/:cl: