### PR TITLE
Removes ballistic module slowdown

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -175,7 +175,7 @@
 */
 /obj/item/armor_module/module/ballistic_armor
 	name = "\improper Hod Accident Prevention Plating"
-	desc = "Designed for mounting on modular armor. A substantial amount of additional reflective ballistic armor plating designed to reduce the impact of friendly fire incidents, will lessen the affects of bullets and lasers. Will impact mobility."
+	desc = "Designed for mounting on modular armor. A substantial amount of additional reflective ballistic armor plating designed to reduce the impact of friendly fire incidents, will lessen the affects of bullets and lasers. Will not impact mobility."
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "mod_ff"
 	item_state = "mod_ff_a"

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -180,7 +180,7 @@
 	icon_state = "mod_ff"
 	item_state = "mod_ff_a"
 	soft_armor = list("melee" = 0, "bullet" = 40, "laser" = 40, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
-	slowdown = 0.2
+	slowdown = 0
 	slot = ATTACHMENT_SLOT_MODULE
 	variants_by_parent_type = list(/obj/item/clothing/suit/modular/xenonauten = "mod_ff_xn", /obj/item/clothing/suit/modular/xenonauten/light = "mod_ff_xn", /obj/item/clothing/suit/modular/xenonauten/heavy = "mod_ff_xn")
 


### PR DESCRIPTION
## About The Pull Request

Changes the ballistic module from 0.2 slowdown to 0.

## Why It's Good For The Game

Ballistic is a very straightforward module that's supposed to dampen damage from FF. It's still affected by armor penetration, shrapnel and fractures, and takes up your armor's module slot. It's rendered less useful due to the fact that it has a significant slowdown for 40 more bullet and laser armor. It should be more on par with Baldur's simplicity and something newer players can use without significant downside for not that impactful of an upside. It also has a cool sprite.

## Changelog
:cl: Slum Lord
balance: ballistic armor no longer slows you down
/:cl: