### PR TITLE
remove Sentry gun voucher

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -91,7 +91,6 @@ GLOBAL_LIST_INIT(engineer_gear_listed_products, list(
 		/obj/item/multitool = list(CAT_ENGSUP, "Multitool", 1, "black"),
 		/obj/item/circuitboard/general = list(CAT_ENGSUP, "General circuit board", 1, "black"),
 		/obj/item/assembly/signaler = list(CAT_ENGSUP, "Signaler (for detpacks)", 1, "black"),
-		/obj/item/stack/voucher/sentry = list(CAT_ENGSUP, "UA 571-C Base defense sentry voucher", 26, "black"),
 	))
 
 GLOBAL_LIST_INIT(medic_gear_listed_products, list(

--- a/code/modules/mining/remote_fob/remote_fob_actions_misc.dm
+++ b/code/modules/mining/remote_fob/remote_fob_actions_misc.dm
@@ -186,12 +186,3 @@
 		return
 	console.eject_mat(EJECT_PLASTEEL)
 	to_chat(owner, span_notice("Plasteel sheets ejected."))
-
-
-/obj/item/stack/voucher/sentry
-	name = "Sentry gun voucher"
-	desc = "A voucher for a UA 571-C sentry gun, redeemable at the Remote FOB Construction Console. Keep buying them for a chance at Bal Di's golden sentry ticket!"
-	icon = 'icons/Marine/remotefob.dmi'
-	icon_state = "sentry_voucher"
-	max_amount = 1
-	w_class = WEIGHT_CLASS_TINY

--- a/code/modules/mining/remote_fob/remote_fob_computer.dm
+++ b/code/modules/mining/remote_fob/remote_fob_computer.dm
@@ -125,14 +125,6 @@
 /obj/machinery/computer/camera_advanced/remote_fob/attackby(obj/item/attackingitem, mob/user, params)
 	if(istype(attackingitem, /obj/item/stack))
 		var/obj/item/stack/attacking_stack = attackingitem
-		if(istype(attacking_stack, /obj/item/stack/voucher/sentry))
-			var/useamount = attacking_stack.amount
-			sentry_remaining += useamount
-			attacking_stack.use(useamount)
-			to_chat(user, span_notice("Sentry voucher redeemed."))
-			playsound(src, 'sound/machines/terminal_insert_disc.ogg', 25, FALSE)
-			flick("fobpc-insert", src)
-			return
 		if(istype(attacking_stack, /obj/item/stack/sheet/metal))
 			var/useamount = attacking_stack.amount
 			metal_remaining += useamount


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. Git will remember.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

PR is bringing awareness to the almost non-existence of this tool.

Engineers have a budget, and spending 26 engineer points for a green sentry, the UA 571-C, is not one of them. Marines spawn with at least four UA 571-C crates which include additional ammo, whereby the voucher does not give more ammo. It is also the fact that if FOB drone is dead, voucher is useless. A time-sensitive item that no one uses should go unless we have a better use of this.

Even if I were to give this to CSE, which is unlikely, CSE has to spawn before Alamo flies, which is even more unlikely than CSE getting a voucher.

Voucher was made by terranaut1, legendary in TGMC, in #3566 . He said, "for sentry gun placement there's vouchers available you can buy at the engi prep vendor for the same cost as a regular sentry". 

Same cost as a regular sentry? Old engineer meta.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: UA 571-C Base defense sentry voucher; old object of an old engineer meta
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
