### PR TITLE
Praetorian, Acid Splash replaced with Acid Gloom.

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -275,6 +275,14 @@
 	color = "#86B028" //Mostly green?
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_ACID|SMOKE_GASP|SMOKE_COUGH|SMOKE_HUGGER_PACIFY
 
+//Praetorian Gloom smoke
+/obj/effect/particle_effect/smoke/xeno/burn/gloom
+	lifetime = 5
+	alpha = 60
+	opacity = FALSE
+	color = "#5ae248" //Mostly green?
+	smoke_traits = SMOKE_XENO|SMOKE_XENO_ACID|SMOKE_GASP|SMOKE_COUGH|SMOKE_HUGGER_PACIFY
+
 //Xeno light acid smoke.for acid huggers
 /obj/effect/particle_effect/smoke/xeno/burn/light
 	lifetime = 4 //Lasts for less time
@@ -351,6 +359,9 @@ datum/effect_system/smoke_spread/tactical
 
 /datum/effect_system/smoke_spread/xeno/acid
 	smoke_type = /obj/effect/particle_effect/smoke/xeno/burn
+
+/datum/effect_system/smoke_spread/xeno/acid/gloom
+	smoke_type = /obj/effect/particle_effect/smoke/xeno/burn/gloom
 
 /datum/effect_system/smoke_spread/xeno/acid/light
 	smoke_type = /obj/effect/particle_effect/smoke/xeno/burn/light

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -34,7 +34,7 @@
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.3 SECONDS
-	spit_types = list(/datum/ammo/xeno/toxin/heavy, /datum/ammo/xeno/acid/heavy)
+	spit_types = list(/datum/ammo/xeno/toxin/heavy, /datum/ammo/xeno/toxin/gloom)
 
 	acid_spray_duration = 10 SECONDS
 	acid_spray_range = 5
@@ -85,7 +85,7 @@
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.2 SECONDS
-	spit_types = list(/datum/ammo/xeno/toxin/heavy/upgrade1, /datum/ammo/xeno/acid/heavy)
+	spit_types = list(/datum/ammo/xeno/toxin/heavy/upgrade1, /datum/ammo/xeno/toxin/gloom/upgrade1)
 
 	acid_spray_damage_on_hit = 39
 	acid_spray_structure_damage = 53
@@ -119,7 +119,7 @@
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.1 SECONDS
-	spit_types = list(/datum/ammo/xeno/toxin/heavy/upgrade2, /datum/ammo/xeno/acid/heavy)
+	spit_types = list(/datum/ammo/xeno/toxin/heavy/upgrade2, /datum/ammo/xeno/toxin/gloom/upgrade2)
 
 	acid_spray_damage_on_hit = 43
 	acid_spray_structure_damage = 61
@@ -154,7 +154,7 @@
 
 	// *** Ranged Attack *** //
 	spit_delay = 1 SECONDS
-	spit_types = list(/datum/ammo/xeno/toxin/heavy/upgrade3, /datum/ammo/xeno/acid/heavy)
+	spit_types = list(/datum/ammo/xeno/toxin/heavy/upgrade3, /datum/ammo/xeno/toxin/gloom/upgrade3)
 
 	acid_spray_damage_on_hit = 47
 	acid_spray_structure_damage = 69
@@ -186,7 +186,7 @@
 
 	// *** Ranged Attack *** //
 	spit_delay = 1 SECONDS
-	spit_types = list(/datum/ammo/xeno/toxin/heavy/upgrade3, /datum/ammo/xeno/acid/heavy)
+	spit_types = list(/datum/ammo/xeno/toxin/heavy/upgrade3, /datum/ammo/xeno/toxin/gloom/upgrade3)
 
 	acid_spray_damage_on_hit = 47
 	acid_spray_structure_damage = 69

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1927,26 +1927,26 @@ datum/ammo/bullet/revolver/tp44
 	name = "acid gloom"
 	icon_state = "xeno_acid"
 	flags_ammo_behavior = AMMO_XENO|AMMO_EXPLOSIVE|AMMO_SKIPS_ALIENS
-	added_spit_delay = 0.5
+	added_spit_delay = 1
 	spit_cost = 80
-	damage = 10.5
+	damage = 12
 	damage_type = BURN
 	bullet_color = COLOR_LIME
 	reagent_transfer_amount = 0
-	smoke_strength = 0.45
+	smoke_strength = 0.55
 	smoke_range = 0
 
 /datum/ammo/xeno/toxin/gloom/set_smoke()
 	smoke_system = new /datum/effect_system/smoke_spread/xeno/acid/gloom()
 
 /datum/ammo/xeno/toxin/gloom/upgrade1
-	smoke_strength = 0.50
+	smoke_strength = 0.60
 
 /datum/ammo/xeno/toxin/gloom/upgrade2
-	smoke_strength = 0.55
+	smoke_strength = 0.65
 
 /datum/ammo/xeno/toxin/gloom/upgrade3
-	smoke_strength = 0.60
+	smoke_strength = 0.70
 
 
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1927,26 +1927,26 @@ datum/ammo/bullet/revolver/tp44
 	name = "acid gloom"
 	icon_state = "xeno_acid"
 	flags_ammo_behavior = AMMO_XENO|AMMO_EXPLOSIVE|AMMO_SKIPS_ALIENS
-	added_spit_delay = 1
-	spit_cost = 100
-	damage = 25
+	added_spit_delay = 0.5
+	spit_cost = 80
+	damage = 10.5
 	damage_type = BURN
 	bullet_color = COLOR_LIME
 	reagent_transfer_amount = 0
-	smoke_strength = 0.4
+	smoke_strength = 0.45
 	smoke_range = 0
 
 /datum/ammo/xeno/toxin/gloom/set_smoke()
 	smoke_system = new /datum/effect_system/smoke_spread/xeno/acid/gloom()
 
 /datum/ammo/xeno/toxin/gloom/upgrade1
-	smoke_strength = 0.45
+	smoke_strength = 0.50
 
 /datum/ammo/xeno/toxin/gloom/upgrade2
-	smoke_strength = 0.5
+	smoke_strength = 0.55
 
 /datum/ammo/xeno/toxin/gloom/upgrade3
-	smoke_strength = 0.55
+	smoke_strength = 0.60
 
 
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1923,11 +1923,34 @@ datum/ammo/bullet/revolver/tp44
 	damage = 20
 	flags_ammo_behavior = AMMO_XENO|AMMO_SKIPS_ALIENS
 
-/datum/ammo/xeno/acid/heavy
-	name = "acid splash"
-	added_spit_delay = 2
-	spit_cost = 70
-	damage = 30
+/datum/ammo/xeno/toxin/gloom
+	name = "acid gloom"
+	icon_state = "xeno_acid"
+	flags_ammo_behavior = AMMO_XENO|AMMO_EXPLOSIVE|AMMO_SKIPS_ALIENS
+	added_spit_delay = 1
+	spit_cost = 100
+	damage = 25
+	damage_type = BURN
+	bullet_color = COLOR_LIME
+	reagent_transfer_amount = 0
+	smoke_strength = 0.4
+	smoke_range = 0
+
+/datum/ammo/xeno/toxin/gloom/set_smoke()
+	smoke_system = new /datum/effect_system/smoke_spread/xeno/acid/gloom()
+
+/datum/ammo/xeno/toxin/gloom/upgrade1
+	smoke_strength = 0.45
+
+/datum/ammo/xeno/toxin/gloom/upgrade2
+	smoke_strength = 0.5
+
+/datum/ammo/xeno/toxin/gloom/upgrade3
+	smoke_strength = 0.55
+
+
+
+
 
 /datum/ammo/xeno/acid/heavy/turret
 	damage = 20


### PR DESCRIPTION
## About The Pull Request

Replaces the boring ability Acid splash with Acid gloom.

## Why It's Good For The Game

Acid splash was the same stats as spitter except the puddle did 14 damage not taking acid armor into account meaning it probably did around 3-4 dmg a tick if someone stood on it, making it a very useless very BORING ability barely useful in sieges not befitting of a T3. 

Acid gloom adds an in-between of acid/light and acid/burn which makes Praetorian more focused towards area denial whilst not making it overpowered, does include clips/screenshot

## Changelog
:cl:
add: replacement ability for praetorian Acid Gloom.
/:cl:

![image](https://user-images.githubusercontent.com/64131993/156101644-744b6919-2be4-4dab-ac7b-e772ce6994e4.png)
Edit: fine tuned after extensive testing via local still needs tm testing

clips

How it looks

https://user-images.githubusercontent.com/64131993/155979880-3169116a-7d15-4649-a6dc-0a42b386f911.mp4



4 shots against a marine with heavy assault and Mimir 1's on helmet and chest which adds up to 76 acid armor

![with mimi1](https://user-images.githubusercontent.com/64131993/156103050-0c92ee7c-da98-4bfe-86a8-f4735164a873.png)


https://user-images.githubusercontent.com/64131993/156103099-c1b1aacd-124b-4e0e-9c0d-ec0a7de31ce2.mp4

Without Mimir same test
![no mimirs](https://user-images.githubusercontent.com/64131993/156103114-dd710032-ff23-4279-a315-f5ef82435ec2.png)


https://user-images.githubusercontent.com/64131993/156103169-4037e769-896d-4384-9900-a0eead6dd767.mp4






