### PR TITLE
TX-8 Scout Rifle impact ammo rebalance

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -575,11 +575,11 @@ datum/ammo/bullet/revolver/tp44
 	hud_state = "hivelo_impact"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	damage = 25
-	penetration = 45
+	penetration = 20
 	sundering = 5
 
-/datum/ammo/bullet/rifle/tx8/impact/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, max_range = 20, stagger = 2, slowdown = 1, knockback = 1, shake = 0)
+/datum/ammo/bullet/rifle/tx8//on_hit_mob(mob/M, obj/projectile/P)
+	staggerstun(M, P, max_range = 20, slowdown = 1, knockback = 1, shake = 0)
 
 /datum/ammo/bullet/rifle/mpi_km
 	name = "crude heavy rifle bullet"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -578,7 +578,7 @@ datum/ammo/bullet/revolver/tp44
 	penetration = 30
 	sundering = 5
 
-/datum/ammo/bullet/rifle/tx8//on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/bullet/rifle/tx8/impact/on_hit_mob(mob/M, obj/projectile/P)
 	staggerstun(M, P, max_range = 20, slowdown = 1, shake = 0)
 
 /datum/ammo/bullet/rifle/mpi_km

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -573,13 +573,13 @@ datum/ammo/bullet/revolver/tp44
 /datum/ammo/bullet/rifle/tx8/impact
 	name = "high velocity impact bullet"
 	hud_state = "hivelo_impact"
-	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
+	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING|AMMO_PASS_THROUGH_MOVABLE
 	damage = 25
-	penetration = 20
+	penetration = 30
 	sundering = 5
 
 /datum/ammo/bullet/rifle/tx8//on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, max_range = 20, slowdown = 1, knockback = 1, shake = 0)
+	staggerstun(M, P, max_range = 20, slowdown = 1, shake = 0)
 
 /datum/ammo/bullet/rifle/mpi_km
 	name = "crude heavy rifle bullet"


### PR DESCRIPTION
## About The Pull Request
Per title.

Stats have been changed as follows;
- Penetration reduced from 45 > 30. Seriously.
- Stagger and knockback removed.
- Shots will now pierce through targets.

## Why It's Good For The Game
TX-8 impact ammo has been really dumb for too long. Stagger, slowdown, and knockback on a gun with 25 damage, 45 penetration, and 5 sunder per bullet.

## Changelog
:cl: Lewdcifer
balance: TX-8 impact ammo; 45 > 30 pen, stagger and knockback removed, shots pierce through targets.
/:cl: