### PR TITLE
Akimbo delay applies to autofire

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -600,6 +600,7 @@
 			return
 		if(gun_user.hand && isgun(gun_user.r_hand) || !gun_user.hand && isgun(gun_user.l_hand)) // If we have a gun in our inactive hand too, both guns get innacuracy maluses
 			dual_wield = TRUE
+			modify_fire_delay(akimbo_additional_delay) // Adds the additional delay to auto_fire
 			if(gun_user.get_inactive_held_item() == src && (gun_firemode == GUN_FIREMODE_SEMIAUTO || gun_firemode == GUN_FIREMODE_BURSTFIRE))
 				return
 		if(gun_user.in_throw_mode)
@@ -650,7 +651,9 @@
 	shots_fired = 0//Let's clean everything
 	set_target(null)
 	windup_checked = WEAPON_WINDUP_NOT_CHECKED
-	dual_wield = FALSE
+	if dual_wield == TRUE
+		modify_fire_delay(-akimbo_additional_delay) // Removes the additional delay from auto_fire
+		dual_wield = FALSE
 	gun_user?.client?.mouse_pointer_icon = initial(gun_user.client.mouse_pointer_icon)
 
 ///Inform the gun if he is currently bursting, to prevent reloading

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -651,7 +651,7 @@
 	shots_fired = 0//Let's clean everything
 	set_target(null)
 	windup_checked = WEAPON_WINDUP_NOT_CHECKED
-	if dual_wield == TRUE
+	if (dual_wield == TRUE)
 		modify_fire_delay(-akimbo_additional_delay) // Removes the additional delay from auto_fire
 		dual_wield = FALSE
 	gun_user?.client?.mouse_pointer_icon = initial(gun_user.client.mouse_pointer_icon)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -651,7 +651,7 @@
 	shots_fired = 0//Let's clean everything
 	set_target(null)
 	windup_checked = WEAPON_WINDUP_NOT_CHECKED
-	if (dual_wield == TRUE)
+	if(dual_wield)
 		modify_fire_delay(-fire_delay + fire_delay/(1 + akimbo_additional_delay)) // Removes the additional delay from auto_fire
 		dual_wield = FALSE
 	gun_user?.client?.mouse_pointer_icon = initial(gun_user.client.mouse_pointer_icon)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -600,7 +600,7 @@
 			return
 		if(gun_user.hand && isgun(gun_user.r_hand) || !gun_user.hand && isgun(gun_user.l_hand)) // If we have a gun in our inactive hand too, both guns get innacuracy maluses
 			dual_wield = TRUE
-			modify_fire_delay(akimbo_additional_delay) // Adds the additional delay to auto_fire
+			modify_fire_delay(fire_delay * akimbo_additional_delay) // Adds the additional delay to auto_fire
 			if(gun_user.get_inactive_held_item() == src && (gun_firemode == GUN_FIREMODE_SEMIAUTO || gun_firemode == GUN_FIREMODE_BURSTFIRE))
 				return
 		if(gun_user.in_throw_mode)
@@ -652,7 +652,7 @@
 	set_target(null)
 	windup_checked = WEAPON_WINDUP_NOT_CHECKED
 	if (dual_wield == TRUE)
-		modify_fire_delay(-akimbo_additional_delay) // Removes the additional delay from auto_fire
+		modify_fire_delay(-(fire_delay - fire_delay/(1 + akimbo_additional_delay))) // Removes the additional delay from auto_fire
 		dual_wield = FALSE
 	gun_user?.client?.mouse_pointer_icon = initial(gun_user.client.mouse_pointer_icon)
 

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -652,7 +652,7 @@
 	set_target(null)
 	windup_checked = WEAPON_WINDUP_NOT_CHECKED
 	if (dual_wield == TRUE)
-		modify_fire_delay(-(fire_delay - fire_delay/(1 + akimbo_additional_delay))) // Removes the additional delay from auto_fire
+		modify_fire_delay(-fire_delay + fire_delay/(1 + akimbo_additional_delay)) // Removes the additional delay from auto_fire
 		dual_wield = FALSE
 	gun_user?.client?.mouse_pointer_icon = initial(gun_user.client.mouse_pointer_icon)
 

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -19,6 +19,7 @@
 	scatter_unwielded = 13
 	recoil_unwielded = 4
 	damage_falloff_mult = 0.5
+	akimbo_additional_delay = 0
 	upper_akimbo_accuracy = 5
 	lower_akimbo_accuracy = 3
 

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -24,6 +24,7 @@
 	fire_delay = 0.3 SECONDS
 	burst_amount = 3
 	recoil_unwielded = 0.5
+	akimbo_additional_delay = 0.2
 
 //-------------------------------------------------------
 // T-19 Machinepistol. It fits here more.


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When firing guns akimbo, there is an extra fire delay associated with it that means you shoot a bit slower. Currently this only applies to semi auto firing, not to full auto.
Makes autofire actually respect the akimbo_additional_delay var.

Also reduced the extra delay value for all SMGs to 0.2 from 0.5. This means guns that fire at 0.15 will fire at 0.2 akimbo.
Rifles reduced to 0 as they're terrible at akimbo, and don't need to be even worse.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Akimbo additional delay now actually works with autofiring. This has balance implications for guns that are used akimbo with autofire :^)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Autofiring while akimbo now actually shoots slower like semi auto
balance: Reduced akimbo additional delay for SMG's and rifles to compensate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
