### PR TITLE
Synthetic gets silo pinpointer

### DIFF
--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -745,6 +745,7 @@
 		/obj/item/tweezers,
 		/obj/item/tool/solderingtool,
 		/obj/item/tool/pickaxe/plasmacutter,
+		/obj/item/pinpointer/pool,
 	)
 
 /obj/effect/essentials_set/white_dress


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Synthetic may push with marines, and guiding them through the hellscape that is xenomorph resin walls is important. Since synthetic is likely to have plasma cutter, they will cut through walls to help marines push to silos.

Or can give pinpointer away. Whatever their choice.

Synthetic is command, and FC, CO, and SLs spawn with it, so it's time for synth to have one.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Synthetic gets silo pinpointer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
