### PR TITLE
Crusher speed buff

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -15,7 +15,7 @@
 	attack_delay = 8
 
 	// *** Speed *** //
-	speed = 0.1
+	speed = -0.1
 
 	// *** Plasma *** //
 	plasma_max = 200
@@ -69,7 +69,7 @@
 	upgrade = XENO_UPGRADE_ONE
 
 	// *** Speed *** //
-	speed = 0.1
+	speed = -0.1
 
 	// *** Plasma *** //
 	plasma_max = 300
@@ -98,7 +98,7 @@
 	melee_damage = 24
 
 	// *** Speed *** //
-	speed = 0.1
+	speed = -0.1
 
 	// *** Plasma *** //
 	plasma_max = 400
@@ -127,7 +127,7 @@
 	melee_damage = 24
 
 	// *** Speed *** //
-	speed = 0.1
+	speed = -0.1
 
 	// *** Plasma *** //
 	plasma_max = 400
@@ -156,7 +156,7 @@
 	melee_damage = 24
 
 	// *** Speed *** //
-	speed = 0.1
+	speed = -0.1
 
 	// *** Plasma *** //
 	plasma_max = 400


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Crusher is one of the weakest T3s in the game, overshadowed by Gorger and Razorwire. This is just a small buff so crushers can flee from barricades quicker.

## Why It's Good For The Game

Buffs weak T3 caste, balance achieved.

## Changelog
:cl:
balance: Crusher speed increased from 0.1 to -0.1
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
