### PR TITLE
T-26 Alt ammo buff and available from req

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -39,7 +39,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	var/armor_type					= "bullet"	// Does this have an override for the armor type the ammo should test? Bullet by default
 	var/sundering					= 0 		// How many stacks of sundering to apply to a mob on hit
 	///how much damage airbursts do to mobs around the target, multiplier of the bullet's damage
-	var/airburst_multiplier	= 0.1		
+	var/airburst_multiplier	= 0.1
 	var/flags_ammo_behavior = NONE
 	///Determines what color our bullet will be when it flies
 	var/bullet_color = COLOR_WHITE
@@ -961,6 +961,7 @@ datum/ammo/bullet/revolver/tp44
 	damage = 90
 	penetration = 0
 	sundering = 25
+	airburst_multiplier	= 0.2
 
 /datum/ammo/bullet/sniper/flak/on_hit_mob(mob/victim, obj/projectile/proj)
 	airburst(victim, proj)

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -333,7 +333,19 @@ WEAPONS
 /datum/supply_packs/weapons/antimaterial_ammo
 	name = "T-26 AMR magazine"
 	contains = list(/obj/item/ammo_magazine/sniper)
+	cost = 3
+	available_against_xeno_only = TRUE
+
+/datum/supply_packs/weapons/antimaterial_incend_ammo
+	name = "T-26 AMR incendiary magazine"
+	contains = list(/obj/item/ammo_magazine/sniper/incendiary)
 	cost = 5
+	available_against_xeno_only = TRUE
+
+/datum/supply_packs/weapons/antimaterial_flak_ammo
+	name = "T-26 AMR flak magazine"
+	contains = list(/obj/item/ammo_magazine/sniper/flak)
+	cost = 4
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/specminigun


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the incendiary and flak ammo for the AMR actually available in game, and tweaked the prices of all three ammo types to be more in line with the superior T-81.

Standard   3 points from 5 (same as T-81)
Flak           4 points
Incendiary 5 points

Also increases flak's airburst multiplier to 0.2, as currently it does nothing of value.

I would drop the AMR cost itself, but there's already a PR for that.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives the AMR something to distinguish it from the cheaper, more powerful NV T-81.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Add T-26 incendiary and flak ammo to req
balance: Decreased the cost of basic T-26 ammo to be in line with T-81 ammo
balance: Increased the AOE damage of flak ammo slightly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
