### PR TITLE
Punch and Forward charge no longer knock down sentries

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -115,9 +115,6 @@
 		X.visible_message(span_danger("[X] plows straight through [S]!"), null, null, 5)
 		S.deconstruct(FALSE) //We want to continue moving, so we do not reset throwing.
 		return // stay registered
-	if(istype(target, /obj/machinery/deployable/mounted/sentry))
-		var/obj/machinery/deployable/mounted/sentry/sentry = target
-		sentry.knock_down()
 	target.hitby(X, speed) //This resets throwing.
 	charge_complete()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -420,10 +420,6 @@
 	update_icon()
 	return TRUE
 
-/obj/machinery/deployable/mounted/sentry/punch_act(mob/living/carbon/xenomorph/X, damage, target_zone)
-	knock_down()
-	return ..()
-
 /obj/machinery/computer/punch_act(mob/living/carbon/xenomorph/X, damage, target_zone) //Break open the machine
 	set_disabled() //Currently only computers use this; falcon punch away its density
 	return ..()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Warrior punch no longer knocks down sentries, instead doing X4 its damage like it does on regular machinery.
Defender charge no longer knocks down sentries either.

## Why It's Good For The Game

Sentries have it a bit hard and warriors aren't supposed to shine during sieges but in 1 on 1 combat.
Defender is a T1 and already very good at crowd control, that's too much utility.

## Changelog
:cl:
balance: Warrior : punch no longer knocks down sentries
balance: Defender : forward charge no longer knocks down sentries
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
