### PR TITLE
Fixes gun safeties

### DIFF
--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -531,7 +531,7 @@ should be alright.
 
 	to_chat(usr, span_notice("You toggle the safety [HAS_TRAIT(src, TRAIT_GUN_SAFETY) ? "<b>off</b>" : "<b>on</b>"]."))
 	playsound(usr, 'sound/weapons/guns/interact/selector.ogg', 15, 1)
-	if(HAS_TRAIT(src, TRAIT_GUN_SAFETY))
+	if(!HAS_TRAIT(src, TRAIT_GUN_SAFETY))
 		ADD_TRAIT(src, TRAIT_GUN_SAFETY, GUN_TRAIT)
 	else
 		REMOVE_TRAIT(src, TRAIT_GUN_SAFETY, GUN_TRAIT)


### PR DESCRIPTION
## About The Pull Request

Fixes #9621

## Why It's Good For The Game

Actually it isn't, more FF is good. This is an objectively terrible PR.

## Changelog
:cl:
fix: After 5 whole months, the safety on all TGMC weapons has now been fixed. What do you mean you never use the safety?
/:cl: