### PR TITLE
Replace 1 platinum miner in Big Red and 2 miners in Prison Station

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -24505,7 +24505,7 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "poJ" = (
-/obj/machinery/miner/damaged/platinum,
+/obj/machinery/miner/damaged,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/s)
 "poX" = (

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -43101,7 +43101,7 @@
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
 "iDz" = (
-/obj/machinery/miner/damaged/platinum,
+/obj/machinery/miner/damaged,
 /turf/open/floor/prison,
 /area/prison/research/secret/dissection)
 "iFe" = (
@@ -44187,7 +44187,7 @@
 /turf/open/floor/plating,
 /area/prison/hangar/main)
 "lPU" = (
-/obj/machinery/miner/damaged/platinum,
+/obj/machinery/miner/damaged,
 /turf/open/floor/prison/blue{
 	dir = 8
 	},


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Big Red ETA's plat miner changed to a phoron miner.

Prison Station's plat miners that tadpole go to changed to phoron miners.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Plat miners are reserved to be in caves. The time that tadpole can land in caves to mine plat miners are over, and we must ensure that we don't relive the glorious days.

Also, if I don't do this now, someone else will with greater effect.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Replace 1 platinum miner in Big Red and 2 miners in Prison Station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
