### PR TITLE
Incendiary Slugs Now Pierce Mobs

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -684,6 +684,7 @@ datum/ammo/bullet/revolver/tp44
 	damage = 70
 	penetration = 15
 	sundering = 2
+	on_pierce_multiplier = 0.75
 	bullet_color = COLOR_TAN_ORANGE
 
 /datum/ammo/bullet/shotgun/incendiary/on_hit_mob(mob/M, obj/projectile/P)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -679,7 +679,7 @@ datum/ammo/bullet/revolver/tp44
 	handful_icon_state = "incendiary slug"
 	hud_state = "shotgun_fire"
 	damage_type = BRUTE
-	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_INCENDIARY|AMMO_SUNDERING
+	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_INCENDIARY|AMMO_SUNDERING|AMMO_PASS_THROUGH_MOVABLE
 	max_range = 15
 	damage = 70
 	penetration = 15

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -687,7 +687,7 @@ datum/ammo/bullet/revolver/tp44
 	bullet_color = COLOR_TAN_ORANGE
 
 /datum/ammo/bullet/shotgun/incendiary/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, shake = 0, knockback = 2, slowdown = 1)
+	staggerstun(M, P, shake = 0, knockback = 2)
 
 /datum/ammo/bullet/shotgun/flechette
 	name = "shotgun flechette shell"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Incendiary slugs now pierce mobs (pierce mult of 0.75).  Slowdown removed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I want to ensure everyone, marines AND xenos suffer. One person should not be subject to the intense pain that is being lit ablaze and dealt medium-high damage. No. Everyone in the shooters wake should feel this pain. The ammo would also be a sufficient enough answer to the great equalizer known as "surround that motherfucker and keep him DOWN" (otherwise known as ganking or stunlocking).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Incendiary slugs now pierce mobs (75% pierce multiplier), leaving a trail of fire in its wake. 
balance: Removes slowdown from incendiary slugs (I would be lying if I said I was high when I added that)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
