### PR TITLE
Fixes the SL Xenonauten helmet using the Jaeger sprite

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -103,7 +103,7 @@
 	item_state = "tyr_head_a"
 	soft_armor = list("melee" = 15, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 10, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 10)
 	slot = ATTACHMENT_SLOT_HEAD_MODULE
-	variants_by_parent_type = list(/obj/item/clothing/head/modular/marine/m10x = "tyr_head_xn")
+	variants_by_parent_type = list(/obj/item/clothing/head/modular/marine/m10x = "tyr_head_xn", /obj/item/clothing/head/modular/marine/m10x/leader = "tyr_head_xn")
 
 /**
  * Environment protecttion module
@@ -154,7 +154,7 @@
 	soft_armor = list("bio" = 40, "rad" = 50, "acid" = 30)
 	slowdown = 0
 	slot = ATTACHMENT_SLOT_HEAD_MODULE
-	variants_by_parent_type = list(/obj/item/clothing/head/modular/marine/m10x = "mimir_head_xn")
+	variants_by_parent_type = list(/obj/item/clothing/head/modular/marine/m10x = "mimir_head_xn", /obj/item/clothing/head/modular/marine/m10x/leader = "mimir_head_xn")
 
 /obj/item/armor_module/module/mimir_environment_protection/mimir_helmet/mark1 //gas protection
 	name = "Mark 1 Mimir Environmental Helmet System"


### PR DESCRIPTION
## About The Pull Request

Right now the SL helmet uses the Jaeger sprite for helmet modules. This PR fixes that, using Xenonauten sprites.
![SL Helmet Fix](https://user-images.githubusercontent.com/95723150/156934677-d6936d60-cbfe-42b3-b9f2-f5c6fae2ceb3.png)
Current(Left) Fixed(Right)

## Why It's Good For The Game

Bug fixes good.

## Changelog
:cl:
fix: Squad Leader helmets now use the proper Xenonauten sprites.
/:cl:

**Pro tip: don't forget to atomize**