### PR TITLE
Give req a single free sidecar upgrade for motorbike round 2

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -543,6 +543,7 @@
 	req_one_access = list(ACCESS_MARINE_CARGO, ACCESS_MARINE_LOGISTICS)
 	products = list(
 		"Surplus Special Equipment" = list(
+			/obj/item/sidecar = 1,
 			/obj/item/beacon/supply_beacon = 1,
 			/obj/item/ammo_magazine/rifle/autosniper = 3,
 			/obj/item/ammo_magazine/rifle/tx8 = 3,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Tivi makes good content, but marines never buy this. They are too busy getting SADAR, B18, autosniper, AT guns, specialized ammo, and weapon systems instead of transport systems. Heck, if I see marines buying more motorbikes, I would be downright surprised. I beomce even more surprised when I see a motorbike sidecar since someone REALLY want this.

It is true that marines can buy the sidecar upgrade since they are given that option, but given the fact that marines have better options, the sidecar upgrade will not see the day of light. The frequency of choosing this item is further decreased since the only upgrade is having two people riding the motorbike.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Give req a single free sidecar upgrade for motorbike
balance: Give req a single free sidecar upgrade for motorbike
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
