### PR TITLE
hazard signs to help FOB engineers

### DIFF
--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -31511,6 +31511,10 @@
 "cQF" = (
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/research)
+"cRJ" = (
+/obj/structure/sign/safety/hazard,
+/turf/closed/wall/r_wall,
+/area/ice_colony/surface/tcomms)
 "cSg" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -33363,6 +33367,10 @@
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/red2,
 /area/ice_colony/underground/security/armory)
+"mKj" = (
+/obj/structure/sign/safety/hazard,
+/turf/closed/wall/r_wall,
+/area/ice_colony/surface/requesitions)
 "mKW" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -40009,7 +40017,7 @@ adY
 wDM
 wDM
 bVc
-aBi
+cRJ
 fDb
 pBf
 pBf
@@ -40780,7 +40788,7 @@ aon
 qrf
 qrf
 ayq
-aBi
+cRJ
 fDb
 jvm
 xTa
@@ -44361,11 +44369,11 @@ acY
 acY
 acY
 acY
+mKj
 acY
 acY
 acY
-acY
-acY
+mKj
 acY
 acY
 iYJ

--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -39760,7 +39760,7 @@ adY
 aFn
 wDM
 arS
-aBi
+pZF
 fDb
 pBf
 aaR
@@ -40017,7 +40017,7 @@ adY
 wDM
 wDM
 bVc
-pZF
+aBi
 fDb
 pBf
 pBf
@@ -44368,13 +44368,13 @@ acY
 acY
 acY
 acY
+fKZ
 acY
 fKZ
 acY
-acY
-acY
 fKZ
 acY
+fKZ
 acY
 iYJ
 omz
@@ -44871,7 +44871,7 @@ bSw
 aae
 pMK
 acY
-acY
+fKZ
 fKZ
 acY
 acY

--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -31511,10 +31511,6 @@
 "cQF" = (
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/research)
-"cRJ" = (
-/obj/structure/sign/safety/hazard,
-/turf/closed/wall/r_wall,
-/area/ice_colony/surface/tcomms)
 "cSg" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -31993,6 +31989,10 @@
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/ice_colony/exterior/surface/clearing/north)
+"fKZ" = (
+/obj/structure/sign/safety/hazard,
+/turf/closed/wall/r_wall,
+/area/ice_colony/surface/requesitions)
 "fNR" = (
 /obj/effect/turf_underlay/icefloor,
 /obj/effect/landmark/lv624/fog_blocker,
@@ -33367,10 +33367,6 @@
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/red2,
 /area/ice_colony/underground/security/armory)
-"mKj" = (
-/obj/structure/sign/safety/hazard,
-/turf/closed/wall/r_wall,
-/area/ice_colony/surface/requesitions)
 "mKW" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -33996,6 +33992,10 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall,
 /area/ice_colony/underground/hallway/south_east)
+"pZF" = (
+/obj/structure/sign/safety/hazard,
+/turf/closed/wall/r_wall,
+/area/ice_colony/surface/tcomms)
 "pZO" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -40017,7 +40017,7 @@ adY
 wDM
 wDM
 bVc
-cRJ
+pZF
 fDb
 pBf
 pBf
@@ -40788,7 +40788,7 @@ aon
 qrf
 qrf
 ayq
-cRJ
+pZF
 fDb
 jvm
 xTa
@@ -44369,11 +44369,11 @@ acY
 acY
 acY
 acY
-mKj
+fKZ
 acY
 acY
 acY
-mKj
+fKZ
 acY
 acY
 iYJ
@@ -44872,7 +44872,7 @@ aae
 pMK
 acY
 acY
-acY
+fKZ
 acY
 acY
 acY

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -11164,6 +11164,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/engineering)
+"iVB" = (
+/obj/structure/sign/safety/hazard,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/spaceport)
 "iVC" = (
 /obj/structure/table/woodentable,
 /turf/open/floor/wood,
@@ -15577,6 +15581,11 @@
 "odE" = (
 /turf/open/floor/plating,
 /area/lv624/ground/river1)
+"oeJ" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/sign/safety/hazard,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/spaceport2)
 "ofx" = (
 /obj/structure/cargo_container/green{
 	dir = 8
@@ -15994,6 +16003,10 @@
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/armory)
+"oFN" = (
+/obj/structure/sign/safety/hazard,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/quartstorage/outdoors)
 "oGP" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 1
@@ -38588,7 +38601,7 @@ tNU
 vbu
 hiy
 ybc
-yaB
+oeJ
 jro
 iwB
 mOs
@@ -38942,7 +38955,7 @@ vvX
 uoM
 pQz
 ybc
-yaB
+oeJ
 jro
 iwB
 mOs
@@ -57531,7 +57544,7 @@ tbe
 tbe
 tbe
 uYo
-wvT
+iVB
 wjg
 mOs
 mOs
@@ -58062,7 +58075,7 @@ tbe
 kqW
 vvl
 uYo
-wvT
+iVB
 qay
 ylZ
 bdh
@@ -58593,7 +58606,7 @@ sKu
 tbe
 ciE
 uYo
-wvT
+iVB
 rOQ
 ksq
 gCL
@@ -59098,7 +59111,7 @@ hlQ
 pMn
 hkF
 uIV
-dPz
+oFN
 hWp
 toR
 gdJ
@@ -59629,7 +59642,7 @@ hlQ
 pMn
 hkF
 keT
-dPz
+oFN
 hWp
 avj
 wvz

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -10793,6 +10793,10 @@
 	icon_state = "whiteyellowfull"
 	},
 /area/lv624/lazarus/sandtemple)
