### PR TITLE
Reqtorio cost balance (again)

### DIFF
--- a/code/modules/factory/outputter.dm
+++ b/code/modules/factory/outputter.dm
@@ -121,16 +121,19 @@
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Outputters."
 	refill_type = /obj/item/factory_part/sadar_wp
+	refill_amount = 15
 
 /obj/item/factory_refill/sadar_ap_refill
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Outputters."
 	refill_type = /obj/item/factory_part/sadar_ap
+	refill_amount = 15
 
 /obj/item/factory_refill/sadar_he_refill
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Outputters."
 	refill_type = /obj/item/factory_part/sadar_he
+	refill_amount = 15
 
 /obj/item/factory_refill/light_rr_missile_refill
 	name = "box of rounded metal plates"

--- a/code/modules/factory/outputter.dm
+++ b/code/modules/factory/outputter.dm
@@ -105,13 +105,12 @@
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Outputters."
 	refill_type = /obj/item/factory_part/phosnade
-	refill_amount = 15
+	refill_amount = 25
 
 /obj/item/factory_refill/bignade_refill
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Outputters."
 	refill_type = /obj/item/factory_part/bignade
-
 
 /obj/item/factory_refill/pizza_refill
 	name = "box of rounded metal plates"
@@ -143,11 +142,6 @@
 	desc = "A box with round metal plates inside. Used to refill Outputters."
 	refill_type = /obj/item/factory_part/normal_rr_missile
 
-/obj/item/factory_refill/sadar_he_refill
-	name = "box of rounded metal plates"
-	desc = "A box with round metal plates inside. Used to refill Outputters."
-	refill_type = /obj/item/factory_part/sadar_he
-
 /obj/item/factory_refill/claymore_refill
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Outputters."
@@ -157,19 +151,17 @@
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Outputters."
 	refill_type = /obj/item/factory_part/smartgunner_rifle_box
-	refill_amount = 15
 
 /obj/item/factory_refill/smartgunner_machinegun_magazine_refill
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Outputters."
 	refill_type = /obj/item/factory_part/smartgunner_machinegun_magazine
-	refill_amount = 12
+	refill_amount = 20
 
 /obj/item/factory_refill/auto_sniper_magazine_refill
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Outputters."
 	refill_type = /obj/item/factory_part/auto_sniper_magazine
-	refill_amount = 18
 
 /obj/item/factory_refill/scout_rifle_magazine_refill
 	name = "box of rounded metal plates"
@@ -177,12 +169,10 @@
 	refill_type = /obj/item/factory_part/scout_rifle_magazine
 	refill_amount = 20
 
-
 /obj/item/factory_refill/mateba_speedloader_refill
 	name = "box of rounded metal plates"
 	desc = "A box with round metal plates inside. Used to refill Outputters."
 	refill_type = /obj/item/factory_part/mateba_speedloader
-	refill_amount = 30
 
 /obj/item/factory_refill/railgun_magazine_refill
 	name = "box of rounded metal plates"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1452,7 +1452,7 @@ FACTORY
 /datum/supply_packs/factory/phosphosrefill
 	name = "Phosphorus-resistant plates refill"
 	contains = list(/obj/item/factory_refill/phosnade_refill)
-	cost = 60
+	cost = 90
 
 /datum/supply_packs/factory/bignaderefill
 	name = "Rounded M15 plates refill"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1472,17 +1472,17 @@ FACTORY
 /datum/supply_packs/factory/sadar_refill_wp
 	name = "SADAR WP missile assembly refill"
 	contains = list(/obj/item/factory_refill/sadar_wp_refill)
-	cost = 110
+	cost = 90
 
 /datum/supply_packs/factory/standard_recoilless_refill
 	name = "Recoilless standard missile assembly refill"
 	contains = list(/obj/item/factory_refill/normal_rr_missile_refill)
-	cost = 20
+	cost = 30
 
 /datum/supply_packs/factory/light_recoilless_refill
 	name = "Recoilless light missile assembly refill"
 	contains = list(/obj/item/factory_refill/light_rr_missile_refill)
-	cost = 20
+	cost = 30
 
 /datum/supply_packs/factory/pizzarefill
 	name = "Nanotrasen \"Eat healthy!\" margerita pizza kit refill"
@@ -1492,7 +1492,7 @@ FACTORY
 /datum/supply_packs/factory/smartrifle_ammo_refill
 	name = "Smart rifle bullet parts refill"
 	contains = list(/obj/item/factory_refill/smartgunner_rifle_box_refill)
-	cost = 30
+	cost = 20
 
 /datum/supply_packs/factory/smartgun_magazine_refill
 	name = "Smart machinegun drum parts refill"
@@ -1512,20 +1512,14 @@ FACTORY
 /datum/supply_packs/factory/claymorerefill
 	name = "Claymore parts refill"
 	contains = list(/obj/item/factory_refill/claymore_refill)
-	cost = 20
-
+	cost = 30
 
 /datum/supply_packs/factory/mateba_speedloader_refill
 	name = "Mateba autorevolver speedloader assembly refill"
 	contains = list(/obj/item/factory_refill/mateba_speedloader_refill)
-	cost = 20
+	cost = 30
 
 /datum/supply_packs/factory/railgun_magazine_refill
 	name = "Railgun magazine assembly refill"
 	contains = list(/obj/item/factory_refill/railgun_magazine_refill)
 	cost = 20
-
-/datum/supply_packs/factory/scout_rifle_magazine_refill
-	name = "TX-8 scout rifle magazine assembly refill"
-	contains = list(/obj/item/factory_refill/scout_rifle_magazine_refill)
-	cost = 90

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1462,17 +1462,17 @@ FACTORY
 /datum/supply_packs/factory/sadar_refill_he
 	name = "SADAR HE missile assembly refill"
 	contains = list(/obj/item/factory_refill/sadar_he_refill)
-	cost = 100
+	cost = 50
 
 /datum/supply_packs/factory/sadar_refill_ap
 	name = "SADAR AP missile assembly refill"
 	contains = list(/obj/item/factory_refill/sadar_ap_refill)
-	cost = 110
+	cost = 60
 
 /datum/supply_packs/factory/sadar_refill_wp
 	name = "SADAR WP missile assembly refill"
 	contains = list(/obj/item/factory_refill/sadar_wp_refill)
-	cost = 90
+	cost = 40
 
 /datum/supply_packs/factory/standard_recoilless_refill
 	name = "Recoilless standard missile assembly refill"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reqtorio was too unbalanced in profit per different refills, this PR makes them more in line with each other. Also removed some duplicate code.

Before:
![изображение](https://user-images.githubusercontent.com/69199543/153276108-70c319d2-ffd8-4a53-9c99-22bbf8f74450.png)

After:
![изображение](https://user-images.githubusercontent.com/69199543/153372425-21b31f8d-3002-4e13-99f6-5723e73cb2ed.png)


## Why It's Good For The Game

Reqtorio is good again.

## Changelog
:cl:
balance: Reqtorio cost balance. Grenades and smart ammo are now more profitable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
