### PR TITLE
Sunder recovery by weeds, recovery pheromones, and resting weeds nerfed.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -79,14 +79,14 @@
 
 	var/sunder_recov = xeno_caste.sunder_recover * -0.5 //Baseline
 
-	if(resting) //Resting doubles sunder recovery
-		sunder_recov *= 2
+	if(resting) //Resting gives a 25% bonus to sunder recovery.
+		sunder_recov *= 1.25
 
-	if(locate(/obj/effect/alien/weeds/resting) in loc) //Resting weeds double sunder recovery
-		sunder_recov *= 2
+	if(locate(/obj/effect/alien/weeds/resting) in loc) //Resting weeds give a 25% bonus to sunder recovery.
+		sunder_recov *= 1.25
 
 	if(recovery_aura)
-		sunder_recov *= 1 + recovery_aura * 0.1 //10% bonus per rank of recovery aura
+		sunder_recov *= 1 + recovery_aura * 0.05 //5% bonus per rank of recovery aura
 
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_SUNDER_REGEN, src)
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -79,11 +79,11 @@
 
 	var/sunder_recov = xeno_caste.sunder_recover * -0.5 //Baseline
 
-	if(resting) //Resting gives a 25% bonus to sunder recovery.
-		sunder_recov *= 1.25
+	if(resting) //Resting gives a 50% bonus to sunder recovery.
+		sunder_recov *= 1.5
 
-	if(locate(/obj/effect/alien/weeds/resting) in loc) //Resting weeds give a 25% bonus to sunder recovery.
-		sunder_recov *= 1.25
+	if(locate(/obj/effect/alien/weeds/resting) in loc) //Resting weeds give a 50% bonus to sunder recovery.
+		sunder_recov *= 1.5
 
 	if(recovery_aura)
 		sunder_recov *= 1 + recovery_aura * 0.05 //5% bonus per rank of recovery aura


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Halved for all of these sources.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sunder recovery is absurd, frankly. It's been powercreeped very high, as mechanics slowly got added to make it higher (Weeds x2, Resting weeds x2, hivelord heal.) Which makes anything but insanely high sources of it basically irrelevant.
This makes sunder for DPS a general mechanic, I want to cut down on sunder recovery powercreep, not increase values.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: sunder bonuses for resting, recovery weeds and pheromones halved.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
