### PR TITLE
Nerfs Sentinel's neurotoxin spit

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1722,12 +1722,11 @@ datum/ammo/bullet/revolver/tp44
 	max_range = 10
 	accuracy_var_low = 3
 	accuracy_var_high = 3
-	damage = 40
+	damage = 30
 	stagger_stacks = 1.1
-	slowdown_stacks = 1.5
 	smoke_strength = 0.5
 	smoke_range = 0
-	reagent_transfer_amount = 1.5
+	reagent_transfer_amount = 2.5
 
 ///Set up the list of reagents the spit transfers upon impact
 /datum/ammo/xeno/toxin/proc/set_reagents()
@@ -1791,15 +1790,15 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/xeno/toxin/upgrade1
 	smoke_strength = 0.6
-	reagent_transfer_amount = 2
+	reagent_transfer_amount = 3
 
 /datum/ammo/xeno/toxin/upgrade2
 	smoke_strength = 0.7
-	reagent_transfer_amount = 2.5
+	reagent_transfer_amount = 3.5
 
 /datum/ammo/xeno/toxin/upgrade3
 	smoke_strength = 0.75
-	reagent_transfer_amount = 3
+	reagent_transfer_amount = 4
 
 
 /datum/ammo/xeno/toxin/heavy //Praetorian

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1727,7 +1727,7 @@ datum/ammo/bullet/revolver/tp44
 	slowdown_stacks = 1.5
 	smoke_strength = 0.5
 	smoke_range = 0
-	reagent_transfer_amount = 4
+	reagent_transfer_amount = 1.5
 
 ///Set up the list of reagents the spit transfers upon impact
 /datum/ammo/xeno/toxin/proc/set_reagents()
@@ -1791,15 +1791,15 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/xeno/toxin/upgrade1
 	smoke_strength = 0.6
-	reagent_transfer_amount = 5
+	reagent_transfer_amount = 2
 
 /datum/ammo/xeno/toxin/upgrade2
 	smoke_strength = 0.7
-	reagent_transfer_amount = 6
+	reagent_transfer_amount = 2.5
 
 /datum/ammo/xeno/toxin/upgrade3
 	smoke_strength = 0.75
-	reagent_transfer_amount = 6.5
+	reagent_transfer_amount = 3
 
 
 /datum/ammo/xeno/toxin/heavy //Praetorian


### PR DESCRIPTION
## About The Pull Request
Per title. List of changes:
- Reagent transfer reduced from 4 > 5 > 6 > 6.5 to 2.5 > 3 > 3.5 > 4.
- On-Hit stamina damage reduced from 40 > 30.
- Slowdown removed from direct hits.

## Why It's Good For The Game
Sentinel's neurospit has been really overwhelming due to its powercreeped stats. This PR aims to amend that.

## Changelog
:cl: Lewdcifer
balance: Sentinel neurospit nerfs. Reagent transfer 2.5 > 3 > 3.5 > 4; on-hit stamina damage 40 > 30; slowdown removed.
/:cl:
