### PR TITLE
No free additional tricord pill bottles in Sulaco

### DIFF
--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -1378,13 +1378,6 @@
 /obj/item/storage/pill_bottle/packet/paracetamol{
 	pixel_y = 7
 	},
-/obj/item/storage/pill_bottle/tricordrazine{
-	pixel_x = 7
-	},
-/obj/item/storage/pill_bottle/tricordrazine,
-/obj/item/storage/pill_bottle/tricordrazine{
-	pixel_x = -7
-	},
 /obj/item/storage/pill_bottle/packet/paracetamol{
 	pixel_y = 7
 	},
@@ -1393,23 +1386,6 @@
 	},
 /obj/item/storage/pill_bottle/packet/paracetamol{
 	pixel_y = 7
-	},
-/obj/item/storage/pill_bottle/packet/paracetamol{
-	pixel_y = 7
-	},
-/obj/item/storage/pill_bottle/tricordrazine{
-	pixel_x = -7
-	},
-/obj/item/storage/pill_bottle/tricordrazine{
-	pixel_x = -7
-	},
-/obj/item/storage/pill_bottle/tricordrazine,
-/obj/item/storage/pill_bottle/tricordrazine,
-/obj/item/storage/pill_bottle/tricordrazine{
-	pixel_x = 7
-	},
-/obj/item/storage/pill_bottle/tricordrazine{
-	pixel_x = 7
 	},
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

When #5809 was made, they added free additional tricord pill bottles. They didn't know that tricord pill bottles will get added in MarineMed, so Sulaco had it.

Either all ships get it, or no ships get it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: No more free additional tricord pill bottles in Sulaco
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
