### PR TITLE
Jones Gets Sturdy

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -137,6 +137,7 @@
 	icon_state = "cat2"
 	var/mob/living/simple_animal/cat/cat
 	flags_equip_slot = ITEM_SLOT_HEAD
+	flags_armor_protection = HEAD
 	var/flags_armor_features = ARMOR_NO_DECAP
 	soft_armor = list("melee" = 25, "bullet" = 25, "laser" = 25, "energy" = 25, "bomb" = 10, "bio" = 5, "rad" = 0, "fire" = 50, "acid" = 50)
 

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -135,7 +135,6 @@
 	desc = "Kitty!!"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "cat2"
-	var/mob/living/simple_animal/cat/cat
 	flags_armor_features = ARMOR_NO_DECAP
 	soft_armor = list("melee" = 25, "bullet" = 25, "laser" = 25, "energy" = 25, "bomb" = 10, "bio" = 5, "rad" = 0, "fire" = 50, "acid" = 50)
 

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -137,7 +137,7 @@
 	icon_state = "cat2"
 	flags_armor_features = ARMOR_NO_DECAP
 	soft_armor = list("melee" = 25, "bullet" = 25, "laser" = 25, "energy" = 25, "bomb" = 10, "bio" = 5, "rad" = 0, "fire" = 50, "acid" = 50)
-
+	var/mob/living/simple_animal/cat/cat
 
 /obj/item/clothing/head/cat/Destroy()
 	if(cat)

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -121,7 +121,7 @@
 	if(H.l_hand && H.r_hand)
 		return
 
-	var/obj/item/cat/C = new
+	var/obj/item/clothing/head/cat/C = new
 	C.name = name
 	C.desc = desc
 	C.icon_state = initial(icon_state)
@@ -130,35 +130,33 @@
 	H.put_in_hands(C)
 
 
-/obj/item/cat
+/obj/item/clothing/head/cat
 	name = "Cat"
 	desc = "Kitty!!"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "cat2"
 	var/mob/living/simple_animal/cat/cat
-	flags_equip_slot = ITEM_SLOT_HEAD
-	flags_armor_protection = HEAD
-	var/flags_armor_features = ARMOR_NO_DECAP
+	flags_armor_features = ARMOR_NO_DECAP
 	soft_armor = list("melee" = 25, "bullet" = 25, "laser" = 25, "energy" = 25, "bomb" = 10, "bio" = 5, "rad" = 0, "fire" = 50, "acid" = 50)
 
 
-/obj/item/cat/Destroy()
+/obj/item/clothing/head/cat/Destroy()
 	if(cat)
 		cat.forceMove(get_turf(src))
 		cat = null
 	return ..()
 
 
-/obj/item/cat/throw_at(atom/target, range, speed, thrower, spin)
+/obj/item/clothing/head/cat/throw_at(atom/target, range, speed, thrower, spin)
 	qdel(src)
 
 
-/obj/item/cat/afterattack(atom/target, mob/user, has_proximity, click_parameters)
+/obj/item/clothing/head/cat/afterattack(atom/target, mob/user, has_proximity, click_parameters)
 	. = ..()
 	qdel(src)
 
 
-/obj/item/cat/dropped(mob/user)
+/obj/item/clothing/head/cat/dropped(mob/user)
 	. = ..()
 	if(loc == user)
 		return

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -137,6 +137,8 @@
 	icon_state = "cat2"
 	var/mob/living/simple_animal/cat/cat
 	flags_equip_slot = ITEM_SLOT_HEAD
+	var/flags_armor_features = ARMOR_NO_DECAP
+	soft_armor = list("melee" = 25, "bullet" = 25, "laser" = 25, "energy" = 25, "bomb" = 10, "bio" = 5, "rad" = 0, "fire" = 50, "acid" = 50)
 
 
 /obj/item/cat/Destroy()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives cat hats half the armor of FC beret and decap immunity.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The brave companions that oversee marines from above now get to join the fight themselves. This tactically vital improvement will both boost the morale of troops and utilization of our limited yet considerable feline forces. As a side effect this might also cause marines to protect cats harder and in the future may even inspire other quad-pedal companions to get inspired to be on the frontlines themselves.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Cat as helmets now provide decap immunity and half the protection of FC beret
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
