### PR TITLE
Neurotoxin does far less direct hit stamina damage

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1724,7 +1724,7 @@ datum/ammo/bullet/revolver/tp44
 	max_range = 10
 	accuracy_var_low = 3
 	accuracy_var_high = 3
-	damage = 20
+	damage = 25
 	stagger_stacks = 1.1
 	slowdown_stacks = 1.1
 	smoke_strength = 0.5
@@ -1808,7 +1808,7 @@ datum/ammo/bullet/revolver/tp44
 	name = "neurotoxic splash"
 	added_spit_delay = 0
 	spit_cost = 100
-	damage = 25
+	damage = 30
 	smoke_strength = 0.9
 	reagent_transfer_amount = 9.5
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1724,7 +1724,7 @@ datum/ammo/bullet/revolver/tp44
 	max_range = 10
 	accuracy_var_low = 3
 	accuracy_var_high = 3
-	damage = 40
+	damage = 20
 	stagger_stacks = 1.1
 	slowdown_stacks = 1.1
 	smoke_strength = 0.5
@@ -1808,7 +1808,7 @@ datum/ammo/bullet/revolver/tp44
 	name = "neurotoxic splash"
 	added_spit_delay = 0
 	spit_cost = 100
-	damage = 40
+	damage = 25
 	smoke_strength = 0.9
 	reagent_transfer_amount = 9.5
 
@@ -1835,7 +1835,7 @@ datum/ammo/bullet/revolver/tp44
 	spit_cost = 50
 	sound_hit = "alien_resin_build2"
 	sound_bounce = "alien_resin_build3"
-	damage = 20 //minor; this is mostly just to provide confirmation of a hit
+	damage = 10 //minor; this is mostly just to provide confirmation of a hit
 	max_range = 40
 	bullet_color = COLOR_PURPLE
 	stagger_stacks = 2

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1835,7 +1835,7 @@ datum/ammo/bullet/revolver/tp44
 	spit_cost = 50
 	sound_hit = "alien_resin_build2"
 	sound_bounce = "alien_resin_build3"
-	damage = 10 //minor; this is mostly just to provide confirmation of a hit
+	damage = 20 //minor; this is mostly just to provide confirmation of a hit
 	max_range = 40
 	bullet_color = COLOR_PURPLE
 	stagger_stacks = 2


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Neurotoxin damage numbers turned from 40->25 for normal, and 40->30 for heavy.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Neurotoxin does too much damage for it's effects on hit, it's better that it gets lowered.
Considering you get a 15% damage bonus every tier, it'll still do quite a bit, just scale far less insanely high (up to the 60s.)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Light neurotoxin hits do 36%~ less damage, scaling unchanged. Heavy Neurotoxin hit (Prae) do 30. (25% less.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
