### PR TITLE
Nerf sandbag integrity

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -1083,7 +1083,7 @@
 	name = "sandbag barricade"
 	desc = "A bunch of bags filled with sand, stacked into a small wall. Surprisingly sturdy, albeit labour intensive to set up. Trusted to do the job since 1914."
 	icon_state = "sandbag_0"
-	max_integrity = 300
+	max_integrity = 200
 	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 80, "acid" = 40)
 	coverage = 128
 	stack_type = /obj/item/stack/sandbags

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -887,7 +887,7 @@ ENGINEERING
 
 /datum/supply_packs/engineering/sandbags
 	name = "50 empty sandbags"
-	contains = list(/obj/item/stack/sandbags_empty/full)
+	contains = list(/obj/item/stack/sandbags_empty/half)
 	cost = 10
 
 /datum/supply_packs/engineering/metal50

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -887,7 +887,7 @@ ENGINEERING
 
 /datum/supply_packs/engineering/sandbags
 	name = "50 empty sandbags"
-	contains = list(/obj/item/stack/sandbags_empty/half)
+	contains = list(/obj/item/stack/sandbags_empty/full)
 	cost = 10
 
 /datum/supply_packs/engineering/metal50


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

From 300 to 200.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

#5758. Metal barricade has 200 health initially, then with barbed wires 250 health. Apparently, even with MJP's nerf, sandbag is still stronger than metal barricade. 

I should also make a PR to improve upgraded metal barricade so that marines actually use it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: nerf sandbag health from 300 to 200; now sandbag is not stronger than barred metal barricade
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
