### PR TITLE
Big Red's cryotube buff by putting an APC next to cryotube

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -3473,6 +3473,7 @@
 /obj/structure/sign/safety/autodoc{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/tile/white/warningstripe{
 	dir = 4
 	},
@@ -6749,12 +6750,14 @@
 "ayO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
+/obj/structure/cable,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
 "ayP" = (
 /obj/item/weapon/broken_bottle,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/corpsespawner/doctor,
+/obj/structure/cable,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
 "ayQ" = (
@@ -24241,6 +24244,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/bigredv2/outside/nw)
+"oAv" = (
+/obj/machinery/power/apc{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/bigredv2/outside/medical)
 "oBu" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
@@ -24588,6 +24598,10 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"pGd" = (
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/bigredv2/outside/medical)
 "pJm" = (
 /obj/effect/decal/sandedge{
 	dir = 4
@@ -26037,6 +26051,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/bigredv2/caves/southeast)
+"tqa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/bigredv2/outside/medical)
 "tqJ" = (
 /obj/effect/landmark/corpsespawner,
 /turf/open/shuttle/escapepod,
@@ -43571,8 +43590,8 @@ atr
 dKh
 awO
 aqz
-koF
-koF
+oAv
+pGd
 iAh
 awl
 apC
@@ -44006,7 +44025,7 @@ iGQ
 awT
 axz
 avw
-koF
+pGd
 azv
 avw
 ayH
@@ -44440,7 +44459,7 @@ azR
 lgf
 koF
 koF
-cHm
+tqa
 azA
 cHm
 aBf


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Wow.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Big Red has a nice addition of having a cryotube in medical. However, often marines ignore it because (1) APC is not near cryotube so they are not compel to fix it, (2) engineers have to search for APC, which is sad, (3) holy smokes, xenomorphs can flank cryotube like no tomorrow becauase medbay is super easy to gank in and is why people OB medbay.

This PR should reward marines for camping in cyrotube however hard it is, and trust me, it's really hard comared to LV-624.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: APC next to Big Red's cryotubes
balance: Easier to defend and set up Big Red's cryotubes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
