### PR TITLE
Fixes Evac

### DIFF
--- a/code/modules/shuttle/escape_pod.dm
+++ b/code/modules/shuttle/escape_pod.dm
@@ -10,9 +10,6 @@
 
 	var/list/doors = list()
 	var/list/cryopods = list()
-	var/max_capacity // set this to override determining capacity by number of cryopods
-	///Number of marines that escaped
-	var/human_escaped = 0
 
 /obj/docking_port/mobile/escape_pod/escape_shuttle
 	name = "escape shuttle"
@@ -30,26 +27,15 @@
 		SSshuttle.escape_pods -= src
 	. = ..()
 
-/obj/docking_port/mobile/escape_pod/proc/check_capacity()
-	var/capacity = 0
-	for(var/t in return_turfs())
-		var/turf/T = t
+/obj/docking_port/mobile/escape_pod/proc/count_escaped_humans()
+	for(var/turf/T AS in return_turfs())
 		for(var/mob/living/carbon/human/marine in T.GetAllContents())
 			if(marine.stat == DEAD)
 				continue
-			human_escaped++
-		for(var/obj/machinery/cryopod/evacuation/E in T.GetAllContents())
-			capacity++
-	if(max_capacity)
-		capacity = max_capacity
-	return human_escaped <= capacity
+			SSevacuation.human_escaped++
 
 /obj/docking_port/mobile/escape_pod/proc/launch(manual = FALSE)
 	if(!can_launch || launch_status == NOLAUNCH)
-		return
-	if(!check_capacity())
-		playsound(return_center_turf(),'sound/effects/alert.ogg', 25, 1)
-		addtimer(CALLBACK(src, .proc/launch), 10 SECONDS, TIMER_UNIQUE)
 		return
 	playsound(return_center_turf(),'sound/effects/escape_pod_warmup.ogg', 25, 1)
 	if(manual)
@@ -79,7 +65,7 @@
 	if(!can_launch)
 		return
 	playsound(return_center_turf(),'sound/effects/escape_pod_launch.ogg', 25, 1)
-	SSevacuation.human_escaped += human_escaped
+	count_escaped_humans()
 	SSshuttle.moveShuttleToTransit(id, TRUE)
 
 /obj/docking_port/stationary/escape_pod


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes max capacity requirement. Any number of marines can now evac.
@Walarks 

## Why It's Good For The Game

With #9227 Marines can now evac after 10 minutes to try and prevent a Xeno major. More than 50% of marines
alive have to evac to attain this round end conclusion but it's harder to do so on some shipmaps like Minerva or on higher pops. This removes the evac capacity limit and fixes a few checks (Tested and seems to work so far).

## Changelog
:cl:
del: Removes evac max capacity.
fix: Fixed an apparent infinite loop check.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
