### PR TITLE
Deployable and tadpole fixes

### DIFF
--- a/code/game/objects/machinery/deployable.dm
+++ b/code/game/objects/machinery/deployable.dm
@@ -113,6 +113,10 @@
 	if(CHECK_BITFIELD(internal_item.flags_item, DEPLOYED_WRENCH_DISASSEMBLE))
 		to_chat(user, "<span class = 'notice'>You cannot disassemble [src] without a wrench.</span>")
 		return
+	if(operator)
+		to_chat(user, "<span class = 'notice'>You cannot disassemble [src] when someone uses it.</span>")
+		return
+
 	disassemble(user)
 
 /obj/machinery/deployable/wrench_act(mob/living/user, obj/item/I)

--- a/code/game/objects/machinery/deployable.dm
+++ b/code/game/objects/machinery/deployable.dm
@@ -114,7 +114,7 @@
 		to_chat(user, "<span class = 'notice'>You cannot disassemble [src] without a wrench.</span>")
 		return
 	if(operator)
-		to_chat(user, "<span class = 'notice'>You cannot disassemble [src] when someone uses it.</span>")
+		to_chat(user, span_notice("You cannot disassemble [src] while someone is using it."))
 		return
 
 	disassemble(user)

--- a/code/modules/projectiles/mounted.dm
+++ b/code/modules/projectiles/mounted.dm
@@ -186,7 +186,10 @@
 		to_chat(operator, "This one is anchored in place and cannot be rotated.")
 		return FALSE
 
-	if(can_be_rotated(angle))
+	var/list/leftright = LeftAndRightOfDir(dir)
+	var/left = leftright[1] - 1
+	var/right = leftright[2] + 1
+	if(!(left == (angle-1)) && !(right == (angle+1)))
 		to_chat(operator, span_warning("[src] cannot be rotated so violently."))
 		return FALSE
 
@@ -210,13 +213,6 @@
 
 	if(aim_toogle)
 		gun_with_new_dir.toggle_aim_mode(operator)
-
-/obj/machinery/deployable/mounted/proc/can_be_rotated(angle)
-	var/list/leftright = LeftAndRightOfDir(dir)
-	var/left = leftright[1] - 1
-	var/right = leftright[2] + 1
-
-	return !(left == (angle-1)) && !(right == (angle+1))
 
 ///Unsets the user from manning the internal gun
 /obj/machinery/deployable/mounted/on_unset_interaction(mob/user)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #9513 
fixes #9366
when you use deployment in aim mode and want to change direction, you will enter in aim mode automaticly

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: aim mode automatically while changing direction using deployable (if you turn on aim mode)
qol: disassemble when someone using deployable is no longer possible
fix: Spamming launch on tadpole no longer lags the server greatly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
