### PR TITLE
Nerfs Flamethrower Direct damage and burn level

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2261,10 +2261,10 @@ datum/ammo/bullet/revolver/tp44
 	flags_ammo_behavior = AMMO_INCENDIARY|AMMO_IGNORE_ARMOR|AMMO_FLAME
 	armor_type = "fire"
 	max_range = 6
-	damage = 50
+	damage = 40
 	bullet_color = LIGHT_COLOR_FIRE
 	var/fire_color = "red"
-	var/burnlevel = 24
+	var/burnlevel = 20
 	var/burntime = 17
 	var/fire_delay = 20
 


### PR DESCRIPTION


## About The Pull Request

Nerfs fire Damage and burn level

## Why It's Good For The Game

Currently there is the meta of using fire to ignite a xeno taking a chunk of health. then chasing them. the issue is that while the xeno is fleeing they take heavy fire tick dmg. and need to resist, but at the same time they are being chased by a marine who is as fast if not faster then them. there have been many scenarios of xenos being caught up in this, set alight and then being chased a long distance only to die from fire tick damage because they couldn't resist as they were being chased.

The flamethrower is a weapon used as a deterrent to make xenos flee or clear weeds and walls. but right now i believe its damage is a bit to much in allowing easy kills and to punishing towards slow xenomorphs and T2/T1's

if you are set on fire and are being chased you cant spare time to resist due to the marine catching up but at the same time you are taking heavy tick damage. one shouldn't also forget that there are underbarrel weapons flamethrowers can use to give extra damage.

Right now gameplay is biased towards marines where they are given weaponry that can achieve easy kills with little effort and skill, whilst xenomorphs are heavily punished for trying to attack and risk more.

When engaging  in solo opportunity's you don't have acid wells everywhere nor do you have resin jelly, nor is the argument that you shouldn't engage solo a good one as ambush attacks are part of the xenos playstyle.

i spent a few days testing on the main server, attacking anyone with a flamethrower and seeing how i could escape.  and trying to figure out a good damage ratio, and what i changed is what i came up with.



## Changelog
:cl:
balance: burn level now 20 down from 24
balance: Fire direct damage now 40 down from 50
/:cl:

