### PR TITLE
Deployables can no longer be deployed into nullspace

### DIFF
--- a/code/datums/elements/deployable_item.dm
+++ b/code/datums/elements/deployable_item.dm
@@ -48,7 +48,7 @@
 	if(!(item_in_active_hand?.flags_item & IS_DEPLOYABLE))
 		return
 	var/list/modifiers = params2list(params)
-	if(!modifiers["ctrl"] || modifiers["right"] || get_turf(user) == location || !(user.Adjacent(object)))
+	if(!modifiers["ctrl"] || modifiers["right"] || get_turf(user) == location || !(user.Adjacent(object)) || !location)
 		return
 	INVOKE_ASYNC(src, .proc/finish_deploy, item_in_active_hand, user, location)
 	return COMSIG_KB_ACTIVATED


### PR DESCRIPTION
## About The Pull Request

Fixes #9612

## Why It's Good For The Game

Stops the marine from deleting the deployable

## Changelog
:cl:
fix: You can no longer send deployables into nullspace by deploying it to your hand.
/:cl: