### PR TITLE
Xeno resin door fixes

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -163,7 +163,7 @@
 	if(!locate(/obj/effect/alien/weeds) in loc)
 		new /obj/effect/alien/weeds(loc)
 
-/obj/structure/mineral_door/resin/CanAllowThrough(atom/movable/mover, turf/target)
+/obj/structure/mineral_door/resin/Cross(atom/movable/mover, turf/target)
 	. = ..()
 	if(!. && isxeno(mover))
 		Open()
@@ -210,7 +210,7 @@
 	playsound(loc, "alien_resin_move", 25)
 	flick("[mineralType]opening",src)
 	density = FALSE
-	opacity = FALSE
+	set_opacity(FALSE)
 	state = 1
 	update_icon()
 	addtimer(CALLBACK(src, .proc/Close), close_delay)
@@ -231,7 +231,7 @@
 /// Change the icon and density of the door
 /obj/structure/mineral_door/resin/proc/do_close()
 	density = TRUE
-	opacity = TRUE
+	set_opacity(TRUE)
 	state = 0
 	update_icon()
 	isSwitchingStates = 0


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Xeno doors are no longer opaque when opened
You can now click a door as a xeno to open it (it was opening then immediatly closing)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Xeno doors are no longer opaque when opened
fix: You can now click a door as a xeno to open it (it was opening then immediatly closing)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
