### PR TITLE
Extreme Requisition Map Makeover: ASRS edition

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -566,6 +566,14 @@
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct,
 /turf/closed/wall/mainship/outer,
 /area/mainship/command/self_destruct)
+"bI" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/obj/machinery/computer/ordercomp,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "bJ" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/drinks/cans/aspen{
@@ -731,6 +739,13 @@
 	dir = 1
 	},
 /area/mainship/hallways/starboard_hallway)
+"cm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "cn" = (
 /obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/black{
@@ -1973,6 +1988,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/reagent_containers/jerrycan,
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
@@ -2185,6 +2201,7 @@
 /area/mainship/hallways/hangar)
 "gW" = (
 /obj/structure/rack,
+/obj/item/reagent_containers/jerrycan,
 /obj/item/reagent_containers/jerrycan,
 /obj/item/reagent_containers/jerrycan,
 /turf/open/floor/mainship/orange{
@@ -2410,11 +2427,11 @@
 "hR" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "hS" = (
 /obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "hT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -2422,7 +2439,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "hU" = (
 /obj/machinery/camera/autoname/mainship{
@@ -2665,45 +2682,51 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "iG" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 6
-	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
-	},
-/turf/open/floor/mainship/floor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "iK" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "supply_elevator_railing"
+/obj/item/frame/table,
+/obj/item/frame/table,
+/obj/item/frame/table,
+/obj/structure/rack,
+/obj/machinery/door_control{
+	dir = 8;
+	id = "reqaccess";
+	name = "Requisitions Access"
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "iL" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "supply_elevator_railing"
+/obj/structure/rack,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 1
-	},
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/adv,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "iM" = (
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 10
-	},
-/turf/open/floor/mainship/floor,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/tool/extinguisher,
+/obj/item/tool/extinguisher/mini,
+/obj/structure/rack,
+/obj/item/flashlight,
+/obj/item/flashlight,
+/obj/item/lightreplacer,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "iN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "iO" = (
 /obj/machinery/light{
@@ -2854,8 +2877,10 @@
 /area/mainship/squads/req)
 "jA" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner,
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "jB" = (
 /obj/machinery/light{
@@ -2864,21 +2889,21 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
-"jC" = (
-/obj/machinery/door/poddoor/railing{
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
 "jD" = (
-/turf/open/floor/mainship/empty,
+/obj/vehicle/ridden/motorbike{
+	dir = 4
+	},
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "jF" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 8;
-	id = "supply_elevator_railing"
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "jG" = (
 /obj/effect/decal/warning_stripes/thin,
@@ -3330,40 +3355,27 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "lq" = (
-/obj/machinery/door/poddoor/railing{
-	id = "supply_elevator_railing"
-	},
-/obj/machinery/floodlight/landing{
-	name = "ASRS Light"
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
+/obj/machinery/autolathe,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "lr" = (
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "ls" = (
-/obj/docking_port/stationary/supply,
-/turf/open/floor/mainship/empty,
+/obj/machinery/vending/weapon,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "lt" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 8;
-	id = "supply_elevator_railing"
-	},
-/obj/machinery/floodlight/landing{
-	name = "ASRS Light"
-	},
-/turf/open/floor/mainship/cargo/arrow{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "lu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3676,22 +3688,27 @@
 /area/mainship/squads/req)
 "mv" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/squads/req)
-"mw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
+"mw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "my" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3699,6 +3716,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
@@ -3712,6 +3732,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "mA" = (
@@ -3720,6 +3743,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
@@ -3733,6 +3759,7 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/structure/disposalpipe/segment/corner,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "mC" = (
@@ -4003,8 +4030,11 @@
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
 "nz" = (
-/obj/machinery/vending/uniform_supply,
-/turf/open/floor/mainship/mono,
+/obj/structure/table/mainship,
+/obj/machinery/cell_charger,
+/obj/effect/spawner/random/powercell,
+/obj/effect/spawner/random/powercell,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "nB" = (
 /obj/structure/cable,
@@ -4067,6 +4097,15 @@
 /obj/item/clothing/suit/replica,
 /turf/open/floor/mainship/red,
 /area/mainship/shipboard/firing_range)
+"nJ" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 2;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 1
+	},
+/area/mainship/squads/req)
 "nK" = (
 /obj/effect/landmark/start/job/squadcorpsman,
 /turf/open/floor/mainship/cargo/arrow{
@@ -4434,10 +4473,12 @@
 /turf/open/floor/mainship/sterile/plain,
 /area/mainship/medical/lower_medical)
 "oI" = (
-/obj/machinery/vending/armor_supply,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/table/mainship,
+/obj/item/stack/sheet/wood/large_stack,
+/obj/item/stack/sheet/glass/reinforced{
+	amount = 30
 	},
+/obj/item/stack/sheet/cardboard,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "oK" = (
@@ -4456,42 +4497,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "oM" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 5
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
-"oN" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
-"oO" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/cargo/arrow,
-/area/mainship/squads/req)
-"oP" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
-	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
-"oQ" = (
-/obj/structure/table/mainship,
-/obj/machinery/cell_charger,
-/obj/effect/spawner/random/powercell,
-/obj/effect/spawner/random/powercell,
+/obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "oR" = (
@@ -4731,37 +4740,17 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "pJ" = (
-/obj/machinery/vending/weapon,
-/obj/machinery/camera/autoname/mainship{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/computer/camera_advanced/overwatch/req,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "pK" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
 /obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/squads/req)
-"pL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "pM" = (
@@ -4778,17 +4767,13 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "pN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "pO" = (
 /obj/machinery/camera/autoname/mainship{
@@ -4800,51 +4785,12 @@
 /obj/structure/window/framed/mainship,
 /turf/open/floor/plating,
 /area/mainship/command/self_destruct)
-"pQ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/squads/req)
-"pS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment/corner,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/squads/req)
 "pT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/machinery/door/poddoor/railing{
+	dir = 2;
+	id = "supply_elevator_railing"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/structure/disposalpipe/junction/flipped,
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/squads/req)
-"pU" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "pV" = (
 /obj/machinery/camera/autoname/mainship{
@@ -4911,6 +4857,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
+"qf" = (
+/obj/machinery/door/poddoor/shutters{
+	dir = 8;
+	id = "reqaccess2"
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "qg" = (
 /obj/structure/closet/crate,
 /obj/item/target/syndicate,
@@ -4972,8 +4925,8 @@
 	},
 /area/mainship/living/evacuation)
 "qy" = (
-/obj/machinery/computer/camera_advanced/overwatch/req,
-/turf/open/floor/mainship/mono,
+/obj/machinery/door/airlock/mainship/marine/requisitions,
+/turf/open/space/basic,
 /area/mainship/squads/req)
 "qz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
@@ -5084,7 +5037,10 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "qT" = (
-/obj/machinery/vending/MarineMed,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/cic_maptable,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "qU" = (
@@ -5101,63 +5057,17 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"qW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"qX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "qY" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
-"qZ" = (
-/obj/machinery/holopad,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"rb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"rc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 8;
-	on = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"rd" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"re" = (
-/obj/structure/disposalpipe/junction,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "rg" = (
-/obj/structure/rack,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/adv,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "rk" = (
 /obj/structure/table/mainship,
@@ -5467,31 +5377,11 @@
 /obj/machinery/door/poddoor/mainship/ammo,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"sm" = (
-/obj/structure/bed/chair/office/dark,
-/obj/effect/landmark/start/job/shiptech,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "sn" = (
 /turf/open/floor/mainship/blue{
 	dir = 8
 	},
 /area/mainship/squads/general)
-"sp" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"sq" = (
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/tool/extinguisher,
-/obj/item/tool/extinguisher/mini,
-/obj/structure/rack,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/lightreplacer,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "sr" = (
 /turf/closed/wall/mainship,
 /area/mainship/squads/general)
@@ -5620,6 +5510,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "sN" = (
@@ -5644,25 +5535,31 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "sP" = (
-/obj/structure/supply_drop,
-/turf/open/floor/mainship/mono,
+/obj/machinery/door/poddoor/railing{
+	id = "supply_elevator_railing"
+	},
+/obj/machinery/floodlight/landing{
+	name = "ASRS Light"
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
 /area/mainship/squads/req)
 "sQ" = (
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
-"sS" = (
-/obj/machinery/computer/supplydrop_console,
-/obj/structure/table/mainship,
-/obj/machinery/light,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"sT" = (
-/obj/structure/rack,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/item/tool/weldpack,
-/turf/open/floor/mainship/mono,
+"sR" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "supply_elevator_railing"
+	},
+/obj/machinery/floodlight/landing{
+	name = "ASRS Light"
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
 /area/mainship/squads/req)
 "sU" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -5683,23 +5580,8 @@
 	},
 /area/mainship/hallways/hangar)
 "sV" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/obj/machinery/computer/crew,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"sW" = (
-/obj/item/frame/table,
-/obj/item/frame/table,
-/obj/item/frame/table,
-/obj/structure/rack,
-/obj/machinery/door_control{
-	dir = 8;
-	id = "reqaccess";
-	name = "Requisitions Access"
-	},
-/turf/open/floor/mainship/mono,
+/obj/docking_port/stationary/supply,
+/turf/open/floor/mainship/empty,
 /area/mainship/squads/req)
 "sX" = (
 /obj/machinery/marine_selector/clothes/smartgun,
@@ -5717,6 +5599,13 @@
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
+"tb" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/cargo/arrow,
+/area/mainship/squads/req)
 "tc" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
@@ -5813,8 +5702,9 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/port_hallway)
 "ts" = (
-/obj/machinery/door/airlock/mainship/marine/requisitions,
-/turf/open/floor/mainship/mono,
+/obj/structure/window/framed/mainship/requisitions,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro,
+/turf/open/space/basic,
 /area/mainship/squads/req)
 "tu" = (
 /obj/structure/closet/emcloset,
@@ -5991,6 +5881,15 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
+"tY" = (
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "tZ" = (
 /obj/structure/ship_ammo/heavygun,
 /obj/machinery/light{
@@ -6005,37 +5904,23 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "ue" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 8;
-	id = "reqaccess2"
-	},
-/turf/open/floor/mainship/mono,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/mainship,
 /area/mainship/squads/req)
 "uf" = (
-/obj/machinery/vending/cargo_supply,
-/turf/open/floor/mainship/mono,
+/obj/structure/window/framed/mainship/requisitions,
+/turf/closed/wall/mainship,
 /area/mainship/squads/req)
 "ug" = (
 /obj/structure/window/framed/mainship/requisitions,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"uh" = (
-/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ui" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/port_hull)
-"uk" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "ul" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "reqaccess"
-	},
+/obj/machinery/door/poddoor/shutters/mainship/req/ro,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "un" = (
@@ -6043,6 +5928,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/ai_node,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "uq" = (
@@ -6383,22 +6269,20 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "vf" = (
-/obj/machinery/cic_maptable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/junction,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "vg" = (
-/obj/structure/closet/firecloset/full,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"vh" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/jerrycan,
-/obj/item/reagent_containers/jerrycan,
-/turf/open/floor/mainship/mono,
+/obj/machinery/door/poddoor/railing{
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "vi" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/empty,
 /area/mainship/squads/req)
 "vk" = (
 /obj/machinery/loadout_vendor,
@@ -6606,6 +6490,7 @@
 	id = "reqaccess2";
 	name = "Requisitions Access"
 	},
+/obj/effect/landmark/start/job/shiptech,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "vT" = (
@@ -6616,36 +6501,30 @@
 "vU" = (
 /obj/structure/table/mainship,
 /obj/item/whistle,
-/obj/item/storage/box/MRE{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/machinery/light,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"vV" = (
-/obj/structure/table/mainship,
 /obj/item/tool/stamp/qm,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"vW" = (
-/obj/vehicle/ridden/motorbike{
-	dir = 4
-	},
-/turf/open/floor/mainship/orange{
-	dir = 1
-	},
+"vV" = (
+/obj/machinery/computer/supplydrop_console,
+/obj/structure/table/mainship,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"vX" = (
-/obj/effect/decal/cleanable/blood/oil/streak,
-/turf/open/floor/mainship/orange{
-	dir = 1
+"vW" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
 	},
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "wb" = (
-/turf/open/floor/mainship/orange{
-	dir = 1
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
 	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "wd" = (
 /obj/structure/cable,
@@ -6896,42 +6775,19 @@
 "wM" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/pilotbunks)
-"wN" = (
-/obj/vehicle/ridden/motorbike{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/mainship/orange,
-/area/mainship/squads/req)
-"wO" = (
-/turf/open/floor/mainship/orange,
-/area/mainship/squads/req)
-"wP" = (
-/obj/machinery/light,
-/turf/open/floor/mainship/orange,
-/area/mainship/squads/req)
 "wQ" = (
-/obj/machinery/autolathe,
-/obj/machinery/light,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "wR" = (
-/obj/structure/table/mainship,
-/obj/item/stack/sheet/wood/large_stack,
-/obj/item/stack/sheet/glass/reinforced{
-	amount = 30
-	},
-/obj/item/stack/sheet/cardboard,
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
+/obj/vehicle/ridden/motorbike,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "wT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/docking_port/stationary/marine_dropship/crash_target,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "wU" = (
@@ -7261,25 +7117,20 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "xT" = (
-/obj/structure/window/framed/mainship/requisitions,
-/obj/machinery/door/poddoor/shutters/mainship/req/ro{
-	dir = 2
-	},
-/turf/closed/wall/mainship,
+/obj/structure/supply_drop,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "xU" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id = "reqaccess"
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "xV" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id = "reqaccess"
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "xW" = (
@@ -7517,9 +7368,20 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "yB" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door_control{
+	dir = 1;
+	id = "reqaccess";
+	name = "Requisitions Access"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/squads/req)
 "yC" = (
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
@@ -7544,6 +7406,7 @@
 	dir = 8
 	},
 /obj/effect/ai_node,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "yF" = (
@@ -7561,8 +7424,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/general)
 "yI" = (
-/obj/machinery/roomba,
-/turf/open/floor/mainship/mono,
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "yJ" = (
 /obj/structure/cable,
@@ -7993,17 +7859,10 @@
 /area/mainship/hallways/starboard_hallway)
 "zS" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "zU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -8025,8 +7884,8 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment/corner,
 /obj/effect/ai_node,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "zW" = (
@@ -9432,6 +9291,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
+"Eo" = (
+/obj/machinery/door/airlock/mainship/marine/requisitions{
+	dir = 2
+	},
+/turf/open/space/basic,
+/area/mainship/squads/req)
 "Ep" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/operating_room_two)
@@ -9986,6 +9851,15 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/bridgebunks)
+"FM" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "FN" = (
 /turf/open/floor/mainship/purple{
 	dir = 4
@@ -10015,6 +9889,14 @@
 	icon_state = "carpetside"
 	},
 /area/mainship/living/commandbunks)
+"FR" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/firecloset,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/hangar)
 "FS" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -11089,6 +10971,13 @@
 	dir = 9
 	},
 /area/mainship/command/cic)
+"Jd" = (
+/obj/structure/window/framed/mainship/requisitions,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
+	},
+/turf/open/space/basic,
+/area/mainship/squads/req)
 "Je" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/fancy/cigar,
@@ -12951,6 +12840,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
+"OM" = (
+/obj/machinery/roomba,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "ON" = (
 /turf/open/floor/mainship/orange{
 	dir = 1
@@ -14086,6 +13979,13 @@
 "SA" = (
 /turf/closed/wall/mainship,
 /area/mainship/squads/req)
+"SB" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
+	},
+/obj/machinery/door/poddoor/shutters/mainship/req/ro,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "SC" = (
 /obj/structure/prop/mainship/sensor_computer3,
 /turf/open/floor/mainship/mono,
@@ -15138,6 +15038,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engine_core)
+"VI" = (
+/obj/machinery/door_control/old/req,
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
+/area/mainship/hallways/starboard_hallway)
 "VJ" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable,
@@ -24268,15 +24174,15 @@ VC
 dz
 az
 VC
-iF
 dz
+FR
 pI
-qS
+VC
 dz
 sL
 VC
 VC
-dz
+iF
 VC
 iF
 VC
@@ -24368,12 +24274,12 @@ lm
 SA
 SA
 SA
-ug
-ug
+qf
+qf
 SA
 sM
 ue
-ue
+SA
 SA
 SA
 SA
@@ -24466,11 +24372,11 @@ lo
 mr
 nz
 oI
-pJ
-qT
+gY
+gY
 kv
 sN
-gY
+fQ
 gY
 vS
 wJ
@@ -24660,8 +24566,8 @@ hS
 jA
 lp
 mv
-mv
-mv
+zS
+cm
 pK
 qV
 qV
@@ -24752,21 +24658,21 @@ ea
 ea
 gt
 gY
-hS
-iG
-jC
-jC
-lq
-jC
-jC
-oM
-pL
 gY
-sm
+gY
+gY
+jz
+gY
+jF
+SA
+SA
+SA
+SA
+uf
 qy
 uf
-vf
-vV
+SA
+ug
 wL
 gY
 Ot
@@ -24850,21 +24756,21 @@ ea
 ea
 gt
 gY
-hS
-iK
-jD
-jD
-jD
-jD
-jD
-oN
-pL
-qW
 gY
-fQ
+iK
+gY
+jz
+gY
+jF
 SA
-ug
-ug
+wQ
+wQ
+wQ
+wQ
+wQ
+wQ
+wQ
+wQ
 SA
 SA
 yA
@@ -24948,23 +24854,23 @@ ea
 ea
 gt
 gY
-hS
-iK
-jD
-jD
-jD
-jD
-jD
-oN
-pN
-qX
 gY
+iM
+jD
+lt
+gY
+jF
+SA
+wQ
+pN
+vg
+vg
 sP
-ug
+vg
 vg
 vW
-wN
-xT
+wQ
+SA
 Ot
 Io
 Jo
@@ -25046,23 +24952,23 @@ ea
 ea
 gt
 gY
-hS
-iL
-jD
-jD
-ls
-jD
-jD
-oO
-pL
-qZ
 gY
-sS
-ug
-vh
-vX
-wO
-xT
+iL
+gY
+oM
+ls
+jF
+SA
+wQ
+pT
+vi
+vi
+vi
+vi
+vi
+wb
+wQ
+SA
 Ot
 Io
 Jo
@@ -25144,23 +25050,23 @@ ea
 ea
 gt
 gY
-hS
-iK
-jD
-jD
-jD
-jD
-jD
-oN
-pQ
-rb
 gY
-sT
-ug
+lq
+gY
+pJ
+vV
+yB
+uf
+wQ
+pT
+vi
+vi
+vi
+vi
 vi
 wb
-wO
-xT
+wQ
+SA
 Ot
 Io
 Jo
@@ -25242,24 +25148,24 @@ fk
 fB
 gt
 gY
-hS
-iK
-jD
-jD
-jD
-jD
-jD
-oN
-pL
-rc
 gY
+gY
+gY
+qT
+xT
+jF
+Eo
+wQ
+nJ
+vi
+vi
 sV
-SA
-SA
-wb
-wP
-SA
-cj
+vi
+vi
+tb
+wQ
+Jd
+VI
 Io
 Jo
 Ci
@@ -25340,22 +25246,22 @@ SA
 SA
 SA
 gZ
-hS
-iM
+gY
+gY
+gY
+jz
+gY
 jF
-jF
-lt
-jF
-jF
-oP
-pS
-rd
-gY
-gY
-uh
-gY
-gY
-gY
+uf
+wQ
+pT
+vi
+vi
+vi
+vi
+vi
+bI
+wQ
 xU
 WS
 zR
@@ -25437,29 +25343,29 @@ eF
 fl
 fO
 gw
-fO
+iG
 hT
 iN
 iN
-iN
+vf
 hT
 mw
-iN
-iN
+SA
+wQ
 pT
-re
-sp
-sp
-uk
-sp
-uk
-sp
+vi
+vi
+vi
+vi
+vi
+wb
+wQ
 xV
-yB
-zS
+WS
+Io
 Jo
 Ci
-Ci
+OM
 Ci
 Ci
 Gq
@@ -25535,26 +25441,26 @@ eH
 fm
 fQ
 ug
-gY
+hS
 gY
 gY
 gY
 gY
 gY
 my
-gY
-gY
-jz
-gY
-gY
-gY
-gY
-yI
-gY
-wQ
 SA
-cj
-zU
+wQ
+tY
+yI
+yI
+sR
+yI
+yI
+FM
+wQ
+Jd
+Ot
+Io
 Jo
 Cn
 Dl
@@ -25640,19 +25546,19 @@ gY
 fQ
 lv
 my
-iO
-oQ
-pU
+SA
+wQ
+wQ
 rg
-sq
-sW
-gY
-gY
-gY
+wQ
+wQ
+wQ
+wQ
+wQ
 wR
 SA
 yC
-zU
+Io
 Jo
 Cg
 Dm
@@ -25739,18 +25645,18 @@ ug
 SA
 mz
 SA
-ug
-ug
 SA
 SA
 SA
+SA
+ts
 ul
-ul
+SB
 ts
 SA
 SA
 cj
-zU
+Io
 AZ
 Cg
 Dn
@@ -25848,7 +25754,7 @@ WS
 eg
 dC
 rL
-zU
+Io
 dU
 eg
 jM
@@ -25934,17 +25840,17 @@ En
 En
 En
 mB
-En
-En
-En
-En
-En
-En
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
 un
-En
+Bj
 un
 wT
-En
+Bj
 yE
 zV
 Bj

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -566,14 +566,6 @@
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct,
 /turf/closed/wall/mainship/outer,
 /area/mainship/command/self_destruct)
-"bI" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
-	},
-/obj/machinery/computer/ordercomp,
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
 "bJ" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/drinks/cans/aspen{
@@ -739,13 +731,6 @@
 	dir = 1
 	},
 /area/mainship/hallways/starboard_hallway)
-"cm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "cn" = (
 /obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/black{
@@ -775,6 +760,14 @@
 "cs" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/port_garden)
+"ct" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/firecloset,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/hangar)
 "cu" = (
 /turf/open/floor/mainship/blue{
 	dir = 4
@@ -1279,6 +1272,15 @@
 	dir = 9
 	},
 /area/mainship/hallways/hangar)
+"dZ" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 2;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 1
+	},
+/area/mainship/squads/req)
 "ea" = (
 /turf/open/floor/plating,
 /area/mainship/squads/req)
@@ -2688,6 +2690,13 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"iH" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/cargo/arrow,
+/area/mainship/squads/req)
 "iK" = (
 /obj/item/frame/table,
 /obj/item/frame/table,
@@ -3894,6 +3903,10 @@
 	},
 /turf/open/floor/mainship_hull,
 /area/space)
+"mW" = (
+/obj/machinery/roomba,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "mY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -4097,15 +4110,6 @@
 /obj/item/clothing/suit/replica,
 /turf/open/floor/mainship/red,
 /area/mainship/shipboard/firing_range)
-"nJ" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 1
-	},
-/area/mainship/squads/req)
 "nK" = (
 /obj/effect/landmark/start/job/squadcorpsman,
 /turf/open/floor/mainship/cargo/arrow{
@@ -4263,6 +4267,14 @@
 	dir = 8
 	},
 /area/mainship/medical/medical_science)
+"oi" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/obj/machinery/computer/ordercomp,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "oj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -4857,13 +4869,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
-"qf" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 8;
-	id = "reqaccess2"
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "qg" = (
 /obj/structure/closet/crate,
 /obj/item/target/syndicate,
@@ -4917,6 +4922,12 @@
 	},
 /turf/open/floor/mainship_hull,
 /area/space)
+"qw" = (
+/obj/machinery/door_control/old/req,
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
+/area/mainship/hallways/starboard_hallway)
 "qx" = (
 /obj/structure/closet/firecloset,
 /obj/item/clothing/mask/gas,
@@ -5549,18 +5560,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
-"sR" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 8;
-	id = "supply_elevator_railing"
-	},
-/obj/machinery/floodlight/landing{
-	name = "ASRS Light"
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
-/area/mainship/squads/req)
 "sU" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -5599,13 +5598,6 @@
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
-"tb" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/cargo/arrow,
-/area/mainship/squads/req)
 "tc" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
@@ -5734,6 +5726,13 @@
 "ty" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/lounge)
+"tz" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
+	},
+/obj/machinery/door/poddoor/shutters/mainship/req/ro,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "tA" = (
 /obj/structure/table/mainship,
 /obj/machinery/chem_dispenser/soda,
@@ -5775,7 +5774,11 @@
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lounge)
 "tI" = (
-/obj/effect/ai_node,
+/obj/effect/decal/warning_stripes/engineer,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
@@ -5881,15 +5884,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
-"tY" = (
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 10
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
 "tZ" = (
 /obj/structure/ship_ammo/heavygun,
 /obj/machinery/light{
@@ -9071,6 +9065,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/general)
+"DF" = (
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "DG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -9291,12 +9294,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
-"Eo" = (
-/obj/machinery/door/airlock/mainship/marine/requisitions{
-	dir = 2
-	},
-/turf/open/space/basic,
-/area/mainship/squads/req)
 "Ep" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/operating_room_two)
@@ -9449,6 +9446,12 @@
 "EM" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/bridgebunks)
+"EN" = (
+/obj/machinery/door/airlock/mainship/marine/requisitions{
+	dir = 2
+	},
+/turf/open/space/basic,
+/area/mainship/squads/req)
 "EO" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/commandbunks)
@@ -9851,15 +9854,6 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/bridgebunks)
-"FM" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
-	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
 "FN" = (
 /turf/open/floor/mainship/purple{
 	dir = 4
@@ -9889,14 +9883,6 @@
 	icon_state = "carpetside"
 	},
 /area/mainship/living/commandbunks)
-"FR" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/closet/firecloset,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/mainship/cargo,
-/area/mainship/hallways/hangar)
 "FS" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -10971,19 +10957,19 @@
 	dir = 9
 	},
 /area/mainship/command/cic)
-"Jd" = (
-/obj/structure/window/framed/mainship/requisitions,
-/obj/machinery/door/poddoor/shutters/mainship/req/ro{
-	dir = 2
-	},
-/turf/open/space/basic,
-/area/mainship/squads/req)
 "Je" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/fancy/cigar,
 /obj/item/tool/lighter/zippo,
 /turf/open/floor/carpet,
 /area/mainship/living/bridgebunks)
+"Jf" = (
+/obj/structure/window/framed/mainship/requisitions,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
+	},
+/turf/open/space/basic,
+/area/mainship/squads/req)
 "Ji" = (
 /obj/structure/cable,
 /obj/structure/bed/chair/comfy/beige{
@@ -12194,6 +12180,13 @@
 "MO" = (
 /turf/open/floor/mainship/tcomms,
 /area/mainship/shipboard/weapon_room)
+"MP" = (
+/obj/machinery/door/poddoor/shutters{
+	dir = 8;
+	id = "reqaccess2"
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "MQ" = (
 /obj/machinery/alarm,
 /turf/open/floor/mainship/floor,
@@ -12840,10 +12833,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
-"OM" = (
-/obj/machinery/roomba,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/briefing)
 "ON" = (
 /turf/open/floor/mainship/orange{
 	dir = 1
@@ -13073,6 +13062,15 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/port_hallway)
+"Px" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "Py" = (
 /obj/structure/dropship_equipment/operatingtable,
 /turf/open/floor/mainship/cargo,
@@ -13214,6 +13212,18 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"PV" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "supply_elevator_railing"
+	},
+/obj/machinery/floodlight/landing{
+	name = "ASRS Light"
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/mainship/squads/req)
 "PW" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -13978,13 +13988,6 @@
 /area/mainship/shipboard/weapon_room)
 "SA" = (
 /turf/closed/wall/mainship,
-/area/mainship/squads/req)
-"SB" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 2
-	},
-/obj/machinery/door/poddoor/shutters/mainship/req/ro,
-/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "SC" = (
 /obj/structure/prop/mainship/sensor_computer3,
@@ -15038,12 +15041,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engine_core)
-"VI" = (
-/obj/machinery/door_control/old/req,
-/turf/open/floor/mainship/black{
-	dir = 1
-	},
-/area/mainship/hallways/starboard_hallway)
 "VJ" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable,
@@ -15605,6 +15602,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/port_atmos)
+"XD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "XE" = (
 /turf/open/floor/mainship_hull,
 /area/space)
@@ -24175,7 +24179,7 @@ dz
 az
 VC
 dz
-FR
+ct
 pI
 VC
 dz
@@ -24274,8 +24278,8 @@ lm
 SA
 SA
 SA
-qf
-qf
+MP
+MP
 SA
 sM
 ue
@@ -24567,7 +24571,7 @@ jA
 lp
 mv
 zS
-cm
+XD
 pK
 qV
 qV
@@ -25154,18 +25158,18 @@ gY
 qT
 xT
 jF
-Eo
+EN
 wQ
-nJ
+dZ
 vi
 vi
 sV
 vi
 vi
-tb
+iH
 wQ
-Jd
-VI
+Jf
+qw
 Io
 Jo
 Ci
@@ -25260,7 +25264,7 @@ vi
 vi
 vi
 vi
-bI
+oi
 wQ
 xU
 WS
@@ -25365,7 +25369,7 @@ WS
 Io
 Jo
 Ci
-OM
+mW
 Ci
 Ci
 Gq
@@ -25450,15 +25454,15 @@ gY
 my
 SA
 wQ
-tY
+DF
 yI
 yI
-sR
+PV
 yI
 yI
-FM
+Px
 wQ
-Jd
+Jf
 Ot
 Io
 Jo
@@ -25651,7 +25655,7 @@ SA
 SA
 ts
 ul
-SB
+tz
 ts
 SA
 SA

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -31,6 +31,15 @@
 	dir = 8
 	},
 /area/mainship/hallways/hangar/droppod)
+"af" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "ag" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
@@ -491,10 +500,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"bK" = (
-/obj/machinery/vending/shared_vending/marine_engi,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
 "bL" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
@@ -717,14 +722,17 @@
 /turf/open/space,
 /area/space)
 "cw" = (
-/obj/structure/table/mainship,
-/obj/item/stack/sheet/wood/large_stack,
-/obj/item/stack/sheet/glass/reinforced{
-	amount = 30
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/item/stack/sheet/cardboard,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/obj/machinery/door/airlock/mainship/generic/pilot,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "cx" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/mono,
@@ -952,8 +960,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "de" = (
+/obj/structure/table/mainship,
 /obj/machinery/door_control/old/req,
-/turf/closed/wall/mainship,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "dg" = (
 /obj/machinery/light/small{
@@ -1273,16 +1282,19 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "ee" = (
-/obj/machinery/vending/nanomed,
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/aft_hallway)
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/airlock/mainship/generic/pilot,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "eh" = (
 /turf/open/floor/mainship/empty,
 /area/mainship/squads/req)
 "ej" = (
-/obj/docking_port/stationary/supply,
-/turf/open/floor/mainship/empty,
-/area/mainship/squads/req)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/hallways/aft_hallway)
 "ek" = (
 /obj/structure/table/mainship,
 /obj/item/camera,
@@ -1459,11 +1471,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "eM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/machinery/vending/nanomed,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/aft_hallway)
 "eN" = (
 /obj/structure/window/framed/mainship,
 /obj/machinery/door/firedoor/mainship{
@@ -1774,10 +1784,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"fR" = (
-/obj/machinery/autolathe,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "fS" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -1809,15 +1815,16 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "fW" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 6
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
 	},
-/obj/structure/table/mainship,
-/obj/machinery/cell_charger,
-/obj/effect/spawner/random/powercell,
-/obj/effect/spawner/random/powercell,
-/turf/open/floor/mainship/mono,
+/obj/structure/disposaloutlet/retrieval{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "fX" = (
 /obj/item/storage/box/pillbottles,
@@ -2015,6 +2022,9 @@
 "gz" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -2287,12 +2297,8 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "ht" = (
@@ -2387,9 +2393,7 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "hP" = (
-/obj/vehicle/ridden/motorbike{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "hQ" = (
@@ -2421,10 +2425,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "hV" = (
-/obj/machinery/light/small,
-/obj/structure/largecrate/guns,
-/turf/open/floor/mainship/cargo,
-/area/mainship/squads/req)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/aft_hallway)
 "hW" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -2508,12 +2513,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "ip" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/machinery/vending/uniform_supply,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/squads/req)
+/obj/machinery/holopad,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/aft_hallway)
 "iq" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner{
@@ -3028,6 +3030,10 @@
 "jU" = (
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
+"jW" = (
+/obj/machinery/roomba,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "jX" = (
 /obj/structure/closet/l3closet/virology,
 /obj/machinery/light{
@@ -3236,12 +3242,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/corporateliaison)
 "kE" = (
-/obj/item/folder/black_random,
-/obj/item/tool/hand_labeler,
-/obj/item/tool/stamp/denied,
-/obj/item/tool/stamp/qm,
-/obj/structure/table/mainship,
-/turf/open/floor/mainship/mono,
+/obj/structure/closet/secure_closet/req_officer,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "kF" = (
 /obj/structure/table/mainship,
@@ -3355,13 +3357,6 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/hangar)
-"kP" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/vending/tool,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
 "kQ" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/mainship/black{
@@ -3369,27 +3364,16 @@
 	},
 /area/mainship/squads/general)
 "kS" = (
-/obj/structure/barricade/metal{
-	dir = 1
-	},
-/turf/open/floor/mainship/cargo,
-/area/mainship/hallways/aft_hallway)
-"kT" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window{
-	dir = 1
-	},
 /obj/machinery/door/poddoor/shutters/mainship/req/ro{
 	dir = 2
 	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/item/tool/hand_labeler,
-/obj/item/tool/hand_labeler,
-/obj/item/tool/hand_labeler,
-/obj/machinery/door/window/secure/req{
-	dir = 2
+/obj/structure/window/framed/mainship/requisitions,
+/turf/open/floor/plating,
+/area/mainship/hallways/aft_hallway)
+"kT" = (
+/obj/effect/landmark/start/job/shiptech,
+/obj/structure/bed/chair/office/dark{
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
@@ -3592,13 +3576,12 @@
 	},
 /area/mainship/command/cic)
 "ly" = (
-/obj/structure/window/framed/mainship/requisitions,
-/obj/structure/sign/ROsign{
+/obj/machinery/computer/ordercomp,
+/obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},
-/obj/machinery/door/poddoor/shutters/mainship/req/ro,
-/turf/open/floor/plating,
-/area/mainship/squads/req)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/aft_hallway)
 "lz" = (
 /obj/machinery/computer/camera_advanced/overwatch/alpha,
 /turf/open/floor/mainship/red{
@@ -3722,12 +3705,9 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar/droppod)
 "lY" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/vending/weapon,
+/obj/machinery/vending/shared_vending/marine_engi,
 /turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/area/mainship/hallways/aft_hallway)
 "lZ" = (
 /obj/machinery/marine_selector/gear/engi,
 /obj/machinery/camera/autoname/mainship,
@@ -3755,14 +3735,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "me" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/structure/largecrate/supply/ammo/standard_ammo,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/mainship,
 /area/mainship/squads/req)
 "mg" = (
 /obj/machinery/light,
@@ -3835,10 +3809,9 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "mq" = (
-/obj/machinery/door/airlock/mainship/generic/pilot,
-/obj/machinery/door/firedoor/mainship,
+/obj/machinery/vending/engivend,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/area/mainship/hallways/aft_hallway)
 "ms" = (
 /obj/structure/dropship_equipment/weapon/heavygun,
 /obj/effect/decal/warning_stripes/thin,
@@ -4092,11 +4065,8 @@
 	},
 /area/mainship/hallways/hangar/droppod)
 "nf" = (
-/obj/machinery/door/poddoor/shutters/mainship/req/ro{
-	dir = 2
-	},
-/obj/structure/window/framed/mainship/requisitions,
-/turf/open/floor/plating,
+/obj/machinery/autolathe,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ng" = (
 /obj/structure/cable,
@@ -4112,6 +4082,12 @@
 	dir = 10
 	},
 /area/mainship/squads/general)
+"ni" = (
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "nj" = (
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 8
@@ -4144,18 +4120,14 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "nq" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 1;
-	name = "\improper Rest and Relaxation Area"
-	},
 /obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
+	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "nr" = (
-/obj/effect/landmark/start/job/shiptech,
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
+/obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ns" = (
@@ -4257,12 +4229,13 @@
 /turf/open/floor/wood,
 /area/mainship/medical/surgery_hallway)
 "nL" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 8;
-	id = "supply_elevator_railing"
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
 	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "nM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4408,17 +4381,12 @@
 	},
 /area/mainship/medical/medical_science)
 "og" = (
-/obj/structure/disposalpipe/segment/corner{
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/disposaloutlet/retrieval{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/mainship/cargo,
-/area/mainship/squads/req)
+/obj/machinery/vending/tool,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/aft_hallway)
 "oh" = (
 /obj/item/paper/crumpled,
 /obj/item/paper/crumpled{
@@ -4428,12 +4396,18 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "oj" = (
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/line_nexter{
+	dir = 1
+	},
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/aft_hallway)
 "ok" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
+/obj/vehicle/ridden/motorbike{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "ol" = (
@@ -4450,42 +4424,35 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
 "on" = (
-/obj/machinery/computer/camera_advanced/overwatch/req,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "op" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 6
-	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"oq" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
-"or" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/cargo/arrow{
+/obj/machinery/light{
 	dir = 1
 	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/squads/req)
+"oq" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/squads/req)
+"or" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "os" = (
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 10
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "ot" = (
 /obj/structure/cable,
@@ -4494,9 +4461,11 @@
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
 "ou" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/cargo/arrow,
 /area/mainship/squads/req)
 "ov" = (
 /obj/structure/table/mainship,
@@ -4511,13 +4480,11 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "ox" = (
-/obj/machinery/door/poddoor/railing{
-	id = "supply_elevator_railing"
+/obj/structure/barricade/metal{
+	dir = 1
 	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
-/area/mainship/squads/req)
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/aft_hallway)
 "oy" = (
 /obj/machinery/light{
 	dir = 1
@@ -4530,13 +4497,12 @@
 	},
 /area/mainship/squads/general)
 "oz" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 8;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
+/obj/structure/table/mainship,
+/obj/structure/paper_bin,
+/obj/item/storage/fancy/cigar,
+/obj/item/tool/lighter/zippo,
+/obj/item/tool/pen,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "oA" = (
 /obj/machinery/computer/arcade,
@@ -4562,11 +4528,15 @@
 	},
 /area/mainship/living/grunt_rnr)
 "oD" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
 	},
-/obj/structure/closet/secure_closet/shiptech,
-/turf/open/floor/mainship/cargo,
+/obj/structure/table/mainship,
+/obj/machinery/cell_charger,
+/obj/effect/spawner/random/powercell,
+/obj/effect/spawner/random/powercell,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "oE" = (
 /obj/structure/bed/stool,
@@ -4575,56 +4545,62 @@
 	},
 /area/mainship/living/grunt_rnr)
 "oF" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
+"oG" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/shiptech,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/cargo,
+/area/mainship/squads/req)
+"oH" = (
+/obj/structure/rack,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/tool/weldpack,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
+"oI" = (
+/obj/structure/rack,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/adv,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
+"oJ" = (
+/obj/structure/window/framed/mainship/requisitions,
+/obj/structure/sign/ROsign{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/mainship/req/ro,
+/turf/open/floor/plating,
+/area/mainship/squads/req)
+"oK" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
 /obj/effect/landmark/start/job/requisitionsofficer,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"oG" = (
-/obj/structure/closet/secure_closet/req_officer,
-/turf/open/floor/mainship/cargo,
-/area/mainship/squads/req)
-"oH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
-"oI" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 5
-	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"oJ" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
-"oK" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/cargo/arrow,
-/area/mainship/squads/req)
 "oL" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
+/obj/structure/table/mainship,
+/obj/item/stack/sheet/wood/large_stack,
+/obj/item/stack/sheet/glass/reinforced{
+	amount = 30
 	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
-	},
+/obj/item/stack/sheet/cardboard,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "oM" = (
@@ -4718,11 +4694,8 @@
 	},
 /area/mainship/command/self_destruct)
 "pb" = (
-/obj/structure/cable,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "pc" = (
 /turf/open/floor/mainship/research/containment/floor2{
@@ -4785,8 +4758,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "pn" = (
-/obj/vehicle/ridden/powerloader,
-/turf/open/floor/mainship/cargo,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "po" = (
 /obj/structure/disposalpipe/segment/corner,
@@ -4800,17 +4778,24 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "pq" = (
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/machinery/vending/lasgun,
-/turf/open/floor/mainship/cargo,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "pr" = (
-/obj/structure/largecrate/guns/merc,
-/turf/open/floor/mainship/cargo,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ps" = (
-/obj/machinery/light/small,
-/obj/structure/largecrate/guns/russian,
-/turf/open/floor/mainship/cargo,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "pt" = (
 /obj/machinery/light,
@@ -4822,21 +4807,27 @@
 	},
 /area/mainship/living/grunt_rnr)
 "pu" = (
-/obj/structure/largecrate/supply/supplies/flares,
-/turf/open/floor/mainship/cargo,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "pv" = (
-/obj/structure/largecrate/supply/supplies/water,
-/turf/open/floor/mainship/cargo,
+/obj/structure/rack,
+/obj/item/pizzabox/meat,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "pw" = (
-/obj/structure/largecrate/supply/supplies/mre,
-/turf/open/floor/mainship/cargo,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "px" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/item/tool/extinguisher,
-/turf/open/floor/mainship/cargo,
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "py" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -4887,12 +4878,9 @@
 	},
 /area/mainship/shipboard/firing_range)
 "pI" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
+/obj/machinery/vending/cargo_supply,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/area/mainship/squads/req)
 "pJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -4900,8 +4888,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
 "pO" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/segment,
+/mob/living/simple_animal/cat/martin,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "pP" = (
@@ -5643,14 +5631,28 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "sy" = (
-/obj/structure/disposalpipe/segment,
-/mob/living/simple_animal/cat/martin,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/aft_hallway)
 "sz" = (
-/obj/machinery/holopad,
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/area/mainship/hallways/aft_hallway)
 "sA" = (
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
@@ -6556,10 +6558,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/aft_hallway)
-"vn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "vo" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -6812,6 +6810,13 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
+"wb" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "wc" = (
 /obj/structure/bed/chair/wood,
 /obj/item/trash/cigbutt/cigarbutt,
@@ -6870,14 +6875,17 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "wk" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
-/obj/structure/supply_drop,
+/obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "wl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/light,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "wm" = (
@@ -7231,12 +7239,12 @@
 /turf/open/floor/mainship/ntlogo/nt3,
 /area/mainship/squads/general)
 "xj" = (
-/obj/machinery/door/airlock/mainship/marine/requisitions,
-/obj/machinery/door/firedoor/mainship,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/window/framed/mainship/requisitions,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "xk" = (
@@ -7462,7 +7470,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "xS" = (
-/obj/machinery/door/airlock/mainship/marine/requisitions{
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
 	dir = 2
 	},
 /turf/open/floor/mainship/mono,
@@ -7867,10 +7876,7 @@
 /turf/open/floor/mainship/orange/corner,
 /area/mainship/engineering/ce_room)
 "yZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "za" = (
@@ -8986,12 +8992,7 @@
 	},
 /area/mainship/hallways/hangar)
 "CC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
+/obj/structure/largecrate/guns,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "CD" = (
@@ -8999,7 +9000,8 @@
 /turf/open/floor/mainship/black/corner,
 /area/mainship/squads/general)
 "CE" = (
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/window/framed/mainship/requisitions,
+/turf/open/space/basic,
 /area/mainship/squads/req)
 "CF" = (
 /obj/structure/disposalpipe/segment{
@@ -9022,15 +9024,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "CH" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/largecrate/supply/ammo/standard_ammo,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
-"CI" = (
-/obj/machinery/vending/engivend,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
 "CJ" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -9070,8 +9066,15 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "CP" = (
-/obj/docking_port/stationary/marine_dropship/crash_target,
-/turf/open/floor/mainship/mono,
+/obj/machinery/door/airlock/mainship/marine/requisitions,
+/obj/machinery/door/firedoor/mainship,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/space/basic,
 /area/mainship/squads/req)
 "CQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -9826,6 +9829,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"ES" = (
+/obj/machinery/newscaster,
+/turf/closed/wall/mainship,
+/area/mainship/squads/req)
 "EW" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/open/floor/mainship/mono,
@@ -9921,6 +9928,15 @@
 /obj/structure/table/mainship,
 /turf/open/floor/freezer,
 /area/mainship/living/cafeteria_starboard)
+"Fu" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/mainship/squads/req)
 "Fv" = (
 /obj/machinery/light{
 	dir = 8
@@ -10071,6 +10087,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
+"FT" = (
+/obj/machinery/door/poddoor/shutters/mainship/req/ro,
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
+	},
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/plating,
+/area/mainship/squads/req)
 "FU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -10208,8 +10232,12 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Gr" = (
@@ -10230,7 +10258,7 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Gu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -10293,7 +10321,8 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "GH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/structure/table/mainship,
+/obj/machinery/computer/supplydrop_console,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "GJ" = (
@@ -10357,6 +10386,14 @@
 /obj/item/pizzabox/meat,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"GT" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/obj/machinery/holopad,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "GU" = (
 /turf/open/floor/mainship/sterile/corner{
 	dir = 4
@@ -11062,15 +11099,10 @@
 	},
 /area/mainship/medical/lower_medical)
 "IP" = (
-/obj/machinery/door/airlock/mainship/marine/requisitions,
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/closed/wall/mainship,
 /area/mainship/squads/req)
 "IQ" = (
 /obj/machinery/firealarm{
@@ -11099,8 +11131,7 @@
 	},
 /area/space)
 "IT" = (
-/obj/structure/rack,
-/obj/item/pizzabox/meat,
+/obj/machinery/cic_maptable,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "IU" = (
@@ -11144,9 +11175,10 @@
 /turf/open/floor/wood,
 /area/mainship/medical/surgery_hallway)
 "Jb" = (
-/obj/machinery/status_display,
-/turf/closed/wall/mainship,
-/area/mainship/hallways/hangar)
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/airlock/mainship/marine/requisitions,
+/turf/open/space/basic,
+/area/mainship/squads/req)
 "Jc" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -11387,11 +11419,24 @@
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "JH" = (
-/obj/structure/noticeboard,
-/obj/structure/sign/ROsign{
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/closed/wall/mainship,
+/obj/structure/table/mainship,
+/obj/item/clipboard,
+/obj/item/paper{
+	pixel_x = 5
+	},
+/obj/item/tool/pen,
+/obj/item/storage/box/MRE{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/whistle,
+/obj/machinery/door_control/mainship/req{
+	pixel_y = -5
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "JI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -11440,7 +11485,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "JO" = (
-/obj/machinery/vending/MarineMed,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/airlock/mainship/marine/requisitions{
+	dir = 2
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "JQ" = (
@@ -11798,10 +11846,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "KK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/rack,
-/obj/item/tool/screwdriver,
 /obj/item/tool/wrench,
 /obj/item/tool/crowbar,
+/obj/item/tool/screwdriver,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "KM" = (
@@ -11884,12 +11933,11 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/command/self_destruct)
 "Le" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/aft_hallway)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/squads/req)
 "Lf" = (
 /obj/machinery/door/poddoor/mainship,
 /turf/open/floor/mainship/mono,
@@ -12071,23 +12119,7 @@
 	},
 /area/mainship/engineering/engine_core)
 "LM" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/mainship,
-/obj/item/clipboard,
-/obj/item/paper{
-	pixel_x = 5
-	},
-/obj/item/tool/pen,
-/obj/item/storage/box/MRE{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/whistle,
-/obj/machinery/door_control/mainship/req{
-	pixel_y = -5
-	},
+/obj/machinery/computer/supplycomp,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "LN" = (
@@ -12221,7 +12253,12 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "Mj" = (
-/obj/machinery/cic_maptable,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Mk" = (
@@ -12525,8 +12562,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "Ne" = (
-/obj/machinery/newscaster,
-/turf/closed/wall/mainship,
+/obj/structure/window/framed/mainship/requisitions,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
+	},
+/turf/open/space/basic,
 /area/mainship/squads/req)
 "Nf" = (
 /obj/structure/cable,
@@ -12638,11 +12678,12 @@
 	},
 /area/mainship/squads/general)
 "Nt" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/door/poddoor/railing{
+	dir = 2;
+	id = "supply_elevator_railing"
 	},
 /turf/open/floor/mainship/floor,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/squads/req)
 "Nu" = (
 /obj/effect/landmark/start/job/squadengineer,
 /obj/machinery/camera/autoname/mainship{
@@ -12720,14 +12761,8 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/surgery_hallway)
 "NE" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
+/obj/machinery/status_display,
+/turf/closed/wall/mainship,
 /area/mainship/hallways/hangar)
 "NF" = (
 /obj/structure/bed/chair/sofa{
@@ -13157,9 +13192,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "OY" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
+/obj/structure/largecrate/supply/supplies/mre,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "OZ" = (
@@ -13328,9 +13364,10 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
 "Pw" = (
-/obj/machinery/firealarm{
+/obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
+/obj/structure/largecrate/supply/supplies/flares,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "Px" = (
@@ -13717,10 +13754,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "QB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/cargo/arrow{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "QC" = (
 /obj/machinery/cryopod/right,
@@ -13732,7 +13772,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "QE" = (
-/obj/structure/rack,
+/obj/structure/supply_drop,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "QF" = (
@@ -13906,6 +13946,15 @@
 	dir = 9
 	},
 /area/mainship/medical/lower_medical)
+"Re" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "Rf" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -13948,14 +13997,21 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "Rl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/door/poddoor/railing{
+	dir = 2;
+	id = "supply_elevator_railing"
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 1
+	},
 /area/mainship/squads/req)
 "Rm" = (
-/obj/machinery/computer/supplycomp,
-/turf/open/floor/mainship/mono,
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "supply_elevator_railing"
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "Rn" = (
 /obj/machinery/door/airlock/mainship/medical/glass{
@@ -14211,6 +14267,10 @@
 /obj/machinery/telecomms/server/presets/bravo,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
+"RY" = (
+/obj/machinery/door_control/old/req,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "RZ" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /obj/machinery/vending/uniform_supply,
@@ -14258,6 +14318,14 @@
 /obj/structure/sign/pods,
 /turf/closed/wall/mainship,
 /area/mainship/hallways/hangar)
+"Si" = (
+/obj/structure/cable,
+/obj/machinery/alarm{
+	dir = 4
+	},
+/obj/structure/largecrate/guns/russian,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/squads/req)
 "Sj" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/closed/wall/mainship,
@@ -14313,10 +14381,11 @@
 	},
 /area/mainship/squads/general)
 "Sv" = (
-/obj/structure/cable,
-/obj/machinery/alarm{
+/obj/machinery/power/apc/mainship{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/structure/largecrate/guns/merc,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "Sw" = (
@@ -14458,8 +14527,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "SR" = (
-/obj/machinery/computer/supplydrop_console,
-/obj/structure/table/mainship,
+/obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ST" = (
@@ -14556,10 +14624,9 @@
 /area/space)
 "Tj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 10
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
 	},
-/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Tl" = (
 /obj/machinery/door/firedoor/mainship,
@@ -14603,6 +14670,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "Tu" = (
@@ -14711,14 +14779,8 @@
 /turf/open/shuttle/escapepod/plain,
 /area/mainship/command/self_destruct)
 "TO" = (
-/obj/structure/rack,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/item/tool/weldpack,
-/turf/open/floor/mainship/mono,
+/obj/vehicle/ridden/powerloader,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "TP" = (
 /obj/machinery/door/firedoor/mainship,
@@ -14848,13 +14910,8 @@
 	},
 /area/mainship/shipboard/firing_range)
 "Ut" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/closed/wall/mainship,
 /area/mainship/squads/req)
 "Uu" = (
 /obj/structure/cable,
@@ -14896,11 +14953,11 @@
 /turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/firing_range)
 "UA" = (
-/obj/machinery/power/apc/mainship{
+/obj/machinery/firealarm{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
+/obj/structure/largecrate/supply/supplies/water,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "UB" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -14990,7 +15047,7 @@
 	},
 /area/mainship/medical/lower_medical)
 "UK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "UL" = (
@@ -15063,13 +15120,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
 "UW" = (
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/tool/extinguisher,
+/obj/item/tool/extinguisher/mini,
 /obj/structure/rack,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/adv,
+/obj/item/flashlight,
+/obj/item/flashlight,
+/obj/item/lightreplacer,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "UX" = (
@@ -15196,11 +15254,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/starboard_missiles)
 "Vn" = (
-/obj/machinery/computer/ordercomp,
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
+/turf/closed/wall/mainship,
 /area/mainship/hallways/aft_hallway)
 "Vo" = (
 /turf/open/floor/mainship_hull/dir,
@@ -15212,7 +15266,9 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "Vq" = (
-/obj/machinery/vending/cargo_supply,
+/obj/vehicle/ridden/motorbike{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Vr" = (
@@ -15342,11 +15398,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "VM" = (
+/obj/item/folder/black_random,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/stamp/denied,
+/obj/item/tool/stamp/qm,
 /obj/structure/table/mainship,
-/obj/structure/paper_bin,
-/obj/item/storage/fancy/cigar,
-/obj/item/tool/lighter/zippo,
-/obj/item/tool/pen,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "VN" = (
@@ -15518,12 +15574,9 @@
 	},
 /area/mainship/living/cryo_cells)
 "Wp" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
-	},
-/obj/machinery/holopad,
-/turf/open/floor/mainship/floor,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro,
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/plating,
 /area/mainship/squads/req)
 "Wr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -15816,8 +15869,21 @@
 	dir = 6
 	},
 /area/mainship/medical/lower_medical)
+"Xm" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/obj/machinery/computer/ordercomp,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "Xn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "Xo" = (
@@ -15944,14 +16010,18 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/upper_engineering)
 "XD" = (
-/obj/machinery/holopad,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/obj/machinery/door/poddoor/railing{
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/mainship/squads/req)
 "XE" = (
-/obj/effect/decal/warning_stripes/thick,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/stack/conveyor/thirty,
 /obj/structure/rack,
 /obj/item/conveyor_switch_construct,
-/obj/item/stack/conveyor/thirty,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "XF" = (
@@ -16209,13 +16279,23 @@
 	},
 /area/mainship/medical/lower_medical)
 "Yq" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/line_nexter{
+/obj/structure/table/reinforced,
+/obj/machinery/door/window{
 	dir = 1
 	},
-/turf/open/floor/mainship/cargo,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
+	},
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/machinery/door/window/secure/req{
+	dir = 2
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "Yr" = (
 /obj/machinery/status_display,
@@ -16254,6 +16334,10 @@
 /turf/open/floor/mainship/black/corner,
 /area/mainship/squads/general)
 "Yy" = (
+/obj/structure/noticeboard,
+/obj/structure/sign/ROsign{
+	dir = 1
+	},
 /turf/closed/wall/mainship,
 /area/mainship/hallways/aft_hallway)
 "Yz" = (
@@ -16302,13 +16386,8 @@
 	},
 /area/mainship/living/grunt_rnr)
 "YF" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
+/obj/machinery/computer/camera_advanced/overwatch/req,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "YH" = (
 /obj/effect/landmark/start/job/squadengineer,
@@ -16585,7 +16664,11 @@
 	},
 /area/mainship/hallways/hangar)
 "ZC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
+	},
+/obj/machinery/light,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "ZE" = (
@@ -16657,16 +16740,9 @@
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "ZO" = (
-/obj/machinery/door/airlock/mainship/generic/pilot,
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/docking_port/stationary/supply,
+/turf/open/floor/mainship/empty,
+/area/mainship/squads/req)
 "ZP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -16684,14 +16760,10 @@
 	},
 /area/mainship/living/numbertwobunks)
 "ZR" = (
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/tool/extinguisher,
-/obj/item/tool/extinguisher/mini,
-/obj/structure/rack,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/lightreplacer,
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/obj/machinery/vending/weapon,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ZS" = (
@@ -35093,12 +35165,12 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
 fI
 fI
 fI
@@ -35350,11 +35422,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
 fI
 fI
 fI
@@ -35607,11 +35679,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
 fI
 fI
 fI
@@ -35864,11 +35936,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
 fI
 fI
 fI
@@ -36121,11 +36193,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
 fI
 fI
 fI
@@ -36382,7 +36454,7 @@ fI
 fI
 fI
 fI
-aa
+fI
 fI
 fI
 aa
@@ -36639,7 +36711,7 @@ fI
 fI
 fI
 fI
-aa
+fI
 fI
 fI
 aa
@@ -36896,7 +36968,7 @@ fI
 fI
 fI
 fI
-aa
+fI
 fI
 fI
 fI
@@ -37153,7 +37225,7 @@ fI
 fI
 fI
 fI
-aa
+fI
 fI
 fI
 fI
@@ -46664,7 +46736,7 @@ po
 UC
 JL
 pX
-JL
+sy
 JL
 JL
 JL
@@ -46907,8 +46979,8 @@ aH
 ap
 NL
 ap
-ap
 Ni
+ap
 Vl
 gd
 rF
@@ -46921,11 +46993,11 @@ gd
 rF
 rF
 AB
-XG
+sz
 rF
 rF
 FB
-oH
+gd
 rF
 PB
 TH
@@ -47164,14 +47236,13 @@ aN
 be
 az
 eO
-eO
-ZO
+cw
 az
-Le
+ej
 Tl
 Tl
 Tl
-qG
+Vn
 Tb
 Tb
 qG
@@ -47179,6 +47250,7 @@ qG
 qG
 qG
 qG
+CP
 qG
 qG
 qG
@@ -47423,12 +47495,12 @@ eN
 Hx
 wl
 NE
-Jb
+Cq
 Cq
 rF
-rF
-bK
-qG
+lY
+Vn
+oz
 VM
 kE
 oG
@@ -47436,7 +47508,7 @@ oD
 TO
 fW
 pn
-og
+kM
 me
 ok
 CC
@@ -47445,7 +47517,7 @@ OY
 Pw
 UA
 Sv
-JN
+Si
 pq
 qG
 jy
@@ -47679,31 +47751,31 @@ kB
 eN
 fc
 gz
-eM
 eN
 Cq
+Cq
 rF
-rF
-CI
+mq
+Vn
 de
+oK
 kM
-oF
 kM
-kM
-vn
+pb
+Tj
 Tj
 QB
 YF
 Ut
 op
+Mj
 Kh
 Kh
-ox
+XD
 Kh
 Kh
-oI
+Re
 JN
-pu
 qG
 za
 Uu
@@ -47936,32 +48008,32 @@ GG
 eN
 fq
 gz
-eM
 eN
 Cq
-XD
+ip
 rF
-kP
-qG
+og
+Vn
+oF
 pO
-sy
-WS
 WS
 WS
 WS
 WS
 WS
 Gt
-oq
-eh
-eh
-eh
-eh
-eh
-oJ
-JN
-pr
+GH
 qG
+oq
+Nt
+eh
+eh
+eh
+eh
+eh
+wb
+JN
+Ne
 MY
 Uu
 jy
@@ -48193,32 +48265,32 @@ Gm
 eN
 yS
 ZC
-pI
 az
-ee
-rF
+eM
+Cq
+ly
 Vn
 Yy
 JH
 LM
-Rm
+kM
 kM
 kM
 Vq
-IT
-QE
+kM
+kM
 QE
 CE
 oq
+Nt
 eh
 eh
 eh
 eh
 eh
-oJ
+Xm
 JN
-ps
-qG
+Ne
 em
 Uu
 oY
@@ -48449,32 +48521,32 @@ gM
 bc
 az
 eO
-eO
-mq
+ee
 dA
-Nt
+hV
+Cq
 rF
-rF
+oj
 Yq
 kT
 nr
-CP
 kM
 kM
+pr
 KK
 XE
 hP
 hP
-CE
+JO
 or
+Rl
 eh
 eh
-ej
+ZO
 eh
 eh
-oK
 ou
-kM
+pw
 xS
 jy
 td
@@ -48711,28 +48783,28 @@ Cq
 Cq
 Cq
 rF
-rF
+ox
 kS
 nf
-fR
-sz
+UK
 kM
 kM
+ps
+pv
+pI
 kM
 kM
-kM
-sz
 CE
-oq
+Le
+Nt
 eh
 eh
 eh
 eh
 eh
-Wp
+GT
 JN
-hV
-qG
+ni
 MZ
 Uu
 jy
@@ -48968,28 +49040,28 @@ Vd
 Vd
 gI
 rF
-rF
+ox
 kS
-nf
-Mj
 kM
-cw
 kM
-GH
+oL
+kM
+pu
+kM
+kM
 UK
-UK
-UK
-Ts
-oq
-eh
-eh
-eh
-eh
-eh
-oJ
-JN
-pv
+IT
 qG
+Le
+Nt
+eh
+eh
+eh
+eh
+eh
+wb
+JN
+Ne
 jy
 Uu
 jy
@@ -49225,9 +49297,9 @@ Cq
 Cq
 KY
 rF
-rF
+ox
 kS
-nf
+oH
 kM
 kM
 kM
@@ -49236,15 +49308,15 @@ kM
 kM
 kM
 kM
-Rl
+qG
 os
 nL
+Rm
 ow
-oz
+Fu
 ow
 ow
-oL
-ou
+af
 pw
 Ne
 jy
@@ -49482,28 +49554,28 @@ mU
 mU
 XN
 rF
-rF
+ox
 kS
-nf
+oI
 UW
 ZR
 on
 SR
 wk
-lY
-JO
-oj
-ip
+kM
+kM
+kM
+qG
 Xn
 yZ
+Ts
 JN
 JN
 JN
 JN
 JN
-pb
 px
-qG
+ES
 Na
 Hb
 jy
@@ -49740,9 +49812,8 @@ mU
 XN
 rF
 rF
-rF
-qG
-ly
+Vn
+oJ
 Tb
 Tb
 Tb
@@ -49750,12 +49821,13 @@ qG
 qG
 qG
 qG
-Tb
-Tb
+Jb
+qG
+qG
 xj
 Tb
-Tb
-Tb
+Wp
+FT
 Tb
 Tb
 qG
@@ -50013,7 +50085,7 @@ NA
 rF
 jy
 jy
-jy
+RY
 jy
 jy
 Fx
@@ -52076,7 +52148,7 @@ QN
 jl
 xn
 SX
-jl
+jW
 xn
 gA
 wp

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -31,15 +31,6 @@
 	dir = 8
 	},
 /area/mainship/hallways/hangar/droppod)
-"af" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
-	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "ag" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
@@ -1022,6 +1013,14 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
+"do" = (
+/obj/structure/cable,
+/obj/machinery/alarm{
+	dir = 4
+	},
+/obj/structure/largecrate/guns/russian,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/squads/req)
 "dp" = (
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/mono,
@@ -3030,10 +3029,6 @@
 "jU" = (
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
-"jW" = (
-/obj/machinery/roomba,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "jX" = (
 /obj/structure/closet/l3closet/virology,
 /obj/machinery/light{
@@ -3102,6 +3097,12 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/port_hallway)
+"kj" = (
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "kl" = (
 /obj/structure/closet/secure_closet/pilot_officer,
 /obj/item/clothing/mask/rebreather/scarf,
@@ -3576,10 +3577,11 @@
 	},
 /area/mainship/command/cic)
 "ly" = (
-/obj/machinery/computer/ordercomp,
-/obj/machinery/camera/autoname/mainship{
+/obj/effect/decal/warning_stripes/engineer,
+/obj/effect/decal/warning_stripes/box/small{
 	dir = 1
 	},
+/obj/effect/decal/warning_stripes/box/small,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "lz" = (
@@ -3705,7 +3707,10 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar/droppod)
 "lY" = (
-/obj/machinery/vending/shared_vending/marine_engi,
+/obj/machinery/computer/ordercomp,
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "lZ" = (
@@ -3809,7 +3814,7 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "mq" = (
-/obj/machinery/vending/engivend,
+/obj/machinery/vending/shared_vending/marine_engi,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "ms" = (
@@ -4082,12 +4087,6 @@
 	dir = 10
 	},
 /area/mainship/squads/general)
-"ni" = (
-/obj/machinery/door/poddoor/shutters/mainship/req/ro{
-	dir = 2
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "nj" = (
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 8
@@ -4381,10 +4380,7 @@
 	},
 /area/mainship/medical/medical_science)
 "og" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/vending/tool,
+/obj/machinery/vending/engivend,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "oh" = (
@@ -4397,12 +4393,10 @@
 /area/mainship/hull/lower_hull)
 "oj" = (
 /obj/machinery/light{
-	dir = 8
+	dir = 4
 	},
-/obj/machinery/line_nexter{
-	dir = 1
-	},
-/turf/open/floor/mainship/cargo,
+/obj/machinery/vending/tool,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "ok" = (
 /obj/vehicle/ridden/motorbike{
@@ -4480,7 +4474,10 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "ox" = (
-/obj/structure/barricade/metal{
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/line_nexter{
 	dir = 1
 	},
 /turf/open/floor/mainship/cargo,
@@ -4497,13 +4494,11 @@
 	},
 /area/mainship/squads/general)
 "oz" = (
-/obj/structure/table/mainship,
-/obj/structure/paper_bin,
-/obj/item/storage/fancy/cigar,
-/obj/item/tool/lighter/zippo,
-/obj/item/tool/pen,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/obj/structure/barricade/metal{
+	dir = 1
+	},
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/aft_hallway)
 "oA" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/mainship/green{
@@ -4545,8 +4540,11 @@
 	},
 /area/mainship/living/grunt_rnr)
 "oF" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
+/obj/structure/table/mainship,
+/obj/structure/paper_bin,
+/obj/item/storage/fancy/cigar,
+/obj/item/tool/lighter/zippo,
+/obj/item/tool/pen,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "oG" = (
@@ -4560,6 +4558,11 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "oH" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
+"oI" = (
 /obj/structure/rack,
 /obj/machinery/light{
 	dir = 8
@@ -4569,7 +4572,7 @@
 /obj/item/tool/weldpack,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"oI" = (
+"oJ" = (
 /obj/structure/rack,
 /obj/item/storage/firstaid/fire{
 	pixel_x = 3;
@@ -4579,7 +4582,7 @@
 /obj/item/storage/firstaid/adv,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"oJ" = (
+"oK" = (
 /obj/structure/window/framed/mainship/requisitions,
 /obj/structure/sign/ROsign{
 	dir = 1
@@ -4587,20 +4590,11 @@
 /obj/machinery/door/poddoor/shutters/mainship/req/ro,
 /turf/open/floor/plating,
 /area/mainship/squads/req)
-"oK" = (
+"oL" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
 /obj/effect/landmark/start/job/requisitionsofficer,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"oL" = (
-/obj/structure/table/mainship,
-/obj/item/stack/sheet/wood/large_stack,
-/obj/item/stack/sheet/glass/reinforced{
-	amount = 30
-	},
-/obj/item/stack/sheet/cardboard,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "oM" = (
@@ -4694,7 +4688,12 @@
 	},
 /area/mainship/command/self_destruct)
 "pb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/obj/structure/table/mainship,
+/obj/item/stack/sheet/wood/large_stack,
+/obj/item/stack/sheet/glass/reinforced{
+	amount = 30
+	},
+/obj/item/stack/sheet/cardboard,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "pc" = (
@@ -4786,14 +4785,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "pr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ps" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
@@ -4807,14 +4804,15 @@
 	},
 /area/mainship/living/grunt_rnr)
 "pu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "pv" = (
-/obj/structure/rack,
-/obj/item/pizzabox/meat,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "pw" = (
@@ -4878,7 +4876,8 @@
 	},
 /area/mainship/shipboard/firing_range)
 "pI" = (
-/obj/machinery/vending/cargo_supply,
+/obj/structure/rack,
+/obj/item/pizzabox/meat,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "pJ" = (
@@ -5631,6 +5630,10 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "sy" = (
+/obj/machinery/vending/cargo_supply,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
+"sz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -5640,18 +5643,6 @@
 	dir = 1
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/aft_hallway)
-"sz" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "sA" = (
 /obj/machinery/photocopier,
@@ -6810,13 +6801,6 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
-"wb" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
 "wc" = (
 /obj/structure/bed/chair/wood,
 /obj/item/trash/cigbutt/cigarbutt,
@@ -7101,6 +7085,14 @@
 /obj/item/tool/extinguisher/mini,
 /turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/firing_range)
+"wP" = (
+/obj/machinery/door/poddoor/shutters/mainship/req/ro,
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
+	},
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/plating,
+/area/mainship/squads/req)
 "wQ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -8666,6 +8658,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"BB" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/mainship/squads/req)
 "BD" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/emails,
@@ -9066,16 +9067,17 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "CP" = (
-/obj/machinery/door/airlock/mainship/marine/requisitions,
-/obj/machinery/door/firedoor/mainship,
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/mainship/squads/req)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/aft_hallway)
 "CQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -9829,9 +9831,9 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"ES" = (
-/obj/machinery/newscaster,
-/turf/closed/wall/mainship,
+"EV" = (
+/obj/docking_port/stationary/supply,
+/turf/open/floor/mainship/empty,
 /area/mainship/squads/req)
 "EW" = (
 /obj/machinery/portable_atmospherics/hydroponics,
@@ -9928,15 +9930,6 @@
 /obj/structure/table/mainship,
 /turf/open/floor/freezer,
 /area/mainship/living/cafeteria_starboard)
-"Fu" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 8;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
-/area/mainship/squads/req)
 "Fv" = (
 /obj/machinery/light{
 	dir = 8
@@ -10087,14 +10080,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
-"FT" = (
-/obj/machinery/door/poddoor/shutters/mainship/req/ro,
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 2
-	},
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/plating,
-/area/mainship/squads/req)
 "FU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -10255,10 +10240,15 @@
 	},
 /area/mainship/command/cic)
 "Gt" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
+/obj/machinery/door/airlock/mainship/marine/requisitions,
+/obj/machinery/door/firedoor/mainship,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/space/basic,
 /area/mainship/squads/req)
 "Gu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -10321,8 +10311,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "GH" = (
-/obj/structure/table/mainship,
-/obj/machinery/computer/supplydrop_console,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "GJ" = (
@@ -10386,14 +10377,6 @@
 /obj/item/pizzabox/meat,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"GT" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
-	},
-/obj/machinery/holopad,
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
 "GU" = (
 /turf/open/floor/mainship/sterile/corner{
 	dir = 4
@@ -11072,6 +11055,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
+"IJ" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/obj/machinery/computer/ordercomp,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "IL" = (
 /obj/structure/table/mainship,
 /obj/machinery/recharger,
@@ -11131,7 +11122,8 @@
 	},
 /area/space)
 "IT" = (
-/obj/machinery/cic_maptable,
+/obj/structure/table/mainship,
+/obj/machinery/computer/supplydrop_console,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "IU" = (
@@ -11175,9 +11167,8 @@
 /turf/open/floor/wood,
 /area/mainship/medical/surgery_hallway)
 "Jb" = (
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/airlock/mainship/marine/requisitions,
-/turf/open/space/basic,
+/obj/machinery/cic_maptable,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Jc" = (
 /obj/machinery/light/small{
@@ -11485,11 +11476,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "JO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/marine/requisitions{
-	dir = 2
-	},
-/turf/open/floor/mainship/mono,
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/airlock/mainship/marine/requisitions,
+/turf/open/space/basic,
 /area/mainship/squads/req)
 "JQ" = (
 /obj/structure/cable,
@@ -11933,10 +11922,11 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/command/self_destruct)
 "Le" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/airlock/mainship/marine/requisitions{
+	dir = 2
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Lf" = (
 /obj/machinery/door/poddoor/mainship,
@@ -12253,13 +12243,10 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "Mj" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
-	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "Mk" = (
 /obj/machinery/firealarm{
@@ -12331,6 +12318,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"Mw" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "Mx" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/shipboard/firing_range)
@@ -12678,11 +12674,13 @@
 	},
 /area/mainship/squads/general)
 "Nt" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "supply_elevator_railing"
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
 	},
-/turf/open/floor/mainship/floor,
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Nu" = (
 /obj/effect/landmark/start/job/squadengineer,
@@ -13946,15 +13944,6 @@
 	dir = 9
 	},
 /area/mainship/medical/lower_medical)
-"Re" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 5
-	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "Rf" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -14001,17 +13990,16 @@
 	dir = 2;
 	id = "supply_elevator_railing"
 	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 1
-	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "Rm" = (
 /obj/machinery/door/poddoor/railing{
-	dir = 8;
+	dir = 2;
 	id = "supply_elevator_railing"
 	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 1
+	},
 /area/mainship/squads/req)
 "Rn" = (
 /obj/machinery/door/airlock/mainship/medical/glass{
@@ -14023,6 +14011,15 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/surgery_hallway)
+"Ro" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "Rp" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -14267,10 +14264,6 @@
 /obj/machinery/telecomms/server/presets/bravo,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
-"RY" = (
-/obj/machinery/door_control/old/req,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
 "RZ" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /obj/machinery/vending/uniform_supply,
@@ -14318,14 +14311,6 @@
 /obj/structure/sign/pods,
 /turf/closed/wall/mainship,
 /area/mainship/hallways/hangar)
-"Si" = (
-/obj/structure/cable,
-/obj/machinery/alarm{
-	dir = 4
-	},
-/obj/structure/largecrate/guns/russian,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/squads/req)
 "Sj" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/closed/wall/mainship,
@@ -14368,6 +14353,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
+"Ss" = (
+/obj/machinery/roomba,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "St" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mainship,
@@ -14667,11 +14656,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
 "Ts" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "supply_elevator_railing"
 	},
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "Tu" = (
 /obj/structure/orbital_cannon,
@@ -14736,6 +14726,10 @@
 /obj/machinery/firealarm,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
+"TF" = (
+/obj/machinery/newscaster,
+/turf/closed/wall/mainship,
+/area/mainship/squads/req)
 "TG" = (
 /obj/structure/window/framed/mainship,
 /obj/structure/cable,
@@ -15119,6 +15113,14 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
+"UV" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/obj/machinery/holopad,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "UW" = (
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
@@ -15574,9 +15576,11 @@
 	},
 /area/mainship/living/cryo_cells)
 "Wp" = (
-/obj/machinery/door/poddoor/shutters/mainship/req/ro,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "Wr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -15869,14 +15873,6 @@
 	dir = 6
 	},
 /area/mainship/medical/lower_medical)
-"Xm" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
-	},
-/obj/machinery/computer/ordercomp,
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
 "Xn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -16010,12 +16006,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/upper_engineering)
 "XD" = (
-/obj/machinery/door/poddoor/railing{
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
+/obj/machinery/door/poddoor/shutters/mainship/req/ro,
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/plating,
 /area/mainship/squads/req)
 "XE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -16163,6 +16156,13 @@
 /obj/effect/landmark/start/latejoin,
 /turf/open/floor/mainship,
 /area/mainship/living/cryo_cells)
+"XW" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "XX" = (
 /obj/structure/window/framed/mainship/hull,
 /turf/open/space/basic,
@@ -16645,6 +16645,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"Zy" = (
+/obj/machinery/door_control/old/req,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "Zz" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -16740,8 +16744,12 @@
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "ZO" = (
-/obj/docking_port/stationary/supply,
-/turf/open/floor/mainship/empty,
+/obj/machinery/door/poddoor/railing{
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
 /area/mainship/squads/req)
 "ZP" = (
 /obj/structure/cable,
@@ -46736,7 +46744,7 @@ po
 UC
 JL
 pX
-sy
+sz
 JL
 JL
 JL
@@ -46993,7 +47001,7 @@ gd
 rF
 rF
 AB
-sz
+CP
 rF
 rF
 FB
@@ -47250,7 +47258,7 @@ qG
 qG
 qG
 qG
-CP
+Gt
 qG
 qG
 qG
@@ -47497,10 +47505,10 @@ wl
 NE
 Cq
 Cq
-rF
-lY
+ly
+mq
 Vn
-oz
+oF
 VM
 kE
 oG
@@ -47517,7 +47525,7 @@ OY
 Pw
 UA
 Sv
-Si
+do
 pq
 qG
 jy
@@ -47755,26 +47763,26 @@ eN
 Cq
 Cq
 rF
-mq
+og
 Vn
 de
-oK
+oL
 kM
 kM
-pb
+pr
 Tj
 Tj
 QB
 YF
 Ut
 op
-Mj
+Nt
 Kh
 Kh
-XD
+ZO
 Kh
 Kh
-Re
+Mw
 JN
 qG
 za
@@ -48012,26 +48020,26 @@ eN
 Cq
 ip
 rF
-og
+oj
 Vn
-oF
+oH
 pO
 WS
 WS
 WS
 WS
 WS
-Gt
 GH
+IT
 qG
 oq
-Nt
+Rl
 eh
 eh
 eh
 eh
 eh
-wb
+XW
 JN
 Ne
 MY
@@ -48268,7 +48276,7 @@ ZC
 az
 eM
 Cq
-ly
+lY
 Vn
 Yy
 JH
@@ -48282,13 +48290,13 @@ kM
 QE
 CE
 oq
-Nt
+Rl
 eh
 eh
 eh
 eh
 eh
-Xm
+IJ
 JN
 Ne
 em
@@ -48526,23 +48534,23 @@ dA
 hV
 Cq
 rF
-oj
+ox
 Yq
 kT
 nr
 kM
 kM
-pr
+ps
 KK
 XE
 hP
 hP
-JO
+Le
 or
-Rl
+Rm
 eh
 eh
-ZO
+EV
 eh
 eh
 ou
@@ -48783,28 +48791,28 @@ Cq
 Cq
 Cq
 rF
-ox
+oz
 kS
 nf
 UK
 kM
 kM
-ps
-pv
+pu
 pI
+sy
 kM
 kM
 CE
-Le
-Nt
+Mj
+Rl
 eh
 eh
 eh
 eh
 eh
-GT
+UV
 JN
-ni
+kj
 MZ
 Uu
 jy
@@ -49040,26 +49048,26 @@ Vd
 Vd
 gI
 rF
-ox
+oz
 kS
 kM
 kM
-oL
+pb
 kM
-pu
+pv
 kM
 kM
 UK
-IT
+Jb
 qG
-Le
-Nt
+Mj
+Rl
 eh
 eh
 eh
 eh
 eh
-wb
+XW
 JN
 Ne
 jy
@@ -49297,9 +49305,9 @@ Cq
 Cq
 KY
 rF
-ox
+oz
 kS
-oH
+oI
 kM
 kM
 kM
@@ -49311,12 +49319,12 @@ kM
 qG
 os
 nL
-Rm
+Ts
 ow
-Fu
+BB
 ow
 ow
-af
+Ro
 pw
 Ne
 jy
@@ -49554,9 +49562,9 @@ mU
 mU
 XN
 rF
-ox
+oz
 kS
-oI
+oJ
 UW
 ZR
 on
@@ -49568,14 +49576,14 @@ kM
 qG
 Xn
 yZ
-Ts
+Wp
 JN
 JN
 JN
 JN
 JN
 px
-ES
+TF
 Na
 Hb
 jy
@@ -49813,7 +49821,7 @@ XN
 rF
 rF
 Vn
-oJ
+oK
 Tb
 Tb
 Tb
@@ -49821,13 +49829,13 @@ qG
 qG
 qG
 qG
-Jb
+JO
 qG
 qG
 xj
 Tb
-Wp
-FT
+XD
+wP
 Tb
 Tb
 qG
@@ -50085,7 +50093,7 @@ NA
 rF
 jy
 jy
-RY
+Zy
 jy
 jy
 Fx
@@ -52148,7 +52156,7 @@ QN
 jl
 xn
 SX
-jW
+Ss
 xn
 gA
 wp

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -5490,15 +5490,6 @@
 	dir = 10
 	},
 /area/sulaco/bridge)
-"aAR" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
-	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
-	},
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
 "aAU" = (
 /turf/open/floor/prison/red,
 /area/sulaco/bridge)
@@ -10714,13 +10705,6 @@
 	dir = 1
 	},
 /area/mainship/shipboard/weapon_room)
-"cws" = (
-/obj/machinery/power/apc/mainship{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/prison/red/corner,
-/area/sulaco/hangar/one)
 "cwG" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/prison/kitchen,
@@ -11362,6 +11346,11 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/basketball)
+"dya" = (
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/sulaco/cargo/prep)
 "dyO" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -11407,15 +11396,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/hallway/central_hall)
-"dAZ" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 5
-	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
-	},
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
 "dCC" = (
 /obj/structure/window/framed/mainship/gray/toughened/hull,
 /turf/open/floor/plating/platebotc,
@@ -11605,13 +11585,6 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
-"dZj" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/prison,
-/area/sulaco/cargo)
 "dZI" = (
 /obj/structure/table/mainship,
 /obj/item/folder/yellow,
@@ -12200,18 +12173,6 @@
 	dir = 5
 	},
 /area/space)
-"fgp" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison/red/corner{
-	dir = 1
-	},
-/area/sulaco/cargo/prep)
 "fjF" = (
 /obj/machinery/vending/medical/shipside,
 /turf/open/floor/prison/whitegreen/corner{
@@ -12245,6 +12206,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_north_maint)
+"fmQ" = (
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/prison,
+/area/sulaco/cargo/prep)
 "fmW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -12284,6 +12249,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plating/mainship,
 /area/sulaco/engineering/engine)
+"fpZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/prison,
+/area/sulaco/cargo/prep)
 "fqb" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/prison/kitchen,
@@ -12316,6 +12287,24 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
+"fqX" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
+/turf/open/floor/prison/plate,
+/area/sulaco/cargo)
+"fsG" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
+/turf/open/floor/prison/plate,
+/area/sulaco/cargo)
 "fsL" = (
 /obj/structure/table/mainship,
 /turf/open/floor/prison,
@@ -12548,14 +12537,6 @@
 /obj/item/storage/firstaid/adv,
 /turf/open/floor/prison,
 /area/sulaco/security)
-"fPn" = (
-/obj/machinery/alarm{
-	dir = 4
-	},
-/turf/open/floor/prison/red/corner{
-	dir = 8
-	},
-/area/sulaco/hangar/one)
 "fPR" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/prison,
@@ -12864,6 +12845,16 @@
 	},
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint)
+"gvp" = (
+/obj/structure/table/mainship,
+/obj/item/weapon/gun/rifle/m412,
+/obj/item/ammo_magazine/rifle,
+/obj/item/ammo_magazine/rifle,
+/obj/item/ammo_magazine/rifle,
+/turf/open/floor/prison/red/corner{
+	dir = 4
+	},
+/area/sulaco/hangar/one)
 "gvt" = (
 /obj/structure/largecrate/guns,
 /turf/open/floor/prison/plate,
@@ -12985,11 +12976,6 @@
 /obj/machinery/suit_storage_unit,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint3)
-"gID" = (
-/turf/open/floor/prison/red/corner{
-	dir = 4
-	},
-/area/sulaco/hangar/one)
 "gJn" = (
 /obj/effect/decal/cleanable/cobweb{
 	dir = 1
@@ -13385,6 +13371,16 @@
 	dir = 1
 	},
 /area/sulaco/medbay/cmo)
+"hxH" = (
+/obj/effect/decal/cleanable/cobweb{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/sulaco/maintenance/lower_maint2)
 "hzl" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -14218,6 +14214,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/hallway/lower_foreship)
+"iTI" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/sulaco/cargo/prep)
 "iTR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -14420,13 +14423,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
-"jjj" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/sulaco/cargo/prep)
 "jnn" = (
 /obj/structure/window/framed/mainship/gray/toughened,
 /obj/machinery/door/poddoor/telecomms,
@@ -14445,6 +14441,14 @@
 /obj/structure/cable,
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay/storage2)
+"jpx" = (
+/obj/machinery/alarm{
+	dir = 4
+	},
+/turf/open/floor/prison/red/corner{
+	dir = 8
+	},
+/area/sulaco/hangar/one)
 "jpD" = (
 /obj/machinery/alarm,
 /turf/open/floor/prison/whitegreen/corner{
@@ -14727,6 +14731,11 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_foreship)
+"jOl" = (
+/turf/open/floor/prison/red/corner{
+	dir = 4
+	},
+/area/sulaco/hangar/one)
 "jPf" = (
 /obj/item/radio/intercom/general{
 	dir = 1
@@ -14777,10 +14786,6 @@
 	dir = 6
 	},
 /area/sulaco/engineering/atmos)
-"jRO" = (
-/obj/machinery/roomba,
-/turf/open/floor/prison/red/corner,
-/area/sulaco/cargo/prep)
 "jSM" = (
 /turf/open/floor/prison/red{
 	dir = 1
@@ -15007,10 +15012,6 @@
 	},
 /turf/open/floor/grass,
 /area/mainship/living/starboard_garden)
-"kkA" = (
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/prison,
-/area/sulaco/cargo/prep)
 "kme" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -15081,12 +15082,6 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
-"kqn" = (
-/obj/machinery/door/poddoor/shutters/mainship/req/ro{
-	dir = 2
-	},
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
 "kqp" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mainship/gray,
@@ -15335,12 +15330,6 @@
 "kOr" = (
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/hangar/storage)
-"kOL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/prison/red,
-/area/sulaco/hangar/one)
 "kRy" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -15974,6 +15963,18 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/prison,
 /area/mainship/shipboard/weapon_room)
+"lSl" = (
+/obj/structure/table/mainship,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/item/weapon/gun/shotgun/pump,
+/obj/item/ammo_magazine/shotgun,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/turf/open/floor/prison/red{
+	dir = 5
+	},
+/area/sulaco/hangar/one)
 "lSB" = (
 /obj/structure/cable,
 /turf/open/floor/prison/sterilewhite,
@@ -17000,6 +17001,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/hangar/one)
+"nKk" = (
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
+	},
+/turf/open/floor/prison/plate,
+/area/sulaco/cargo)
 "nKB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -17654,16 +17661,6 @@
 /obj/item/clothing/suit/chef,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
-"oDc" = (
-/obj/structure/table/mainship,
-/obj/item/weapon/gun/rifle/m412,
-/obj/item/ammo_magazine/rifle,
-/obj/item/ammo_magazine/rifle,
-/obj/item/ammo_magazine/rifle,
-/turf/open/floor/prison/red/corner{
-	dir = 4
-	},
-/area/sulaco/hangar/one)
 "oDe" = (
 /obj/machinery/light{
 	dir = 4
@@ -18448,11 +18445,6 @@
 /obj/item/reagent_containers/glass/bucket/janibucket,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint2)
-"pLH" = (
-/turf/open/floor/prison/red/corner{
-	dir = 1
-	},
-/area/sulaco/cargo/prep)
 "pLJ" = (
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/bridge/office)
@@ -18505,6 +18497,10 @@
 	},
 /turf/open/floor/wood,
 /area/sulaco/marine/chapel/chapel_office)
+"pTz" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/prison,
+/area/sulaco/hangar/one)
 "pVC" = (
 /obj/item/radio/intercom/general{
 	dir = 1
@@ -19090,11 +19086,6 @@
 /obj/item/reagent_containers/glass/bucket/janibucket,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_north_maint)
-"rbh" = (
-/turf/open/floor/prison/red{
-	dir = 4
-	},
-/area/sulaco/cargo/prep)
 "rbr" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 1
@@ -19286,11 +19277,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/prison,
 /area/sulaco/cargo/office)
-"rnN" = (
-/obj/machinery/door_control/old/req,
-/obj/structure/table/mainship,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/sulaco/cargo)
 "rnR" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -19354,6 +19340,12 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/engineering/atmos)
+"rsV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/prison/red,
+/area/sulaco/hangar/one)
 "rta" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -20203,16 +20195,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/sulaco/bridge)
-"sKv" = (
-/obj/effect/decal/cleanable/cobweb{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/sulaco/maintenance/lower_maint2)
 "sKM" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -20564,6 +20546,11 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
+"tjN" = (
+/turf/open/floor/prison/red/corner{
+	dir = 1
+	},
+/area/sulaco/cargo/prep)
 "tjS" = (
 /obj/machinery/door/airlock/mainship/generic,
 /obj/machinery/door/firedoor,
@@ -20628,6 +20615,21 @@
 /obj/structure/largecrate/random,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_north_maint)
+"toz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 10
+	},
+/obj/structure/closet/crate,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/turf/open/floor/prison/red{
+	dir = 6
+	},
+/area/sulaco/hangar/one)
 "toM" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -20737,6 +20739,14 @@
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/research)
+"tuP" = (
+/obj/effect/decal/warning_stripes/engineer,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
+/turf/open/floor/prison,
+/area/sulaco/hallway/lower_main_hall)
 "tvk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/holopad{
@@ -21260,14 +21270,6 @@
 	dir = 1
 	},
 /area/sulaco/engineering/lower_engineering)
-"upr" = (
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/airlock/mainship/marine/requisitions{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo/office)
 "uqO" = (
 /obj/machinery/researchcomp,
 /turf/open/floor/prison/whitegreen/corner{
@@ -21395,6 +21397,11 @@
 /obj/vehicle/unmanned/droid,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint)
+"uEa" = (
+/obj/machinery/door_control/old/req,
+/obj/structure/table/mainship,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/sulaco/cargo)
 "uFe" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/prison/arrow/clean,
@@ -21592,18 +21599,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/sulaco/engineering)
-"uVt" = (
-/obj/structure/table/mainship,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/obj/item/weapon/gun/shotgun/pump,
-/obj/item/ammo_magazine/shotgun,
-/obj/item/ammo_magazine/shotgun/buckshot,
-/obj/item/ammo_magazine/shotgun/buckshot,
-/turf/open/floor/prison/red{
-	dir = 5
-	},
-/area/sulaco/hangar/one)
 "uVA" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mainship/gray,
@@ -21617,6 +21612,13 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
+"uVS" = (
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/prison/red/corner,
+/area/sulaco/hangar/one)
 "uWC" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison,
@@ -21676,6 +21678,14 @@
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
+"vaf" = (
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/airlock/mainship/marine/requisitions{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/prison/plate,
+/area/sulaco/cargo/office)
 "vai" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -21789,12 +21799,6 @@
 /obj/machinery/vending/weapon,
 /turf/open/floor/prison,
 /area/sulaco/marine)
-"vgX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/prison,
-/area/sulaco/cargo/prep)
 "vhh" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/structure/cable,
@@ -21831,6 +21835,10 @@
 /obj/structure/sign/atmosplaque,
 /turf/closed/wall/mainship/gray,
 /area/sulaco/engineering/atmos)
+"vjP" = (
+/obj/machinery/roomba,
+/turf/open/floor/prison/red/corner,
+/area/sulaco/cargo/prep)
 "vkI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/green{
@@ -21939,6 +21947,18 @@
 	},
 /turf/open/floor/prison,
 /area/mainship/shipboard/weapon_room)
+"vwH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/red/corner{
+	dir = 1
+	},
+/area/sulaco/cargo/prep)
 "vwM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
@@ -22334,21 +22354,6 @@
 	dir = 4
 	},
 /area/mainship/shipboard/weapon_room)
-"wkg" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 10
-	},
-/obj/structure/closet/crate,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/turf/open/floor/prison/red{
-	dir = 6
-	},
-/area/sulaco/hangar/one)
 "wkO" = (
 /obj/machinery/light{
 	dir = 8
@@ -23017,6 +23022,13 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
+"xpj" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/prison,
+/area/sulaco/cargo)
 "xpm" = (
 /turf/closed/wall/mainship/gray,
 /area/mainship/living/pilotbunks)
@@ -23104,10 +23116,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/ai,
 /area/sulaco/command/ai)
-"xzo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/prison,
-/area/sulaco/hangar/one)
 "xzB" = (
 /obj/structure/table/mainship,
 /obj/item/clipboard,
@@ -47419,7 +47427,7 @@ ptg
 mqT
 mqT
 ptg
-upr
+vaf
 ptg
 hCz
 ali
@@ -47933,7 +47941,7 @@ tBy
 uOd
 tBy
 tBy
-dAZ
+fqX
 ajb
 txO
 vSd
@@ -48190,7 +48198,7 @@ abV
 abV
 abV
 abV
-dZj
+xpj
 ajb
 txO
 vSd
@@ -48450,7 +48458,7 @@ abV
 aiz
 ajc
 aiS
-jjj
+iTI
 bwe
 anK
 otR
@@ -48706,8 +48714,8 @@ abV
 abV
 iYq
 fCm
-kqn
-vgX
+nKk
+fpZ
 vSd
 uig
 vSd
@@ -48961,7 +48969,7 @@ abV
 abV
 abV
 abV
-dZj
+xpj
 fCm
 txO
 hKB
@@ -49218,7 +49226,7 @@ abV
 abV
 abV
 abV
-dZj
+xpj
 fCm
 mZj
 vSd
@@ -49475,15 +49483,15 @@ exd
 vln
 exd
 exd
-aAR
-rnN
+fsG
+uEa
 lpY
 whS
-rbh
-fgp
-jRO
-rbh
-pLH
+dya
+vwH
+vjP
+dya
+tjN
 xMC
 bjX
 xKR
@@ -50245,15 +50253,15 @@ hWv
 vdJ
 aRy
 uPG
-fPn
+jpx
 gzY
 aRj
-oDc
+gvp
 alx
-kkA
+fmQ
 rEe
 alx
-kkA
+fmQ
 rpg
 sbT
 qLP
@@ -50505,7 +50513,7 @@ iKy
 nJV
 aiV
 eAf
-xzo
+pTz
 alx
 vSd
 rEe
@@ -51017,8 +51025,8 @@ aiV
 aRy
 vRR
 bhA
-kOL
-gID
+rsV
+jOl
 bhA
 erP
 erP
@@ -51273,9 +51281,9 @@ sCO
 tBz
 aRy
 iKy
-cws
-wkg
-uVt
+uVS
+toz
+lSl
 kqQ
 erP
 slc
@@ -51790,7 +51798,7 @@ una
 una
 una
 una
-sKv
+hxH
 erP
 kSh
 hXU
@@ -53856,7 +53864,7 @@ jtC
 aGy
 bjX
 xKR
-bjX
+tuP
 rZH
 fVo
 xzB

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -71,12 +71,9 @@
 /turf/open/floor/plating/mainship,
 /area/sulaco/engineering/engine)
 "aal" = (
-/obj/structure/closet/crate/internals,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/obj/machinery/vending/weapon,
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "aam" = (
 /turf/closed/wall/mainship/white,
 /area/sulaco/medbay/west)
@@ -201,12 +198,6 @@
 "aaJ" = (
 /turf/closed/wall/mainship/white,
 /area/sulaco/medbay)
-"aaK" = (
-/obj/structure/target_stake,
-/turf/open/floor/prison/red{
-	dir = 9
-	},
-/area/sulaco/hangar/one)
 "aaM" = (
 /obj/structure/window/framed/mainship/white,
 /obj/machinery/door/firedoor/mainship,
@@ -214,11 +205,12 @@
 /turf/open/floor/plating/platebotc,
 /area/sulaco/medbay/chemistry)
 "aaN" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/obj/structure/rack,
+/obj/item/tool/screwdriver,
+/obj/item/tool/wrench,
+/obj/item/tool/crowbar,
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "aaP" = (
 /obj/structure/closet/secure_closet/chemical,
 /turf/open/floor/prison/whitegreen/corner{
@@ -322,15 +314,9 @@
 	},
 /area/sulaco/medbay/surgery_one)
 "abf" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 10
-	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
-	},
-/obj/effect/ai_node,
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/obj/effect/landmark/start/job/squadengineer,
+/turf/open/floor/prison/sterilewhite,
+/area/sulaco/cryosleep)
 "abg" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison,
@@ -358,10 +344,9 @@
 	},
 /area/sulaco/medbay/chemistry)
 "abj" = (
-/turf/open/floor/prison/red{
-	dir = 8
-	},
-/area/sulaco/hangar/one)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/plate,
+/area/sulaco/cargo)
 "abk" = (
 /obj/machinery/vending/medical/shipside,
 /turf/open/floor/prison/whitegreen/corner,
@@ -1214,17 +1199,17 @@
 /turf/open/floor/prison/kitchen,
 /area/sulaco/cafeteria)
 "aed" = (
-/turf/open/floor/prison/red{
-	dir = 6
-	},
+/obj/structure/sign/securearea/firingrange,
+/turf/open/floor/prison/red,
 /area/sulaco/hangar/one)
 "aee" = (
-/obj/machinery/power/apc/mainship{
-	dir = 8
+/obj/effect/decal/siding{
+	dir = 9
 	},
-/obj/structure/cable,
-/turf/open/floor/prison/red/corner,
-/area/sulaco/hangar/one)
+/turf/open/floor/mainship/terragov/south{
+	dir = 9
+	},
+/area/space)
 "aeh" = (
 /turf/closed/wall/mainship/gray,
 /area/sulaco/engineering/ce)
@@ -1535,19 +1520,15 @@
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay)
 "aeR" = (
-/obj/structure/closet/crate,
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "aeS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
-"aeT" = (
-/obj/machinery/door/poddoor/railing{
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/prison,
-/area/sulaco/cargo)
 "aeV" = (
 /obj/machinery/power/monitor,
 /obj/structure/cable,
@@ -1658,12 +1639,8 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
 "afK" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/prison/red{
-	dir = 4
-	},
+/obj/effect/ai_node,
+/turf/open/floor/prison,
 /area/sulaco/hangar/one)
 "afQ" = (
 /obj/structure/table/mainship,
@@ -1750,21 +1727,21 @@
 /turf/open/floor/freezer,
 /area/sulaco/showers)
 "agM" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
+/obj/effect/decal/siding{
+	dir = 1
 	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
+/turf/open/floor/mainship/terragov/south{
+	dir = 1
 	},
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/area/space)
 "agN" = (
-/obj/docking_port/stationary/supply,
-/turf/open/floor/mainship/empty,
-/area/sulaco/cargo)
-"agR" = (
-/obj/structure/supply_drop,
-/turf/open/floor/prison/plate,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/cargo)
 "agS" = (
 /obj/structure/window/reinforced/tinted/frosted,
@@ -1854,27 +1831,19 @@
 /obj/item/cell/high,
 /obj/item/clothing/glasses/welding,
 /obj/item/lightreplacer,
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "ahT" = (
-/obj/structure/table/mainship,
-/obj/machinery/cell_charger,
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/obj/effect/decal/siding{
+	dir = 5
+	},
+/turf/open/floor/mainship/terragov/south{
+	dir = 5
+	},
+/area/space)
 "aia" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 10
-	},
-/obj/structure/closet/crate,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/turf/open/floor/prison/red{
-	dir = 6
-	},
+/obj/machinery/holopad,
+/turf/open/floor/prison/red/full,
 /area/sulaco/hangar/one)
 "aib" = (
 /obj/machinery/status_display,
@@ -1946,12 +1915,12 @@
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay)
 "aiz" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
-	dir = 8
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/obj/effect/ai_node,
-/turf/open/floor/prison/plate,
+/obj/machinery/computer/ordercomp,
+/turf/open/floor/prison,
 /area/sulaco/cargo)
 "aiA" = (
 /obj/machinery/computer/med_data,
@@ -1960,18 +1929,15 @@
 	},
 /area/sulaco/medbay)
 "aiS" = (
-/obj/machinery/door/airlock/mainship/marine/requisitions{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/mainship/generic/canteen,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
+	},
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
 "aiV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
 /turf/open/floor/prison/red,
 /area/sulaco/hangar/one)
 "aiW" = (
@@ -2003,25 +1969,27 @@
 	},
 /area/sulaco/medbay)
 "ajb" = (
-/obj/machinery/computer/supplydrop_console,
-/obj/structure/table/mainship,
-/turf/open/floor/prison/plate,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/cargo)
 "ajc" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/prison/plate,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/cargo)
 "aje" = (
-/obj/structure/table/mainship,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/obj/item/weapon/gun/shotgun/pump,
-/obj/item/ammo_magazine/shotgun,
-/obj/item/ammo_magazine/shotgun/buckshot,
-/obj/item/ammo_magazine/shotgun/buckshot,
 /turf/open/floor/prison/red{
-	dir = 5
+	dir = 1
 	},
 /area/sulaco/hangar/one)
 "ajj" = (
@@ -2504,7 +2472,7 @@
 /obj/effect/decal/warning_stripes/thick{
 	dir = 1
 	},
-/obj/effect/landmark/start/job/squadengineer,
+/obj/effect/landmark/start/job/squadmarine,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
 "amp" = (
@@ -3152,12 +3120,9 @@
 /turf/closed/wall/mainship/gray,
 /area/sulaco/cargo/office)
 "aqn" = (
-/obj/structure/closet/crate/freezer/rations,
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/obj/vehicle/ridden/motorbike,
+/turf/open/floor/prison/marked,
+/area/sulaco/cargo/office)
 "aqt" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -5525,6 +5490,15 @@
 	dir = 10
 	},
 /area/sulaco/bridge)
+"aAR" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
+/turf/open/floor/prison/plate,
+/area/sulaco/cargo)
 "aAU" = (
 /turf/open/floor/prison/red,
 /area/sulaco/bridge)
@@ -6902,8 +6876,8 @@
 /turf/open/floor/tile/hydro,
 /area/sulaco/hydro)
 "aIj" = (
-/obj/effect/landmark/start/job/squadmarine,
 /obj/structure/cable,
+/obj/effect/landmark/start/job/squadengineer,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
 "aIl" = (
@@ -7096,6 +7070,7 @@
 /obj/effect/landmark/start/latejoin,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/effect/landmark/start/job/squadsmartgunner,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
 "aJs" = (
@@ -7455,9 +7430,11 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hydro)
 "aLh" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/sulaco/cargo)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "aLk" = (
 /turf/open/floor/prison/green/full,
 /area/sulaco/marine)
@@ -7470,12 +7447,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/prison/green/full,
 /area/sulaco/marine)
-"aLn" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
 "aLo" = (
 /obj/machinery/vending/nanomed,
 /turf/open/floor/prison/green{
@@ -8157,11 +8128,12 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar/cas)
 "aPL" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
 	},
-/turf/open/floor/prison/marked,
-/area/sulaco/hangar/one)
+/obj/effect/landmark/start/job/squadengineer,
+/turf/open/floor/prison/sterilewhite,
+/area/sulaco/cryosleep)
 "aPM" = (
 /obj/machinery/door/airlock/mainship/secure/tcomms{
 	dir = 1
@@ -8423,8 +8395,10 @@
 /turf/open/floor/cult,
 /area/sulaco/morgue)
 "aRj" = (
+/obj/structure/table/mainship,
+/obj/item/clothing/ears/earmuffs,
 /turf/open/floor/prison/red{
-	dir = 1
+	dir = 9
 	},
 /area/sulaco/hangar/one)
 "aRk" = (
@@ -10050,9 +10024,9 @@
 /area/sulaco/liaison/quarters)
 "bfC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/obj/structure/closet/crate/ammo,
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "bgm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -10146,14 +10120,13 @@
 /turf/open/floor/prison/plate,
 /area/shuttle/distress/arrive_2)
 "bkX" = (
-/obj/structure/closet/crate/construction,
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/obj/machinery/cic_maptable,
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "blt" = (
-/obj/structure/cable,
 /obj/structure/closet/crate/medical,
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "bmI" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
@@ -10281,10 +10254,9 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_foreship)
 "bEP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/sulaco/cargo)
+/obj/structure/closet/crate/construction,
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "bER" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
@@ -10687,13 +10659,8 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
 "csB" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 8;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/prison/arrow{
-	dir = 4
-	},
+/obj/item/tool/mop,
+/turf/open/floor/prison/plate,
 /area/sulaco/cargo)
 "csJ" = (
 /obj/structure/table/mainship,
@@ -10738,17 +10705,22 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_main_hall)
 "cvJ" = (
-/obj/structure/window/framed/mainship/gray/toughened,
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/turf/open/floor/plating/platebotc,
+/obj/structure/table/mainship,
+/obj/machinery/cell_charger,
+/turf/open/floor/prison,
 /area/sulaco/cargo/office)
 "cwp" = (
 /turf/open/floor/prison/red{
 	dir = 1
 	},
 /area/mainship/shipboard/weapon_room)
+"cws" = (
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/prison/red/corner,
+/area/sulaco/hangar/one)
 "cwG" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/prison/kitchen,
@@ -10938,13 +10910,9 @@
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/security)
 "cJZ" = (
-/obj/effect/decal/siding{
-	dir = 6
-	},
-/turf/open/floor/mainship/terragov/south{
-	dir = 6
-	},
-/area/space)
+/obj/structure/janitorialcart,
+/turf/open/floor/prison/plate,
+/area/sulaco/cargo)
 "cMp" = (
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/food/snacks/monkeyburger,
@@ -11267,11 +11235,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/prison/plate,
 /area/shuttle/distress/arrive_1)
-"dkR" = (
-/turf/open/floor/prison/red/corner{
-	dir = 1
-	},
-/area/sulaco/hangar/one)
 "dlV" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/cobweb{
@@ -11289,8 +11252,8 @@
 /turf/open/floor/prison/green/full,
 /area/sulaco/marine)
 "dnW" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/plating_catwalk/prison,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/prison/plate,
 /area/sulaco/cargo)
 "dpg" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
@@ -11413,8 +11376,7 @@
 /turf/open/floor/wood,
 /area/sulaco/medbay/west)
 "dyW" = (
-/obj/structure/largecrate/guns/merc,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
 "dzn" = (
@@ -11445,6 +11407,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/hallway/central_hall)
+"dAZ" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
+/turf/open/floor/prison/plate,
+/area/sulaco/cargo)
 "dCC" = (
 /obj/structure/window/framed/mainship/gray/toughened/hull,
 /turf/open/floor/plating/platebotc,
@@ -11474,10 +11445,11 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar/cas)
 "dFM" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 10
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plating/plating_catwalk/prison,
+/turf/open/floor/prison/plate,
 /area/sulaco/cargo)
 "dIn" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
@@ -11633,6 +11605,13 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
+"dZj" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/prison,
+/area/sulaco/cargo)
 "dZI" = (
 /obj/structure/table/mainship,
 /obj/item/folder/yellow,
@@ -11664,10 +11643,11 @@
 /turf/open/floor/prison,
 /area/sulaco/bridge/quarters)
 "eaW" = (
-/turf/open/floor/prison/red/corner{
-	dir = 1
+/obj/structure/target_stake,
+/turf/open/floor/prison/red{
+	dir = 5
 	},
-/area/sulaco/cargo/prep)
+/area/sulaco/hangar/one)
 "ebp" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -11712,13 +11692,10 @@
 /turf/open/floor/mainship/ai,
 /area/sulaco/command/ai)
 "ehi" = (
-/obj/machinery/door_control/mainship/req{
-	dir = 8;
-	id = "qm_warehouse";
-	name = "RO Warehouse Shutters"
-	},
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/freezer/rations,
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "ehA" = (
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar/droppod)
@@ -11840,10 +11817,11 @@
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/marine)
 "exd" = (
-/obj/structure/window/framed/mainship/gray/toughened,
-/obj/machinery/door/poddoor/shutters/mainship/req/ro,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/plating/platebotc,
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/prison,
 /area/sulaco/cargo)
 "eyu" = (
 /obj/machinery/door/airlock/mainship/generic{
@@ -11869,7 +11847,7 @@
 /area/sulaco/hallway/central_hall3)
 "eAf" = (
 /turf/open/floor/prison/red/corner{
-	dir = 4
+	dir = 1
 	},
 /area/sulaco/hangar/one)
 "eAL" = (
@@ -11916,8 +11894,13 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/machinery/computer/camera_advanced/overwatch/req,
-/turf/open/floor/prison/plate,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/cargo)
 "eEB" = (
 /obj/machinery/light{
@@ -11927,11 +11910,9 @@
 /area/sulaco/marine/chapel)
 "eEH" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/sulaco/cargo)
+/obj/structure/cable,
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "eEP" = (
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct,
 /obj/structure/cable,
@@ -12011,8 +11992,12 @@
 /area/sulaco/engineering/atmos)
 "eKx" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/obj/structure/closet/crate/weapon,
+/obj/machinery/alarm{
+	dir = 4
+	},
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "eLg" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/prison,
@@ -12072,10 +12057,9 @@
 	},
 /area/sulaco/hangar/droppod)
 "eOE" = (
-/obj/machinery/light,
-/obj/machinery/computer/supplycomp,
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/obj/structure/closet/crate/internals,
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "eON" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -12216,6 +12200,18 @@
 	dir = 5
 	},
 /area/space)
+"fgp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/red/corner{
+	dir = 1
+	},
+/area/sulaco/cargo/prep)
 "fjF" = (
 /obj/machinery/vending/medical/shipside,
 /turf/open/floor/prison/whitegreen/corner{
@@ -12223,14 +12219,10 @@
 	},
 /area/sulaco/medbay/west)
 "fki" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 5
-	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
-	},
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "fkQ" = (
 /obj/structure/table/mainship,
 /obj/item/taperecorder,
@@ -12556,6 +12548,14 @@
 /obj/item/storage/firstaid/adv,
 /turf/open/floor/prison,
 /area/sulaco/security)
+"fPn" = (
+/obj/machinery/alarm{
+	dir = 4
+	},
+/turf/open/floor/prison/red/corner{
+	dir = 8
+	},
+/area/sulaco/hangar/one)
 "fPR" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/prison,
@@ -12661,10 +12661,11 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "gcc" = (
-/turf/open/floor/prison/red{
-	dir = 10
+/obj/machinery/camera/autoname{
+	dir = 4
 	},
-/area/sulaco/hangar/one)
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "gcq" = (
 /obj/structure/prop/mainship/cannon_cables,
 /obj/effect/decal/warning_stripes/thin{
@@ -12807,10 +12808,11 @@
 /turf/open/floor/prison/red,
 /area/sulaco/bridge)
 "gpi" = (
-/turf/open/floor/prison/red{
-	dir = 4
+/obj/structure/sink{
+	dir = 8
 	},
-/area/sulaco/hangar/one)
+/turf/open/floor/prison/plate,
+/area/sulaco/cargo)
 "gpO" = (
 /obj/machinery/light{
 	dir = 1
@@ -12841,10 +12843,10 @@
 /area/sulaco/medbay/surgery_one)
 "gsz" = (
 /obj/effect/decal/siding{
-	dir = 8
+	dir = 10
 	},
 /turf/open/floor/mainship/terragov/south{
-	dir = 8
+	dir = 10
 	},
 /area/space)
 "gtD" = (
@@ -12863,17 +12865,9 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint)
 "gvt" = (
-/obj/structure/table/mainship,
-/obj/item/weapon/gun/smg/m25,
-/obj/item/ammo_magazine/smg/m25,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/obj/item/ammo_magazine/smg/m25,
-/obj/item/ammo_magazine/smg/m25,
-/turf/open/floor/prison/red/corner{
-	dir = 1
-	},
-/area/sulaco/hangar/one)
+/obj/structure/largecrate/guns,
+/turf/open/floor/prison/plate,
+/area/sulaco/cargo)
 "gwm" = (
 /obj/structure/window/framed/mainship/gray/toughened/hull,
 /turf/open/floor/plating/platebotc,
@@ -12900,8 +12894,15 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint2)
 "gzY" = (
-/obj/machinery/holopad,
-/turf/open/floor/prison/red/full,
+/obj/structure/closet/crate,
+/obj/item/target/alien,
+/obj/item/target/alien,
+/obj/item/target/alien,
+/obj/item/target/alien,
+/obj/item/target/alien,
+/turf/open/floor/prison/red{
+	dir = 10
+	},
 /area/sulaco/hangar/one)
 "gAc" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -12948,8 +12949,12 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/hallway/lower_foreship)
 "gDf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/vehicle/ridden/motorbike,
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket/janibucket,
+/obj/item/tool/wet_sign,
+/obj/item/tool/wet_sign,
+/obj/item/tool/wet_sign,
+/obj/item/storage/bag/trash,
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
 "gEE" = (
@@ -12980,6 +12985,11 @@
 /obj/machinery/suit_storage_unit,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint3)
+"gID" = (
+/turf/open/floor/prison/red/corner{
+	dir = 4
+	},
+/area/sulaco/hangar/one)
 "gJn" = (
 /obj/effect/decal/cleanable/cobweb{
 	dir = 1
@@ -13040,14 +13050,9 @@
 /turf/open/floor/prison/bright_clean,
 /area/mainship/command/self_destruct)
 "gPi" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/sulaco/cargo)
+/obj/vehicle/ridden/powerloader,
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "gQS" = (
 /obj/machinery/light,
 /turf/open/floor/prison/bright_clean,
@@ -13220,10 +13225,10 @@
 /area/sulaco/morgue)
 "hcB" = (
 /obj/effect/decal/siding{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/mainship/terragov/south{
-	dir = 4
+	dir = 6
 	},
 /area/space)
 "hff" = (
@@ -13314,14 +13319,9 @@
 /turf/open/floor/tile/hydro,
 /area/sulaco/hydro)
 "hnW" = (
-/obj/structure/target_stake,
-/obj/item/target,
-/obj/item/clothing/suit/replica,
-/obj/effect/ai_node,
-/turf/open/floor/prison/red{
-	dir = 4
-	},
-/area/sulaco/hangar/one)
+/obj/structure/largecrate/guns/russian,
+/turf/open/floor/prison/plate,
+/area/sulaco/cargo)
 "hoF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/whitegreen{
@@ -13517,7 +13517,8 @@
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay/storage2)
 "hKB" = (
-/turf/open/floor/prison/red/corner,
+/obj/machinery/door_control/old/req,
+/turf/open/floor/prison,
 /area/sulaco/cargo/prep)
 "hKJ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -13648,12 +13649,9 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
 "hSX" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
-	},
+/obj/machinery/vending/uniform_supply,
 /turf/open/floor/prison,
-/area/sulaco/cargo)
+/area/sulaco/cargo/office)
 "hTi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
@@ -13665,7 +13663,7 @@
 /area/sulaco/cafeteria/kitchen)
 "hTL" = (
 /obj/machinery/door/poddoor/railing{
-	dir = 8;
+	dir = 2;
 	id = "supply_elevator_railing"
 	},
 /turf/open/floor/prison,
@@ -13692,28 +13690,20 @@
 	},
 /area/mainship/living/basketball)
 "hWi" = (
-/obj/machinery/camera/autoname/mainship,
 /obj/structure/target_stake,
 /turf/open/floor/prison/red{
-	dir = 1
+	dir = 9
 	},
 /area/sulaco/hangar/one)
 "hWs" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 10
-	},
-/turf/open/floor/plating/plating_catwalk/prison,
+/obj/structure/largecrate/guns/merc,
+/turf/open/floor/prison/plate,
 /area/sulaco/cargo)
 "hWv" = (
-/obj/machinery/door/airlock/mainship/maint{
+/turf/open/floor/prison/red{
 	dir = 8
 	},
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/sulaco/maintenance/lower_maint2)
+/area/sulaco/hangar/one)
 "hXk" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/prison,
@@ -13744,12 +13734,8 @@
 	},
 /area/sulaco/research)
 "iaY" = (
-/obj/machinery/door/airlock/mainship/marine/requisitions{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/sulaco/cargo/office)
@@ -14108,10 +14094,6 @@
 /turf/open/floor/mainship/stripesquare,
 /area/sulaco/command/ai)
 "iKy" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/marked,
 /area/sulaco/hangar/one)
 "iKY" = (
@@ -14312,10 +14294,17 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
 "iYq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
 	},
-/turf/open/floor/prison/plate,
+/obj/machinery/holopad{
+	active_power_usage = 130;
+	desc = "It's a floor-mounted device for projecting holographic images. This one appears to have a larger lense.";
+	holo_range = 7;
+	name = "modfied holopad"
+	},
+/turf/open/floor/prison/arrow,
 /area/sulaco/cargo)
 "iZD" = (
 /obj/machinery/light{
@@ -14431,6 +14420,13 @@
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
+"jjj" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/sulaco/cargo/prep)
 "jnn" = (
 /obj/structure/window/framed/mainship/gray/toughened,
 /obj/machinery/door/poddoor/telecomms,
@@ -14596,7 +14592,25 @@
 /turf/open/floor/plating/platebotc,
 /area/sulaco/cargo/office)
 "jCo" = (
-/obj/machinery/cic_maptable,
+/obj/structure/table/mainship,
+/obj/item/stack/sheet/glass/reinforced{
+	amount = 50
+	},
+/obj/item/stack/sheet/wood/large_stack,
+/obj/item/tool/hand_labeler,
+/obj/item/stack/sheet/cardboard{
+	amount = 50
+	},
+/obj/item/frame/rack,
+/obj/item/frame/rack,
+/obj/item/frame/rack,
+/obj/item/frame/rack,
+/obj/item/frame/rack,
+/obj/item/frame/rack,
+/obj/item/frame/rack,
+/obj/item/frame/rack,
+/obj/item/frame/rack,
+/obj/item/frame/rack,
 /turf/open/floor/prison,
 /area/sulaco/cargo/office)
 "jCy" = (
@@ -14763,6 +14777,10 @@
 	dir = 6
 	},
 /area/sulaco/engineering/atmos)
+"jRO" = (
+/obj/machinery/roomba,
+/turf/open/floor/prison/red/corner,
+/area/sulaco/cargo/prep)
 "jSM" = (
 /turf/open/floor/prison/red{
 	dir = 1
@@ -14976,6 +14994,7 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
 "kji" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/red,
 /area/sulaco/hangar/one)
 "kjm" = (
@@ -14988,6 +15007,10 @@
 	},
 /turf/open/floor/grass,
 /area/mainship/living/starboard_garden)
+"kkA" = (
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/prison,
+/area/sulaco/cargo/prep)
 "kme" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -15058,20 +15081,28 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
+"kqn" = (
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
+	},
+/turf/open/floor/prison/plate,
+/area/sulaco/cargo)
 "kqp" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mainship/gray,
 /area/sulaco/marine)
 "kqQ" = (
-/obj/effect/decal/cleanable/cobweb{
+/obj/structure/table/mainship,
+/obj/item/weapon/gun/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/turf/open/floor/prison/red/corner{
 	dir = 1
 	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/sulaco/maintenance/lower_maint2)
+/area/sulaco/hangar/one)
 "krk" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 9
@@ -15235,9 +15266,9 @@
 /turf/open/floor/prison/darkyellow,
 /area/sulaco/engineering/ce)
 "kLh" = (
-/obj/structure/closet/crate/internals,
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "kLi" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -15304,6 +15335,12 @@
 "kOr" = (
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/hangar/storage)
+"kOL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/prison/red,
+/area/sulaco/hangar/one)
 "kRy" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -15362,7 +15399,9 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_main_hall)
 "kVY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/structure/target_stake,
+/obj/item/target,
+/obj/item/clothing/suit/replica,
 /turf/open/floor/prison,
 /area/sulaco/hangar/one)
 "kWb" = (
@@ -15474,10 +15513,11 @@
 	},
 /area/sulaco/engineering)
 "lfO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison/red{
+/obj/machinery/door/airlock/mainship/maint{
 	dir = 8
 	},
+/obj/effect/ai_node,
+/turf/open/floor/plating,
 /area/sulaco/hangar/one)
 "lgl" = (
 /turf/closed/wall/mainship/gray,
@@ -15614,14 +15654,16 @@
 	},
 /area/sulaco/medbay)
 "lsj" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 6
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
+/obj/effect/decal/cleanable/cobweb{
+	dir = 4
 	},
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/obj/machinery/camera/autoname,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/sulaco/maintenance/lower_maint2)
 "lsz" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -15674,9 +15716,9 @@
 /turf/open/floor/prison,
 /area/sulaco/telecomms/office)
 "lvm" = (
-/obj/machinery/vending/uniform_supply,
-/turf/open/floor/prison,
-/area/sulaco/cargo/prep)
+/obj/vehicle/ridden/motorbike,
+/turf/open/floor/prison/marked,
+/area/sulaco/cargo)
 "lwx" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/machinery/door/firedoor,
@@ -15852,7 +15894,7 @@
 /turf/open/floor/prison/plate,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
 "lIE" = (
-/obj/machinery/vending/armor_supply,
+/obj/machinery/vending/uniform_supply,
 /turf/open/floor/prison,
 /area/sulaco/cargo/prep)
 "lJH" = (
@@ -15996,17 +16038,9 @@
 	},
 /area/sulaco/hangar/droppod)
 "lZd" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
-	},
-/obj/machinery/holopad{
-	active_power_usage = 130;
-	desc = "It's a floor-mounted device for projecting holographic images. This one appears to have a larger lense.";
-	holo_range = 7;
-	name = "modfied holopad"
-	},
-/turf/open/floor/prison/arrow,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/cargo)
 "lZk" = (
 /obj/machinery/firealarm{
@@ -16117,21 +16151,20 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_north_maint)
 "mhY" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "supply_elevator_railing"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/red{
+	dir = 8
 	},
-/turf/open/floor/prison/arrow{
-	dir = 1
-	},
-/area/sulaco/cargo)
+/area/sulaco/hangar/one)
 "miH" = (
-/obj/machinery/light{
+/obj/structure/target_stake,
+/obj/item/target,
+/obj/item/clothing/suit/replica,
+/obj/effect/ai_node,
+/turf/open/floor/prison/red{
 	dir = 4
 	},
-/obj/machinery/vending/weapon,
-/turf/open/floor/mainship/mono,
-/area/sulaco/cargo)
+/area/sulaco/hangar/one)
 "mju" = (
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/hangar/cas)
@@ -16169,12 +16202,7 @@
 	},
 /area/sulaco/marine/chapel)
 "mlv" = (
-/obj/structure/target_stake,
-/obj/item/target,
-/obj/item/clothing/suit/replica,
-/turf/open/floor/prison/red{
-	dir = 8
-	},
+/turf/closed/wall/mainship/gray,
 /area/sulaco/hangar/one)
 "mlR" = (
 /obj/structure/cable,
@@ -16191,12 +16219,9 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_north_maint)
 "mmj" = (
-/obj/effect/decal/warning_stripes/thick{
-	dir = 1
-	},
-/obj/effect/landmark/start/job/squadmarine,
-/turf/open/floor/prison/sterilewhite,
-/area/sulaco/cryosleep)
+/obj/machinery/vending/MarineMed,
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "mmw" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
@@ -16240,12 +16265,8 @@
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "mqT" = (
-/obj/effect/decal/warning_stripes/thick,
-/obj/structure/rack,
-/obj/item/conveyor_switch_construct,
-/obj/item/stack/conveyor/thirty,
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/turf/closed/wall/mainship/gray/outer,
+/area/sulaco/cargo/office)
 "mrg" = (
 /obj/structure/rack,
 /obj/item/circuitboard/computer/arcade,
@@ -16253,10 +16274,10 @@
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "mte" = (
-/turf/open/floor/prison/red{
-	dir = 4
-	},
-/area/sulaco/cargo/prep)
+/obj/structure/table/mainship,
+/obj/machinery/computer/supplydrop_console,
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "mur" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
@@ -16666,14 +16687,11 @@
 	},
 /area/sulaco/research)
 "mZj" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id = "qm_warehouse";
-	name = "Warehouse Shutters"
+/obj/structure/window/framed/mainship/gray/toughened,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
 	},
-/turf/open/floor/prison/arrow{
-	dir = 1
-	},
+/turf/open/floor/prison/plate,
 /area/sulaco/cargo)
 "mZO" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -16753,21 +16771,20 @@
 	},
 /area/sulaco/marine)
 "nhR" = (
-/obj/structure/closet/crate/medical,
-/obj/machinery/power/apc/mainship{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/structure/table/mainship,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
 /turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/area/sulaco/cargo/office)
 "nio" = (
-/obj/machinery/door/poddoor/railing{
-	id = "supply_elevator_railing"
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
+	dir = 1
 	},
-/turf/open/floor/prison/arrow{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
 	},
-/area/sulaco/cargo)
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "niH" = (
 /obj/machinery/alarm{
 	dir = 4
@@ -16909,8 +16926,9 @@
 /turf/open/floor/wood,
 /area/sulaco/marine/chapel/chapel_office)
 "nEh" = (
+/obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/closed/wall/mainship/gray,
-/area/sulaco/hangar/one)
+/area/sulaco/cargo)
 "nFU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -17229,11 +17247,10 @@
 /area/space)
 "obO" = (
 /obj/structure/rack,
-/obj/item/tool/screwdriver,
-/obj/item/tool/wrench,
-/obj/item/tool/crowbar,
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/obj/item/conveyor_switch_construct,
+/obj/item/stack/conveyor/thirty,
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "oct" = (
 /turf/open/floor/tile/darkgreen/darkgreen2{
 	dir = 10
@@ -17398,27 +17415,13 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
 "ooe" = (
-/obj/structure/table/mainship,
-/obj/item/stack/sheet/glass/reinforced{
-	amount = 50
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/item/stack/sheet/wood/large_stack,
-/obj/item/tool/hand_labeler,
-/obj/item/stack/sheet/cardboard{
-	amount = 50
+/turf/open/floor/prison/red{
+	dir = 4
 	},
-/obj/item/frame/rack,
-/obj/item/frame/rack,
-/obj/item/frame/rack,
-/obj/item/frame/rack,
-/obj/item/frame/rack,
-/obj/item/frame/rack,
-/obj/item/frame/rack,
-/obj/item/frame/rack,
-/obj/item/frame/rack,
-/obj/item/frame/rack,
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/area/sulaco/hangar/one)
 "opj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -17651,6 +17654,16 @@
 /obj/item/clothing/suit/chef,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
+"oDc" = (
+/obj/structure/table/mainship,
+/obj/item/weapon/gun/rifle/m412,
+/obj/item/ammo_magazine/rifle,
+/obj/item/ammo_magazine/rifle,
+/obj/item/ammo_magazine/rifle,
+/turf/open/floor/prison/red/corner{
+	dir = 4
+	},
+/area/sulaco/hangar/one)
 "oDe" = (
 /obj/machinery/light{
 	dir = 4
@@ -17981,13 +17994,9 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
 "peT" = (
-/obj/machinery/alarm{
-	dir = 4
-	},
-/turf/open/floor/prison/red/corner{
-	dir = 8
-	},
-/area/sulaco/hangar/one)
+/obj/structure/supply_drop,
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "pfc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -18224,9 +18233,8 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar/cas)
 "ptg" = (
-/obj/structure/table/mainship,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
+/obj/structure/window/framed/mainship/gray/toughened,
+/obj/machinery/door/firedoor/mainship,
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo/office)
 "ptE" = (
@@ -18305,8 +18313,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
 "pxX" = (
-/obj/structure/largecrate/guns/russian,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname,
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
 "pxY" = (
@@ -18364,7 +18371,12 @@
 /turf/open/floor/plating,
 /area/sulaco/briefing)
 "pGN" = (
-/obj/vehicle/ridden/powerloader,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
 "pHg" = (
@@ -18380,13 +18392,14 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_north_maint)
 "pHm" = (
-/obj/effect/decal/siding{
-	dir = 10
+/obj/machinery/door/poddoor/railing{
+	dir = 2;
+	id = "supply_elevator_railing"
 	},
-/turf/open/floor/mainship/terragov/south{
-	dir = 10
+/turf/open/floor/prison/arrow{
+	dir = 1
 	},
-/area/space)
+/area/sulaco/cargo)
 "pHZ" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 1
@@ -18435,6 +18448,11 @@
 /obj/item/reagent_containers/glass/bucket/janibucket,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint2)
+"pLH" = (
+/turf/open/floor/prison/red/corner{
+	dir = 1
+	},
+/area/sulaco/cargo/prep)
 "pLJ" = (
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/bridge/office)
@@ -18576,9 +18594,14 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "qhv" = (
-/obj/effect/decal/siding,
-/turf/open/floor/mainship/terragov/south,
-/area/space)
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
+/turf/open/floor/prison/plate,
+/area/sulaco/cargo)
 "qhI" = (
 /obj/structure/cable,
 /turf/open/floor/prison/sterilewhite,
@@ -18626,12 +18649,7 @@
 	},
 /area/sulaco/medbay)
 "qjZ" = (
-/obj/effect/decal/siding{
-	dir = 1
-	},
-/turf/open/floor/mainship/terragov/south{
-	dir = 1
-	},
+/turf/open/floor/mainship/terragov,
 /area/space)
 "qkp" = (
 /obj/docking_port/stationary/ert/target{
@@ -18686,12 +18704,11 @@
 	},
 /area/sulaco/hangar/droppod)
 "qod" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "supply_elevator_railing"
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/prison,
-/area/sulaco/cargo)
+/area/sulaco/cargo/office)
 "qoV" = (
 /obj/structure/bed/chair,
 /turf/open/floor/tile/darkgreen/darkgreen2{
@@ -18798,7 +18815,7 @@
 	holo_range = 7;
 	name = "modfied holopad"
 	},
-/turf/open/floor/prison/red/corner,
+/turf/open/floor/prison,
 /area/sulaco/cargo/prep)
 "qye" = (
 /obj/structure/window/framed/mainship/gray/toughened/hull,
@@ -18966,9 +18983,13 @@
 /turf/open/floor/plating/platebotc,
 /area/sulaco/engineering/lower_engineering)
 "qND" = (
-/obj/structure/closet/crate/ammo,
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/obj/structure/target_stake,
+/obj/item/target,
+/obj/item/clothing/suit/replica,
+/turf/open/floor/prison/red{
+	dir = 8
+	},
+/area/sulaco/hangar/one)
 "qNF" = (
 /obj/structure/cable,
 /obj/structure/bed,
@@ -19046,9 +19067,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
-/turf/open/floor/prison/red/corner{
-	dir = 1
-	},
+/turf/open/floor/prison,
 /area/sulaco/cargo/prep)
 "qWq" = (
 /obj/structure/closet/walllocker/emerglocker,
@@ -19059,15 +19078,23 @@
 /turf/open/floor/tile/hydro,
 /area/sulaco/hydro)
 "qZW" = (
-/obj/structure/largecrate/guns,
-/obj/machinery/camera/autoname,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "raA" = (
 /obj/item/reagent_containers/glass/bucket/janibucket,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_north_maint)
+"rbh" = (
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/sulaco/cargo/prep)
 "rbr" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 1
@@ -19085,9 +19112,12 @@
 /turf/open/floor/wood,
 /area/sulaco/liaison)
 "rcl" = (
-/obj/structure/closet/crate/weapon,
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/obj/machinery/power/apc/mainship{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "rcs" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 9
@@ -19252,12 +19282,13 @@
 /area/sulaco/hallway/central_hall3)
 "rmV" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
+"rnN" = (
+/obj/machinery/door_control/old/req,
+/obj/structure/table/mainship,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/cargo)
 "rnR" = (
@@ -20014,9 +20045,7 @@
 "szj" = (
 /obj/machinery/light,
 /obj/structure/sign/ROsign,
-/turf/open/floor/prison/red{
-	dir = 1
-	},
+/turf/open/floor/prison,
 /area/sulaco/cargo/prep)
 "szr" = (
 /obj/structure/bed,
@@ -20094,16 +20123,10 @@
 /turf/open/floor/prison/cleanmarked,
 /area/sulaco/hangar)
 "sCO" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/cobweb{
+/turf/open/floor/prison/red{
 	dir = 4
 	},
-/obj/machinery/camera/autoname,
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/sulaco/maintenance/lower_maint2)
+/area/sulaco/hangar/one)
 "sEx" = (
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 10
@@ -20166,10 +20189,10 @@
 /area/sulaco/security)
 "sIy" = (
 /obj/effect/decal/siding{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/mainship/terragov/south{
-	dir = 5
+	dir = 4
 	},
 /area/space)
 "sJR" = (
@@ -20180,6 +20203,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/sulaco/bridge)
+"sKv" = (
+/obj/effect/decal/cleanable/cobweb{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/sulaco/maintenance/lower_maint2)
 "sKM" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -20270,19 +20303,20 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall)
 "sPk" = (
-/obj/structure/table/mainship,
-/obj/item/clothing/ears/earmuffs,
-/turf/open/floor/prison/red{
-	dir = 9
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/airlock/mainship/marine/requisitions{
+	dir = 8
 	},
-/area/sulaco/hangar/one)
-"sPp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/closet/crate,
 /turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/area/sulaco/cargo/office)
+"sPp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "sPA" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -20752,6 +20786,9 @@
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
+	},
 /turf/open/floor/plating/platebotc,
 /area/sulaco/cargo)
 "tzn" = (
@@ -20799,12 +20836,15 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
 "tBy" = (
-/obj/docking_port/stationary/marine_dropship/crash_target,
-/turf/closed/wall/mainship/gray,
+/obj/machinery/door/poddoor/railing{
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/prison,
 /area/sulaco/cargo)
 "tBz" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison/red,
+/turf/open/floor/prison/red{
+	dir = 6
+	},
 /area/sulaco/hangar/one)
 "tBB" = (
 /obj/machinery/status_display,
@@ -21220,6 +21260,14 @@
 	dir = 1
 	},
 /area/sulaco/engineering/lower_engineering)
+"upr" = (
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/airlock/mainship/marine/requisitions{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/prison/plate,
+/area/sulaco/cargo/office)
 "uqO" = (
 /obj/machinery/researchcomp,
 /turf/open/floor/prison/whitegreen/corner{
@@ -21239,9 +21287,9 @@
 	},
 /area/sulaco/medbay)
 "utJ" = (
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/mainship/mono,
-/area/sulaco/cargo)
+/obj/effect/landmark/start/job/shiptech,
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "utO" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/freezer,
@@ -21269,7 +21317,8 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
 "uwH" = (
-/turf/open/floor/mainship/terragov,
+/obj/effect/decal/siding,
+/turf/open/floor/mainship/terragov/south,
 /area/space)
 "uwO" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -21282,9 +21331,9 @@
 /turf/open/floor/plating,
 /area/sulaco/engineering/storage)
 "uxf" = (
-/obj/machinery/vending/MarineMed,
-/turf/open/floor/mainship/mono,
-/area/sulaco/cargo)
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "uyf" = (
 /obj/machinery/door/airlock/mainship/marine/requisitions{
 	dir = 1
@@ -21325,8 +21374,11 @@
 /turf/closed/wall/mainship/gray,
 /area/sulaco/engineering)
 "uBX" = (
-/turf/open/floor/prison/marked,
-/area/sulaco/hangar/one)
+/obj/structure/window/framed/mainship/gray/toughened,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro,
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/plating/platebotc,
+/area/sulaco/cargo)
 "uCA" = (
 /obj/structure/table/woodentable,
 /obj/machinery/computer/security/wooden_tv,
@@ -21465,15 +21517,13 @@
 /turf/open/floor/plating,
 /area/sulaco/engineering/engine_monitoring)
 "uOd" = (
-/obj/structure/table/mainship,
-/obj/item/weapon/gun/rifle/m412,
-/obj/item/ammo_magazine/rifle,
-/obj/item/ammo_magazine/rifle,
-/obj/item/ammo_magazine/rifle,
-/turf/open/floor/prison/red/corner{
-	dir = 4
+/obj/machinery/door/poddoor/railing{
+	id = "supply_elevator_railing"
 	},
-/area/sulaco/hangar/one)
+/turf/open/floor/prison/arrow{
+	dir = 8
+	},
+/area/sulaco/cargo)
 "uPy" = (
 /obj/structure/window/framed/mainship/white,
 /obj/machinery/door/poddoor/shutters/opened/medbay{
@@ -21485,8 +21535,10 @@
 /turf/open/floor/plating/platebotc,
 /area/sulaco/medbay/chemistry)
 "uPG" = (
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/prison,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/prison/marked,
 /area/sulaco/hangar/one)
 "uQi" = (
 /obj/structure/window/reinforced{
@@ -21501,10 +21553,9 @@
 /turf/open/floor/wood,
 /area/mainship/living/basketball)
 "uQQ" = (
-/obj/structure/window/framed/mainship/gray/toughened,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/plating/platebotc,
-/area/sulaco/cargo/office)
+/obj/docking_port/stationary/supply,
+/turf/open/floor/mainship/empty,
+/area/sulaco/cargo)
 "uRy" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/machinery/door/firedoor,
@@ -21541,6 +21592,18 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/sulaco/engineering)
+"uVt" = (
+/obj/structure/table/mainship,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/item/weapon/gun/shotgun/pump,
+/obj/item/ammo_magazine/shotgun,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/turf/open/floor/prison/red{
+	dir = 5
+	},
+/area/sulaco/hangar/one)
 "uVA" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mainship/gray,
@@ -21675,16 +21738,19 @@
 /area/sulaco/security)
 "vdn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/freezer/rations,
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "vdG" = (
 /obj/machinery/holopad,
 /turf/open/floor/prison,
 /area/sulaco/cargo/office)
 "vdJ" = (
-/obj/structure/sign/securearea/firingrange,
-/turf/open/floor/prison/red,
+/turf/open/floor/prison/red{
+	dir = 10
+	},
 /area/sulaco/hangar/one)
 "vfa" = (
 /obj/effect/decal/cleanable/cobweb{
@@ -21723,6 +21789,12 @@
 /obj/machinery/vending/weapon,
 /turf/open/floor/prison,
 /area/sulaco/marine)
+"vgX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/prison,
+/area/sulaco/cargo/prep)
 "vhh" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/structure/cable,
@@ -21766,11 +21838,13 @@
 	},
 /area/sulaco/marine)
 "vln" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "supply_elevator_railing"
 	},
-/obj/machinery/vending/uniform_supply,
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/prison/arrow{
+	dir = 4
+	},
 /area/sulaco/cargo)
 "vlG" = (
 /obj/effect/decal/cleanable/cobweb{
@@ -21798,9 +21872,10 @@
 	},
 /area/sulaco/marine/chapel)
 "vnZ" = (
+/obj/machinery/camera/autoname/mainship,
 /obj/structure/target_stake,
 /turf/open/floor/prison/red{
-	dir = 5
+	dir = 1
 	},
 /area/sulaco/hangar/one)
 "vpx" = (
@@ -21851,9 +21926,7 @@
 	},
 /area/sulaco/medbay)
 "vuy" = (
-/obj/structure/target_stake,
-/obj/item/target,
-/obj/item/clothing/suit/replica,
+/obj/machinery/camera/autoname/mainship,
 /turf/open/floor/prison,
 /area/sulaco/hangar/one)
 "vwo" = (
@@ -22063,15 +22136,11 @@
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay/west)
 "vRR" = (
-/obj/structure/closet/crate,
-/obj/item/target/alien,
-/obj/item/target/alien,
-/obj/item/target/alien,
-/obj/item/target/alien,
-/obj/item/target/alien,
-/turf/open/floor/prison/red{
-	dir = 10
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/marked,
 /area/sulaco/hangar/one)
 "vSc" = (
 /obj/structure/cable,
@@ -22098,8 +22167,8 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/structure/cable,
 /obj/effect/ai_node,
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "vTl" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -22239,16 +22308,11 @@
 	},
 /area/sulaco/hallway/central_hall3)
 "whS" = (
-/obj/machinery/door_control/mainship/req{
-	id = "qm_warehouse";
-	name = "RO Warehouse Shutters"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/roomba,
-/turf/open/floor/prison/red,
+/turf/open/floor/prison/red/corner,
 /area/sulaco/cargo/prep)
 "wie" = (
 /obj/machinery/light/small{
@@ -22270,6 +22334,21 @@
 	dir = 4
 	},
 /area/mainship/shipboard/weapon_room)
+"wkg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 10
+	},
+/obj/structure/closet/crate,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/turf/open/floor/prison/red{
+	dir = 6
+	},
+/area/sulaco/hangar/one)
 "wkO" = (
 /obj/machinery/light{
 	dir = 8
@@ -22355,12 +22434,9 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
 "wsa" = (
-/obj/structure/closet/crate/ammo,
-/obj/machinery/alarm{
-	dir = 4
-	},
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
+/obj/machinery/computer/camera_advanced/overwatch/req,
+/turf/open/floor/prison,
+/area/sulaco/cargo/office)
 "wth" = (
 /turf/open/floor/mainship/terragov{
 	dir = 1
@@ -22557,8 +22633,9 @@
 /turf/closed/wall/mainship/gray,
 /area/sulaco/marine)
 "wKj" = (
-/obj/machinery/door/airlock/mainship/marine/requisitions,
-/turf/open/floor/prison/plate,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/cargo)
 "wKl" = (
 /obj/machinery/alarm,
@@ -23027,6 +23104,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/ai,
 /area/sulaco/command/ai)
+"xzo" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/prison,
+/area/sulaco/hangar/one)
 "xzB" = (
 /obj/structure/table/mainship,
 /obj/item/clipboard,
@@ -23396,10 +23477,10 @@
 /area/sulaco/hallway/lower_main_hall)
 "yht" = (
 /obj/effect/decal/siding{
-	dir = 9
+	dir = 8
 	},
 /turf/open/floor/mainship/terragov/south{
-	dir = 9
+	dir = 8
 	},
 /area/space)
 "yhJ" = (
@@ -41159,8 +41240,8 @@ aaY
 ogJ
 aiX
 aiX
-mmj
-iNW
+amp
+ogJ
 aaH
 aaH
 aJy
@@ -41671,8 +41752,8 @@ axG
 fVO
 kiJ
 aEL
-uHR
-uHR
+riP
+riP
 riP
 mdq
 gRM
@@ -41927,10 +42008,10 @@ amn
 aiX
 amn
 aaY
-ogJ
+abf
 aiX
 aiX
-jWW
+uHR
 mdq
 nrh
 eAP
@@ -42184,10 +42265,10 @@ amn
 aiX
 amn
 aaY
-ogJ
+abf
 aiX
 aiX
-jWW
+aPL
 aaA
 vbW
 agZ
@@ -43216,8 +43297,8 @@ akZ
 bIr
 aeH
 aaH
-lSB
-iNW
+aIj
+abf
 aaH
 aJy
 acD
@@ -43474,7 +43555,7 @@ vPy
 aeH
 aaH
 aIj
-iNW
+abf
 iTc
 anw
 eHj
@@ -43988,7 +44069,7 @@ bIr
 aeH
 aaH
 aIj
-iNW
+abf
 aaH
 anw
 abS
@@ -44245,7 +44326,7 @@ vPy
 aeH
 aaH
 aIj
-iNW
+abf
 aaH
 anw
 lpg
@@ -46046,7 +46127,7 @@ baT
 eKx
 bfC
 aeR
-aeR
+mmj
 aal
 aqn
 wsa
@@ -46300,19 +46381,19 @@ mDu
 mDu
 mDu
 bOh
-bPM
-bfC
+blt
+ehi
 sPp
-aeR
+kLh
 kLh
 vdn
-qND
-bkX
-blt
-rcl
-ahT
-cvJ
-ptg
+alk
+utJ
+alk
+qBu
+alk
+alk
+alk
 alk
 alk
 anC
@@ -46557,18 +46638,18 @@ vDU
 mDu
 mDu
 bOh
-bPM
-fCm
-dFM
-aLh
-aLh
-aLh
-aLh
-aLh
 bEP
+eOE
+alk
+alk
+alk
+aLh
+alk
+alk
+alk
 eEH
-ooe
-cvJ
+alk
+alk
 hqJ
 alk
 alk
@@ -46815,13 +46896,13 @@ nzi
 mDu
 baT
 aaN
-fCm
-lsj
-aeT
-aeT
+alk
+alk
+alk
+alk
 nio
-aeT
-aeT
+fki
+fki
 fki
 rmV
 vTh
@@ -47072,17 +47153,17 @@ nzi
 mDu
 bOh
 obO
-fCm
+gcc
 qod
-abV
-abV
-abV
-abV
-abV
+mte
+peT
+qZW
+alk
+uxf
 hSX
 gPi
-bPM
-cvJ
+alk
+alk
 kXs
 vIy
 vdG
@@ -47329,18 +47410,18 @@ nzi
 mDu
 bOh
 mqT
-fCm
-qod
-abV
-abV
-abV
-abV
-abV
-hSX
-gPi
-bPM
-cvJ
-uQQ
+mqT
+mqT
+mqT
+ptg
+sPk
+ptg
+mqT
+mqT
+ptg
+upr
+ptg
+hCz
 ali
 akh
 tsM
@@ -47585,17 +47666,17 @@ aaa
 nzi
 mDu
 baT
-qZW
-fCm
-mhY
-abV
-abV
-agN
-abV
-abV
-lZd
-gPi
 bPM
+gpi
+bPM
+fCm
+fCm
+agN
+lZd
+lZd
+lZd
+wKj
+wKj
 eEp
 hCz
 jBX
@@ -47843,17 +47924,17 @@ nzi
 mDu
 bOh
 pxX
-fCm
-qod
-abV
-abV
-abV
-abV
-abV
-hSX
-gPi
 bPM
-agR
+bPM
+fCm
+pGN
+tBy
+tBy
+uOd
+tBy
+tBy
+dAZ
+ajb
 txO
 vSd
 amd
@@ -48101,15 +48182,15 @@ mDu
 bOh
 dyW
 dnW
-qod
-abV
-abV
-abV
-abV
-abV
-hSX
-gPi
 bPM
+fCm
+hTL
+abV
+abV
+abV
+abV
+abV
+dZj
 ajb
 txO
 vSd
@@ -48356,20 +48437,20 @@ aaa
 nzi
 mDu
 baT
-aaN
-fCm
-abf
-hTL
-hTL
 csB
+gvt
+bPM
+fCm
 hTL
-hTL
-agM
-hWs
+abV
+abV
+abV
+abV
+abV
 aiz
 ajc
 aiS
-bwe
+jjj
 bwe
 anK
 otR
@@ -48613,20 +48694,20 @@ aaa
 nzi
 mDu
 bOh
-bPM
-dnW
+cJZ
+hnW
+lvm
 fCm
-fCm
-fCm
-fCm
-fCm
-fCm
-fCm
-fCm
+pHm
+abV
+abV
+uQQ
+abV
+abV
 iYq
-eOE
-txO
-vSd
+fCm
+kqn
+vgX
 vSd
 uig
 vSd
@@ -48871,24 +48952,24 @@ nzi
 mDu
 bOh
 gDf
+hWs
 bPM
-bPM
-bPM
-bPM
-bPM
-bPM
-bPM
-bPM
-bPM
-eKx
-pGN
+fCm
+hTL
+abV
+abV
+abV
+abV
+abV
+dZj
+fCm
 txO
 hKB
-mte
+vSd
 qWi
 qxQ
-mte
-eaW
+vSd
+vSd
 hFf
 bsi
 leD
@@ -49127,24 +49208,24 @@ aaa
 nzi
 mDu
 baT
-gDf
 bPM
+abj
 bPM
-bPM
-aLn
-ehi
-miH
-uxf
-utJ
-vln
-bPM
-bPM
+fCm
+hTL
+abV
+abV
+abV
+abV
+abV
+dZj
+fCm
 mZj
-alx
-lvm
-aoM
-alx
-lvm
+vSd
+vSd
+qWi
+vSd
+vSd
 szj
 sbT
 sqS
@@ -49384,25 +49465,25 @@ aaa
 nzi
 mDu
 baT
-lpY
-lpY
-wKj
-tBy
-lpY
-lpY
-lpY
-lpY
+dFM
+bPM
+bPM
+fCm
+qhv
 exd
 exd
+vln
 exd
 exd
+aAR
+rnN
 lpY
 whS
-vSd
-aoM
-alx
-vSd
-jSM
+rbh
+fgp
+jRO
+rbh
+pLH
 xMC
 bjX
 xKR
@@ -49640,20 +49721,20 @@ aaa
 aaa
 nzi
 mDu
-aPn
-aaK
+baT
 abj
-lfO
-nGG
-mlv
 abj
-gcc
-aRy
-aPL
-peT
-vRR
-sPk
-uOd
+bPM
+fCm
+fCm
+fCm
+fCm
+fCm
+fCm
+fCm
+fCm
+fCm
+lpY
 alx
 lIE
 aoM
@@ -49897,20 +49978,20 @@ aaa
 aaa
 nzi
 mDu
-aPn
-ace
-vuy
-nJV
-bhA
-bhA
-bhA
-tBz
-aRy
+baT
+lpY
+lpY
+lpY
+nEh
+lpY
+lpY
+lpY
+lpY
 uBX
-nJV
-kji
-dkR
-kVY
+uBX
+uBX
+uBX
+lpY
 ipz
 jCJ
 pwD
@@ -50156,23 +50237,23 @@ nzi
 mDu
 aPn
 hWi
-bhA
-bhA
-bhA
-bhA
-bhA
+hWv
+mhY
+nGG
+qND
+hWv
 vdJ
-nEh
+aRy
 uPG
-bhA
+fPn
 gzY
 aRj
-bhA
+oDc
 alx
-sGB
+kkA
 rEe
 alx
-sGB
+kkA
 rpg
 sbT
 qLP
@@ -50413,18 +50494,18 @@ nzi
 mDu
 aPn
 ace
-bhA
+kVY
 nJV
 bhA
-vuy
+bhA
 bhA
 kji
 aRy
 iKy
-bhA
+nJV
 aiV
 eAf
-bhA
+xzo
 alx
 vSd
 rEe
@@ -50670,18 +50751,18 @@ nzi
 mDu
 aPn
 vnZ
-gpi
-hnW
+bhA
+bhA
 afK
-gpi
-gpi
+bhA
+bhA
 aed
-aRy
-uBX
-aee
+mlv
+vuy
+bhA
 aia
 aje
-gvt
+bhA
 oVi
 kWQ
 aoU
@@ -50925,20 +51006,20 @@ aaa
 aaa
 nzi
 mDu
-aPg
-aPg
-hWv
-aQh
-aQh
-aQh
-aQh
-aQh
-aQh
-aQh
-aQh
-aQh
-aQh
-aQh
+aPn
+ace
+bhA
+nJV
+bhA
+kVY
+bhA
+aiV
+aRy
+vRR
+bhA
+kOL
+gID
+bhA
 erP
 erP
 erP
@@ -51182,19 +51263,19 @@ aaa
 aaa
 nzi
 mDu
-mDu
-aPg
+aPn
+eaW
 sCO
-una
-una
-una
-una
-una
-iwk
-una
-una
-una
-una
+miH
+ooe
+sCO
+sCO
+tBz
+aRy
+iKy
+cws
+wkg
+uVt
 kqQ
 erP
 slc
@@ -51439,20 +51520,20 @@ aaa
 aaa
 nzi
 mDu
-mDu
-aPg
-aPg
-aPg
-aPg
-aPg
-aPg
-aPg
-aPg
-aPg
-aPg
-aPg
-aPg
-iwk
+aPn
+aPn
+lfO
+mlv
+mlv
+mlv
+mlv
+mlv
+mlv
+mlv
+mlv
+mlv
+mlv
+mlv
 oBg
 sQE
 nxT
@@ -51697,19 +51778,19 @@ aaa
 nzi
 mDu
 mDu
-mDu
-mDu
-mDu
-mDu
-mDu
-mDu
-mDu
-mDu
-mDu
-mDu
-mDu
-aPg
-phy
+cyv
+lsj
+una
+una
+una
+una
+una
+iwk
+una
+una
+una
+una
+sKv
 erP
 kSh
 hXU
@@ -51952,11 +52033,11 @@ aaa
 aaa
 aaa
 nzi
-mDu
+aee
 yht
 gsz
-pHm
-mDu
+cyv
+cyv
 aPg
 aPg
 aPg
@@ -52209,10 +52290,10 @@ aaa
 aaa
 aaa
 nzi
-mDu
+agM
 qjZ
 uwH
-qhv
+aaa
 mDu
 aPg
 sBH
@@ -52466,10 +52547,10 @@ aaa
 aaa
 aaa
 nzi
-mDu
+ahT
 sIy
 hcB
-cJZ
+aaa
 mDu
 aPg
 fuZ

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -353,12 +353,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
 "abt" = (
-/obj/structure/table/mainship,
-/obj/structure/paper_bin,
-/obj/item/clipboard,
-/obj/item/tool/hand_labeler,
-/obj/item/tool/pen,
-/obj/item/megaphone,
+/obj/structure/bed/chair/office/light,
+/obj/effect/landmark/start/job/requisitionsofficer,
 /turf/open/floor/mainship/green{
 	dir = 10
 	},
@@ -381,23 +377,18 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/alpha)
 "abx" = (
-/obj/structure/table/mainship,
-/obj/item/cell/hyper,
-/obj/machinery/cell_charger,
-/turf/open/floor/mainship/green{
-	dir = 8
-	},
-/area/mainship/squads/req)
+/obj/machinery/vending/weapon,
+/turf/open/floor/mainship/mono,
+/area/mainship/shipboard/firing_range)
 "aby" = (
 /obj/structure/closet/secure_closet/bar/captain,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "abz" = (
-/obj/structure/table/mainship,
-/obj/item/attachable/motiondetector,
-/turf/open/floor/mainship/green{
-	dir = 8
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
 	},
+/turf/open/floor/plating,
 /area/mainship/squads/req)
 "abA" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -603,9 +594,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/open/floor/mainship/green{
 	dir = 8
 	},
@@ -618,7 +606,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "aco" = (
 /obj/machinery/door/firedoor/mainship{
@@ -675,6 +663,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/tool/hand_labeler,
 /turf/open/floor/mainship/green{
 	dir = 8
 	},
@@ -904,14 +893,17 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_umbilical)
 "adg" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/stripesquare,
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket/janibucket,
+/obj/item/tool/wet_sign,
+/obj/item/tool/wet_sign,
+/obj/item/tool/wet_sign,
+/obj/item/storage/bag/trash,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "adh" = (
 /obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/green{
+/turf/open/floor/mainship/green/corner{
 	dir = 1
 	},
 /area/mainship/squads/req)
@@ -1073,7 +1065,7 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},
-/turf/open/floor/mainship/green,
+/turf/open/floor/mainship/green/corner,
 /area/mainship/squads/req)
 "adG" = (
 /obj/machinery/light{
@@ -1745,8 +1737,10 @@
 	},
 /area/mainship/command/self_destruct)
 "avZ" = (
-/obj/structure/bed/chair/wheelchair,
 /obj/effect/ai_node,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/mainship/green{
 	dir = 5
 	},
@@ -1917,10 +1911,11 @@
 	},
 /area/mainship/living/basketball)
 "aAP" = (
-/obj/machinery/alarm,
-/turf/open/floor/mainship/green{
-	dir = 1
+/obj/structure/window/framed/mainship/requisitions,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
 	},
+/turf/open/space/basic,
 /area/mainship/squads/req)
 "aAV" = (
 /obj/machinery/alarm,
@@ -3772,9 +3767,6 @@
 	},
 /area/mainship/command/cic)
 "bkB" = (
-/obj/structure/barricade/metal{
-	dir = 8
-	},
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
@@ -4206,29 +4198,21 @@
 /turf/closed/wall/mainship,
 /area/mainship/squads/req)
 "bnG" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
 /obj/structure/window/framed/mainship/requisitions,
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id = "ROoffice";
-	layer = 3.3;
-	name = "RO Office"
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/mainship/squads/req)
 "bnH" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/mainship/marine/requisitions{
-	dir = 2
-	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/mono,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
+	},
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/turf/open/floor/plating,
 /area/mainship/squads/req)
 "bnI" = (
 /obj/machinery/cryopod,
@@ -4469,22 +4453,25 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "bpw" = (
-/obj/structure/closet/crate/ammo,
-/turf/open/floor/mainship/cargo,
+/obj/machinery/alarm,
+/turf/closed/wall/mainship,
 /area/mainship/squads/req)
 "bpx" = (
-/obj/machinery/camera/autoname/mainship,
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/fire,
+/obj/structure/closet/crate/medical,
+/turf/open/floor/mainship/cargo,
+/area/mainship/squads/req)
+"bpz" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
-"bpz" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/mainship/cargo,
-/area/mainship/squads/req)
 "bpB" = (
-/obj/structure/reagent_dispensers,
+/obj/vehicle/ridden/powerloader,
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "bpD" = (
@@ -4493,14 +4480,14 @@
 	dir = 1
 	},
 /area/mainship/squads/alpha)
-"bpE" = (
-/obj/structure/disposaloutlet/retrieval,
-/turf/open/floor/mainship/cargo,
-/area/mainship/squads/req)
 "bpF" = (
-/obj/effect/landmark/start/job/squadspecialist,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/living/cryo_cells)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/green{
+	dir = 5
+	},
+/area/mainship/squads/req)
 "bpG" = (
 /obj/effect/landmark/start/latejoin_gateway,
 /turf/open/floor/plating/plating_catwalk,
@@ -4663,9 +4650,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/marine/requisitions{
-	name = "\improper Requisitions Storage"
-	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "brn" = (
@@ -4673,13 +4657,13 @@
 	dir = 8;
 	on = 1
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "bro" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/mainship/cargo/arrow,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "brp" = (
 /obj/machinery/camera/autoname/mainship,
@@ -4843,33 +4827,22 @@
 	},
 /area/mainship/squads/alpha)
 "bsU" = (
-/obj/structure/closet/crate/construction,
-/turf/open/floor/mainship/cargo,
+/obj/structure/reagent_dispensers,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "bsV" = (
-/obj/item/storage/firstaid/o2,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid,
-/obj/item/storage/firstaid/fire,
-/obj/structure/closet/crate/medical,
-/turf/open/floor/mainship/cargo,
+/obj/structure/sink{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "bsY" = (
-/obj/structure/largecrate/guns/merc,
+/obj/structure/closet/crate,
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "bta" = (
-/obj/structure/rack,
-/obj/item/tool/extinguisher/mini,
-/obj/item/tool/extinguisher/mini,
-/obj/item/tool/extinguisher/mini,
-/obj/item/tool/extinguisher/mini,
-/obj/item/tool/extinguisher,
-/obj/item/tool/extinguisher,
-/obj/item/tool/extinguisher,
-/obj/item/tool/extinguisher,
-/obj/item/tool/extinguisher,
-/turf/open/floor/mainship/cargo,
+/obj/structure/janitorialcart,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "btd" = (
 /obj/effect/landmark/start/job/squadengineer,
@@ -4987,11 +4960,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "buI" = (
-/obj/machinery/door/airlock/mainship/marine/requisitions{
-	dir = 1;
-	name = "\improper Requisitions Storage"
-	},
-/turf/open/floor/mainship/mono,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "buK" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -5123,10 +5093,6 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cafeteria_starboard)
 "bwe" = (
-/obj/machinery/computer/supplycomp,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/item/radio/intercom/general,
 /turf/open/floor/mainship/green{
 	dir = 9
@@ -5143,7 +5109,9 @@
 	},
 /area/mainship/shipboard/firing_range)
 "bwn" = (
-/obj/machinery/firealarm,
+/obj/machinery/firealarm{
+	dir = 4
+	},
 /turf/open/floor/mainship/green{
 	dir = 1
 	},
@@ -5251,12 +5219,8 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "bxX" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/mainship/green{
-	dir = 8
-	},
+/obj/item/tool/mop,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "byf" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -5268,11 +5232,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "byg" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "supply_elevator_railing"
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/turf/open/floor/mainship/green{
+	dir = 8
 	},
-/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "byh" = (
 /obj/machinery/vending/MarineMed,
@@ -5385,16 +5348,14 @@
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/chemistry)
 "bzq" = (
-/obj/machinery/vending/MarineMed,
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/green{
-	dir = 8
-	},
+/obj/structure/table/mainship,
+/obj/machinery/cell_charger,
+/obj/item/cell/high,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "bzr" = (
-/turf/open/floor/mainship/empty,
+/obj/structure/window/framed/mainship/requisitions,
+/turf/open/space/basic,
 /area/mainship/squads/req)
 "bzs" = (
 /obj/structure/disposalpipe/segment{
@@ -5535,21 +5496,19 @@
 	},
 /area/mainship/engineering/lower_engineering)
 "bAK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	on = 1
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "bAP" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
 	},
-/obj/effect/landmark/start/job/squadleader,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cryo_cells)
 "bAS" = (
-/obj/effect/landmark/start/job/squadsmartgunner,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
 	},
@@ -5814,14 +5773,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/medical/surgery_hallway)
 "bDI" = (
-/obj/effect/landmark/start/job/squadleader,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cryo_cells)
 "bDJ" = (
-/obj/effect/landmark/start/job/squadsmartgunner,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
 	},
@@ -5966,25 +5923,25 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/door/airlock/mainship/marine/requisitions{
+	name = "\improper Requisitions Storage"
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "bGj" = (
-/obj/vehicle/ridden/powerloader,
-/turf/open/floor/mainship/cargo,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "bGk" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/floor,
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship/green,
 /area/mainship/squads/req)
 "bGl" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},
 /turf/open/floor/mainship/green{
-	dir = 10
+	dir = 8
 	},
 /area/mainship/squads/req)
 "bGm" = (
@@ -6080,17 +6037,10 @@
 	},
 /area/mainship/medical/surgery_hallway)
 "bHn" = (
-/obj/machinery/vending/medical/shipside,
+/obj/machinery/vending/MarineMed/Blood,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/surgery_hallway)
 "bHo" = (
-/obj/structure/table/mainship,
-/obj/item/storage/belt/combatLifesaver,
-/obj/item/storage/belt/combatLifesaver,
-/obj/item/storage/belt/combatLifesaver,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
 /obj/machinery/light,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/surgery_hallway)
@@ -6275,7 +6225,7 @@
 /area/mainship/medical/lower_medical)
 "bJI" = (
 /obj/effect/decal/warning_stripes/thin{
-	dir = 6
+	dir = 10
 	},
 /obj/machinery/gear{
 	id = "supply_elevator_gear"
@@ -6424,13 +6374,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "bKU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/door/airlock/mainship/marine/requisitions{
-	name = "\improper Requisitions Break Room"
-	},
-/turf/open/floor/wood,
+/obj/machinery/holopad,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "bKX" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -6654,11 +6599,8 @@
 	},
 /area/mainship/medical/medical_science)
 "bMy" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/cargo/arrow{
+/obj/machinery/vending/lasgun,
+/turf/open/floor/mainship/green{
 	dir = 1
 	},
 /area/mainship/squads/req)
@@ -6668,9 +6610,10 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
 "bMA" = (
-/obj/structure/bed/chair/office/light,
-/obj/effect/landmark/start/job/requisitionsofficer,
-/turf/open/floor/mainship/floor,
+/obj/structure/largecrate/guns/russian,
+/turf/open/floor/mainship/green{
+	dir = 1
+	},
 /area/mainship/squads/req)
 "bMB" = (
 /obj/structure/table/mainship,
@@ -6681,11 +6624,10 @@
 	},
 /area/mainship/squads/req)
 "bMF" = (
-/obj/structure/bed/chair{
-	dir = 4
+/obj/structure/largecrate/guns/merc,
+/turf/open/floor/mainship/green/corner{
+	dir = 1
 	},
-/obj/effect/landmark/start/job/shiptech,
-/turf/open/floor/wood,
 /area/mainship/squads/req)
 "bMH" = (
 /obj/machinery/light,
@@ -6792,13 +6734,8 @@
 	},
 /area/mainship/living/cryo_cells)
 "bOt" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 10
-	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
-	},
-/turf/open/floor/mainship/mono,
+/obj/structure/largecrate/guns,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "bOy" = (
 /obj/structure/cable,
@@ -6851,15 +6788,6 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"bPo" = (
-/obj/effect/decal/warning_stripes/thick,
-/obj/structure/rack,
-/obj/item/conveyor_switch_construct,
-/obj/item/stack/conveyor/thirty,
-/turf/open/floor/mainship/green{
-	dir = 8
-	},
-/area/mainship/squads/req)
 "bPp" = (
 /obj/machinery/landinglight/ds1{
 	dir = 1
@@ -6946,16 +6874,18 @@
 /area/mainship/hallways/hangar)
 "bPT" = (
 /obj/machinery/door/poddoor/railing{
+	dir = 8;
 	id = "supply_elevator_railing"
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "bQb" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 8;
-	id = "supply_elevator_railing"
+/obj/structure/rack,
+/obj/item/conveyor_switch_construct,
+/obj/item/stack/conveyor/thirty,
+/turf/open/floor/mainship/green{
+	dir = 8
 	},
-/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "bQh" = (
 /obj/structure/disposalpipe/segment{
@@ -7664,10 +7594,6 @@
 "bWd" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cafeteria_port)
-"bWq" = (
-/obj/structure/window/framed/mainship,
-/turf/open/floor/plating,
-/area/mainship/squads/req)
 "bWr" = (
 /obj/machinery/atm,
 /turf/closed/wall/mainship,
@@ -8545,13 +8471,24 @@
 /obj/item/reagent_containers/food/snacks/protein_pack,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cafeteria_port)
-"cnU" = (
-/obj/machinery/door_control/mainship/req{
-	id = "ROoffice";
-	name = "RO Office Shutters"
+"cni" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
+/obj/machinery/door/airlock/mainship/marine/requisitions{
+	name = "\improper Requisitions Storage"
+	},
+/turf/open/floor/wood,
+/area/mainship/squads/req)
+"cnU" = (
 /obj/structure/table/mainship,
 /obj/item/radio/intercom/general,
+/obj/item/megaphone,
+/obj/item/whistle,
+/obj/item/tool/stamp{
+	name = "Quartermaster's stamp"
+	},
+/obj/item/tool/stamp/denied,
 /turf/open/floor/mainship/green{
 	dir = 5
 	},
@@ -8802,10 +8739,6 @@
 /obj/machinery/light,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
-"cKV" = (
-/obj/machinery/roomba,
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
 "cLn" = (
 /obj/machinery/door/airlock/mainship/evacuation,
 /turf/open/floor/mainship/mono,
@@ -9019,14 +8952,14 @@
 	dir = 8
 	},
 /area/mainship/command/cic)
-"daR" = (
-/obj/machinery/light{
-	dir = 8
+"dbv" = (
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
 	},
-/obj/machinery/cic_maptable,
-/turf/open/floor/mainship/green{
-	dir = 8
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
 	},
+/turf/open/floor/plating,
 /area/mainship/squads/req)
 "dbD" = (
 /obj/machinery/landinglight/ds2/delayone{
@@ -9090,12 +9023,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"dgQ" = (
-/obj/machinery/computer/camera_advanced/overwatch/req,
-/turf/open/floor/mainship/green{
-	dir = 8
-	},
-/area/mainship/squads/req)
 "dhn" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
@@ -9150,7 +9077,6 @@
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "dom" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment/corner,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
@@ -9163,6 +9089,21 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"dpC" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/cic_maptable,
+/turf/open/floor/mainship/green{
+	dir = 4
+	},
+/area/mainship/squads/req)
+"dqa" = (
+/obj/machinery/computer/camera_advanced/overwatch/req,
+/turf/open/floor/mainship/green{
+	dir = 4
+	},
+/area/mainship/squads/req)
 "dqA" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/mainship{
@@ -9852,6 +9793,14 @@
 "eDN" = (
 /turf/open/floor/mainship/silver/corner,
 /area/mainship/hallways/bow_hallway)
+"eEE" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/green{
+	dir = 6
+	},
+/area/mainship/squads/req)
 "eEW" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/mainship/maint{
@@ -10395,11 +10344,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/alpha)
-"fFz" = (
-/obj/structure/table/mainship,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/turf/open/floor/mainship/mono,
+"fFq" = (
+/obj/structure/window/framed/mainship/requisitions,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
+	},
+/turf/closed/wall/mainship,
 /area/mainship/squads/req)
 "fFB" = (
 /obj/machinery/light{
@@ -10493,7 +10443,6 @@
 "fQp" = (
 /obj/structure/table/mainship,
 /obj/item/storage/syringe_case/regular,
-/obj/item/clothing/glasses/hud/health,
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/side{
@@ -10612,11 +10561,10 @@
 	},
 /area/mainship/hull/port_hull)
 "gas" = (
-/obj/structure/table/mainship,
-/obj/item/cell/high,
-/obj/item/cell/high,
-/obj/item/clothing/glasses/welding,
-/turf/open/floor/mainship/green,
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship/green/corner{
+	dir = 4
+	},
 /area/mainship/squads/req)
 "gaW" = (
 /obj/structure/cable,
@@ -10666,12 +10614,10 @@
 /turf/open/floor/wood,
 /area/mainship/living/officer_study)
 "geJ" = (
-/obj/structure/table/mainship,
-/obj/machinery/door_control/old/req,
-/turf/open/floor/mainship/green{
-	dir = 8
-	},
-/area/mainship/squads/req)
+/obj/effect/landmark/start/latejoin,
+/obj/effect/landmark/start/job/squadleader,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/cryo_cells)
 "geQ" = (
 /obj/machinery/door/airlock/mainship/command,
 /turf/open/floor/mainship/mono,
@@ -11060,6 +11006,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/bridge)
+"gST" = (
+/obj/machinery/vending/cargo_supply,
+/turf/open/floor/mainship/green{
+	dir = 8
+	},
+/area/mainship/squads/req)
 "gUG" = (
 /obj/machinery/firealarm{
 	dir = 8
@@ -11607,12 +11559,6 @@
 /obj/machinery/vending/weapon,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/alpha)
-"hPS" = (
-/obj/structure/supply_drop,
-/turf/open/floor/mainship/green{
-	dir = 8
-	},
-/area/mainship/squads/req)
 "hPY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -11665,15 +11611,6 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/carpet,
 /area/mainship/living/commandbunks)
-"hUD" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/vending/cargo_supply,
-/turf/open/floor/mainship/green{
-	dir = 4
-	},
-/area/mainship/squads/req)
 "hVi" = (
 /obj/structure/table/mainship,
 /obj/machinery/prop/mainship/computer,
@@ -11757,13 +11694,6 @@
 /obj/machinery/light,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cafeteria_port)
-"iel" = (
-/obj/structure/table/mainship,
-/obj/machinery/computer/supplydrop_console,
-/turf/open/floor/mainship/green{
-	dir = 8
-	},
-/area/mainship/squads/req)
 "iev" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -11866,21 +11796,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "irZ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/mainship{
+/obj/structure/window/framed/mainship/requisitions,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
 	dir = 2
-	},
-/obj/machinery/door/window/secure/req{
-	dir = 1
-	},
-/obj/machinery/door/window{
-	dir = 2
-	},
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id = "ROoffice";
-	layer = 3.3;
-	name = "RO Office"
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
@@ -11901,10 +11819,11 @@
 /area/mainship/hallways/repair_bay)
 "itb" = (
 /obj/machinery/door/poddoor/railing{
+	dir = 8;
 	id = "supply_elevator_railing"
 	},
 /turf/open/floor/mainship/cargo/arrow{
-	dir = 8
+	dir = 4
 	},
 /area/mainship/squads/req)
 "ivC" = (
@@ -11971,8 +11890,13 @@
 	},
 /area/mainship/hallways/hangar)
 "iBQ" = (
-/obj/docking_port/stationary/supply,
-/turf/open/floor/mainship/empty,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "iBV" = (
 /obj/structure/cable,
@@ -12079,6 +12003,10 @@
 	dir = 4
 	},
 /area/mainship/medical/upper_medical)
+"iLR" = (
+/obj/structure/window/framed/mainship,
+/turf/open/floor/plating,
+/area/mainship/squads/req)
 "iLV" = (
 /obj/machinery/vending/weapon,
 /obj/structure/window/reinforced{
@@ -12227,11 +12155,12 @@
 /area/mainship/hull/starboard_hull)
 "iZS" = (
 /obj/effect/decal/warning_stripes/thin{
-	dir = 5
+	dir = 9
 	},
 /obj/machinery/gear{
 	id = "supply_elevator_gear"
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "jbI" = (
@@ -12326,19 +12255,19 @@
 /area/mainship/medical/operating_room_three)
 "jiv" = (
 /obj/machinery/door/poddoor/railing{
-	dir = 1;
+	dir = 2;
 	id = "supply_elevator_railing"
 	},
-/turf/open/floor/mainship/cargo/arrow,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "jiQ" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
+/obj/machinery/door/poddoor/railing{
+	dir = 2;
+	id = "supply_elevator_railing"
 	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 1
 	},
-/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "jjk" = (
 /turf/open/floor/mainship/floor,
@@ -12389,7 +12318,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/starboard_garden)
 "jnG" = (
-/obj/structure/closet/crate/weapon,
 /turf/open/floor/mainship/green{
 	dir = 6
 	},
@@ -12409,6 +12337,10 @@
 	dir = 5
 	},
 /area/mainship/hallways/aft_hallway)
+"jpq" = (
+/obj/machinery/door_control/old/req,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "jrq" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
@@ -12768,12 +12700,6 @@
 /area/mainship/living/bridgebunks)
 "kfp" = (
 /obj/structure/window/framed/mainship,
-/obj/machinery/door/poddoor/shutters{
-	dir = 8;
-	id = "ROoffice";
-	layer = 3.3;
-	name = "RO Office"
-	},
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/plating,
 /area/mainship/squads/req)
@@ -12803,6 +12729,15 @@
 	dir = 4
 	},
 /area/mainship/hallways/port_hallway)
+"kkN" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "klS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13119,8 +13054,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/brig)
 "kLG" = (
-/obj/machinery/vending/MarineMed/Blood,
 /obj/machinery/firealarm,
+/obj/structure/bed/chair/wheelchair,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -13326,12 +13261,6 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_umbilical)
-"lbM" = (
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/mainship/green{
-	dir = 4
-	},
-/area/mainship/squads/req)
 "lbX" = (
 /turf/open/floor/mainship/orange{
 	dir = 8
@@ -13373,6 +13302,12 @@
 /obj/effect/decal/warning_stripes/leader,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/delta)
+"leS" = (
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/mainship/green{
+	dir = 8
+	},
+/area/mainship/squads/req)
 "lff" = (
 /turf/open/floor/mainship/purple{
 	dir = 8
@@ -13646,6 +13581,12 @@
 "lAe" = (
 /turf/open/shuttle/escapepod/five,
 /area/mainship/command/self_destruct)
+"lBa" = (
+/obj/structure/supply_drop,
+/turf/open/floor/mainship/green{
+	dir = 4
+	},
+/area/mainship/squads/req)
 "lBc" = (
 /obj/effect/attach_point/weapon/dropship1,
 /turf/open/floor/plating,
@@ -13669,6 +13610,13 @@
 /obj/structure/window/framed/mainship,
 /turf/open/floor/plating,
 /area/mainship/hallways/aft_hallway)
+"lDM" = (
+/obj/docking_port/stationary/marine_dropship/crash_target,
+/obj/machinery/light{
+	light_color = "#da2f1b"
+	},
+/turf/open/floor/mainship/green,
+/area/mainship/squads/req)
 "lDQ" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -13996,6 +13944,14 @@
 	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/medical_science)
+"may" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/obj/machinery/computer/ordercomp,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "mdp" = (
 /obj/machinery/door/airlock/mainship/maint{
 	name = "Tool Closet"
@@ -14185,6 +14141,12 @@
 	dir = 10
 	},
 /area/mainship/squads/delta)
+"mxf" = (
+/obj/item/radio/intercom/general{
+	dir = 8
+	},
+/turf/open/floor/mainship/cargo/arrow,
+/area/mainship/squads/req)
 "mxO" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -14212,6 +14174,12 @@
 /obj/structure/dropship_equipment/weapon/minirocket_pod,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"mzi" = (
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/mainship/green{
+	dir = 8
+	},
+/area/mainship/squads/req)
 "mzG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -14325,7 +14293,6 @@
 /turf/open/floor/wood,
 /area/mainship/living/pilotbunks)
 "mIL" = (
-/obj/effect/landmark/start/job/squadmarine,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -14604,7 +14571,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "nfz" = (
-/obj/machinery/computer/supplycomp,
+/obj/structure/table/mainship,
+/obj/machinery/door_control/old/req,
 /turf/open/floor/mainship/green,
 /area/mainship/squads/req)
 "nga" = (
@@ -14937,13 +14905,10 @@
 /area/mainship/hull/port_hull)
 "nMf" = (
 /obj/structure/window/framed/mainship/requisitions,
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id = "ROoffice";
-	layer = 3.3;
-	name = "RO Office"
-	},
 /obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
 	dir = 2
 	},
 /turf/open/floor/plating,
@@ -15027,16 +14992,7 @@
 	},
 /area/mainship/living/pilotbunks)
 "nQq" = (
-/obj/structure/table/mainship,
-/obj/item/folder/black_random,
-/obj/item/tool/stamp/denied,
-/obj/item/tool/stamp{
-	name = "Quartermaster's stamp"
-	},
-/obj/item/eftpos{
-	eftpos_name = "Cargo Bay EFTPOS scanner"
-	},
-/obj/item/whistle,
+/obj/machinery/computer/supplycomp,
 /turf/open/floor/mainship/green{
 	dir = 8
 	},
@@ -15316,6 +15272,10 @@
 	dir = 6
 	},
 /area/mainship/medical/lower_medical)
+"otD" = (
+/obj/machinery/roomba,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "ovC" = (
 /obj/machinery/door_control/ai/interior{
 	dir = 4
@@ -15463,24 +15423,25 @@
 	},
 /area/mainship/engineering/lower_engine_monitoring)
 "oHy" = (
-/obj/effect/landmark/start/job/squadsmartgunner,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/landmark/start/job/squadmarine,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cryo_cells)
 "oHW" = (
-/obj/machinery/door/airlock/mainship/marine/requisitions{
-	dir = 2
-	},
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
+	},
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/turf/open/floor/plating,
 /area/mainship/squads/req)
 "oIu" = (
 /obj/machinery/door/airlock/mainship/marine/general/corps{
@@ -15807,6 +15768,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/aft_hallway)
+"pnA" = (
+/obj/docking_port/stationary/supply,
+/turf/open/floor/mainship/empty,
+/area/mainship/squads/req)
 "pnP" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
@@ -15859,10 +15824,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/starboard_emb)
 "prr" = (
-/obj/machinery/door/airlock/mainship/marine/requisitions{
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 2
 	},
-/turf/open/floor/mainship/mono,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro,
+/turf/open/floor/plating,
 /area/mainship/squads/req)
 "prM" = (
 /turf/open/floor/carpet{
@@ -15943,6 +15910,9 @@
 "pAc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	on = 1
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "pAf" = (
@@ -16041,6 +16011,12 @@
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
+"pLZ" = (
+/obj/machinery/door/airlock/mainship/marine/requisitions{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "pNi" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -16297,11 +16273,8 @@
 	},
 /area/mainship/living/port_emb)
 "qiL" = (
-/obj/structure/table/mainship,
-/obj/item/tool/extinguisher,
-/obj/item/tool/extinguisher/mini,
-/obj/item/reagent_containers/spray,
-/turf/open/floor/mainship/mono,
+/obj/machinery/line_nexter,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "qjs" = (
 /obj/machinery/light/small{
@@ -16379,6 +16352,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
 "qqs" = (
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/mainship/green{
 	dir = 10
 	},
@@ -16557,12 +16533,10 @@
 	},
 /area/mainship/engineering/engine_core)
 "qDD" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/door/poddoor/railing{
+	id = "supply_elevator_railing"
 	},
-/turf/open/floor/mainship/green{
-	dir = 6
-	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "qEl" = (
 /obj/structure/cable,
@@ -16732,6 +16706,16 @@
 /obj/machinery/light,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
+"qVf" = (
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/obj/structure/window/framed/mainship/requisitions,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/mainship/squads/req)
 "qVk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -16761,15 +16745,6 @@
 	dir = 1
 	},
 /area/mainship/hallways/hangar)
-"qWS" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/vending/MarineMed,
-/turf/open/floor/mainship/green{
-	dir = 4
-	},
-/area/mainship/squads/req)
 "qXa" = (
 /turf/open/floor/mainship/silver{
 	dir = 4
@@ -17020,11 +16995,13 @@
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/surgery_hallway)
 "rws" = (
-/obj/structure/barricade/metal{
-	dir = 1
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/line_nexter,
-/turf/open/floor/mainship/cargo,
+/obj/machinery/vending/weapon,
+/turf/open/floor/mainship/green{
+	dir = 4
+	},
 /area/mainship/squads/req)
 "rxv" = (
 /obj/item/radio/intercom/general{
@@ -17207,16 +17184,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_umbilical)
 "rTt" = (
-/obj/structure/table/reinforced{
-	layer = 2.1
-	},
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/window/secure/req,
 /obj/machinery/door/poddoor/shutters/mainship/req/ro,
-/obj/machinery/door/window{
-	dir = 8
-	},
-/turf/open/floor/prison/marked,
+/turf/open/floor/plating,
 /area/mainship/squads/req)
 "rTw" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -17412,11 +17381,11 @@
 	},
 /area/mainship/medical/operating_room_three)
 "siC" = (
-/obj/machinery/door/airlock/mainship/marine/requisitions{
-	dir = 8
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
 	},
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/mono,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro,
+/turf/open/floor/plating,
 /area/mainship/squads/req)
 "siJ" = (
 /turf/open/floor/mainship/red/corner{
@@ -18097,6 +18066,13 @@
 	dir = 1
 	},
 /area/mainship/squads/delta)
+"twq" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/cargo/arrow,
+/area/mainship/squads/req)
 "txr" = (
 /obj/structure/table/mainship,
 /obj/item/storage/box/syringes{
@@ -18247,9 +18223,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/port_hull)
 "tKO" = (
-/obj/structure/barricade/metal{
-	dir = 8
-	},
+/obj/machinery/door_control/old/req,
 /turf/open/floor/mainship/green{
 	dir = 4
 	},
@@ -18357,6 +18331,14 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/engineering/ce_room)
+"tTu" = (
+/obj/machinery/door/poddoor/railing{
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/mainship/squads/req)
 "tUM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -18542,12 +18524,6 @@
 	},
 /turf/open/floor/mainship/blue/full,
 /area/mainship/hallways/hangar)
-"uoD" = (
-/obj/machinery/vending/uniform_supply,
-/turf/open/floor/mainship/green{
-	dir = 4
-	},
-/area/mainship/squads/req)
 "upS" = (
 /obj/machinery/vending/weapon,
 /obj/machinery/camera/autoname/mainship{
@@ -18565,12 +18541,8 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/delta)
 "utR" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mainship/green{
-	dir = 5
-	},
+/obj/structure/window/framed/mainship/requisitions,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "uuf" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -18743,7 +18715,6 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
 	},
-/obj/machinery/vending/lasgun,
 /turf/open/floor/mainship/red{
 	dir = 6
 	},
@@ -18981,10 +18952,6 @@
 	},
 /turf/open/floor/mainship/green,
 /area/mainship/living/numbertwobunks)
-"vda" = (
-/obj/machinery/holopad,
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
 "vfD" = (
 /obj/machinery/alarm,
 /obj/machinery/computer/arcade,
@@ -19002,15 +18969,10 @@
 	},
 /area/mainship/command/bridge)
 "vfW" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/table/mainship,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/item/lightreplacer,
+/obj/machinery/computer/supplydrop_console,
 /turf/open/floor/mainship/green{
-	dir = 8
+	dir = 4
 	},
 /area/mainship/squads/req)
 "vhI" = (
@@ -19257,6 +19219,14 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/basketball)
+"vEt" = (
+/obj/effect/decal/warning_stripes/engineer,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "vFs" = (
 /obj/machinery/light{
 	dir = 8
@@ -19451,6 +19421,18 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engine_core)
+"vYx" = (
+/obj/machinery/door/window/secure/req,
+/obj/machinery/door/window{
+	dir = 8
+	},
+/obj/structure/table/reinforced{
+	layer = 2.1
+	},
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro,
+/turf/open/floor/prison/marked,
+/area/mainship/squads/req)
 "vYD" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/mainship/orange,
@@ -19522,12 +19504,20 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
+"wfH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/start/job/shiptech,
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/mainship/squads/req)
 "wgD" = (
-/obj/structure/table/mainship,
-/obj/machinery/cell_charger,
-/obj/item/cell/high,
-/obj/item/tool/hand_labeler,
-/obj/item/tool/hand_labeler,
+/obj/structure/barricade/metal{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "wgT" = (
@@ -19989,9 +19979,6 @@
 /area/mainship/living/starboard_emb)
 "xas" = (
 /obj/machinery/computer/ordercomp,
-/obj/item/radio/intercom/general{
-	dir = 8
-	},
 /turf/open/floor/mainship/green{
 	dir = 6
 	},
@@ -20043,10 +20030,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_umbilical)
 "xhL" = (
-/obj/machinery/vending/weapon,
-/turf/open/floor/mainship/green{
-	dir = 4
-	},
+/turf/open/floor/mainship/empty,
 /area/mainship/squads/req)
 "xik" = (
 /obj/structure/cable,
@@ -20108,6 +20092,17 @@
 	dir = 6
 	},
 /area/mainship/command/cic)
+"xoW" = (
+/obj/structure/table/mainship,
+/obj/item/storage/belt/combatLifesaver,
+/obj/item/storage/belt/combatLifesaver,
+/obj/item/storage/belt/combatLifesaver,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/machinery/light,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/surgery_hallway)
 "xpi" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
@@ -54300,7 +54295,7 @@ fQp
 iCy
 mqf
 hRN
-bHn
+xoW
 nSl
 csh
 eMT
@@ -55824,7 +55819,7 @@ bev
 bfu
 seI
 fuc
-vvd
+abx
 fxw
 biu
 bjV
@@ -59688,9 +59683,9 @@ bnB
 wvf
 eRq
 mgo
-aat
-iEE
 aci
+iEE
+aat
 acx
 byh
 bzq
@@ -59956,7 +59951,7 @@ seG
 seG
 seG
 seG
-seG
+vEt
 seG
 seG
 fPK
@@ -60467,7 +60462,7 @@ kzX
 hit
 vaF
 seG
-seG
+otD
 seG
 seG
 seG
@@ -60975,17 +60970,17 @@ bKP
 bnF
 bnF
 bnE
-rws
+seG
+bnD
+bnD
 tKO
-tKO
-tKO
-tKO
+bnD
 bkB
 pyl
 xas
-bnF
+mxf
 wgD
-fFz
+wgD
 qiL
 bnF
 kuC
@@ -61233,17 +61228,17 @@ bGj
 bnF
 bnF
 rTt
+prr
 vZh
 vZh
 vZh
-vZh
-bnF
+rTt
 siC
 bnF
 bnF
 kfp
 kfp
-kfp
+vYx
 bnF
 ext
 bQw
@@ -61486,15 +61481,15 @@ acw
 seG
 jFn
 bAG
-bGj
+bsU
 bnF
 bwe
-bxX
-geJ
-abx
-gas
-abz
-vfW
+iWe
+hit
+hit
+hit
+hit
+hit
 iWe
 bkD
 bnF
@@ -61744,20 +61739,20 @@ bnF
 bpn
 kzX
 bGl
-bnF
+byg
 adh
-iWe
-iWe
-iWe
-iWe
-iWe
-iWe
-iWe
+iBQ
+qDD
+qDD
+tTu
+qDD
+qDD
+kkN
 jER
 iYu
 muC
 iWe
-bMA
+iWe
 irZ
 ruj
 bQw
@@ -62001,15 +61996,15 @@ wcO
 bpq
 iWe
 iWe
-prr
-iWe
-iWe
-iWe
-iWe
-iWe
-iWe
-iWe
-bJB
+seG
+bKU
+jiv
+xhL
+xhL
+xhL
+xhL
+xhL
+may
 qNK
 bnF
 cnU
@@ -62259,21 +62254,21 @@ bpr
 bnD
 bGm
 wcO
-bDM
-pbV
-hUD
-lbM
+bMy
+jiv
 xhL
-uoD
-qWS
-jFn
+xhL
+xhL
+xhL
+xhL
+bAK
 qNK
 nMf
 bJL
 pBI
 bMB
 bnF
-ruj
+qhN
 bQw
 bWC
 cbn
@@ -62516,14 +62511,14 @@ bnF
 wcO
 bnF
 bnF
-bDM
-bAG
-bnF
-bWq
-bWq
-bWq
-bnF
-bDM
+bMA
+jiQ
+xhL
+xhL
+pnA
+xhL
+xhL
+twq
 qNK
 bnF
 bnF
@@ -62773,20 +62768,20 @@ kCp
 hit
 sPW
 hit
-vaF
-kzX
-daR
-dgQ
-iel
-hPS
-bPo
-vaF
+bMF
+jiv
+xhL
+xhL
+xhL
+xhL
+xhL
+bAK
 qNt
 gSD
-gSD
+hit
 acl
 qqs
-wcO
+qVf
 ruj
 hIv
 ruj
@@ -63030,13 +63025,13 @@ bpt
 brk
 hCr
 bJB
-bMP
-iWe
-iWe
-cKV
-vda
-iWe
-iWe
+bOt
+jiv
+xhL
+xhL
+xhL
+xhL
+xhL
 bAK
 dom
 pAc
@@ -63282,12 +63277,12 @@ aWH
 aFq
 bjV
 biu
-bnG
-utR
+abz
+iWe
 bBX
-bnD
-bnD
-jFn
+iWe
+iWe
+bMP
 bJI
 bPT
 bPT
@@ -63295,12 +63290,12 @@ itb
 bPT
 bPT
 iZS
-pbV
-bnD
-bnD
+iWe
+iWe
+iWe
 bBX
-qDD
-wcO
+iWe
+dbv
 ruj
 bQw
 ruj
@@ -63538,27 +63533,27 @@ vTf
 aWH
 jQk
 bjV
-blj
-bnF
-bnF
+biu
+aAP
+bpF
 brm
-bnF
-bnF
-adh
-byg
-bzr
-bzr
-bzr
-bzr
-bzr
-bGk
+bnD
+bnD
+gas
+iWe
+iWe
+iWe
+iWe
+iWe
+iWe
+iWe
 adF
-bnF
-bnF
-bKU
-bnF
-bnF
-nsv
+bnD
+bnD
+bBX
+eEE
+fFq
+jpq
 bQw
 ruj
 cbn
@@ -63795,27 +63790,27 @@ oaW
 aWH
 biu
 bjV
-biu
+blj
 bnF
-bpw
+bnF
 bGh
-bsU
 bnF
-bpn
-byg
-bzr
-bzr
-bzr
-bzr
-bzr
-bGk
-kWq
 bnF
-bJN
-svt
-bMF
 bnF
-qhN
+bnF
+bzr
+utR
+pLZ
+utR
+bzr
+bnF
+bnF
+bnF
+bnF
+cni
+bnF
+bnF
+nsv
 bQw
 bWC
 cbn
@@ -64055,21 +64050,21 @@ bke
 acw
 bnF
 bpx
-bGh
+bBX
 bsV
-bnF
+bAG
 bwn
-bMy
-bzr
-bzr
-iBQ
-bzr
-bzr
-jiv
+iWe
+iWe
+iWe
+iWe
+iWe
+iWe
+iWe
 bAG
 bnF
 bJN
-svt
+wfH
 abv
 bnF
 rbP
@@ -64313,17 +64308,17 @@ biu
 bnF
 bpz
 brn
-bsY
-bnF
-bpn
-byg
-bzr
-bzr
-bzr
-bzr
-bzr
-bGk
+buI
 bAG
+bDM
+pbV
+rws
+vfW
+lBa
+dqa
+dpC
+jFn
+lDM
 bnF
 bJN
 svt
@@ -64569,17 +64564,17 @@ bjV
 biu
 bnF
 bpB
-seG
-seG
-buI
+iWe
+bxX
+bAG
 bDM
-byg
-bzr
-bzr
-bzr
-bzr
-bzr
-bGk
+bAG
+bnF
+iLR
+iLR
+iLR
+bnF
+bDM
 kWq
 bnF
 bJO
@@ -64824,19 +64819,19 @@ aWH
 biu
 bjV
 blj
-bnF
+bpw
 bsY
-seG
+iWe
 bta
-bnF
-aAP
-bOt
+bAG
+bDM
+kzX
 bQb
-bQb
-bQb
-bQb
-bQb
-jiQ
+gST
+leS
+mzi
+byh
+vaF
 bAG
 bIH
 tMR
@@ -65082,13 +65077,13 @@ aLX
 bjV
 biu
 bnF
-bpE
+bsY
 bro
 adg
-bnF
+bGk
 avZ
 bnD
-ace
+bnD
 bnD
 bMP
 bnD
@@ -66125,7 +66120,7 @@ aLt
 ayA
 bzu
 btd
-bpF
+btd
 bnI
 blY
 ruj
@@ -66368,7 +66363,7 @@ gYz
 biu
 blY
 bnJ
-smz
+btd
 btd
 bnJ
 kyh
@@ -66382,7 +66377,7 @@ bpN
 bpN
 bnJ
 btd
-bpF
+btd
 bnJ
 blY
 ruj
@@ -66882,10 +66877,10 @@ gYz
 biu
 blY
 bnI
-bpN
+brr
 btd
 bnI
-kyh
+geJ
 bpH
 bzu
 sfB
@@ -66893,7 +66888,7 @@ nwy
 sfB
 bzu
 bpH
-bpN
+bpH
 bnI
 btd
 bpH
@@ -67142,7 +67137,7 @@ bnL
 brt
 btd
 bnJ
-kyh
+geJ
 bpH
 bnJ
 sfB
@@ -67150,10 +67145,10 @@ mKX
 sfB
 bnJ
 bpH
-bpN
+brt
 bnJ
 btd
-bpH
+brt
 bNX
 blZ
 nsv


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Alright, this is going to be huge.

Change req map so that ALL MARINES can have walk to ASRS conveyor belt BUT CANNOT walk into certain designated req locations.

Where in req squad marines, corpsman, engineer, smartgunner, and SL can walk into:
- ASRS conveyor belt
- supply boxes
- one motorcycle

Where in req squad marines, corpsman, engineer, smartgunner, and SL cannot walk into:
- RO's office
- operational vendor (I will put suicide vests and other stuff from operational vendor into marine vendor)
- console to accept req orders (marines don't even have access to it in the first place, so why even try?)
- Reqtorio
- supply drop
- powerloader
- the second motorcycle

Supply drop is closer to ASRS conveyor belt, but there is a req door that separate supply drop from ASRS.

PoS and Sulaco have more room for Reqtorio.

I also add a few map quality of life such as using tiles to help engineers find the TerraGov Engineer System Vendor and changing spawn point around for traffic.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Any RO, ST, or req people let marines come into req so that they can pick up their req orders out of the ASRS conveyor belt. This leads to hacking a few req doors open just to let marines come in and out.

This COMPLETE remapping of all req maps change that. Yes, the remapping is for a small thing, but such small thing is so relevant in the gameplay loop that it really is a noticable thing.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Public access to ASRS conveyor belt BUT private access to the rest of req
expansion: PoS and Sulaco for more room to build Reqtorio
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->