### PR TITLE
Light Marksman bullet Buff and Battle Rifle auto burst Buff

### DIFF
--- a/code/datums/components/autofire.dm
+++ b/code/datums/components/autofire.dm
@@ -37,7 +37,7 @@
 	auto_fire_shot_delay = _auto_fire_shot_delay
 	burstfire_shot_delay = _burstfire_shot_delay
 	burst_shots_to_fire = _burst_shots_to_fire
-	auto_burst_fire_shot_delay = _auto_burst_fire_shot_delay ? auto_burst_fire_shot_delay : 3 * auto_fire_shot_delay
+	auto_burst_fire_shot_delay = _auto_burst_fire_shot_delay ? _auto_burst_fire_shot_delay : 3 * auto_fire_shot_delay
 	fire_mode = _fire_mode
 	callback_bursting = _callback_bursting
 	callback_reset_fire = _callback_reset_fire

--- a/code/datums/components/autofire.dm
+++ b/code/datums/components/autofire.dm
@@ -24,7 +24,7 @@
 	///Callback to ask the parent to fire
 	var/datum/callback/callback_fire
 
-/datum/component/automatedfire/autofire/Initialize(_auto_fire_shot_delay = 0.3 SECONDS, _burstfire_shot_delay, _burst_shots_to_fire = 3, _fire_mode = GUN_FIREMODE_SEMIAUTO, datum/callback/_callback_bursting, datum/callback/_callback_reset_fire, datum/callback/_callback_fire)
+/datum/component/automatedfire/autofire/Initialize(_auto_fire_shot_delay = 0.3 SECONDS, _auto_burst_fire_shot_delay, _burstfire_shot_delay, _burst_shots_to_fire = 3, _fire_mode = GUN_FIREMODE_SEMIAUTO, datum/callback/_callback_bursting, datum/callback/_callback_reset_fire, datum/callback/_callback_fire)
 	. = ..()
 
 	RegisterSignal(parent, COMSIG_GUN_FIRE_MODE_TOGGLE, .proc/modify_fire_mode)
@@ -37,7 +37,7 @@
 	auto_fire_shot_delay = _auto_fire_shot_delay
 	burstfire_shot_delay = _burstfire_shot_delay
 	burst_shots_to_fire = _burst_shots_to_fire
-	auto_burst_fire_shot_delay = 3 * auto_fire_shot_delay
+	auto_burst_fire_shot_delay = _auto_burst_fire_shot_delay ? auto_burst_fire_shot_delay : 3 * auto_fire_shot_delay
 	fire_mode = _fire_mode
 	callback_bursting = _callback_bursting
 	callback_reset_fire = _callback_reset_fire

--- a/code/datums/components/autofire.dm
+++ b/code/datums/components/autofire.dm
@@ -24,7 +24,7 @@
 	///Callback to ask the parent to fire
 	var/datum/callback/callback_fire
 
-/datum/component/automatedfire/autofire/Initialize(_auto_fire_shot_delay = 0.3 SECONDS, _auto_burst_fire_shot_delay, _burstfire_shot_delay, _burst_shots_to_fire = 3, _fire_mode = GUN_FIREMODE_SEMIAUTO, datum/callback/_callback_bursting, datum/callback/_callback_reset_fire, datum/callback/_callback_fire)
+/datum/component/automatedfire/autofire/Initialize(_auto_fire_shot_delay = 0.3 SECONDS, _auto_burst_fire_delay, _burstfire_shot_delay, _burst_shots_to_fire = 3, _fire_mode = GUN_FIREMODE_SEMIAUTO, datum/callback/_callback_bursting, datum/callback/_callback_reset_fire, datum/callback/_callback_fire)
 	. = ..()
 
 	RegisterSignal(parent, COMSIG_GUN_FIRE_MODE_TOGGLE, .proc/modify_fire_mode)
@@ -35,9 +35,9 @@
 	RegisterSignal(parent, list(COMSIG_GUN_STOP_FIRE, COMSIG_XENO_STOP_FIRE), .proc/stop_firing)
 
 	auto_fire_shot_delay = _auto_fire_shot_delay
+	auto_burst_fire_shot_delay = _auto_burst_fire_delay ? _auto_burst_fire_delay : 3 * auto_fire_shot_delay
 	burstfire_shot_delay = _burstfire_shot_delay
 	burst_shots_to_fire = _burst_shots_to_fire
-	auto_burst_fire_shot_delay = _auto_burst_fire_shot_delay ? _auto_burst_fire_shot_delay : 3 * auto_fire_shot_delay
 	fire_mode = _fire_mode
 	callback_bursting = _callback_bursting
 	callback_reset_fire = _callback_reset_fire

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -609,7 +609,7 @@ datum/ammo/bullet/revolver/tp44
 	hud_state_empty = "hivelo_empty"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	penetration = 12
-	damage = 40
+	damage = 38
 	sundering = 1.2
 
 /datum/ammo/bullet/rifle/standard_br/incendiary

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -608,9 +608,9 @@ datum/ammo/bullet/revolver/tp44
 	hud_state = "hivelo"
 	hud_state_empty = "hivelo_empty"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
-	penetration = 10
-	damage = 30
-	sundering = 1
+	penetration = 12
+	damage = 40
+	sundering = 1.2
 
 /datum/ammo/bullet/rifle/standard_br/incendiary
 	name = "incendiary light marksman bullet"

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -329,7 +329,7 @@
 	update_force_list() //This gives the gun some unique verbs for attacking.
 
 	setup_firemodes()
-	AddComponent(/datum/component/automatedfire/autofire, fire_delay, burst_delay, _auto_burst_fire_shot_delay, burst_amount, gun_firemode, CALLBACK(src, .proc/set_bursting), CALLBACK(src, .proc/reset_fire), CALLBACK(src, .proc/Fire)) //This should go after handle_starting_attachment() and setup_firemodes() to get the proper values set.
+	AddComponent(/datum/component/automatedfire/autofire, fire_delay, burst_delay, auto_burst_fire_shot_delay, burst_amount, gun_firemode, CALLBACK(src, .proc/set_bursting), CALLBACK(src, .proc/reset_fire), CALLBACK(src, .proc/Fire)) //This should go after handle_starting_attachment() and setup_firemodes() to get the proper values set.
 	AddComponent(/datum/component/attachment_handler, attachments_by_slot, attachable_allowed, attachable_offset, starting_attachment_types, null, CALLBACK(src, .proc/on_attachment_attach), CALLBACK(src, .proc/on_attachment_detach), attachment_overlays)
 	if(CHECK_BITFIELD(flags_gun_features, GUN_IS_ATTACHMENT))
 		AddElement(/datum/element/attachment, slot, icon, .proc/on_attach, .proc/on_detach, .proc/activate, .proc/can_attach, pixel_shift_x, pixel_shift_y, flags_attach_features, attach_delay, detach_delay, "firearms", SKILL_FIREARMS_DEFAULT, 'sound/machines/click.ogg')

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -329,7 +329,7 @@
 	update_force_list() //This gives the gun some unique verbs for attacking.
 
 	setup_firemodes()
-	AddComponent(/datum/component/automatedfire/autofire, fire_delay, burst_delay, auto_burst_fire_shot_delay, burst_amount, gun_firemode, CALLBACK(src, .proc/set_bursting), CALLBACK(src, .proc/reset_fire), CALLBACK(src, .proc/Fire)) //This should go after handle_starting_attachment() and setup_firemodes() to get the proper values set.
+	AddComponent(/datum/component/automatedfire/autofire, fire_delay, burst_delay, auto_burst_fire_delay, burst_amount, gun_firemode, CALLBACK(src, .proc/set_bursting), CALLBACK(src, .proc/reset_fire), CALLBACK(src, .proc/Fire)) //This should go after handle_starting_attachment() and setup_firemodes() to get the proper values set.
 	AddComponent(/datum/component/attachment_handler, attachments_by_slot, attachable_allowed, attachable_offset, starting_attachment_types, null, CALLBACK(src, .proc/on_attachment_attach), CALLBACK(src, .proc/on_attachment_detach), attachment_overlays)
 	if(CHECK_BITFIELD(flags_gun_features, GUN_IS_ATTACHMENT))
 		AddElement(/datum/element/attachment, slot, icon, .proc/on_attach, .proc/on_detach, .proc/activate, .proc/can_attach, pixel_shift_x, pixel_shift_y, flags_attach_features, attach_delay, detach_delay, "firearms", SKILL_FIREARMS_DEFAULT, 'sound/machines/click.ogg')

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -206,9 +206,9 @@
 	var/movement_acc_penalty_mult = 2
 	///For regular shots, how long to wait before firing again.
 	var/fire_delay = 6
-	///Modifies the speed of projectiles fired.
+	///For auto burst-fire, how long to wait before firing again.
 	var/auto_burst_fire_delay = 0
-	///Only applied so it's the same as fire delay on auto-burst firing mode.
+	///Modifies the speed of projectiles fired.
 	var/shell_speed_mod	= 0
 	///Modifies projectile damage by a % when a marine gets passed, but not hit
 	var/iff_marine_damage_falloff = 0

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -207,6 +207,8 @@
 	///For regular shots, how long to wait before firing again.
 	var/fire_delay = 6
 	///Modifies the speed of projectiles fired.
+	var/auto_burst_fire_delay = 0
+	///Only applied so it's the same as fire delay on auto-burst firing mode.
 	var/shell_speed_mod	= 0
 	///Modifies projectile damage by a % when a marine gets passed, but not hit
 	var/iff_marine_damage_falloff = 0
@@ -327,7 +329,7 @@
 	update_force_list() //This gives the gun some unique verbs for attacking.
 
 	setup_firemodes()
-	AddComponent(/datum/component/automatedfire/autofire, fire_delay, burst_delay, burst_amount, gun_firemode, CALLBACK(src, .proc/set_bursting), CALLBACK(src, .proc/reset_fire), CALLBACK(src, .proc/Fire)) //This should go after handle_starting_attachment() and setup_firemodes() to get the proper values set.
+	AddComponent(/datum/component/automatedfire/autofire, fire_delay, burst_delay, _auto_burst_fire_shot_delay, burst_amount, gun_firemode, CALLBACK(src, .proc/set_bursting), CALLBACK(src, .proc/reset_fire), CALLBACK(src, .proc/Fire)) //This should go after handle_starting_attachment() and setup_firemodes() to get the proper values set.
 	AddComponent(/datum/component/attachment_handler, attachments_by_slot, attachable_allowed, attachable_offset, starting_attachment_types, null, CALLBACK(src, .proc/on_attachment_attach), CALLBACK(src, .proc/on_attachment_detach), attachment_overlays)
 	if(CHECK_BITFIELD(flags_gun_features, GUN_IS_ATTACHMENT))
 		AddElement(/datum/element/attachment, slot, icon, .proc/on_attach, .proc/on_detach, .proc/activate, .proc/can_attach, pixel_shift_x, pixel_shift_y, flags_attach_features, attach_delay, detach_delay, "firearms", SKILL_FIREARMS_DEFAULT, 'sound/machines/click.ogg')

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -292,6 +292,7 @@
 	aim_fire_delay = 0.2 SECONDS
 	aim_speed_modifier = 3
 
+	auto_burst_fire_delay = 0.35 SECONDS
 	fire_delay = 0.35 SECONDS
 	burst_amount = 3
 	burst_delay = 0.10 SECONDS


### PR DESCRIPTION
## About The Pull Request

As per title says. Also changes autoburst_delay to 1.5 so it's closer to burst fire. 
Now requires https://github.com/tgstation/TerraGov-Marine-Corps/pull/9509 .
## Why It's Good For The Game

1. Makes the Battle Rifle bullets less underpowered. This will reward marines using the T-64 BR for it's higher magazine capacity over the T-37 DMR but has less damage, range and accuracy. 
2. We're also making Burst fire and Auto Burst a closer value so you get less clicking. Thanks to https://github.com/tgstation/TerraGov-Marine-Corps/pull/9509 .

## Changelog
:cl:
balance: Added 8 damage, 2 AP, 0.2 sundering to the Light Marksman Bullet for the T-64 BR (from 30 damage, 10 penetration, 1 sunder) and made it's auto burst delay shorter.
/:cl:
