### PR TITLE
Thrown items respect mob armor

### DIFF
--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -244,7 +244,7 @@
 	sharp = IS_SHARP_ITEM_ACCURATE
 	force = 20
 	w_class = WEIGHT_CLASS_TINY
-	throwforce = 35
+	throwforce = 45
 	throw_speed = 5
 	throw_range = 7
 	hitsound = 'sound/weapons/slash.ogg'

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -339,7 +339,7 @@ Contains most of the procs that are called when a mob is attacked by something
 
 	visible_message(span_warning("[src] has been hit in the [affecting.display_name] by \the [thrown_item]."), null, null, 5)
 
-	apply_damage(throw_damage, dtype, zone, armor, is_sharp(thrown_item), has_edge(thrown_item), updating_health = TRUE)
+	apply_damage(max(0, throw_damage - (throw_damage * soft_armor.getRating("melee") * 0.01)), dtype, zone, armor, is_sharp(thrown_item), has_edge(thrown_item), updating_health = TRUE)
 
 	var/list/hit_report = list("(RAW DMG: [throw_damage])")
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -75,7 +75,7 @@
 		var/armor = run_armor_check(null, "melee")
 
 		if(armor < 1)
-			apply_damage(throw_damage, dtype, null, armor, is_sharp(O), has_edge(O), TRUE)
+			apply_damage(max(0, throw_damage - (throw_damage * soft_armor.getRating("melee") * 0.01)), dtype, null, armor, is_sharp(O), has_edge(O), TRUE)
 
 		if(O.item_fire_stacks)
 			fire_stacks += O.item_fire_stacks


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

https://www.youtube.com/watch?v=DwhcaMFB-UQ

## Why It's Good For The Game

No more ancient Crushers and Queens dying in 0.5 seconds from funny throwing knifes. "Only a few people use throwing knifes" is not an argument, buff their damage instead if needed.

## Changelog
:cl:
code: thrown items respect mob armor
balance: throwing knifes throwforce changed from 35 to 45
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
