### PR TITLE
Wraith laser armor/energyarmor balance changes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
@@ -76,7 +76,7 @@
 	upgrade_threshold = 240
 
 	// *** Defense *** //
-	soft_armor = list("melee" = 30, "bullet" = 30, "laser" = 10, "energy" = 10, "bomb" = XENO_BOMB_RESIST_0, "bio" = 15, "rad" = 20, "fire" = 20, "acid" = 15)
+	soft_armor = list("melee" = 30, "bullet" = 30, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 15, "rad" = 20, "fire" = 20, "acid" = 15)
 
 
 /datum/xeno_caste/wraith/elder
@@ -102,7 +102,7 @@
 	upgrade_threshold = 480
 
 	// *** Defense *** //
-	soft_armor = list("melee" = 35, "bullet" = 35, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 25, "fire" = 25, "acid" = 18)
+	soft_armor = list("melee" = 35, "bullet" = 35, "laser" = 20, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 25, "fire" = 25, "acid" = 18)
 
 
 /datum/xeno_caste/wraith/ancient
@@ -128,7 +128,7 @@
 	upgrade_threshold = 480
 
 	// *** Defense *** //
-	soft_armor = list("melee" = 40, "bullet" = 40, "laser" = 20, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 25, "fire" = 30, "acid" = 18)
+	soft_armor = list("melee" = 40, "bullet" = 40, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 25, "fire" = 30, "acid" = 18)
 
 /datum/xeno_caste/wraith/primordial
 	upgrade_name = "Primordial"
@@ -153,7 +153,7 @@
 	upgrade_threshold = 580
 
 	// *** Defense *** //
-	soft_armor = list("melee" = 40, "bullet" = 40, "laser" = 20, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 25, "fire" = 30, "acid" = 18)
+	soft_armor = list("melee" = 40, "bullet" = 40, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 25, "fire" = 30, "acid" = 18)
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,


### PR DESCRIPTION

## About The Pull Request

overdue adjustment of armor for wraith that has been the same since prehitscan, incredibly unfair and imbalanced.

## Why It's Good For The Game

Wraith ancient has a laser and energy armor of just 20, it was fine before hit scan lasers as you had some time to move, but now that lasers are instant you take more damage and have less time to blink away. 

at least now wraiths have a fair armor value that DOESN'T make it less then a T1 drone. Ancient runner has a laser/energy armor of just 19 whilst wraith is 20???? how does this make sense that its only an increase of 1 lol.

just because it can blink and hyper-position does not mean every circumstance will allow it so. as being hit by bullets slows your blink and hyper position requires you to stand still for a moment.

## Changelog
:cl:
balance: wraith laser/energy armor adjusted for maturitys, now 15/20/30 instead of 10/15/20
/:cl:

