### PR TITLE
Soldering Tool Is For Engineers

### DIFF
--- a/code/game/objects/items/tools/soldering_tool.dm
+++ b/code/game/objects/items/tools/soldering_tool.dm
@@ -11,16 +11,16 @@
 	if(!istype(H) || user.a_intent != INTENT_HELP)
 		return ..()
 
+	var/datum/limb/affecting = CHECK_BITFIELD(user.client.prefs.toggles_gameplay, RADIAL_MEDICAL) ? radial_medical(H, user) : H.get_limb(user.zone_selected)
+	if(!affecting)
+		return TRUE
+
 	if(user.skills.getRating("engineer") < SKILL_ENGINEER_ENGI)
 		user.visible_message(span_notice("[user] begins to try to solder [H == user ? "[H.p_their()]" : "[H]'s"]"),
 		span_notice("You begin trying to solder [H == user ? "your" : "[H]'s"] [affecting.display_name]."))
 		var/fumbling_time = 15 SECONDS - 2 SECONDS * user.skills.getRating("engineer")
 		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
 			return ..()
-
-	var/datum/limb/affecting = CHECK_BITFIELD(user.client.prefs.toggles_gameplay, RADIAL_MEDICAL) ? radial_medical(H, user) : H.get_limb(user.zone_selected)
-	if(!affecting)
-		return TRUE
 
 	if(affecting.limb_status != LIMB_ROBOT)
 		balloon_alert(user, "Limb not robotic")

--- a/code/game/objects/items/tools/soldering_tool.dm
+++ b/code/game/objects/items/tools/soldering_tool.dm
@@ -12,8 +12,8 @@
 		return ..()
 
 	if(user.skills.getRating("engineer") < SKILL_ENGINEER_ENGI)
-		user.visible_message(span_notice("[user] begins to try to solder [target].."),
-		span_notice("You begin trying to find a cutting point on the [target]..."))
+		user.visible_message(span_notice("[user] begins to try to solder [TARGET_HUMAN].."),
+		span_notice("You begin trying to find a cutting point on the [TARGET_HUMAN]..."))
 		var/fumbling_time = 15 SECONDS - 2 SECONDS * user.skills.getRating("ENGINEER")
 		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
 			return ..()

--- a/code/game/objects/items/tools/soldering_tool.dm
+++ b/code/game/objects/items/tools/soldering_tool.dm
@@ -7,8 +7,6 @@
 	var/skill_type = "engineer"
 	var/skill_threshold = SKILL_ENGINEER_ENGI
 
-#define ENGINEER_DELAY = 2 seconds
-
 /obj/item/tool/solderingtool/attack(mob/living/carbon/human/H, mob/user)
 	if(!istype(H) || user.a_intent != INTENT_HELP)
 		return ..()

--- a/code/game/objects/items/tools/soldering_tool.dm
+++ b/code/game/objects/items/tools/soldering_tool.dm
@@ -13,7 +13,7 @@
 
 	if(user.skills.getRating("engineer") < SKILL_ENGINEER_ENGI)
 		user.visible_message(span_notice("[user] begins to try to solder [TARGET_HUMAN].."),
-		span_notice("You begin trying to find a cutting point on the [TARGET_HUMAN]..."))
+		span_notice("You begin trying to solder [TARGET_HUMAN]..."))
 		var/fumbling_time = 15 SECONDS - 2 SECONDS * user.skills.getRating("ENGINEER")
 		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
 			return ..()

--- a/code/game/objects/items/tools/soldering_tool.dm
+++ b/code/game/objects/items/tools/soldering_tool.dm
@@ -7,6 +7,8 @@
 	var/skill_type = "engineer"
 	var/skill_threshold = SKILL_ENGINEER_ENGI
 
+#define ENGINEER_DELAY = 2 seconds
+
 /obj/item/tool/solderingtool/attack(mob/living/carbon/human/H, mob/user)
 	if(!istype(H) || user.a_intent != INTENT_HELP)
 		return ..()

--- a/code/game/objects/items/tools/soldering_tool.dm
+++ b/code/game/objects/items/tools/soldering_tool.dm
@@ -11,6 +11,13 @@
 	if(!istype(H) || user.a_intent != INTENT_HELP)
 		return ..()
 
+	if(user.skills.getRating("engineer") < SKILL_ENGINEER_ENGI)
+		user.visible_message(span_notice("[user] begins to try to solder [target].."),
+		span_notice("You begin trying to find a cutting point on the [target]..."))
+		var/fumbling_time = 15 SECONDS - 2 SECONDS * user.skills.getRating("ENGINEER")
+		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
+			return ..()
+
 	var/datum/limb/affecting = CHECK_BITFIELD(user.client.prefs.toggles_gameplay, RADIAL_MEDICAL) ? radial_medical(H, user) : H.get_limb(user.zone_selected)
 	if(!affecting)
 		return TRUE

--- a/code/game/objects/items/tools/soldering_tool.dm
+++ b/code/game/objects/items/tools/soldering_tool.dm
@@ -14,7 +14,7 @@
 	if(user.skills.getRating("engineer") < SKILL_ENGINEER_ENGI)
 		user.visible_message(span_notice("[user] begins to try to solder [H == user ? "[H.p_their()]" : "[H]'s"]"),
 		span_notice("You begin trying to solder [H == user ? "your" : "[H]'s"] [affecting.display_name]."))
-		var/fumbling_time = 15 SECONDS - 2 SECONDS * user.skills.getRating("ENGINEER")
+		var/fumbling_time = 15 SECONDS - 2 SECONDS * user.skills.getRating("engineer")
 		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
 			return ..()
 

--- a/code/game/objects/items/tools/soldering_tool.dm
+++ b/code/game/objects/items/tools/soldering_tool.dm
@@ -1,9 +1,11 @@
 /obj/item/tool/solderingtool
 	name = "soldering tool"
-	desc = "A hand tool to fix combat robot's trauma. You do not need welding goggles for this and you need medical skills for this."
+	desc = "A hand tool to fix combat robot's trauma. You do not need welding goggles for this and you need engineer skills for this."
 	icon = 'icons/obj/items/surgery_tools.dmi'
 	icon_state = "alien_hemostat"
 	w_class = WEIGHT_CLASS_SMALL
+	var/skill_type = "engineer"
+	var/skill_threshold = SKILL_ENGINEER_ENGI
 
 /obj/item/tool/solderingtool/attack(mob/living/carbon/human/H, mob/user)
 	if(!istype(H) || user.a_intent != INTENT_HELP)

--- a/code/game/objects/items/tools/soldering_tool.dm
+++ b/code/game/objects/items/tools/soldering_tool.dm
@@ -12,8 +12,8 @@
 		return ..()
 
 	if(user.skills.getRating("engineer") < SKILL_ENGINEER_ENGI)
-		user.visible_message(span_notice("[user] begins to try to solder [TARGET_HUMAN].."),
-		span_notice("You begin trying to solder [TARGET_HUMAN]..."))
+		user.visible_message(span_notice("[user] begins to try to solder [H == user ? "[H.p_their()]" : "[H]'s"]"),
+		span_notice("You begin trying to solder [H == user ? "your" : "[H]'s"] [affecting.display_name]."))
 		var/fumbling_time = 15 SECONDS - 2 SECONDS * user.skills.getRating("ENGINEER")
 		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
 			return ..()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a skill check for combat engineer skill level and adds the fumble mechanic for those who don't meet the requirements.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Engineer was given the soldering tool but the item was never given a skill check to make sure engineers were actually better at using it. I added this so engineers now have one more role to fill that others can't.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Changed soldering tool to have a SKILL_ENGINEER_ENGI check for use. Fumble for those who fail the check.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
