### PR TITLE
Autolathe Contraband Removal

### DIFF
--- a/code/game/objects/machinery/autolathe_datums.dm
+++ b/code/game/objects/machinery/autolathe_datums.dm
@@ -262,19 +262,16 @@ GLOBAL_LIST_EMPTY(autolathe_categories)
 /datum/autolathe/recipe/electropack
 	name = "electropack"
 	path = /obj/item/electropack
-	hidden = 1
 	category = "Devices and Components"
 
 /datum/autolathe/recipe/welder_industrial
 	name = "industrial blowtorch"
 	path = /obj/item/tool/weldingtool/largetank
-	hidden = 1
 	category = "Tools"
 
 /datum/autolathe/recipe/handcuffs
 	name = "handcuffs"
 	path = /obj/item/restraints/handcuffs
-	hidden = 1
 	category = "General"
 
 

--- a/code/game/objects/machinery/autolathe_datums.dm
+++ b/code/game/objects/machinery/autolathe_datums.dm
@@ -259,22 +259,6 @@ GLOBAL_LIST_EMPTY(autolathe_categories)
 	path = /obj/item/ashtray/glass
 	category = "General"
 
-/datum/autolathe/recipe/electropack
-	name = "electropack"
-	path = /obj/item/electropack
-	category = "Devices and Components"
-
-/datum/autolathe/recipe/welder_industrial
-	name = "industrial blowtorch"
-	path = /obj/item/tool/weldingtool/largetank
-	category = "Tools"
-
-/datum/autolathe/recipe/handcuffs
-	name = "handcuffs"
-	path = /obj/item/restraints/handcuffs
-	category = "General"
-
-
 /datum/autolathe/recipe/camera_assembly
 	name = "camera assembly"
 	path = /obj/item/frame/camera


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes contraband items from autolathe
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Further removal of hacking from commonly used machines. Autolathe is something marines rarely use anyways so having a barrier for the only useful item, the industrial blowtorch, was kinda meaningless anyways.

If requested I will also fully remove handcuffs and electropack since they are both obsolete items
EDIT: The request was to remove ALL items so industrial welder is gone from the game.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Autolathe contraband items removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
