### PR TITLE
Boiler cloud radius no longer scales past Ancient

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2091,7 +2091,7 @@ datum/ammo/bullet/revolver/tp44
 		var/mob/living/carbon/xenomorph/X = firer
 		smoke_system.strength = X.xeno_caste.bomb_strength
 		if(fixed_spread_range == -1)
-			range = max(2, range + min(X.upgrade_as_number(), 4))
+			range = max(2, range + min(X.upgrade_as_number(), 3))
 		else
 			range = fixed_spread_range
 	smoke_system.set_up(range, T)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2091,7 +2091,7 @@ datum/ammo/bullet/revolver/tp44
 		var/mob/living/carbon/xenomorph/X = firer
 		smoke_system.strength = X.xeno_caste.bomb_strength
 		if(fixed_spread_range == -1)
-			range = max(2, range + X.upgrade_as_number())
+			range = max(2, range + min(X.upgrade_as_number(), 4))
 		else
 			range = fixed_spread_range
 	smoke_system.set_up(range, T)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Primo isn't supposed to scale stats, however boiler gas clouds scale with maturity, leading to monstrously huge clouds when Primo. Fixes this, seriously, ancient clouds are already massive.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Big stinky cloud go home.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Boiler gas cloud no longer scales in size past Ancient
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
