### PR TITLE
Removes old/no longer needed boiler fire windup.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -270,7 +270,7 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 
 	to_chat(X, span_xenonotice("We begin building up pressure."))
 
-	if(!do_after(X, 2 SECONDS, FALSE, target, BUSY_ICON_DANGER))
+	if(!do_after(X, 0 SECONDS, FALSE, target, BUSY_ICON_DANGER))
 		to_chat(X, span_warning("We decide not to launch."))
 		return fail_activate()
 


### PR DESCRIPTION

## About The Pull Request

Boiler does not need so many restrictions for an ability that has a long cooldown + 2 seconds to deploy, this makes firing instant with a click.

## Why It's Good For The Game

This is no longer needed due to current metas, it also gives boilers quicker play and more use rather then having to cancel 90% of the time right when you are about to finish to flee.



## Changelog
:cl:
balance: bombard windup from 2 to 0
/:cl:


Notes: current winrates as of making this PR 
![image](https://user-images.githubusercontent.com/64131993/150149503-90b59ea9-f5a1-4fd2-a2b8-a70f7a370a02.png)
 Xenos either need a bit of-power creep or marine weaponry needs to be nerfed.