### PR TITLE
Removes plasma pistol from the T35 and T39 as an attachment option

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1557,7 +1557,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	pixel_shift_y = 17
 	stream_type = FLAMER_STREAM_CONE
 
-///Funny red wide nozzle that can fill entire screens with flames. Admeme only. 
+///Funny red wide nozzle that can fill entire screens with flames. Admeme only.
 /obj/item/attachable/flamer_nozzle/wide/red
 	name = "red spray flamer nozzle"
 	desc = "It is red, therefore its obviously more effective."

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -238,7 +238,6 @@ can cause issues with ammo types getting mixed up during the burst.
 		/obj/item/attachable/heavy_barrel,
 		/obj/item/attachable/compensator,
 		/obj/item/attachable/magnetic_harness,
-		/obj/item/weapon/gun/pistol/plasma_pistol,
 		/obj/item/attachable/motiondetector,
 	)
 
@@ -931,7 +930,6 @@ can cause issues with ammo types getting mixed up during the burst.
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/stock/t35stock,
 		/obj/item/attachable/motiondetector,
-		/obj/item/weapon/gun/pistol/plasma_pistol,
 		/obj/item/attachable/buildasentry,
 	)
 


### PR DESCRIPTION
## About The Pull Request

Removes Plasma Pistol from the T35 and T39 as an attachment

## Why It's Good For The Game

Under barrel flamers were removed for the exact same reason I am removing this. Plasmapistol under barrel, for those unaware, allows a marine to add a weapon that sets xenos on fire to their firearm. This is allowed on shotguns, leading to people being able to solo most castes in the game more so then they already can. When combined with a group of marines helping, this almost always results in the xenos death if caught in the blast. Removing this is a good step in removing powercreep features.

Examples of why this is powercreep:
https://www.youtube.com/watch?v=6KGZCEojNSA

This does not even take into consideration the fact that there would be more than likely more than one marine shooting at these xenos, since this was done in a controlled environment. I have no plans on removing it from other guns, but they should not be on shotguns.

## Changelog
:cl:
balance: Removed plasma pistol as an option from T35 and T39 attachments
/:cl:
