### PR TITLE
Xeno's turret deploy time reduced to 10s.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -151,7 +151,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	psypoint_cost = XENO_TURRET_PRICE
 	flags_gamemode = ABILITY_DISTRESS
 	///How long to build one turret
-	var/build_time = 7 SECONDS
+	var/build_time = 10 SECONDS
 	///What type of turret is built
 	var/turret_type = /obj/structure/xeno/xeno_turret
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -151,7 +151,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	psypoint_cost = XENO_TURRET_PRICE
 	flags_gamemode = ABILITY_DISTRESS
 	///How long to build one turret
-	var/build_time = 15 SECONDS
+	var/build_time = 7 SECONDS
 	///What type of turret is built
 	var/turret_type = /obj/structure/xeno/xeno_turret
 


### PR DESCRIPTION
## About The Pull Request

Halves the build time for xeno turrets. If its balance or QoL I dont mind either. 15s to build something is too much.

## Why It's Good For The Game

When prepping as a hive leader be either low pop or normal pop the 15s timer for a turret that will start with 300 hp feels like a punishment. Even if your being pushed hard by marines, 15s to make a defense structure is too much when you will be mostly needed at the front.

## Changelog
:cl:
balance: Build time from 15s to 10s.
/:cl:
