### PR TITLE
Prep signs for marine role in shipside

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -1360,6 +1360,11 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "et" = (
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
+/obj/effect/decal/warning_stripes/engineer,
 /turf/open/floor/mainship/purple{
 	dir = 1
 	},
@@ -2601,6 +2606,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "ix" = (
+/obj/effect/decal/warning_stripes/box/small,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/medical,
 /turf/open/floor/mainship/blue/corner{
 	dir = 1
 	},
@@ -2800,6 +2810,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "ju" = (
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
+/obj/effect/decal/warning_stripes/engineer,
 /turf/open/floor/mainship/purple/corner{
 	dir = 4
 	},
@@ -8759,6 +8774,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "Co" = (
+/obj/effect/decal/warning_stripes/box/small,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/medical,
 /turf/open/floor/mainship/blue{
 	dir = 1
 	},
@@ -13269,6 +13289,14 @@
 	},
 /turf/open/floor/mainship/ai,
 /area/mainship/command/airoom)
+"Qe" = (
+/obj/effect/decal/warning_stripes/leader,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "Qf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -14793,6 +14821,14 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
+"US" = (
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
+/obj/effect/decal/warning_stripes/smartgunner,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "UT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -26510,7 +26546,7 @@ qd
 rm
 sr
 ta
-tc
+US
 vk
 tc
 tc
@@ -26804,7 +26840,7 @@ qg
 rp
 sr
 ta
-tc
+Qe
 vl
 tc
 tc

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -2258,6 +2258,11 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},
+/obj/effect/decal/warning_stripes/smartgunner,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
 /turf/open/floor/mainship/black/full,
 /area/mainship/living/cafeteria_starboard)
 "hf" = (
@@ -4176,6 +4181,16 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/mainship/living/pilotbunks)
+"nh" = (
+/obj/effect/decal/warning_stripes/engineer,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
+/turf/open/floor/mainship/black{
+	dir = 10
+	},
+/area/mainship/squads/general)
 "nj" = (
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 8
@@ -6028,6 +6043,11 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment/corner,
+/obj/effect/decal/warning_stripes/leader,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
 /turf/open/floor/mainship/black{
 	dir = 8
 	},
@@ -10328,6 +10348,11 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/effect/decal/warning_stripes/medical,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
 /turf/open/floor/mainship/black{
 	dir = 8
 	},
@@ -12212,6 +12237,11 @@
 /area/space)
 "Ly" = (
 /obj/structure/disposalpipe/segment/corner,
+/obj/effect/decal/warning_stripes/engineer,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
 /turf/open/floor/mainship/black{
 	dir = 8
 	},
@@ -15718,6 +15748,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "Wl" = (
+/obj/effect/decal/warning_stripes/smartgunner,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
 /turf/open/floor/mainship/black/full,
 /area/mainship/living/cafeteria_starboard)
 "Wn" = (
@@ -15905,6 +15940,16 @@
 "WP" = (
 /turf/open/floor/plating/mainship,
 /area/mainship/hallways/starboard_hallway)
+"WQ" = (
+/obj/effect/decal/warning_stripes/medical,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
+/turf/open/floor/mainship/black{
+	dir = 10
+	},
+/area/mainship/squads/general)
 "WR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -52038,11 +52083,11 @@ Ku
 BY
 Gh
 qa
-IX
+WQ
 st
 qa
 ko
-IX
+nh
 LE
 Ly
 Co

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -1378,13 +1378,6 @@
 /obj/item/storage/pill_bottle/packet/paracetamol{
 	pixel_y = 7
 	},
-/obj/item/storage/pill_bottle/tricordrazine{
-	pixel_x = 7
-	},
-/obj/item/storage/pill_bottle/tricordrazine,
-/obj/item/storage/pill_bottle/tricordrazine{
-	pixel_x = -7
-	},
 /obj/item/storage/pill_bottle/packet/paracetamol{
 	pixel_y = 7
 	},
@@ -1393,23 +1386,6 @@
 	},
 /obj/item/storage/pill_bottle/packet/paracetamol{
 	pixel_y = 7
-	},
-/obj/item/storage/pill_bottle/packet/paracetamol{
-	pixel_y = 7
-	},
-/obj/item/storage/pill_bottle/tricordrazine{
-	pixel_x = -7
-	},
-/obj/item/storage/pill_bottle/tricordrazine{
-	pixel_x = -7
-	},
-/obj/item/storage/pill_bottle/tricordrazine,
-/obj/item/storage/pill_bottle/tricordrazine,
-/obj/item/storage/pill_bottle/tricordrazine{
-	pixel_x = 7
-	},
-/obj/item/storage/pill_bottle/tricordrazine{
-	pixel_x = 7
 	},
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
@@ -5283,6 +5259,11 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
+/obj/effect/decal/warning_stripes/engineer,
+/obj/effect/decal/warning_stripes/box/small,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
 /turf/open/floor/prison/green{
 	dir = 6
 	},
@@ -7655,6 +7636,11 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
+/obj/effect/decal/warning_stripes/leader,
+/obj/effect/decal/warning_stripes/box/small,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
 /turf/open/floor/prison/green,
 /area/sulaco/marine)
 "aMg" = (
@@ -7730,6 +7716,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
+	},
+/obj/effect/decal/warning_stripes/leader,
+/obj/effect/decal/warning_stripes/box/small,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
 	},
 /turf/open/floor/prison/green{
 	dir = 6
@@ -7826,6 +7817,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 8
+	},
+/obj/effect/decal/warning_stripes/medical,
+/obj/effect/decal/warning_stripes/box/small,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
 	},
 /turf/open/floor/prison/green{
 	dir = 6
@@ -10817,6 +10813,11 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/decal/warning_stripes/smartgunner,
+/obj/effect/decal/warning_stripes/box/small,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
 /turf/open/floor/prison/green{
 	dir = 8
 	},
@@ -18023,6 +18024,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes/smartgunner,
+/obj/effect/decal/warning_stripes/box/small,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
 /turf/open/floor/prison/red{
 	dir = 1
 	},
@@ -20620,6 +20626,14 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/sulaco/command/ai)
+"tpx" = (
+/obj/effect/decal/warning_stripes/engineer,
+/obj/effect/decal/warning_stripes/box/small,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/turf/open/floor/prison/green,
+/area/sulaco/marine)
 "tpA" = (
 /obj/machinery/light{
 	dir = 4
@@ -43219,7 +43233,7 @@ xJd
 qzc
 xJd
 cWP
-wmQ
+tpx
 ayn
 cWP
 xJd

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -8393,6 +8393,14 @@
 	dir = 1
 	},
 /area/space)
+"cjA" = (
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
+/obj/effect/decal/warning_stripes/engineer,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/delta)
 "cjE" = (
 /obj/structure/table/mainship,
 /obj/item/storage/firstaid/o2{
@@ -9225,6 +9233,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
+"dzM" = (
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
+/obj/effect/decal/warning_stripes/leader,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/alpha)
 "dBR" = (
 /obj/machinery/power/apc/mainship{
 	dir = 4
@@ -10039,6 +10055,14 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/grunt_rnr)
+"fgi" = (
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
+/obj/effect/decal/warning_stripes/medical,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/alpha)
 "fgj" = (
 /obj/structure/bed/chair/wood/wings{
 	dir = 4
@@ -10972,6 +10996,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
+"gQc" = (
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
+/obj/effect/decal/warning_stripes/smartgunner,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/delta)
 "gQo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -13176,6 +13208,14 @@
 /obj/structure/window/framed/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
+"kUl" = (
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
+/obj/effect/decal/warning_stripes/smartgunner,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/alpha)
 "kUP" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -13297,6 +13337,14 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engine_core)
+"leA" = (
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
+/obj/effect/decal/warning_stripes/leader,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/delta)
 "lff" = (
 /turf/open/floor/mainship/purple{
 	dir = 8
@@ -13698,6 +13746,14 @@
 	dir = 8
 	},
 /area/mainship/hallways/port_hallway)
+"lIO" = (
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
+/obj/effect/decal/warning_stripes/medical,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/delta)
 "lIX" = (
 /obj/machinery/door/window{
 	dir = 8
@@ -16576,6 +16632,14 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
+"qOp" = (
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
+/obj/effect/decal/warning_stripes/engineer,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/alpha)
 "qOJ" = (
 /obj/structure/table/mainship,
 /obj/item/storage/toolbox/electrical,
@@ -61882,7 +61946,7 @@ oBV
 iJv
 cKy
 bdC
-iJv
+kUl
 abg
 kMY
 brj
@@ -61922,7 +61986,7 @@ awz
 ktN
 sVt
 vJr
-pGn
+gQc
 fEO
 pGn
 pGn
@@ -62910,7 +62974,7 @@ aCI
 iJv
 iJv
 bfJ
-iJv
+fgi
 fEX
 gbG
 brj
@@ -62950,7 +63014,7 @@ iLV
 ktN
 acY
 aiM
-pGn
+lIO
 oIu
 pGn
 pGn
@@ -63938,7 +64002,7 @@ aWQ
 iJv
 iJv
 biv
-iJv
+qOp
 jZv
 iJv
 iJv
@@ -63978,7 +64042,7 @@ pGn
 pGn
 add
 vJr
-pGn
+cjA
 rkn
 pGn
 pGn
@@ -64709,7 +64773,7 @@ hOm
 ack
 iJv
 bkg
-iJv
+dzM
 jZv
 iJv
 iJv
@@ -64749,7 +64813,7 @@ pGn
 pGn
 trp
 vJr
-pGn
+leA
 bZY
 pGn
 iwd


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Mapping QoL. Become better at QoL than CM.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

New players doing a new job may not know where their vendors are unless they point and right click on doors to positive identify their location. Also, veteran players may sometime not know where other prep are when going to a new job.

This helps to deal with that. If marines are still lost, skill issue, not map issue.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Prep signs for marine role in shipside. Now you can stumble to your leader, smartgunner, corpsman, or engineer job easier; thanks to RipGrayson for making these due to Vahalla!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
