### PR TITLE
Miner upgrades in engineer point vendor

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -87,6 +87,8 @@ GLOBAL_LIST_INIT(engineer_gear_listed_products, list(
 		/obj/item/storage/box/explosive_mines = list(CAT_ENGSUP, "M20 mine box", 18, "black"),
 		/obj/item/storage/box/explosive_mines/large = list(CAT_ENGSUP, "Large M20 mine box", 35, "black"),
 		/obj/item/minelayer = list(CAT_ENGSUP, "M21 APRDS \"Minelayer\"", 5, "black"),
+		/obj/item/minerupgrade/overclock = list(CAT_ENGSUP, "Mining well overclock upgrade", 4, "black"),
+		/obj/item/minerupgrade/reinforcement = list(CAT_ENGSUP, "Mining well reinforcement upgrade", 4, "black"),
 		/obj/item/storage/pouch/explosive/razorburn = list(CAT_ENGSUP, "Pack of Razorburn grenades", 11, "orange"),
 		/obj/item/explosive/grenade/chem_grenade/razorburn_large = list(CAT_ENGSUP, "Razorburn canister", 7, "black"),
 		/obj/item/explosive/grenade/chem_grenade/razorburn_smol = list(CAT_ENGSUP, "Razorburn grenade", 3, "black"),


### PR DESCRIPTION
## About The Pull Request
Title. For 4 points since that's the same points you would spend if you were to convert bought metal into miner modules back when they were in the autolathe. 

## Why It's Good For The Game
Removing them from the autolathe is good since it prevents printing infinite miner modules with enough patience, but removing an engineer's ability to acquire them outside of req stomps on any mining plans an engineer might have for the round. This returns miner control to the role that is responsible for repairing them.

## Changelog
:cl:
balance: miner upgrades in engineer point vendor for 4 points (does not include autominer)
/:cl: