### PR TITLE
Add specialist armor to requisition

### DIFF
--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -324,7 +324,7 @@
 	name = "\improper M3-T light armor"
 	desc = "A custom set of M3 armor designed for users of long ranged explosive weaponry."
 	icon_state = "demolitionist"
-	soft_armor = list("melee" = 60, "bullet" = 55, "laser" = 45, "energy" = 30, "bomb" = 55, "bio" = 35, "rad" = 15, "fire" = 30, "acid" = 30)
+	soft_armor = list("melee" = 60, "bullet" = 55, "laser" = 45, "energy" = 30, "bomb" = 80, "bio" = 35, "rad" = 15, "fire" = 30, "acid" = 30)
 	slowdown = SLOWDOWN_ARMOR_LIGHT
 	allowed = list(/obj/item/weapon/gun/launcher/rocket)
 

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -602,7 +602,7 @@ ARMOR
 		/obj/item/clothing/suit/storage/marine/M3T,
 		/obj/item/clothing/head/helmet/durag,
 	)
-	cost = 50
+	cost = 30
 
 /datum/supply_packs/armor/sniper
 	name = "Sniper Armor Set"
@@ -610,7 +610,7 @@ ARMOR
 		/obj/item/clothing/suit/storage/marine/sniper,
 		/obj/item/clothing/head/helmet/marine/sniper,
 	)
-	cost = 50
+	cost = 30
 
 /datum/supply_packs/armor/scout
 	name = "Scout Armor Set"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -596,6 +596,37 @@ ARMOR
 	)
 	cost = B17_PRICE
 
+/datum/supply_packs/armor/demolitionist
+	name = "Demolitionist Armor Set"
+	contains = list(
+		/obj/item/clothing/suit/storage/marine/M3T,
+		/obj/item/clothing/head/helmet/durag,
+	)
+	cost = 50
+
+/datum/supply_packs/armor/sniper
+	name = "Sniper Armor Set"
+	contains = list(
+		/obj/item/clothing/suit/storage/marine/sniper,
+		/obj/item/clothing/head/helmet/marine/sniper,
+	)
+	cost = 50
+
+/datum/supply_packs/armor/scout
+	name = "Scout Armor Set"
+	contains = list(
+		/obj/item/clothing/suit/storage/marine/M3S,
+		/obj/item/clothing/head/helmet/marine/scout,
+	)
+	cost = 50
+
+/datum/supply_packs/armor/pyro
+	name = "Pyrotechnician Armor Set"
+	contains = list(
+		/obj/item/clothing/suit/storage/marine/M35,
+		/obj/item/clothing/head/helmet/marine/pyro,
+	)
+	cost = 50
 /datum/supply_packs/armor/scout_cloak
 	name = "Scout Cloak"
 	contains = list(/obj/item/storage/backpack/marine/satchel/scout_cloak/scout)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds 4 missing specialist sets of armor to requisition (Demolitionist, Scout, Sniper, Pyrotechnician), 50 points for Scout and Pyro, 30 points for Demo and Sniper.
![изображение](https://user-images.githubusercontent.com/69199543/149745484-10212d5d-3d21-42ed-ba7d-7c9e644224d4.png)

## Why It's Good For The Game

They look badass (especially Pyro), have some quirks, and people requested to add them back. I dont see a reason not to add them (for a reasonable price), along with B17 and B18.

## Changelog
:cl:
add: added 4 sets of specialist armor to requisition
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
