### PR TITLE
Motorbike can now hold 2 jerry cans

### DIFF
--- a/code/modules/vehicles/motorbike.dm
+++ b/code/modules/vehicles/motorbike.dm
@@ -207,9 +207,15 @@
 	return ..()
 
 /obj/item/storage/internal/motorbike_pack
-	storage_slots = 4
+	storage_slots = 2
 	max_w_class = WEIGHT_CLASS_SMALL
 	max_storage_space = 8
+	bypass_w_limit = list(
+		/obj/item/reagent_containers/jerrycan,
+	)
+	can_hold = list(
+		/obj/item/reagent_containers/jerrycan,
+	)
 
 
 /obj/item/storage/internal/motorbike_pack/handle_mousedrop(mob/user, obj/over_object)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Have you ever need to refill your motorbike? I am assuming yes.

Well, have you ever want to just hold a jerry can on you on your free hand so that you can refill your motorbike? I am assuming no.

Did you also know that motorbike have storage? I am assuming that if you have ridden a motorbike, you will raise your eyebrow on this one.

This PR opens up the ability to refill your motorbike while being in planetside. This means that the motorbike's total fuel amount is 1400u fuel (motorbike's total fuel which is 1000u + 2 jerry cans, and one jerry can holds 200u fuel). That said, I reduce motorbike's storage in light of this (not that ANYONE use it). A marine CAN REALLY powergame by just dragging a fuel tank with them, totaling up to 2400u fuel tank, but that is at the risk of getting a spitter or marine blowing up the fuel tank. RISK IT FOR THE FUEL, BABY!

REMEMBER, fuel tank is limited in planetside, and motorbike drivers HAVE to plan out their trip if they want to endlessly refill. In gameplay loop, logistics is involved, and drivers must keep fuel tanks accounted for to not be short on tank.

Tivi, I know motorbike is your baby, so lets talk this out.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

expansion: Motorbike can now hold jerry can but no more than two jerry cans to enable driver to refill motorbike without hugging onto a jerry can with an empty hand
qol: Any motorbike drivers can now refill motorbike
balance: Reduce storage slot of motorbike by 2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