+"ixE" = (
+/obj/structure/sign/safety/hazard,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/canteen)
 "ixO" = (
 /obj/effect/decal/sandytile,
 /obj/structure/stairs/cornerdark{
@@ -57008,11 +57012,11 @@ pqp
 qyP
 ryY
 iAC
-iAC
+ixE
+wvT
+wvT
+wvT
 bTL
-wvT
-wvT
-wvT
 wvT
 rOQ
 bdh
@@ -58757,7 +58761,7 @@ rYv
 pMn
 hkF
 uIV
-dPz
+wui
 xoN
 mqK
 mqK
@@ -59111,7 +59115,7 @@ hlQ
 pMn
 hkF
 uIV
-wui
+dPz
 hWp
 toR
 gdJ
@@ -59465,7 +59469,7 @@ rYv
 pMn
 hkF
 uIV
-dPz
+wui
 hWp
 csS
 wvz
@@ -59642,7 +59646,7 @@ hlQ
 pMn
 hkF
 keT
-wui
+dPz
 hWp
 avj
 wvz
@@ -59996,7 +60000,7 @@ kwq
 wIK
 mdD
 vXt
-dPz
+wui
 cTW
 kLN
 wvz

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -5298,6 +5298,10 @@
 /obj/machinery/computer/nuke_disk_generator/blue,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple/sideroom)
+"bTL" = (
+/obj/structure/sign/safety/hazard,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/spaceport)
 "bUp" = (
 /obj/effect/landmark/nuke_spawn,
 /obj/structure/cable,
@@ -11164,10 +11168,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/engineering)
-"iVB" = (
-/obj/structure/sign/safety/hazard,
-/turf/closed/wall/r_wall,
-/area/lv624/lazarus/spaceport)
 "iVC" = (
 /obj/structure/table/woodentable,
 /turf/open/floor/wood,
@@ -15578,14 +15578,14 @@
 /obj/item/weapon/gun/revolver/small,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/secure_storage)
-"odE" = (
-/turf/open/floor/plating,
-/area/lv624/ground/river1)
-"oeJ" = (
+"odC" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/sign/safety/hazard,
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/spaceport2)
+"odE" = (
+/turf/open/floor/plating,
+/area/lv624/ground/river1)
 "ofx" = (
 /obj/structure/cargo_container/green{
 	dir = 8
@@ -16003,10 +16003,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/armory)
-"oFN" = (
-/obj/structure/sign/safety/hazard,
-/turf/closed/wall/r_wall,
-/area/lv624/lazarus/quartstorage/outdoors)
 "oGP" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 1
@@ -22968,6 +22964,10 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle1)
+"wui" = (
+/obj/structure/sign/safety/hazard,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/quartstorage/outdoors)
 "wvm" = (
 /obj/machinery/light{
 	dir = 4
@@ -38601,7 +38601,7 @@ tNU
 vbu
 hiy
 ybc
-oeJ
+odC
 jro
 iwB
 mOs
@@ -38955,7 +38955,7 @@ vvX
 uoM
 pQz
 ybc
-oeJ
+odC
 jro
 iwB
 mOs
@@ -57009,7 +57009,7 @@ qyP
 ryY
 iAC
 iAC
-wvT
+bTL
 wvT
 wvT
 wvT
@@ -57544,7 +57544,7 @@ tbe
 tbe
 tbe
 uYo
-iVB
+bTL
 wjg
 mOs
 mOs
@@ -58075,7 +58075,7 @@ tbe
 kqW
 vvl
 uYo
-iVB
+bTL
 qay
 ylZ
 bdh
@@ -58606,7 +58606,7 @@ sKu
 tbe
 ciE
 uYo
-iVB
+bTL
 rOQ
 ksq
 gCL
@@ -59111,7 +59111,7 @@ hlQ
 pMn
 hkF
 uIV
-oFN
+wui
 hWp
 toR
 gdJ
@@ -59642,7 +59642,7 @@ hlQ
 pMn
 hkF
 keT
-oFN
+wui
 hWp
 avj
 wvz

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -46999,6 +46999,10 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar_storage/research)
+"tsM" = (
+/obj/structure/sign/safety/hazard,
+/turf/closed/wall/r_wall/prison,
+/area/prison/hangar/main)
 "ttr" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/prison/bright_clean,
@@ -107153,7 +107157,7 @@ aNH
 vsh
 aXt
 aYL
-aYL
+tsM
 aYL
 aXt
 aXt


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In Big Red, there are big red signs to tell engineers where to put barricades. I put some in Prison Station, Ice Colony, and LV-624.

If you don't see hazard sign, it probably means you don't need to cade that reinforced wall.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Consistency between map is good. Helps with ensuring that one good map practice transfers between other maps.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: hazard signs to help FOB engineers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
