### PR TITLE
Lowers ZX76's cost to 40

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -317,7 +317,7 @@ WEAPONS
 /datum/supply_packs/weapons/zx76
 	name = "ZX-76 Twin-Barrled Burst Shotgun"
 	contains = list(/obj/item/weapon/gun/shotgun/zx76)
-	cost = 100
+	cost = 40
 
 /datum/supply_packs/weapons/shotguntracker
 	name = "12 Gauge Tracker Shells"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the cost of ZX76 from 100 to 40.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The ZX is a sidegrade shotgun bordering downgrade in more cases than not. Other than PBing xenos or just funny double slug snipe on big xenos that don't get knocked back (more on that below), it doesn't do much better than the other shotguns or is actively worse at it. Not only that, its benefits also become a massive detriment in case of FF. Burst damage of two flechettes that can be achieved with DB is not worth more req points than a Tx8 with a full ammo belt.

In normal usage it also ends up accidentally worse than it should be on paper. This is because using it with buckshot or slugs causes a knockback on most xenos, which has them actually miss the second shot due to being on the ground. End effect of this is a gun that does what a t35 does at the cost of twice the ammo usage + way higher fire delay, using individual shells unlike the Tx16 which uses mags with simpler reload. Double barrel becomes better in this instance because you can time the shots so that they get up and get hit by the second volley for a gun that is available from roundstart on vendors.

Exhibit A: Slug burst, one hits xeno, other misses due to xeno being on the ground knocked down
![image](https://user-images.githubusercontent.com/72712909/152713717-8dc41623-68f5-48f8-99c1-7b131d3d0480.png)
![image](https://user-images.githubusercontent.com/72712909/152713726-703f7d19-1646-478e-b2f5-e022ffbe7dd8.png)


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added new mechanics or gameplay changes
add: Added more mechanics or gameplay changes
expansion: Expands content of an existing feature
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
