### PR TITLE
Fixes mortar flares

### DIFF
--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -339,8 +339,9 @@
 	invisibility = INVISIBILITY_MAXIMUM
 	resistance_flags = RESIST_ALL
 	mouse_opacity = 0
+	light_color = COLOR_VERY_SOFT_YELLOW
 	light_system = HYBRID_LIGHT
-	light_mask_type = /atom/movable/lighting_mask/flicker
+	light_power = 8
 	light_range = 9 //Way brighter than most lights
 
 /obj/effect/mortar_flare/Initialize()


### PR DESCRIPTION
## About The Pull Request

Makes flare shells decent again, and more in-line with their clone, the CAS illumination flares.
-Adds a light_power of 8 (same as CAS flares) to flare shells. This does **NOT** change their actual light range of 9, but it does provide the actual light. Basically, fixes flares so they actually produce light.
-Gives flare shells the same light as CAS flares. They work similarly, last for the same amount of time, and have near the same range. They are literally clones of each other.
-Removes the 'flicker' effect from flare shells. CAS flares don't have it, it looks very jumpy with a larger light radius, and it limits light range. It just doesn't fit as it is now.

Before:
![image](https://user-images.githubusercontent.com/80229419/152646380-5bd206ae-baa5-4bca-818a-edf9dcb14511.png)
After:
![image](https://user-images.githubusercontent.com/80229419/152646134-bd2e0c92-dac9-436a-a47f-d56de43246af.png)

## Why It's Good For The Game

Makes mortar flare actually useful. Judging by the light_range of 9, but the lack of actual light produced, this looks unintentional. I really would not consider this powercreep considering how absolutely useless mortar flares are right now. 

## Changelog
:cl:
fix: Mortar flares now actually produce light
balance: ..and so mortar flares are no longer useless
/:cl:
