### PR TITLE
Adds population dependent modular map support

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -32,6 +32,8 @@ SUBSYSTEM_DEF(mapping)
 	var/groundmap_voted = FALSE
 	///If true, non-admin players will not be able to initiate a vote to change shipmap
 	var/shipmap_voted = FALSE
+	//The number of connected clients for the previous round
+	var/last_round_player_count
 
 //dlete dis once #39770 is resolved
 /datum/controller/subsystem/mapping/proc/HACK_LoadMapConfig()
@@ -62,12 +64,20 @@ SUBSYSTEM_DEF(mapping)
 
 	loadWorld()
 	repopulate_sorted_areas()
+	load_last_round_playercount()
 	preloadTemplates()
 	// Add the transit level
 	transit = add_new_zlevel("Transit/Reserved", list(ZTRAIT_RESERVED = TRUE))
 	repopulate_sorted_areas()
 	initialize_reserved_level(transit.z_value)
 	return ..()
+
+//Loads the number of players we had last round, for use in modular mapping
+/datum/controller/subsystem/mapping/proc/load_last_round_playercount()
+	var/json_file = file("data/last_round_player_count.json")
+	if(!fexists(json_file))
+		return
+	last_round_player_count = json_decode(file2text(json_file))
 
 /datum/controller/subsystem/mapping/proc/wipe_reservations(wipe_safety_delay = 100)
 	if(clearing_reserved_turfs || !initialized)			//in either case this is just not needed.
@@ -281,7 +291,7 @@ SUBSYSTEM_DEF(mapping)
 		LAZYINITLIST(modular_templates[M.modular_id])
 		if(M.min_player_num == null || M.max_player_num == null) //maps without an assigned max or min player count are always added to the modular map list
 			modular_templates[M.modular_id] += M
-		else if (TGS_CLIENT_COUNT >= M.min_player_num && TGS_CLIENT_COUNT <= M.max_player_num) //if we exceed the minimum or maximum players numbers for a modular map don't add it to our list of valid modules that can be loaded
+		else if (last_round_player_count >= M.min_player_num && last_round_player_count <= M.max_player_num) //if we exceed the minimum or maximum players numbers for a modular map don't add it to our list of valid modules that can be loaded
 			modular_templates[M.modular_id] += M
 		map_templates[M.type] = M
 

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -32,7 +32,7 @@ SUBSYSTEM_DEF(mapping)
 	var/groundmap_voted = FALSE
 	///If true, non-admin players will not be able to initiate a vote to change shipmap
 	var/shipmap_voted = FALSE
-	//The number of connected clients for the previous round
+	///The number of connected clients for the previous round
 	var/last_round_player_count
 
 //dlete dis once #39770 is resolved

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -283,7 +283,6 @@ SUBSYSTEM_DEF(mapping)
 			modular_templates[M.modular_id] += M
 		else if (TGS_CLIENT_COUNT >= M.min_player_num && TGS_CLIENT_COUNT <= M.max_player_num) //if we exceed the minimum or maximum players numbers for a modular map don't add it to our list of valid modules that can be loaded
 			modular_templates[M.modular_id] += M
-			log_world("[TGS_CLIENT_COUNT]clients are logged in, minimum number is [M.min_player_num] & maximum number is [M.max_player_num] for map [M.name]")
 		map_templates[M.type] = M
 
 /datum/controller/subsystem/mapping/proc/RequestBlockReservation(width, height, z, type = /datum/turf_reservation, turf_type_override)

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -279,7 +279,11 @@ SUBSYSTEM_DEF(mapping)
 		var/datum/map_template/modular/M = new modular_type()
 
 		LAZYINITLIST(modular_templates[M.modular_id])
-		modular_templates[M.modular_id] += M
+		if(M.min_player_num == null || M.max_player_num == null) //maps without an assigned max or min player count are always added to the modular map list
+			modular_templates[M.modular_id] += M
+		else if (TGS_CLIENT_COUNT >= M.min_player_num && TGS_CLIENT_COUNT <= M.max_player_num) //if we exceed the minimum or maximum players numbers for a modular map don't add it to our list of valid modules that can be loaded
+			modular_templates[M.modular_id] += M
+			log_world("[TGS_CLIENT_COUNT]clients are logged in, minimum number is [M.min_player_num] & maximum number is [M.max_player_num] for map [M.name]")
 		map_templates[M.type] = M
 
 /datum/controller/subsystem/mapping/proc/RequestBlockReservation(width, height, z, type = /datum/turf_reservation, turf_type_override)

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -53,6 +53,7 @@ SUBSYSTEM_DEF(persistence)
 /datum/controller/subsystem/persistence/proc/CollectData()
 	save_custom_loadouts_list()
 	save_last_civil_war_round_time()
+	save_player_number()
 	return
 
 ///Loads the last civil war round date
@@ -94,6 +95,11 @@ SUBSYSTEM_DEF(persistence)
 	var/json_file = file("data/custom_loadouts.json")
 	fdel(json_file)
 	WRITE_FILE(json_file, json_encode(custom_loadouts))
+
+/datum/controller/subsystem/persistence/proc/save_player_number()
+	var/json_file = file("data/last_round_player_count.json")
+	fdel(json_file)
+	WRITE_FILE(json_file, json_encode(TGS_CLIENT_COUNT))
 
 ///Save a loadout into the persistence savefile
 /datum/controller/subsystem/persistence/proc/save_loadout(datum/loadout/loadout)

--- a/code/modules/mapping/modular_mapping.dm
+++ b/code/modules/mapping/modular_mapping.dm
@@ -9,8 +9,11 @@
 	var/template_width = 0
 	///Bool for whether we want to to be spawning from the middle or to the topright of the spawner (true is centered)
 	var/keepcentered = FALSE
-	var/min_player_num //minimum player number for a modular to be added to the pool of potential modular map spawns.
-	var/max_player_num //maximum player number for a modular to be added to the pool of potential modular map spawns.
+	//minimum player number for a modular map template to be added to the list of potential modular map spawns.
+	var/min_player_num 
+	//maximum player number for a modular map template to be added to the list of potential modular map spawns.
+	var/max_player_num 
+
 	//FOR MIN AND MAX PLAYER COUNTS TO WORK YOUR MODULAR MAP MUST HAVE BOTH FIELDS, MAPS WITH UNINITIALIZED MIN/MAX VALUES OR WITH JUST ONE OF EITHER VAR WILL ENTER THE MODULAR LIST REGARDLESS OF POP
 
 /datum/map_template/modular/prison

--- a/code/modules/mapping/modular_mapping.dm
+++ b/code/modules/mapping/modular_mapping.dm
@@ -9,6 +9,9 @@
 	var/template_width = 0
 	///Bool for whether we want to to be spawning from the middle or to the topright of the spawner (true is centered)
 	var/keepcentered = FALSE
+	var/min_player_num //minimum player number for a modular to be added to the pool of potential modular map spawns.
+	var/max_player_num //maximum player number for a modular to be added to the pool of potential modular map spawns.
+	//FOR MIN AND MAX PLAYER COUNTS TO WORK YOUR MODULAR MAP MUST HAVE BOTH FIELDS, MAPS WITH UNINITIALIZED MIN/MAX VALUES OR WITH JUST ONE OF EITHER VAR WILL ENTER THE MODULAR LIST REGARDLESS OF POP
 
 /datum/map_template/modular/prison
 	mappath = "_maps/modularmaps/prison"

--- a/code/modules/mapping/modular_mapping.dm
+++ b/code/modules/mapping/modular_mapping.dm
@@ -9,19 +9,11 @@
 	var/template_width = 0
 	///Bool for whether we want to to be spawning from the middle or to the topright of the spawner (true is centered)
 	var/keepcentered = FALSE
-<<<<<<< HEAD
 	//minimum player number for a modular map template to be added to the list of potential modular map spawns.
 	var/min_player_num 
 	//maximum player number for a modular map template to be added to the list of potential modular map spawns.
 	var/max_player_num 
 
-=======
-	var/min_player_num 
-	//minimum player number for a modular map template to be added to the list of potential modular map spawns.
-	var/max_player_num 
-	//maximum player number for a modular map template to be added to the list of potential modular map spawns.
-	
->>>>>>> population-dependent-map-inserts
 	//FOR MIN AND MAX PLAYER COUNTS TO WORK YOUR MODULAR MAP MUST HAVE BOTH FIELDS, MAPS WITH UNINITIALIZED MIN/MAX VALUES OR WITH JUST ONE OF EITHER VAR WILL ENTER THE MODULAR LIST REGARDLESS OF POP
 
 /datum/map_template/modular/prison

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,6 +1,6 @@
 pygit2==1.0.1
 bidict==0.13.1
-Pillow==8.3.2
+Pillow==9.0.0
 
 # changelogs
 PyYaml==5.4


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I've been needing to do this for a bit, essentially allows for mappers to define min and max player values needed for a modular mapping insert to be in "rotation" for a given map.
E.g I could define a LV dome to only show up with a population of between 50 and 100. 

## Why It's Good For The Game

This sort of thing has been needed for quite a while and the potential is fairly limitless. We could theoretically define places in big maps like Chigusa and Magmoor that shrink on lower pop and grow at higher pop, allowing for much more flexible maps.

## Changelog
:cl:
code: Added population dependent mapping insert support.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
