### PR TITLE
Helmet QOL, specifically leader helmets.

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -705,6 +705,7 @@ GLOBAL_LIST_INIT(loadout_role_essential_set, list(
 		/obj/item/binoculars/tactical = 1,
 		/obj/item/pinpointer/pool = 1,
 		/obj/item/clothing/glasses/hud/health = 1,
+		/obj/item/clothing/head/modular/marine/m10x/leader = 1,
 	)
 ))
 

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -770,7 +770,6 @@
 	desc = "A set of light Xenonauten pattern armor, including an armor suit and helmet."
 	spawned_gear_list = list(
 		/obj/item/clothing/head/modular/marine/m10x,
-		/obj/item/clothing/head/modular/marine/m10x/heavy,
 		/obj/item/clothing/suit/modular/xenonauten/light,
 	)
 
@@ -778,7 +777,6 @@
 	desc = "A set of medium Xenonauten pattern armor, including an armor suit and helmet."
 	spawned_gear_list = list(
 		/obj/item/clothing/head/modular/marine/m10x,
-		/obj/item/clothing/head/modular/marine/m10x/heavy,
 		/obj/item/clothing/suit/modular/xenonauten,
 	)
 
@@ -786,23 +784,25 @@
 	desc = "A set of heavy Xenonauten pattern armor, including an armor suit and helmet."
 	spawned_gear_list = list(
 		/obj/item/clothing/head/modular/marine/m10x,
-		/obj/item/clothing/head/modular/marine/m10x/heavy,
 		/obj/item/clothing/suit/modular/xenonauten/heavy,
 	)
 
 /obj/effect/essentials_set/xenonauten_light/leader
+	desc = "A set of light Xenonauten pattern armor, including an armor suit and a fancier helmet."
 	spawned_gear_list = list(
 		/obj/item/clothing/head/modular/marine/m10x/leader,
 		/obj/item/clothing/suit/modular/xenonauten/light,
 	)
 
 /obj/effect/essentials_set/xenonauten_medium/leader
+	desc = "A set of medium Xenonauten pattern armor, including an armor suit and a fancier helmet."
 	spawned_gear_list = list(
 		/obj/item/clothing/head/modular/marine/m10x/leader,
 		/obj/item/clothing/suit/modular/xenonauten,
 	)
 
 /obj/effect/essentials_set/xenonauten_heavy/leader
+	desc = "A set of heavy Xenonauten pattern armor, including an armor suit and a fancier helmet."
 	spawned_gear_list = list(
 		/obj/item/clothing/head/modular/marine/m10x/leader,
 		/obj/item/clothing/suit/modular/xenonauten/heavy,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows SLs to save and get the leader class helmet from the loadout vendor.
Also removing the enclosed Xenonauten helmet from essentials kits and giving the leader armor essentials kit a description.

## Why It's Good For The Game

When you try to save a loadout with a leader helmet it will not give you the helmet, this fixes that.
The "Heavy" helmet is just a different sprite and just serves as clutter in the essentials kit (Don't worry you can still get it from surplus)
The description for leader armor sets just keeps it up to par with other armor essential sets.

## Changelog
:cl:
qol: Leader armor essential sets have have their own description now.
del: The enclosed helmet no longer comes with the Xenonauten essentials kit (check your surplus vendor to find it)
fix: SLs can now save their leader helmets in their loadouts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
