### PR TITLE
Gives the SL the compass

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -710,7 +710,7 @@ GLOBAL_LIST_INIT(loadout_role_essential_set, list(
 		/obj/item/explosive/plastique = 1,
 		/obj/item/beacon/supply_beacon = 2,
 		/obj/item/whistle = 1,
-		/obj/item/radio = 1,
+		/obj/item/compass = 1,
 		/obj/item/binoculars/tactical = 1,
 		/obj/item/pinpointer/pool = 1,
 		/obj/item/clothing/glasses/hud/health = 1,


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/TerraGov-Marine-Corps/pull/9684 removes squad leader radio from vendor but not essentials. Elsa's reasoning is that no one uses it, therefore I trust that removing it from the essential is also wise (I have also not seen anyone use it, if you have please tell me). However the main point of this PR is giving the SL a compass as part of their essentials. Yes compasses are free but by making it part of the essentials it will be brought more to their attention.

## Why It's Good For The Game

The compass gives coordinates (the type you use for a drop pod) and is a mostly unused item. Putting it directly in the hands of  SLs makes it a more known tool and allows SLs to easily give coordinates to those wishing to drop pod right into combat.

## Changelog
:cl:
balance: replaces SL essentials kit radio with a compass
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
