### PR TITLE
Acid turret nerf- Durablity and Starting health, Explosion resistance

### DIFF
--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -845,8 +845,8 @@ TUNNEL
 	desc = "A menacing looking construct of resin, it seems to be alive. It fires acid against intruders."
 	bound_width = 32
 	bound_height = 32
-	obj_integrity = 600
-	max_integrity = 1500
+	obj_integrity = 400
+	max_integrity = 1200
 	layer =  ABOVE_MOB_LAYER
 	density = TRUE
 	resistance_flags = UNACIDABLE | DROPSHIP_IMMUNE
@@ -909,16 +909,16 @@ TUNNEL
 		if(EXPLODE_DEVASTATE)
 			take_damage(1500)
 		if(EXPLODE_HEAVY)
-			take_damage(750)
+			take_damage(1200)
 		if(EXPLODE_LIGHT)
 			take_damage(300)
 
 /obj/structure/xeno/xeno_turret/flamer_fire_act()
-	take_damage(60, BURN, "fire")
+	take_damage(40, BURN, "fire")
 	ENABLE_BITFIELD(resistance_flags, ON_FIRE)
 
 /obj/structure/xeno/xeno_turret/fire_act()
-	take_damage(60, BURN, "fire")
+	take_damage(40, BURN, "fire")
 	ENABLE_BITFIELD(resistance_flags, ON_FIRE)
 
 /obj/structure/xeno/xeno_turret/update_overlays()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Acid turrets have less Max durablity, Starting health and Explosion resistance. Reduced by 200 hp overall.

Fire damage reduced in kind. If at max durablity, turrets take longer to die from fire, but other sources will kill them.

Heavy explosions one shot them now.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I feel like acid turrets hold chokepoints far too well against ballistic weapons, but nerfing them without nerfing their hardcounter of fire seems too much, so I nerfed fire damage if they're at max health.

They also feel too strong at spawn. I feel like you should place turrets in anticipation, not because the marine horde is nearby.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Acid turret health reduced by 200 overall, dies to heavy explosions easier, but dies to fire slower.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
