### PR TITLE
Primordial drone buff

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
@@ -66,8 +66,8 @@
 	name = "Sow"
 	action_icon_state = "place_trap"
 	mechanics_text = "Sow the seeds of an alien plant."
-	plasma_cost = 500
-	cooldown_timer = 1 MINUTES
+	plasma_cost = 200
+	cooldown_timer = 45 SECONDS
 	use_state_flags = XACT_USE_LYING
 	keybind_signal = COMSIG_XENOABILITY_DROP_PLANT
 	alternate_keybind_signal = COMSIG_XENOABILITY_CHOOSE_PLANT

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -1349,9 +1349,9 @@ TUNNEL
 	desc = "A beautiful flower, what purpose it could serve to the alien hive is beyond you however..."
 	icon_state = "stealth_plant_immature"
 	mature_icon_state = "stealth_plant"
-	maturation_time = 5 MINUTES
+	maturation_time = 4 MINUTES
 	///The radius of the passive structure camouflage, requires line of sight
-	var/camouflage_range = 5
+	var/camouflage_range = 7
 	///The range of the active stealth ability, does not require line of sight
 	var/active_camouflage_pulse_range = 10
 	///How long should veil last


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Buffs primordial drone.
Cooldown 60 seconds -> 45 seconds
Plasma cost 500 -> 200

Night shade 
Passive cloaking range 5 tiles -> 7 tiles
Maturation time 5 minutes -> 4 minutes

## Why It's Good For The Game

The plasma price was way too high and forced drones to choose between planting or building.
Night Shade took way too long to grow for what it offered 
## Changelog
:cl:
balance: Primordial drone : Reduced plasma cost and cooldown, night shade takes less time to grow and has greater range.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
