### PR TITLE
Allow TL127 and Mosin to take bipod attachment

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1122,6 +1122,7 @@
 		/obj/item/attachable/bayonet,
 		/obj/item/attachable/bayonetknife,
 		/obj/item/attachable/compensator,
+		/obj/item/attachable/bipod,
 	)
 
 	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -339,6 +339,7 @@
 		/obj/item/attachable/scope/mosin,
 		/obj/item/attachable/scope/marine,
 		/obj/item/attachable/flashlight,
+		/obj/item/attachable/bipod,
 		/obj/item/attachable/bayonet,
 		/obj/item/attachable/motiondetector,
 		/obj/item/attachable/buildasentry,


### PR DESCRIPTION
## About The Pull Request
Title

## Why It's Good For The Game
The recent change to the bipod a 50% aim mode delay removal makes the attachment a good complement to these long-range sniper guns. Now you can truly feel like a sniper.

## Changelog
:cl:
balance: you can attach bipod to tl127 and mosin
/:cl:
