### PR TITLE
Fixes sentries los not being blocked by now opaque hemodile and transvitox

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -300,13 +300,11 @@
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_NEURO|SMOKE_GASP|SMOKE_COUGH|SMOKE_NEURO_LIGHT //Light neuro smoke doesn't extinguish
 
 /obj/effect/particle_effect/smoke/xeno/hemodile
-	alpha = 255
 	smoke_can_spread_through = TRUE
 	color = "#0287A1"
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_HEMODILE|SMOKE_GASP
 
 /obj/effect/particle_effect/smoke/xeno/transvitox
-	alpha = 255
 	smoke_can_spread_through = TRUE
 	color = "#abf775"
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_TRANSVITOX|SMOKE_COUGH

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -301,14 +301,12 @@
 
 /obj/effect/particle_effect/smoke/xeno/hemodile
 	alpha = 255
-	opacity = FALSE
 	smoke_can_spread_through = TRUE
 	color = "#0287A1"
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_HEMODILE|SMOKE_GASP
 
 /obj/effect/particle_effect/smoke/xeno/transvitox
 	alpha = 255
-	opacity = FALSE
 	smoke_can_spread_through = TRUE
 	color = "#abf775"
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_TRANSVITOX|SMOKE_COUGH


### PR DESCRIPTION
## About The Pull Request

Fixes the sentry sightline issue in new opaque gasses #9394 

## Why It's Good For The Game

Bugfixes are always good, and continuing the trend of making the gasses function similarly (I.E. #9407) is also good

## Changelog
:cl:
fix: Hemodile and Transvitox now block sentry line of sight like other defiler gases
/:cl: