### PR TITLE
PO Qol (Small Buff really) 2.0

### DIFF
--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -368,6 +368,8 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 /datum/skills/pilot
 	name = PILOT_OFFICER
 	pilot = SKILL_PILOT_TRAINED
+	engineer = SKILL_ENGINEER_ENGI
+	construction = SKILL_CONSTRUCTION_PLASTEEL
 	powerloader = SKILL_POWERLOADER_PRO
 	leadership = SKILL_LEAD_TRAINED
 


### PR DESCRIPTION
Adds engi skills to PO

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives PO Engi skills.

## Why It's Good For The Game

Would be nice for the PO to be able to reinforce tadpole or even FOB in some scenarios without having to rely on engineers all the time.

## Changelog
:cl:
balance: Gave PO engi and Construction skills
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
