### PR TITLE
Razorwire fix

### DIFF
--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -128,7 +128,10 @@
 
 
 /obj/structure/razorwire/proc/on_exited(datum/source, atom/movable/AM, direction)
-	if(isliving(AM))
+	if(!isliving(AM))
+		return
+	var/mob/living/crossing_mob = AM
+	if(CHECK_BITFIELD(crossing_mob.restrained_flags, RESTRAINED_RAZORWIRE))
 		razorwire_untangle(AM)
 
 /obj/structure/razorwire/Destroy()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Prevents razor wires from slowing you down twice when you managed to get on top of them and attempted to resist out.

## Why It's Good For The Game

Crushers no longer turn into snails the moment they touch the apex predator.
closes #9418
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Razorwires no longer apply their slowdown twice when resisted out of (notabily by Crushers).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
