### PR TITLE
fixes the dumb overlapping vent on lv fitness dome

### DIFF
--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -19340,14 +19340,6 @@
 /obj/machinery/floodlight/colony,
 /turf/open/floor,
 /area/lv624/ground/river2)
-"sMc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 1
-	},
-/turf/open/floor/tile/purple/whitepurplecorner{
-	dir = 4
-	},
-/area/lv624/lazarus/fitness)
 "sNh" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
@@ -21713,6 +21705,14 @@
 /obj/structure/jungle/vines,
 /turf/open/ground/grass/grass2,
 /area/lv624/ground/jungle3)
+"voV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 1
+	},
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
 "voZ" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirt,
@@ -48916,7 +48916,7 @@ xJa
 iEv
 kRJ
 jsN
-sMc
+voV
 wgH
 wgH
 wgH

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -3719,6 +3719,14 @@
 /obj/structure/flora/ausbushes/palebush,
 /turf/open/ground/river,
 /area/lv624/ground/river3)
+"bdv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 1
+	},
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
 "bdC" = (
 /obj/item/tool/shovel,
 /turf/open/floor/tile/red/yellowfull,
@@ -21705,14 +21713,6 @@
 /obj/structure/jungle/vines,
 /turf/open/ground/grass/grass2,
 /area/lv624/ground/jungle3)
-"voV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 1
-	},
-/turf/open/floor/tile/purple/whitepurplecorner{
-	dir = 4
-	},
-/area/lv624/lazarus/fitness)
 "voZ" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirt,
@@ -48916,7 +48916,7 @@ xJa
 iEv
 kRJ
 jsN
-voV
+bdv
 wgH
 wgH
 wgH

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -11499,12 +11499,9 @@
 /turf/closed/wall,
 /area/lv624/lazarus/main_hall)
 "jsN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
 /turf/open/floor/tile/purple/whitepurplecorner{
 	dir = 4
@@ -11921,6 +11918,9 @@
 "jQr" = (
 /obj/structure/window/framed/colony,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/fitness)
 "jQy" = (
@@ -19340,6 +19340,14 @@
 /obj/machinery/floodlight/colony,
 /turf/open/floor,
 /area/lv624/ground/river2)
+"sMc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 1
+	},
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
 "sNh" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
@@ -48908,7 +48916,7 @@ xJa
 iEv
 kRJ
 jsN
-wgH
+sMc
 wgH
 wgH
 wgH


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

BEFORE:
![image](https://user-images.githubusercontent.com/52432736/150734317-ea0f86b7-2a32-40b4-96ea-fb903153fb5e.png)

AFTER:
![image](https://user-images.githubusercontent.com/52432736/150734287-2742fe00-6159-4e9c-917c-883468f5d4ea.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

you can go through this area of the vents now without being forced out
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Fixed vent overlap in LV624 Fitness Dome
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
