### PR TITLE
Make the T-64 Great Again

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -608,9 +608,9 @@ datum/ammo/bullet/revolver/tp44
 	hud_state = "hivelo"
 	hud_state_empty = "hivelo_empty"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
-	penetration = 10
-	damage = 30
-	sundering = 1
+	penetration = 15
+	damage = 32.5
+	sundering = 1.25
 
 /datum/ammo/bullet/rifle/standard_br/incendiary
 	name = "incendiary light marksman bullet"

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -277,8 +277,6 @@
 		/obj/item/attachable/scope/mini,
 		/obj/item/attachable/motiondetector,
 		/obj/item/weapon/gun/pistol/plasma_pistol,
-		/obj/item/weapon/gun/shotgun/combat/masterkey,
-		/obj/item/weapon/gun/flamer/mini_flamer,
 		/obj/item/weapon/gun/grenade_launcher/underslung,
 		/obj/item/attachable/buildasentry,
 		/obj/item/weapon/gun/rifle/pepperball/pepperball_mini,
@@ -294,12 +292,12 @@
 	aim_speed_modifier = 3
 
 	autoburst_delay = 0.5 SECONDS
-	fire_delay = 0.3 SECONDS
+	fire_delay = 0.35 SECONDS
 	burst_amount = 3
-	burst_delay = 0.2 SECONDS
-	extra_delay = 0.2 SECONDS
+	burst_delay = 0.1 SECONDS
+	extra_delay = 0.15 SECONDS
 	accuracy_mult = 1.25
-	scatter = 6
+	scatter = 0
 
 //-------------------------------------------------------
 //M412 Pulse Rifle

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -276,7 +276,6 @@
 		/obj/item/attachable/scope/marine,
 		/obj/item/attachable/scope/mini,
 		/obj/item/attachable/motiondetector,
-		/obj/item/weapon/gun/pistol/plasma_pistol,
 		/obj/item/weapon/gun/grenade_launcher/underslung,
 		/obj/item/attachable/buildasentry,
 		/obj/item/weapon/gun/rifle/pepperball/pepperball_mini,

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -293,12 +293,14 @@
 	aim_fire_delay = 0.2 SECONDS
 	aim_speed_modifier = 3
 
-	fire_delay = 0.35 SECONDS
+	autoburst_delay = 0.6 SECONDS
+	fire_delay = 0.3 SECONDS
 	burst_amount = 3
-	burst_delay = 0.10 SECONDS
-	extra_delay = 0.35 SECONDS
+	burst_delay = 0.2 SECONDS
+	extra_delay = 0.3 SECONDS
 	accuracy_mult = 1.25
-	scatter = 0
+	scatter = 6
+
 //-------------------------------------------------------
 //M412 Pulse Rifle
 

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -293,11 +293,11 @@
 	aim_fire_delay = 0.2 SECONDS
 	aim_speed_modifier = 3
 
-	autoburst_delay = 0.6 SECONDS
+	autoburst_delay = 0.5 SECONDS
 	fire_delay = 0.3 SECONDS
 	burst_amount = 3
 	burst_delay = 0.2 SECONDS
-	extra_delay = 0.3 SECONDS
+	extra_delay = 0.2 SECONDS
 	accuracy_mult = 1.25
 	scatter = 6
 

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -290,11 +290,11 @@
 	aim_fire_delay = 0.2 SECONDS
 	aim_speed_modifier = 3
 
-	autoburst_delay = 0.55 SECONDS
+	autoburst_delay = 0.65 SECONDS
 	fire_delay = 0.35 SECONDS
 	burst_amount = 3
-	burst_delay = 0.1 SECONDS
-	extra_delay = 0.2 SECONDS
+	burst_delay = 0.10 SECONDS
+	extra_delay = 0.30 SECONDS
 	accuracy_mult = 1.25
 	scatter = 0
 

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -290,12 +290,12 @@
 	aim_fire_delay = 0.2 SECONDS
 	aim_speed_modifier = 3
 
-	autoburst_delay = 0.65 SECONDS
-	fire_delay = 0.35 SECONDS
+	autoburst_delay = 0.60 SECONDS
+	fire_delay = 0.3 SECONDS
 	burst_amount = 3
 	burst_delay = 0.10 SECONDS
-	extra_delay = 0.30 SECONDS
-	accuracy_mult = 1.25
+	extra_delay = 0.25 SECONDS
+	accuracy_mult = 0.75
 	scatter = 0
 
 //-------------------------------------------------------

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -291,11 +291,11 @@
 	aim_fire_delay = 0.2 SECONDS
 	aim_speed_modifier = 3
 
-	autoburst_delay = 0.5 SECONDS
+	autoburst_delay = 0.56 SECONDS
 	fire_delay = 0.35 SECONDS
 	burst_amount = 3
 	burst_delay = 0.1 SECONDS
-	extra_delay = 0.15 SECONDS
+	extra_delay = 0.21 SECONDS
 	accuracy_mult = 1.25
 	scatter = 0
 

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -291,11 +291,11 @@
 	aim_fire_delay = 0.2 SECONDS
 	aim_speed_modifier = 3
 
-	autoburst_delay = 0.56 SECONDS
+	autoburst_delay = 0.55 SECONDS
 	fire_delay = 0.35 SECONDS
 	burst_amount = 3
 	burst_delay = 0.1 SECONDS
-	extra_delay = 0.21 SECONDS
+	extra_delay = 0.2 SECONDS
 	accuracy_mult = 1.25
 	scatter = 0
 


### PR DESCRIPTION
## About The Pull Request

Made it a uniquely good weapon at medium to long range since autoburst delay and extra delay are shorter.

## Why It's Good For The Game

Autoburst gets to be equal to burst, you shouldn't need to be a good CS:GO player to use the Battle Rifle.

~~Scatter forces you to use a recoil compensator or a vertical grip while making long range shots more difficult, therefore you are more likely to miss, but you have better punch ESPECIALLY AT CLOSE RANGE.~~ Only low scatter (from burst multiplier) makes it a weapon of choice for ranged, ~~plus the accuracy multiplier of 1.25,~~  this is magnified by the bullet changes, but then we remove plasma pistol, UBF and masterkey. 

Last change I made was the accuracy and fine tune balance change.
## Changelog
:cl:
balance: Light marksman bullet gets 5 AP, 2.5 damage and 0.25 sunder.
balance: The T-64 Battle rifle gets slightly better stats in autoburst and burst, can no longer use UBF, plasma pistol and masterkey.
/:cl:
