### PR TITLE
Give a button outside of Tadpole when someone lockdowns tadpole from inside

### DIFF
--- a/_maps/shuttles/minidropship.dmm
+++ b/_maps/shuttles/minidropship.dmm
@@ -3,6 +3,11 @@
 /obj/structure/window/framed/mainship/spaceworthy{
 	icon_state = "col_window10"
 	},
+/obj/machinery/door_control{
+	dir = 1;
+	id = "minidropship_podlock";
+	name = "outer door-control"
+	},
 /turf/open/floor/mainship_hull,
 /area/shuttle/minidropship)
 "b" = (
@@ -22,7 +27,7 @@
 "j" = (
 /obj/machinery/door_control{
 	id = "minidropship_podlock";
-	name = "outer door-control"
+	name = "inner door-control"
 	},
 /turf/open/floor/mainship/orange{
 	dir = 5


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There is a way to lockdown tadpole and NOT let anyone bring up the shutters again unless you shoot your way through.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Seen it happen, and it's weird that marines have to shoot it down. Also, prevent griefing the tadpole.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Give a button outside of Tadpole when someone lockdowns tadpole from inside so that you can open tadpole's shutters from the outside.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
