### PR TITLE
Smart Gunner gets T-81; no more T-81 for marines

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -157,6 +157,8 @@ GLOBAL_LIST_INIT(smartgunner_gear_listed_products, list(
 	/obj/item/weapon/gun/rifle/standard_smartrifle = list(CAT_LEDSUP, "T-25 smartrifle", 30 , "white"),
 	/obj/item/ammo_magazine/rifle/standard_smartrifle = list(CAT_LEDSUP, "T-25 smartrifle magazine", 2 , "black"),
 	/obj/item/ammo_magazine/packet/t25 = list(CAT_LEDSUP, "T-25 smartrifle ammo box", 6 , "black"),
+	/obj/item/weapon/gun/rifle/standard_autosniper/sg = list(CAT_LEDSUP, "T-81 Smart Automatic sniper rifle", 30 , "black"),
+	/obj/item/ammo_magazine/rifle/autosniper = list(CAT_LEDSUP, "T-81 Smart Automatic sniper rifle ammo", 3 , "black"), //buy only 5 mags, total up to 120 rounds; choose your shot wisely
 	))
 
 

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1166,6 +1166,7 @@
 	default_ammo_type = /obj/item/ammo_magazine/rifle/autosniper
 	allowed_ammo_types = list(/obj/item/ammo_magazine/rifle/autosniper)
 	attachable_allowed = list(
+		/obj/item/attachable/scope/marine,
 		/obj/item/attachable/autosniperbarrel,
 		/obj/item/attachable/scope/nightvision,
 		/obj/item/attachable/extended_barrel,
@@ -1177,6 +1178,7 @@
 
 	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER|GUN_IFF
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_AUTOMATIC)
+	gun_skill_category = GUN_SKILL_SMARTGUN //Uses SG skill for the penalties.
 	attachable_offset = list("muzzle_x" = 48, "muzzle_y" = 18,"rail_x" = 23, "rail_y" = 23, "under_x" = 38, "under_y" = 16, "stock_x" = 9, "stock_y" = 12)
 	starting_attachment_types = list(
 		/obj/item/attachable/autosniperbarrel,
@@ -1193,6 +1195,15 @@
 	recoil_unwielded = 4
 	aim_slowdown = 1
 	wield_delay = 1.3 SECONDS
+
+/obj/item/weapon/gun/rifle/standard_autosniper/sg // no nvg for u
+	name = "\improper T-81 smart automatic sniper rifle"
+	desc = "The T-81 is the TerraGov Marine Corps's automatic sniper rifle. It is rather well-known for it's night vision scope and IFF ammo, however this one was packed without the former, for cost reasons.. It is mostly used by people who prefer to do more careful shooting than most. Uses 8.6x70mm caseless IFF caliber."
+
+	starting_attachment_types = list(
+		/obj/item/attachable/autosniperbarrel,
+		/obj/item/attachable/scope/marine,
+	)
 
 //-------------------------------------------------------
 //TX-11 Rifle, based on the gamer-11

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1182,7 +1182,7 @@
 	attachable_offset = list("muzzle_x" = 48, "muzzle_y" = 18,"rail_x" = 23, "rail_y" = 23, "under_x" = 38, "under_y" = 16, "stock_x" = 9, "stock_y" = 12)
 	starting_attachment_types = list(
 		/obj/item/attachable/autosniperbarrel,
-		/obj/item/attachable/scope/nightvision,
+		/obj/item/attachable/scope/marine, //if my PR gets merged, then buying T-81 through req provides free T-46 NVG Scope; this line prevents that
 	)
 
 	burst_amount = 0

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -328,6 +328,12 @@ WEAPONS
 	cost = 3
 	available_against_xeno_only = TRUE
 
+/datum/supply_packs/attachments/t81scope
+	name = "T-46 NVG Scope"
+	notes = "Used on T-81s."
+	contains = list(/obj/item/attachable/scope/nightvision)
+	cost = 15
+
 /datum/supply_packs/weapons/antimaterial
 	name = "T-26 Antimaterial rifle kit"
 	contains = list(/obj/item/weapon/gun/rifle/sniper/antimaterial)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bring back #7560.

> sg can buy t-81
> no nvg scope though you gotta buy that seperately for 15 points else it'd be overpowered so i added the crate for it
> oh and t81 can use normal marine scopes for the 1 in 50000 rounds that it'll matter

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

T-81 is very strong. Either we nerf the stats, increase price, or limit the number of it. Currently, #9327 is increasing price.

What way to severely nerf the T-81 than to bring back MJP's PR? It was closed due to sprites being bad.

Time to make smartgunner the IFF marine it deserves to be.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
expansion: Expands sg content with new gun
balance: t-81 can use normal marine scopes, and sgs can buy t-81s without nvg scopes in their thing instead of t-29s or smartrifles
balance: marines cannot use T-81 anymore; be smartgunner
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
