### PR TITLE
Fixes global narrate

### DIFF
--- a/code/modules/admin/fun_verbs.dm
+++ b/code/modules/admin/fun_verbs.dm
@@ -151,7 +151,7 @@
 	if(!check_rights(R_FUN))
 		return
 
-	var/msg = tgui_input_text(usr, "Enter the text you wish to appear to everyone.", "Global Narrate", multiline = TRUE, , encode = FALSE)
+	var/msg = tgui_input_text(usr, "Enter the text you wish to appear to everyone.", "Global Narrate", multiline = TRUE , encode = FALSE)
 
 	if(!msg)
 		return


### PR DESCRIPTION
## About The Pull Request

Closes #9312

A random comma was left over, causing a runtime

## Why It's Good For The Game

Less bugs, unless inconsistent =/= unintentional and this was some insidious grand plan to stop admins from using this verb

## Changelog

:cl:
fix: The Global narrate verb is fixed.
/:cl:

