### PR TITLE
Combat robots can be revived without defib

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -72,7 +72,7 @@
 
 				if((HAS_TRAIT(src, TRAIT_UNDEFIBBABLE ) || src.suiciding))
 					H.visible_message(span_warning("[src]'s backup battery blinks weakly, too late to save this one."),
-					span_warning("[src]'s backup battery ran dry, it cannot be restarted"))
+					span_warning("[src]'s backup battery ran dry, it cannot be restarted."))
 					return FALSE
 
 				if(!src.client) //Freak case, no client at all. This is a braindead mob (like a colonist)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -99,7 +99,6 @@
 
 				src.visible_message(span_notice("[icon2html(src, viewers(H))] [src] beeps: Restart sequence successful."))
 				src.set_stat(UNCONSCIOUS)
-				src.emote("gasp")
 				src.regenerate_icons()
 				src.reload_fullscreens()
 				src.flash_act()

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -47,7 +47,7 @@
 					notify_ghost(G, "<font size=3>Someone is trying to revive your body. Return to it if you want to be resurrected!</font>", ghost_sound = 'sound/effects/adminhelp.ogg', enter_text = "Enter", enter_link = "reentercorpse=1", source = src, action = NOTIFY_JUMP)
 				else if(!src.client)
 					//We couldn't find a suitable ghost, this means the person is not returning
-					to_chat(H, span_warning("Maintenance panel of [src] is locked tight, this unit refuses to be restarted."))
+					to_chat(H, span_warning("The maintenance panel of [src] is locked tight, this unit refuses to be restarted."))
 					return FALSE
 
 				var/restart_damage_threshold = 50 * (H.skills.getRating("engineer"))


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes combat robots revivable by clicking them with an empty hand. The revive damage threshold is lower than defibbing depending on your engi skill.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Engineers can now repair AND revive combat robots. Everybody else can do so but the revive threshold is 50*engiskill so a marine or a medic has to fully repair them before attempting revive. Engineers can revive at 150 health and ST can revive at 200. They can still be defibbed like normal at 200 and revival by hand also requires armor to be taken off.

No more medics dragging a robot to engi before defibbing. Engineers are (almost) fully responsible for robot health and safety. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Robots can be revived (or restarted) by hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
