### PR TITLE
Swaps Prae and Defiler Pheromone levels, gives primodal defiler strength 5 pheromones.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
@@ -58,7 +58,7 @@
 	)
 
 	// *** Pheromones *** //
-	aura_strength = 1.7 //Defilers aura begins at 1.7 and ends at 2.6. It's .1 better than a carrier at ancient.
+	aura_strength = 3 //Defilers aura begins at 3 and ends at 4.5
 	aura_allowed = list("frenzy", "warding", "recovery")
 
 /datum/xeno_caste/defiler/young
@@ -89,7 +89,7 @@
 	soft_armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 35, "rad" = 35, "fire" = 30, "acid" = 35)
 
 	// *** Pheromones *** //
-	aura_strength = 2 //Defilers aura begins at 1.7 and ends at 2.6. It's .1 better than a carrier at ancient.
+	aura_strength = 3.5
 
 /datum/xeno_caste/defiler/elder
 	upgrade_name = "Elder"
@@ -117,7 +117,7 @@
 	soft_armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 35, "bomb" = XENO_BOMB_RESIST_0, "bio" = 38, "rad" = 38, "fire" = 35, "acid" = 38)
 
 		// *** Pheromones *** //
-	aura_strength = 2.1 //Defilers aura begins at 1.7 and ends at 2.6. It's .1 better than a carrier at ancient.
+	aura_strength = 4
 
 /datum/xeno_caste/defiler/ancient
 	upgrade_name = "Ancient"
@@ -145,7 +145,7 @@
 	soft_armor = list("melee" = 45, "bullet" = 45, "laser" = 45, "energy" = 40, "bomb" = XENO_BOMB_RESIST_0, "bio" = 40, "rad" = 40, "fire" = 40, "acid" = 40)
 
 	// *** Pheromones *** //
-	aura_strength = 2.6 //Defilers aura begins at 1.7 and ends at 2.6. It's .1 better than a carrier at ancient.
+	aura_strength = 4.5
 
 
 /datum/xeno_caste/defiler/primordial
@@ -174,7 +174,7 @@
 	soft_armor = list("melee" = 45, "bullet" = 45, "laser" = 45, "energy" = 40, "bomb" = XENO_BOMB_RESIST_0, "bio" = 40, "rad" = 40, "fire" = 40, "acid" = 40)
 
 	// *** Pheromones *** //
-	aura_strength = 2.6 //Defilers aura begins at 1.7 and ends at 2.6. It's .1 better than a carrier at ancient.
+	aura_strength = 5
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -43,7 +43,7 @@
 	acid_spray_structure_damage = 45
 
 	// *** Pheromones *** //
-	aura_strength = 3 //Praetorian's aura starts strong. They are the Queen's right hand. Climbs by 1 to 4.5
+	aura_strength = 1.7 //Praetorians aura starts at 1.7 and ends at 2.6. Leaving them slightly better than average.
 	aura_allowed = list("frenzy", "warding", "recovery")
 
 	// *** Abilities *** //
@@ -91,7 +91,7 @@
 	acid_spray_structure_damage = 53
 
 	// *** Pheromones *** //
-	aura_strength = 3.5
+	aura_strength = 2
 
 /datum/xeno_caste/praetorian/elder
 	upgrade_name = "Elder"
@@ -125,7 +125,7 @@
 	acid_spray_structure_damage = 61
 
 	// *** Pheromones *** //
-	aura_strength = 4
+	aura_strength = 2.4
 
 /datum/xeno_caste/praetorian/ancient
 	upgrade_name = "Ancient"
@@ -160,4 +160,4 @@
 	acid_spray_structure_damage = 69
 
 	// *** Pheromones *** //
-	aura_strength = 4.5
+	aura_strength = 2.6


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Aswell has primodial defiler has strength 5 pheromones, so it isn't the exact same as ancient, which I think is fine once priomidals come out (if ever)
Elder prae gets 2.4 instead of 2.6, though.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prae's toolbox is too wide and it doesn't sacrifice in any of the places it has a toolkit, it's aurastrength being the best of the T3s is a longterm CM holdover, it could stand to lose something in comparison to other T3s, and defiler needs some other utility past neurogassing people constantly.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Prae and Defiler have swapped pheromone levels, Prae caps at 2.6, Defiler at 4.5.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
