### PR TITLE
Removed duplicate code from energy weapons

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -436,7 +436,6 @@
 	fire_delay = 0.2 SECONDS
 	accuracy_mult = 1.15
 	accuracy_mult_unwielded = 0.55
-	scatter_unwielded = 10
 	damage_falloff_mult = 0.2
 	mode_list = list(
 		"Standard" = /datum/lasrifle/base/energy_rifle_mode/standard,
@@ -500,11 +499,10 @@
 	akimbo_additional_delay = 0.9
 	wield_delay = 0.6 SECONDS
 	scatter = 3
-	scatter_unwielded = 4
+	scatter_unwielded = 0
 	fire_delay = 0.15 SECONDS
 	accuracy_mult = 1.1
 	accuracy_mult_unwielded = 0.9
-	scatter_unwielded = 0
 	damage_falloff_mult = 0.2
 	mode_list = list(
 		"Standard" = /datum/lasrifle/base/energy_pistol_mode/standard,
@@ -588,7 +586,6 @@
 	burst_delay = 0.15 SECONDS
 	accuracy_mult = 1.1
 	accuracy_mult_unwielded = 0.65
-	scatter_unwielded = 15
 	damage_falloff_mult = 0.5
 	mode_list = list(
 		"Auto burst standard" = /datum/lasrifle/base/energy_carbine_mode/auto_burst_standard,
@@ -666,7 +663,6 @@
 	fire_delay = 1 SECONDS
 	accuracy_mult = 1.35
 	accuracy_mult_unwielded = 0.5
-	scatter_unwielded = 10
 	mode_list = list(
 		"Standard" = /datum/lasrifle/base/energy_sniper_mode/standard,
 		"Heat" = /datum/lasrifle/base/energy_sniper_mode/heat,

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -499,7 +499,7 @@
 	akimbo_additional_delay = 0.9
 	wield_delay = 0.6 SECONDS
 	scatter = 3
-	scatter_unwielded = 0
+	scatter_unwielded = 4
 	fire_delay = 0.15 SECONDS
 	accuracy_mult = 1.1
 	accuracy_mult_unwielded = 0.9


### PR DESCRIPTION
Cleaned up duplicate lines of code for energy weapons

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Some duplicate lines of code snuck into marine energy guns for unwielded scatter.
Edit: energy pistol now correctly has 4 scatter. Previously it was using 0 so was more accurate in one hand than wielded.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Extra code is bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: removed unneeded code
fix: Energy pistol is no longer more accurate one handed than wielded
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
