### PR TITLE
sentry rework

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -39,7 +39,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	var/armor_type					= "bullet"	// Does this have an override for the armor type the ammo should test? Bullet by default
 	var/sundering					= 0 		// How many stacks of sundering to apply to a mob on hit
 	///how much damage airbursts do to mobs around the target, multiplier of the bullet's damage
-	var/airburst_multiplier	= 0.1		
+	var/airburst_multiplier	= 0.1
 	var/flags_ammo_behavior = NONE
 	///Determines what color our bullet will be when it flies
 	var/bullet_color = COLOR_WHITE
@@ -1083,9 +1083,9 @@ datum/ammo/bullet/revolver/tp44
 	hud_state_empty = "smartgun_empty"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING|AMMO_SENTRY
 	accurate_range = 10
-	damage = 50
-	penetration = 5
-	damage_falloff = 0.5
+	damage = 25
+	penetration = 20
+	damage_falloff = 0.25
 
 /datum/ammo/bullet/turret/dumb
 	icon_state = "bullet"
@@ -1096,8 +1096,8 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/bullet/turret/mini
 	name = "small caliber autocannon bullet"
-	damage = 25
-	penetration = 5
+	damage = 20
+	penetration = 20
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SENTRY
 
 

--- a/code/modules/projectiles/guns/sentries.dm
+++ b/code/modules/projectiles/guns/sentries.dm
@@ -55,12 +55,13 @@
 
 /obj/item/weapon/gun/sentry/big_sentry
 	name = "\improper UA 571-C sentry gun"
-	desc = "A deployable, semi-automated turret with AI targeting capabilities. Armed with a M30 autocannon and a 25-round box magazine."
+	desc = "A deployable, fully automatic turret with AI targeting capabilities. Armed with a M30 autocannon and a 500-round drum magazine."
 	icon_state = "sentry"
 
 	turret_range = 8
-	deploy_time = 8 SECONDS
-	max_shells = 50
+	deploy_time = 6 SECONDS
+	max_shells = 500
+	fire_delay = 0.25 SECONDS
 
 	scatter = 2
 
@@ -126,14 +127,14 @@
 	desc = "A deployable, automated turret with AI targeting capabilities. This is a lightweight portable model meant for rapid deployment and point defense. Armed with an light, high velocity machine gun and a 100-round drum magazine."
 	icon_state = "minisentry"
 
-	max_shells = 100
+	max_shells = 300
 	knockdown_threshold = 80
 
 	ammo_datum_type = /datum/ammo/bullet/turret/mini
 	default_ammo_type = /obj/item/ammo_magazine/minisentry
 	allowed_ammo_types = list(/obj/item/ammo_magazine/minisentry)
 
-	fire_delay = 0.3 SECONDS
+	fire_delay = 0.2 SECONDS
 	burst_delay = 0.2 SECONDS
 	burst_amount = 3
 	extra_delay = 0.3 SECONDS

--- a/code/modules/projectiles/magazines/sentries.dm
+++ b/code/modules/projectiles/magazines/sentries.dm
@@ -5,7 +5,7 @@
 	icon_state = "ua571c"
 	flags_magazine = NONE //can't be refilled or emptied by hand
 	caliber = CALIBER_10X28
-	max_rounds = 75
+	max_rounds = 500
 	default_ammo = /datum/ammo/bullet/turret
 
 /obj/item/ammo_magazine/minisentry
@@ -15,7 +15,7 @@
 	icon_state = "ua580"
 	flags_magazine = NONE //can't be refilled or emptied by hand
 	caliber = CALIBER_10X20
-	max_rounds = 100
+	max_rounds = 300
 	default_ammo = /datum/ammo/bullet/turret/mini
 
 /obj/item/ammo_magazine/sentry_premade/dumb
@@ -24,7 +24,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	flags_magazine = NONE //can't be refilled or emptied by hand
 	caliber = CALIBER_10X28
-	max_rounds = 50
+	max_rounds = 500
 	default_ammo = /datum/ammo/bullet/turret/dumb
 
 /obj/item/ammo_magazine/sentry/fob_sentry


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
571

Damage 50-> 25
pen 5->20
Halved falloff (0.25)
Ammo Capacity 50->500 (300 might be better, will talk about)
Fire delay 0.6->0.25
Deploy shortened.

580
Damage 25 -> 20
Pen 5->20
FD 0.3 -> 0.2
Ammo Cap 100->300
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes sentries good at point defense rather than being this weird thing that is a sniper more than a point defense. I can readd the sniper turret gimmick in another PR, probably.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Sentry rebalance, 571s have much higher capacity and fire much faster, aswell as deploy faster. 580s have a bit less damage, higher pen and higher fire delay, and more capacity.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
