### PR TITLE
Teleporter has max_integrity of 250, half of its health

### DIFF
--- a/code/game/objects/structures/teleporter.dm
+++ b/code/game/objects/structures/teleporter.dm
@@ -1,6 +1,7 @@
 #define TELEPORTING_COST 250
 /obj/machinery/deployable/teleporter
 	density = FALSE
+	max_integrity = 250
 	resistance_flags = XENO_DAMAGEABLE
 	idle_power_usage = 50
 	///List of all teleportable types
@@ -24,7 +25,7 @@
 	if(!COOLDOWN_CHECK(kit, teleport_cooldown))
 		to_chat(user, span_warning("The [src] is still recharging! It will be ready in [round(COOLDOWN_TIMELEFT(kit, teleport_cooldown) / 10)] seconds."))
 		return
-	
+
 	if(!kit.linked_teleporter)
 		to_chat(user, span_warning("The [src] is not linked to any other teleporter."))
 		return
@@ -32,23 +33,23 @@
 	if(!istype(kit.linked_teleporter.loc, /obj/machinery/deployable/teleporter))
 		to_chat(user, span_warning("The other teleporter is not deployed!"))
 		return
-	
+
 	var/obj/machinery/deployable/teleporter/deployed_linked_teleporter = kit.linked_teleporter.loc
 	var/obj/item/teleporter_kit/linked_kit = deployed_linked_teleporter.internal_item
 
 	if(deployed_linked_teleporter.z != z)
 		to_chat(user, span_warning("[src] and [deployed_linked_teleporter] are too far apart!"))
 		return
-	
+
 	if(!deployed_linked_teleporter.powered() && (!linked_kit.cell || linked_kit.cell.charge < TELEPORTING_COST))
 		to_chat(user, span_warning("[deployed_linked_teleporter] is not powered!"))
 		return
-	
+
 	var/list/atom/movable/teleporting = list()
 	for(var/atom/movable/thing in loc)
 		if(is_type_in_list(thing, teleportable_types) && !thing.anchored)
 			teleporting += thing
-	
+
 	if(!teleporting.len)
 		to_chat(user, span_warning("No teleportable content was detected on [src]!"))
 		return
@@ -63,7 +64,7 @@
 	update_icon()
 	if(deployed_linked_teleporter.powered())
 		deployed_linked_teleporter.use_power(TELEPORTING_COST * 200)
-	else	
+	else
 		linked_kit.cell.charge -= TELEPORTING_COST
 	deployed_linked_teleporter.update_icon()
 	for(var/atom/movable/thing_to_teleport AS in teleporting)
@@ -139,7 +140,7 @@
 /obj/item/teleporter_kit/Destroy()
 	linked_teleporter = null
 	QDEL_NULL(cell)
-	return ..()	
+	return ..()
 
 ///Link the two teleporters
 /obj/item/teleporter_kit/proc/set_linked_teleporter(obj/item/teleporter_kit/linked_teleporter)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Teleporter inherits max_integrity from objs.dm for a max_integrity of 500 (thank you, @Lumipharon). This is okay if it is in limited supply, but engineers can grab this for free in their engineer vendor AND get a plasma cutter. The current backpack selections that engineers can choose are a radiopack, a welderpack, and pair of teleporters.

Teleporter is reshaping TGMC's meta really fast, and letting teleporter have 500 max_integrity is too much for xenomorphs to deal with if their mission is to destroy the teleporter.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: novaepee and Lumipharon
balance: Engineer's teleporter has health of 250, half of what it used to have
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
