### PR TITLE
Remove any mention of /obj/item/cell/lasgun/tesla

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1233,7 +1233,6 @@
 	products = list(
 		"Weapon" = list(
 			/obj/item/weapon/gun/energy/lasgun/tesla = -1,
-			/obj/item/cell/lasgun/tesla = -1,
 			/obj/item/weapon/gun/rifle/railgun = -1,
 			/obj/item/ammo_magazine/railgun = -1,
 			/obj/item/weapon/gun/rifle/tx8 = -1,

--- a/code/modules/projectiles/magazines/energy.dm
+++ b/code/modules/projectiles/magazines/energy.dm
@@ -13,13 +13,6 @@
 	///Magazine flags.
 	var/flags_magazine_features = MAGAZINE_REFUND_IN_CHAMBER
 
-/obj/item/cell/lasgun/tesla// Large special battery
-	name = "\improper Energy Rifle battery"
-	desc = "An advanced, ultrahigh capacity battery used to power experimental weapons."
-	base_ammo_icon = "m43_e"
-	icon_state = "m43_e"
-	maxcharge = 2000
-
 /obj/item/cell/lasgun/M43
 	name = "\improper M43 lasgun battery"
 	desc = "A specialized high density battery used to power the M43 lasgun."

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -210,8 +210,7 @@ WEAPONS
 
 /datum/supply_packs/weapons/tesla
 	name = "Tesla Shock Rifle"
-	contains = list(
-		/obj/item/weapon/gun/energy/lasgun/tesla)
+	contains = list(/obj/item/weapon/gun/energy/lasgun/tesla)
 	cost = 60
 
 /datum/supply_packs/weapons/recoillesskit

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -211,20 +211,8 @@ WEAPONS
 /datum/supply_packs/weapons/tesla
 	name = "Tesla Shock Rifle"
 	contains = list(
-		/obj/item/weapon/gun/energy/lasgun/tesla,
-		/obj/item/cell/lasgun/tesla,
-		/obj/item/cell/lasgun/tesla,
-	)
+		/obj/item/weapon/gun/energy/lasgun/tesla)
 	cost = 60
-
-/datum/supply_packs/ammo
-	name = "Energy Rifle cells 3x"
-	contains = list(
-		/obj/item/cell/lasgun/tesla,
-		/obj/item/cell/lasgun/tesla,
-		/obj/item/cell/lasgun/tesla,
-	)
-	cost = 10
 
 /datum/supply_packs/weapons/recoillesskit
 	name = "T-160 Recoilless rifle kit"
@@ -1015,7 +1003,7 @@ ENGINEERING
 	contains = list(/obj/machinery/power/port_gen/pacman/mobile_power)
 	cost = 20
 
-/datum/supply_packs/engineering/teleporter 
+/datum/supply_packs/engineering/teleporter
 	name = "Teleporter pads"
 	contains = list(/obj/effect/teleporter_linker)
 	cost = 50


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #9575 by doing the exact opposite of what the author wants, removing any mention of /obj/item/cell/lasgun/tesla .

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

When I made the tesla gun free, I was told to make it take in the same mag as the energy weapons, the Terra Experimental standard battery. Due to that, the /obj/item/cell/lasgun/tesla kinda existed in supply pack and in code without any use whatsoever. It even showed in Vahalla!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Remove any mention of /obj/item/cell/lasgun/tesla
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
