### PR TITLE
Makes announcement hearable even if deaf

### DIFF
--- a/code/__HELPERS/announce.dm
+++ b/code/__HELPERS/announce.dm
@@ -28,7 +28,7 @@
 	var/s = sound(sound, channel = CHANNEL_ANNOUNCEMENTS)
 	for(var/i in receivers)
 		var/mob/M = i
-		if(!isnewplayer(M) && !isdeaf(M))
+		if(!isnewplayer(M))
 			to_chat(M, announcement)
 			SEND_SOUND(M, s)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lets deaf, crit, or dead humans hear all announcements, like in CM.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently, TGMC is extremely momentum based. If you start losing, it can be hard to stop it. Part of this problem is how common deafness is. 
When someone is deaf, they cannot hear anything, sometimes for an extended period of time. You get absolutely NO information, except what is _visible_ on your screen, and that's absolutely crushing. ESPECIALLY when some things deafen you for _half a fucking hour at times_. Deafness is an **incredibly** strong debuff.
But this PR doesn't change that, and that's why I think it's balanced. The only thing this allows command to do, is _ensure_ that everybody heard something. Nothing else really fills that role currently, and from how organised CM is at times, I think it's something that'd make here a lot more cohesive and overall fun to play.

TL;DR:
- Raises marine awareness, and probably competence
- Lets command ensure everybody has heard something, rather than having to guess
- Gives better opportunities for shipside roles, e.g RO, to let people know what's going on
- Makes communicating with your team easier, in the team-based game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Announcements (including command ones) can now be heard while deaf, in crit, or dead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
