### PR TITLE
Chem Lab QoL and Standardization

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -3251,7 +3251,6 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
 "lc" = (
@@ -3262,6 +3261,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
 "lg" = (
@@ -10884,6 +10884,7 @@
 /area/mainship/medical/chemistry)
 "Iv" = (
 /obj/machinery/chem_master,
+/obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/sterile/purple/corner{
 	dir = 4
 	},
@@ -11153,7 +11154,6 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/open/floor/mainship/sterile/purple/side{
 	dir = 4
@@ -13098,6 +13098,7 @@
 /area/mainship/engineering/engineering_workshop)
 "Pi" = (
 /obj/machinery/chem_master,
+/obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/sterile/purple/corner,
 /area/mainship/medical/chemistry)
 "Pj" = (

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -2203,7 +2203,6 @@
 	pixel_y = 3
 	},
 /obj/item/tool/hand_labeler,
-/obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/dropper,
 /obj/machinery/alarm{
@@ -2459,6 +2458,7 @@
 "id" = (
 /obj/machinery/chem_master,
 /obj/machinery/firealarm,
+/obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/surgery_hallway)
 "ig" = (
@@ -2597,8 +2597,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "iD" = (
-/obj/structure/filingcabinet,
 /obj/machinery/camera/autoname/mainship,
+/obj/machinery/chem_dispenser,
 /turf/open/floor/mainship/sterile/corner{
 	dir = 1
 	},
@@ -8296,19 +8296,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "As" = (
-/obj/structure/table/mainship,
-/obj/item/storage/belt/medical,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/o2{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/healthanalyzer,
+/obj/machinery/chem_master,
+/obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -10554,6 +10543,8 @@
 	pixel_y = 9
 	},
 /obj/item/healthanalyzer,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
@@ -11735,6 +11726,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
+"KC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "KD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -14012,7 +14012,6 @@
 	pixel_y = 3
 	},
 /obj/item/tool/hand_labeler,
-/obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/dropper,
 /obj/machinery/alarm{
@@ -14189,6 +14188,7 @@
 "RU" = (
 /obj/machinery/chem_master,
 /obj/machinery/firealarm,
+/obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/chemistry)
 "RV" = (
@@ -43332,7 +43332,7 @@ dX
 QC
 nD
 As
-BI
+KC
 iL
 fK
 EL

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -30,6 +30,7 @@
 	dir = 9
 	},
 /obj/machinery/chem_master,
+/obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
 "aag" = (
@@ -96,7 +97,6 @@
 /obj/item/mass_spectrometer,
 /obj/item/reagent_scanner,
 /obj/item/tool/hand_labeler,
-/obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
 	},
@@ -353,6 +353,9 @@
 	name = "modifed holopad"
 	},
 /mob/living/simple_animal/catslug/newt,
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
@@ -374,6 +377,7 @@
 /area/sulaco/medbay/chemistry)
 "abm" = (
 /obj/machinery/chem_master,
+/obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay/chemistry)
 "abn" = (
@@ -479,13 +483,8 @@
 	},
 /area/sulaco/medbay/west)
 "abE" = (
-/obj/structure/sign/directions/science{
-	dir = 1
-	},
-/obj/machinery/camera/autoname,
-/turf/open/floor/prison/whitegreen/corner{
-	dir = 1
-	},
+/obj/structure/sign/chemistry,
+/turf/closed/wall/mainship/white,
 /area/sulaco/medbay/west)
 "abF" = (
 /obj/structure/cable,
@@ -506,15 +505,11 @@
 /turf/open/floor/freezer,
 /area/sulaco/showers)
 "abJ" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/sign/directions/science{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/mainship{
-	dir = 4
-	},
-/turf/open/floor/prison/whitegreen/corner,
-/area/sulaco/medbay/chemistry)
+/turf/closed/wall/mainship/white,
+/area/sulaco/medbay/west)
 "abL" = (
 /obj/machinery/light{
 	dir = 8
@@ -566,9 +561,9 @@
 /turf/closed/wall/mainship/white,
 /area/sulaco/medbay)
 "abY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/cable,
-/obj/effect/ai_node,
+/obj/machinery/door/airlock/mainship/medical/glass/chemistry,
+/obj/machinery/door/firedoor,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
 	},
@@ -608,9 +603,7 @@
 	},
 /area/sulaco/hangar/one)
 "acf" = (
-/obj/machinery/door/airlock/mainship/medical/glass/chemistry,
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
@@ -624,15 +617,21 @@
 	},
 /area/sulaco/medbay/west)
 "ach" = (
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor,
 /obj/machinery/door/firedoor/mainship,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/mainship/medical/glass{
+	dir = 2
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
 /area/sulaco/medbay/west)
 "aci" = (
-/obj/structure/cable,
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
 	},
@@ -644,10 +643,16 @@
 	},
 /area/sulaco/medbay/west)
 "acm" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/structure/cable,
-/turf/open/floor/prison/whitegreen/corner,
-/area/sulaco/medbay/west)
+/obj/machinery/chem_master,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 8
+	},
+/area/sulaco/medbay/chemistry)
 "aco" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
 /obj/structure/cable,
@@ -717,18 +722,22 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_north_maint)
 "acy" = (
-/obj/machinery/door/firedoor/mainship,
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/ai_node,
 /turf/open/floor/prison/whitegreen/corner{
-	dir = 1
+	dir = 4
 	},
 /area/sulaco/medbay/west)
 "acz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/prison/whitegreen/corner,
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 8
+	},
 /area/sulaco/medbay/west)
 "acA" = (
 /obj/structure/cable,
@@ -8957,7 +8966,6 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker,
 /obj/item/reagent_containers/glass/beaker,
-/obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 5
 	},
@@ -18840,12 +18848,14 @@
 	},
 /area/sulaco/medbay/surgery_two)
 "qAW" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
 	},
@@ -21406,6 +21416,13 @@
 	dir = 4
 	},
 /area/sulaco/marine/chapel)
+"uJG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 8
+	},
+/area/sulaco/medbay/west)
 "uKB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -23132,11 +23149,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
 "xKv" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
 /obj/machinery/holopad{
@@ -23145,6 +23158,8 @@
 	holo_range = 7;
 	name = "modfied holopad"
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
@@ -23280,8 +23295,14 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
 "xWb" = (
-/obj/structure/sign/chemistry,
-/turf/closed/wall/mainship/white,
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship{
+	dir = 4
+	},
+/obj/structure/table/mainship,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 4
+	},
 /area/sulaco/medbay/chemistry)
 "xWz" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -48380,7 +48401,7 @@ aTg
 aVH
 bjX
 aam
-aam
+abJ
 aam
 abN
 aam
@@ -48639,10 +48660,10 @@ bjX
 aam
 abb
 abC
-abR
-abD
+acy
+acz
 ach
-abD
+uJG
 xKv
 abD
 acI
@@ -48895,11 +48916,11 @@ leD
 bjX
 aam
 abE
-abG
+aam
 abY
-acm
-acy
-acz
+aam
+aam
+abG
 qAW
 oxv
 aam
@@ -49152,9 +49173,9 @@ xKR
 bIb
 aan
 xWb
-aan
+acm
 acf
-aan
+abl
 aan
 acj
 onD
@@ -49409,7 +49430,7 @@ xKR
 bjX
 uPy
 aaq
-abJ
+aax
 aci
 abk
 aan

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -2141,6 +2141,7 @@
 /area/mainship/living/starboard_emb)
 "aJj" = (
 /obj/machinery/chem_master,
+/obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
@@ -5339,6 +5340,7 @@
 "byW" = (
 /obj/machinery/chem_master,
 /obj/machinery/light,
+/obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/sterile/corner{
 	dir = 8
 	},
@@ -9530,7 +9532,6 @@
 "dUJ" = (
 /obj/structure/table/mainship,
 /obj/item/tool/hand_labeler,
-/obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/chemistry)
 "dVK" = (
@@ -9966,6 +9967,7 @@
 /area/mainship/squads/req)
 "eRr" = (
 /obj/machinery/chem_master,
+/obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/medical_science)
 "eRE" = (
@@ -10231,8 +10233,6 @@
 	pixel_x = 5
 	},
 /obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/glass/beaker/bluespace,
-/obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/medical_science)
 "ftB" = (


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

All shipside maps have three bluespace beakers.

Move bluespace beaker to spawn on top of chem master.

All shipside maps have two chem dispensers and chem masters next to each other for marines to use and a dedicated chem lab for researcher.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Some maps, like Sulaco and PoS, did not have all the standardization of chem labs that are across other shipside maps. It's time to fix that.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: All shipside maps have two chem dispensers and chem masters next to each other for marines to use and a dedicated chem lab for researcher.
qol: Move bluespace beaker to spawn on top of chem master.
balance: All shipside maps have three bluespace beakers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
