### PR TITLE
Fixes footsteps

### DIFF
--- a/code/datums/components/footstep.dm
+++ b/code/datums/components/footstep.dm
@@ -77,7 +77,7 @@
 /datum/component/footstep/proc/play_humanstep()
 	SIGNAL_HANDLER
 	var/mob/living/carbon/human/H = parent
-	if (!CHECK_MULTIPLE_BITFIELDS(H.flags_pass, HOVERING))//We don't make step sounds when flying
+	if(CHECK_MULTIPLE_BITFIELDS(H.flags_pass, HOVERING))//We don't make step sounds when flying
 		return
 	var/turf/open/T = prepare_step()
 	if(!T)
@@ -88,7 +88,7 @@
 			TRUE,
 			GLOB.barefootstep[FOOTSTEP_RESIN][3] + e_range)
 		return
-	if(H.shoes) //are we wearing shoes 
+	if(H.shoes) //are we wearing shoes
 		playsound(T, pick(GLOB.shoefootstep[T.shoefootstep][1]),
 			GLOB.shoefootstep[T.shoefootstep][2] * volume,
 			TRUE,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When you walk you're supposed to hear footsteps as a marine (or monkey) but it's currently broken so you don't hear anything. This PR corrects the error so you can hear footsteps like you're supposed to.

## Why It's Good For The Game

Fixes good, also I was asked to fix this error so there's *somebody* out there who wants to hear the sounds of feet slapping the ground.
 
## Changelog
:cl:
fix: You can now make footsteps again as a marine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
