### PR TITLE
Plasma Cutter Balance: Synthetic Edition

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -5614,8 +5614,6 @@
 /area/mainship/squads/req)
 "sT" = (
 /obj/structure/rack,
-/obj/item/tool/pickaxe/plasmacutter,
-/obj/item/tool/pickaxe/plasmacutter,
 /obj/item/storage/belt/utility/full,
 /obj/item/storage/belt/utility/full,
 /obj/item/tool/weldpack,

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -14931,11 +14931,9 @@
 /area/mainship/command/self_destruct)
 "TO" = (
 /obj/structure/rack,
-/obj/item/tool/pickaxe/plasmacutter,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/tool/pickaxe/plasmacutter,
 /obj/item/storage/belt/utility/full,
 /obj/item/storage/belt/utility/full,
 /obj/item/tool/weldpack,

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -1874,7 +1874,6 @@
 /area/sulaco/medbay/cmo)
 "ahS" = (
 /obj/structure/table/mainship,
-/obj/item/tool/pickaxe/plasmacutter,
 /obj/item/cell/high,
 /obj/item/cell/high,
 /obj/item/clothing/glasses/welding,

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -10575,7 +10575,6 @@
 /area/mainship/hull/port_hull)
 "gas" = (
 /obj/structure/table/mainship,
-/obj/item/tool/pickaxe/plasmacutter,
 /obj/item/cell/high,
 /obj/item/cell/high,
 /obj/item/clothing/glasses/welding,

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -744,6 +744,7 @@
 		/obj/item/reagent_containers/hypospray/advanced/oxycodone,
 		/obj/item/tweezers,
 		/obj/item/tool/solderingtool,
+		/obj/item/tool/pickaxe/plasmacutter,
 	)
 
 /obj/effect/essentials_set/white_dress


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

No more free plasma cutter in req. You either get it as a synthetic or as an engineer.

I'm sorry, engineer players. This is to make it easier on you when MJP's engineers rework come in.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Marines can clear resin walls with grenades, plasma cutter, melee weapons, mortar, CAS, and railgun. The last three are null when marines push caves, so this leaves grenades, plasma cutter, and melee weapons as the best option to clear resin walls.

Maybe I can give CSE plasma cutter while we are at it. CSE is practically SL of engineers.

I will make concessions in light of this PR. If maintainers allow, I can make plasma cutters cheap.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Remove free plasma cutters from req in preparation of MJP's rework; it must be done so that engineer players can adapt NOW than later.
add: Synthetic has plasma cutter. Find it in vendor.
balance: Remove free plasma cutters from req
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
