### PR TITLE
Specialist equipment crates can be bought from Requisitions

### DIFF
--- a/code/game/objects/items/storage/marine_boxes.dm
+++ b/code/game/objects/items/storage/marine_boxes.dm
@@ -213,8 +213,6 @@
 	new /obj/item/detpack(src)
 	new /obj/item/assembly/signaler(src)
 
-
-
 /obj/item/storage/box/spec/sniper
 	name = "\improper Sniper equipment"
 	desc = "A large case containing your very own long-range sniper rifle. Drag this sprite into you to open it up!\nNOTE: You cannot put items back inside this case."
@@ -293,7 +291,6 @@
 	new /obj/item/explosive/grenade/smokebomb/cloak(src)
 	new /obj/item/bodybag/tarp(src)
 
-
 /obj/item/storage/box/spec/scoutshotgun
 	name = "\improper Scout equipment"
 	desc = "A large case containing Scout equipment; this one features the ZX-76 assault shotgun. Drag this sprite into you to open it up!\nNOTE: You cannot put items back inside this case."
@@ -315,6 +312,7 @@
 	new /obj/item/weapon/gun/pistol/vp70(src)
 	new /obj/item/ammo_magazine/pistol/vp70(src)
 	new /obj/item/ammo_magazine/pistol/vp70(src)
+	new /obj/item/weapon/gun/shotgun/zx76(src)
 	new /obj/item/ammo_magazine/shotgun/incendiary(src)
 	new /obj/item/ammo_magazine/shotgun/incendiary(src)
 	new /obj/item/storage/backpack/marine/satchel/scout_cloak/scout(src)
@@ -322,7 +320,6 @@
 	new /obj/item/explosive/grenade/smokebomb/cloak(src)
 	new /obj/item/explosive/grenade/smokebomb/cloak(src)
 	new /obj/item/explosive/grenade/smokebomb/cloak(src)
-
 
 /obj/item/storage/box/spec/tracker
 	name = "\improper Scout equipment"
@@ -382,15 +379,13 @@
 	new /obj/item/ammo_magazine/flamer_tank/large(src)
 	new /obj/item/ammo_magazine/flamer_tank/large/X(src)
 
-
-
 /obj/item/storage/box/spec/heavy_grenadier
 	name = "\improper Heavy Grenadier case"
 	desc = "A large case containing B17 Heavy Armor and a heavy-duty multi-shot grenade launcher, the Armat Systems M92. Drag this sprite into you to open it up!\nNOTE: You cannot put items back inside this case."
 	icon = 'icons/Marine/marine-weapons.dmi'
 	icon_state = "grenade_case"
 	w_class = WEIGHT_CLASS_HUGE
-	storage_slots = 6
+	storage_slots = 9
 	slowdown = 1
 	can_hold = list() //Nada. Once you take the stuff out it doesn't fit back in.
 	foldable = null
@@ -426,7 +421,6 @@
 	new /obj/item/weapon/gun/minigun(src)
 	new /obj/item/belt_harness/marine(src)
 	new /obj/item/ammo_magazine/minigun_powerpack(src)
-
 
 /obj/item/spec_kit //For events/WO, allowing the user to choose a specalist kit
 	name = "specialist kit"
@@ -478,9 +472,7 @@
 			new /obj/item/storage/box/spec/tracker (T)
 	qdel(src)
 
-
 ////////////////// portable marine kits ///////////////////////////:
-
 
 /obj/item/storage/box/squadmarine
 	icon = 'icons/Marine/marine-weapons.dmi'

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1039,6 +1039,46 @@ SUPPLIES
 	)
 	cost = 5
 
+/datum/supply_packs/supplies/demolitionist
+	name = "Demolitionist equipment crate"
+	contains = list(/obj/item/storage/box/spec/demolitionist)
+	cost = 5
+
+/datum/supply_packs/supplies/sniper
+	name = "Sniper equipment crate"
+	contains = list(/obj/item/storage/box/spec/sniper)
+	cost = 5
+
+/datum/supply_packs/supplies/scout
+	name = "Scout equipment crate"
+	contains = list(/obj/item/storage/box/spec/scout)
+	cost = 5
+
+/datum/supply_packs/supplies/scoutshotgun
+	name = "Shotgun scout equipment crate"
+	contains = list(/obj/item/storage/box/spec/scoutshotgun)
+	cost = 5
+
+/datum/supply_packs/supplies/tracker
+	name = "Tracker scout equipment crate"
+	contains = list(/obj/item/storage/box/spec/tracker)
+	cost = 5
+
+/datum/supply_packs/supplies/pyro
+	name = "Pyrotechnician equipment crate"
+	contains = list(/obj/item/storage/box/spec/pyro)
+	cost = 5
+
+/datum/supply_packs/supplies/heavy_grenadier
+	name = "Heavy Grenadier equipment crate"
+	contains = list(/obj/item/storage/box/spec/heavy_grenadier)
+	cost = 5
+
+/datum/supply_packs/supplies/heavy_gunner
+	name = "Heavy Minigunner equipment crate"
+	contains = list(/obj/item/storage/box/spec/heavy_gunner)
+	cost = 5
+
 /*******************************************************************************
 Imports
 *******************************************************************************/

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1042,42 +1042,42 @@ SUPPLIES
 /datum/supply_packs/supplies/demolitionist
 	name = "Demolitionist equipment crate"
 	contains = list(/obj/item/storage/box/spec/demolitionist)
-	cost = 5
+	cost = 160
 
 /datum/supply_packs/supplies/sniper
 	name = "Sniper equipment crate"
 	contains = list(/obj/item/storage/box/spec/sniper)
-	cost = 5
+	cost = 160
 
 /datum/supply_packs/supplies/scout
 	name = "Scout equipment crate"
 	contains = list(/obj/item/storage/box/spec/scout)
-	cost = 5
+	cost = 170
 
 /datum/supply_packs/supplies/scoutshotgun
 	name = "Shotgun scout equipment crate"
 	contains = list(/obj/item/storage/box/spec/scoutshotgun)
-	cost = 5
+	cost = 180
 
 /datum/supply_packs/supplies/tracker
 	name = "Tracker scout equipment crate"
 	contains = list(/obj/item/storage/box/spec/tracker)
-	cost = 5
+	cost = 120
 
 /datum/supply_packs/supplies/pyro
 	name = "Pyrotechnician equipment crate"
 	contains = list(/obj/item/storage/box/spec/pyro)
-	cost = 5
+	cost = 130
 
 /datum/supply_packs/supplies/heavy_grenadier
 	name = "Heavy Grenadier equipment crate"
 	contains = list(/obj/item/storage/box/spec/heavy_grenadier)
-	cost = 5
+	cost = 180
 
 /datum/supply_packs/supplies/heavy_gunner
 	name = "Heavy Minigunner equipment crate"
 	contains = list(/obj/item/storage/box/spec/heavy_gunner)
-	cost = 5
+	cost = 180
 
 /*******************************************************************************
 Imports


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Specialist equipment crates can be bought from Requisitions. Cost is calculated from the all items inside, with a small discount applied.

![изображение](https://user-images.githubusercontent.com/69199543/153707426-fcaa6297-af14-4ea5-85d9-83c4945e01ed.png)

## Why It's Good For The Game

- You can cosplay a spec;
- You get access to some unique stuff like spec armor or scout binoculars;
- Yes, it's expensive, but you get cool stuff that might not otherwise be used;

## Changelog
:cl:
add: specialist equipment crates can be bought from requisitions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
