### PR TITLE
burst fire rebalances

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -80,7 +80,7 @@
 
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.1 SECONDS
-	extra_delay = 0.4 SECONDS
+	extra_delay = 0.3 SECONDS
 	accuracy_mult = 1.10
 	scatter = 2
 	burst_amount = 4
@@ -151,7 +151,7 @@
 
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.15 SECONDS
-	extra_delay = 0.25 SECONDS
+	extra_delay = 0.1 SECONDS
 	accuracy_mult = 1.15
 	scatter = 0
 	wield_delay = 0.7 SECONDS
@@ -1235,7 +1235,7 @@
 	aim_fire_delay = 0.15 SECONDS
 
 	fire_delay = 0.25 SECONDS
-	extra_delay = 0.4 SECONDS
+	extra_delay = 0.35 SECONDS
 	burst_amount = 3
 	burst_delay = 0.05 SECONDS
 	accuracy_mult_unwielded = 0.5

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -80,6 +80,7 @@
 
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.1 SECONDS
+	extra_delay = 0.4 SECONDS
 	accuracy_mult = 1.10
 	scatter = 2
 	burst_amount = 4
@@ -150,6 +151,7 @@
 
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.15 SECONDS
+	extra_delay = 0.35 SECONDS
 	accuracy_mult = 1.15
 	scatter = 0
 	wield_delay = 0.7 SECONDS
@@ -1233,6 +1235,7 @@
 	aim_fire_delay = 0.15 SECONDS
 
 	fire_delay = 0.25 SECONDS
+	extra_delay = 0.4 SECONDS
 	burst_amount = 3
 	burst_delay = 0.05 SECONDS
 	accuracy_mult_unwielded = 0.5

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -151,7 +151,7 @@
 
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.15 SECONDS
-	extra_delay = 0.35 SECONDS
+	extra_delay = 0.25 SECONDS
 	accuracy_mult = 1.15
 	scatter = 0
 	wield_delay = 0.7 SECONDS


### PR DESCRIPTION
## About The Pull Request

T18, T12, and Tx11 burst firerates have all been nerfed with extra_delay.

Because someone thought it was a great idea to merge MJP's fuckin batshit T18 and TX11 buff that gave them fucking 250 and 400 dps respectively. 

## Why It's Good For The Game

Let me tell y'all a thing or two about powercreep, yeah?

Let's say, hypothetically, someone buffs two specific guns to have double or triple the DPS of every other gun.
Let's say, hypothetically, that they take over the meta because they have double/triple the DPS of every other gun.
Let's say, hypothetically, insanely powerful shit appears on the other side and is justified by the existence of these two guns.
Let's say, hypothetically, every other gun in the same weight class can no longer keep up as everything gets stronger around them and they can no longer compete.

The moral of this story?
Fuck you, Hyper, you smell. Why the fuck did you merge #9278, what is wrong with you?

Anyways, here's some numbers for you nerds.

Tx11 burst delay is 0.05, shoots three bullets. With zero extra delay and 20 damage bullet, that's 400 DPS.
With 0.35 extra delay, we get 120 dps. 

T12 goes from 166.66... DPS to 136.36... with the addition of 0.1 extra delay

T18 goes from 250 DPS to 142~ with the addition of 0.3 extra delay
## Changelog
:cl:
balance: T18, T12, and Tx11 burst firerates have all been nerfed.
/:cl: