### PR TITLE
Better snow digging

### DIFF
--- a/code/game/objects/items/stacks/snow.dm
+++ b/code/game/objects/items/stacks/snow.dm
@@ -64,6 +64,9 @@
 			if(T.slayer >= 3)
 				to_chat(user, "This ground is already full of snow.")
 				return
+			if(amount < 5)
+				to_chat(user, span_warning("You need 5 piles of snow to cover the ground."))
+				return
 			to_chat(user, "You start putting some snow back on the ground.")
 			if(!do_after(user, 15, FALSE, target, BUSY_ICON_BUILD))
 				return
@@ -84,7 +87,7 @@
 		return
 
 	if(amount < 5)
-		to_chat(user, span_warning("You need 5 layers of snow to build a barricade."))
+		to_chat(user, span_warning("You need 5 piles of snow to build a barricade."))
 		return
 
 	//Using same safeties as other constructions
@@ -112,4 +115,4 @@
 	user.visible_message(span_notice("[user] assembles a snow barricade."),
 	span_notice("You assemble a snow barricade."))
 	SB.setDir(user.dir)
-	use(3)
+	use(5)

--- a/code/game/objects/items/stacks/snow.dm
+++ b/code/game/objects/items/stacks/snow.dm
@@ -72,7 +72,7 @@
 			to_chat(user, "You put a new snow layer on the ground.")
 			T.slayer += 1
 			T.update_icon(TRUE, FALSE)
-			use(1)
+			use(5)
 
 /obj/item/stack/snow/attack_self(mob/user)
 	var/turf/T = get_turf(user)
@@ -83,8 +83,8 @@
 	if(user.do_actions)
 		return
 
-	if(amount < 3)
-		to_chat(user, span_warning("You need 3 layers of snow to build a barricade."))
+	if(amount < 5)
+		to_chat(user, span_warning("You need 5 layers of snow to build a barricade."))
 		return
 
 	//Using same safeties as other constructions
@@ -102,7 +102,7 @@
 	span_notice("You start assembling a snow barricade."))
 	if(!do_after(user, 20, TRUE, src, BUSY_ICON_BUILD))
 		return
-	if(amount < 3)
+	if(amount < 5)
 		return
 	for(var/obj/O in user.loc) //Objects, we don't care about mobs. Turfs are checked elsewhere
 		if(O.density)

--- a/code/game/objects/items/tools/shovel_tools.dm
+++ b/code/game/objects/items/tools/shovel_tools.dm
@@ -84,7 +84,6 @@
 					var/turf/open/floor/plating/ground/snow/ST = T
 					if(!ST.slayer)
 						return
-					transf_amt = min(ST.slayer, dirt_amt_per_dig)
 					ST.slayer -= 1
 					ST.update_icon(1,0)
 					to_chat(user, span_notice("You dig up some snow."))

--- a/code/game/objects/items/tools/shovel_tools.dm
+++ b/code/game/objects/items/tools/shovel_tools.dm
@@ -85,7 +85,7 @@
 					if(!ST.slayer)
 						return
 					transf_amt = min(ST.slayer, dirt_amt_per_dig)
-					ST.slayer -= transf_amt
+					ST.slayer -= 1
 					ST.update_icon(1,0)
 					to_chat(user, span_notice("You dig up some snow."))
 				else

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -303,7 +303,7 @@
 	barricade_type = "snow"
 	max_integrity = 75
 	stack_type = /obj/item/stack/snow
-	stack_amount = 3
+	stack_amount = 5
 	destroyed_stack_amount = 0
 	can_wire = FALSE
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Right now every other diggable tile in game can give you an infinite amount of dirt to fill your sandbags with. However on the ice planets you have to dig 5 snow layers to make one sandbag cade (and often times most snow is shallow). This makes it easier and less annoying to fill sandbags on ice planets while making sure there aren't any snow duplication silliness. Snow cades now also require 5 snow as part of this.

## Why It's Good For The Game

Right now every other diggable tile in game can give you an infinite amount of dirt to fill your sandbags with. However on the ice planets you have to dig 5 snow layers to make one sandbag cade (and often times most snow is shallow). This makes it easier and less annoying to fill sandbags on ice planets while making sure there aren't any snow duplication silliness. Snow cades now also require 5 snow as part of this.

## Changelog
:cl:
balance: Digging up snow now gives a 5 stack of snow like all other dig tiles, snow cades now also need five to be built.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
