### PR TITLE
Makes it so the plasma pistol can only be fired while wielded if attached

### DIFF
--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -119,6 +119,17 @@
 	to_chat(attacher, span_warning("You cannot attach [src] to [attaching_to] while [attachments_by_slot[ATTACHMENT_SLOT_RAIL]] occupies [src]'s rail slot."))
 	return FALSE
 
+/obj/item/weapon/gun/pistol/plasma_pistol/on_attach(obj/item/attached_to, mob/user)
+	if(!(flags_gun_features & GUN_WIELDED_FIRING_ONLY))
+		flags_gun_features += GUN_WIELDED_FIRING_ONLY
+	. = ..()
+
+/obj/item/weapon/gun/pistol/plasma_pistol/on_detach(obj/item/attached_to, mob/user)
+	if(flags_gun_features & GUN_WIELDED_FIRING_ONLY )
+		flags_gun_features -= GUN_WIELDED_FIRING_ONLY
+	. = ..()
+
+
 /obj/item/weapon/gun/pistol/plasma_pistol/guardsman_pistol
 	name = "\improper Guardsman\'s plasma pistol"
 	desc = "FOR THE EMPEROR!"


### PR DESCRIPTION

## About The Pull Request

Closes #9248

Makes it so the plasma pistol can only be fired while wielded if it's attached to a gun

## Why It's Good For The Game

Apparently this behaviour was inconsistent with other underbarrel attachments.

## Changelog
:cl:
balance: You can't fire the TX-7 one handed while it's being used as an attachment
/:cl: