### PR TITLE
Adds the heat absorbent coifs crates to ice colony.

### DIFF
--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -32049,6 +32049,10 @@
 	dir = 8
 	},
 /area/ice_colony/exterior/surface/valley/north)
+"fYO" = (
+/obj/structure/largecrate/supply/supplies/coifs,
+/turf/open/floor/plating/ground/ice,
+/area/ice_colony/exterior/surface/landing_pad_external)
 "fYR" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -33918,6 +33922,15 @@
 "pwi" = (
 /turf/closed/ice_rock/corners{
 	dir = 10
+	},
+/area/ice_colony/exterior/surface/landing_pad2)
+"pxL" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/largecrate/supply/supplies/coifs,
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
 	},
 /area/ice_colony/exterior/surface/landing_pad2)
 "pxM" = (
@@ -42831,7 +42844,7 @@ ahB
 ajp
 ajW
 xGZ
-adB
+pxL
 xGZ
 xaL
 xGZ
@@ -79936,7 +79949,7 @@ mxE
 mxE
 mxE
 mxE
-mxE
+fYO
 aYB
 aYC
 aYC


### PR DESCRIPTION
## About The Pull Request
Adds heat absorbent coif crates to each LZ on ice colony.
![StrongDMM_2022-02-05_11-07-59](https://user-images.githubusercontent.com/17747087/152637853-d32ae3ad-d079-47fa-b05f-e0f8db48671e.png)
![StrongDMM_2022-02-05_11-08-09](https://user-images.githubusercontent.com/17747087/152637857-601357cc-086f-4497-9df7-99db38a61b89.png)

This has not been tested on a local build but given that it builds without error and that it's a really simple map edit i feel it should cause no major issue.
## Why It's Good For The Game
As i said in my icy caves PR (#9484)
> Heat absorbent coif crates on both landing pads!
> You didn't forget your heat absorbent coif, did you?
> (i'll add these to ice colony once this PR is merged, gotta atomize y'know? Though if it doesn't get merged i'll just make it a separate thing for both maps.)

So now i'm doing that

Eitherway this is just good for any marine that either hasn't realized it's ice colony or forgot to put one on before launching groundside.
## Changelog
:cl: Vondiech
add: added heat absorbent coif crates to each LZ of ice colony.
/:cl:
