### PR TITLE
Tadpole Part 2: Bring Back Medbus

### DIFF
--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -425,22 +425,42 @@
 	name = "Flight surgeron medical equipment dispenser"
 	desc = "Dedicated for the surgeron with wings, this humble box contains a lot for its size."
 	products = list(
-		/obj/item/storage/pill_bottle/russian_red = 1,
-		/obj/item/reagent_containers/hypospray/autoinjector/sleeptoxin = 0,
-		/obj/item/reagent_containers/hypospray/autoinjector/combat = 0,
-		/obj/item/reagent_containers/hypospray/autoinjector/bicaridine = 0,
-		/obj/item/reagent_containers/hypospray/autoinjector/kelotane = 0,
-		/obj/item/reagent_containers/hypospray/autoinjector/dylovene = 0,
-		/obj/item/reagent_containers/hypospray/autoinjector/tricordrazine = 0,
-		/obj/item/reagent_containers/hypospray/autoinjector/tramadol = 0,
-		/obj/item/reagent_containers/hypospray/autoinjector/hypervene = 0,
-		/obj/item/reagent_containers/hypospray/autoinjector/inaprovaline = 0,
-		/obj/item/stack/medical/heal_pack/gauze = 2,
-		/obj/item/stack/medical/heal_pack/ointment = 2,
-		/obj/item/stack/medical/heal_pack/advanced/bruise_pack = 5,
-		/obj/item/stack/medical/heal_pack/advanced/burn_pack = 5,
-		/obj/item/healthanalyzer = 1,
-		/obj/item/stack/medical/splint = 1,
+		"Autoinjectors" = list(
+			/obj/item/reagent_containers/hypospray/autoinjector/combat = 1,
+			/obj/item/reagent_containers/hypospray/autoinjector/sleeptoxin = 2,
+			/obj/item/reagent_containers/hypospray/autoinjector/bicaridine = 1,
+			/obj/item/reagent_containers/hypospray/autoinjector/kelotane = 1,
+			/obj/item/reagent_containers/hypospray/autoinjector/dylovene = 1,
+			/obj/item/reagent_containers/hypospray/autoinjector/tricordrazine = 1,
+			/obj/item/reagent_containers/hypospray/autoinjector/tramadol = 1,
+			/obj/item/reagent_containers/hypospray/autoinjector/hypervene = 1,
+			/obj/item/reagent_containers/hypospray/autoinjector/inaprovaline = 1,
+			/obj/item/reagent_containers/hypospray/autoinjector/dexalinplus = 1,
+		),
+		"Reagent Bottles" = list(
+			/obj/item/reagent_containers/syringe = 10,
+			/obj/item/reagent_containers/glass/bottle/dylovene = 1,
+			/obj/item/reagent_containers/glass/bottle/bicaridine = 1,
+			/obj/item/reagent_containers/glass/bottle/inaprovaline = 1,
+			/obj/item/reagent_containers/glass/bottle/spaceacillin = 1,
+			/obj/item/reagent_containers/glass/bottle/peridaxon = 1,
+			/obj/item/reagent_containers/glass/bottle/kelotane = 1,
+			/obj/item/reagent_containers/glass/bottle/dexalin = 1,
+			/obj/item/reagent_containers/glass/bottle/tramadol = 1,
+			/obj/item/reagent_containers/glass/bottle/oxycodone = 1,
+			/obj/item/reagent_containers/glass/bottle/polyhexanide = 1,
+		),
+		"Heal Pack" = list(
+			/obj/item/stack/medical/heal_pack/gauze = 2,
+			/obj/item/stack/medical/heal_pack/ointment = 2,
+			/obj/item/stack/medical/heal_pack/advanced/bruise_pack = 5,
+			/obj/item/stack/medical/heal_pack/advanced/burn_pack = 5,
+			/obj/item/healthanalyzer = 1,
+			/obj/item/stack/medical/splint = 1,
+		),
+		"EMERGENCY USE!" = list(
+			/obj/item/storage/pill_bottle/russian_red = 1,
+		),
 	)
 
 /obj/machinery/vending/security


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Flight surgeron medical equipment dispenser is stock of reagent bottles and autoinjectors like its previous dispenser, the NanotrasenMed Plus.

Also, you can refill autoinjectors and reagent bottles. It does not need to be 0 to refill as my video demostrates.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This brings back the medbus to fully operational again. Good players that use medbus should not be punish for the sharable NanotrasenMed Plus that hinder the glory that is the medbus.

Previously, medbus players bring the NanotrasenMed Plus for surgery and healing. Many, if not all, the chems are used to help wounded marines. Since #9533, they can no longer do that. #9561 attempts to fix that, but it is not enough.

This is not going to buff marines any way, it is just bringing back to a tadpole's state for the better.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: restock the Flight surgeron medical equipment dispenser, that funny medical box in tadpole, to an inventory similar to the NanotrasenMed Plus so that medbus can rise again. Yes, you can refill.
balance: restock the Flight surgeron medical equipment dispenser, that funny medical box in tadpole, to an inventory similar to the NanotrasenMed Plus so that medbus can rise again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
