### PR TITLE
Reduces Acid well Cost.

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -443,7 +443,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define XENO_DEFAULT_VENT_EXIT_TIME 2 SECONDS //Standard time for a xeno to exit a vent.
 #define XENO_DEFAULT_ACID_PUDDLE_DAMAGE 14 //Standard damage dealt by acid puddles
 #define XENO_ACID_WELL_FILL_TIME 2 SECONDS //How long it takes to add a charge to an acid pool
-#define XENO_ACID_WELL_FILL_COST 200 //Cost in plasma to apply a charge to an acid pool
+#define XENO_ACID_WELL_FILL_COST 100 //Cost in plasma to apply a charge to an acid pool
 #define XENO_ACID_WELL_MAX_CHARGES 5 //Maximum number of charges for the acid well
 
 #define HIVE_CAN_HIJACK (1<<0)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -443,7 +443,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define XENO_DEFAULT_VENT_EXIT_TIME 2 SECONDS //Standard time for a xeno to exit a vent.
 #define XENO_DEFAULT_ACID_PUDDLE_DAMAGE 14 //Standard damage dealt by acid puddles
 #define XENO_ACID_WELL_FILL_TIME 2 SECONDS //How long it takes to add a charge to an acid pool
-#define XENO_ACID_WELL_FILL_COST 100 //Cost in plasma to apply a charge to an acid pool
+#define XENO_ACID_WELL_FILL_COST 150 //Cost in plasma to apply a charge to an acid pool
 #define XENO_ACID_WELL_MAX_CHARGES 5 //Maximum number of charges for the acid well
 
 #define HIVE_CAN_HIJACK (1<<0)

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -296,7 +296,7 @@
 	name = "Place acid well"
 	action_icon_state = "place_trap"
 	mechanics_text = "Place an acid well that can put out fires."
-	plasma_cost = 250
+	plasma_cost = 400
 	cooldown_timer = 2 MINUTES
 
 /datum/action/xeno_action/place_acidwell/can_use_action(silent = FALSE, override_flags)

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -296,7 +296,7 @@
 	name = "Place acid well"
 	action_icon_state = "place_trap"
 	mechanics_text = "Place an acid well that can put out fires."
-	plasma_cost = 500
+	plasma_cost = 250
 	cooldown_timer = 2 MINUTES
 
 /datum/action/xeno_action/place_acidwell/can_use_action(silent = FALSE, override_flags)


### PR DESCRIPTION

## About The Pull Request

Attempts to find a good price for Acid well so it doesn't cost an arm and a leg to make or fill up whilst also making sure its not super spammed

## Why It's Good For The Game

Acid well's are a defensive & utility structurefor xenomorphs, but they use up a LOT of plasma 500 to make and 200 to build, when creating a maze or base xenos wont be able to spare the plasma, Lowered Acid Well cost will allow xenos to better hold defensive lines rather then falling victim to marine pushes hat cant be stopped.

When retreating Marines will often follow xenos into weeded areas, but I believe with the reduced cost for acid wells they will think twice.

## Changelog
:cl:
balance: Acidwell now 400 down from 500
balance: Filling an acidwell is now 150 down from 200
/:cl:


