### PR TITLE
Fixes zero stacks of handfuls

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -172,12 +172,12 @@
 		user?.hud_used.update_ammo_hud(user, src)
 		if(current_rounds <= 0)
 			user.temporarilyRemoveItemFromInventory(src)
-			QDEL_NULL(src)
+			qdel(src)
 		return rounds //Give the number created.
 	else
 		update_icon()
 		if(current_rounds <= 0)
-			QDEL_NULL(src)
+			qdel(src)
 		return new_handful
 
 ///Called on a /ammo_magazine that wishes to be a handful. It generates all the data required for the handful.

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -170,9 +170,14 @@
 		to_chat(user, span_notice("You grab <b>[rounds]</b> round\s from [src]."))
 		update_icon() //Update the other one.
 		user?.hud_used.update_ammo_hud(user, src)
+		if(current_rounds <= 0)
+			user.temporarilyRemoveItemFromInventory(src)
+			QDEL_NULL(src)
 		return rounds //Give the number created.
 	else
 		update_icon()
+		if(current_rounds <= 0)
+			QDEL_NULL(src)
 		return new_handful
 
 ///Called on a /ammo_magazine that wishes to be a handful. It generates all the data required for the handful.


### PR DESCRIPTION
## About The Pull Request

Fixes #9651. I'm not sure this is the best way to go around this, but I can't think of another way.

## Why It's Good For The Game

Stops marines from making infinite ammo.

## Changelog
:cl:
fix: Marines can no longer create 0 handfuls and shoot phantom ammo.
/:cl: