### PR TITLE
Fixes quick equip exploit for the revolver toss trick

### DIFF
--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -80,6 +80,10 @@
 		return
 	invisibility = 0
 	playsound(user, thud_sound, 25, 1)
+
+	if(user.get_active_held_item() != src)
+		return
+
 	if(user.get_inactive_held_item())
 		user.visible_message("[user] catches [src] with the same hand!",span_notice(" You catch [src] as it spins in to your hand!"))
 		return


### PR DESCRIPTION
## About The Pull Request

Closes #9317

So there's a 5 frame window where you can use quick equip to quickly put the revolver (while it's invisible for the trick) away into an inventory. This fixes that. 

## Why It's Good For The Game

Less bugs. Unless unintended =/= inconsistent applies here and this revolver trick should be uniquely bugged.

## Changelog
:cl:
fix: The revolver toss trick should no longer bug inventories out if you quick equip it while it's in the air.
/:cl:
