### PR TITLE
Removes gun bloat from marine vendor, moves Martini, Derringer and Leichester to seasonals.

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -257,6 +257,8 @@ SUBSYSTEM_DEF(persistence)
 		/obj/item/ammo_magazine/pistol/vp78 = -1,
 		/obj/item/weapon/gun/pistol/highpower = -1,
 		/obj/item/ammo_magazine/pistol/highpower = -1,
+		/obj/item/weapon/gun/shotgun/double/derringer = -1,
+		/obj/item/ammo_magazine/pistol/derringer = -1,
 		)
 
 /datum/season_datum/weapons/guns/copsandrobbers_seasonal

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -35,7 +35,8 @@ SUBSYSTEM_DEF(persistence)
 		/datum/season_datum/weapons/guns/copsandrobbers_seasonal,
 		/datum/season_datum/weapons/guns/smg_seasonal,
 		/datum/season_datum/weapons/guns/storm_seasonal,
-		/datum/season_datum/weapons/guns/shotgun_seasonal
+		/datum/season_datum/weapons/guns/shotgun_seasonal,
+		/datum/season_datum/weapons/guns/oldandnew_seasonal,
 		)
 	)
 	///The saved list of custom outfits names
@@ -295,5 +296,16 @@ SUBSYSTEM_DEF(persistence)
 	item_list = list(
 		/obj/item/weapon/gun/shotgun/combat = -1,
 		/obj/item/weapon/gun/shotgun/pump/cmb = -1,
+		)
+
+/datum/season_datum/weapons/guns/oldandnew_seasonal
+	name = "Old and New"
+	description = "A aged classic and a new take on a old and tried lever design."
+	item_list = list(
+		/obj/item/weapon/gun/shotgun/double/martini = -1,
+		/obj/item/ammo_magazine/rifle/martini = -1,
+		/obj/item/storage/belt/shotgun/martini = -1,
+		/obj/item/weapon/gun/shotgun/pump/lever/repeater = -1,
+		/obj/item/ammo_magazine/packet/p4570 = -1,
 		)
 

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -19,7 +19,6 @@
 			/obj/item/ammo_magazine/rifle/standard_skirmishrifle = -1,
 			/obj/item/weapon/gun/rifle/tx11 = -1,
 			/obj/item/ammo_magazine/rifle/tx11 = -1,
-			/obj/item/weapon/gun/shotgun/pump/lever/repeater = -1,
 		),
 		"Energy Weapons" = list(
 			/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_rifle = -1,
@@ -44,8 +43,6 @@
 			/obj/item/ammo_magazine/rifle/chamberedrifle = -1,
 			/obj/item/weapon/gun/shotgun/pump/bolt = -1,
 			/obj/item/ammo_magazine/rifle/bolt = -1,
-			/obj/item/weapon/gun/shotgun/double/martini = -1,
-			/obj/item/ammo_magazine/rifle/martini = -1,
 		),
 		"Shotgun" = list(
 			/obj/item/weapon/gun/shotgun/pump/t35 = -1,
@@ -305,7 +302,6 @@
 			/obj/item/ammo_magazine/packet/p10x26mm = 100,
 			/obj/item/ammo_magazine/packet/p10x27mm = 100,
 			/obj/item/ammo_magazine/packet/p492x34mm = 100,
-			/obj/item/ammo_magazine/packet/p4570 = 100,
 			/obj/item/storage/box/visual/magazine = 30,
 			/obj/item/storage/box/visual/grenade = 10,
 		),
@@ -580,7 +576,6 @@
 			/obj/item/storage/box/visual/magazine/compact/standard_assaultrifle/full = 1,
 			/obj/item/storage/box/visual/magazine/compact/standard_carbine/full = 1,
 			/obj/item/storage/box/visual/magazine/compact/standard_skirmishrifle/full = 1,
-			/obj/item/storage/box/visual/magazine/compact/martini/full = 1,
 			/obj/item/storage/box/visual/magazine/compact/tx11/full = 1,
 			/obj/item/storage/box/visual/magazine/compact/lasrifle/marine/full = 1,
 			/obj/item/storage/box/visual/magazine/compact/tx15/flechette/full = 1,
@@ -1135,7 +1130,6 @@
 		"Belts" = list(
 			/obj/item/storage/belt/marine = -1,
 			/obj/item/storage/belt/shotgun = -1,
-			/obj/item/storage/belt/shotgun/martini = -1,
 			/obj/item/storage/belt/grenade = -1,
 			/obj/item/storage/belt/knifepouch = -1,
 			/obj/item/belt_harness/marine = -1,

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -77,8 +77,6 @@
 			/obj/item/ammo_magazine/pistol/vp70 = -1,
 			/obj/item/weapon/gun/pistol/plasma_pistol = -1,
 			/obj/item/ammo_magazine/pistol/plasma_pistol = -1,
-			/obj/item/weapon/gun/shotgun/double/derringer = 10,
-			/obj/item/ammo_magazine/pistol/derringer = 15,
 		),
 		"Specialized" = list(
 			/obj/item/weapon/gun/grenade_launcher/multinade_launcher = -1,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Moves guns that should really be in seasonals over to seasonals-
Martini and Leichester are being moved to a shared seasonal.
Derringer is moved to a pistol seasonal.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Martini, Leichester and Derringer are semi-meme guns that should've been in seasonal in the first place, and they really don't serve any purpose as they're very subpar, I think they'd fit better in seasonals, which would let you balance them to be more gimmicky.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: moved martini, derringer, and leichester repeater to seasonal guns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
