### PR TITLE
Left click takes cells out of handheld chargers again

### DIFF
--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -516,6 +516,17 @@
 	to_chat(user, span_notice("You remove the cell from [src]."))
 	icon_state = "handheldcharger_black_empty"
 
+/obj/item/tool/handheld_charger/attack_hand(mob/living/user)
+	if(user.get_inactive_held_item() != src)
+		return ..()
+	if(!cell)
+		return ..()
+	cell.update_icon()
+	user.put_in_active_hand(cell)
+	cell = null
+	playsound(user, 'sound/machines/click.ogg', 20, 1, 5)
+	to_chat(user, span_notice("You remove the cell from [src]."))
+	icon_state = "handheldcharger_black_empty"
 
 /obj/item/tool/handheld_charger/Destroy()
 	QDEL_NULL(cell)


### PR DESCRIPTION
## About The Pull Request

Fixes #9643

Re adds the left click code again. I dunno if I should go and move the code into a proc or not so yeah.

## Why It's Good For The Game

Apparently this was messing with people's muscle memory. Also those who have not embraced the light of right click should not be discriminated against.

## Changelog
:cl:
qol: Left click takes cells out of handheld chargers again
/:cl: