### PR TITLE
Necrosis removal surgery clears germs

### DIFF
--- a/code/modules/surgery/necrosis.dm
+++ b/code/modules/surgery/necrosis.dm
@@ -64,6 +64,7 @@
 	..()
 
 /datum/surgery_step/necro/treat_necrosis/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
+	affected.germ_level = 0
 	affected.remove_limb_flags(LIMB_NECROTIZED)
 	target.update_body()
 


### PR DESCRIPTION
## About The Pull Request
Surgery to remove necrosis will sterilize the limb it's performed on.

## Why It's Good For The Game
If you're in surgery you can do this anyway by opening and closing an incision, this just skips the knowledge check to have to do so first.

## Changelog
:cl:
add: Necrosis removal surgery clears germs on its own
/:cl: