### PR TITLE
T-81 AutoSniper no longer has NVG

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1167,6 +1167,8 @@
 	allowed_ammo_types = list(/obj/item/ammo_magazine/rifle/autosniper)
 	attachable_allowed = list(
 		/obj/item/attachable/autosniperbarrel,
+		/obj/item/attachable/scope/marine,
+		/obj/item/attachable/scope/mini,
 		/obj/item/attachable/extended_barrel,
 		/obj/item/attachable/suppressor,
 		/obj/item/attachable/bayonet,
@@ -1179,6 +1181,7 @@
 	attachable_offset = list("muzzle_x" = 48, "muzzle_y" = 18,"rail_x" = 23, "rail_y" = 23, "under_x" = 38, "under_y" = 16, "stock_x" = 9, "stock_y" = 12)
 	starting_attachment_types = list(
 		/obj/item/attachable/autosniperbarrel,
+		/obj/item/attachable/scope/marine,
 	)
 
 	burst_amount = 0

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1167,7 +1167,6 @@
 	allowed_ammo_types = list(/obj/item/ammo_magazine/rifle/autosniper)
 	attachable_allowed = list(
 		/obj/item/attachable/autosniperbarrel,
-		/obj/item/attachable/scope/nightvision,
 		/obj/item/attachable/extended_barrel,
 		/obj/item/attachable/suppressor,
 		/obj/item/attachable/bayonet,
@@ -1180,7 +1179,6 @@
 	attachable_offset = list("muzzle_x" = 48, "muzzle_y" = 18,"rail_x" = 23, "rail_y" = 23, "under_x" = 38, "under_y" = 16, "stock_x" = 9, "stock_y" = 12)
 	starting_attachment_types = list(
 		/obj/item/attachable/autosniperbarrel,
-		/obj/item/attachable/scope/nightvision,
 	)
 
 	burst_amount = 0


### PR DESCRIPTION
## About The Pull Request
Per title. The gun has also been given access to normal scope attachments to compensate, and will now start with a T-47 rail scope attached by default.

## Why It's Good For The Game
T-81 is way too good at what it does. This should make it so it doesn't have that much of an edge, while keeping it as a better sniper rifle.

## Changelog
:cl: Lewdcifer
balance: T-81 Autosniper no longer has a NVG scope, now starts with a T-47 rail scope.
/:cl: