### PR TITLE
CIC roles get free HealthMate HUD spawn in backpack

### DIFF
--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -78,6 +78,9 @@ Godspeed, captain! And remember, you are not above the law."})
 	jobtype = /datum/job/terragov/command/captain/rebel
 	ears = /obj/item/radio/headset/mainship/mcom/rebel
 
+/datum/outfit/job/command/captain/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	H.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/health, SLOT_IN_BACKPACK)
 
 /datum/job/terragov/command/captain/after_spawn(mob/living/new_mob, mob/user, latejoin)
 	. = ..()
@@ -266,6 +269,10 @@ You are in charge of logistics and the overwatch system. You are also in line to
 /datum/outfit/job/command/staffofficer/rebel
 	jobtype = /datum/job/terragov/command/staffofficer/rebel
 	ears = /obj/item/radio/headset/mainship/mcom/rebel
+
+/datum/outfit/job/command/staffofficer/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	H.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/health, SLOT_IN_BACKPACK)
 
 //Pilot Officer
 /datum/job/terragov/command/pilot


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

HealthMate HUD for CIC is actually pretty important to see how marines are doing. All good players in CIC have a HealthMate HUD, and when they spawn late, they don't get HealthMate HUD since marines have taken the free HealthMate HUD. In CM, CIC gets free HealthMate HUD, so we should do the same since CIC really needs it.

Also, I'm not spawning it in map since I know marines will raid CIC for them when there are no CIC, so to deal with that, only CIC roles spawn with HealthMate HUD.

I know the powergamers will either give this away for free, that's a given. What is worrisome is deployable SO with free HealthMate HUD, so admins, keep an eye out.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: CIC roles get free HealthMate HUD spawn in backpack
qol: CIC roles get free HealthMate HUD spawn in backpack for better Overwatch
admins: policy regarding planetside SO should get check over in light of SO getting free HealthMate HUD; I forsee gamers using deployable SO more frequent with free HealthMate HUD
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
