### PR TITLE
Bluespace teleporters can be damaged by xenos

### DIFF
--- a/code/game/objects/structures/teleporter.dm
+++ b/code/game/objects/structures/teleporter.dm
@@ -1,6 +1,7 @@
 #define TELEPORTING_COST 250
 /obj/machinery/deployable/teleporter
 	density = FALSE
+	resistance_flags = XENO_DAMAGEABLE
 	idle_power_usage = 50
 	///List of all teleportable types
 	var/static/list/teleportable_types = typecacheof(list(


### PR DESCRIPTION
teleporter is no longer immune to beno.
Zack cannot into git. I assume he tested this though.

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows xenos to damage teleporters
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Invulnerable shit is bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: teleporters are no longer invulnerable to xenos
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
