### PR TITLE
Give req a single free sidecar upgrade for motorbike

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -6900,6 +6900,10 @@
 	dir = 1
 	},
 /area/mainship/living/evacuation)
+"xb" = (
+/obj/item/sidecar,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "xd" = (
 /turf/open/floor/mainship/black{
 	dir = 1
@@ -24834,7 +24838,7 @@ gt
 gY
 gY
 iK
-gY
+xb
 sT
 yB
 jF

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -10217,6 +10217,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"Gn" = (
+/obj/item/sidecar,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "Go" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -48279,7 +48283,7 @@ kM
 kM
 kM
 Vq
-kM
+Gn
 kM
 kM
 CE

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -15506,6 +15506,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
+"oRD" = (
+/obj/item/sidecar,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "oRR" = (
 /obj/structure/cable,
 /obj/machinery/light{
@@ -64788,7 +64792,7 @@ iWe
 iWe
 iWe
 iWe
-iWe
+oRD
 bAG
 bIH
 tMR


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Tivi makes good content, but marines never buy this. They are too busy getting SADAR, B18, autosniper, AT guns, specialized ammo, and weapon systems instead of transport systems. Heck, if I see marines buying more motorbikes, I would be downright surprised. I beomce even more surprised when I see a motorbike sidecar since someone REALLY want this.

It is true that marines can buy the sidecar upgrade since they are given that option, but given the fact that marines have better options, the sidecar upgrade will not see the day of light. The frequency of choosing this item is further decreased since the only upgrade is having two people riding the motorbike. The driver must use two hands, and the rider one hand, meaning that one person is there for the ride.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Give req a single free sidecar upgrade for motorbike
balance: Give req a single free sidecar upgrade for motorbike
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
