### PR TITLE
Removes old ammo scatter values

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -395,7 +395,6 @@ datum/ammo/bullet/revolver/tp44
 	damage_falloff = 0
 	accuracy = 15
 	accurate_range = 15
-	scatter = -15
 	damage = 30
 	penetration = 10
 
@@ -601,7 +600,6 @@ datum/ammo/bullet/revolver/tp44
 	accurate_range = 30
 	max_range = 40
 	damage = 65
-	scatter = -15
 	penetration = 15
 	sundering = 2
 
@@ -937,7 +935,6 @@ datum/ammo/bullet/revolver/tp44
 	shell_speed = 4
 	accurate_range = 30
 	max_range = 40
-	scatter = -20
 	damage = 80
 	penetration = 60
 	sundering = 15
@@ -950,7 +947,6 @@ datum/ammo/bullet/revolver/tp44
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_INCENDIARY|AMMO_SNIPER|AMMO_SUNDERING
 	accuracy_var_high = 7
 	max_range = 20
-	scatter = 15
 	damage = 50
 	penetration = 20
 	sundering = 5
@@ -1041,7 +1037,6 @@ datum/ammo/bullet/revolver/tp44
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	accurate_range = 15
 	damage = 20
-	scatter = -10
 	penetration = 20
 	sundering = 1
 


### PR DESCRIPTION
Splinter forgot to removes these values :^)

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A few ammo types have rather large scatter modifiers that make them wack with the new scatter system. Removes these values as they break balance.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
pinpoint accurate akimbo DMR is not fun for beno.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: DMR is no longer pinpoint accurate unwielded.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
