### PR TITLE
T-26 Antimaterial Sniper Rifle added to smartgunner; also, T-25 Smart assault rifle name change

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -157,8 +157,8 @@ GLOBAL_LIST_INIT(smartgunner_gear_listed_products, list(
 	/obj/item/weapon/gun/rifle/standard_smartrifle = list(CAT_LEDSUP, "T-25 Smart assault rifle", 30 , "white"),
 	/obj/item/ammo_magazine/rifle/standard_smartrifle = list(CAT_LEDSUP, "T-25 Smart assault rifle magazine", 2 , "black"),
 	/obj/item/ammo_magazine/packet/t25 = list(CAT_LEDSUP, "T-25 Smart assault rifle ammo box", 6 , "black"),
-	/obj/item/weapon/gun/rifle/sniper/antimaterial  = list(CAT_LEDSUP, "T-26 Antimaterial sniper rifle", 30 , "black"),
-	/obj/item/ammo_magazine/sniper = list(CAT_LEDSUP, "T-26 Antimaterial sniper rifle ammo", 5 , "black"), //T-26 smartgunner will get 6 mags, a total of 90 rounds
+	/obj/item/weapon/gun/rifle/sniper/antimaterial  = list(CAT_LEDSUP, "T-26 Antimaterial sniper rifle", 29 , "black"),
+	/obj/item/ammo_magazine/sniper = list(CAT_LEDSUP, "T-26 Antimaterial sniper rifle ammo", 4 , "black"), //T-26 smartgunner will get 5 mags, a total of 75 rounds
 	))
 
 

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -152,11 +152,13 @@ GLOBAL_LIST_INIT(leader_gear_listed_products, list(
 
 GLOBAL_LIST_INIT(smartgunner_gear_listed_products, list(
 	/obj/item/clothing/glasses/night/m56_goggles = list(CAT_ESS, "M26 head mounted sight", 0, "white"),
-	/obj/item/weapon/gun/rifle/standard_smartmachinegun = list(CAT_LEDSUP, "T-29 Smartmachinegun", 29 , "white"), //If a smartgunner buys T-29, then they will have 16 points to purchase 4 T-29 drums
-	/obj/item/ammo_magazine/standard_smartmachinegun = list(CAT_LEDSUP, "T-29 Smartmachinegun ammo", 4 , "black"),
-	/obj/item/weapon/gun/rifle/standard_smartrifle = list(CAT_LEDSUP, "T-25 smartrifle", 30 , "white"),
-	/obj/item/ammo_magazine/rifle/standard_smartrifle = list(CAT_LEDSUP, "T-25 smartrifle magazine", 2 , "black"),
-	/obj/item/ammo_magazine/packet/t25 = list(CAT_LEDSUP, "T-25 smartrifle ammo box", 6 , "black"),
+	/obj/item/weapon/gun/rifle/standard_smartmachinegun = list(CAT_LEDSUP, "T-29 Smart machinegun", 29 , "white"), //If a smartgunner buys T-29, then they will have 16 points to purchase 4 T-29 drums
+	/obj/item/ammo_magazine/standard_smartmachinegun = list(CAT_LEDSUP, "T-29 Smart machinegun ammo", 4 , "black"),
+	/obj/item/weapon/gun/rifle/standard_smartrifle = list(CAT_LEDSUP, "T-25 Smart assault rifle", 30 , "white"),
+	/obj/item/ammo_magazine/rifle/standard_smartrifle = list(CAT_LEDSUP, "T-25 Smart assault rifle magazine", 2 , "black"),
+	/obj/item/ammo_magazine/packet/t25 = list(CAT_LEDSUP, "T-25 Smart assault rifle ammo box", 6 , "black"),
+	/obj/item/weapon/gun/rifle/sniper/antimaterial  = list(CAT_LEDSUP, "T-26 Antimaterial sniper rifle", 30 , "black"),
+	/obj/item/ammo_magazine/sniper = list(CAT_LEDSUP, "T-26 Antimaterial sniper rifle ammo", 5 , "black"), //T-26 smartgunner will get 6 mags, a total of 90 rounds
 	))
 
 

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -157,8 +157,8 @@ GLOBAL_LIST_INIT(smartgunner_gear_listed_products, list(
 	/obj/item/weapon/gun/rifle/standard_smartrifle = list(CAT_LEDSUP, "T-25 Smart assault rifle", 30 , "white"),
 	/obj/item/ammo_magazine/rifle/standard_smartrifle = list(CAT_LEDSUP, "T-25 Smart assault rifle magazine", 2 , "black"),
 	/obj/item/ammo_magazine/packet/t25 = list(CAT_LEDSUP, "T-25 Smart assault rifle ammo box", 6 , "black"),
-	/obj/item/weapon/gun/rifle/sniper/antimaterial  = list(CAT_LEDSUP, "T-26 Antimaterial sniper rifle", 29 , "black"),
-	/obj/item/ammo_magazine/sniper = list(CAT_LEDSUP, "T-26 Antimaterial sniper rifle ammo", 4 , "black"), //T-26 smartgunner will get 5 mags, a total of 75 rounds
+	/obj/item/weapon/gun/rifle/sniper/antimaterial  = list(CAT_LEDSUP, "T-26 Antimaterial rifle", 29 , "black"),
+	/obj/item/ammo_magazine/sniper = list(CAT_LEDSUP, "T-26 Antimaterial rifle ammo", 4 , "black"), //T-26 smartgunner will get 5 mags, a total of 75 rounds
 	))
 
 

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -862,7 +862,7 @@
 
 /obj/item/storage/box/visual/magazine/compact/standard_smartrifle
 	name = "T-25 magazine box"
-	desc = "A box specifically designed to hold a large amount of T-25 smartgun magazines."
+	desc = "A box specifically designed to hold a large amount of T-25 smart assault rifle magazines."
 	storage_slots = 30
 	closed_overlay = "mag_box_small_overlay_t25"
 	can_hold = list(

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -942,6 +942,8 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/bullet/sniper/antimaterial
 	name = "antimaterial bullet"
+	hud_state = "sniper"
+	hud_state_empty = "sniper_empty"
 	penetration = 40
 	sundering = 5
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -937,6 +937,11 @@ datum/ammo/bullet/revolver/tp44
 	max_range = 40
 	scatter = -20
 	damage = 80
+	penetration = 60
+	sundering = 15
+
+/datum/ammo/bullet/sniper/antimaterial
+	name = "antimaterial bullet"
 	penetration = 40
 	sundering = 5
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -937,8 +937,8 @@ datum/ammo/bullet/revolver/tp44
 	max_range = 40
 	scatter = -20
 	damage = 80
-	penetration = 60
-	sundering = 15
+	penetration = 40
+	sundering = 5
 
 /datum/ammo/bullet/sniper/incendiary
 	name = "incendiary sniper bullet"

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -997,7 +997,7 @@
 // T-25 Smartrifle
 
 /obj/item/weapon/gun/rifle/standard_smartrifle
-	name = "\improper T-25 smartrifle"
+	name = "\improper T-25 Smart assault rifle"
 	desc = "The T-25 is the TGMC's current standard IFF-capable rifle. It's known for its ability to lay down quick fire support very well. Requires special training and it cannot turn off IFF. It uses 10x26mm ammunition."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "t25"

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -24,7 +24,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 //Pow! Headshot
 
 /obj/item/weapon/gun/rifle/sniper/antimaterial
-	name = "\improper T-26 Antimaterial sniper rifle"
+	name = "\improper T-26 Antimaterial rifle"
 	desc = "The T-26 is an IFF capable sniper rifle which is mostly used by long range marksmen and smartgunner who excellence ammo management. It excels in long-range combat situations and support sniping. It has a laser designator installed, and the scope itself has IFF integrated into it. Uses specialized 10x28 caseless rounds made to work with the guns odd IFF-scope system.  \nIt has an integrated Target Marker and a Laser Targeting system.\n\"Peace Through Superior Firepower\"."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "t26"

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -24,8 +24,8 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 //Pow! Headshot
 
 /obj/item/weapon/gun/rifle/sniper/antimaterial
-	name = "\improper T-26 scoped rifle"
-	desc = "The T-26 is an IFF capable sniper rifle which is mostly used by long range marksmen. It excels in long-range combat situations and support sniping. It has a laser designator installed, and the scope itself has IFF integrated into it. Uses specialized 10x28 caseless rounds made to work with the guns odd IFF-scope system.  \nIt has an integrated Target Marker and a Laser Targeting system.\n\"Peace Through Superior Firepower\"."
+	name = "\improper T-26 Antimaterial sniper rifle"
+	desc = "The T-26 is an IFF capable sniper rifle which is mostly used by long range marksmen and smartgunner who excellence ammo management. It excels in long-range combat situations and support sniping. It has a laser designator installed, and the scope itself has IFF integrated into it. Uses specialized 10x28 caseless rounds made to work with the guns odd IFF-scope system.  \nIt has an integrated Target Marker and a Laser Targeting system.\n\"Peace Through Superior Firepower\"."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "t26"
 	item_state = "t26"
@@ -55,6 +55,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 		/obj/item/attachable/shoulder_mount,
 	)
 	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER|GUN_IFF
+	gun_skill_category = GUN_SKILL_SMARTGUN //Uses SG skill for the penalties.
 	starting_attachment_types = list(/obj/item/attachable/scope/antimaterial, /obj/item/attachable/sniperbarrel)
 
 	fire_delay = 2.5 SECONDS

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -9,7 +9,7 @@
 	icon_state = "t26"
 	w_class = WEIGHT_CLASS_NORMAL
 	max_rounds = 15
-	default_ammo = /datum/ammo/bullet/sniper
+	default_ammo = /datum/ammo/bullet/sniper/antimaterial
 	reload_delay = 3
 	icon_state_mini = "mag_sniper"
 

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -328,18 +328,6 @@ WEAPONS
 	cost = 3
 	available_against_xeno_only = TRUE
 
-/datum/supply_packs/weapons/antimaterial
-	name = "T-26 Antimaterial rifle kit"
-	contains = list(/obj/item/weapon/gun/rifle/sniper/antimaterial)
-	cost = 75
-	available_against_xeno_only = TRUE
-
-/datum/supply_packs/weapons/antimaterial_ammo
-	name = "T-26 AMR magazine"
-	contains = list(/obj/item/ammo_magazine/sniper)
-	cost = 5
-	available_against_xeno_only = TRUE
-
 /datum/supply_packs/weapons/specminigun
 	name = "MIC-A7 Vindicator Minigun"
 	contains = list(/obj/item/weapon/gun/minigun)
@@ -366,27 +354,39 @@ WEAPONS
 	cost = 7
 
 /datum/supply_packs/weapons/smartgun
-	name = "T-29 Smart Machinegun"
+	name = "T-29 Smart machinegun"
 	contains = list(/obj/item/weapon/gun/rifle/standard_smartmachinegun)
 	cost = 40
 
 /datum/supply_packs/weapons/smartgun_ammo
-	name = "T-29 smartmachinegun ammo"
+	name = "T-29 Smart machinegun ammo"
 	contains = list(/obj/item/ammo_magazine/standard_smartmachinegun)
 	cost = 5
 
+/datum/supply_packs/weapons/antimaterial
+	name = "T-26 Antimaterial sniper rifle kit"
+	contains = list(/obj/item/weapon/gun/rifle/sniper/antimaterial)
+	cost = 40
+	available_against_xeno_only = TRUE
+
+/datum/supply_packs/weapons/antimaterial_ammo
+	name = "T-26 Antimaterial sniper rifle magazine"
+	contains = list(/obj/item/ammo_magazine/sniper)
+	cost = 5
+	available_against_xeno_only = TRUE
+
 /datum/supply_packs/weapons/smartrifle
-	name = "T-25 Smart Rifle"
+	name = "T-25 Smart assault rifle"
 	contains = list(/obj/item/weapon/gun/rifle/standard_smartrifle)
 	cost = 40
 
 /datum/supply_packs/weapons/smartrifle_ammo
-	name = "T-25 smartrifle magazine"
+	name = "T-25 Smart assault rifle magazine"
 	contains = list(/obj/item/ammo_magazine/rifle/standard_smartrifle)
 	cost = 2
 
 /datum/supply_packs/weapons/smartrifle_pack
-	name = "T-25 smartrifle ammo box"
+	name = "T-25 Smart assault rifle ammo box"
 	notes = "Contains a box with 200 rounds for a T-25 (MAGAZINES SOLD SEPERATELY)"
 	contains = list(/obj/item/ammo_magazine/packet/t25)
 	cost = 4

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -364,13 +364,13 @@ WEAPONS
 	cost = 5
 
 /datum/supply_packs/weapons/antimaterial
-	name = "T-26 Antimaterial sniper rifle kit"
+	name = "T-26 Antimaterial rifle kit"
 	contains = list(/obj/item/weapon/gun/rifle/sniper/antimaterial)
 	cost = 40
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/antimaterial_ammo
-	name = "T-26 Antimaterial sniper rifle magazine"
+	name = "T-26 Antimaterial rifle magazine"
 	contains = list(/obj/item/ammo_magazine/sniper)
 	cost = 5
 	available_against_xeno_only = TRUE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The T-26 Antimaterial Sniper Rifle found a home in the smartgunner family. It has gun_skill_category = GUN_SKILL_SMARTGUN, so only smartgunner can use it.

T-26 is the most expensive out of all the smartgunner weapon so far. It spawns with 90 total rounds, so you have to make your shot count.

Since we have two rifles in smartgunner vendor, give the adjective assault to T-25 Smart assault rifle. Yeah, it's an assault rifle.

Bravemole approves. MJP, better luck next time.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This weapon belongs to marines, and marines barely use it. It was collecting web and dust in req, so it is time to give this baby a go.

Bravemole approves of putting this in smartgunner.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: T-26 Antimaterial Sniper Rifle added to smartgunner
expansion: T-25 smart rifle is now called T-25 smart assault rifle
balance: Smartgunners have new weapon!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
