### PR TITLE
Resin Turrets Same Price as Acid

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -206,7 +206,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	name = "Sticky resin turret"
 	desc = "Places a sticky spit spitting resin turret under you. Must be at least 6 tiles away from other turrets, not near fog and on a weeded area."
 	icon = "resinturret"
-	psypoint_cost = 50
+	psypoint_cost = XENO_TURRET_PRICE
 	turret_type = /obj/structure/xeno/xeno_turret/sticky
 
 /datum/hive_upgrade/xenos


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title explains it
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Resin Turrets can currently be spammed out and are especially egregious at lower population levels when it takes an entire marine push many minutes just to push past 1-2 of these turrets. They slow you down to ridiculous speeds and allow you to get warrior/shrike/crusher displaced extremely easily for a cheap cost. You can also double up or triple up on them in the same area which will outright kill a marine if he gets stunned into them. This is about the same effect as an acid turret, but these actually deplete stamina. Therefore, I believe that these turrets should be the same price as acid turrets which is 100. Currently double resin turrets current price, but they are extremely effective. They can help xenos take out jetpack marines more effectively than acid can and they are very useful for chokepoints. For example, here are three images where lowpop xenos just spammed them to great effect. Marines got all the way to silo and crumbled due to 5 in the same area with shrike and warrior using them to kill marines.


![resin turrets](https://user-images.githubusercontent.com/77871802/156986062-57e9f21f-587d-46d7-bedc-1a1519d52df2.PNG)

![resin](https://user-images.githubusercontent.com/77871802/156986074-fd62e310-f138-49ee-bf9f-fa77b3eff21a.PNG)

![res](https://user-images.githubusercontent.com/77871802/156986078-6ce86671-8680-4054-837b-05e74ffc7dce.PNG)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Made resin turrets 100 psypoints just like acid turrets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
