### PR TITLE
Icy caves v2.0

### DIFF
--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -3076,7 +3076,9 @@
 /area/icy_caves/caves/northern)
 "pf" = (
 /obj/effect/ai_node,
-/turf/open/floor/tile/dark/brown2,
+/turf/open/floor/tile/dark/brown2/corner{
+	dir = 8
+	},
 /area/icy_caves/outpost/refinery)
 "pg" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -4726,6 +4728,10 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
+"wQ" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/brown2,
+/area/icy_caves/outpost/refinery)
 "wT" = (
 /obj/structure/lattice,
 /obj/structure/monorail{
@@ -15574,7 +15580,7 @@ DY
 DY
 DY
 Rf
-pf
+wQ
 wx
 QJ
 md
@@ -16500,7 +16506,7 @@ XJ
 Gw
 Ub
 DY
-Dv
+pf
 Pq
 XU
 DY

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -22,9 +22,6 @@
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/plating/dmg1,
 /area/icy_caves/caves/crashed_ship)
-"af" = (
-/turf/closed/wall/r_wall/unmeltable,
-/area/lv624/lazarus/console)
 "ag" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/effect/landmark/nuke_spawn,
@@ -53,9 +50,11 @@
 /turf/open/floor/plating/dmg1,
 /area/icy_caves/caves/crashed_ship)
 "am" = (
-/obj/machinery/telecomms/relay/preset/telecomms,
-/turf/open/floor/plating/icefloor,
-/area/lv624/lazarus/console)
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "an" = (
 /obj/structure/xenoautopsy/tank/broken,
 /obj/effect/decal/cleanable/blood/xeno,
@@ -66,10 +65,6 @@
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
-"ap" = (
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
 "aq" = (
 /obj/structure/xenoautopsy/tank/broken,
 /turf/open/floor/plating/mainship,
@@ -208,14 +203,26 @@
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "aR" = (
-/obj/structure/largecrate/lisa,
+/obj/structure/closet/crate/weapon,
+/obj/item/weapon/energy/sword,
+/obj/item/weapon/gun/rifle/m16,
+/obj/item/ammo_magazine/rifle/m16,
+/obj/item/ammo_magazine/rifle/m16,
+/obj/item/ammo_magazine/rifle/m16,
+/obj/item/ammo_magazine/rifle/m16,
+/obj/item/ammo_magazine/rifle/m16,
+/obj/item/ammo_magazine/rifle/m16,
+/obj/item/ammo_magazine/rifle/m16,
+/obj/item/ammo_magazine/rifle/m16,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "aS" = (
-/obj/structure/closet/crate/freezer/rations,
-/obj/item/storage/box/MRE,
-/obj/item/storage/box/MRE,
-/obj/item/storage/box/MRE,
+/obj/structure/closet/crate/explosives,
+/obj/item/storage/box/visual/grenade/frag,
+/obj/item/explosive/plastique,
+/obj/item/explosive/plastique,
+/obj/item/explosive/plastique,
+/obj/item/explosive/plastique,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "aT" = (
@@ -240,15 +247,18 @@
 /turf/closed/ice,
 /area/icy_caves/caves/northern)
 "aY" = (
-/obj/structure/closet/crate/radiation,
+/obj/structure/closet/crate/ammo,
+/obj/item/ammo_magazine/rifle/bolt,
+/obj/item/ammo_magazine/rifle/bolt,
+/obj/item/ammo_magazine/rifle/bolt,
+/obj/item/ammo_magazine/rifle/bolt,
+/obj/item/ammo_magazine/rifle/bolt,
+/obj/item/ammo_magazine/rifle/bolt,
+/obj/item/ammo_magazine/rifle/bolt,
+/obj/item/ammo_magazine/rifle/bolt,
+/obj/item/ammo_magazine/rifle/bolt,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
-"aZ" = (
-/obj/structure/mirror{
-	dir = 8
-	},
-/turf/open/floor/freezer,
-/area/icy_caves/outpost/dorms)
 "ba" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -329,11 +339,11 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
 "bq" = (
+/obj/structure/rack,
 /obj/item/tool/shovel,
 /obj/item/tool/shovel,
 /obj/item/tool/shovel,
 /obj/item/tool/shovel,
-/obj/structure/rack/nometal,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ1)
 "br" = (
@@ -345,9 +355,14 @@
 	},
 /area/icy_caves/outpost/refinery)
 "bs" = (
+/obj/structure/closet/crate/medical,
 /obj/item/defibrillator,
 /obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
 /obj/item/storage/firstaid/fire,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/reagent_containers/glass/beaker/bluespace,
@@ -508,6 +523,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
+"bW" = (
+/obj/structure/cryofeed/right{
+	name = "\improper coolant feed"
+	},
+/turf/open/floor/podhatch/floor{
+	icon_state = "bcircuitoff"
+	},
+/area/icy_caves/caves/northern)
 "bX" = (
 /turf/closed/ice_rock/singlePart,
 /area/icy_caves/caves)
@@ -550,6 +573,12 @@
 	dir = 8
 	},
 /area/icy_caves/caves/northern)
+"ch" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/floor,
+/area/space)
 "ci" = (
 /turf/closed/ice/thin/junction,
 /area/icy_caves/caves/northern)
@@ -576,11 +605,25 @@
 	dir = 4
 	},
 /area/icy_caves/caves/northern)
-"cp" = (
-/obj/item/lightstick/anchored,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
+"co" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/mainship/tcomms,
 /area/icy_caves/caves/northern)
+"cp" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/corners,
+/area/icy_caves/caves)
 "cq" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating/ground/ice,
@@ -595,15 +638,15 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "cs" = (
+/obj/structure/cable,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/end{
-	dir = 8
-	},
+/turf/closed/wall/r_wall,
 /area/icy_caves/caves/northern)
 "ct" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/corner{
-	dir = 8
+/obj/effect/ai_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
 	},
 /area/icy_caves/caves/northern)
 "cu" = (
@@ -613,57 +656,96 @@
 /turf/closed/ice/corner{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "cv" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/junction{
-	dir = 8
-	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "cw" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/junction{
-	dir = 4
-	},
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "cx" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/end{
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/area/icy_caves/caves/northern)
-"cC" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/end,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"cy" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/LZ2)
+"cz" = (
+/obj/structure/grille,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/LZ2)
+"cC" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"cD" = (
+/obj/item/tool/surgery/circular_saw,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"cE" = (
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
+"cF" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/structure/monorail{
+	dir = 5
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
+"cG" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/red2{
+	dir = 5
+	},
+/area/icy_caves/outpost/LZ2)
 "cI" = (
 /turf/closed/ice/thin/single,
 /area/icy_caves/caves/northern)
 "cJ" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/junction{
-	dir = 4
-	},
+/turf/closed/wall/r_wall,
 /area/icy_caves/caves/northern)
 "cK" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/junction{
-	dir = 8
-	},
+/turf/closed/ice_rock/corners,
+/area/icy_caves/caves/northern)
+"cL" = (
+/obj/structure/monorail,
+/turf/open/floor/mainship_hull,
 /area/icy_caves/caves/northern)
 "cM" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/crashed_ship)
 "cN" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/corner{
-	dir = 4
-	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/green2,
 /area/icy_caves/caves/northern)
 "cO" = (
+/obj/structure/window/framed/colony/reinforced,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/straight,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "cP" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -675,13 +757,19 @@
 	dir = 1
 	},
 /area/icy_caves/caves/northern)
-"cU" = (
-/turf/open/floor/plating/icefloor/warnplate,
-/area/icy_caves/outpost/LZ1)
 "cW" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/corner,
-/area/icy_caves/caves/west)
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/space/basic,
+/area/space)
+"cX" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "cY" = (
 /turf/closed/ice/thin/corner{
 	dir = 8
@@ -696,31 +784,47 @@
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "dd" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/junction{
-	dir = 1
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
 	},
-/area/icy_caves/caves/west)
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "de" = (
 /turf/closed/ice/thin/junction{
 	dir = 1
 	},
 /area/icy_caves/caves/west)
 "df" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/corner{
+/obj/structure/dropship_piece/two/front/left,
+/turf/open/floor/mainship_hull/dir{
 	dir = 8
 	},
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "dg" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/west)
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/structure/dropship_piece/two/front,
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
 "dh" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 1
 	},
 /area/icy_caves/caves/west)
+"di" = (
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "dj" = (
 /turf/closed/ice,
 /area/icy_caves/caves/west)
@@ -751,6 +855,27 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"ds" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"du" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"dv" = (
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/obj/structure/largecrate/supply/explosives,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "dw" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 4
@@ -765,9 +890,12 @@
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/west)
 "dz" = (
-/obj/machinery/computer/nuke_disk_generator/green,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/south)
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "dA" = (
 /obj/machinery/light,
 /turf/open/floor/plating/ground/ice,
@@ -808,39 +936,29 @@
 /area/icy_caves/caves/east)
 "dK" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/intersection,
-/area/icy_caves/caves/northern)
+/turf/closed/ice_rock/eastWall,
+/area/icy_caves/caves)
 "dL" = (
-/obj/structure/closet/crate/science,
-/obj/item/stack/sheet/mineral/phoron/medium_stack,
+/obj/effect/ai_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
-"dM" = (
-/obj/machinery/power/apc/drained,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "dN" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "dO" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
-"dP" = (
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "dQ" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/corner{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "dR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/tile/dark,
@@ -876,13 +994,14 @@
 /turf/closed/ice/thin/end,
 /area/icy_caves/caves/east)
 "dZ" = (
-/obj/machinery/power/port_gen/pacman,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/turf/closed/shuttle/dropship2{
+	icon_state = "24"
+	},
+/area/icy_caves/caves/northern)
 "ea" = (
 /obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "eb" = (
 /turf/closed/ice/end,
 /area/icy_caves/caves/west)
@@ -894,12 +1013,12 @@
 "ed" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "eg" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
 "eh" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -907,18 +1026,14 @@
 /area/icy_caves/caves/west)
 "ei" = (
 /obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
 "ej" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
-"el" = (
-/obj/item/clothing/suit/radiation,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/crashed_ship)
 "em" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark,
@@ -938,11 +1053,11 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
 "eo" = (
+/obj/item/tool/pickaxe/plasmacutter,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
 	},
 /obj/effect/ai_node,
-/obj/item/tool/pickaxe,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
 "ep" = (
@@ -975,40 +1090,27 @@
 /area/icy_caves/caves/east)
 "eu" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/east)
+/turf/closed/ice/intersection,
+/area/icy_caves/caves/northern)
 "ev" = (
-/obj/structure/closet/crate,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick,
-/obj/item/storage/box/lightstick,
-/obj/effect/spawner/random/powercell,
-/obj/item/clothing/glasses/welding,
-/obj/item/explosive/plastique,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/item/tool/pickaxe,
+/obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "ew" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "ex" = (
-/obj/machinery/door/airlock/mainship/secure/locked/free_access{
-	name = "\improper Mining Storage"
-	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/door/airlock/mainship/secure/locked/free_access,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "ey" = (
 /turf/closed/ice,
 /area/icy_caves/caves/crashed_ship)
@@ -1033,11 +1135,23 @@
 	dir = 9
 	},
 /area/icy_caves/caves/northern)
+"eC" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	name = "Canteen"
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"eD" = (
+/obj/structure/table,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "eF" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/west)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/corner{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "eG" = (
 /obj/machinery/light{
 	dir = 8
@@ -1075,33 +1189,31 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
 "eL" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/east)
-"eM" = (
-/obj/structure/closet/crate,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick,
-/obj/item/storage/box/lightstick,
-/obj/effect/spawner/random/powercell,
-/obj/item/explosive/plastique,
-/obj/item/tool/pickaxe,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/end{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "eN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
+"eO" = (
+/obj/structure/table/reinforced,
+/obj/item/tool/surgery/scalpel/laser3,
+/obj/item/reagent_containers/spray/pepper,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "eP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "eR" = (
 /turf/closed/ice/end{
 	dir = 1
@@ -1109,18 +1221,18 @@
 /area/icy_caves/caves/south)
 "eS" = (
 /obj/machinery/light,
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
 "eT" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "eU" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
 "eV" = (
 /obj/structure/ore_box,
@@ -1152,11 +1264,11 @@
 	},
 /area/icy_caves/caves)
 "eZ" = (
+/obj/item/tool/pickaxe/plasmacutter,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/item/tool/pickaxe,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
 "fa" = (
@@ -1174,13 +1286,19 @@
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/fire,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
+"fc" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "fd" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/powercell,
 /obj/effect/spawner/random/powercell,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "fe" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/tech_supply,
@@ -1191,7 +1309,7 @@
 /obj/item/clothing/glasses/welding,
 /obj/machinery/light/small,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "ff" = (
 /obj/structure/rack,
 /obj/structure/rack,
@@ -1199,7 +1317,7 @@
 /obj/effect/spawner/random/toolbox,
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "fg" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/tool,
@@ -1207,7 +1325,7 @@
 /obj/effect/spawner/random/tool,
 /obj/item/storage/belt/utility/full,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "fh" = (
 /turf/closed/ice/thin/junction,
 /area/icy_caves/caves/south)
@@ -1242,10 +1360,20 @@
 	dir = 1
 	},
 /area/icy_caves/caves/east)
-"fs" = (
+"fq" = (
 /obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow/layer1,
+/turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ1)
+"fs" = (
+/obj/structure/barricade/guardrail{
+	dir = 1
+	},
+/obj/structure/dropship_piece/two/front,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "ft" = (
 /turf/closed/ice/thin/junction{
 	dir = 4
@@ -1297,6 +1425,16 @@
 	dir = 9
 	},
 /area/icy_caves/caves/south)
+"fD" = (
+/obj/machinery/power/apc/drained,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "fE" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
@@ -1315,6 +1453,9 @@
 	dir = 1
 	},
 /area/icy_caves/caves/south)
+"fI" = (
+/turf/closed/ice/thin,
+/area/icy_caves/outpost/LZ2)
 "fK" = (
 /turf/closed/ice/thin/corner{
 	dir = 1
@@ -1447,10 +1588,6 @@
 "gB" = (
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/refinery)
-"gC" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
 "gF" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -1469,17 +1606,51 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
+"gK" = (
+/obj/structure/monorail,
+/obj/structure/dropship_piece/two/front,
+/turf/open/floor/mainship_hull,
+/area/icy_caves/caves/northern)
 "gL" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/closed/ice_rock/corners,
 /area/icy_caves/caves)
+"gM" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/turf/open/floor/mainship/cargo,
+/area/icy_caves/caves/northern)
 "gN" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
+"gP" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
+"gQ" = (
+/obj/structure/dropship_piece/one/corner/middleright,
+/obj/structure/dropship_piece/two/corner/rearright,
+/turf/open/floor/mainship_hull/dir{
+	dir = 10
+	},
+/area/icy_caves/caves/northern)
 "gS" = (
 /turf/closed/ice/thin/end{
 	dir = 8
@@ -1490,6 +1661,12 @@
 	dir = 6
 	},
 /area/icy_caves/caves/south)
+"gU" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd{
+	dir = 8
+	},
+/area/icy_caves/caves)
 "gV" = (
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves/east)
@@ -1502,12 +1679,23 @@
 	},
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"gZ" = (
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "hb" = (
 /turf/closed/ice/junction,
 /area/icy_caves/caves/south)
 "hc" = (
 /turf/closed/ice/straight,
 /area/icy_caves/caves/east)
+"hd" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "he" = (
 /turf/closed/ice/junction{
 	dir = 4
@@ -1525,9 +1713,8 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/research)
 "hi" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/caves/east)
 "hj" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/outpost/outside)
@@ -1612,9 +1799,9 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
 "hB" = (
-/obj/item/clothing/head/radiation,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/crashed_ship)
+/obj/structure/largecrate/supply,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "hD" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/floor/plating/ground/ice,
@@ -1624,6 +1811,17 @@
 	dir = 8
 	},
 /area/icy_caves/caves/east)
+"hF" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice,
+/area/icy_caves/caves)
+"hG" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/research_and_development,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "hI" = (
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/ai_node,
@@ -1634,9 +1832,23 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"hM" = (
+/turf/closed/ice_rock/corners{
+	dir = 10
+	},
+/area/icy_caves/caves/northern)
 "hO" = (
 /turf/closed/ice/thin/single,
 /area/icy_caves/caves/east)
+"hP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "hQ" = (
 /obj/machinery/space_heater,
 /turf/open/floor/tile/dark/blue2,
@@ -1645,6 +1857,11 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"hT" = (
+/obj/machinery/vending/medical,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "hU" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/ice,
@@ -1652,6 +1869,12 @@
 "hV" = (
 /turf/closed/ice_rock/singlePart,
 /area/icy_caves/caves/south)
+"hW" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "hX" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/effect/ai_node,
@@ -1689,6 +1912,22 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
+"in" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall/unmeltable,
+/area/icy_caves/caves/northern)
+"io" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
+"ip" = (
+/obj/structure/closet/l3closet/janitor,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "iu" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -1698,45 +1937,49 @@
 /area/icy_caves/outpost/outside/center)
 "ix" = (
 /obj/structure/cable,
-/obj/effect/landmark/excavation_site_spawner,
+/obj/effect/ai_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
-"iC" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/northern)
 "iG" = (
 /turf/open/floor/tile/dark/yellow2{
 	dir = 4
 	},
 /area/icy_caves/outpost/engineering)
-"iI" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 6
-	},
-/area/icy_caves/outpost/LZ2)
 "iJ" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/lowcharge,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
+/obj/machinery/computer/intel_computer,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/mining/west)
 "iK" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
+"iN" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "iQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
+"iS" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/southWall,
+/area/icy_caves/caves)
 "iT" = (
 /turf/closed/ice/end{
 	dir = 1
 	},
+/area/icy_caves/outpost/LZ2)
+"iV" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "iZ" = (
 /turf/open/floor/tile/dark/brown2,
@@ -1751,11 +1994,34 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"jc" = (
+/obj/machinery/door/poddoor/mainship/indestructible,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
+"jd" = (
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "je" = (
 /turf/closed/ice/thin/corner{
 	dir = 1
 	},
 /area/icy_caves/outpost/outside)
+"jf" = (
+/obj/item/stool,
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
+"jk" = (
+/obj/structure/table/mainship,
+/obj/item/tool/surgery/cautery,
+/obj/item/tool/surgery/retractor,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"jo" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/northern)
 "jt" = (
 /obj/machinery/floodlight/landing,
 /obj/effect/decal/warning_stripes,
@@ -1780,13 +2046,17 @@
 /turf/closed/ice/thin/single,
 /area/icy_caves/caves/west)
 "jA" = (
-/obj/item/tool/pickaxe,
+/obj/item/tool/pickaxe/plasmacutter,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
 "jB" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"jC" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "jE" = (
 /obj/structure/table/reinforced,
 /obj/effect/landmark/dropship_console_spawn_lz1,
@@ -1798,12 +2068,23 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"jI" = (
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/caves)
 "jJ" = (
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"jL" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "jM" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = /obj/item/storage/backpack/satchel/norm;
@@ -1816,7 +2097,7 @@
 	name = "Shaft Miner"
 	},
 /obj/effect/decal/cleanable/blood,
-/obj/item/tool/pickaxe,
+/obj/item/tool/pickaxe/plasmacutter,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
 "jN" = (
@@ -1837,9 +2118,8 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
 "jR" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
 "jS" = (
 /obj/machinery/miner/damaged,
@@ -1860,9 +2140,27 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/research)
+"jW" = (
+/obj/structure/ore_box,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
+"jX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"jY" = (
+/obj/machinery/door/airlock/mainship/security,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "ka" = (
-/obj/structure/fence,
-/turf/open/floor/plating/ground/snow/layer0,
+/obj/machinery/door/airlock/multi_tile/mainship/research,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "kb" = (
 /obj/machinery/landinglight/ds1/delayone{
@@ -1876,9 +2174,18 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"kd" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "ke" = (
 /turf/closed/ice/junction,
 /area/icy_caves/outpost/outside)
+"kf" = (
+/obj/machinery/computer3/server/rack,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "kg" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/mining/east)
@@ -1905,93 +2212,56 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
+"kn" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/structure/dropship_piece/two/front,
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
 "ko" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
+	dir = 10
 	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/largecrate/cow,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves)
 "kp" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/radio,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/obj/machinery/miner/damaged/platinum,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/northern)
 "kq" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
+	dir = 5
 	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/storage/fancy/cigarettes/dromedaryco,
-/obj/item/storage/fancy/cigar,
-/obj/item/tool/lighter,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves)
 "kr" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "ku" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/largecrate/supply/supplies/water,
+/obj/machinery/vending/dinnerware,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "kv" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"kw" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/largecrate/supply/supplies,
+/obj/machinery/vending/snack,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "kx" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/item/binoculars,
+/obj/structure/bed/chair,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "ky" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/end{
 	dir = 1
 	},
-/obj/item/big_ammo_box,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/northern)
 "kA" = (
 /obj/machinery/landinglight/ds1/delaytwo{
 	dir = 4
@@ -2032,6 +2302,12 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
+"kL" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/corner{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "kM" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/singlePart{
@@ -2043,26 +2319,17 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
-"kO" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
+"kR" = (
+/obj/structure/table/mainship,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
 	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/northern)
 "kS" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/structure/largecrate/random/case,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"kT" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/structure/largecrate/supply/ammo/standard_smg,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/intersection,
+/area/icy_caves/caves/northern)
 "kW" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -2077,6 +2344,12 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/office)
+"kY" = (
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "lc" = (
 /turf/closed/ice/straight{
 	dir = 4
@@ -2104,50 +2377,38 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "ll" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
+/obj/machinery/camera{
+	dir = 5
 	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/prop/mainship/hangar_stencil/two,
+/obj/effect/ai_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"lm" = (
-/obj/effect/decal/warning_stripes/thin{
+/area/icy_caves/caves/northern)
+"ln" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/corner{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/thin,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"ln" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/largecrate/supply/supplies,
-/obj/structure/prop/mainship/hangar_stencil/two,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/northern)
 "lo" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/largecrate/supply/ammo/shotgun,
-/obj/structure/prop/mainship/hangar_stencil/two,
+/obj/structure/table,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "lp" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
+/obj/structure/bed/chair{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "lt" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"lv" = (
+/obj/machinery/door/poddoor/two_tile_ver,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "lx" = (
 /obj/machinery/light{
 	dir = 8
@@ -2157,7 +2418,7 @@
 "lA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "lB" = (
 /obj/structure/table,
 /obj/structure/paper_bin,
@@ -2172,7 +2433,7 @@
 /turf/closed/ice/junction{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "lD" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark/brown2{
@@ -2188,6 +2449,17 @@
 	dir = 5
 	},
 /area/icy_caves/caves)
+"lH" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/mining/west)
+"lL" = (
+/turf/closed/ice/thin/corner{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "lM" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -2199,6 +2471,14 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
+"lO" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "lP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -2211,6 +2491,12 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"lR" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "lS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -2236,8 +2522,17 @@
 /obj/machinery/power/apc/lowcharge{
 	dir = 8
 	},
-/turf/open/floor/tile/dark,
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
 /area/icy_caves/outpost/LZ2)
+"ma" = (
+/obj/structure/dropship_piece/one/corner/middleleft,
+/obj/structure/dropship_piece/two/corner/rearleft,
+/turf/open/floor/mainship_hull/dir{
+	dir = 6
+	},
+/area/icy_caves/caves/northern)
 "mb" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/outpost/LZ1)
@@ -2253,14 +2548,36 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/refinery)
+"mg" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "mh" = (
 /turf/closed/ice/thin/junction{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "mi" = (
-/turf/closed/ice/thin/end,
-/area/icy_caves/outpost/LZ1)
+/turf/closed/wall/r_wall/unmeltable,
+/area/lv624/lazarus/console)
+"mj" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 4;
+	pixel_x = -16
+	},
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern)
 "mk" = (
 /obj/docking_port/stationary/marine_dropship/lz2,
 /turf/open/floor/plating,
@@ -2285,6 +2602,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"mq" = (
+/obj/machinery/miner/damaged/platinum,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "mr" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
@@ -2304,9 +2625,25 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"mu" = (
+/obj/machinery/vending/security,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "mv" = (
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves)
+/turf/closed/ice_rock/corners,
+/area/space)
+"mw" = (
+/obj/structure/bookcase/manuals/research_and_development,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 9
+	},
+/area/icy_caves/caves/northern)
 "mx" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 8
@@ -2316,64 +2653,37 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
 "mz" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/largecrate/random/case/small,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/ai_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/northern)
 "mA" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/end{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/largecrate/random/barrel/yellow,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/northern)
 "mC" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/corner{
 	dir = 1
 	},
-/obj/item/tank/air,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"mD" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/largecrate/goat,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/northern)
 "mE" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/corners{
+	dir = 5
 	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/largecrate/random/barrel/green,
-/turf/open/floor/tile/dark,
+/area/icy_caves/caves)
+"mF" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/tile/dark/yellow2,
 /area/icy_caves/outpost/LZ2)
 "mG" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/structure/dispenser,
+/turf/open/floor/tile/dark/yellow2{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/item/storage/backpack,
-/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "mH" = (
 /turf/closed/ice/corner{
@@ -2405,78 +2715,58 @@
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/caves/south)
 "mP" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "mQ" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/single,
+/area/icy_caves/caves/northern)
+"mV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"mX" = (
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/largecrate/random/barrel/white,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"mR" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/pizzabox/margherita,
-/obj/item/storage/donut_box,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
 "mY" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/reagent_scanner/adv,
-/obj/item/storage/firstaid/o2,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/westWall,
+/area/icy_caves/caves)
+"mZ" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "nb" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/straight{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
+"nc" = (
+/turf/open/floor/tile/dark/brown2{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
-/obj/item/flashlight,
-/obj/structure/prop/mainship/hangar_stencil/two,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
-"nc" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/machinery/light/small,
-/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "nd" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/largecrate/random/barrel/white,
-/turf/open/floor/tile/dark,
+/obj/structure/largecrate/random/case/double,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
 "ne" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/reagent_dispensers/watertank,
-/obj/structure/prop/mainship/hangar_stencil/two,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ2)
+/obj/item/lightstick/anchored,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/northern)
 "nf" = (
-/obj/effect/decal/warning_stripes/thin{
+/turf/open/floor/tile/dark/brown2{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/table,
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/crayons,
-/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "ng" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -2496,33 +2786,47 @@
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/garage)
 "nl" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/table,
-/obj/item/roller,
-/obj/item/storage/firstaid,
-/obj/structure/prop/mainship/hangar_stencil/two,
-/turf/open/floor/tile/dark,
+/turf/open/floor/tile/dark/yellow2,
 /area/icy_caves/outpost/LZ2)
 "nm" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 6
 	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/structure/largecrate/random/case,
-/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "np" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
+"ns" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "nu" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"nv" = (
+/obj/structure/table,
+/obj/item/corncob,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"nw" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
+"nx" = (
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/mining/west)
 "ny" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/ice_rock/single,
@@ -2531,14 +2835,22 @@
 /obj/docking_port/stationary/crashmode,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
-"nC" = (
-/turf/open/floor/plating/icefloor/warnplate,
 /area/icy_caves/outpost/LZ2)
+"nB" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "nD" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
+"nF" = (
+/obj/structure/janitorialcart,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "nH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -2549,6 +2861,10 @@
 "nI" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ2)
+"nK" = (
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "nL" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/outside/center)
@@ -2563,11 +2879,6 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
-"nQ" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 10
-	},
-/area/icy_caves/outpost/LZ2)
 "nS" = (
 /turf/open/floor/plating/dmg1,
 /area/icy_caves/caves/crashed_ship)
@@ -2595,11 +2906,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside/center)
-"ob" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ2)
 "oc" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -2608,6 +2914,9 @@
 	dir = 10
 	},
 /area/icy_caves/outpost/garage)
+"od" = (
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/mining/west)
 "of" = (
 /turf/closed/ice/thin/end{
 	dir = 4
@@ -2641,6 +2950,20 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"op" = (
+/obj/structure/prop/mainship/sensor_computer3/sd,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern)
+"oq" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "or" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/structure/cable,
@@ -2688,6 +3011,16 @@
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
+"oM" = (
+/obj/structure/dropship_piece/two/front/right,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
+"oN" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside/center)
 "oO" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -2695,10 +3028,35 @@
 "oP" = (
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ2)
+"oQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
+"oR" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 6
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "oS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"oT" = (
+/obj/structure/largecrate/supply/floodlights,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "oU" = (
 /obj/item/tool/pickaxe,
 /obj/structure/rack,
@@ -2711,11 +3069,17 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
+"pa" = (
+/turf/closed/wall,
+/area/icy_caves/outpost/outside)
 "pb" = (
 /turf/closed/ice_rock/corners{
 	dir = 9
 	},
 /area/icy_caves/caves/west)
+"pc" = (
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "pf" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = /obj/item/storage/backpack/satchel/norm;
@@ -2737,6 +3101,12 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"ph" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "pj" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -2745,9 +3115,8 @@
 /turf/closed/ice/straight,
 /area/icy_caves/caves/northern)
 "pl" = (
-/obj/structure/ore_box,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
+/turf/closed/wall/r_wall/unmeltable,
+/area/icy_caves/caves/northern)
 "pm" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/cable,
@@ -2756,7 +3125,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "po" = (
 /turf/open/floor/tile/dark/purple2{
 	dir = 4
@@ -2767,6 +3136,12 @@
 	dir = 1
 	},
 /area/icy_caves/caves)
+"pr" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "ps" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/dmg1,
@@ -2775,8 +3150,14 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/refinery)
+"pu" = (
+/obj/structure/barricade/guardrail{
+	dir = 4
+	},
+/obj/item/clothing/head/warning_cone,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "pw" = (
-/obj/structure/ore_box,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -2807,11 +3188,6 @@
 /obj/item/clothing/mask/rebreather,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
-"pz" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 5
-	},
-/area/icy_caves/outpost/LZ1)
 "pB" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -2824,6 +3200,11 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside)
+"pE" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
 "pF" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/smg/m25,
@@ -2834,18 +3215,52 @@
 /obj/item/ammo_magazine/smg/m25,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"pH" = (
+/turf/closed/ice_rock/corners{
+	dir = 10
+	},
+/area/icy_caves/caves/west)
+"pL" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"pN" = (
+/obj/structure/janitorialcart,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "pO" = (
 /obj/item/ammo_casing,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"pP" = (
+/obj/structure/closet/crate,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick,
+/obj/item/storage/box/lightstick,
+/obj/item/tool/pickaxe/plasmacutter,
+/obj/effect/spawner/random/powercell,
+/obj/item/explosive/plastique,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "pR" = (
 /obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
+"pS" = (
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "pT" = (
 /obj/effect/landmark/fob_sentry,
+/obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "pU" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -2867,16 +3282,16 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
 "pZ" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 6
-	},
-/area/icy_caves/outpost/LZ1)
+/obj/item/paper/crumpled/bloody,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "qa" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/space)
 "qb" = (
-/obj/machinery/conveyor/inverted{
+/obj/machinery/conveyor{
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -2896,16 +3311,16 @@
 	},
 /area/icy_caves/outpost/refinery)
 "qe" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/LZ2)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/single,
+/area/icy_caves/caves/northern)
 "qf" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "qg" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plating,
@@ -2916,7 +3331,7 @@
 /area/icy_caves/outpost/mining/east)
 "qi" = (
 /obj/item/tool/pickaxe,
-/obj/structure/rack/nometal,
+/obj/structure/rack,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
 "qj" = (
@@ -2924,10 +3339,16 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/rack,
 /obj/item/tool/pickaxe,
-/obj/structure/rack/nometal,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
+"qk" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
 "ql" = (
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
@@ -2972,6 +3393,13 @@
 	dir = 10
 	},
 /area/icy_caves/outpost/refinery)
+"qu" = (
+/obj/structure/dropship_piece/one/corner/middleleft,
+/obj/structure/dropship_piece/two/corner/rearleft,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "qw" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1
@@ -2992,6 +3420,15 @@
 "qz" = (
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves)
+"qA" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
 "qB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/tile/dark,
@@ -2999,6 +3436,9 @@
 "qC" = (
 /turf/closed/ice/thin/junction,
 /area/icy_caves/outpost/LZ2)
+"qE" = (
+/turf/closed/ice_rock/single,
+/area/icy_caves/outpost/outside/center)
 "qF" = (
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/tile/dark/brown2{
@@ -3021,12 +3461,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"qM" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 1
+"qL" = (
+/turf/open/floor/tile/dark/yellow2{
+	dir = 8
 	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "qN" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -3037,13 +3476,18 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
 "qP" = (
-/obj/machinery/mineral/processing_unit,
-/turf/open/floor/plating,
+/obj/machinery/conveyor{
+	id = "lower_garbage"
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
 "qQ" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"qR" = (
+/turf/closed/ice_rock/northWall,
+/area/icy_caves/caves/west)
 "qS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -3108,6 +3552,11 @@
 "rf" = (
 /turf/closed/ice/thin/end,
 /area/icy_caves/caves/northern)
+"rg" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 5
+	},
+/area/icy_caves/caves/northern)
 "rh" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/machinery/door/airlock/multi_tile/mainship/research{
@@ -3115,12 +3564,24 @@
 	},
 /turf/open/floor/tile/dark/purple2,
 /area/icy_caves/outpost/research)
+"rk" = (
+/obj/structure/table/reinforced,
+/obj/structure/xenoautopsy,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
 "rl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
+"rm" = (
+/turf/open/floor/tile/dark/brown2{
+	dir = 5
+	},
+/area/icy_caves/outpost/LZ2)
 "rn" = (
 /obj/structure/closet/crate/science,
 /turf/open/floor/tile/dark/purple2{
@@ -3135,7 +3596,7 @@
 /turf/closed/ice/thin/end{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "rq" = (
 /obj/structure/closet/fireaxecabinet,
 /turf/closed/wall/r_wall,
@@ -3166,6 +3627,10 @@
 /obj/item/tool/kitchen/knife,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
+"rw" = (
+/obj/structure/grille,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/mining/west)
 "rx" = (
 /obj/structure/table,
 /obj/item/reagent_containers/dropper,
@@ -3268,11 +3733,11 @@
 /area/icy_caves/outpost/research)
 "rS" = (
 /obj/structure/table,
+/obj/item/tool/pickaxe/plasmacutter,
 /obj/effect/spawner/random/powercell,
 /obj/item/clothing/head/welding,
 /obj/item/clothing/glasses/welding,
 /obj/item/explosive/plastique,
-/obj/effect/spawner/random/powercell,
 /turf/open/floor/tile/dark/yellow2{
 	dir = 1
 	},
@@ -3314,9 +3779,9 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
 "sb" = (
-/obj/machinery/floodlight/landing,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/straight,
+/area/icy_caves/caves/northern)
 "sc" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -3363,8 +3828,8 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
 "sk" = (
-/obj/machinery/conveyor/inverted{
-	dir = 9
+/obj/machinery/conveyor{
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/refinery)
@@ -3407,6 +3872,12 @@
 /obj/effect/landmark/corpsespawner/doctor,
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
+"ss" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd{
+	dir = 4
+	},
+/area/icy_caves/caves)
 "st" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table,
@@ -3462,18 +3933,17 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
-"sD" = (
-/obj/machinery/landinglight/ds1/delaythree{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
 "sE" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"sG" = (
+/obj/structure/bed/chair,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "sH" = (
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
@@ -3481,9 +3951,14 @@
 /turf/closed/ice/thin/corner,
 /area/icy_caves/caves/east)
 "sK" = (
-/obj/docking_port/stationary/marine_dropship/lz1,
-/turf/open/floor/plating,
+/obj/machinery/power/apc/lowcharge,
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
 /area/icy_caves/outpost/LZ1)
+"sM" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/refinery)
 "sN" = (
 /obj/structure/table/flipped,
 /obj/item/flashlight,
@@ -3501,13 +3976,15 @@
 /area/icy_caves/outpost/LZ2)
 "sV" = (
 /obj/structure/rack,
-/obj/item/ammo_magazine/rifle/mpi_km,
-/obj/item/ammo_magazine/rifle/mpi_km,
-/obj/item/ammo_magazine/rifle/mpi_km,
-/obj/item/ammo_magazine/rifle/mpi_km,
-/obj/item/weapon/gun/rifle/mpi_km,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"ta" = (
+/obj/effect/decal/cleanable/vomit,
+/obj/machinery/camera{
+	dir = 5
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "tb" = (
 /obj/structure/sink,
 /obj/machinery/light{
@@ -3561,6 +4038,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"tp" = (
+/obj/item/lightstick/anchored,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "tq" = (
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/plating/ground/ice,
@@ -3578,12 +4060,17 @@
 	dir = 2
 	},
 /turf/closed/ice/junction,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "tw" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice_rock/singleEnd{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/caves/northern)
+"tx" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "tB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -3592,8 +4079,8 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
 "tC" = (
+/obj/structure/rack,
 /obj/structure/largecrate/random/case/small,
-/obj/structure/rack/nometal,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "tD" = (
@@ -3611,6 +4098,17 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/engineering)
+"tF" = (
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
+"tG" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "tH" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/research)
@@ -3623,6 +4121,11 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
+"tJ" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/refinery)
 "tK" = (
 /obj/item/ammo_casing,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -3661,6 +4164,11 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"tT" = (
+/obj/structure/table/mainship,
+/obj/machinery/computer/med_data,
+/turf/open/floor/mainship/mono,
+/area/icy_caves/caves/northern)
 "tU" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -3730,6 +4238,15 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
+"ul" = (
+/obj/structure/dropship_piece/two/corner/rearright,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
+"un" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "uo" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -3752,6 +4269,18 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ2)
+"us" = (
+/obj/structure/shuttle/engine/router{
+	dir = 1
+	},
+/obj/structure/dropship_equipment/weapon/heavygun,
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/shuttle/dropship/floor,
+/area/space)
+"uu" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "uv" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/grilledcheese,
@@ -3760,6 +4289,16 @@
 "uw" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
+"ux" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/mass_spectrometer/adv,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/icy_caves/caves/northern)
 "uy" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -3801,11 +4340,15 @@
 /turf/closed/ice/straight{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "uN" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"uO" = (
+/obj/structure/dropship_piece/two/corner/rearleft,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "uP" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -3832,6 +4375,13 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/medbay)
+"uT" = (
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "uX" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -3863,6 +4413,12 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"ve" = (
+/obj/machinery/power/apc/drained{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "vf" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/outpost/outside)
@@ -3893,6 +4449,11 @@
 	dir = 10
 	},
 /area/icy_caves/outpost/engineering)
+"vn" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "25"
+	},
+/area/icy_caves/caves/northern)
 "vo" = (
 /obj/machinery/light{
 	dir = 1
@@ -3913,6 +4474,10 @@
 	dir = 6
 	},
 /area/icy_caves/outpost/garage)
+"vr" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/ice/thin/straight,
+/area/icy_caves/outpost/LZ1)
 "vs" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -3923,11 +4488,11 @@
 /obj/structure/bed/roller,
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
-"vw" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 5
-	},
-/area/icy_caves/outpost/LZ2)
+"vv" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "vx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
@@ -3989,7 +4554,7 @@
 "vR" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/end,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "vS" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/tile/dark,
@@ -3999,7 +4564,13 @@
 	dir = 1
 	},
 /turf/closed/ice/corner,
-/area/icy_caves/caves/east)
+/area/icy_caves/outpost/LZ2)
+"vW" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/straight{
+	dir = 4
+	},
+/area/icy_caves/caves)
 "vX" = (
 /obj/item/flashlight,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4034,16 +4605,30 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
+"wf" = (
+/obj/structure/barricade/guardrail{
+	dir = 1
+	},
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "wg" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
+"wh" = (
+/obj/structure/morgue/crematorium,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "wi" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/tile/dark/green2{
 	dir = 4
 	},
 /area/icy_caves/outpost/medbay)
+"wj" = (
+/obj/structure/largecrate/random/barrel/yellow,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "wk" = (
 /turf/open/floor/tile/dark/red2/corner,
 /area/icy_caves/outpost/security)
@@ -4066,6 +4651,17 @@
 	dir = 8
 	},
 /area/icy_caves/caves/northern)
+"wq" = (
+/obj/machinery/light,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
+"ws" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "wu" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
@@ -4079,6 +4675,10 @@
 "wv" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/outpost/LZ2)
+"ww" = (
+/obj/structure/grille,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/refinery)
 "wx" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -4096,15 +4696,23 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/medbay)
+"wE" = (
+/obj/docking_port/mobile/crashmode/bigbury,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/refinery)
+"wG" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "wH" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/refinery)
 "wL" = (
-/obj/machinery/landinglight/ds1/delaythree{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/turf/open/floor/mech_bay_recharge_floor,
 /area/icy_caves/outpost/LZ1)
 "wM" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -4115,7 +4723,12 @@
 "wN" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
+"wO" = (
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "wP" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -4129,6 +4742,23 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
+"wQ" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/brown2,
+/area/icy_caves/outpost/refinery)
+"wT" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/space)
 "wW" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
@@ -4144,6 +4774,10 @@
 	dir = 1
 	},
 /area/icy_caves/caves/south)
+"xe" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/caves)
 "xf" = (
 /obj/structure/closet/secure_closet/scientist,
 /turf/open/floor/tile/dark/purple2,
@@ -4182,17 +4816,39 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
 "xn" = (
-/obj/structure/cable,
 /obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ1)
+"xo" = (
+/obj/structure/closet/crate,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick,
+/obj/item/storage/box/lightstick,
+/obj/item/tool/pickaxe/plasmacutter,
+/obj/effect/spawner/random/powercell,
+/obj/item/clothing/glasses/welding,
+/obj/item/explosive/plastique,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "xr" = (
 /obj/machinery/mineral/stacking_machine,
 /obj/machinery/conveyor{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/refinery)
+"xs" = (
+/obj/structure/barricade/guardrail,
+/turf/open/floor/mainship/red/full,
+/area/icy_caves/caves/northern)
+"xt" = (
+/obj/structure/largecrate/supply/medicine,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "xu" = (
 /obj/structure/cargo_container/green,
 /turf/open/floor/plating,
@@ -4206,6 +4862,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"xx" = (
+/turf/open/floor/tile/dark/yellow2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "xA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -4244,6 +4905,10 @@
 "xR" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"xS" = (
+/obj/machinery/computer3/server,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "xT" = (
 /turf/open/floor/tile/dark/green2/corner{
 	dir = 4
@@ -4256,13 +4921,38 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"xW" = (
+/obj/structure/largecrate/supply/explosives/mortar_flare,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "xX" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/caves/south)
+"xZ" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "ya" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves)
+"yb" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
+"yd" = (
+/obj/structure/monorail,
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/floor/mainship_hull,
+/area/space)
 "yg" = (
 /obj/structure/bookcase/manuals,
 /obj/machinery/light{
@@ -4276,12 +4966,24 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
+"yi" = (
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "yj" = (
 /obj/structure/closet/crate/secure/weapon,
 /obj/item/weapon/gun/smg/m25,
 /obj/item/weapon/gun/smg/m25,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"yk" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "yl" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/tile/dark/blue2{
@@ -4299,6 +5001,12 @@
 "yq" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/outpost/LZ2)
+"yv" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "yw" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/machinery/light,
@@ -4307,6 +5015,10 @@
 "yx" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/engineering)
+"yz" = (
+/obj/structure/bed/chair,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "yB" = (
 /turf/closed/ice/thin/junction{
 	dir = 8
@@ -4323,6 +5035,14 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"yF" = (
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/space)
 "yG" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -4331,6 +5051,12 @@
 	dir = 8
 	},
 /area/icy_caves/caves)
+"yH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "yJ" = (
 /obj/structure/closet/crate/construction,
 /obj/item/cell/hyper,
@@ -4348,11 +5074,6 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
-"yL" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ1)
 "yR" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -4372,20 +5093,21 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/garage)
-"yW" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
+"yV" = (
+/obj/effect/spawner/gibspawner/human,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
 	},
-/turf/closed/ice_rock/singlePart{
-	dir = 6
-	},
-/area/icy_caves/outpost/outside)
-"zb" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"yZ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice_rock/fourway,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/caves)
+"ze" = (
+/obj/structure/largecrate/random/case/double,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "zh" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -4394,6 +5116,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"zi" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/ice_rock/corners{
+	dir = 9
+	},
+/area/icy_caves/caves)
 "zk" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleT{
@@ -4407,7 +5137,7 @@
 /turf/closed/ice/corner{
 	dir = 8
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "zm" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/drained,
@@ -4433,6 +5163,22 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/garage)
+"zq" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
+"zu" = (
+/obj/machinery/door/airlock/multi_tile/mainship/secdoor,
+/turf/open/floor/mainship/red/full,
+/area/icy_caves/caves/northern)
 "zw" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -4445,6 +5191,7 @@
 /turf/open/floor/tile/dark/purple2,
 /area/icy_caves/outpost/research)
 "zy" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice/junction{
 	dir = 4
 	},
@@ -4453,6 +5200,9 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/refinery)
+"zB" = (
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "zC" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/tile/dark,
@@ -4461,15 +5211,10 @@
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"zE" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 9
-	},
-/area/icy_caves/outpost/LZ2)
 "zF" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 4
+/obj/machinery/space_heater,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 10
 	},
 /area/icy_caves/outpost/LZ2)
 "zG" = (
@@ -4492,15 +5237,17 @@
 /turf/closed/ice_rock/singlePart,
 /area/icy_caves/caves)
 "zM" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/obj/machinery/landinglight/ds1/delaytwo,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "zN" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"zO" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/caves)
 "zP" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
@@ -4513,16 +5260,10 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
-"zR" = (
-/obj/machinery/conveyor{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/refinery)
 "zS" = (
-/turf/closed/ice/end{
-	dir = 4
-	},
+/obj/machinery/landinglight/ds1/delaytwo,
+/obj/machinery/floodlight/landing,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "zT" = (
 /obj/machinery/iv_drip,
@@ -4554,14 +5295,25 @@
 	dir = 9
 	},
 /area/icy_caves/outpost/medbay)
+"zZ" = (
+/obj/machinery/door/airlock/mainship/secure/locked/free_access{
+	dir = 2
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Aa" = (
 /obj/item/storage/box/flashbangs,
 /obj/item/storage/box/m94,
 /obj/item/storage/box/m94,
-/obj/structure/closet/crate/secure/phoron,
-/obj/item/stack/sheet/mineral/phoron,
+/obj/item/explosive/plastique,
+/obj/item/explosive/plastique,
+/obj/structure/closet/crate/secure/explosives,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Ab" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "Ad" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -4571,12 +5323,19 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/garage)
-"Ag" = (
-/obj/machinery/landinglight/ds1/delaytwo{
-	dir = 4
+"Ae" = (
+/turf/closed/ice_rock/eastWall,
+/area/icy_caves/caves/northern)
+"Af" = (
+/obj/vehicle/multitile/root/cm_armored/tank{
+	dir = 1;
+	layer = 1
 	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
+/obj/structure/dropship_equipment/weapon/laser_beam_gun,
+/obj/effect/turf_overlay/shuttle/heater,
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/shuttle/dropship/floor,
+/area/space)
 "Ah" = (
 /obj/effect/landmark/corpsespawner/security{
 	corpsebelt = /obj/item/weapon/gun/revolver/cmb;
@@ -4606,10 +5365,12 @@
 /obj/machinery/processor,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"Ap" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ2)
+"Aq" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/snow,
+/area/icy_caves/outpost/LZ1)
 "Ar" = (
 /obj/structure/closet/crate/secure/ammo,
 /obj/item/ammo_magazine/smg/m25,
@@ -4652,10 +5413,12 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"AA" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
+"Ay" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/corners{
+	dir = 6
+	},
+/area/icy_caves/caves)
 "AB" = (
 /turf/closed/ice/thin/end{
 	dir = 1
@@ -4699,23 +5462,25 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/office)
-"AH" = (
-/obj/machinery/landinglight/ds1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
 "AI" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 4
 	},
 /area/icy_caves/outpost/refinery)
+"AJ" = (
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "AK" = (
 /turf/closed/ice/end{
 	dir = 1
 	},
 /area/icy_caves/outpost/outside)
+"AL" = (
+/turf/closed/ice/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "AM" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/cable,
@@ -4728,6 +5493,19 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
+"AQ" = (
+/obj/machinery/disposal,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"AR" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
 "AS" = (
 /obj/machinery/power/geothermal,
 /obj/machinery/light/small{
@@ -4778,6 +5556,14 @@
 	dir = 4
 	},
 /area/icy_caves/caves)
+"Bb" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/caves/west)
+"Bc" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/northWall,
+/area/icy_caves/caves)
 "Bd" = (
 /obj/machinery/door/airlock/multi_tile/mainship/secdoor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4790,6 +5576,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"Bf" = (
+/turf/open/floor/tile/dark/green2{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "Bi" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/prison/kitchen,
@@ -4804,6 +5595,12 @@
 	dir = 1
 	},
 /area/icy_caves/caves/east)
+"Bo" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Bq" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/prison/kitchen,
@@ -4811,6 +5608,10 @@
 "Bs" = (
 /turf/open/floor/podhatch/floor,
 /area/icy_caves/outpost/engineering)
+"Bt" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "Bu" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -4841,19 +5642,19 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
-"BD" = (
-/obj/structure/largecrate/random/secure,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/garage)
+"BB" = (
+/obj/structure/cryofeed,
+/turf/open/floor/podhatch/floor{
+	icon_state = "bcircuitoff"
+	},
+/area/icy_caves/caves/northern)
 "BF" = (
-/obj/effect/attach_point/weapon/dropship1{
-	dir = 8;
-	icon_state = "equip_base_l_wing"
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
 	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ2)
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "BI" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -4862,15 +5663,31 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"BK" = (
+/obj/structure/prop/mainship/hangar_stencil/two,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "BL" = (
 /turf/closed/ice/end{
 	dir = 8
 	},
 /area/icy_caves/outpost/outside)
 "BM" = (
-/obj/docking_port/stationary/crashmode,
-/turf/closed/wall/r_wall,
-/area/icy_caves/outpost/dorms)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/straight,
+/area/icy_caves/caves/northern)
+"BN" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "52"
+	},
+/area/icy_caves/caves/northern)
+"BO" = (
+/obj/machinery/door/airlock/multi_tile/secure{
+	dir = 2
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "BP" = (
 /turf/closed/ice/junction{
 	dir = 4
@@ -4906,6 +5723,12 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"BW" = (
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "BX" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -4915,14 +5738,25 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "BY" = (
-/turf/closed/ice/thin/end{
-	dir = 8
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 6
 	},
-/area/icy_caves/outpost/LZ1)
-"Cc" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
+/obj/structure/monorail{
+	dir = 10
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/space)
+"BZ" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Ch" = (
+/obj/machinery/computer3/server/rack,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Ci" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -4936,6 +5770,31 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
+"Cl" = (
+/obj/machinery/camera{
+	dir = 5
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Cm" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
+"Co" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/corners{
+	dir = 10
+	},
+/area/icy_caves/caves)
+"Cq" = (
+/turf/closed/ice/thin/end{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "Cs" = (
 /obj/item/ammo_casing,
 /turf/open/floor/wood,
@@ -4957,6 +5816,11 @@
 /obj/item/clothing/shoes/rainbow,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"CH" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 10
+	},
+/area/icy_caves/caves/northern)
 "CN" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/south)
@@ -4984,18 +5848,16 @@
 	dir = 9
 	},
 /area/icy_caves/outpost/refinery)
+"CX" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "CZ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ2)
-"Da" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ1)
 "Dc" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/up,
 /turf/open/floor/tile/dark,
@@ -5025,7 +5887,7 @@
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
 "Dk" = (
-/obj/structure/rack/nometal,
+/obj/structure/rack,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "Dl" = (
@@ -5034,6 +5896,13 @@
 	},
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
+"Dm" = (
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "Dn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -5041,6 +5910,15 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
+"Do" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "Dp" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleEnd{
@@ -5091,6 +5969,13 @@
 /obj/effect/decal/cleanable/blood/writing,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"DH" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/closed/ice/end{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
 "DJ" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 4
@@ -5106,7 +5991,7 @@
 /turf/closed/ice/thin/corner{
 	dir = 8
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "DM" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 10
@@ -5117,12 +6002,28 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"DQ" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating/icefloor/warnplate{
+"DO" = (
+/obj/machinery/light{
 	dir = 8
 	},
+/turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ2)
+"DS" = (
+/obj/structure/dropship_piece/one/corner/middleright,
+/obj/structure/dropship_piece/two/corner/rearright,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
+"DU" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
+"DV" = (
+/obj/structure/mopbucket,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "DW" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -5133,6 +6034,11 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/garage)
+"DX" = (
+/turf/closed/ice_rock/corners{
+	dir = 9
+	},
+/area/icy_caves/outpost/LZ1)
 "DY" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
@@ -5141,6 +6047,12 @@
 	dir = 6
 	},
 /area/icy_caves/caves/west)
+"Ea" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Eb" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/effect/ai_node,
@@ -5165,6 +6077,14 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"Eh" = (
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/space)
 "Ej" = (
 /obj/structure/table,
 /obj/item/stack/nanopaste,
@@ -5172,17 +6092,26 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/medbay)
+"Ek" = (
+/obj/structure/table/mainship,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "El" = (
 /obj/structure/table/reinforced,
 /obj/effect/landmark/dropship_console_spawn_lz2,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/console)
+"Em" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice,
+/area/icy_caves/outpost/outside)
 "En" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Ep" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -5208,10 +6137,15 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"Ex" = (
+/obj/effect/decal/cleanable/mucus,
+/obj/structure/table,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "Ey" = (
 /obj/effect/landmark/fob_sentry_rebel,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "Ez" = (
 /obj/structure/bed,
 /turf/open/floor/wood,
@@ -5225,6 +6159,11 @@
 	},
 /turf/closed/ice_rock/singlePart{
 	dir = 8
+	},
+/area/icy_caves/caves)
+"EE" = (
+/turf/closed/ice/straight{
+	dir = 4
 	},
 /area/icy_caves/caves)
 "EH" = (
@@ -5259,20 +6198,34 @@
 /area/icy_caves/caves/south)
 "EO" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/closed/wall/r_wall,
-/area/icy_caves/outpost/outside)
+/turf/closed/ice/thin/junction,
+/area/icy_caves/outpost/LZ1)
+"EP" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "EQ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/corner{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "ES" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/closed/ice_rock/westWall,
 /area/icy_caves/caves)
+"EU" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"EX" = (
+/obj/structure/largecrate/supply/floodlights,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "EZ" = (
 /obj/item/ammo_casing,
 /obj/structure/cable,
@@ -5311,6 +6264,17 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"Fj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Fk" = (
+/obj/structure/barricade/guardrail,
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "Fm" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -5328,6 +6292,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"Fq" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "Fr" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/purple2{
@@ -5366,6 +6334,16 @@
 "Fy" = (
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
+"FB" = (
+/obj/machinery/light,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"FD" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/end{
+	dir = 4
+	},
+/area/icy_caves/outpost/outside)
 "FF" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -5397,6 +6375,9 @@
 /obj/structure/sink{
 	dir = 4
 	},
+/obj/structure/mirror{
+	pixel_x = 24
+	},
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
 "FP" = (
@@ -5407,11 +6388,10 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
 "FR" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
+/turf/closed/shuttle/dropship2/transparent{
+	icon_state = "109"
 	},
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/caves/northern)
 "FU" = (
 /obj/structure/cargo_container/ch_red,
 /turf/open/floor/plating,
@@ -5452,6 +6432,24 @@
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Gf" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Gh" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/structure/table/mainship,
+/obj/structure/cable,
+/obj/machinery/computer/nuke_disk_generator/blue,
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern)
+"Gj" = (
+/obj/machinery/computer/operating,
+/obj/structure/table/reinforced,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Gk" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -5459,6 +6457,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/office)
+"Gl" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/LZ2)
 "Gm" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -5469,6 +6471,10 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"Gn" = (
+/obj/structure/largecrate/random/barrel/green,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Go" = (
 /turf/open/floor/tile/dark/purple2/corner{
 	dir = 1
@@ -5482,25 +6488,43 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
+"Gs" = (
+/turf/closed/ice_rock/corners,
+/area/icy_caves/caves/northern)
 "Gu" = (
 /turf/closed/ice,
 /area/icy_caves/outpost/outside)
 "Gw" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/refinery)
+"Gx" = (
+/obj/structure/mopbucket,
+/obj/machinery/power/apc/drained,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "Gz" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleT,
 /area/icy_caves/caves)
-"GC" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow,
-/area/icy_caves/outpost/LZ1)
 "GD" = (
 /turf/open/floor/tile/dark/red2/corner{
 	dir = 1
 	},
 /area/icy_caves/outpost/security)
+"GE" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
+"GF" = (
+/turf/closed/wall,
+/area/icy_caves/caves/west)
+"GG" = (
+/turf/closed/ice/thin/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "GH" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/ice,
@@ -5512,7 +6536,7 @@
 /turf/closed/ice/thin/corner{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "GK" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
@@ -5533,6 +6557,32 @@
 	dir = 4
 	},
 /area/icy_caves/caves)
+"GN" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/space)
+"GO" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ2)
+"GQ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "GR" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -5547,6 +6597,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"GU" = (
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "GV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -5556,7 +6612,6 @@
 	},
 /area/icy_caves/outpost/medbay)
 "GX" = (
-/obj/machinery/computer/nuke_disk_generator/blue,
 /turf/open/floor/tile/dark/purple2{
 	dir = 9
 	},
@@ -5574,6 +6629,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
+"He" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Hf" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/dorms)
@@ -5593,10 +6652,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
+"Hj" = (
+/obj/structure/table/mainship,
+/obj/machinery/recharger,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "Hl" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "Hm" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -5621,6 +6688,14 @@
 /obj/machinery/light/small,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"Hw" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
+"Hx" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/outside)
 "HA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -5634,10 +6709,13 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "HC" = (
-/turf/closed/ice_rock/singlePart{
+/obj/structure/monorail,
+/obj/structure/lattice,
+/obj/structure/monorail{
 	dir = 4
 	},
-/area/icy_caves/outpost/LZ1)
+/turf/open/floor/mainship_hull,
+/area/space)
 "HE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -5645,6 +6723,11 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
+"HF" = (
+/turf/closed/ice/corner{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "HG" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/south)
@@ -5655,13 +6738,18 @@
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "HJ" = (
 /obj/machinery/vending/MarineMed/Blood,
 /turf/open/floor/tile/dark/green2{
 	dir = 4
 	},
 /area/icy_caves/outpost/medbay)
+"HL" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 6
+	},
+/area/icy_caves/caves/northern)
 "HM" = (
 /obj/item/ammo_casing,
 /turf/open/floor/tile/dark/brown2/corner{
@@ -5676,6 +6764,21 @@
 /obj/item/clothing/head/nun_hood,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"HP" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"HQ" = (
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "HR" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -5692,6 +6795,18 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"HT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"HU" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "HV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/corners{
@@ -5712,19 +6827,37 @@
 /obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"Id" = (
-/obj/structure/cargo_container/gorg,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/garage)
 "Ie" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"If" = (
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor/mainship/cargo,
+/area/icy_caves/caves/northern)
+"Ig" = (
+/obj/docking_port/mobile/crashmode/bigbury,
+/turf/closed/ice,
+/area/icy_caves/caves/south)
 "Ih" = (
 /obj/structure/cargo_container/green{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Ii" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside)
+"Ij" = (
+/obj/structure/largecrate/random/barrel/green,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "Ik" = (
 /obj/structure/table,
 /obj/item/storage/box/flashbangs,
@@ -5733,9 +6866,13 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/security)
+"Il" = (
+/turf/closed/ice_rock/southWall,
+/area/icy_caves/caves/northern)
 "Im" = (
-/turf/open/floor/plating/ground/snow,
-/area/icy_caves/outpost/outside)
+/obj/item/shard,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "In" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -5804,6 +6941,12 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
+"IF" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/junction{
+	dir = 1
+	},
+/area/icy_caves/caves)
 "IG" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -5822,24 +6965,42 @@
 	},
 /turf/open/floor/tile/dark/red2,
 /area/icy_caves/outpost/security)
+"II" = (
+/obj/item/paper/crumpled/bloody/csheet,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "IJ" = (
 /obj/machinery/vending/security,
 /turf/open/floor/tile/dark/red2{
 	dir = 9
 	},
 /area/icy_caves/outpost/security)
+"IK" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "IO" = (
+/obj/structure/closet/crate/construction,
+/obj/item/stack/sheet/metal/medium_stack,
+/obj/item/stack/sheet/plasteel/medium_stack,
+/obj/item/stack/sandbags_empty{
+	amount = 25
+	},
+/obj/item/stack/barbed_wire/half_stack,
 /obj/effect/landmark/excavation_site_spawner,
-/obj/structure/closet/crate/hydroponics,
-/obj/item/seeds/tomatoseed{
-	pixel_y = -5
-	},
-/obj/item/seeds/potatoseed{
-	pixel_x = -5
-	},
-/obj/item/seeds/sunflowerseed,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
+"IP" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "IR" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
@@ -5857,6 +7018,14 @@
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"IY" = (
+/obj/item/tool/surgery/hemostat,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"IZ" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/closed/wall/r_wall,
+/area/icy_caves/outpost/LZ2)
 "Je" = (
 /turf/closed/ice/thin/end{
 	dir = 8
@@ -5896,7 +7065,10 @@
 /turf/closed/ice/thin/junction{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
+"Jn" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "Jo" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
@@ -5912,11 +7084,17 @@
 /turf/closed/ice/end{
 	dir = 1
 	},
-/area/icy_caves/caves/east)
+/area/icy_caves/outpost/LZ2)
 "Jq" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"Js" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/end{
+	dir = 1
+	},
+/area/icy_caves/outpost/outside)
 "Jv" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -5959,6 +7137,13 @@
 /obj/item/lightstick/anchored,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"JF" = (
+/obj/machinery/vending/cola,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "JH" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/pepper,
@@ -5978,9 +7163,9 @@
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
 "JN" = (
-/obj/docking_port/mobile/crashmode/bigbury,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/refinery)
+/obj/machinery/door/airlock/multi_tile/mainship/research,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/LZ2)
 "JO" = (
 /obj/machinery/bodyscanner,
 /turf/open/floor/tile/dark/green2,
@@ -5991,6 +7176,16 @@
 	dir = 5
 	},
 /area/icy_caves/caves)
+"JR" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/structure/monorail{
+	dir = 9
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
 "JS" = (
 /obj/structure/closet/crate/freezer/rations,
 /turf/open/floor/tile/dark,
@@ -6001,11 +7196,16 @@
 	dir = 6
 	},
 /area/icy_caves/outpost/medbay)
+"JW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside/center)
 "JX" = (
 /turf/closed/ice/end,
 /area/icy_caves/caves/south)
 "JY" = (
-/turf/closed/ice/thin/single,
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "Ka" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -6018,10 +7218,11 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/office)
-"Kc" = (
-/obj/structure/rack/nometal,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/garage)
+"Kd" = (
+/turf/open/floor/tile/dark/red2{
+	dir = 10
+	},
+/area/icy_caves/outpost/LZ2)
 "Ke" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -6050,8 +7251,10 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "Ko" = (
-/turf/closed/ice_rock/singleEnd,
-/area/icy_caves/outpost/outside)
+/turf/open/floor/tile/dark/red2{
+	dir = 6
+	},
+/area/icy_caves/outpost/LZ2)
 "Kp" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
@@ -6060,6 +7263,10 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/garage)
+"Kt" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/blue2,
+/area/icy_caves/outpost/LZ2)
 "Ku" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/item/reagent_containers/hypospray/autoinjector/tricordrazine,
@@ -6080,6 +7287,12 @@
 /obj/machinery/space_heater,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"Kz" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "KA" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/machinery/light{
@@ -6112,12 +7325,18 @@
 "KJ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "KK" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 1
 	},
 /area/icy_caves/caves/south)
+"KL" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "KM" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 9
@@ -6126,9 +7345,14 @@
 "KO" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/structure/closet/cabinet,
-/obj/item/clothing/under/colonist,
+/obj/item/clothing/suit/hgpirate,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"KP" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "54"
+	},
+/area/icy_caves/caves/northern)
 "KS" = (
 /turf/open/floor/tile/dark/red2{
 	dir = 5
@@ -6190,12 +7414,28 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
+"Lo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	on = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Lq" = (
 /obj/machinery/power/geothermal,
 /obj/machinery/light/small,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
+"Lr" = (
+/obj/item/shard,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
+"Ls" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Lt" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = null;
@@ -6215,6 +7455,10 @@
 "Lv" = (
 /turf/closed/ice/thin,
 /area/icy_caves/outpost/outside)
+"Lw" = (
+/obj/structure/closet/l3closet/virology,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "Lx" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 10
@@ -6233,6 +7477,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"LB" = (
+/turf/open/floor/tile/dark/brown2{
+	dir = 9
+	},
+/area/icy_caves/outpost/LZ2)
 "LC" = (
 /obj/machinery/light/small,
 /turf/open/floor/wood,
@@ -6245,6 +7494,13 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"LF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "LH" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
@@ -6276,9 +7532,9 @@
 /area/icy_caves/outpost/garage)
 "LL" = (
 /obj/machinery/landinglight/ds1/delaytwo{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "LO" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -6291,7 +7547,7 @@
 /turf/closed/ice/thin/end{
 	dir = 8
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "LQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -6340,6 +7596,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"LY" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "LZ" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -6347,6 +7607,17 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"Me" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
+"Mf" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/red/full,
+/area/icy_caves/caves/northern)
 "Mg" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 5
@@ -6392,10 +7663,19 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
+"Mq" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
+"Mr" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/single,
+/area/icy_caves/caves)
 "Ms" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Mt" = (
 /obj/item/ammo_casing,
 /turf/open/floor/tile/dark/red2{
@@ -6410,12 +7690,34 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"Mv" = (
+/obj/machinery/optable,
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Mw" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
+"Mx" = (
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Mz" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/corner{
 	dir = 4
 	},
 /area/icy_caves/outpost/LZ1)
+"MA" = (
+/obj/structure/barricade/guardrail,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "MB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -6431,6 +7733,11 @@
 	dir = 8
 	},
 /area/icy_caves/caves/south)
+"MH" = (
+/turf/closed/ice/thin/end{
+	dir = 1
+	},
+/area/icy_caves/caves)
 "MJ" = (
 /turf/closed/ice/corner{
 	dir = 1
@@ -6456,10 +7763,10 @@
 	},
 /area/icy_caves/caves/south)
 "MO" = (
-/obj/machinery/landinglight/ds1{
-	dir = 1
+/obj/machinery/landinglight/ds1/delaytwo{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "MP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -6472,6 +7779,11 @@
 /obj/machinery/space_heater,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
+"MT" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/cheeseburger,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "MV" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -6483,6 +7795,13 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"MY" = (
+/obj/item/reagent_containers/spray/pepper,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 6
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "MZ" = (
 /obj/machinery/door/airlock/mainship/command/free_access{
 	dir = 1;
@@ -6534,10 +7853,10 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "Np" = (
 /turf/closed/ice/intersection,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Nq" = (
 /turf/closed/ice/end{
 	dir = 4
@@ -6551,11 +7870,16 @@
 /obj/structure/cable,
 /obj/effect/landmark/fob_sentry,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Nt" = (
 /obj/item/ammo_magazine/smg/m25,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"Nu" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "Nv" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -6592,6 +7916,12 @@
 	},
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/refinery)
+"NH" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside)
 "NJ" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -6613,6 +7943,13 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"NM" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "NN" = (
 /obj/structure/filingcabinet,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -6626,9 +7963,10 @@
 /obj/item/storage/box/lightstick/red,
 /obj/item/storage/box/lightstick,
 /obj/item/storage/box/lightstick,
+/obj/item/tool/pickaxe/plasmacutter,
 /obj/effect/spawner/random/powercell,
 /obj/item/clothing/glasses/welding,
-/obj/item/newspaper,
+/obj/item/explosive/plastique,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "NS" = (
@@ -6643,6 +7981,15 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/outside)
+"NU" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 10
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"NW" = (
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "Ob" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark,
@@ -6651,6 +7998,16 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"Od" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 6
+	},
+/obj/structure/monorail{
+	dir = 10
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
 "Oe" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark/brown2{
@@ -6701,14 +8058,18 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
+"Ox" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern)
 "Oy" = (
 /obj/docking_port/mobile/crashmode/bigbury,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/LZ2)
-"Oz" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating,
+/turf/open/floor/tile/dark/red2{
+	dir = 8
+	},
 /area/icy_caves/outpost/LZ2)
 "OA" = (
 /turf/closed/ice/thin/corner{
@@ -6722,7 +8083,7 @@
 "OD" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "OE" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/dark/brown2,
@@ -6743,24 +8104,30 @@
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
 "OI" = (
-/obj/machinery/computer/intel_computer,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/space)
 "OJ" = (
 /turf/closed/ice/end,
 /area/icy_caves/outpost/outside)
 "OL" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/docking_port/mobile/crashmode/bigbury,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside/center)
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ2)
+"OM" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd,
+/area/icy_caves/caves)
 "OO" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
+"OP" = (
+/turf/open/floor/mainship/red/full,
+/area/icy_caves/caves/northern)
 "OQ" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/kitchen,
@@ -6769,13 +8136,30 @@
 /turf/closed/ice,
 /area/icy_caves/caves/east)
 "OZ" = (
-/obj/item/tool/pickaxe,
-/obj/structure/rack/nometal,
+/obj/structure/cargo_container/gorg,
 /turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
+/area/icy_caves/outpost/garage)
+"Pc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark/blue2{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "Pd" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/security)
+"Pg" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Pi" = (
 /turf/closed/ice/corner{
 	dir = 8
@@ -6796,6 +8180,10 @@
 	dir = 8
 	},
 /area/icy_caves/caves/south)
+"Pp" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "Pq" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 8
@@ -6814,6 +8202,11 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/refinery)
+"Pv" = (
+/turf/closed/ice/junction{
+	dir = 1
+	},
+/area/icy_caves/caves)
 "Pz" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -6827,11 +8220,6 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
-"PB" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ1)
 "PC" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -6839,7 +8227,7 @@
 /turf/closed/ice/junction{
 	dir = 8
 	},
-/area/icy_caves/caves/east)
+/area/icy_caves/outpost/LZ2)
 "PD" = (
 /turf/closed/ice/corner{
 	dir = 4
@@ -6864,6 +8252,13 @@
 	dir = 8
 	},
 /area/icy_caves/caves)
+"PN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8;
+	welded = 1
+	},
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "PO" = (
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
@@ -6873,6 +8268,14 @@
 /obj/item/weapon/gun/smg/m25,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"PR" = (
+/turf/closed/ice/junction{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
+"PS" = (
+/turf/closed/ice/thin/corner,
+/area/icy_caves/outpost/LZ2)
 "PT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -6908,6 +8311,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
+"PZ" = (
+/turf/open/floor/tile/dark/green2,
+/area/icy_caves/caves/northern)
 "Qa" = (
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
@@ -6920,12 +8326,24 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"Qe" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "Qf" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/green2{
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
+"Qg" = (
+/obj/structure/prop/mainship/sensor_computer2,
+/obj/structure/cable,
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern)
 "Qh" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 6
@@ -6942,11 +8360,24 @@
 "Qk" = (
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"Qp" = (
-/turf/closed/ice_rock/singleEnd{
+"Qn" = (
+/obj/structure/barricade/guardrail,
+/obj/structure/bed/chair/dropship/passenger{
 	dir = 8
 	},
-/area/icy_caves/outpost/outside)
+/turf/open/shuttle/dropship/seven,
+/area/space)
+"Qo" = (
+/turf/closed/ice_rock/corners{
+	dir = 9
+	},
+/area/icy_caves/caves/northern)
+"Qp" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ2)
 "Qq" = (
 /turf/closed/ice/corner{
 	dir = 4
@@ -6975,6 +8406,12 @@
 /obj/effect/decal/cleanable/blood/writing,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"QD" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/red/full,
+/area/icy_caves/caves/northern)
 "QF" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating,
@@ -7009,8 +8446,8 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
 "QM" = (
+/obj/structure/rack,
 /obj/structure/largecrate/random/case,
-/obj/structure/rack/nometal,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "QO" = (
@@ -7018,6 +8455,18 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/outside)
+"QP" = (
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/caves)
+"QQ" = (
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "QR" = (
 /obj/machinery/light,
 /turf/open/floor/tile/dark/brown2,
@@ -7036,11 +8485,9 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"QU" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 9
-	},
-/area/icy_caves/outpost/LZ1)
+"QW" = (
+/turf/open/floor/tile/dark/blue2,
+/area/icy_caves/outpost/LZ2)
 "QX" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -7127,6 +8574,15 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"Rt" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Ru" = (
 /obj/structure/table/woodentable,
 /obj/structure/paper_bin,
@@ -7136,6 +8592,18 @@
 "Rv" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves)
+"Rw" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "103"
+	},
+/area/icy_caves/caves/northern)
+"Rx" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/blood,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "Ry" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 8
@@ -7149,8 +8617,11 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
 "RA" = (
-/turf/closed/ice_rock/singleT,
-/area/icy_caves/outpost/outside)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/LZ2)
 "RB" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/brown2{
@@ -7187,6 +8658,18 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"RL" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
+"RM" = (
+/obj/structure/monorail,
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 4
+	},
+/turf/open/floor/mainship_hull,
+/area/icy_caves/caves/northern)
 "RN" = (
 /turf/closed/ice_rock/corners{
 	dir = 5
@@ -7199,12 +8682,16 @@
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
 "RQ" = (
-/turf/closed/ice_rock/fourway,
-/area/icy_caves/outpost/outside)
+/obj/machinery/light,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "RS" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/southWall,
 /area/icy_caves/caves)
+"RU" = (
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/caves/east)
 "RW" = (
 /turf/closed/ice/end{
 	dir = 4
@@ -7226,10 +8713,30 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"Sb" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/junction{
+	dir = 1
+	},
+/area/icy_caves/outpost/outside)
 "Sc" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/crashed_ship)
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ2)
+"Se" = (
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
+"Sf" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern)
 "Sg" = (
 /turf/closed/ice/end{
 	dir = 4
@@ -7239,8 +8746,16 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/closed/ice_rock/single,
+/turf/closed/ice_rock/singleEnd{
+	dir = 8
+	},
 /area/icy_caves/caves)
+"Si" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
 "Sk" = (
 /obj/machinery/space_heater,
 /turf/open/floor/tile/dark/red2{
@@ -7270,16 +8785,23 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/security)
+"Sq" = (
+/turf/closed/ice,
+/area/icy_caves/caves)
+"Ss" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "104"
+	},
+/area/icy_caves/caves/northern)
 "Sv" = (
 /turf/closed/ice_rock/singleT{
 	dir = 4
 	},
 /area/icy_caves/caves/south)
 "Sw" = (
-/turf/closed/ice_rock/singleEnd{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ1)
+/obj/machinery/telecomms/relay/preset/telecomms,
+/turf/open/floor/plating/icefloor,
+/area/lv624/lazarus/console)
 "Sy" = (
 /turf/open/floor/tile/dark/green2/corner{
 	dir = 8
@@ -7290,6 +8812,11 @@
 	dir = 4
 	},
 /area/icy_caves/caves/south)
+"SB" = (
+/turf/closed/ice/thin/end{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ1)
 "SD" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 4
@@ -7307,18 +8834,13 @@
 "SI" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
-"SJ" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/closed/ice_rock/singlePart{
-	dir = 4
-	},
-/area/icy_caves/outpost/outside)
 "SM" = (
 /obj/structure/closet/crate/internals,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"SO" = (
+/turf/closed/ice_rock/eastWall,
+/area/icy_caves/caves/west)
 "SP" = (
 /turf/closed/ice_rock/singleT{
 	dir = 1
@@ -7349,6 +8871,12 @@
 	},
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/caves)
+"SY" = (
+/obj/structure/bookcase/manuals/research_and_development,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
 "Tb" = (
 /turf/closed/ice_rock/singleT{
 	dir = 1
@@ -7369,21 +8897,44 @@
 /turf/closed/ice_rock/singleEnd{
 	dir = 8
 	},
+/area/icy_caves/outpost/LZ1)
+"Th" = (
+/obj/structure/barricade/guardrail{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Tj" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside)
 "Tk" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside/center)
+"Tl" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ2)
 "Tm" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/turf/closed/ice/thin/straight,
+/area/icy_caves/outpost/LZ1)
 "Tr" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"Ts" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Tu" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 1
@@ -7397,6 +8948,17 @@
 	dir = 5
 	},
 /area/icy_caves/caves)
+"Tx" = (
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor{
+	name = "\improper Lambda Lab"
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Tz" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "TB" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -7407,6 +8969,22 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"TC" = (
+/obj/structure/barricade/guardrail{
+	dir = 4
+	},
+/obj/structure/xenoautopsy/tank/escaped,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
+"TD" = (
+/obj/machinery/camera{
+	dir = 9
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "TE" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -7420,32 +8998,40 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
 "TI" = (
-/obj/machinery/landinglight/ds1/delaytwo{
-	dir = 1
+/obj/machinery/landinglight/ds1/delaythree{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "TJ" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/east)
+"TK" = (
+/turf/open/floor/mainship/red,
+/area/icy_caves/caves/northern)
 "TL" = (
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/fire,
-/obj/structure/closet/crate/secure/surgery,
-/obj/item/storage/firstaid/regular,
+/obj/structure/cargo_container/gorg{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "TM" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/LZ1)
+"TN" = (
+/obj/effect/spawner/gibspawner/human,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "TQ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "TR" = (
 /obj/structure/table/flipped,
+/obj/machinery/computer/nuke_disk_generator/green,
 /turf/open/floor/tile/dark/red2{
 	dir = 1
 	},
@@ -7453,7 +9039,7 @@
 "TT" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "TU" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/docking_port/mobile/crashmode/bigbury,
@@ -7477,6 +9063,16 @@
 	dir = 6
 	},
 /area/icy_caves/caves)
+"TZ" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 10
+	},
+/obj/structure/monorail{
+	dir = 6
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/space)
 "Ub" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 1
@@ -7502,8 +9098,10 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "Ud" = (
-/obj/machinery/floodlight/landing,
-/turf/open/floor/plating/ground/snow/layer2,
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "Ug" = (
 /obj/machinery/power/apc/drained,
@@ -7517,7 +9115,7 @@
 	dir = 2
 	},
 /turf/closed/ice/intersection,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Uk" = (
 /turf/closed/ice/thin/end,
 /area/icy_caves/caves/south)
@@ -7527,19 +9125,23 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"Uo" = (
+/obj/structure/largecrate/random/case,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "Up" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/closed/ice/intersection,
-/area/icy_caves/caves/east)
+/area/icy_caves/outpost/LZ2)
 "Uq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
 	},
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Us" = (
 /turf/closed/ice_rock/singleT{
 	dir = 8
@@ -7548,6 +9150,10 @@
 "Uu" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ1)
+"Uy" = (
+/obj/structure/largecrate/random,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "Uz" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/wood,
@@ -7612,6 +9218,10 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/security)
+"UR" = (
+/obj/structure/largecrate/supply/medicine/medivend,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "US" = (
 /obj/structure/table,
 /obj/item/clothing/suit/chef/classic,
@@ -7623,11 +9233,23 @@
 /obj/item/clothing/shoes/blue,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"UU" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "UV" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 8
 	},
 /area/icy_caves/caves/east)
+"UW" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark/yellow2{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "UY" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/black,
@@ -7643,6 +9265,12 @@
 /obj/item/analyzer,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
+"UZ" = (
+/obj/structure/dropship_piece/two/front,
+/turf/closed/shuttle/dropship2/transparent{
+	icon_state = "109"
+	},
+/area/icy_caves/caves/northern)
 "Vb" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 10
@@ -7652,7 +9280,7 @@
 /turf/closed/ice/thin/junction{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Vd" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/corners,
@@ -7676,6 +9304,10 @@
 /obj/item/storage/fancy/vials,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/research)
+"Vj" = (
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "Vk" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow,
@@ -7684,18 +9316,39 @@
 /obj/structure/table,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"Vq" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/mainship/cargo,
+/area/icy_caves/caves/northern)
 "Vr" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/closed/ice_rock/southWall,
 /area/icy_caves/caves)
+"Vs" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
+"Vt" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 9
+	},
+/area/icy_caves/caves/northern)
 "Vu" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/corner{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "Vx" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -7717,26 +9370,33 @@
 	dir = 4
 	},
 /area/icy_caves/caves/west)
+"VC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/outside/center)
 "VD" = (
 /obj/structure/largecrate/supply/medicine/iv,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "VE" = (
-/obj/structure/cargo_container/gorg{
-	dir = 4
-	},
+/obj/structure/largecrate/random/secure,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "VG" = (
-/turf/closed/ice/thin/junction,
-/area/icy_caves/outpost/outside)
+/obj/structure/barricade/guardrail{
+	dir = 8
+	},
+/obj/structure/xenoautopsy/tank,
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
 "VI" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/northern)
 "VJ" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/machinery/landinglight/ds1{
 	dir = 8
 	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "VK" = (
 /obj/machinery/light{
@@ -7752,6 +9412,18 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/security)
+"VL" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/turf/open/floor/mainship/cargo,
+/area/icy_caves/caves/northern)
 "VM" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/security)
@@ -7769,11 +9441,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/research)
-"VP" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 10
-	},
-/area/icy_caves/outpost/LZ1)
 "VQ" = (
 /turf/open/floor/tile/dark/red2{
 	dir = 4
@@ -7782,12 +9449,17 @@
 "VR" = (
 /obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	locked = 1;
 	name = "\improper Underground Security Armory"
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"VS" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
 "VT" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/outpost/LZ1)
@@ -7815,32 +9487,74 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"VZ" = (
+/obj/item/shard,
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "Wa" = (
+/obj/structure/largecrate/supply/explosives,
 /obj/item/explosive/plastique,
 /obj/item/explosive/plastique,
-/obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"Wb" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 4
+"Wc" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2;
+	name = "Canteen"
 	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Wd" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "We" = (
 /turf/closed/ice/junction{
 	dir = 1
 	},
 /area/icy_caves/outpost/outside/center)
 "Wg" = (
-/obj/effect/landmark/fob_sentry_rebel,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/obj/structure/barricade/guardrail{
+	dir = 4
+	},
+/obj/structure/xenoautopsy/tank/alien,
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
+"Wi" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Wj" = (
 /turf/closed/ice/thin/end{
 	dir = 4
 	},
 /area/icy_caves/caves/south)
+"Wm" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
+"Wo" = (
+/obj/effect/landmark/fob_sentry_rebel,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/LZ1)
+"Wp" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Wr" = (
+/obj/machinery/door/airlock/mainship/maint,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Ws" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "Wt" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs,
@@ -7852,7 +9566,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Ww" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -7861,12 +9575,25 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
+"Wx" = (
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/caves/west)
+"Wy" = (
+/turf/open/shuttle/dropship/floor,
+/area/space)
 "WA" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
+/turf/open/floor/tile/dark/red2{
+	dir = 8
 	},
-/turf/closed/ice/thin/end,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
+"WB" = (
+/obj/machinery/vending/dinnerware,
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "WD" = (
 /turf/open/floor/plating/ground/snow,
 /area/icy_caves/outpost/LZ1)
@@ -7877,21 +9604,28 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"WF" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
+"WG" = (
+/turf/closed/ice_rock/corners,
+/area/icy_caves/caves/west)
 "WI" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside)
 "WK" = (
-/turf/open/floor/mech_bay_recharge_floor,
+/obj/docking_port/stationary/marine_dropship/lz1,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
-"WM" = (
-/obj/effect/attach_point/weapon/dropship1{
-	dir = 8;
-	icon_state = "equip_base_l_wing"
-	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ1)
+"WO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"WP" = (
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern)
 "WQ" = (
 /turf/closed/ice/thin/end{
 	dir = 8
@@ -7907,8 +9641,10 @@
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/caves)
 "WT" = (
-/obj/machinery/landinglight/ds1/delaytwo,
-/turf/open/floor/plating,
+/obj/machinery/landinglight/ds1{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "WU" = (
 /obj/structure/closet/cabinet,
@@ -7917,13 +9653,31 @@
 /obj/item/clothing/head/pirate,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"WW" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
+"WX" = (
+/obj/machinery/computer3/laptop,
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "WY" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/medbay)
 "Xa" = (
-/obj/machinery/landinglight/ds1/delayone,
-/turf/open/floor/plating,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/ice/thin/end{
+	dir = 1
+	},
 /area/icy_caves/outpost/LZ1)
+"Xb" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/LZ2)
 "Xf" = (
 /obj/effect/landmark/start/job/survivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -7938,6 +9692,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"Xh" = (
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Xi" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -7979,16 +9739,21 @@
 	},
 /area/icy_caves/caves)
 "Xq" = (
-/obj/machinery/landinglight/ds1,
-/turf/open/floor/plating,
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "Xr" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/dmg3,
 /area/icy_caves/caves/crashed_ship)
 "Xs" = (
-/obj/machinery/landinglight/ds1/delaythree,
-/turf/open/floor/plating,
+/obj/machinery/landinglight/ds1/delaythree{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "Xu" = (
 /turf/closed/ice/end{
@@ -8005,11 +9770,33 @@
 /turf/closed/ice/thin/straight,
 /area/icy_caves/caves/northern)
 "Xx" = (
-/obj/structure/closet/crate/internals,
-/obj/item/storage/box/MRE,
-/obj/item/storage/box/MRE,
+/obj/structure/closet/crate/explosives,
+/obj/item/storage/box/m94,
+/obj/item/storage/box/m94,
+/obj/item/storage/box/visual/grenade/teargas,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Xy" = (
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/shuttle/dropship/floor,
+/area/space)
+"Xz" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"XA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/east)
+"XD" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "XF" = (
 /turf/closed/ice/corner,
 /area/icy_caves/caves/west)
@@ -8044,6 +9831,13 @@
 "XJ" = (
 /turf/closed/ice_rock/singleEnd,
 /area/icy_caves/caves/west)
+"XL" = (
+/obj/structure/barricade/guardrail{
+	dir = 1
+	},
+/obj/structure/dropship_piece/two/front,
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "XM" = (
 /obj/structure/bed/chair,
 /obj/effect/landmark/corpsespawner/colonist,
@@ -8063,15 +9857,19 @@
 "XP" = (
 /turf/closed/ice_rock/singleEnd,
 /area/icy_caves/caves/northern)
+"XQ" = (
+/obj/machinery/door/poddoor/mainship/indestructible,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "XR" = (
 /obj/structure/closet/crate,
 /obj/item/storage/box/lightstick/red,
 /obj/item/storage/box/lightstick/red,
 /obj/item/storage/box/lightstick,
 /obj/item/storage/box/lightstick,
+/obj/item/tool/pickaxe/plasmacutter,
 /obj/effect/spawner/random/powercell,
-/obj/item/weapon/gun/pistol/holdout,
-/obj/item/stack/sheet/mineral/phoron,
+/obj/item/explosive/plastique,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "XS" = (
@@ -8084,7 +9882,7 @@
 /turf/closed/ice/thin/junction{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "XU" = (
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 1
@@ -8127,6 +9925,10 @@
 	dir = 1
 	},
 /area/icy_caves/caves)
+"Yh" = (
+/obj/machinery/power/apc/drained,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Yi" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/green2{
@@ -8134,11 +9936,21 @@
 	},
 /area/icy_caves/outpost/medbay)
 "Yj" = (
-/obj/machinery/landinglight/ds1/delaythree{
+/obj/machinery/landinglight/ds1/delaytwo{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/floodlight/landing,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
+"Yk" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Yl" = (
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/caves)
 "Ym" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/swat,
@@ -8161,18 +9973,16 @@
 /turf/closed/ice/thin/junction{
 	dir = 8
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "Yv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Yw" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 8
-	},
+/obj/machinery/landinglight/ds1/delaytwo,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "Yx" = (
@@ -8197,6 +10007,16 @@
 "YA" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/kitchen)
+"YB" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 10
+	},
+/obj/structure/monorail{
+	dir = 6
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
 "YF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -8208,8 +10028,8 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/closed/ice_rock/singleT,
-/area/icy_caves/outpost/outside)
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/LZ1)
 "YI" = (
 /turf/closed/ice/thin/end{
 	dir = 1
@@ -8234,6 +10054,15 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"YP" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "YQ" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/space)
@@ -8249,6 +10078,13 @@
 "YT" = (
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"YV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern)
 "YW" = (
 /turf/closed/ice,
 /area/icy_caves/caves/south)
@@ -8304,15 +10140,19 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "Zk" = (
-/obj/machinery/button/door/open_only/landing_zone{
-	pixel_x = -5
-	},
+/obj/machinery/button/door/open_only/landing_zone,
 /obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ1)
+"Zl" = (
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Zm" = (
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ1)
@@ -8380,10 +10220,16 @@
 "ZB" = (
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/caves/south)
+"ZD" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ2)
 "ZE" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ1)
 "ZF" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -8404,16 +10250,26 @@
 /turf/closed/ice/straight,
 /area/icy_caves/caves/south)
 "ZK" = (
-/obj/machinery/landinglight/ds1{
+/obj/machinery/floodlight/landing,
+/obj/machinery/landinglight/ds1/delaytwo{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "ZL" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
+"ZM" = (
+/turf/open/floor/tile/dark/yellow2{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
+"ZN" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/LZ2)
 "ZP" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 4
@@ -8424,10 +10280,14 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "ZU" = (
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"ZV" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern)
 "ZW" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -8446,6 +10306,12 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
+"ZZ" = (
+/obj/structure/morgue{
+	dir = 2
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 
 (1,1,1) = {"
 YQ
@@ -8605,12 +10471,12 @@ YQ
 "}
 (2,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+mi
+mi
+mi
+mv
+mv
+mv
 Yf
 Yf
 Yf
@@ -8761,6 +10627,12 @@ YQ
 "}
 (3,1,1) = {"
 YQ
+mi
+Sw
+mi
+mv
+mv
+mv
 Yf
 Yf
 Yf
@@ -8788,22 +10660,16 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+WF
+WF
+WF
+WF
+WF
+WF
+dF
+dF
+dF
+dF
 Yf
 Yf
 Yf
@@ -8917,6 +10783,12 @@ YQ
 "}
 (4,1,1) = {"
 YQ
+mi
+mi
+mi
+mv
+mv
+mv
 Yf
 Yf
 Yf
@@ -8944,22 +10816,16 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+WF
+mw
+cE
+ta
+hW
+kY
+Vj
+AJ
+eO
+dF
 Yf
 Yf
 Yf
@@ -9047,25 +10913,25 @@ Zk
 Zm
 UE
 UE
+fq
 Uu
 Uu
-qz
-aG
-pq
-aI
-pq
-eY
-zS
-JY
-JY
-zS
-aG
-pq
-aI
-pq
-eY
-XH
-qz
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
 lX
 Bu
 bD
@@ -9073,6 +10939,12 @@ YQ
 "}
 (5,1,1) = {"
 YQ
+mv
+mv
+mv
+mv
+mv
+mv
 Yf
 Yf
 Yf
@@ -9100,22 +10972,16 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+WF
+SY
+AJ
+AJ
+jf
+Ex
+II
+AJ
+kf
+dF
 Yf
 Yf
 Yf
@@ -9197,31 +11063,31 @@ qs
 uA
 TW
 qz
-UE
-WD
-Zm
-Zm
-UE
-UE
-UE
-UE
-UE
-UE
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-UE
-UE
-UE
-UE
-UE
-Uu
-Uu
-Uu
+wL
+uw
+Xs
+Xs
+WT
+Ud
+LL
+Xs
+WT
+Ud
+LL
+Xs
+Ud
+Ud
+LL
+Xs
+WT
+Xq
+LL
+Xs
+WT
+Xq
+Yj
+uw
+uw
 Vb
 Ww
 bD
@@ -9229,6 +11095,12 @@ YQ
 "}
 (6,1,1) = {"
 YQ
+mv
+mv
+mv
+mv
+mv
+mv
 Yf
 Yf
 Yf
@@ -9256,6 +11128,16 @@ Yf
 Yf
 Yf
 Yf
+WF
+AR
+VZ
+AJ
+AJ
+Fq
+tx
+AJ
+kf
+dF
 Yf
 Yf
 Yf
@@ -9308,40 +11190,24 @@ Yf
 Yf
 Yf
 Yf
+MH
+MH
 Yf
 Yf
+MH
+MH
+re
 Yf
+MH
+MH
 Yf
 Yf
 Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+qy
+qy
 Yf
 Yf
 Yf
@@ -9353,31 +11219,31 @@ qs
 ED
 qz
 UM
-WD
-WD
-WD
-GC
-WD
-UE
-WD
-WD
-WD
-UE
-UE
-UM
-fs
-UE
-UE
-UE
-UE
-UE
-WD
-WD
-GC
-UE
-Uu
-Ud
-Uu
+uw
+zM
+Yn
+Yn
+JY
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+JY
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+JY
+Yw
+uw
+uw
 VU
 uc
 bD
@@ -9418,6 +11284,16 @@ Yf
 Yf
 Yf
 Yf
+WF
+rk
+AJ
+WP
+AJ
+AJ
+MY
+gZ
+yH
+dF
 Yf
 Yf
 Yf
@@ -9468,38 +11344,28 @@ Yf
 Yf
 Yf
 Yf
+MH
+YI
+YI
+YI
+ZU
+ZU
+ZU
+GF
+re
+re
+re
+MH
 Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+MH
+MH
+qy
+qy
+qy
+MH
 Yf
 Yf
 Yf
@@ -9507,33 +11373,33 @@ Yf
 Yf
 qy
 RC
-WD
-UE
-WK
-Yj
-Yj
-AH
-Wb
-Ag
-Yj
-AH
-Wb
-Ag
-Yj
-WK
-Wb
-Ag
-Yj
-AH
-Wb
-Ag
-Yj
-AH
-Wb
-Ag
-WK
-Uu
-Uu
+TM
+uw
+uw
+zM
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yw
+uw
+uw
 qH
 Ww
 bD
@@ -9546,6 +11412,27 @@ Yf
 Yf
 Yf
 Yf
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
 Yf
 Yf
 Yf
@@ -9553,37 +11440,16 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+WF
+ux
+hG
+Rx
+AJ
+AJ
+HU
+AJ
+Lr
+dF
 Yf
 Yf
 Yf
@@ -9635,61 +11501,61 @@ Yf
 Yf
 Yf
 Yf
+ZU
+YI
+ZU
+ZU
+Wx
+Wx
+Bb
+WI
+WI
+WI
+WI
+MH
 Yf
 Yf
 Yf
+MH
+MH
+WI
+WI
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qy
-aG
-Ww
-Sw
-UE
-WT
-QU
-VJ
-VJ
-VJ
-VJ
-VJ
-VJ
-WM
-VJ
-VJ
-FR
-VJ
-VJ
-VJ
-VJ
-VJ
-VJ
-VJ
-VJ
-VJ
-VP
-wL
-UE
-UE
+MH
+MH
+MH
+MH
+DX
+AB
+zi
+TM
+uw
+uw
+zM
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yw
+uw
+uw
 XH
 Ne
 Yf
@@ -9702,6 +11568,27 @@ Yf
 Yf
 Yf
 Yf
+WF
+Qg
+mj
+GQ
+yb
+dF
+Ls
+Zl
+EU
+Zl
+Zl
+EU
+Zl
+nK
+Gn
+dF
+EU
+Zl
+LF
+Zl
+WF
 Yf
 Yf
 Yf
@@ -9709,37 +11596,16 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+WF
+EP
+EP
+dF
+AJ
+AJ
+HU
+AJ
+GE
+dF
 Yf
 Yf
 Yf
@@ -9788,44 +11654,41 @@ Yf
 Yf
 Yf
 Yf
+MH
+MH
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-VU
-qz
+ZU
+ZU
+gx
+ZU
+ZU
+ZU
+Bb
+WI
+pa
+Si
+WI
+WI
+MH
+MH
+MH
+MH
+pa
+Si
+WI
+WI
+MH
+MH
+MH
+Uu
+Uu
+DX
+DX
 Sh
-HC
-UE
-Xa
-yL
-Yn
-AA
-Cc
+sK
+bU
+uw
+zM
 Yn
 Yn
 Yn
@@ -9840,12 +11703,15 @@ Yn
 Yn
 Yn
 Yn
-AA
 Yn
-cU
-MO
-WD
-UE
+Yn
+Yn
+Yn
+Yn
+Yn
+Yw
+uw
+uw
 VU
 Ne
 Yf
@@ -9858,57 +11724,57 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-re
-re
-re
-re
-re
-re
+WF
+op
+Ox
+yi
+Dm
+dF
+Zl
+Zl
+Zl
+Zl
+He
+Zl
+Zl
+Zl
+wj
+dF
+Zl
+Zl
+BZ
+Zl
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+Zl
+He
+dF
+EP
+Zl
+YP
+EP
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
 Yf
 Yf
 Yf
@@ -9945,63 +11811,63 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-aK
-VU
-yW
+YI
+ZU
+ZU
+ZU
+ZU
+ZU
+ZU
+ZU
+Bb
+WI
+Tj
+SI
+SI
+SI
+SI
+SI
+SI
+SI
+SI
+WI
+WI
+WI
+WI
+WI
+WI
+Uu
+Uu
+DX
+Ml
+Tf
 TM
-UE
-Xq
-yL
-Yn
-Yn
-hi
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-cU
+bU
+uw
 zM
-UE
-UE
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yw
+uw
+uw
 bH
 Ne
 Yf
@@ -10009,62 +11875,62 @@ YQ
 "}
 (11,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-af
-af
-af
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
-dy
-dy
-dy
-dy
-dy
-dy
+pl
+pl
+pl
+pl
+pl
+WF
+Gh
+co
+oR
+lO
+iN
+Tz
+Tz
+Tz
+ph
+Tz
+Tz
+Tz
+Tz
+Tz
+kd
+Tz
+Tz
+UU
+Zl
+Xz
+Zl
+Zl
+Cl
+EU
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+AJ
+AJ
+HU
+AJ
+Zl
+Zl
+Zl
+Zl
+EU
+Zl
+LF
+Zl
+dF
+Zl
+Mx
+NM
+xo
+pP
+dF
 bD
 Yf
 Yf
@@ -10101,40 +11967,40 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qy
-XH
-XH
-YH
+ZU
+gx
+ez
+ZU
+ZU
+ZU
+ZU
+ZU
+Bb
+WI
+WI
+SI
+Ln
+SI
+SI
+SI
+SI
+SI
+SI
+AW
+WI
+XO
+XO
+XO
+AW
+Uu
+Uu
+Uu
+Ml
+Tf
 TM
+bU
 uw
-Xs
-yL
+zS
 Yn
 Yn
 Yn
@@ -10145,6 +12011,7 @@ Yn
 Yn
 Yn
 Yn
+WK
 Yn
 Yn
 Yn
@@ -10154,10 +12021,9 @@ Yn
 Yn
 Yn
 Yn
-cU
-TI
-UE
-UE
+Yw
+uw
+uw
 bH
 Ne
 Yf
@@ -10165,62 +12031,62 @@ YQ
 "}
 (12,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-af
+pl
+bW
+bW
+bW
+bW
+in
+mu
+yi
+oQ
+yi
+zu
+TK
+Zl
+Zl
+BZ
+Zl
+Zl
+Zl
+Zl
+Zl
+Wp
+Zl
+Zl
+Wd
+Tz
 am
-af
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
-dL
-dZ
+Tz
+Tz
+Tz
+Tz
+TN
+Tz
+Yk
+Zl
+Zl
+Zl
+Zl
+Pp
+AJ
+HU
+AJ
+Zl
+Zl
+Zl
+He
+Zl
+Zl
+BZ
+Zl
+dF
+Zl
+Zl
 ev
-eM
+Zl
 fb
-dy
+dF
 bD
 Yf
 Yf
@@ -10257,40 +12123,40 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+ZU
+ZU
+ZU
+ZU
+ZU
+ZU
 re
 re
 re
-re
-re
-re
-re
-re
-re
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-re
-qy
-qz
-qz
-qz
-YH
+WI
+WI
+SI
+SI
+WI
+WI
+WI
+WI
+SI
+SI
+WI
+WI
+WI
+WI
+WI
+WI
+xn
+Uu
+Uu
+Uu
+Aq
 TM
-iJ
-WT
-yL
+bU
+uw
+zM
 Yn
 Yn
 Yn
@@ -10310,10 +12176,10 @@ Yn
 Yn
 Yn
 Yn
-cU
-wL
-WD
-UE
+Yn
+Yw
+uw
+uw
 bH
 Ne
 Yf
@@ -10321,62 +12187,62 @@ YQ
 "}
 (13,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-af
-af
-af
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
-dM
-ap
+pl
+BB
+BB
+BB
+BB
+nw
+Sf
+yi
+wG
+ct
+OP
+TK
+Zl
+Zl
+BZ
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+cX
+Zl
+ev
+He
+Zl
+Zl
+Zl
+dL
+Zl
+Wi
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+vv
+Zl
+Zl
+Zl
+Gf
+Zl
+dL
+Zl
+BZ
+Zl
+zZ
+Zl
+Zl
 ix
 eN
 fd
-dy
+dF
 bD
 Yf
 Yf
@@ -10413,40 +12279,40 @@ Yf
 Yf
 re
 re
-re
-re
-re
-re
-re
-re
+ZU
+ZU
+ZU
+ZU
+Di
+Di
 lG
 lX
 lG
-lX
-lG
-lX
-lG
-re
-re
-re
-re
-re
-Yf
-Yf
-Yf
-Yf
-qs
-VU
-aG
-aH
-TW
-VU
-qz
-SJ
+WI
+WI
+SI
+SI
+WI
+pD
+WI
+WI
+SI
+SI
+WI
+WI
+WI
+WI
+WI
+WI
+Uu
+Uu
+Uu
+Uu
+YH
 TM
 bU
-Xa
-yL
+uw
+zM
 Yn
 Yn
 Yn
@@ -10456,7 +12322,6 @@ Yn
 Yn
 Yn
 Yn
-sK
 Yn
 Yn
 Yn
@@ -10466,10 +12331,11 @@ Yn
 Yn
 Yn
 Yn
-cU
-MO
-UE
-UE
+Yn
+Yn
+Yw
+uw
+uw
 bH
 Ne
 Yf
@@ -10477,62 +12343,62 @@ YQ
 "}
 (14,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
+pl
+bW
+bW
+bW
+bW
+nw
+gP
+yi
+yi
+yi
+EP
+Zl
+Zl
+Zl
+BZ
+Zl
+Zl
+Zl
+Zl
+Zl
+EP
+Zl
+Zl
+BZ
+Zl
+Xz
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+pL
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Wi
+Tz
+un
+Tz
+Tz
+Tz
+Tz
+Tz
+HP
+un
+Hw
 dN
-dP
+Tz
 ew
 eP
 fe
-dy
+dF
 bD
 Yf
 Yf
@@ -10566,66 +12432,66 @@ re
 re
 re
 re
-re
-qy
-lX
-mv
-mv
-mv
-bX
-pq
-lG
+ZU
+ZU
+SF
+ZU
+ZU
+ZU
+ZU
+Di
+Mg
 ec
 Vb
 eY
-Vb
-eY
-Vb
-eY
-qz
-qz
-qz
-eY
-re
-re
-re
-re
-re
-qy
-XH
-lX
-aK
-lX
-eY
-Qh
-zb
+mX
+WI
+SI
+SI
+WI
+WI
+WI
+WI
+SI
+SI
+WI
+WI
+MH
+qs
+WI
+WI
+Uu
+Uu
+Uu
+Ml
+Tf
 Tb
 XW
-Xq
-yL
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-cU
+uw
 zM
-UE
-Uu
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yw
+uw
+uw
 XH
 Ne
 Yf
@@ -10633,62 +12499,62 @@ YQ
 "}
 (15,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
+pl
+BB
+BB
+BB
+BB
+WF
+fD
+yi
+Do
+wq
+dF
+Bo
+Zl
+Zl
+BZ
+Zl
+He
+Zl
+Zl
+Zl
+dF
+Zl
+Zl
+BZ
+Zl
+WF
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+BZ
+Pg
+ve
+Zl
+Zl
+Zl
+Zl
+BZ
+Zl
+Zl
+Pg
+TD
+Zl
+Zl
+Zl
+Zl
+Zl
+dF
 dO
 ea
-dQ
+nB
 eT
 ff
-dy
+dF
 bD
 Yf
 Yf
@@ -10721,44 +12587,44 @@ TW
 dj
 Di
 XF
-Di
-XF
-qz
-mv
+DZ
 ZU
 ZU
+SF
+ZU
+gx
 ZU
 ZU
-aG
-eY
+RG
+ec
 fT
 xI
 xI
 xI
+nx
+od
+lH
+nx
 xI
 xI
 xI
-xI
-xI
-xI
-xI
-pq
-aG
-pq
-lG
-lX
-pq
-lG
-XH
-XH
-XH
-qz
-Qp
+SI
+SI
+WI
+MH
+Yf
+Yf
+MH
+WI
+Uu
+Uu
+Ml
+Ml
 Tf
 Ml
 XW
-Xs
-yL
+uw
+zM
 Yn
 Yn
 Yn
@@ -10778,10 +12644,10 @@ Yn
 Yn
 Yn
 Yn
-cU
-TI
-UE
-Uu
+Yn
+Yw
+uw
+uw
 VU
 Ne
 Yf
@@ -10789,62 +12655,62 @@ YQ
 "}
 (16,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
+pl
+dF
+dF
+dF
+dF
+dF
+wO
+yi
+Hj
+kR
+dF
+Zl
+Zl
+Zl
+ds
+Zl
+Zl
+Zl
+Zl
+FB
+dF
+dv
+hB
+BZ
+Zl
+pE
+WF
+WF
+WF
+ev
+BO
+WF
+VS
+dF
+dF
+dF
+dF
+dF
+Zl
+YP
+dF
+dF
+dF
+dF
+dF
+Wr
+dF
+dF
+dF
+dF
 nD
 ed
-ZW
-dP
+nB
+Zl
 fg
-dy
+dF
 bD
 Yf
 Yf
@@ -10876,51 +12742,48 @@ XH
 qz
 ZU
 gz
-Jg
-Jg
-DK
-ez
-ZU
-ZU
 ZU
 ZU
 ZU
 ez
+SF
 ZU
+ZU
+ZU
+ZU
+ez
+SF
 ZU
 nO
 oI
+oI
 wW
-pl
 pw
-OI
+oI
 pf
 oZ
 oK
 xI
-VU
-lX
-pq
-WS
-eY
-VU
-XH
-aG
-TW
-qz
+SI
+SI
 WI
-Wg
-Tm
+MH
+Yf
+Yf
+Yf
+MH
+Uu
+Wo
+Uu
+UE
+TQ
 Uu
 Vk
-WT
-yL
+uw
+zM
 Yn
 Yn
-hi
-Yn
-Yn
-Yn
+JY
 Yn
 Yn
 Yn
@@ -10928,16 +12791,19 @@ Yn
 Yn
 Yn
 Yn
+JY
 Yn
 Yn
 Yn
 Yn
 Yn
 Yn
-cU
-wL
-UE
-Uu
+Yn
+Yn
+JY
+Yw
+uw
+uw
 qH
 Ne
 Yf
@@ -10945,62 +12811,62 @@ YQ
 "}
 (17,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
-dy
-dy
+Gs
+Gs
+Gs
+Gs
+Gs
+dF
+jY
+dF
+EP
+EP
+dF
+pu
+dF
+dF
+dF
+Zl
+VL
+Vq
+Vq
+Vq
+dF
+dF
+dF
+BZ
+Zl
+WF
+Gs
+WF
+hT
+Zl
+Zl
+Zl
+AQ
+dF
+Gs
+Gs
+Gs
+dF
+Zl
+BZ
+dF
+DV
+EX
+jd
+jd
+jd
+dF
+Gs
+Il
+dF
+dF
+dF
 ex
-dy
-dy
-dy
+dF
+dF
+dF
 bh
 Yf
 Yf
@@ -11018,12 +12884,12 @@ eb
 ZU
 ZU
 ZU
+SF
 ZU
 ZU
 ZU
 ZU
-ZU
-ZU
+SF
 ZU
 ZU
 ez
@@ -11032,8 +12898,8 @@ ZU
 ZU
 ZU
 ZU
-gz
-DK
+ZU
+ZU
 ez
 ZU
 dx
@@ -11042,58 +12908,58 @@ gA
 Mg
 ZU
 ZU
-ZU
+SF
 fT
 xI
 oJ
 au
-xn
+ax
 oI
 oI
 oI
 oI
-OZ
+oU
 xI
-eY
-bH
-VU
-XH
-aG
-aI
-TW
-qz
-WI
-WI
-WI
-XO
+SI
+SI
+MH
+Yf
+Yf
+Yf
+qs
+qs
+Uu
+Uu
+Uu
+Uu
 TQ
 Uu
 bU
-Xa
-yL
-Yn
-AA
-Cc
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-AA
-Yn
-cU
+uw
+uw
+TI
 MO
-UE
-Uu
+GU
+VJ
+TI
+MO
+GU
+TI
+TI
+MO
+GU
+VJ
+TI
+MO
+GU
+VJ
+TI
+MO
+MO
+MO
+ZK
+uw
+uw
 XH
 Ne
 Yf
@@ -11101,70 +12967,70 @@ YQ
 "}
 (18,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-lX
-TW
+YQ
+YQ
+dF
+dF
+dF
+OP
+OP
+OP
+OP
+Se
+xs
+OP
+Mf
+OP
+dF
+dF
+Se
+Se
+Se
+Se
+Vt
+CH
+dF
+mg
+Zl
+WF
+Gs
+WF
+tT
+Zl
+pZ
+IY
+BZ
+dF
+Gs
+Gs
+Gs
+dF
+Zl
+Wi
+Ts
+ZV
+ZV
+Vs
+Jn
+Jn
+dF
+Gs
+Il
+bI
+XP
 eg
 ZW
 eU
-VU
-lX
-lG
-bD
-Yf
-Yf
-Yf
-qy
-nM
-nM
+dw
+DZ
+Mg
+qR
+WG
+WG
+WG
+pb
+SD
+SD
 ZU
 ZU
 ZU
@@ -11174,12 +13040,12 @@ ZU
 ZU
 ez
 ZU
-ZU
+SF
 Eb
 ZU
 ZU
 gx
-ZU
+SF
 ez
 ZU
 gx
@@ -11210,117 +13076,117 @@ qo
 qO
 oU
 xI
-VU
-XH
-qH
-TW
-qz
+NH
+SI
 WI
+jI
+jI
+jI
 WI
-WI
-WI
-XO
-XO
-XO
+jI
+Uu
+UE
+UE
+UE
 TQ
 UE
 XW
-Xq
-pz
-PB
-PB
-PB
-PB
-PB
-PB
-PB
-PB
-PB
-Da
-PB
-PB
-PB
-PB
-PB
-PB
-PB
-PB
-PB
-pZ
-zM
-UE
-Uu
+uw
+uw
+uw
+uw
+uw
+uw
+dW
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+dW
+uw
+uw
+uw
+uw
+uw
+uw
+uw
 VU
 Ne
 Yf
 YQ
 "}
 (19,1,1) = {"
-YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-bH
-ZU
-eh
+cW
+qa
+yF
+jL
+Me
+Me
+df
+Rw
+BN
+BN
+pc
+BN
+BN
+BN
+qu
+Rw
+BN
+jc
+jc
+XQ
+XQ
+dZ
+ma
+dF
+BZ
+Zl
+WF
+Gs
+WF
+Ch
+Zl
+cD
+Zl
+pL
+dF
+Gs
+Gs
+Gs
+dF
+Lo
+UU
+dF
+nF
+mZ
+PN
+Lw
+Lw
+dF
+Gs
+Il
+bR
+SR
+RL
 ZW
-ZU
-Vb
-aI
-eY
-bD
-Yf
-Yf
-qy
-lX
-WS
-eY
+zB
+Lx
+Ga
+ec
+qR
+WG
+WG
+pb
+DZ
+Rj
+ec
 gx
 ZU
 ZU
@@ -11353,7 +13219,7 @@ Lx
 ec
 ZU
 ZU
-ZU
+gx
 da
 DK
 xI
@@ -11366,116 +13232,116 @@ pX
 oI
 oU
 xI
-eY
-aG
-eY
+SI
+SI
 WI
 WI
 WI
 WI
 WI
 WI
-WI
-XO
-XO
+Uu
+Uu
+UE
+UE
 TQ
 WD
 XW
-WK
-Yw
-Yw
-ZK
-sD
-LL
-Yw
-ZK
-sD
-LL
-Yw
-WK
-sD
-LL
-Yw
-ZK
-sD
-LL
-Yw
-ZK
-sD
-LL
-WK
-UE
-Uu
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
 qH
 Ne
 Yf
 YQ
 "}
 (20,1,1) = {"
-YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-Vb
-TW
-ZU
+cW
+BY
+wT
+Od
+JR
+Od
+dg
+FR
+qk
+wf
+pc
+MA
+TC
+Wg
+Ss
+ul
+Fk
+NW
+XD
+NW
+NW
+fs
+UZ
+Zl
+BZ
+Zl
+WF
+Gs
+WF
+WX
+Zl
+Gf
+Mv
+ns
+dF
+dF
+dF
+dF
+dF
+Zl
+BZ
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+Gs
+Il
+bJ
+XP
+zB
 ZW
-eh
+RL
 ZU
 Di
 XF
-bh
-re
-qy
-aG
-WS
-eY
+pH
+SO
+pb
+RG
+Rj
+ec
 ZU
 ZU
 ZU
@@ -11522,20 +13388,20 @@ qp
 oI
 oK
 xI
+SI
+SI
 XO
-XO
-XO
 WI
 WI
 WI
 WI
 WI
-WI
-AW
-XO
-XO
-TQ
+Uu
+Uu
 UE
+UE
+Aq
+Ml
 gI
 UE
 WD
@@ -11546,9 +13412,9 @@ uw
 uw
 uw
 uw
+dW
 uw
 uw
-sb
 dW
 HE
 uw
@@ -11558,79 +13424,79 @@ uw
 uw
 uw
 HB
-WD
-UE
-UM
-Uu
+uw
+uw
+uw
+uw
 XH
 Ne
 Yf
 YQ
 "}
 (21,1,1) = {"
-YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-Di
-eb
+cW
+HC
+yd
+RM
+cL
+RM
+gK
+FR
+pc
+pc
+Bt
+pc
+pc
+MA
+Xy
+Wy
+Wy
+Wy
+ch
+Af
+us
+Wy
+FR
+Zl
+BZ
+Zl
+WF
+Gs
+WF
+xS
+Zl
+IY
+jk
+BZ
+dF
+EX
+jd
+ze
+dF
+Zl
+BZ
+dF
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Il
+PD
+Ho
 ei
 ZW
-ZU
+zB
 Xu
 Jg
 DK
-lX
-pq
-lG
+DZ
+dh
+Mg
 fT
-XH
+dD
 ZU
 ez
 ZU
@@ -11669,7 +13535,7 @@ ZU
 gz
 XF
 xI
-oZ
+iJ
 oI
 wW
 oI
@@ -11686,12 +13552,12 @@ WI
 WI
 WI
 WI
-WI
-XO
-XO
-XO
-TQ
-Uu
+fq
+UE
+UE
+UE
+Tm
+Ml
 Vk
 XW
 bU
@@ -11714,79 +13580,79 @@ uw
 uw
 uw
 uw
-WD
-WD
-UE
-Uu
+uw
+uw
+uw
+uw
 XH
 uy
 Yf
 YQ
 "}
 (22,1,1) = {"
-YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-re
-re
-re
-re
-Yf
-Yf
-re
-re
-qy
-do
-ZU
-ZU
+cW
+TZ
+GN
+YB
+cF
+YB
+kn
+FR
+qA
+wf
+Im
+MA
+VG
+VG
+Rw
+uO
+Qn
+NW
+XD
+yv
+NW
+XL
+UZ
+Zl
+BZ
+Zl
+WF
+Gs
+WF
+Gj
+cD
+ll
+Zl
+ds
+dF
+Ij
+jd
+jd
+Ea
+He
+BZ
+dF
+Ae
+Ae
+Ae
+Gs
+Gs
+Ae
+Ae
+Qo
+ce
+SR
+zB
 ZW
-ZU
+zB
 Xu
 Jg
 eb
-bH
-qz
-XH
-qz
-qz
+hn
+xa
+dD
+xa
+xa
 ez
 ZU
 DZ
@@ -11827,7 +13693,7 @@ do
 xI
 xI
 xI
-xI
+rw
 pB
 ig
 qw
@@ -11836,34 +13702,34 @@ xI
 xI
 Za
 SI
-Za
+XO
 XO
 WI
 WI
 WI
-XO
-XO
-XO
-XO
-XO
+np
+UE
+UE
+UE
+UE
 LP
-UE
-UE
-UE
-WD
+VT
+VT
+VT
+VT
 WD
 uw
 vi
 WD
 WD
-WD
-UE
+AB
+AB
 AB
 Nr
 jE
 Zm
 bq
-BY
+Ml
 UE
 UE
 UE
@@ -11871,8 +13737,8 @@ WD
 uw
 uw
 Zm
-WD
-UE
+VT
+Ml
 VU
 VU
 uc
@@ -11880,65 +13746,65 @@ bD
 YQ
 "}
 (23,1,1) = {"
-YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-PD
-pk
-cJ
+cW
+OI
+Eh
+IP
+DU
+DU
+oM
+Ss
+KP
+KP
+pc
+KP
+KP
+KP
+DS
+Ss
+KP
+jc
+jc
+vn
+vn
+vn
+gQ
+dF
+BZ
+Zl
+WF
+Gs
+WF
+ws
+He
+Zl
+ZZ
+Zl
+dF
+dF
+dF
+dF
+dF
+Zl
+BZ
+dF
+bA
 bA
 Nd
-bh
-qy
-bX
-pq
-TW
-da
-eb
-ZU
+hM
+Qo
+cd
+Tu
+XP
+ot
+Ho
+zB
 ZW
-ZU
+zB
 Xu
 Jg
 XF
-XH
+dD
 fi
 gp
 Sn
@@ -11975,11 +13841,11 @@ ZU
 ZU
 lj
 ZU
-ZU
+gx
 EB
 EB
 ez
-ZU
+SF
 XO
 XO
 XO
@@ -11992,43 +13858,43 @@ WI
 WI
 XO
 SI
-Za
 XO
 XO
 XO
 XO
 XO
 XO
-WI
-XO
-lW
+UE
+Uu
+UE
+AB
 Yq
 VT
-Nr
-UE
-UE
+VT
+VT
+VT
 Zm
 uw
 vi
 Zm
 Zm
-WD
-UE
+Ml
+Ml
 AB
 mb
 Nr
-TM
-TM
+JA
+JA
 JA
 fN
-mi
-UE
-Zm
+Ml
+Ml
+VT
 uw
 uw
-Zm
-UE
-aG
+VT
+Ml
+XH
 WS
 WS
 Ww
@@ -12037,60 +13903,60 @@ YQ
 "}
 (24,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-re
-qy
-ce
-PD
-cK
+YQ
+YQ
+dF
+dF
+dF
+OP
+OP
+OP
+xs
+tF
+xs
+OP
+QD
+OP
+dF
+dF
+tF
+lv
+dF
+dF
+rg
+HL
+dF
+mg
+Zl
+WF
+Gs
+WF
+wh
+TD
+Pg
+ZZ
+ve
+dF
+Gs
+Gs
+Ae
+dF
+Zl
+BZ
+dF
+bM
 bM
 Fu
-qz
-lX
-TW
+bS
+bI
+XP
 qT
-cW
-dp
-ZU
-eh
+Zt
+Sg
+SR
+RL
 ZW
-ZU
+zB
 ZU
 dp
 do
@@ -12134,11 +14000,11 @@ Bw
 ZU
 ZU
 cY
-ZU
-ZU
+gx
+SF
 XO
 Za
-Za
+XO
 Za
 Za
 Dn
@@ -12154,10 +14020,10 @@ XO
 XO
 XO
 XO
-WI
-XO
-XO
-XO
+Uu
+UE
+UE
+UE
 TT
 EQ
 XT
@@ -12169,8 +14035,8 @@ HI
 ZE
 ZE
 KJ
-TT
-ZE
+Xa
+Xa
 Vu
 DL
 EO
@@ -12178,13 +14044,13 @@ EO
 rp
 Vu
 vR
-TT
-ZE
+vr
+vr
 Hl
 Hl
-ZE
-TT
-TT
+vr
+vr
+vr
 PL
 PL
 HV
@@ -12198,55 +14064,55 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qy
-VU
-VU
-qz
-ce
-Sg
-yh
+dF
+Wr
+dF
+dF
+Zl
+Th
+Th
+dF
+dF
+dF
+Zl
+gM
+If
+Zl
+dF
+dF
+dF
+dF
+BZ
+Zl
+WF
+Gs
+WF
+dF
+dF
+dF
+dF
+dF
+dF
+Gs
+Qo
+bP
+dF
+Zl
+cX
+dF
+SR
 SR
 Sg
-aG
-eY
+Io
+eB
 qT
 IC
-dd
-ZU
-ZU
-ZU
+cm
+SR
+SR
+zB
 ZW
-ZU
+zB
 eh
 ZU
 dp
@@ -12291,12 +14157,12 @@ fz
 ZU
 ZU
 ja
-ZU
+SF
 XO
 XO
 XO
 oO
-Za
+XO
 Dn
 SI
 Za
@@ -12311,37 +14177,37 @@ Za
 XO
 XO
 XO
-XO
-XO
-XO
-XO
-of
-of
+UE
+UE
+UE
+UE
+SB
+SB
 Ey
-XO
-XO
-SI
-Dn
-Za
-Za
-Im
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-Za
-SI
-SI
-Za
+UE
+UE
+uw
+vi
+Zm
+Zm
+WD
+UE
+UE
+UE
+UE
+UE
+UE
+UE
+UE
+UE
+UE
+Zm
+uw
+uw
+Zm
 Ey
-XO
-XO
+UE
+UE
 qz
 bD
 Yf
@@ -12354,55 +14220,55 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-qy
-lX
-WS
-WS
-TW
-Sg
-SR
-cb
+dF
+Jn
+pN
+dF
+dL
+Zl
+Zl
+LF
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+EU
+pS
+Zl
+Wi
+HT
+WF
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Ae
+Qo
+bI
+Rh
+dF
+Zl
+yV
+dF
+im
 SR
 SR
 SR
 cj
 IC
 cg
-df
-ZU
-ZU
-ZU
-ZW
-ZU
+bT
+SR
+SR
+zB
+Cm
+zB
 ZU
 gx
 jb
@@ -12415,14 +14281,14 @@ ZU
 ZU
 ZU
 ZU
-ZU
+SF
 ZU
 ZU
 ZU
 ZU
 gx
 ZU
-ZU
+SF
 ZU
 ZU
 ZU
@@ -12444,7 +14310,7 @@ ZU
 dE
 Sn
 xa
-xa
+dE
 ez
 ZU
 ht
@@ -12467,37 +14333,37 @@ CV
 Za
 Za
 Za
-Za
-Za
-Za
-XO
-XO
-XO
-XO
-Za
-Za
-SI
-Dn
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-SI
-SI
-Za
-Za
-Za
-XO
+Zm
+Zm
+Zm
+UE
+UE
+UE
+UE
+Zm
+Zm
+uw
+vi
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+uw
+uw
+Zm
+Zm
+Zm
+UE
 bF
 Yf
 Yf
@@ -12510,55 +14376,55 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-qy
+dF
+oT
+Jn
+dF
+Bo
+dL
+Zl
+BZ
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+dd
+Zl
+WF
+Gs
+Gs
+Gs
+Gs
+Gs
+Ae
+Qo
 PD
 Ho
-Vb
-eY
-XH
+bJ
+eB
+dF
+Zl
+YP
+dF
 SR
-SR
-SR
-yh
 SR
 SR
 im
-bC
+SR
 QK
 SR
-dg
-ZU
-gx
-ZU
+SR
+SR
+im
+zB
 ZW
-ez
+Ws
 ZU
 ZU
 SF
@@ -12571,14 +14437,14 @@ ZU
 ZU
 ZU
 gx
-ZU
+SF
 ZU
 ZU
 ez
 ZU
 ZU
 ZU
-ZU
+SF
 ZU
 ez
 gx
@@ -12610,8 +14476,8 @@ XO
 np
 Za
 SI
-Ln
 SI
+Ln
 SI
 SI
 SI
@@ -12620,40 +14486,40 @@ SI
 SI
 SI
 pY
-Al
-vy
-vy
-Al
 vy
 vy
 vy
-vy
-vy
+Nu
+Nu
+Nu
+Nu
+Nu
+Nu
 Nn
-vy
-vy
-Al
-qf
-SI
-SI
-SI
-SI
-SI
-SI
-SI
-Ln
-SI
-SI
-SI
-SI
-SI
-SI
-SI
-Ln
-SI
-SI
-Ln
-XO
+Nu
+Nu
+Mw
+Qe
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+dW
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+dW
+uw
+uw
+dW
+UE
 bD
 Yf
 Yf
@@ -12666,55 +14532,55 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qy
+dF
+Ek
+uu
+dF
+Zl
+Zl
+Zl
+BZ
+Zl
+He
+Zl
+Zl
+Zl
+lR
+lR
+Zl
+Zl
+Zl
+BZ
+Zl
+WF
+Gs
+Gs
+Gs
+Gs
+Qo
 PD
 bA
 VI
 Ho
-yh
 SR
 SR
 SR
-im
+Zl
+uT
+Zl
 SR
-yh
 wo
 SR
 SR
 SR
-bl
+SR
 we
-dg
-ZU
-ZU
-ZU
-dQ
-eF
+SR
+SR
+SR
+zB
+ZW
+Ab
 ZU
 ZU
 SF
@@ -12727,7 +14593,7 @@ ZU
 ZU
 ZU
 ZU
-ZU
+SF
 gx
 ZU
 ZU
@@ -12765,7 +14631,7 @@ XO
 XO
 XO
 XO
-qa
+XO
 XO
 XO
 XO
@@ -12779,17 +14645,17 @@ SI
 SI
 SI
 SI
-SI
-SI
-SI
-SI
-SI
-SI
-Dn
-SI
-SI
-SI
-SI
+uw
+uw
+uw
+uw
+uw
+uw
+vi
+uw
+uw
+uw
+uw
 SI
 SI
 SI
@@ -12806,10 +14672,10 @@ SI
 SI
 SI
 SI
-SI
-SI
-SI
-XO
+uw
+uw
+uw
+UE
 bD
 Yf
 Yf
@@ -12822,55 +14688,55 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
+dF
+Gx
+YV
+dF
+Zl
+Zl
+Zl
+Wi
+Tz
+Tz
+Tz
+Tz
+du
+Hw
+Hw
+sG
+Tz
+Tz
+UU
+Zl
+WF
+Gs
+Gs
+Gs
+Il
 PD
 Fu
 ot
 by
-bl
-yh
+SR
+SR
 SR
 im
-SR
-bl
-ok
-cO
+Zl
+BZ
+Zl
+pk
 VI
 Nd
 SR
 SR
 SR
 SR
-dg
-gx
-ZU
-ZU
+SR
+im
+SR
+zB
 ZW
-ZU
+zB
 ZU
 ZU
 dx
@@ -12902,7 +14768,7 @@ ZU
 ZU
 ez
 ZU
-ZU
+SF
 ZU
 ZU
 ZU
@@ -12916,7 +14782,7 @@ ZU
 ZU
 YI
 cY
-ZU
+SF
 XO
 XO
 XO
@@ -12940,12 +14806,12 @@ XO
 XO
 XO
 XO
-SI
-Dn
-Za
-Za
-Za
-Za
+uw
+vi
+Zm
+Zm
+Zm
+Zm
 XO
 XO
 XO
@@ -12978,55 +14844,55 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
+dF
+ip
+hd
+Ts
+Tz
+Tz
+Tz
+UU
+Zl
+di
+Pg
+Zl
+KL
+dF
+dF
+yz
+Zl
+Zl
+BZ
+Zl
+WF
+Gs
+Gs
+Gs
+Il
 ce
 ot
 by
 hX
 SR
-yh
+SR
 SR
 wo
-GH
+mq
+BZ
+Zl
 SR
-SR
-yh
 Lm
 by
 SR
 SR
 SR
 SR
-DZ
-Mg
-ZU
-ZU
+bI
+bL
+SR
+zB
 ZW
-ZU
+zB
 ZU
 Xu
 Jg
@@ -13058,21 +14924,21 @@ ZU
 ZU
 kE
 ZU
+SF
+ZU
+ZU
+ZU
+gx
 ZU
 ZU
 ZU
 ZU
-ZU
-ZU
-ZU
-ZU
-ZU
-ZU
-ZU
+SF
+gx
 ez
 ZU
 ZU
-ZU
+SF
 ZU
 XO
 AW
@@ -13134,55 +15000,55 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
+dF
+dF
+dF
+WF
+Zl
+Zl
+Zl
+BZ
+dF
+dF
+dF
+xW
+Zl
+Rt
+fc
+Zl
+Zl
+Zl
+BZ
+He
+WF
+Gs
+Gs
+Gs
+Il
 ce
 ce
 SR
 im
 SR
-yh
+SR
 PD
 Fu
+Zl
+BZ
+FB
+dF
 SR
-bl
 SR
-yh
-SR
-bl
 im
 SR
-bl
+SR
 Io
-Rj
-Rj
-Mg
-ZU
+Rh
+Rh
+bL
+zB
 ZW
-ZU
+zB
 Xu
 VB
 Jg
@@ -13223,19 +15089,19 @@ ZU
 Qd
 ZU
 ZU
+SF
 ZU
 ZU
 ZU
-ZU
-ZU
-ZU
+gx
+SF
 ZU
 WI
 WI
 Gw
 Gw
 Gw
-Gw
+sM
 Gw
 Gw
 Gw
@@ -13245,7 +15111,7 @@ Gw
 Ri
 DY
 DY
-gB
+wQ
 Gw
 lD
 me
@@ -13293,50 +15159,50 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qy
+WF
+Zl
+Zl
+Zl
+BZ
+dF
+Gs
+dF
+hB
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+BZ
+FB
+WF
+Gs
+Gs
+Gs
+Qo
 ce
 Sg
 SR
-bC
 SR
-kl
+SR
+ok
 bM
 VI
-Nd
+Zl
+BZ
+Zl
 SR
-wo
-yh
-yh
-yh
-yh
-yh
-cN
-cP
-Lx
-Rj
-ec
-ZU
+SR
+SR
+SR
+SR
+qT
+Zt
+bJ
+Rh
+eB
+zB
 ZW
 eS
 dy
@@ -13416,7 +15282,7 @@ XO
 WI
 KZ
 Lu
-TL
+Sm
 tQ
 tQ
 Sm
@@ -13449,39 +15315,39 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-qz
+WF
+Zl
+Zl
+Zl
+BZ
+dF
+Gs
+dF
+UR
+dL
+Zl
+Zl
+Zl
+Zl
+Zl
+cX
+Zl
+WF
+Gs
+Gs
+Il
+bS
 Sg
 SR
 SR
 im
 SR
-cs
+bN
 bN
 Lm
-VI
-pk
-VI
+Zl
+BZ
+Zl
 Ho
 SR
 SR
@@ -13489,12 +15355,12 @@ SR
 qT
 bT
 KU
-EB
-dD
-gx
-ZU
+Zt
+Ry
+im
+zB
 ZW
-ZU
+zB
 YI
 ft
 EB
@@ -13602,55 +15468,55 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-VU
+cp
+cp
+cp
+cs
+cv
+cv
+cv
+cx
+cJ
+cK
+cJ
+dF
+Zl
+dF
+dF
+Zl
+Zl
+Gf
+BZ
+Zl
+WF
+Gs
+Gs
+Il
+bP
 qT
 rf
 SR
 SR
 cj
-ct
+bT
 cn
 bN
-Sg
-bN
-Sg
-SR
+Zl
+BZ
+Zl
+rf
 SR
 im
 SR
 KU
 Zt
 qT
-de
-ZU
-ZU
-ZU
+cm
+SR
+SR
+zB
 ZW
-ZU
+zB
 ZU
 dE
 de
@@ -13701,9 +15567,9 @@ Xu
 eb
 SD
 Gw
-zR
+qc
 DY
-qQ
+tJ
 RZ
 DY
 qc
@@ -13758,42 +15624,42 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-nM
+cp
+WF
+WF
+WF
+EP
+Zl
+Wc
+BF
+dF
+Gs
+cK
+dF
+Zl
+dF
+dF
+Zl
+Zl
+Zl
+BZ
+Zl
+WF
+Gs
+Gs
+Il
+QZ
 KU
 rf
 SR
 Zb
 SR
-cs
-cn
-cn
 bN
 cn
-qT
+cn
+Zl
+BZ
+Zl
 rf
 SR
 SR
@@ -13801,12 +15667,12 @@ SR
 Zb
 KU
 IC
-Bw
-EB
-BQ
-ZU
+IC
+Zt
+Zb
+zB
 ZW
-gx
+Ab
 ZU
 YI
 de
@@ -13865,7 +15731,7 @@ DY
 sl
 DY
 DY
-JN
+wE
 yK
 DY
 DY
@@ -13914,42 +15780,42 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-qH
-TW
+cp
+WF
+Zl
+EU
+Zl
+Bf
+Bf
+BZ
+dF
+dF
+cJ
+dF
+Bo
+Zl
+Zl
+Zl
+Zl
+Zl
+BZ
+Zl
+WF
+Gs
+Gs
+Il
+cc
+XP
 SR
 SR
 SR
 cj
-cv
+cg
 IC
-IC
-bT
-cn
-KU
+ci
+Zl
+BZ
+Zl
 rf
 SR
 SR
@@ -13957,12 +15823,12 @@ SR
 SR
 SR
 KU
-cY
-dE
-Sn
-ZU
+bT
+KU
+rf
+zB
 ZW
-ZU
+zB
 ZU
 fi
 de
@@ -14070,42 +15936,42 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-qy
-qH
-lG
-bp
+cp
+WF
+Zl
+WO
+Zl
+Gf
+Zl
+cC
+Zl
+Zl
+cJ
+Zl
+Fj
+Tz
+Tz
+Tz
+Tz
+Tz
+UU
+Zl
+WF
+Gs
+Ae
+Qo
+cc
+bL
+im
 SR
-bl
+SR
 cj
-cw
+Ir
 cm
 ci
-Xw
-Xw
-rf
+Zl
+BZ
+Zl
 SR
 Zb
 SR
@@ -14113,12 +15979,12 @@ SR
 PD
 Nd
 PD
-XF
-Di
-eb
-ZU
+Nd
+PD
+Ho
+zB
 ZW
-ZU
+zB
 YI
 fz
 cY
@@ -14163,7 +16029,7 @@ dp
 gS
 dD
 ZU
-ZU
+gx
 ZU
 dx
 xa
@@ -14226,42 +16092,42 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
+cp
+WF
+Xh
+Xh
+Zl
+Zl
+cw
+HQ
+Xh
+Zl
+cO
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+BZ
+FB
+WF
+Il
 PD
 Nd
-Vb
-eY
+bJ
+eB
 SR
 SR
 bI
 XP
-cx
 QK
-cn
-qT
-Zt
-qT
+QK
+dF
+Bo
+BZ
+Zl
 rf
 PI
 PI
@@ -14269,12 +16135,12 @@ PI
 Lm
 VI
 Fu
-da
-DK
-ZU
-ZU
+ot
+by
+SR
+zB
 ZW
-ZU
+zB
 Xu
 xP
 xP
@@ -14327,7 +16193,7 @@ SD
 Gw
 Ub
 gB
-Gw
+ww
 Gw
 Gw
 Ub
@@ -14382,42 +16248,42 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
+cp
+WF
+MT
+eD
+Zl
+dL
+Zl
+nv
+MT
+cN
+eC
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+He
+cX
+Zl
+WF
+Il
 ce
 Lm
 Nd
-yh
-yh
-yh
+SR
+SR
+SR
 bR
 bI
 Tu
 bL
 ci
-cm
-KU
-bT
+Zl
+BZ
+Zl
 SR
 SR
 SR
@@ -14425,12 +16291,12 @@ SR
 SR
 Sg
 Lm
-DK
-ZU
-ZU
-ZU
+by
+SR
+SR
+zB
 ZW
-ZU
+zB
 ZU
 RG
 fB
@@ -14538,28 +16404,28 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-re
-re
-re
-re
-qy
+cp
+WF
+eD
+eD
+Zl
+He
+Zl
+IK
+eD
+PZ
+cv
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+BZ
+Zl
+WF
+Qo
 ce
 PD
 by
@@ -14571,9 +16437,9 @@ Rh
 XP
 QZ
 QK
-QK
-SR
-SR
+Zl
+cX
+Zl
 SR
 im
 bl
@@ -14581,12 +16447,12 @@ SR
 SR
 SR
 im
-ZU
-ZU
-ZU
-ZU
+SR
+SR
+SR
+zB
 ZW
-ez
+Ws
 ZU
 RG
 fS
@@ -14618,7 +16484,7 @@ ZU
 ZU
 ZU
 ZU
-ZU
+SF
 ZU
 ZU
 ZU
@@ -14669,8 +16535,8 @@ Dk
 Aa
 Qa
 bE
-Qa
-Id
+OZ
+Dk
 Nc
 XR
 tQ
@@ -14694,27 +16560,27 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-lX
-pq
-TW
-bX
-lG
+cp
+WF
+BW
+BW
+WO
+Zl
+Zl
+QQ
+BW
+Zl
+cO
+di
+Pg
+Zl
+Zl
+Zl
+Zl
+Zl
+BZ
+Zl
+WF
 PD
 by
 Sg
@@ -14727,7 +16593,9 @@ bR
 Io
 Rh
 XP
-im
+WO
+BZ
+Zl
 SR
 SR
 SR
@@ -14737,12 +16605,10 @@ SR
 SR
 SR
 SR
-ZU
-ZU
-ZU
-ZU
+SR
+zB
 rP
-ZU
+zB
 RG
 fB
 Rj
@@ -14774,8 +16640,8 @@ ZU
 gx
 ZU
 ZU
-ZU
-ZU
+SF
+gx
 ZU
 ZU
 ZU
@@ -14825,7 +16691,7 @@ xu
 Ar
 yj
 bE
-SM
+TL
 VE
 Nc
 tQ
@@ -14850,27 +16716,27 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-bH
-qT
-Ir
-Zt
-XH
+cp
+WF
+Yh
+Zl
+Fj
+Tz
+Tz
+eP
+WO
+FB
+cs
+WF
+WF
+WF
+WF
+Zl
+Zl
+Zl
+BZ
+Zl
+WF
 ot
 Ho
 SR
@@ -14882,10 +16748,10 @@ cc
 Rh
 XP
 Ry
-SR
-SR
-SR
-SR
+Zl
+Zl
+BZ
+Zl
 bN
 SR
 SR
@@ -14893,12 +16759,12 @@ SR
 wo
 SR
 PD
-XF
-ZU
-ZU
-ZU
+Nd
+SR
+SR
+zB
 ZW
-ZU
+zB
 DZ
 Rj
 Rj
@@ -15006,42 +16872,42 @@ Yf
 Yf
 Yf
 Yf
+cp
+WF
+Zl
+Zl
+WB
+JF
+CX
+Zl
+Zl
+Zl
+cs
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-qy
-bH
-KU
-IC
-IC
-Zt
-Sg
+Gs
+WF
+Bo
+Zl
+Zl
+BZ
+Zl
+Xz
 SR
 SR
 SR
 SR
 SR
+dF
 Io
 ca
 Ry
 bS
 SR
-im
-SR
-SR
-qT
+WO
+Zl
+BZ
+Zl
 cm
 SR
 SR
@@ -15049,12 +16915,12 @@ ok
 VI
 bA
 VI
-Om
-XF
-ZU
-ZU
+bM
+Nd
+SR
+zB
 ZW
-ZU
+zB
 Lx
 Ga
 Ga
@@ -15162,42 +17028,42 @@ Yf
 Yf
 Yf
 Yf
+cp
+cs
+cs
+cs
+cs
+cs
+cs
+cs
+cs
+cs
+cs
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-lX
-pq
-WS
-TW
-KU
-cg
-bT
-SR
-im
-SR
-bP
-SR
-SR
-SR
-bJ
-XP
-SR
-SR
-SR
-SR
-cj
-IC
+Il
+WF
+LF
+Zl
+Zl
+BZ
+Zl
+Tx
+Zl
+WO
+Zl
+Zl
+Zl
+EU
+Zl
+Zl
+Zl
+Zl
+Zl
+LF
+Zl
+BZ
+WF
 bT
 SR
 SR
@@ -15205,12 +17071,12 @@ ok
 VI
 bM
 by
-Di
-DK
-xa
-ZU
+PD
+by
+bS
+zB
 ZW
-ZU
+zB
 gx
 ZU
 ZU
@@ -15331,29 +17197,29 @@ Yf
 Yf
 Yf
 Yf
-qs
-bH
-lX
-eY
-SR
-SR
-SR
-SR
-SR
-SR
-Io
-eB
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-PD
-Nd
-QK
+Il
+WF
+NU
+Tz
+Tz
+dz
+Tz
+mV
+Tz
+Tz
+Tz
+Tz
+Tz
+mz
+Tz
+Tz
+Tz
+Tz
+Tz
+HP
+Tz
+jX
+WF
 SR
 im
 SR
@@ -15361,12 +17227,12 @@ SR
 Lm
 Nd
 PD
-DK
-dw
-dw
-ZU
+by
+bP
+bP
+zB
 ZW
-ez
+zB
 ZU
 ZU
 ZU
@@ -15392,9 +17258,9 @@ Lx
 Mg
 dE
 Sn
-ZU
-ZU
-ZU
+SF
+SF
+SF
 dE
 Bw
 Bw
@@ -15449,8 +17315,8 @@ KZ
 KZ
 KZ
 tI
-BD
-Kc
+xR
+xR
 iZ
 KZ
 KZ
@@ -15488,28 +17354,28 @@ Yf
 Yf
 Yf
 qs
-bH
-bH
-SR
-bp
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-bl
-SR
-im
-we
-SR
-SR
-ok
-VI
-VI
-Ho
+WF
+Zl
+Zl
+dL
+Zl
+Zl
+pr
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+WO
+jC
+Zl
+Zl
+DH
+WF
+WF
+WF
 SR
 SR
 SR
@@ -15522,7 +17388,7 @@ Rj
 dy
 ej
 ZW
-ZU
+zB
 fi
 ft
 EB
@@ -15618,7 +17484,7 @@ li
 my
 my
 DD
-li
+DD
 Vb
 lG
 YQ
@@ -15644,13 +17510,13 @@ Yf
 Yf
 re
 qy
-bH
-XH
-SR
-SR
-SR
-PD
-Nd
+WF
+Xz
+ev
+xZ
+Xz
+WF
+WF
 aX
 bN
 bN
@@ -15676,9 +17542,9 @@ Tu
 dh
 Ga
 dD
-ZU
+zB
 ZW
-ZU
+zB
 dE
 Bw
 fz
@@ -15774,8 +17640,8 @@ my
 my
 Iw
 DD
-li
-ow
+DD
+DD
 nM
 YQ
 "}
@@ -15804,7 +17670,7 @@ XH
 SR
 SR
 SR
-PD
+SR
 VI
 VI
 Nd
@@ -15812,7 +17678,7 @@ ci
 IC
 cm
 qT
-rf
+SR
 SR
 cq
 SR
@@ -15832,9 +17698,9 @@ Tu
 dh
 XJ
 ZU
-ZU
+zB
 ZW
-ZU
+zB
 fi
 Bw
 ft
@@ -15930,8 +17796,8 @@ my
 my
 my
 DD
-li
-li
+DD
+DD
 nM
 YQ
 "}
@@ -15988,9 +17854,9 @@ Zt
 dj
 dx
 ZU
-ZU
+zB
 ZW
-BQ
+tp
 dE
 cY
 dE
@@ -16082,12 +17948,12 @@ li
 li
 li
 li
-li
+DD
 my
 my
 DD
 DD
-li
+DD
 XH
 YQ
 "}
@@ -16144,9 +18010,9 @@ QK
 Xu
 Jg
 eb
-ZU
+zB
 ZW
-ZU
+zB
 ZU
 Xu
 xP
@@ -16238,12 +18104,12 @@ ND
 ND
 ND
 ND
-li
+DD
 my
 my
 DD
 DD
-li
+DD
 qz
 YQ
 "}
@@ -16300,9 +18166,9 @@ Ir
 EB
 do
 dj
-ZU
+zB
 ZW
-ZU
+zB
 ZU
 Xu
 xP
@@ -16394,12 +18260,12 @@ JC
 wZ
 Ez
 ND
-li
+DD
 my
 my
 DD
-li
-li
+DD
+DD
 qz
 YQ
 "}
@@ -16456,9 +18322,9 @@ IC
 de
 do
 ZU
-ZU
+zB
 ZW
-ZU
+zB
 DZ
 Mg
 fT
@@ -16550,12 +18416,12 @@ wZ
 wZ
 LC
 ND
-li
+DD
 my
 my
 DD
-li
-ow
+DD
+DD
 VU
 YQ
 "}
@@ -16612,9 +18478,9 @@ cg
 ME
 xb
 Yp
-ym
+Td
 gG
-ym
+Td
 EM
 fC
 dC
@@ -16706,12 +18572,12 @@ Ze
 wZ
 Ez
 ND
-li
+DD
 my
 my
 DD
-li
-li
+DD
+DD
 qH
 YQ
 "}
@@ -16768,9 +18634,9 @@ Tu
 fx
 Qw
 MM
-ym
+Td
 gG
-ym
+Td
 YS
 KK
 Iy
@@ -16796,9 +18662,9 @@ dC
 dC
 hb
 Yp
-ym
-ym
-ym
+ij
+ij
+ij
 YS
 gT
 ZB
@@ -16862,7 +18728,7 @@ Hf
 Hf
 Hf
 ND
-li
+DD
 my
 my
 DD
@@ -16924,9 +18790,9 @@ qT
 Uk
 YK
 ym
-ym
+Td
 gG
-ym
+Td
 ym
 fF
 UL
@@ -17078,11 +18944,11 @@ SR
 qT
 IC
 Uk
-dz
 ym
 ym
+Td
 gG
-ym
+Td
 ym
 ym
 Wj
@@ -17229,7 +19095,7 @@ ci
 rf
 SR
 SR
-SR
+im
 SR
 cn
 QK
@@ -17414,7 +19280,7 @@ ym
 ym
 ym
 ym
-ym
+Be
 ym
 gX
 ym
@@ -17429,7 +19295,7 @@ li
 lx
 li
 li
-li
+VC
 li
 li
 lx
@@ -17464,7 +19330,7 @@ DD
 DD
 DD
 my
-OL
+HA
 li
 YA
 YL
@@ -17558,7 +19424,7 @@ Td
 Qs
 Td
 Td
-Td
+Qs
 fE
 Td
 Td
@@ -17591,7 +19457,7 @@ my
 my
 my
 my
-my
+JW
 my
 my
 my
@@ -17885,7 +19751,7 @@ Td
 Td
 Td
 Td
-Td
+Qs
 Td
 Td
 Td
@@ -17893,7 +19759,7 @@ Td
 xE
 my
 my
-my
+JW
 my
 my
 my
@@ -18008,7 +19874,7 @@ pk
 Ho
 SR
 SR
-SR
+im
 SR
 SR
 wo
@@ -18026,7 +19892,7 @@ Be
 ym
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -18058,7 +19924,7 @@ li
 li
 li
 li
-li
+VC
 li
 li
 li
@@ -18854,7 +20720,7 @@ my
 my
 my
 my
-my
+oN
 Iw
 my
 my
@@ -18986,7 +20852,7 @@ Xj
 Je
 ym
 ym
-ym
+Be
 ym
 Wj
 fh
@@ -19027,7 +20893,7 @@ li
 HA
 my
 li
-BM
+ND
 Ez
 wZ
 tk
@@ -19082,12 +20948,12 @@ pk
 pk
 pk
 Ho
-yh
-yh
-yh
-yh
-yh
-yh
+SR
+SR
+SR
+SR
+SR
+SR
 bP
 aX
 Zy
@@ -19126,7 +20992,7 @@ xX
 xX
 hv
 ST
-YW
+Ig
 YW
 YW
 YW
@@ -19300,7 +21166,7 @@ Uk
 ym
 cl
 ym
-ym
+Be
 dT
 Wj
 SA
@@ -19397,7 +21263,7 @@ bZ
 Rh
 XP
 SR
-bC
+SR
 SR
 Io
 Rh
@@ -19410,7 +21276,7 @@ cc
 eB
 SR
 SR
-SR
+im
 SR
 cj
 Ir
@@ -19667,7 +21533,7 @@ tg
 tg
 Hf
 Dl
-aZ
+Fy
 FN
 ND
 li
@@ -19707,12 +21573,12 @@ VI
 VI
 Nd
 Ry
-yh
-yh
-yh
-yh
-yh
-cp
+SR
+SR
+SR
+SR
+SR
+Zb
 qT
 Zt
 qT
@@ -19926,7 +21792,7 @@ YW
 hb
 Yp
 ym
-ym
+Be
 ym
 ym
 Ps
@@ -20195,7 +22061,7 @@ SR
 bl
 SR
 SR
-SR
+im
 SR
 SR
 SR
@@ -20291,7 +22157,7 @@ tg
 Ky
 Hf
 Dl
-aZ
+Fy
 FN
 ND
 li
@@ -20365,7 +22231,7 @@ Ps
 ym
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -20392,7 +22258,7 @@ YW
 YW
 hb
 JX
-ym
+Be
 ym
 ym
 ym
@@ -20681,7 +22547,7 @@ ST
 ST
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -21161,7 +23027,7 @@ ym
 ym
 gT
 gq
-ym
+Be
 ym
 ym
 fF
@@ -21309,7 +23175,7 @@ ZB
 gq
 ym
 ym
-ym
+Be
 ym
 xb
 MM
@@ -21336,7 +23202,7 @@ JX
 cl
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -21479,7 +23345,7 @@ fx
 ym
 cl
 ym
-ym
+Be
 ym
 ym
 QL
@@ -21497,7 +23363,7 @@ ym
 ym
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -21785,7 +23651,7 @@ ym
 ym
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -21799,7 +23665,7 @@ TH
 ym
 ym
 ym
-ym
+Be
 ym
 ZP
 Ps
@@ -22101,7 +23967,7 @@ Je
 dT
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -22160,7 +24026,7 @@ VM
 VM
 VM
 VM
-li
+qE
 li
 li
 li
@@ -22264,7 +24130,7 @@ ym
 Qw
 Yp
 zQ
-ym
+Be
 ym
 YK
 KK
@@ -22314,9 +24180,9 @@ VQ
 Sk
 VM
 li
-li
-li
-DD
+qE
+qE
+qE
 DD
 DD
 DD
@@ -22431,7 +24297,7 @@ ZB
 fx
 Ps
 ym
-ym
+Be
 ym
 fF
 fW
@@ -22627,9 +24493,9 @@ li
 li
 li
 li
-li
-qz
-lX
+DD
+Yl
+Yl
 TW
 XH
 XH
@@ -22783,9 +24649,9 @@ DD
 DD
 li
 qz
-VU
-VU
-XH
+Yl
+Yl
+Yl
 VU
 bF
 oW
@@ -22890,7 +24756,7 @@ fp
 TJ
 TV
 YT
-YT
+eK
 JD
 Bn
 xN
@@ -22937,12 +24803,12 @@ ow
 ow
 VU
 aG
-TW
-aG
-aI
-aI
-pq
-eY
+Sq
+Sq
+Yl
+Yl
+Yl
+EE
 bD
 Yf
 Yf
@@ -23092,13 +24958,13 @@ VU
 aG
 bX
 aI
-pq
-TW
-bF
-oW
-oW
-oW
-oW
+Pv
+Pv
+Sq
+Yl
+Yl
+Yl
+EE
 Yf
 Yf
 Yf
@@ -23240,21 +25106,21 @@ ow
 ow
 ow
 ow
-bF
-qz
-VU
-VU
-XH
-VU
-bF
-oW
-oW
-oW
-Yf
-Yf
-Yf
-Yf
-Yf
+Ay
+Mr
+ss
+ss
+gU
+ss
+Ay
+IF
+IF
+hF
+hF
+zO
+zO
+vW
+EE
 Yf
 Yf
 Yf
@@ -23292,20 +25158,20 @@ Yf
 Yf
 Yf
 Yf
-Yf
-qs
-Vb
-lG
-KU
-bT
-SR
-SR
-SR
-bS
-SR
-wo
-ce
-Zy
+cp
+iS
+ko
+kq
+cQ
+kL
+yh
+yh
+yh
+mQ
+yh
+mA
+nb
+qe
 Zy
 bS
 bS
@@ -23396,21 +25262,21 @@ li
 ow
 ow
 ow
-qz
+Mr
 VU
 VU
 aI
 pq
 eY
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+Pv
+Pv
+Sq
+Sq
+Yl
+Yl
+Yl
+vW
+Pv
 Yf
 Yf
 Yf
@@ -23448,7 +25314,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+cp
 Yf
 RN
 Vb
@@ -23461,7 +25327,7 @@ SR
 SR
 ce
 ce
-Zy
+qe
 Zy
 Zy
 bS
@@ -23483,7 +25349,7 @@ YT
 fo
 YT
 YT
-YT
+eK
 YT
 Tr
 dq
@@ -23532,11 +25398,11 @@ XO
 WI
 XO
 XO
-fQ
-gW
-fv
-TV
-fv
+RU
+RU
+RU
+RU
+RU
 TV
 fP
 TJ
@@ -23552,21 +25418,21 @@ li
 ow
 VU
 VU
-qz
+Mr
 qH
 WS
 oW
 oW
 oW
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+Pv
+Sq
+Sq
+Yl
+Yl
+Yl
+Yl
+vW
+Pv
 Yf
 Yf
 Yf
@@ -23604,7 +25470,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+cp
 Yf
 qs
 qz
@@ -23617,7 +25483,7 @@ wo
 wo
 ce
 ce
-Zy
+qe
 Zy
 Zy
 Zy
@@ -23690,9 +25556,9 @@ Za
 Za
 oO
 XO
-fy
-fp
-dk
+hi
+hi
+RU
 fP
 TJ
 dk
@@ -23707,21 +25573,21 @@ tH
 qz
 VU
 qH
-WS
-TW
+yZ
+OM
 XH
 Vb
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+Sq
+Sq
+Yl
+Yl
+Yl
+Yl
+Yl
+EE
+vW
 Yf
 Yf
 Yf
@@ -23760,7 +25626,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+cp
 Yf
 qy
 lX
@@ -23773,7 +25639,7 @@ VI
 VI
 bM
 by
-Zy
+qe
 Zy
 Zy
 Zy
@@ -23863,21 +25729,21 @@ tH
 aG
 eY
 XH
-Vb
+ko
 TW
 bF
-oW
+Pv
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+Sq
+Sq
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+EE
+cp
 Yf
 Yf
 Yf
@@ -23916,20 +25782,20 @@ Yf
 Yf
 Yf
 Yf
-re
+dK
 qy
 lX
 WS
 eY
 SR
-SR
+bC
 SR
 SR
 Sg
 ot
 pk
 Ho
-Zy
+qe
 Zy
 Zy
 Zy
@@ -24019,21 +25885,21 @@ tH
 lX
 lG
 qz
-bF
+Ay
 oW
+Pv
+Pv
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+Sq
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+EE
+IF
 Yf
 Yf
 Yf
@@ -24072,7 +25938,7 @@ Yf
 Yf
 Yf
 qy
-PD
+dQ
 Ho
 Vb
 eY
@@ -24085,7 +25951,7 @@ SR
 Lm
 Ho
 Zy
-Zy
+qe
 Zy
 Zy
 Zy
@@ -24175,21 +26041,21 @@ tH
 Vb
 WS
 lG
-bD
+Bc
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+Sq
+Sq
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+EE
+IF
 Yf
 Yf
 Yf
@@ -24214,11 +26080,11 @@ eJ
 eJ
 MQ
 sH
-hB
+sH
 MQ
 sH
 aj
-Sc
+sH
 bt
 MQ
 bz
@@ -24228,7 +26094,7 @@ Yf
 Yf
 qy
 PD
-VI
+eu
 bA
 Ho
 SR
@@ -24241,7 +26107,7 @@ im
 SR
 ok
 pk
-pk
+sb
 pk
 pk
 pk
@@ -24256,7 +26122,7 @@ SR
 SR
 wo
 YT
-YT
+eK
 Bz
 YT
 YT
@@ -24308,7 +26174,7 @@ ke
 OJ
 XO
 Za
-XO
+Za
 XO
 of
 of
@@ -24331,21 +26197,21 @@ tH
 qz
 Vb
 eY
-bD
+Bc
+Pv
+Sq
+Sq
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+Yl
+Yl
+Yl
+xe
+Yl
+Yl
+Yl
+EE
+Pv
+IF
 Yf
 Yf
 Yf
@@ -24384,7 +26250,7 @@ Yf
 qs
 PD
 VI
-by
+eF
 Sg
 SR
 SR
@@ -24397,7 +26263,7 @@ bl
 SR
 SR
 ok
-pk
+sb
 pk
 pk
 pk
@@ -24436,7 +26302,7 @@ fy
 lc
 YT
 YT
-YT
+eK
 YT
 YT
 YT
@@ -24462,9 +26328,9 @@ Za
 XO
 xM
 WI
-WI
-XO
-XO
+Za
+Za
+Za
 XO
 XO
 XO
@@ -24487,21 +26353,21 @@ tH
 KE
 GY
 Gu
-bh
+Co
 re
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+Sq
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+EE
+Pv
+cp
 Yf
 Yf
 Yf
@@ -24540,7 +26406,7 @@ Yf
 qy
 ot
 Fu
-Sg
+eL
 SR
 bl
 SR
@@ -24553,7 +26419,7 @@ SR
 bl
 SR
 SR
-cj
+ky
 Xw
 Xw
 Ir
@@ -24562,7 +26428,7 @@ Xw
 Xw
 rf
 SR
-SR
+im
 SR
 ok
 VI
@@ -24643,21 +26509,21 @@ tH
 Nq
 GZ
 GY
+Em
 Gu
-Gu
-bh
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+EE
+EE
+Pv
+cp
 Yf
 Yf
 Yf
@@ -24686,7 +26552,7 @@ sH
 MQ
 aS
 IO
-el
+sH
 sH
 MQ
 bz
@@ -24696,20 +26562,20 @@ qy
 PD
 VI
 Fu
-SR
-bl
-GH
-SR
-cj
-IC
-bT
-qT
-IC
-Zt
-SR
-bl
-Zb
-SR
+yh
+jo
+kp
+yh
+ky
+kS
+kL
+ln
+kS
+cP
+yh
+jo
+ne
+yh
 cj
 Xw
 IC
@@ -24773,18 +26639,18 @@ Za
 XO
 XO
 XO
-XO
+Za
 WI
 XO
 XO
 Za
 XO
+Za
 XO
-XO
-WI
-WI
-WI
-WI
+Za
+Za
+Za
+Za
 Hh
 QO
 vf
@@ -24796,24 +26662,24 @@ qG
 qm
 Ee
 tH
-WI
-WI
-WI
-WI
-GY
-Gu
-bh
+nI
+nI
+nI
+Gl
+Za
+Za
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+EE
+Pv
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -24912,39 +26778,39 @@ XO
 XO
 XO
 km
-WI
-WI
-WI
-XO
-XO
-XO
-XO
-WI
-WI
-WI
-XO
-XO
-Za
-XO
-XO
-XO
-WI
-WI
-WI
-XO
-km
-XO
-XO
-XO
-WI
-WI
-WI
-WI
-WI
-of
-WI
-WI
-XO
+nI
+nI
+nI
+oP
+oP
+oP
+oP
+nI
+nI
+nI
+oP
+oP
+wa
+oP
+oP
+oP
+nI
+wa
+nI
+oP
+GO
+oP
+oP
+oP
+nI
+nI
+nI
+wa
+wa
+Cq
+nI
+nI
+oP
 tH
 Ck
 nH
@@ -24952,24 +26818,24 @@ hh
 vM
 fu
 tH
-WI
-WI
-WI
-WI
-GZ
-GY
-Gu
+nI
+nI
+wa
+Gl
+Za
+Za
+Za
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
 Yf
+EE
+Pv
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -25039,7 +26905,7 @@ YT
 AU
 Bz
 AU
-YT
+eK
 YT
 fR
 gw
@@ -25068,39 +26934,39 @@ XO
 Za
 XO
 XO
-WI
-WI
-XO
-Za
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-WI
-WI
-WI
-WI
-WI
-XO
-Za
-XO
-XO
-WI
+nI
+nI
+oP
+wa
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+wa
+wa
+wa
+wa
+nI
+oP
+wa
+oP
+wa
+nI
 OD
-WI
-WI
-WI
-WI
-XO
-XO
-XO
+nI
+wa
+nI
+nI
+oP
+oP
+oP
 tH
 CC
 jU
@@ -25108,24 +26974,24 @@ UH
 po
 rn
 tH
-WI
-WI
-xM
-Gu
-bh
+nI
+wa
+Za
+Hx
+QP
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+EE
+Pv
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -25224,39 +27090,39 @@ XO
 XO
 XO
 XO
-OO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-Za
-XO
-XO
-XO
-WI
-WI
-WI
-XO
-XO
-XO
-XO
-XO
+Tl
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+wa
+oP
+oP
+oP
+wa
+oP
+oP
+wa
+nI
+wa
+wa
+oP
+oP
+oP
+oP
+oP
 tH
 Mh
 kK
@@ -25264,24 +27130,24 @@ rh
 Mh
 tH
 tH
-WI
-WI
-GZ
-GY
-BL
-bD
+nI
+nI
+XO
+Ii
+Za
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yf
+EE
+EE
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -25380,64 +27246,64 @@ XO
 Za
 Za
 Za
-Za
-Za
-oO
-Za
-Za
-Za
-Za
-XO
-XO
-Za
-Za
-oO
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
+wa
+wa
+uq
+wa
+wa
+wa
+wa
+oP
+oP
+wa
+wa
+uq
+wa
+wa
+wa
+wa
+wa
+wa
+wa
+wa
 Uq
-SI
-SI
-SI
+IT
+IT
+IT
+oP
+oP
+wa
+wa
+sT
+IT
+IT
+IT
+IT
+IT
+IT
+io
+IT
+oP
+oP
+oP
+nI
+nI
 XO
-XO
-XO
-XO
-np
-SI
-SI
-SI
-SI
-SI
-SI
-FV
-SI
-XO
-XO
-XO
-WI
-WI
-AK
-KV
-xM
-bD
+Ii
+Za
+QP
+Yl
+Yl
+Yl
+Yf
+EE
+EE
+EE
 Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -25536,64 +27402,64 @@ vy
 vy
 vy
 vy
-vy
-vy
-vy
-vy
-vy
-vy
-vy
-vy
-vy
-vy
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
 Ns
-vy
-vy
-vy
-vy
-vy
-vy
-vy
-vy
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
 Yv
 Ow
-vy
-vy
-vy
-vy
-vy
-vy
-vy
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
 Ns
-vy
-vy
-vy
-vy
-vy
-vy
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
 qf
-SI
+td
+wa
+wa
+wa
+oP
+oP
+oP
+Ii
 Za
-Za
-Za
-XO
-XO
-WI
-BL
-xM
-bD
+QP
+Yl
+Yl
+Yl
+EE
+Pv
+Pv
+Pv
 Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -25648,7 +27514,7 @@ SR
 SR
 SR
 SR
-SR
+im
 SR
 SR
 SR
@@ -25662,7 +27528,7 @@ AU
 AU
 dI
 eI
-AU
+XA
 AU
 AU
 YT
@@ -25692,11 +27558,11 @@ YT
 XO
 np
 Za
-Za
-Za
-oO
-Za
-Za
+wa
+wa
+uq
+wa
+wa
 lA
 lA
 wN
@@ -25728,28 +27594,28 @@ wN
 wN
 wN
 lA
-XO
-XO
-XO
+oP
+oP
+oP
+wa
+oP
+oP
 Za
-XO
-XO
-AK
-KV
-xM
-bD
+Ii
+Za
+Yl
+Yl
+Yf
+EE
+Pv
+Pv
 Yf
 Yf
 Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -25848,52 +27714,56 @@ fo
 WI
 XO
 XO
-XO
-XO
-XO
-Za
-lW
+oP
+oP
+oP
+wa
+CP
 Jm
-jO
-Hh
+PS
+OA
 mh
-hj
-mI
-Za
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-Dn
-SI
-XO
-XO
-XO
-XO
-XO
-WI
-WI
-WI
-Hh
+yq
+nW
+wa
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+at
+IT
+oP
+oP
+oP
+oP
+oP
+nI
+nI
+nI
+OA
 mh
 mh
 mh
-jO
-XO
+PS
+oP
 iK
-XO
-XO
-Lv
-XO
-Za
-XO
-WI
-WI
+oP
+oP
+fI
+oP
+wa
+oP
+nI
+Gl
 BL
 xM
+EE
+Pv
+Pv
+Pv
 Yf
 Yf
 Yf
@@ -25901,11 +27771,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -26004,52 +27870,54 @@ Tc
 WI
 XO
 XO
-XO
-XO
-XO
-Za
+oP
+oP
+oP
+wa
 pR
 GI
 Vc
-VG
-vf
+qC
+wv
 mh
-mI
-oP
-wa
-CP
-on
 nW
-wa
-wa
-oP
+cz
+on
+on
+on
+on
+on
+Xb
+Sc
 at
-IT
-oP
-wa
-wa
-oP
-wa
+Kz
+Sc
+Xb
+on
+on
+on
 CP
 yq
 yq
-QO
-QO
-QO
-wm
-of
-XO
+yB
+yB
+yB
+lL
+Cq
+oP
 iK
-XO
-WI
-Lv
-XO
-Za
-XO
-XO
-AK
+oP
+nI
+fI
+oP
+wa
+oP
+oP
+Js
 NT
 xM
+Pv
+Pv
 Yf
 Yf
 Yf
@@ -26059,9 +27927,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -26160,64 +28026,64 @@ gt
 fZ
 XO
 WI
-XO
-Lv
-Za
-Za
-WI
+oP
+fI
+wa
+wa
+nI
 Wu
 oP
-Zx
-je
-vf
-jO
+WQ
+GG
+wv
+PS
 oP
-wa
-oP
-oP
-oP
-oP
-oP
-wa
-at
-IT
-wa
+RA
+Sc
+WA
+WA
+WA
+WA
+WA
+cG
+Ko
+WA
 Oy
+ZN
+nd
+oq
+tL
+tL
+jW
+fI
+fI
+fI
+fI
+WQ
 oP
-oP
-wa
-oP
-nI
-nI
-Lv
-Lv
-Lv
-Lv
-Zx
-XO
 iK
-XO
-XO
-Lv
-XO
-XO
-XO
+oP
+oP
+fI
+oP
+oP
+oP
 AK
 zy
-NT
-Nq
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+Sb
+FD
+cp
+cp
+cp
+cp
+cp
+cp
+cp
+cp
+cp
+cp
+cp
+cp
 Yf
 Yf
 Yf
@@ -26316,49 +28182,49 @@ oW
 RN
 WI
 WI
-WI
-XO
-XO
-Za
-XO
+nI
+oP
+oP
+wa
+oP
 Wu
 CP
-vf
-jO
-je
-wm
-oP
+on
+wa
+wa
+wa
+sT
 wa
 ka
-ka
-ka
-ka
-oP
-wa
-at
 IT
+IT
+BK
+ZD
+IT
+hP
+Kt
+nc
+LB
+LY
+tL
+tL
+tL
+tL
+jW
+fI
+fI
+fI
+OA
+wv
+nI
+En
 wa
 oP
-ka
-ka
-ka
-ka
+oP
+oP
 wa
+oP
 nI
-Lv
-Lv
-Lv
-Hh
-vf
-jO
-En
-Za
-XO
-XO
-XO
-Za
-XO
-WI
 GZ
 KV
 bF
@@ -26420,13 +28286,13 @@ bl
 Ry
 KU
 Ir
-IC
-Zt
-SR
-bl
-SR
-SR
-Lm
+kS
+cP
+yh
+jo
+yh
+yh
+mC
 by
 Zy
 Zy
@@ -26472,48 +28338,48 @@ Yf
 qs
 WI
 WI
-WI
-XO
-XO
-Za
-XO
-Wu
-oP
-je
-vf
-jO
-Zx
 nI
 oP
-ka
-ko
-mP
-ll
-wa
-wa
-at
-IT
+oP
 wa
 oP
-mz
-mP
-nb
-ka
+Wu
+oP
+IZ
 wa
 wa
-Lv
-Lv
-Hh
-vf
-vf
-QO
-WA
+wa
+nI
+oP
+IT
+IT
+IT
+IT
+on
+on
+Pc
+QW
+nf
+rm
+tL
+tL
+tL
+tL
+tL
+tL
+fI
+fI
+OA
+cy
+nI
+nI
+En
 pT
-XO
-Za
-XO
-XO
-WI
+oP
+wa
+oP
+oP
+nI
 lX
 lG
 Gu
@@ -26576,13 +28442,13 @@ SR
 bl
 SR
 QK
-KU
+cQ
 IC
 rf
 SR
 bl
 SR
-SR
+yh
 bP
 bS
 bS
@@ -26628,47 +28494,47 @@ Yf
 qs
 WI
 WI
-XO
-Lv
-XO
-XO
-XO
-qM
-wa
 oP
-je
-QO
-wm
+fI
+oP
+oP
+oP
+CZ
+wa
+JN
+Kd
+IT
+IT
+IT
+IT
+Wm
+IT
+IT
+RQ
+on
+on
+hP
+QW
+IT
+IT
+Wm
+tL
+tL
+on
+on
+on
+on
+on
+GG
 nI
-wa
-on
-kp
-IT
-IT
-IT
-IT
-at
-IT
-IT
-IT
-IT
-IT
-nc
-on
-oP
-oP
-tw
-PK
-je
-QO
-wm
+nI
 oP
 En
-Za
-Za
-XO
-XO
-WI
+wa
+wa
+oP
+oP
+nI
 lX
 WS
 eY
@@ -26732,13 +28598,13 @@ SR
 SR
 bl
 Zb
-SR
+yh
 QK
 Xw
 rf
 PI
 PI
-Io
+tw
 ca
 bS
 bS
@@ -26768,7 +28634,7 @@ YT
 YT
 YT
 YT
-YT
+eK
 YT
 YT
 YT
@@ -26784,46 +28650,46 @@ Yf
 qs
 WI
 WI
-XO
-XO
-np
-XO
-Za
-qM
-nI
-nI
-nI
-nI
-nI
-qe
 oP
-ka
-kq
-kO
-lm
-wa
 oP
-at
-IT
-wa
-wa
-mA
-mQ
-nd
-ka
+sT
 oP
 wa
-tw
-RQ
+CZ
+nI
+wa
 Ko
+IT
+IT
+td
+IT
+on
+IT
+IT
+IT
+IT
+mP
+hP
+QW
+IT
+IT
+on
+tL
+nd
+on
+oP
+wa
+wa
+wa
+wa
 nI
 oP
 oP
 iK
-XO
-XO
-XO
-WI
+oP
+oP
+oP
+nI
 lX
 WS
 eY
@@ -26888,7 +28754,7 @@ lG
 SR
 SR
 bl
-SR
+yh
 SR
 SR
 SR
@@ -26907,7 +28773,7 @@ XP
 Sg
 SR
 SR
-SR
+im
 YT
 dq
 YT
@@ -26940,45 +28806,45 @@ Yf
 qs
 WI
 XO
-XO
-XO
-XO
-XO
-XO
+oP
+oP
+oP
+oP
+oP
 ZS
 oP
+IZ
 oP
 oP
 oP
-oP
-oP
-wa
-ka
-ka
-ka
-ka
-oP
-oP
-at
 IT
-oP
-oP
-ka
-ka
-ka
-ka
+IT
+on
+IT
+IT
+IT
+IT
+IT
+hP
+QW
+IT
+IT
+on
+tL
+Uy
+on
 wa
 oP
+nI
+nI
+wa
 oP
-RA
-Ko
+nI
 oP
-Hh
-mI
 iK
-XO
-XO
-WI
+oP
+oP
+nI
 lX
 WS
 eY
@@ -27044,16 +28910,16 @@ Vb
 lG
 SR
 VU
-bl
+jo
 SR
 SR
 we
 bl
 SR
 yh
-im
-cj
-Xw
+cb
+ky
+BM
 cP
 qT
 Xw
@@ -27103,36 +28969,36 @@ pq
 TW
 CZ
 oP
+on
+OL
+oP
+oP
+IT
+IT
+on
+on
+on
+on
+on
+on
+hP
+QW
+IT
+IT
+on
+xt
+Uo
+on
+oP
 wa
+nI
+nI
 oP
 oP
-oP
-sT
-oP
-oP
-oP
-oP
-oP
-oP
-wa
-at
-td
-wa
-oP
-oP
-oP
-oP
-oP
-oP
-wa
-sT
-Qp
-oP
-oP
-of
-wa
+nI
+nI
 En
-XO
+oP
 aG
 pq
 WS
@@ -27200,13 +29066,13 @@ RN
 Vb
 pq
 eY
-wo
+mA
 wo
 SR
 wo
 wo
 bl
-yh
+SR
 SR
 SR
 bl
@@ -27259,34 +29125,34 @@ hc
 he
 vV
 oP
-oP
-oP
-wa
+on
 oP
 wa
 oP
-ka
-ka
-ka
-ka
-wa
-oP
-at
 IT
-oP
-oP
-ka
-ka
-ka
-ka
+IT
+on
+WW
+IT
+mP
+IT
+on
+hP
+QW
+IT
+IT
+on
+on
+on
+on
 wa
 wa
-oP
+nI
 oP
 oP
 wa
-wa
-wa
+nI
+nI
 En
 BL
 aG
@@ -27356,13 +29222,13 @@ Yf
 oW
 oW
 RN
-Lm
+mC
 VI
 pk
 VI
 bM
 Nd
-yh
+SR
 im
 SR
 SR
@@ -27415,32 +29281,32 @@ gc
 gt
 Up
 TV
-nI
+on
 oP
 oP
 wa
-wa
-oP
-ka
-ku
-kS
-ln
-wa
-wa
-at
 IT
-wa
-wa
-mC
-mP
-ne
+IT
+on
+ku
+IT
+IT
+IT
 ka
+hP
+QW
+IT
+IT
+IT
+mP
+IT
+Wm
 wa
 wa
-wa
-wa
-wa
-wa
+nI
+nI
+nI
+nI
 oP
 oP
 cu
@@ -27512,13 +29378,13 @@ Yf
 Yf
 Yf
 Yf
-RN
+mE
 Lm
 Ho
 ce
 Zy
 VI
-cC
+Ho
 SR
 bC
 SR
@@ -27528,7 +29394,7 @@ QK
 SR
 SR
 SR
-SR
+im
 SR
 SR
 Zy
@@ -27572,33 +29438,33 @@ gc
 PC
 TJ
 TV
-nI
+on
 oP
 oP
-wa
-oP
+IT
+RQ
 on
 kv
 IT
+iV
 IT
 IT
-IT
-at
-IT
-IT
-IT
-IT
-IT
+hP
+QW
 nc
-on
+nc
+nc
+nc
+nc
+ka
 wa
 wa
-wa
-wa
+nI
+nI
 oP
 wa
 oP
-KE
+HF
 Uj
 OJ
 bF
@@ -27668,13 +29534,13 @@ Yf
 Yf
 Yf
 Yf
-Yf
+cp
 oW
 RN
 Lm
 pk
 by
-yh
+SR
 SR
 SR
 bl
@@ -27729,32 +29595,32 @@ Jp
 gt
 TJ
 TV
-nI
+on
 oP
-oP
-wa
-ka
-kw
-kO
-lm
-oP
-wa
-at
+IT
+IT
+on
+kx
+lo
+lo
+IT
+on
+hP
+Kt
+nf
+nf
+nf
+nf
+nf
 IT
 wa
-oP
-mD
-mR
-nf
-ka
-wa
-wa
+uq
 oP
 oP
 oP
-wa
+uq
 oP
-GZ
+AL
 Uj
 GY
 bD
@@ -27824,16 +29690,16 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-oW
-RN
-VU
-VU
-SR
-VU
-VU
+cp
+cp
+cp
+mY
+mE
+ss
+ss
+yh
+ss
+ss
 yh
 SR
 SR
@@ -27886,23 +29752,23 @@ gc
 gt
 TJ
 TV
-oP
-oP
-wa
-ka
-ka
-ka
-ka
-oP
-wa
-at
-td
-wa
-oP
-ka
-ka
-ka
-ka
+on
+IT
+IT
+on
+kx
+lo
+lo
+IT
+on
+hP
+QW
+IT
+IT
+IT
+IT
+IT
+Wm
 wa
 oP
 oP
@@ -28043,22 +29909,22 @@ gc
 TJ
 TJ
 fZ
-oP
-wa
-oP
-oP
-oP
-oP
-oP
-oP
-at
 IT
-wa
-wa
-oP
-oP
-oP
-oP
+IT
+on
+IT
+lp
+IT
+RQ
+on
+Pc
+QW
+on
+on
+on
+on
+on
+on
 oP
 oP
 nI
@@ -28066,7 +29932,7 @@ nI
 nI
 wa
 oP
-AK
+iT
 lC
 xM
 bD
@@ -28199,22 +30065,22 @@ gc
 TJ
 TJ
 fZ
-oP
-wa
-ka
-ka
-ka
-ka
-wa
-oP
-at
+td
 IT
-oP
-oP
 ka
-ka
-ka
-ka
+IT
+IT
+iV
+IT
+on
+hP
+QW
+on
+tG
+qL
+qL
+zF
+on
 oP
 nI
 WQ
@@ -28309,13 +30175,13 @@ pk
 by
 aX
 bH
-cQ
-dK
-cP
-eu
-eu
-eu
-eu
+KU
+IC
+Zt
+YT
+YT
+YT
+YT
 YT
 lc
 bD
@@ -28354,31 +30220,31 @@ qy
 qy
 fp
 dk
-nI
-oP
-wa
-ka
-kx
-kT
-lo
-oP
-wa
-at
+on
 IT
-wa
-wa
-mE
-mY
-nl
+IT
+IT
+kx
+lo
+lo
+IT
 ka
+hP
+QW
+yk
+IT
+IT
+IT
+nl
+on
 oP
-OA
+wa
 wv
 yB
 nW
 wa
 oP
-AK
+iT
 lC
 xM
 bD
@@ -28510,31 +30376,31 @@ aG
 nI
 nI
 nI
-oP
+Qp
+IT
+IT
+on
+IT
+lo
+lo
+IT
+IT
+hP
+QW
+xx
+IT
+IT
+IT
+mF
+on
 oP
 wa
-on
-kv
-IT
-IT
-IT
-IT
-at
-IT
-IT
-IT
-IT
-IT
-nc
-on
-oP
-qC
 wv
 nW
 oP
 wa
 oP
-KE
+HF
 Uj
 NT
 bD
@@ -28667,30 +30533,30 @@ nI
 nI
 oP
 wa
-wa
-wa
-ka
-ky
-kO
-lp
-oP
-wa
-at
 IT
-wa
-oP
+IT
+on
+IT
+ZD
+lp
+IT
+on
+hP
+QW
+on
+ZM
 mG
-kO
+UW
 nm
-ka
-CP
-yB
+on
+on
+on
 yB
 nW
-wa
-wa
-AK
-NT
+on
+cz
+iT
+PR
 tv
 KV
 bD
@@ -28781,7 +30647,7 @@ RN
 VU
 VU
 YT
-eL
+eK
 YT
 nM
 bH
@@ -28823,29 +30689,29 @@ nI
 oP
 oP
 wa
-wa
-oP
-ka
-ka
-ka
-ka
-oP
-wa
-at
 IT
+IT
+on
+on
+on
+on
+on
+on
+hP
+QW
+on
+on
+on
+on
+on
+on
+nI
+DO
+nI
+oP
 wa
 oP
-ka
-ka
-ka
-ka
-nI
-nI
-nI
-oP
-wa
-oP
-KE
+HF
 Np
 zl
 bF
@@ -28979,30 +30845,30 @@ nI
 oP
 wa
 wa
-oP
-oP
-oP
-oP
-oP
-oP
-oP
-wa
-at
 IT
-wa
-oP
-wa
+IT
 oP
 oP
-oP
-oP
-oP
+Qp
 oP
 oP
 wa
+zq
+QW
+wa
 oP
-GZ
-KV
+wa
+Qp
+oP
+oP
+oP
+oP
+oP
+oP
+wa
+oP
+AL
+mH
 kW
 Yf
 Yf
@@ -29135,8 +31001,8 @@ oP
 oP
 wa
 wa
-sT
-oP
+td
+IT
 oP
 oP
 oP
@@ -29144,7 +31010,7 @@ oP
 wa
 lP
 lZ
-td
+Kt
 IT
 wa
 wa
@@ -29153,10 +31019,10 @@ oP
 oP
 oP
 nI
-sT
+oP
 oP
 wa
-oP
+sT
 qz
 bF
 XN
@@ -29291,8 +31157,8 @@ oP
 oP
 wa
 wa
-oP
-oP
+IT
+IT
 oP
 IT
 IT
@@ -29914,27 +31780,27 @@ XH
 oP
 wa
 ih
-zE
+tL
+tL
 jR
+tL
+tL
+tL
+tL
+tL
+tL
+tL
 jR
+tL
+tL
+tL
+tL
+tL
+tL
+tL
+tL
 jR
-jR
-jR
-jR
-BF
-jR
-jR
-DQ
-jR
-jR
-jR
-jR
-jR
-jR
-jR
-jR
-jR
-nQ
+tL
 oy
 oP
 nI
@@ -30070,10 +31936,6 @@ lG
 oP
 wa
 ju
-iC
-tL
-Oz
-Ap
 tL
 tL
 tL
@@ -30088,9 +31950,13 @@ tL
 tL
 tL
 tL
-Oz
 tL
-nC
+tL
+tL
+tL
+tL
+tL
+tL
 oA
 wa
 nI
@@ -30226,10 +32092,6 @@ eY
 oP
 wa
 jv
-iC
-tL
-tL
-gC
 tL
 tL
 tL
@@ -30246,7 +32108,11 @@ tL
 tL
 tL
 tL
-nC
+tL
+tL
+tL
+tL
+tL
 oD
 wa
 oP
@@ -30382,7 +32248,6 @@ lG
 oP
 wa
 jw
-iC
 tL
 tL
 tL
@@ -30402,7 +32267,8 @@ tL
 tL
 tL
 tL
-nC
+tL
+tL
 oE
 wa
 oP
@@ -30538,7 +32404,6 @@ eY
 oP
 wa
 ih
-iC
 tL
 tL
 tL
@@ -30558,7 +32423,8 @@ tL
 tL
 tL
 tL
-nC
+tL
+tL
 oy
 wa
 oP
@@ -30694,7 +32560,7 @@ TW
 oP
 wa
 ju
-iC
+tL
 tL
 tL
 tL
@@ -30714,7 +32580,7 @@ tL
 tL
 tL
 tL
-nC
+tL
 oA
 wa
 oP
@@ -30850,7 +32716,6 @@ TW
 oP
 wa
 jv
-iC
 tL
 tL
 tL
@@ -30870,7 +32735,8 @@ tL
 tL
 tL
 tL
-nC
+tL
+tL
 oD
 wa
 nI
@@ -31006,7 +32872,6 @@ TW
 oP
 wa
 jw
-iC
 tL
 tL
 tL
@@ -31026,7 +32891,8 @@ tL
 tL
 tL
 tL
-nC
+tL
+tL
 oE
 wa
 oP
@@ -31162,10 +33028,6 @@ VU
 oP
 wa
 ih
-iC
-tL
-tL
-gC
 tL
 tL
 tL
@@ -31182,7 +33044,11 @@ tL
 tL
 tL
 tL
-nC
+tL
+tL
+tL
+tL
+tL
 oy
 wa
 oP
@@ -31318,10 +33184,6 @@ bH
 oP
 wa
 ju
-iC
-tL
-Oz
-Ap
 tL
 tL
 tL
@@ -31336,9 +33198,13 @@ tL
 tL
 tL
 tL
-Oz
 tL
-nC
+tL
+tL
+tL
+tL
+tL
+tL
 oA
 wa
 oP
@@ -31474,27 +33340,27 @@ bH
 oP
 wa
 jv
-vw
-ob
-ob
-ob
-ob
-ob
-ob
-ob
-ob
-ob
-zF
-ob
-ob
-ob
-ob
-ob
-ob
-ob
-ob
-ob
-iI
+tL
+tL
+jR
+tL
+tL
+tL
+tL
+tL
+tL
+tL
+jR
+tL
+tL
+tL
+tL
+tL
+tL
+tL
+tL
+jR
+tL
 oD
 oP
 oP

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -1661,12 +1661,6 @@
 	dir = 6
 	},
 /area/icy_caves/caves/south)
-"gU" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singleEnd{
-	dir = 8
-	},
-/area/icy_caves/caves)
 "gV" = (
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves/east)
@@ -1811,10 +1805,6 @@
 	dir = 8
 	},
 /area/icy_caves/caves/east)
-"hF" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice,
-/area/icy_caves/caves)
 "hG" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/research_and_development,
@@ -2999,6 +2989,10 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"oF" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice,
+/area/icy_caves/caves)
 "oI" = (
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
@@ -3081,18 +3075,9 @@
 /turf/open/shuttle/dropship/floor,
 /area/icy_caves/caves/northern)
 "pf" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpseback = /obj/item/storage/backpack/satchel/norm;
-	corpsehelmet = /obj/item/clothing/head/hardhat/white;
-	corpseradio = /obj/item/radio/headset/survivor;
-	corpseshoes = /obj/item/clothing/shoes/snow;
-	corpsesuit = /obj/item/clothing/suit/storage/snow_suit;
-	corpseuniform = /obj/item/clothing/under/rank/miner;
-	mobname = "Shaft Miner";
-	name = "Shaft Miner"
-	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/brown2,
+/area/icy_caves/outpost/refinery)
 "pg" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -3436,9 +3421,6 @@
 "qC" = (
 /turf/closed/ice/thin/junction,
 /area/icy_caves/outpost/LZ2)
-"qE" = (
-/turf/closed/ice_rock/single,
-/area/icy_caves/outpost/outside/center)
 "qF" = (
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/tile/dark/brown2{
@@ -4532,6 +4514,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"vJ" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/caves)
 "vL" = (
 /obj/effect/decal/cleanable/blood/gibs/robot,
 /turf/open/floor/tile/dark/brown2/corner,
@@ -4565,12 +4551,6 @@
 	},
 /turf/closed/ice/corner,
 /area/icy_caves/outpost/LZ2)
-"vW" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/straight{
-	dir = 4
-	},
-/area/icy_caves/caves)
 "vX" = (
 /obj/item/flashlight,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4696,6 +4676,10 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/medbay)
+"wD" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/caves)
 "wE" = (
 /obj/docking_port/mobile/crashmode/bigbury,
 /turf/open/floor/tile/dark,
@@ -4742,10 +4726,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
-"wQ" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark/brown2,
-/area/icy_caves/outpost/refinery)
 "wT" = (
 /obj/structure/lattice,
 /obj/structure/monorail{
@@ -4774,10 +4754,6 @@
 	dir = 1
 	},
 /area/icy_caves/caves/south)
-"xe" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/caves)
 "xf" = (
 /obj/structure/closet/secure_closet/scientist,
 /turf/open/floor/tile/dark/purple2,
@@ -5211,6 +5187,12 @@
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"zE" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/end{
+	dir = 4
+	},
+/area/icy_caves/outpost/outside)
 "zF" = (
 /obj/machinery/space_heater,
 /turf/open/floor/tile/dark/yellow2{
@@ -5244,10 +5226,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
-"zO" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/caves)
 "zP" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
@@ -6008,6 +5986,12 @@
 	},
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ2)
+"DP" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/junction{
+	dir = 1
+	},
+/area/icy_caves/caves)
 "DS" = (
 /obj/structure/dropship_piece/one/corner/middleright,
 /obj/structure/dropship_piece/two/corner/rearright,
@@ -6159,11 +6143,6 @@
 	},
 /turf/closed/ice_rock/singlePart{
 	dir = 8
-	},
-/area/icy_caves/caves)
-"EE" = (
-/turf/closed/ice/straight{
-	dir = 4
 	},
 /area/icy_caves/caves)
 "EH" = (
@@ -6338,12 +6317,6 @@
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"FD" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/end{
-	dir = 4
-	},
-/area/icy_caves/outpost/outside)
 "FF" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -6611,6 +6584,12 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
+"GW" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd{
+	dir = 8
+	},
+/area/icy_caves/caves)
 "GX" = (
 /turf/open/floor/tile/dark/purple2{
 	dir = 9
@@ -6891,6 +6870,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"Iq" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside/center)
 "Ir" = (
 /turf/closed/ice/thin/junction{
 	dir = 4
@@ -6941,12 +6924,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
-"IF" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/junction{
-	dir = 1
-	},
-/area/icy_caves/caves)
 "IG" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -8024,6 +8001,11 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"Ol" = (
+/turf/closed/ice/straight{
+	dir = 4
+	},
+/area/icy_caves/caves)
 "Om" = (
 /turf/closed/ice/junction{
 	dir = 8
@@ -8675,6 +8657,12 @@
 	dir = 5
 	},
 /area/icy_caves/caves)
+"RO" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/straight{
+	dir = 4
+	},
+/area/icy_caves/caves)
 "RP" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
@@ -9316,6 +9304,10 @@
 /obj/structure/table,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"Vp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside/center)
 "Vq" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -10094,6 +10086,9 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"YZ" = (
+/turf/closed/ice_rock/single,
+/area/icy_caves/outpost/outside/center)
 "Za" = (
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/outside)
@@ -12749,7 +12744,7 @@ ez
 SF
 ZU
 ZU
-ZU
+ez
 ZU
 ez
 SF
@@ -12759,8 +12754,8 @@ oI
 oI
 wW
 pw
+wW
 oI
-pf
 oZ
 oK
 xI
@@ -12916,7 +12911,7 @@ au
 ax
 oI
 oI
-oI
+wW
 oI
 oU
 xI
@@ -13624,13 +13619,13 @@ cD
 ll
 Zl
 ds
-dF
+Ea
 Ij
 jd
 jd
 Ea
 He
-BZ
+cX
 dF
 Ae
 Ae
@@ -14388,7 +14383,7 @@ Zl
 Zl
 Zl
 Zl
-Zl
+dL
 Zl
 Zl
 Zl
@@ -14487,7 +14482,7 @@ SI
 SI
 pY
 vy
-vy
+Al
 vy
 Nu
 Nu
@@ -15111,7 +15106,7 @@ Gw
 Ri
 DY
 DY
-wQ
+gB
 Gw
 lD
 me
@@ -15579,7 +15574,7 @@ DY
 DY
 DY
 Rf
-gB
+pf
 wx
 QJ
 md
@@ -17640,7 +17635,7 @@ my
 my
 Iw
 DD
-DD
+Vp
 DD
 nM
 YQ
@@ -17793,10 +17788,10 @@ my
 my
 my
 my
-my
+JW
 my
 DD
-DD
+Iq
 DD
 nM
 YQ
@@ -17952,7 +17947,7 @@ DD
 my
 my
 DD
-DD
+Vp
 DD
 XH
 YQ
@@ -18104,7 +18099,7 @@ ND
 ND
 ND
 ND
-DD
+Vp
 my
 my
 DD
@@ -18263,7 +18258,7 @@ ND
 DD
 my
 my
-DD
+Vp
 DD
 DD
 qz
@@ -18575,7 +18570,7 @@ ND
 DD
 my
 my
-DD
+Vp
 DD
 DD
 qH
@@ -24026,7 +24021,7 @@ VM
 VM
 VM
 VM
-qE
+YZ
 li
 li
 li
@@ -24180,9 +24175,9 @@ VQ
 Sk
 VM
 li
-qE
-qE
-qE
+YZ
+YZ
+YZ
 DD
 DD
 DD
@@ -24808,7 +24803,7 @@ Sq
 Yl
 Yl
 Yl
-EE
+Ol
 bD
 Yf
 Yf
@@ -24964,7 +24959,7 @@ Sq
 Yl
 Yl
 Yl
-EE
+Ol
 Yf
 Yf
 Yf
@@ -25110,17 +25105,17 @@ Ay
 Mr
 ss
 ss
-gU
+GW
 ss
 Ay
-IF
-IF
-hF
-hF
-zO
-zO
-vW
-EE
+DP
+DP
+oF
+oF
+wD
+wD
+RO
+Ol
 Yf
 Yf
 Yf
@@ -25275,7 +25270,7 @@ Sq
 Yl
 Yl
 Yl
-vW
+RO
 Pv
 Yf
 Yf
@@ -25431,7 +25426,7 @@ Yl
 Yl
 Yl
 Yl
-vW
+RO
 Pv
 Yf
 Yf
@@ -25586,8 +25581,8 @@ Yl
 Yl
 Yl
 Yl
-EE
-vW
+Ol
+RO
 Yf
 Yf
 Yf
@@ -25742,7 +25737,7 @@ Yl
 Yl
 Yl
 Yl
-EE
+Ol
 cp
 Yf
 Yf
@@ -25898,8 +25893,8 @@ Yl
 Yl
 Yl
 Yl
-EE
-IF
+Ol
+DP
 Yf
 Yf
 Yf
@@ -26054,8 +26049,8 @@ Yl
 Yl
 Yl
 Yl
-EE
-IF
+Ol
+DP
 Yf
 Yf
 Yf
@@ -26205,13 +26200,13 @@ Yf
 Yl
 Yl
 Yl
-xe
+vJ
 Yl
 Yl
 Yl
-EE
+Ol
 Pv
-IF
+DP
 Yf
 Yf
 Yf
@@ -26365,7 +26360,7 @@ Yl
 Yl
 Yl
 Yl
-EE
+Ol
 Pv
 cp
 Yf
@@ -26520,8 +26515,8 @@ Yl
 Yl
 Yl
 Yl
-EE
-EE
+Ol
+Ol
 Pv
 cp
 Yf
@@ -26676,7 +26671,7 @@ Yl
 Yl
 Yl
 Yl
-EE
+Ol
 Pv
 Yf
 cp
@@ -26832,7 +26827,7 @@ Yl
 Yl
 Yl
 Yf
-EE
+Ol
 Pv
 Yf
 cp
@@ -26987,7 +26982,7 @@ Yl
 Yl
 Yl
 Yl
-EE
+Ol
 Pv
 Yf
 Yf
@@ -27142,8 +27137,8 @@ Yl
 Yl
 Yl
 Yf
-EE
-EE
+Ol
+Ol
 Yf
 Yf
 Yf
@@ -27296,9 +27291,9 @@ Yl
 Yl
 Yl
 Yf
-EE
-EE
-EE
+Ol
+Ol
+Ol
 Yf
 Yf
 Yf
@@ -27451,7 +27446,7 @@ QP
 Yl
 Yl
 Yl
-EE
+Ol
 Pv
 Pv
 Pv
@@ -27606,7 +27601,7 @@ Za
 Yl
 Yl
 Yf
-EE
+Ol
 Pv
 Pv
 Yf
@@ -27760,7 +27755,7 @@ nI
 Gl
 BL
 xM
-EE
+Ol
 Pv
 Pv
 Pv
@@ -28071,7 +28066,7 @@ oP
 AK
 zy
 Sb
-FD
+zE
 cp
 cp
 cp
@@ -29614,7 +29609,7 @@ nf
 nf
 IT
 wa
-uq
+wa
 oP
 oP
 oP
@@ -30222,7 +30217,7 @@ fp
 dk
 on
 IT
-IT
+td
 IT
 kx
 lo
@@ -30230,7 +30225,7 @@ lo
 IT
 ka
 hP
-QW
+Kt
 yk
 IT
 IT
@@ -31019,7 +31014,7 @@ oP
 oP
 oP
 nI
-oP
+sT
 oP
 wa
 sT


### PR DESCRIPTION
## About The Pull Request

**NEW PR: past one was too old and gave errors that i couldn't fix. thankfully they are fixed now**

I have been getting some dm's to bring back my icy caves edit, so here it is with fixes and some changes.

## Why It's Good For The Game

Swaps around Crash disk locations, move some stupid silo spots in Crash and changes them up to make it a bit more challenging for marines as they dominate this map whilst not giving Xenos free handouts either. LZ2 is redone sorta. Lz1 has been tinkered with and northwest caves have a new area, 

## Changelog
:cl:
balance: LZ2 semi redone to make it more appealing for marines
balance: some LZ1 changes
balance: moved crash disk locations
balance: removed some silos like that one in the nuke disk area and replaced them elsewhere
balance: caves have been fully pre wedded as they should
add: new area northeast of caves transit station (not pre wedded)

/:cl:

**Updated pictures**

(1)
![image](https://user-images.githubusercontent.com/64131993/148223147-f4ee20f1-2f33-4b8f-b515-fadacc446414.png)


(2)
![image](https://user-images.githubusercontent.com/64131993/149647666-f0db1f9e-ebe8-420c-88ec-754d18c164ce.png)


(3)
![image](https://user-images.githubusercontent.com/64131993/149647640-712bbaee-0376-4c9b-89a7-e346e3a49d2d.png)


(4)
![image](https://user-images.githubusercontent.com/64131993/149647609-b2081493-50fb-4001-bbc2-e1e3fcb26e31.png)

(5)
![image](https://user-images.githubusercontent.com/64131993/149647623-e6a6004a-916c-46f3-9fd1-02ac64621c99.png)

