### PR TITLE
Moving YouTool code to marine_vending.dm

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -520,6 +520,9 @@
 		/obj/item/tool/lighter/random = 20,
 	)
 
+/obj/machinery/vending/cigarette/nopower
+	use_power = NO_POWER_USE
+
 /obj/machinery/vending/cargo_supply
 	name = "\improper Operational Supplies Vendor"
 	desc = "A large vendor for dispensing specialty and bulk supplies. Restricted to cargo personnel only."
@@ -1291,5 +1294,20 @@
 		)
 	)
 
-/obj/machinery/vending/cigarette/nopower
+/obj/machinery/vending/tool
+	name = "YouTool"
+	desc = "Tools for tools."
+	icon_state = "tool"
+	icon_deny = "tool-deny"
+	isshared = TRUE
+	products = list(
+		/obj/item/stack/cable_coil = -1,
+		/obj/item/tool/crowbar = -1,
+		/obj/item/tool/weldingtool = -1,
+		/obj/item/tool/wirecutters = -1,
+		/obj/item/tool/wrench = -1,
+		/obj/item/tool/screwdriver = -1,
+	)
+
+/obj/machinery/vending/tool/nopower
 	use_power = NO_POWER_USE

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -449,21 +449,6 @@
 	)
 	idle_power_usage = 211
 
-/obj/machinery/vending/tool
-	name = "YouTool"
-	desc = "Tools for tools."
-	icon_state = "tool"
-	icon_deny = "tool-deny"
-	isshared = TRUE
-	products = list(
-		/obj/item/stack/cable_coil = -1,
-		/obj/item/tool/crowbar = -1,
-		/obj/item/tool/weldingtool = -1,
-		/obj/item/tool/wirecutters = -1,
-		/obj/item/tool/wrench = -1,
-		/obj/item/tool/screwdriver = -1,
-	)
-
 /obj/machinery/vending/engivend
 	name = "Engi-Vend"
 	desc = "Spare engineer vending. What? Did you expect some witty description?"
@@ -478,6 +463,9 @@
 		/obj/item/cell/high = 10,
 		/obj/item/clothing/head/hardhat = 4,
 	)
+
+/obj/machinery/vending/engivend/nopower
+	use_power = NO_POWER_USE
 
 //This one's from bay12
 /obj/machinery/vending/robotics
@@ -543,12 +531,6 @@
 	use_power = NO_POWER_USE
 
 /obj/machinery/vending/sovietsoda/nopower
-	use_power = NO_POWER_USE
-
-/obj/machinery/vending/tool/nopower
-	use_power = NO_POWER_USE
-
-/obj/machinery/vending/engivend/nopower
 	use_power = NO_POWER_USE
 
 /obj/machinery/vending/engineering/nopower


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

Also move /obj/machinery/vending/cigarette/nopower and /obj/machinery/vending/engivend/nopower to their respective location just to make it easier to see child.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Have you ever wonder why when you want to save a crowbar in your loadout (except in engineering belt and tool pouch), crowbar doesn't appear in loadout?

Just me? Okay.

I give you a reason why. Loadout checks marine_vending.dm but not vending_type.dm. I don't know the magic behind this, but it works. It's why MarineMed slowly loses pill bottles over the round.

Yes, I really want to keep a crowbar on person at all time, and I'm too lazy to go to vendor to get one myself. It's why I have loadout. Also, I find this a weird oversight of not being able to save tools beside in engineering belt and tool pouch. We have infinite tools, and alas we cannot save it in loadout other than the engineering belt and tool pouch. Do be like that.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Moving YouTool code to marine_vending.dm
fix: Now you can save cable coil, crowbar, welding tool, wirecutters, wrench, and screwdriver anywhere you want in your loadout beside inside an engineering belt or tool pouch
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
