### PR TITLE
Fire deals more damage to walls, light explosions deal less

### DIFF
--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -71,7 +71,7 @@
 		if(EXPLODE_HEAVY)
 			take_damage(rand(400))
 		if(EXPLODE_LIGHT)
-			take_damage(rand(100, 125))
+			take_damage(rand(75, 100))
 
 
 /turf/closed/wall/resin/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)

--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -21,7 +21,7 @@
 
 
 /turf/closed/wall/resin/flamer_fire_act()
-	take_damage(15, BURN, "fire")
+	take_damage(25, BURN, "fire")
 
 
 /turf/closed/wall/resin/proc/thicken()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Grenades deal 50 less overall damage to walls.
Fire got a 10 point per tick buff. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fire probably got massively overnerfed in the Wall rework PR, and grenades and other light explosions deal too much damage to resin walls.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Fire deals more damage to walls, light explosions deal a decent bit less now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
