### PR TITLE
Makes plasma pistol attachment shoot only while wielded

### DIFF
--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -120,14 +120,12 @@
 	return FALSE
 
 /obj/item/weapon/gun/pistol/plasma_pistol/on_attach(obj/item/attached_to, mob/user)
-	if(!(flags_gun_features & GUN_WIELDED_FIRING_ONLY))
-		flags_gun_features += GUN_WIELDED_FIRING_ONLY
-	. = ..()
+	flags_gun_features |= GUN_WIELDED_FIRING_ONLY
+	return ..()
 
 /obj/item/weapon/gun/pistol/plasma_pistol/on_detach(obj/item/attached_to, mob/user)
-	if(flags_gun_features & GUN_WIELDED_FIRING_ONLY )
-		flags_gun_features -= GUN_WIELDED_FIRING_ONLY
-	. = ..()
+	flags_gun_features &= ~GUN_WIELDED_FIRING_ONLY
+	return ..()
 
 
 /obj/item/weapon/gun/pistol/plasma_pistol/guardsman_pistol

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -119,6 +119,17 @@
 	to_chat(attacher, span_warning("You cannot attach [src] to [attaching_to] while [attachments_by_slot[ATTACHMENT_SLOT_RAIL]] occupies [src]'s rail slot."))
 	return FALSE
 
+/obj/item/weapon/gun/pistol/plasma_pistol/on_attach(obj/item/attached_to, mob/user)
+	if(!(flags_gun_features & GUN_WIELDED_FIRING_ONLY))
+		flags_gun_features += GUN_WIELDED_FIRING_ONLY
+	. = ..()
+
+/obj/item/weapon/gun/pistol/plasma_pistol/on_detach(obj/item/attached_to, mob/user)
+	if(flags_gun_features & GUN_WIELDED_FIRING_ONLY )
+		flags_gun_features -= GUN_WIELDED_FIRING_ONLY
+	. = ..()
+
+
 /obj/item/weapon/gun/pistol/plasma_pistol/guardsman_pistol
 	name = "\improper Guardsman\'s plasma pistol"
 	desc = "FOR THE EMPEROR!"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This doesn't stop the plasma pistol from normally shooting in it's unattached version. I also stole this code from #9316 thanks to Notamaniac for making this.

https://user-images.githubusercontent.com/24631139/154784939-9b6d6ea2-b345-4728-a9c4-67ff3579ef27.mp4

(tested the code anyway so I don't perish)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A less nuclear option than #9664 as shotguns aren't really the main problem here, it's mostly underattachments as a whole not having a clear indication that the gun possesses them, blindsiding xenos with surprise ugl impacts or ubf/masterkey, but the big difference between these under attachments and plasmapistol is that they need to be fully wielded to actually start shooting, giving xenos that are more hit and run a moment to leave. (runners, hunters etc.) Most stuns are only for 2 seconds, making marines with synaptazine instantly get up and shoot their plasma pistol attachment, while prepping up for another volley/burst punishing you even if you used your tools well.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Plasma pistol can no longer shoot onehanded while attached to a gun. Note that this doesn't prevent from plasma pistol shooting one-handed while unattached.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
