### PR TITLE
T-35 Buckshot + Bayonet combo no longer 1 shots Elder T1's

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -731,7 +731,7 @@ datum/ammo/bullet/revolver/tp44
 	accuracy_var_high = 9
 	accurate_range = 3
 	max_range = 10
-	damage = 40
+	damage = 35
 	damage_falloff = 4
 	penetration = 0
 
@@ -747,7 +747,7 @@ datum/ammo/bullet/revolver/tp44
 	accuracy_var_high = 9
 	accurate_range = 3
 	max_range = 10
-	damage = 40
+	damage = 35
 	damage_falloff = 4
 	penetration = 0
 


### PR DESCRIPTION


## About The Pull Request

This aims to add a bit of balance by adjusting base buckshot and its extra projectile damages

## Why It's Good For The Game

Because its overpowered and not fair. it currently 1 shots elder runners with little effort needed.

## Changelog
:cl:
balance: buckshot ammo and spread ammo now 35 down from 40
/:cl:

adding clips in a bit.
