### PR TITLE
Defiler Hemodile and Transvitox gas is no longer transparent.

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -300,17 +300,17 @@
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_NEURO|SMOKE_GASP|SMOKE_COUGH|SMOKE_NEURO_LIGHT //Light neuro smoke doesn't extinguish
 
 /obj/effect/particle_effect/smoke/xeno/hemodile
-	alpha = 40
+	alpha = 255
 	opacity = FALSE
 	smoke_can_spread_through = TRUE
 	color = "#0287A1"
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_HEMODILE|SMOKE_GASP
 
 /obj/effect/particle_effect/smoke/xeno/transvitox
-	alpha = 60
+	alpha = 255
 	opacity = FALSE
 	smoke_can_spread_through = TRUE
-	color = "#C0FF94"
+	color = "#abf775"
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_TRANSVITOX|SMOKE_COUGH
 
 //Toxic smoke when the Defiler successfully uses Defile


### PR DESCRIPTION
## About The Pull Request

Changes Transvitox and hemodile to non transparent.

## Why It's Good For The Game

Makes both now viable for use rather then heavily risk death in a group combat scenario because of its opacity

## Changelog
:cl:
balance: opacity for transvitox and hemodile no longer 60 but 255
/:cl:

1
![image](https://user-images.githubusercontent.com/64131993/149967678-a701911b-2347-4079-8170-c45893594ccf.png)
2
![image](https://user-images.githubusercontent.com/64131993/149967734-063a0ea1-d2d4-40ff-8f38-6e43be233c8b.png)

