### PR TITLE
Sentry kit box can only hold ammo and sentries

### DIFF
--- a/code/modules/projectiles/guns/sentries.dm
+++ b/code/modules/projectiles/guns/sentries.dm
@@ -39,6 +39,10 @@
 	max_w_class = 5
 	storage_slots = 6
 	max_storage_space = 16
+	can_hold = list(
+		/obj/item/weapon/gun/sentry,
+		/obj/item/ammo_magazine/sentry,
+	)
 	bypass_w_limit = list(
 		/obj/item/weapon/gun/sentry,
 		/obj/item/ammo_magazine/sentry,


### PR DESCRIPTION
## About The Pull Request

Closes #9252

Restricts the sentry kit box to only be able to hold sentries and it's ammo

## Why It's Good For The Game

Fixes storage creep, unless we're going with the inconsistent=/= unintentional thing again. I did ask and was only met with cold contemptuous discord silence, which more or less implied "Is this guy for real?" 

## Changelog
:cl:
fix: Sentry kit boxes can only hold sentries and their respective ammo now, crushing the horrible meta of being able to carry 5 backpacks by hand, or 5 other objects of large and dubious size.
/:cl: