### PR TITLE
Remove acid gas and plasma cutters in Barrenquilla

### DIFF
--- a/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
+++ b/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
@@ -516,7 +516,6 @@
 /turf/open/lavaland/basalt,
 /area/bigredv2/outside/c)
 "da" = (
-/obj/item/tool/pickaxe/plasmacutter,
 /turf/open/lavaland/basalt,
 /area/bigredv2/caves/southwest)
 "db" = (
@@ -952,10 +951,6 @@
 /area/barren/civilian)
 "fi" = (
 /obj/item/organ/xenos/eggsac,
-/obj/effect/particle_effect/smoke/xeno/burn{
-	lifetime = 99999999
-	},
-/obj/effect/xenomorph/acid,
 /turf/open/lavaland/basalt,
 /area/bigredv2/caves/south)
 "fl" = (
@@ -1188,7 +1183,6 @@
 /turf/open/floor/tile/dark2,
 /area/barren/engie/engine)
 "gs" = (
-/obj/item/tool/pickaxe/plasmacutter,
 /turf/open/lavaland/basalt,
 /area/bigredv2/outside/n)
 "gt" = (
@@ -1753,9 +1747,6 @@
 /area/bigredv2/caves/south)
 "jA" = (
 /obj/item/organ/xenos/acidgland,
-/obj/effect/particle_effect/smoke/xeno/burn{
-	lifetime = 99999999
-	},
 /turf/open/lavaland/basalt,
 /area/bigredv2/caves/southwest)
 "jB" = (
@@ -2449,7 +2440,6 @@
 	},
 /area/barren/civilian)
 "nJ" = (
-/obj/item/tool/pickaxe/plasmacutter,
 /turf/open/lavaland/basalt,
 /area/bigredv2/caves/south)
 "nK" = (
@@ -2660,9 +2650,6 @@
 	},
 /area/bigredv2/outside/c)
 "oT" = (
-/obj/effect/particle_effect/smoke/xeno/burn{
-	lifetime = 99999999
-	},
 /turf/open/lavaland/basalt,
 /area/bigredv2/caves/south)
 "oU" = (
@@ -4202,10 +4189,6 @@
 /area/barren/misc/genstorage)
 "xX" = (
 /obj/item/organ/xenos/acidgland,
-/obj/effect/particle_effect/smoke/xeno/burn{
-	lifetime = 99999999
-	},
-/obj/effect/xenomorph/acid,
 /turf/open/lavaland/basalt,
 /area/bigredv2/caves/south)
 "xY" = (
@@ -4459,9 +4442,6 @@
 /area/bigredv2/outside/general_offices)
 "zF" = (
 /obj/item/organ/xenos/acidgland,
-/obj/effect/particle_effect/smoke/xeno/burn{
-	lifetime = 99999999
-	},
 /turf/open/lavaland/basalt,
 /area/bigredv2/caves/southeast)
 "zH" = (
@@ -4882,7 +4862,6 @@
 /turf/open/floor/tile/vault,
 /area/barren/civilian)
 "Cg" = (
-/obj/item/tool/pickaxe/plasmacutter,
 /turf/open/floor/tile/dark2,
 /area/barren/misc/refinery)
 "Ci" = (
@@ -4904,10 +4883,6 @@
 /area/bigredv2/outside/c)
 "Cl" = (
 /obj/item/organ/xenos/eggsac,
-/obj/effect/particle_effect/smoke/xeno/burn{
-	lifetime = 99999999
-	},
-/obj/effect/xenomorph/acid,
 /turf/open/lavaland/basalt,
 /area/bigredv2/caves/southeast)
 "Cn" = (
@@ -6312,9 +6287,6 @@
 /area/barren/engie/engine)
 "Ks" = (
 /obj/item/organ/xenos/eggsac,
-/obj/effect/particle_effect/smoke/xeno/burn{
-	lifetime = 99999999
-	},
 /obj/effect/xenomorph/acid,
 /turf/open/lavaland/basalt,
 /area/bigredv2/caves/southwest)
@@ -6610,14 +6582,6 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/lavaland/basalt,
 /area/bigredv2/outside/w)
-"Mr" = (
-/obj/item/organ/xenos/hivenode,
-/obj/effect/particle_effect/smoke/xeno/burn{
-	lifetime = 99999999
-	},
-/obj/effect/xenomorph/acid,
-/turf/open/lavaland/basalt,
-/area/bigredv2/caves/south)
 "Mt" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/toolbox,
@@ -6870,10 +6834,6 @@
 /turf/open/floor,
 /area/barren/cave/lz1)
 "NX" = (
-/obj/effect/xenomorph/acid,
-/obj/effect/particle_effect/smoke/xeno/burn{
-	lifetime = 99999999
-	},
 /turf/open/lavaland/basalt,
 /area/bigredv2/caves/southeast)
 "NY" = (
@@ -7196,10 +7156,6 @@
 /area/barren/cave/lz1)
 "PZ" = (
 /obj/item/organ/xenos/acidgland,
-/obj/effect/particle_effect/smoke/xeno/burn{
-	lifetime = 99999999
-	},
-/obj/effect/xenomorph/acid,
 /turf/open/lavaland/basalt,
 /area/bigredv2/caves/southwest)
 "Qc" = (
@@ -7222,10 +7178,6 @@
 /area/barren/cave/lz1)
 "Qk" = (
 /obj/item/organ/xenos/hivenode,
-/obj/effect/particle_effect/smoke/xeno/burn{
-	lifetime = 99999999
-	},
-/obj/effect/xenomorph/acid,
 /turf/open/lavaland/basalt,
 /area/bigredv2/caves/southwest)
 "Qm" = (
@@ -7267,10 +7219,6 @@
 /turf/open/floor/tile/dark2,
 /area/barren/engie/engine)
 "Qx" = (
-/obj/effect/particle_effect/smoke/xeno/burn{
-	lifetime = 99999999
-	},
-/obj/effect/xenomorph/acid,
 /turf/open/lavaland/basalt,
 /area/bigredv2/caves/southwest)
 "Qy" = (
@@ -8332,10 +8280,6 @@
 /turf/open/floor/freezer,
 /area/barren/medical/research)
 "WY" = (
-/obj/effect/particle_effect/smoke/xeno/burn{
-	lifetime = 99999999
-	},
-/obj/effect/xenomorph/acid,
 /turf/open/lavaland/basalt,
 /area/bigredv2/caves/south)
 "Xa" = (
@@ -8587,10 +8531,6 @@
 /area/barren/civilian/cook)
 "YR" = (
 /obj/item/organ/xenos/plasmavessel,
-/obj/effect/particle_effect/smoke/xeno/burn{
-	lifetime = 99999999
-	},
-/obj/effect/xenomorph/acid,
 /turf/open/lavaland/basalt,
 /area/bigredv2/caves/southeast)
 "YS" = (
@@ -8667,11 +8607,7 @@
 /turf/open/floor/plating,
 /area/maintenance/dormitory)
 "Zm" = (
-/obj/effect/xenomorph/acid,
 /obj/item/organ/xenos/acidgland,
-/obj/effect/particle_effect/smoke/xeno/burn{
-	lifetime = 99999999
-	},
 /turf/open/lavaland/basalt,
 /area/bigredv2/caves/southeast)
 "Zn" = (
@@ -8688,9 +8624,6 @@
 /area/barren/security)
 "Zq" = (
 /obj/item/organ/xenos/eggsac,
-/obj/effect/particle_effect/smoke/xeno/burn{
-	lifetime = 99999999
-	},
 /turf/open/lavaland/basalt,
 /area/bigredv2/caves/south)
 "Zs" = (
@@ -8715,10 +8648,6 @@
 /area/bigredv2/outside/general_offices)
 "Zz" = (
 /obj/item/organ/xenos/acidgland,
-/obj/effect/particle_effect/smoke/xeno/burn{
-	lifetime = 99999999
-	},
-/obj/effect/xenomorph/acid,
 /turf/open/lavaland/basalt,
 /area/bigredv2/caves/southeast)
 "ZB" = (
@@ -26495,8 +26424,8 @@ Zd
 Zd
 Zg
 Zg
-xX
-Mr
+VJ
+ij
 Zg
 WF
 Zg


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Tivi orders Shiryu to do this else map gets remove from rotation, and Shiryu hasn't respond yet, so I'm doing the initative to do this ahead of him.

While I'm on it, no free plasma cutters. That's all.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: acid gas landmark in Barrenquilla
del: free plasma cutters in Barrenquilla
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
