### PR TITLE
Anti-Mat sniper buff.

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -128,8 +128,8 @@
 
 //Define sniper laser multipliers
 
-#define SNIPER_LASER_DAMAGE_MULTIPLIER 1.5 //+50% damage vs the aimed target
-#define SNIPER_LASER_ARMOR_MULTIPLIER 1.5 //+50% penetration vs the aimed target
+#define SNIPER_LASER_DAMAGE_MULTIPLIER 1.7 //+50% damage vs the aimed target
+#define SNIPER_LASER_ARMOR_MULTIPLIER 1.7 //+50% penetration vs the aimed target
 #define SNIPER_LASER_SLOWDOWN_STACKS 3
 
 //Define lasrifle

--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -128,8 +128,8 @@
 
 //Define sniper laser multipliers
 
-#define SNIPER_LASER_DAMAGE_MULTIPLIER 1.7 //+50% damage vs the aimed target
-#define SNIPER_LASER_ARMOR_MULTIPLIER 1.7 //+50% penetration vs the aimed target
+#define SNIPER_LASER_DAMAGE_MULTIPLIER 1.7 //+70% damage vs the aimed target
+#define SNIPER_LASER_ARMOR_MULTIPLIER 1.7 //+70% penetration vs the aimed target
 #define SNIPER_LASER_SLOWDOWN_STACKS 3
 
 //Define lasrifle

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -935,9 +935,9 @@ datum/ammo/bullet/revolver/tp44
 	shell_speed = 4
 	accurate_range = 30
 	max_range = 40
-	damage = 80
-	penetration = 60
-	sundering = 15
+	damage = 90
+	penetration = 80
+	sundering = 0
 
 /datum/ammo/bullet/sniper/incendiary
 	name = "incendiary sniper bullet"


### PR DESCRIPTION
## About The Pull Request
Gives an overall buff to the underused, Anti-mat T-26 sniper rifle.
From 80 damage to 90, 60 to 80 pen, and removed all sundering.
Additionally, the Laser was made to have a 1.7 across the board buff from a 1.5 in damage and pen.


## Why It's Good For The Game
An underused sniper rifle, overshadowed by the new "Auto-Sniper", and considered a waste of points by some, gives it an edge over the weapons, making people consider using it more. And as a general note, I make it embrace its AP heritage, removing the Sunder from it, making it pure damage inflicting weapon for late-game Ancient/Primordial xenos, and setting the stage for Marines to chase the said Xeno down.


## Changelog
:cl:
balance: rebalanced the T-26 sniper rifle to have an additional 10 damage per bullet, with the addition of the lase now being 1.7 instead of a 1.5 damage multiplier in a nutshell.
/:cl:
