### PR TITLE
Overlay on Suit Toggle Button when Turning On and Off Suit light

### DIFF
--- a/code/datums/actions/item_action.dm
+++ b/code/datums/actions/item_action.dm
@@ -49,11 +49,6 @@
 	name = "Toggle [target]"
 	button.name = name
 
-/datum/action/item_action/toggle/suit_toggle/New(Target)
-	. = ..()
-	name = "Toggle [target]"
-	button.name = name
-
 /datum/action/item_action/toggle/suit_toggle/update_button_icon()
 	. = ..()
 	if(!holder_item.light_on)

--- a/code/datums/actions/item_action.dm
+++ b/code/datums/actions/item_action.dm
@@ -49,7 +49,12 @@
 	name = "Toggle [target]"
 	button.name = name
 
-/datum/action/item_action/toggle/update_button_icon()
+/datum/action/item_action/toggle/suit_toggle/New(Target)
+	. = ..()
+	name = "Toggle [target]"
+	button.name = name
+
+/datum/action/item_action/toggle/suit_toggle/update_button_icon()
 	. = ..()
 	if(!holder_item.light_on)
 		return

--- a/code/datums/actions/item_action.dm
+++ b/code/datums/actions/item_action.dm
@@ -49,6 +49,16 @@
 	name = "Toggle [target]"
 	button.name = name
 
+/datum/action/item_action/toggle/suit_toggle/New(Target)
+	. = ..()
+	name = "Toggle [target]"
+	button.name = name
+
+/datum/action/item_action/toggle/suit_toggle/update_button_icon()
+	. = ..()
+	if(holder_item.light_on)
+		button.overlays += image('icons/Marine/marine-weapons.dmi', src, "active")
+
 /datum/action/item_action/toggle/motion_detector/action_activate()
 	. = ..()
 	update_button_icon()

--- a/code/datums/actions/item_action.dm
+++ b/code/datums/actions/item_action.dm
@@ -49,15 +49,11 @@
 	name = "Toggle [target]"
 	button.name = name
 
-/datum/action/item_action/toggle/suit_toggle/New(Target)
+/datum/action/item_action/toggle/update_button_icon()
 	. = ..()
-	name = "Toggle [target]"
-	button.name = name
-
-/datum/action/item_action/toggle/suit_toggle/update_button_icon()
-	. = ..()
-	if(holder_item.light_on)
-		button.overlays += image('icons/Marine/marine-weapons.dmi', src, "active")
+	if(!holder_item.light_on)
+		return
+	button.overlays += image('icons/Marine/marine-weapons.dmi', src, "active")
 
 /datum/action/item_action/toggle/motion_detector/action_activate()
 	. = ..()

--- a/code/modules/clothing/modular_armor/modular.dm
+++ b/code/modules/clothing/modular_armor/modular.dm
@@ -40,7 +40,7 @@
 	permeability_coefficient = 1
 	gas_transfer_coefficient = 1
 
-	actions_types = list(/datum/action/item_action/toggle)
+	actions_types = list(/datum/action/item_action/toggle/suit_toggle)
 
 	attachments_by_slot = list(
 		ATTACHMENT_SLOT_CHESTPLATE,

--- a/code/modules/clothing/modular_armor/modular.dm
+++ b/code/modules/clothing/modular_armor/modular.dm
@@ -40,7 +40,7 @@
 	permeability_coefficient = 1
 	gas_transfer_coefficient = 1
 
-	actions_types = list(/datum/action/item_action/toggle/suit_toggle)
+	actions_types = list(/datum/action/item_action/toggle)
 
 	attachments_by_slot = list(
 		ATTACHMENT_SLOT_CHESTPLATE,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. Thank you Bravemole and Hyper for helping me through my insanity and fumbling check of 2 hours for essentially adding 6 lines of code.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Sometimes, turning on lights doesn't tell you that your lights are on. The reason for this is because the action icon or the mob's armor sprites doesn't indicate anything about it.

Long time ago before Jaegar, all armors have shoulder lights to indicate whether you have lights on or not. This is a design from CM SS13 that we inherited but lost due to Jaegar. 

This is why marines tell smartgunners or marines with imagers to turn on their lights. There is almost no way of telling whether your, that is the smargunner or imager players, lights are on or not. The surest way is to turn off NVG or imager, but (1) you can't do that in the middle of combat and (2) you forget that suit light is off after you have died, revived, and put on armor that doesn't have lights on.

We cannot add shoulder lights on armor sprites since Kuro says no shoulder lights on Jaegar, so Hyper suggests the idea of putting an overlay on the toggle action to indicate whether the suit light is on.

Again, thank you Bravemole and Hyper for helping me through my insanity and fumbling check of 2 hours for essentially adding 10 lines of code. I gave part of my soul on this.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: overlay on suit toggle button when turning on and off suit light
qol: now you know if your armor light is on or not
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
