### PR TITLE
Buy upgrade button in hive blessing menu no longer disabled

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -85,7 +85,7 @@
 	.["upgrades"] = list()
 	for(var/datum/hive_upgrade/upgrade AS in buyable_upgrades)
 		.["upgrades"] += list(list("name" = upgrade.name, "desc" = upgrade.desc, "category" = upgrade.category,\
-		"cost" = upgrade.psypoint_cost, "times_bought" = upgrade.times_bought, "can_buy" = upgrade.can_buy(user, TRUE), "iconstate" = upgrade.icon))
+		"cost" = upgrade.psypoint_cost, "times_bought" = upgrade.times_bought, "iconstate" = upgrade.icon))
 	.["psypoints"] = SSpoints.xeno_points_by_hive[hivenumber]
 
 /datum/hive_status/ui_static_data(mob/user)
@@ -99,7 +99,7 @@
 			var/buying = params["buyname"]
 			var/datum/hive_upgrade/upgrade = upgrades_by_name[buying]
 			var/mob/living/carbon/xenomorph/user = usr
-			if(!upgrade.can_buy(user))
+			if(!upgrade.can_buy(user, FALSE))
 				return
 			if(!upgrade.on_buy(user))
 				return

--- a/tgui/packages/tgui/interfaces/BlessingMenu.tsx
+++ b/tgui/packages/tgui/interfaces/BlessingMenu.tsx
@@ -17,7 +17,6 @@ type UpgradeData = {
   category: string,
   cost: number,
   times_bought: number,
-  can_buy: number,
 }
 
 const categoryIcons = {
@@ -110,7 +109,6 @@ const Upgrades = (props, context) => {
                 upgrade_desc={upgrade.desc}
                 upgrade_cost={upgrade.cost}
                 upgrade_times_bought={upgrade.times_bought}
-                upgrade_can_buy={upgrade.can_buy}
                 upgradeicon={upgrade.iconstate} />)
             )
         )}
@@ -125,7 +123,6 @@ type UpgradeEntryProps = {
   upgrade_desc: string,
   upgrade_cost: number,
   upgrade_times_bought: number,
-  upgrade_can_buy: number,
   upgradeicon: string,
 }
 
@@ -137,7 +134,6 @@ const UpgradeEntry = (props: UpgradeEntryProps, context) => {
     upgrade_desc,
     upgrade_cost,
     upgrade_times_bought,
-    upgrade_can_buy,
     upgradeicon,
   } = props;
 
@@ -146,7 +142,6 @@ const UpgradeEntry = (props: UpgradeEntryProps, context) => {
       title={`${upgrade_name} (click for details)`}
       buttons={(
         <Button
-          disabled={!upgrade_can_buy}
           tooltip={upgrade_cost + " points"}
           onClick={() => act('buy', { buyname: upgrade_name })}>
           Claim Blessing


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

You can click on buttons now

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

There was no way of distinguishing visually disabled button from working one, so this information was useless. Plus, when a button is disabled, clicking on it didn't tell you why. This is now fixed and you have the error message (not enough points for exemple)

## Changelog
:cl:
qol: Buy upgrade button in hive blessing menu no longer disabled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
