### PR TITLE
Fixes rail scopes zooming in when detached

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -681,9 +681,10 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 
 /obj/item/attachable/scope/activate(mob/living/carbon/user, turn_off)
 	if(turn_off)
-		zoom(user)
+		if(SEND_SIGNAL(user, COMSIG_ITEM_ZOOM) &  COMSIG_ITEM_ALREADY_ZOOMED)
+			zoom(user)
 		return TRUE
-
+	
 	if(!(master_gun.flags_item & WIELDED) && !CHECK_BITFIELD(master_gun.flags_item, IS_DEPLOYED))
 		if(user)
 			to_chat(user, span_warning("You must hold [master_gun] with two hands to use [src]."))


### PR DESCRIPTION
## About The Pull Request

The turn_off var was assuming that the object was already zoomed. And activate is called every time an attachment gets detached. Add both together and you zoom in whenever you detach a scope. 

Closes #9289

## Why It's Good For The Game

No more free zooming without a railscope.

## Changelog
:cl:
fix: Scopes should no longer attempt to zoom you in when being detached. 
/:cl: