### PR TITLE
Light Marksman bullet Buff and Battle Rifle auto-burst Buff

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -608,9 +608,9 @@ datum/ammo/bullet/revolver/tp44
 	hud_state = "hivelo"
 	hud_state_empty = "hivelo_empty"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
-	penetration = 10
-	damage = 30
-	sundering = 1
+	penetration = 12
+	damage = 37.5
+	sundering = 1.2
 
 /datum/ammo/bullet/rifle/standard_br/incendiary
 	name = "incendiary light marksman bullet"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -609,7 +609,7 @@ datum/ammo/bullet/revolver/tp44
 	hud_state_empty = "hivelo_empty"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	penetration = 12
-	damage = 37.5
+	damage = 39.99
 	sundering = 1.2
 
 /datum/ammo/bullet/rifle/standard_br/incendiary

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -292,6 +292,7 @@
 	aim_fire_delay = 0.2 SECONDS
 	aim_speed_modifier = 3
 
+	autoburst_delay = 1.3
 	fire_delay = 0.35 SECONDS
 	burst_amount = 3
 	burst_delay = 0.10 SECONDS


### PR DESCRIPTION
## About The Pull Request

As per title says, but it is balanced.
Now requires https://github.com/tgstation/TerraGov-Marine-Corps/pull/9509 .

## Why It's Good For The Game

1-hand: Makes the Battle Rifle bullets moderately less underpowered. This will slightly reward marines using the T-64 BR for it's higher magazine capacity over the T-37 DMR but has less damage, range and accuracy. THIS DOES NOT MAKE BURST SUPERIOR TO AUTOFIRE.
2nd-hand: You don't need to click as much. That's for the benefit of just burst users.

## Changelog
:cl:
balance: Added 9.99 damage, 2 AP, 0.2 sundering to the Light Marksman Bullet for the T-64 BR (from 30 damage, 10 penetration, 1 sunder) and made it's auto burst delay shorter.
/:cl:
