### PR TITLE
Detpack fixes

### DIFF
--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -55,8 +55,10 @@
 		nullvars()
 	else
 		nullvars()
-		return ..()
+	return ..()
 
+/obj/item/detpack/ex_act()
+	return
 
 /obj/item/detpack/proc/set_frequency(new_frequency)
 	SSradio.remove_object(src, frequency)
@@ -280,6 +282,8 @@
 			if(T.drag_delay < 3) //Anything with a fast drag delay we need to modify to avoid kamikazi tactics
 				target_drag_delay = T.drag_delay
 				T.drag_delay = 3
+		if(radio_connection == null)
+			set_frequency(frequency)
 		update_icon()
 
 /obj/item/detpack/proc/change_to_loud_sound()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a couple of detpack bugs:

- Fixes detpacks breaking when taken off a surface, and put on another
 ^ This might also have happened when 'Send signal' was spammed, and if it did, that's fixed too
- Detpacks are now immune to explosions, including explosions from _other detpacks too close_ and friendly grenades/OBs
- Detpacks now delete properly when destroyed

This should fix #9544  and might fix #9543 (I'm pretty sure 9543 was caused by explosions (like from an OB or other detpacks) fucking things up, not walls being deleted under the detpacks)

## Why It's Good For The Game
Detpack is regarded as one of the worst ways to take down a wall at the minute, and the thing itself, from whenever I've used it, isn't so bad. What IS bad, however, is the fact that half the time it doesn't bloody work. Hopefully by making it actually function as intended, it becomes - _not absolute dogshit._
Also bugfixes good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Detpacks now delete properly when destroyed
fix: Detpacks no longer break when picked up and placed again
fix: Detpacks are now immune to explosions, meaning they aren't instantly deleted by other detpacks placed too close
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
