### PR TITLE
AT gun nerf and removes IFF on it

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -675,7 +675,8 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	desc = "An unremovable set of long range scopes, very complex to properly range. Requires time to aim.."
 	icon_state = "sniperscope_invisible"
 	flags_attach_features = ATTACH_ACTIVATION
-	scope_delay = 4 SECONDS
+	scope_delay = 2 SECONDS
+	zoom_tile_offset = 7
 
 /obj/item/attachable/scope/unremovable/tl102
 	name = "TL-102 smart sight"

--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -234,7 +234,7 @@
 
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO)
 	actions_types = list(/datum/action/item_action/aim_mode)
-	aim_time = 4 SECONDS
+	aim_time = 6 SECONDS
 	reciever_flags = AMMO_RECIEVER_MAGAZINES|AMMO_RECIEVER_AUTO_EJECT
 	soft_armor = list("melee" = 60, "bullet" = 50, "laser" = 0, "energy" = 0, "bomb" = 80, "bio" = 100, "rad" = 0, "fire" = 0, "acid" = 0)
 

--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -230,7 +230,7 @@
 	attachable_allowed = list(/obj/item/attachable/scope/unremovable/standard_atgun)
 
 	flags_item = IS_DEPLOYABLE|TWOHANDED|DEPLOYED_NO_PICKUP|DEPLOY_ON_INITIALIZE
-	flags_gun_features = GUN_AMMO_COUNTER|GUN_DEPLOYED_FIRE_ONLY|GUN_WIELDED_FIRING_ONLY|GUN_IFF
+	flags_gun_features = GUN_AMMO_COUNTER|GUN_DEPLOYED_FIRE_ONLY|GUN_WIELDED_FIRING_ONLY
 
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO)
 	actions_types = list(/datum/action/item_action/aim_mode)

--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -243,7 +243,7 @@
 	fire_delay = 3 SECONDS
 	burst_amount = 1
 	undeploy_time = 2000 SECONDS
-	max_integrity = 800
+	max_integrity = 500
 	deployed_item = /obj/machinery/deployable/mounted/atgun
 
 /obj/machinery/deployable/mounted/atgun


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reduce max_integrity from 800 to 500.

Aim mode takes 6 seconds to do. 

Scope now takes 2 seconds to use.

Scope now 7 tiles instead of 11 tiles that it inherits.

Remove AT gun having IFF. Sleep deprivation is dangerous. Don't do it. Have 7+ hours.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The nerfs that xenomorph players have been waiting for.

It was either this PR or removing it from armament vendor since David asked me to remove it, but MJP and I got a plan.

Decrease range so that boiler can shoot it with ease, making AT gun less of SADAR lite with sniper scope. MJP agrees to reduce range since it has a sniper scope on it; 11 tiles, holy smokes. Due to a decreased timer on activating AT gun scope, it makes sense to decrease it range.

Now AT gun is weaker and susceptible to CQC. Slash it enough, and MAYBE you can break it!

I personally think that aim mode should take longer, but MJP approves this number.

This will help xenomorphs cope and seeth less against AT gun. Entire hive hates this gun.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: novaepee, MJP
balance: Aim mode on AT gun takes 6 seconds to do.
balance: Reduce AT gun's health to 500, originally 800.
balance: Scope on AT gun now takes 2 seconds to use.
balance: Scope on AT gun now 7 tiles instead of 11 tiles that it inherits.
fix: Remove AT gun having IFF.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
