### PR TITLE
DNRs no longer show up as defibbable on the minimap

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -275,6 +275,9 @@
 				var/mob/dead/observer/ghost = get_ghost()
 				if(!ghost?.can_reenter_corpse)
 					status_hud.icon_state = "huddead"
+					if(istype(wear_ear, /obj/item/radio/headset/mainship))
+						var/obj/item/radio/headset/mainship/headset = wear_ear
+						headset.set_undefibbable_on_minimap()
 					return TRUE
 			var/stage
 			switch(dead_ticks)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When ungas go DNR, they currently still show as defibbable on the minimap until their defib timer runs out.

I am a brainlet coder, but this seems to work and it's been an annoying bug forever.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Marines seethe when they risk their lives to try save a dead guy, only to find out when they reach them that they're actually DNR.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: DNR's no longer show as revivable on the minimap
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
