### PR TITLE
Adjust combat robot armor values

### DIFF
--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -811,7 +811,7 @@
 	item_state = "robot_armor_medium"
 	species_exception = list(/datum/species/robot)
 	flags_item_map_variant = (ITEM_JUNGLE_VARIANT|ITEM_ICE_VARIANT|ITEM_PRISON_VARIANT)
-	soft_armor = list("melee" = 40, "bullet" = 60, "laser" = 60, "energy" = 45, "bomb" = 45, "bio" = 45, "rad" = 45, "fire" = 45,"acid" = 50)
+	soft_armor = list("melee" = 45, "bullet" = 65, "laser" = 65, "energy" = 55, "bomb" = 50, "bio" = 50, "rad" = 50, "fire" = 50, "acid" = 55)
 	slowdown = 0.5
 
 /obj/item/clothing/suit/storage/marine/robot/mob_can_equip(mob/M, slot, warning, override_nodrop)
@@ -825,7 +825,7 @@
 	desc = "Light armor plating designed for self mounting on TerraGov combat robotics. It has self-sealing bolts for mounting on robotic owners inside."
 	icon_state = "robot_armor_light"
 	item_state = "robot_armor_light"
-	soft_armor = list("melee" = 35, "bullet" = 55, "laser" = 50, "energy" = 45, "bomb" = 45, "bio" = 45, "rad" = 45, "fire" = 45,"acid" = 45)
+	soft_armor = list("melee" = 40, "bullet" = 60, "laser" = 60, "energy" = 55, "bomb" = 50, "bio" = 50, "rad" = 50, "fire" = 50, "acid" = 50)
 	slowdown = 0.3
 
 /obj/item/clothing/suit/storage/marine/robot/heavy
@@ -833,7 +833,7 @@
 	desc = "Heavy armor plating designed for self mounting on TerraGov combat robotics. It has self-sealing bolts for mounting on robotic owners inside."
 	icon_state = "robot_armor_heavy"
 	item_state = "robot_armor_heavy"
-	soft_armor = list("melee" = 45, "bullet" = 65, "laser" = 60, "energy" = 45, "bomb" = 45, "bio" = 45, "rad" = 45, "fire" = 45,"acid" = 55)
+	soft_armor = list("melee" = 50, "bullet" = 70, "laser" = 70, "energy" = 55, "bomb" = 50, "bio" = 50, "rad" = 50, "fire" = 50, "acid" = 60)
 	slowdown = 0.7
 
 /obj/item/clothing/suit/storage/marine/harness/cowboy


### PR DESCRIPTION
## About The Pull Request
Title. It's a fix. This PR #8723 removed armor from uniforms, but forgot to change combat robot armor to reflect the changes so combat robots have been suffering with inferior armor for (time) now.

## Why It's Good For The Game
Consistency.

## Changelog
:cl:
fix: combat robot armor now has the same armor values as marine armor
/:cl: