### PR TITLE
Defiler's gasses block sentry vision

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -301,14 +301,12 @@
 
 /obj/effect/particle_effect/smoke/xeno/hemodile
 	alpha = 255
-	opacity = FALSE
 	smoke_can_spread_through = TRUE
 	color = "#0287A1"
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_HEMODILE|SMOKE_GASP
 
 /obj/effect/particle_effect/smoke/xeno/transvitox
 	alpha = 255
-	opacity = FALSE
 	smoke_can_spread_through = TRUE
 	color = "#abf775"
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_TRANSVITOX|SMOKE_COUGH


### PR DESCRIPTION
## About The Pull Request

Defiler's gasses are opaque now but hemodile/transvitox dont block sentries line of fire. 

## Why It's Good For The Game

Now that they are opaque and have the same radius it should be able to block said line of fire. 

## Changelog

:cl:
Fix : Gives opacity to hemodile/transvitox gasses in smoke.
/:cl:


