### PR TITLE
Adds Turbo inhalant

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -775,3 +775,6 @@
 
 //Signals for ais
 #define ESCORTING_ATOM_BEHAVIOUR_CHANGED "escorting_behaviour_changed"
+
+//Not sure where else this could go
+#define COMSIG_STAMINA_REGEN "stamina_regen"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -43,12 +43,17 @@
 
 
 /mob/living/proc/handle_staminaloss()
+	var/list/regen_modifier = list()
+	var/regen_bonus = 1
+	SEND_SIGNAL(src, COMSIG_STAMINA_REGEN, regen_modifier)
+	for(var/values in regen_modifier)
+		regen_bonus *= values
 	if(world.time < last_staminaloss_dmg + 3 SECONDS)
 		return
 	if(staminaloss > 0)
-		adjustStaminaLoss(-maxHealth * 0.2, TRUE, FALSE)
+		adjustStaminaLoss((-maxHealth * 0.2) * regen_bonus, TRUE, FALSE)	//Default tired regen speed is 20 per tick
 	else if(staminaloss > -max_stamina_buffer)
-		adjustStaminaLoss(-max_stamina_buffer * 0.08, TRUE, FALSE)
+		adjustStaminaLoss((-max_stamina_buffer * 0.08) * regen_bonus, TRUE, FALSE)	//Default normal regen speed is 4 per tick
 
 
 /mob/living/proc/handle_regular_hud_updates()

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -696,7 +696,6 @@
 	RegisterSignal(L, COMSIG_STAMINA_REGEN, .proc/modify_stamina_regen)
 	to_chat(L, span_notice("The world around you slows down slightly. You feel like you could run for hours!"))
 	L.max_stamina_buffer = 75	//1.5x more stamina "health"
-	L.adjustStaminaLoss(-25)	//Initial stamina boost to pair with the increase in max stamina
 
 /datum/reagent/turbo/on_mob_delete(mob/living/L, metabolism)
 	UnregisterSignal(L, COMSIG_STAMINA_REGEN)


### PR DESCRIPTION
## About The Pull Request

Chemical that boosts stamina regeneration. Not familiar with current TGMC balance so feel free to suggest appropriate values. Also not adding reactions or an item to deliver it as those are balancing matters.

Provides:
- 75 max stamina buffer (default 50)
- 3 times faster stamina regenerated per tick when at rest and not tired
- 2 times faster stamina regenerated when tired

Turbo comes with addiction and non-critical overdose penalties.

## Why It's Good For The Game

Seemed well received in the Discord, so may as well contribute upstream.

## Changelog
:cl:
add: Turbo inhalant: boosts natural stamina regeneration.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
