### PR TITLE
Attempt to make Water useful

### DIFF
--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -34,7 +34,7 @@
 	color = "#0064C8" // rgb: 0, 100, 200
 	overdose_threshold = REAGENTS_OVERDOSE * 2
 	custom_metabolism = REAGENTS_METABOLISM * 5 //1.0/tick
-	purge_list = list(/datum/reagent/toxin, /datum/reagent/medicine, /datum/reagent/consumable)
+	purge_list = list(/datum/reagent/medicine, /datum/reagent/consumable)
 	purge_rate = 1
 	taste_description = "water"
 
@@ -57,16 +57,8 @@
 
 
 /datum/reagent/water/on_mob_life(mob/living/L,metabolism)
-	switch(current_cycle)
-		if(4 to 5) //1 sip, starting at the end
-			L.adjustStaminaLoss(-2*effect_str)
-			L.heal_limb_damage(effect_str, effect_str)
-		if(6 to 10) //sip 2
-			L.adjustStaminaLoss(-0.5*effect_str)
-			L.heal_limb_damage(0.1*effect_str, 0.1*effect_str)
-		if(11 to INFINITY) //anything after
-			L.adjustStaminaLoss(-0.15*effect_str)
-			L.heal_limb_damage(0.1*effect_str, 0.1*effect_str)
+	L.adjustStaminaLoss(-15*effect_str)
+	L.heal_limb_damage(effect_str, effect_str)
 	return ..()
 
 /datum/reagent/water/overdose_process(mob/living/L, metabolism)

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -35,7 +35,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE * 2
 	custom_metabolism = REAGENTS_METABOLISM * 5 //1.0/tick
 	purge_list = list(/datum/reagent/medicine, /datum/reagent/consumable)
-	purge_rate = 1
+	purge_rate = 2
 	taste_description = "water"
 
 /datum/reagent/water/reaction_turf(turf/T, volume)


### PR DESCRIPTION
## About The Pull Request
Water no longer purges toxin, increases its purge rate from 1 to 2, but in exchange you gain double the stamina regen of synaptizine. Personally, I think trading your premed in exchange for stamina regen is interesting. You're still fighting against pain slowdown and with enough neurotoxin, the benefits water provides can become a liability instead.

## Why It's Good For The Game
Attempts to make water useful, now those Nanotrasen-sponsored bottled spring water sitting in FOB actually has a use now. 

## Changelog
:cl:
balance: water no longer purges toxin, purge rate increased from 1 to 2, in exchange you get double the stamina regen of synaptizine
/:cl: