### PR TITLE
Refactors some plasmacutter behavior, squashes a number of plasmacutter bugs

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -31,17 +31,6 @@
 
 #define ismineralturf(A) (istype(A, /turf/closed/mineral))
 
-#define isjungleturf(A) (istype(A, /turf/closed/gm))
-
-#define isiceturf(A) (istype(A, /turf/closed/ice))
-
-#define isicerockturf(A) (istype(A, /turf/closed/ice_rock))
-
-#define isvolcanicturf(A) (istype(A, /turf/closed/brock))
-
-#define isdesertrockwallturf(A) (istype(A, /turf/closed/desertdamrockwall))
-
-
 //Mobs
 #define isliving(A) (istype(A, /mob/living))
 

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -31,6 +31,16 @@
 
 #define ismineralturf(A) (istype(A, /turf/closed/mineral))
 
+#define isjungleturf(A) (istype(A, /turf/closed/gm))
+
+#define isiceturf(A) (istype(A, /turf/closed/ice))
+
+#define isicerockturf(A) (istype(A, /turf/closed/ice_rock))
+
+#define isvolcanicturf(A) (istype(A, /turf/closed/brock))
+
+#define isdesertrockwallturf(A) (istype(A, /turf/closed/desertdamrockwall))
+
 
 //Mobs
 #define isliving(A) (istype(A, /mob/living))

--- a/code/game/objects/structures/cas_plane_parts.dm
+++ b/code/game/objects/structures/cas_plane_parts.dm
@@ -7,6 +7,7 @@
 	layer = OBJ_LAYER
 	plane = GAME_PLANE
 	opacity = FALSE
+	resistance_flags = PLASMACUTTER_IMMUNE
 
 /turf/closed/shuttle/cas/computer
 	name = "Condor piloting computer"

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -168,10 +168,10 @@
 
 	if(istype(I, /obj/item/tool/pickaxe/plasmacutter) && !user.do_actions)
 		var/obj/item/tool/pickaxe/plasmacutter/P = I
-		if(istype(src, /turf/closed/wall)) //walls handle plasma cutter effects on their own
-			return
 		if(CHECK_BITFIELD(resistance_flags, RESIST_ALL) || CHECK_BITFIELD(resistance_flags, PLASMACUTTER_IMMUNE))
 			to_chat(user, span_warning("[P] can't cut through this!"))
+			return
+		if(istype(src, /turf/closed/wall)) //walls handle plasma cutter effects on their own
 			return
 		else if(!P.start_cut(user, name, src))
 			return

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -180,8 +180,6 @@
 		if(CHECK_BITFIELD(resistance_flags, RESIST_ALL) || CHECK_BITFIELD(resistance_flags, PLASMACUTTER_IMMUNE))
 			to_chat(user, span_warning("[P] can't cut through this!"))
 			return
-		if(iswallturf(src)) //walls handle plasma cutter effects on their own
-			return
 		else if(!P.start_cut(user, name, src))
 			return
 		else if(!do_after(user, PLASMACUTTER_CUT_DELAY, TRUE, src, BUSY_ICON_FRIENDLY))
@@ -285,6 +283,7 @@
 	icon = 'icons/turf/shuttle.dmi'
 	plane = FLOOR_PLANE
 	smoothing_behavior = NO_SMOOTHING
+	resistance_flags = PLASMACUTTER_IMMUNE
 
 /turf/closed/shuttle/re_corner/notdense
 	icon_state = "re_cornergrass"

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -166,14 +166,12 @@
 /turf/closed/attackby(obj/item/I, mob/user, params)
 	. = ..()
 
-	var/turf/targettedwall = get_turf(src)
-
 	if(istype(I, /obj/item/tool/pickaxe/plasmacutter) && !user.do_actions)
 		var/obj/item/tool/pickaxe/plasmacutter/P = I
 		if(CHECK_BITFIELD(resistance_flags, RESIST_ALL) || CHECK_BITFIELD(resistance_flags, PLASMACUTTER_IMMUNE))
 			to_chat(user, span_warning("[P] can't cut through this!"))
 			return
-		if(iswallturf(targettedwall)) //walls handle plasma cutter effects on their own
+		if(iswallturf(src)) //walls handle plasma cutter effects on their own
 			return
 		else if(!P.start_cut(user, name, src))
 			return
@@ -183,19 +181,19 @@
 			P.cut_apart(user, name, src) //purely a cosmetic effect
 
 		//change targetted turf to a new one to simulate deconstruction
-		if(ismineralturf(targettedwall))
+		if(ismineralturf(src))
 			ChangeTurf(/turf/open/floor/plating/ground/desertdam/cave/inner_cave_floor)
 
-		else if(isdesertrockwallturf(targettedwall))
+		else if(isdesertrockwallturf(src))
 			ChangeTurf(/turf/open/floor/plating/ground/desertdam/cave/inner_cave_floor)
 
-		else if(isjungleturf(targettedwall))
+		else if(isjungleturf(src))
 			ChangeTurf(/turf/open/ground/jungle/clear)
 
-		else if(isiceturf(targettedwall) || isicerockturf(targettedwall))
+		else if(isiceturf(src) || isicerockturf(src))
 			ChangeTurf(/turf/open/floor/plating/ground/ice)
 
-		else if(isvolcanicturf(targettedwall))
+		else if(isvolcanicturf(src))
 			var/choice = rand(1,50)
 			if(choice == 50)
 				ChangeTurf(/turf/open/lavaland/basalt/glowing)

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -166,12 +166,14 @@
 /turf/closed/attackby(obj/item/I, mob/user, params)
 	. = ..()
 
+	var/turf/targettedwall = get_turf(src)
+
 	if(istype(I, /obj/item/tool/pickaxe/plasmacutter) && !user.do_actions)
 		var/obj/item/tool/pickaxe/plasmacutter/P = I
 		if(CHECK_BITFIELD(resistance_flags, RESIST_ALL) || CHECK_BITFIELD(resistance_flags, PLASMACUTTER_IMMUNE))
 			to_chat(user, span_warning("[P] can't cut through this!"))
 			return
-		if(istype(src, /turf/closed/wall)) //walls handle plasma cutter effects on their own
+		if(iswallturf(targettedwall)) //walls handle plasma cutter effects on their own
 			return
 		else if(!P.start_cut(user, name, src))
 			return
@@ -181,20 +183,27 @@
 			P.cut_apart(user, name, src) //purely a cosmetic effect
 
 		//change targetted turf to a new one to simulate deconstruction
-		if(ismineralturf(src) || istype(src, /turf/closed/desertdamrockwall))
+		if(ismineralturf(targettedwall))
 			ChangeTurf(/turf/open/floor/plating/ground/desertdam/cave/inner_cave_floor)
-		else if(istype(src, /turf/closed/gm))
+
+		else if(isdesertrockwallturf(targettedwall))
+			ChangeTurf(/turf/open/floor/plating/ground/desertdam/cave/inner_cave_floor)
+
+		else if(isjungleturf(targettedwall))
 			ChangeTurf(/turf/open/ground/jungle/clear)
-		else if(istype(src, /turf/closed/ice) || istype(src, /turf/closed/ice_rock))
+
+		else if(isiceturf(targettedwall) || isicerockturf(targettedwall))
 			ChangeTurf(/turf/open/floor/plating/ground/ice)
-		else if(istype(src, /turf/closed/brock))
+
+		else if(isvolcanicturf(targettedwall))
 			var/choice = rand(1,50)
 			if(choice == 50)
 				ChangeTurf(/turf/open/lavaland/basalt/glowing)
 			else
 				ChangeTurf(/turf/open/lavaland/basalt)
-		else if(!istype(src, /turf/closed/wall)) //walls handle deconstruction on their own so don't apply plating
-			ChangeTurf(/turf/open/floor/plating) //if none of the above apply regular plating as a fallback
+		
+		else //default case for any turf that isn't one of the above
+			ChangeTurf(/turf/open/floor/plating) //apply basic plating as fallback
 
 //Ice Thin Wall
 /turf/closed/ice/thin

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -42,7 +42,7 @@
 	smoothing_behavior = NO_SMOOTHING //big red does not currently have its own 3/4ths cave tileset, so it uses the old one without smoothing
 	smoothing_groups = NONE
 
-/turf/closed/mineral/indestructible/mineral
+/turf/closed/mineral/indestructible
 	name = "impenetrable rock"
 	icon_state = "lvwall-0-0-0-0"
 	walltype = "lvwall"
@@ -168,27 +168,31 @@
 
 	if(istype(I, /obj/item/tool/pickaxe/plasmacutter) && !user.do_actions)
 		var/obj/item/tool/pickaxe/plasmacutter/P = I
-		if(!ismineralturf(src) && !istype(src, /turf/closed/gm/dense) && !istype(src, /turf/closed/glass) && !istype(src, /turf/closed/desertdamrockwall) && !istype(src, /turf/closed/brock))
+		if(CHECK_BITFIELD(resistance_flags, RESIST_ALL) || CHECK_BITFIELD(resistance_flags, PLASMACUTTER_IMMUNE))
 			to_chat(user, span_warning("[P] can't cut through this!"))
 			return
-		if(!P.start_cut(user, name, src))
+		else if(!P.start_cut(user, name, src))
 			return
-
-		if(!do_after(user, PLASMACUTTER_CUT_DELAY, TRUE, src, BUSY_ICON_FRIENDLY))
+		else if(!do_after(user, PLASMACUTTER_CUT_DELAY, TRUE, src, BUSY_ICON_FRIENDLY))
 			return
+		else
+			P.cut_apart(user, name, src) //purely a cosmetic effect
 
-		P.cut_apart(user, name, src)
-
+		//change targetted turf to a new one to simulate deconstruction
 		if(ismineralturf(src) || istype(src, /turf/closed/desertdamrockwall))
 			ChangeTurf(/turf/open/floor/plating/ground/desertdam/cave/inner_cave_floor)
-		else if(istype(src, /turf/closed/gm/dense))
+		else if(istype(src, /turf/closed/gm))
 			ChangeTurf(/turf/open/ground/jungle/clear)
+		else if(istype(src, /turf/closed/ice) || istype(src, /turf/closed/ice_rock))
+			ChangeTurf(/turf/open/floor/plating/ground/ice)
 		else if(istype(src, /turf/closed/brock))
 			var/choice = rand(1,50)
 			if(choice == 50)
 				ChangeTurf(/turf/open/lavaland/basalt/glowing)
 			else
 				ChangeTurf(/turf/open/lavaland/basalt)
+		else if(!istype(src, /turf/closed/wall)) //walls handle deconstruction on their own
+			ChangeTurf(/turf/open/floor/plating) //if none of the above apply regular plating as a fallback
 
 //Ice Thin Wall
 /turf/closed/ice/thin
@@ -215,36 +219,6 @@
 
 /turf/closed/ice/thin/intersection
 	icon_state = "Intersection"
-
-/turf/closed/attackby(obj/item/I, mob/user, params)
-	. = ..()
-
-	if(istype(I, /obj/item/tool/pickaxe/plasmacutter) && !user.do_actions)
-		var/obj/item/tool/pickaxe/plasmacutter/P = I
-		if(!ismineralturf(src) && !istype(src, /turf/closed/gm/dense) && !istype(src, /turf/closed/ice) && !istype(src, /turf/closed/desertdamrockwall) && !istype(src, /turf/closed/brock))
-			to_chat(user, span_warning("[P] can't cut through this!"))
-			return
-		if(!P.start_cut(user, name, src))
-			return
-
-		if(!do_after(user, PLASMACUTTER_CUT_DELAY, TRUE, src, BUSY_ICON_FRIENDLY))
-			return
-
-		P.cut_apart(user, name, src)
-
-		if(ismineralturf(src) || istype(src, /turf/closed/desertdamrockwall))
-			ChangeTurf(/turf/open/floor/plating/ground/desertdam/cave/inner_cave_floor)
-		else if(istype(src, /turf/closed/gm/dense))
-			ChangeTurf(/turf/open/ground/jungle/clear)
-		else if(istype(src, /turf/closed/brock))
-			var/choice = rand(1,50)
-			if(choice == 50)
-				ChangeTurf(/turf/open/lavaland/basalt/glowing)
-			else
-				ChangeTurf(/turf/open/lavaland/basalt)
-		else
-			ChangeTurf(/turf/open/floor/plating/ground/ice)
-
 
 //ROCK WALLS------------------------------//
 

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -168,6 +168,8 @@
 
 	if(istype(I, /obj/item/tool/pickaxe/plasmacutter) && !user.do_actions)
 		var/obj/item/tool/pickaxe/plasmacutter/P = I
+		if(istype(src, /turf/closed/wall)) //walls handle plasma cutter effects on their own
+			return
 		if(CHECK_BITFIELD(resistance_flags, RESIST_ALL) || CHECK_BITFIELD(resistance_flags, PLASMACUTTER_IMMUNE))
 			to_chat(user, span_warning("[P] can't cut through this!"))
 			return
@@ -191,7 +193,7 @@
 				ChangeTurf(/turf/open/lavaland/basalt/glowing)
 			else
 				ChangeTurf(/turf/open/lavaland/basalt)
-		else if(!istype(src, /turf/closed/wall)) //walls handle deconstruction on their own
+		else if(!istype(src, /turf/closed/wall)) //walls handle deconstruction on their own so don't apply plating
 			ChangeTurf(/turf/open/floor/plating) //if none of the above apply regular plating as a fallback
 
 //Ice Thin Wall

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -237,6 +237,7 @@
 /turf/closed/ice_rock
 	name = "Icy rock"
 	icon = 'icons/turf/rockwall.dmi'
+	resistance_flags = PLASMACUTTER_IMMUNE
 
 /turf/closed/ice_rock/single
 	icon_state = "single"

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -9,6 +9,8 @@
 	var/walltype
 	///The neighbours
 	var/junctiontype = NONE
+	///used for plasmacutter deconstruction
+	var/open_turf_type = /turf/open/floor/plating
 
 /turf/closed/mineral
 	name = "rock"
@@ -17,6 +19,7 @@
 	walltype = "lvwall"
 	smoothing_behavior = DIAGONAL_SMOOTHING
 	smoothing_groups = SMOOTH_MINERAL_STRUCTURES
+	open_turf_type = /turf/open/floor/plating/ground/desertdam/cave/inner_cave_floor
 
 /turf/closed/mineral/Initialize(mapload)
 	. = ..()
@@ -58,6 +61,7 @@
 	smoothing_behavior = DIAGONAL_SMOOTHING
 	smoothing_groups = SMOOTH_FLORA
 	walltype = "jungle"
+	open_turf_type = /turf/open/ground/jungle/clear
 
 /turf/closed/gm/tree
 	name = "dense jungle trees"
@@ -74,6 +78,7 @@
 
 /turf/closed/gm/dense
 	name = "dense jungle wall"
+	resistance_flags = PLASMACUTTER_IMMUNE
 	
 //desertdam rock
 /turf/closed/desertdamrockwall
@@ -84,6 +89,7 @@
 	walltype = "cave_wall"
 	smoothing_behavior = DIAGONAL_SMOOTHING
 	smoothing_groups = SMOOTH_GENERAL_STRUCTURES
+	open_turf_type = /turf/open/floor/plating/ground/desertdam/cave/inner_cave_floor
 
 /turf/closed/desertdamrockwall/invincible
 	resistance_flags = RESIST_ALL
@@ -93,6 +99,8 @@
 	name = "basalt rock"
 	icon = 'icons/turf/lava.dmi'
 	icon_state = "brock"
+	open_turf_type = /turf/open/lavaland/basalt
+
 
 /turf/closed/brock/Initialize(mapload)
 	. = ..()
@@ -118,6 +126,7 @@
 	icon = 'icons/turf/icewall.dmi'
 	icon_state = "Single"
 	desc = "It is very thick."
+	open_turf_type = /turf/open/floor/plating/ground/ice
 
 /turf/closed/ice/single
 	icon_state = "Single"
@@ -181,27 +190,7 @@
 			P.cut_apart(user, name, src) //purely a cosmetic effect
 
 		//change targetted turf to a new one to simulate deconstruction
-		if(ismineralturf(src))
-			ChangeTurf(/turf/open/floor/plating/ground/desertdam/cave/inner_cave_floor)
-
-		else if(isdesertrockwallturf(src))
-			ChangeTurf(/turf/open/floor/plating/ground/desertdam/cave/inner_cave_floor)
-
-		else if(isjungleturf(src))
-			ChangeTurf(/turf/open/ground/jungle/clear)
-
-		else if(isiceturf(src) || isicerockturf(src))
-			ChangeTurf(/turf/open/floor/plating/ground/ice)
-
-		else if(isvolcanicturf(src))
-			var/choice = rand(1,50)
-			if(choice == 50)
-				ChangeTurf(/turf/open/lavaland/basalt/glowing)
-			else
-				ChangeTurf(/turf/open/lavaland/basalt)
-		
-		else //default case for any turf that isn't one of the above
-			ChangeTurf(/turf/open/floor/plating) //apply basic plating as fallback
+		ChangeTurf(open_turf_type)
 
 //Ice Thin Wall
 /turf/closed/ice/thin
@@ -236,6 +225,7 @@
 	name = "Icy rock"
 	icon = 'icons/turf/rockwall.dmi'
 	resistance_flags = PLASMACUTTER_IMMUNE
+	open_turf_type = /turf/open/floor/plating/ground/ice
 
 /turf/closed/ice_rock/single
 	icon_state = "single"

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -242,6 +242,9 @@
 	return
 
 /turf/closed/wall/indestructible/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/tool/pickaxe/plasmacutter)) //needed for user feedback, if not included the user will not receive a message when trying plasma cutter wall/indestructible turfs
+		var/obj/item/tool/pickaxe/plasmacutter/P = I
+		to_chat(user, span_warning("[P] can't cut through this!"))
 	return
 
 /turf/closed/wall/indestructible/can_be_dissolved()

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -331,9 +331,6 @@
 		if(!P.start_cut(user, name, src))
 			return
 
-		if(!do_after(user, P.calc_delay(user), TRUE, src, BUSY_ICON_HOSTILE))
-			return
-
 		P.cut_apart(user, name, src)
 		dismantle_wall()
 

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -331,6 +331,9 @@
 		if(!P.start_cut(user, name, src))
 			return
 
+		if(!do_after(user, P.calc_delay(user), TRUE, src, BUSY_ICON_HOSTILE))
+			return
+
 		P.cut_apart(user, name, src)
 		dismantle_wall()
 

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -326,6 +326,9 @@
 	else if(resistance_flags & INDESTRUCTIBLE)
 		to_chat(user, "[span_warning("[src] is much too tough for you to do anything to it with [I]")].")
 
+	else if(istype(I, /obj/item/tool/pickaxe/plasmacutter) && !user.do_actions)
+		return
+
 	else if(wall_integrity < max_integrity && iswelder(I))
 		var/obj/item/tool/weldingtool/WT = I
 		if(!WT.remove_fuel(0, user))

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -326,17 +326,6 @@
 	else if(resistance_flags & INDESTRUCTIBLE)
 		to_chat(user, "[span_warning("[src] is much too tough for you to do anything to it with [I]")].")
 
-	else if(istype(I, /obj/item/tool/pickaxe/plasmacutter) && !user.do_actions)
-		var/obj/item/tool/pickaxe/plasmacutter/P = I
-		if(!P.start_cut(user, name, src))
-			return
-
-		if(!do_after(user, P.calc_delay(user), TRUE, src, BUSY_ICON_HOSTILE))
-			return
-
-		P.cut_apart(user, name, src)
-		dismantle_wall()
-
 	else if(wall_integrity < max_integrity && iswelder(I))
 		var/obj/item/tool/weldingtool/WT = I
 		if(!WT.remove_fuel(0, user))


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Refactors plasmacutter behavior when used on walls, fixing a number of bugs (see changelog for details) and making the code more concise. Also addresses and fixes https://github.com/tgstation/TerraGov-Marine-Corps/issues/9468.

## Why It's Good For The Game

Bugs are bad, fixes good.

## Changelog
:cl:
balance: Plasmacutters will now cut down walls without leaving a girder
fix: Plasmacutters now respect resistance flags and cannot destroy turfs that have RESIST_ALL or PLASMACUTTER_IMMUNE. 
fix: Plasmacutters no longer spam "can't cut through this" messages when destroying some closed turfs.
fix: Fixes a rare situation where plasmacutters would take multiple charges to cut down some ship walls.
refactor: Refactored plasmacutter behavior for closed turfs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
