### PR TITLE
Fixed ALF autoburst delay

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1344,6 +1344,8 @@
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.1 SECONDS
 	extra_delay = 0.5 SECONDS
+	///Same delay as normal burst mode
+	autoburst_delay = 0.7 SECONDS
 	accuracy_mult = 1
 	scatter = 7
 	burst_amount = 4


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The ALF is currently firing faster on autoburst compared to normal burst fire (0.4 instead of 0.7), due to it's unusually high extra delay and how autoburst delay is calculated.

Sets autoburst delay to 0.7 so it's the same as normal burst fire. Dunno if that makes it terrible but this is a bug fix not a balance change so eh.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gun shooting considerably faster than it should do is not fun for beno.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The ALF machinecarbine no longer shoots abnormally fast on autoburst.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
