### PR TITLE
Fixes cryo icon not updating

### DIFF
--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -29,10 +29,9 @@
 	else
 		showpipe = FALSE
 		plane = FLOOR_PLANE
-		return ..()
 
 	if(!showpipe)
-		return //no need to update the pipes if they aren't showing
+		return ..()
 
 	var/connected = 0 //Direction bitset
 

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -19,7 +19,6 @@
 
 /obj/machinery/atmospherics/components/update_icon()
 	update_icon_nopipes()
-	update_icon_state()
 
 	underlays.Cut()
 
@@ -30,6 +29,7 @@
 	else
 		showpipe = FALSE
 		plane = FLOOR_PLANE
+		return ..()
 
 	if(!showpipe)
 		return //no need to update the pipes if they aren't showing
@@ -49,6 +49,7 @@
 
 	if(!shift_underlay_only)
 		PIPING_LAYER_SHIFT(src, piping_layer)
+	return ..()
 
 /obj/machinery/atmospherics/components/proc/get_pipe_underlay(state, dir, color = null)
 	if(color)

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -19,6 +19,7 @@
 
 /obj/machinery/atmospherics/components/update_icon()
 	update_icon_nopipes()
+	update_icon_state()
 
 	underlays.Cut()
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -112,6 +112,10 @@
 		beaker = null
 		updateUsrDialog()
 
+/obj/machinery/atmospherics/components/unary/cryo_cell/update_icon()
+	update_icon_state()
+	return ..()
+
 /obj/machinery/atmospherics/components/unary/cryo_cell/update_icon_state()
 	if(!on)
 		icon_state = "cell-off"

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -112,10 +112,6 @@
 		beaker = null
 		updateUsrDialog()
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/update_icon()
-	update_icon_state()
-	return ..()
-
 /obj/machinery/atmospherics/components/unary/cryo_cell/update_icon_state()
 	if(!on)
 		icon_state = "cell-off"


### PR DESCRIPTION
## About The Pull Request

Fixes #9597

tbh I'm not sure whether I should be changing the call in /obj/machinery/atmospherics/components/update_icon() instead, in the off chance that I break something, or if I should be using the same signal code present in atom/proc/update_icon() to check for updates instead, but hey bandaid fix, maintainers asleep, wooooo

## Why It's Good For The Game

Fixes buggy sprite

## Changelog
:cl:
fix: Cryotube should now update it's icon properly
/:cl:
