### PR TITLE
Tadpole nerf

### DIFF
--- a/code/modules/shuttle/mini_dropship.dm
+++ b/code/modules/shuttle/mini_dropship.dm
@@ -45,7 +45,7 @@
 	/// If this computer was damaged by a xeno
 	var/damaged = FALSE
 	/// How long before you can launch tadpole after a landing
-	var/launching_delay = 10 SECONDS
+	var/launching_delay = 30 SECONDS
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/Initialize(mapload)
 	..()

--- a/code/modules/shuttle/mini_dropship.dm
+++ b/code/modules/shuttle/mini_dropship.dm
@@ -45,7 +45,7 @@
 	/// If this computer was damaged by a xeno
 	var/damaged = FALSE
 	/// How long before you can launch tadpole after a landing
-	var/launching_delay = 30 SECONDS
+	var/launching_delay = 20 SECONDS
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/Initialize(mapload)
 	..()


### PR DESCRIPTION
## About The Pull Request

A tadpole lauch nerf from 10 seconds to 20


## Why It's Good For The Game

Tadpole is able to land and lauch too fast making mistakes like lauching middle of a hive or in bad positions really hard to be punished, this PR focus on making tadpole require more brain to be used, if the time is too big it also will be reduced, thats only a test after all.


## Changelog
:cl:

balance: Make tad cooldown from 10 to 20

/:cl:


