### PR TITLE
Engineer range-finder buff

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -79,7 +79,6 @@ GLOBAL_LIST_INIT(engineer_gear_listed_products, list(
 		/obj/item/tool/shovel/etool = list(CAT_ENGSUP, "Entrenching tool", 1, "black"),
 		/obj/item/tool/handheld_charger = list(CAT_ENGSUP, "Hand-held cell charger", 3, "black"),
 		/obj/item/tool/weldingtool/hugetank = list(CAT_ENGSUP, "High-capacity industrial blowtorch", 5, "black"),
-		/obj/item/binoculars/tactical/range = list(CAT_ENGSUP, "Range Finder", 10, "black"),
 		/obj/item/cell/high = list(CAT_ENGSUP, "High capacity powercell", 1, "black"),
 		/obj/item/cell/rtg/small = list(CAT_ENGSUP, "Recharger powercell", 5, "black"),
 		/obj/item/cell/rtg/large = list(CAT_ENGSUP, "Large recharger powercell", 15, "black"),
@@ -680,6 +679,7 @@ GLOBAL_LIST_INIT(loadout_role_essential_set, list(
 		/obj/item/circuitboard/general = 1,
 		/obj/item/clothing/under/marine/engineer = 1,
 		/obj/item/tool/solderingtool = 1,
+		/obj/item/binoculars/tactical/range = 1,
 	),
 	SQUAD_CORPSMAN = list(
 		/obj/item/bodybag/cryobag = 1,

--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -29,6 +29,7 @@
 	var/cooldown_duration = 200 //20 seconds
 	var/obj/effect/overlay/temp/laser_target/laser
 	var/target_acquisition_delay = 100 //10 seconds
+	var/rangefinder = FALSE
 	var/mode = 0  //Able to be switched between modes, 0 for cas laser, 1 for finding coordinates, 2 for directing railgun, 3 for orbital bombardment, 4 for range finding and mortar targeting.
 	var/changable = TRUE //If set to FALSE, you can't toggle the mode between CAS and coordinate finding
 	var/ob_fired = FALSE // If the user has fired the OB
@@ -134,7 +135,10 @@
 	if(!changable)
 		to_chat(user, "These binoculars only have one mode.")
 		return
-	mode += 1
+	if (rangefinder)
+		mode += 3
+	else
+		mode += 1
 	if(mode > MODE_RANGE_FINDER)
 		mode = MODE_CAS
 	switch(mode)
@@ -314,8 +318,8 @@
 //For events
 /obj/item/binoculars/tactical/range
 	name = "range-finder"
-	desc = "A pair of binoculars designed to find coordinates. Shift+Click or Ctrl+Click to get coordinates when using."
-	changable = 0
+	desc = "A pair of binoculars designed to find coordinates, with a laser targeting function for close air support. Alt+Click or unique action to toggle between CAS and range-finding targeting mode. Ctrl+Click when using to target something. Shift+Click to get coordinates."
+	rangefinder = 1
 	mode = MODE_RANGE_FINDER
 
 #undef MODE_CAS

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -412,7 +412,6 @@
 	new /obj/item/mortal_shell/flare(src)
 	new /obj/item/encryptionkey/engi(src)
 	new /obj/item/encryptionkey/engi(src)
-	new /obj/item/binoculars/tactical/range(src)
 	new /obj/item/encryptionkey/cas(src)
 	new /obj/item/encryptionkey/cas(src)
 	new /obj/item/encryptionkey/cas(src)

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -700,6 +700,7 @@
 		/obj/item/lightreplacer,
 		/obj/item/circuitboard/general,
 		/obj/item/tool/solderingtool,
+		/obj/item/binoculars/tactical/range,
 	)
 
 /obj/effect/essentials_set/leader


### PR DESCRIPTION
## About The Pull Request
The engineer range-finder can now laze for CAS. 
I made it part of the engineer essential kit and removed it from the points vendor, making every engineer have one for free. It's up to them to use it. 
Removed the free rangefinder from the mortar kit.

## Why It's Good For The Game
The engineer rangefinder is an item that has potential to do more, giving it the ability to laze for CAS gives more opportunity for marine teamwork. Now, the PO has to yell not only at engineers, but also at marines to give them vision.

## Changelog
:cl:
add: engineer rangefinder can laze for CAS
del: removes rangefinder from the mortar kit
balance: removes rangefinder from engineer points vendor, it is now part of the engineer essential kit
/:cl: