### PR TITLE
Removes hard skill lock from research xenomorph analyzer

### DIFF
--- a/code/game/objects/items/tools/research_tools.dm
+++ b/code/game/objects/items/tools/research_tools.dm
@@ -46,11 +46,15 @@
 		to_chat(user, span_notice("[target_xeno] has already been probed."))
 		return ..()
 
-	if(user.skills.getRating(skill_type) < skill_threshold)
-		to_chat(user, "You need higher [skill_type] skill.")
-		return ..()
-
-	if(user.do_actions || !do_after(user, RESEARCH_DELAY, TRUE, target_xeno, BUSY_ICON_FRIENDLY, null, PROGRESS_BRASS))
+	if(user.skills.getRating("medical") < SKILL_MEDICAL_EXPERT)
+		user.visible_message(span_notice("[user] begins trying to find a cutting point on the [target_xeno].."),
+		span_notice("You begin trying to find a cutting point on the [target_xeno]..."))
+		var/fumbling_time = 15 SECONDS - 2 SECONDS * user.skills.getRating("medical")
+		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
+			return ..()
+	user.visible_message(span_notice("[user] begins cutting into the [target_xeno]."))
+	to_chat(user, span_info("You begin cutting into the [target_xeno]."))
+	if(!do_after(user, 5 SECONDS, TRUE, src, BUSY_ICON_FRIENDLY))
 		return ..()
 
 	if(HAS_TRAIT(target_xeno, TRAIT_RESEARCHED))


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes hard skill lock from xenomorph analyzer, enabling everyone to use them with a 15 second fumble dependent on your medical skill. No change to excavations.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Hard locks against TGMC ethos, allows a variation of playstyles if nobody's playing researcher. Dying as xenos now has a much higher risk.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Xenomorph analyzer is now useable by all, with a delay to reflect lack of skill.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
