### PR TITLE
Tesla gun rebalance

### DIFF
--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -174,7 +174,7 @@
 			continue
 		source.beam(living, icon_state="lightning[rand(1,12)]", time = 3, maxdistance = zap_range + 2)
 		if(living.xeno_caste.caste_flags & CASTE_CAN_BE_GIVEN_PLASMA) //need 1 second more than the actual effect time
-			living.apply_status_effect(/datum/status_effect/noplasmaregen, 5 SECONDS/length(.))
-			living.apply_status_effect(/datum/status_effect/plasmadrain, 5 SECONDS/length(.))
+			living.apply_status_effect(/datum/status_effect/noplasmaregen, 3 SECONDS)
+			living.apply_status_effect(/datum/status_effect/plasmadrain, 3 SECONDS)
 		living.add_slowdown(2)
 		log_attack("[living] was zapped by [source]")

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -176,5 +176,5 @@
 		if(living.xeno_caste.caste_flags & CASTE_CAN_BE_GIVEN_PLASMA) //need 1 second more than the actual effect time
 			living.apply_status_effect(/datum/status_effect/noplasmaregen, 5 SECONDS/length(.))
 			living.apply_status_effect(/datum/status_effect/plasmadrain, 5 SECONDS/length(.))
-		living.adjust_stagger(0.75) //stacks for every zap
+		living.add_slowdown(2)
 		log_attack("[living] was zapped by [source]")

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -173,9 +173,8 @@
 		if(living in blacklistmobs)
 			continue
 		source.beam(living, icon_state="lightning[rand(1,12)]", time = 3, maxdistance = zap_range + 2)
-		if(living.xeno_caste.caste_flags & CASTE_CAN_BE_GIVEN_PLASMA)
-			living.apply_status_effect(/datum/status_effect/noplasmaregen, 10 SECONDS/length(.))
-			living.apply_status_effect(/datum/status_effect/plasmadrain, 10 SECONDS/length(.))
-		living.adjust_stagger(1)
-		living.add_slowdown(2)
+		if(living.xeno_caste.caste_flags & CASTE_CAN_BE_GIVEN_PLASMA) //need 1 second more than the actual effect time
+			living.apply_status_effect(/datum/status_effect/noplasmaregen, 5 SECONDS/length(.))
+			living.apply_status_effect(/datum/status_effect/plasmadrain, 5 SECONDS/length(.))
+		living.adjust_stagger(0.75) //stacks for every zap
 		log_attack("[living] was zapped by [source]")

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -202,7 +202,7 @@
 /datum/status_effect/plasmadrain/tick()
 	var/mob/living/carbon/xenomorph/xenoowner = owner
 	if(xenoowner.plasma_stored >= 0)
-		var/remove_plasma_amount = xenoowner.xeno_caste.plasma_max / 17
+		var/remove_plasma_amount = xenoowner.xeno_caste.plasma_max / 10
 		xenoowner.plasma_stored -= remove_plasma_amount
 		if(xenoowner.plasma_stored <= 0)
 			xenoowner.plasma_stored = 0

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1416,7 +1416,7 @@ datum/ammo/bullet/revolver/tp44
 	bullet_color = COLOR_TESLA_BLUE
 
 /datum/ammo/energy/tesla/ammo_process(obj/projectile/proj, damage)
-	zap_beam(proj, 2, damage)
+	zap_beam(proj, 3, damage)
 
 /datum/ammo/energy/droidblast
 	name = "energetic plasma bolt"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1410,13 +1410,13 @@ datum/ammo/bullet/revolver/tp44
 	hud_state = "taser"
 	hud_state_empty = "battery_empty"
 	flags_ammo_behavior = AMMO_ENERGY|SPECIAL_PROCESS
-	shell_speed = 0.1
-	damage = 20
+	shell_speed = 0.3
+	damage = 40
 	penetration = 20
 	bullet_color = COLOR_TESLA_BLUE
 
 /datum/ammo/energy/tesla/ammo_process(obj/projectile/proj, damage)
-	zap_beam(proj, 4, damage)
+	zap_beam(proj, 2, damage)
 
 /datum/ammo/energy/droidblast
 	name = "energetic plasma bolt"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1410,18 +1410,17 @@ datum/ammo/bullet/revolver/tp44
 	hud_state = "taser"
 	hud_state_empty = "battery_empty"
 	flags_ammo_behavior = AMMO_ENERGY|SPECIAL_PROCESS
-	shell_speed = 0.3
-	damage = 40
+	shell_speed = 0.1
+	damage = 20
 	penetration = 20
 	bullet_color = COLOR_TESLA_BLUE
 	var/drain_multiplier = 0.3 //Drains 10% of max plasma on hit
 
 /datum/ammo/energy/tesla/ammo_process(obj/projectile/proj, damage)
-	zap_beam(proj, 3, damage)
+	zap_beam(proj, 4, damage)
 
 
 /datum/ammo/energy/tesla/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, max_range = 10, slowdown = 3, stagger = 2)
 	var/mob/living/carbon/xenomorph/X = M
 	X.use_plasma(drain_multiplier * X.xeno_caste.plasma_max * X.xeno_caste.plasma_regen_limit)
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1414,15 +1414,15 @@ datum/ammo/bullet/revolver/tp44
 	damage = 20
 	penetration = 20
 	bullet_color = COLOR_TESLA_BLUE
-	var/drain_multiplier = 0.3 //Drains 10% of max plasma on hit
 
 /datum/ammo/energy/tesla/ammo_process(obj/projectile/proj, damage)
 	zap_beam(proj, 4, damage)
 
 
 /datum/ammo/energy/tesla/on_hit_mob(mob/M,obj/projectile/P)
-	var/mob/living/carbon/xenomorph/X = M
-	X.use_plasma(drain_multiplier * X.xeno_caste.plasma_max * X.xeno_caste.plasma_regen_limit)
+	if(isxeno(M)) //need 1 second more than the actual effect time
+		var/mob/living/carbon/xenomorph/X = M
+		X.use_plasma(0.3 * X.xeno_caste.plasma_max * X.xeno_caste.plasma_regen_limit) //Drains 30% of max plasma on hit
 
 
 /datum/ammo/energy/droidblast

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1414,6 +1414,7 @@ datum/ammo/bullet/revolver/tp44
 	damage = 40
 	penetration = 20
 	bullet_color = COLOR_TESLA_BLUE
+	var/drain_multiplier = 0.3 //Drains 10% of max plasma on hit
 
 /datum/ammo/energy/tesla/ammo_process(obj/projectile/proj, damage)
 	zap_beam(proj, 3, damage)
@@ -1421,6 +1422,9 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/energy/tesla/on_hit_mob(mob/M,obj/projectile/P)
 	staggerstun(M, P, max_range = 10, slowdown = 3, stagger = 2)
+	var/mob/living/carbon/xenomorph/X = M
+	X.use_plasma(drain_multiplier * X.xeno_caste.plasma_max * X.xeno_caste.plasma_regen_limit)
+
 
 /datum/ammo/energy/droidblast
 	name = "energetic plasma bolt"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1418,6 +1418,10 @@ datum/ammo/bullet/revolver/tp44
 /datum/ammo/energy/tesla/ammo_process(obj/projectile/proj, damage)
 	zap_beam(proj, 3, damage)
 
+
+/datum/ammo/energy/tesla/on_hit_mob(mob/M,obj/projectile/P)
+	staggerstun(M, P, max_range = 10, slowdown = 3, stagger = 2)
+
 /datum/ammo/energy/droidblast
 	name = "energetic plasma bolt"
 	icon_state = "pulse2"

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -116,7 +116,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	default_ammo_type = /obj/item/cell/lasgun/lasrifle
 	allowed_ammo_types = list(/obj/item/cell/lasgun/lasrifle)
-	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_ENERGY|GUN_AMMO_COUNTER|GUN_AMMO_COUNT_BY_SHOTS_REMAINING|GUN_NO_PITCH_SHIFT_NEAR_EMPTY|GUN_IFF
+	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_ENERGY|GUN_AMMO_COUNTER|GUN_AMMO_COUNT_BY_SHOTS_REMAINING|GUN_NO_PITCH_SHIFT_NEAR_EMPTY
 
 	muzzle_flash_color = COLOR_TESLA_BLUE
 

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -119,8 +119,8 @@
 	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_ENERGY|GUN_AMMO_COUNTER|GUN_AMMO_COUNT_BY_SHOTS_REMAINING|GUN_NO_PITCH_SHIFT_NEAR_EMPTY
 	muzzle_flash_color = COLOR_TESLA_BLUE
 
-	rounds_per_shot = 150
-	fire_delay = 4 SECONDS
+	rounds_per_shot = 100
+	fire_delay = 3.5 SECONDS
 	turret_flags = TURRET_INACCURATE
 	attachable_allowed = list(
 		/obj/item/attachable/flashlight,

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -116,7 +116,8 @@
 	w_class = WEIGHT_CLASS_BULKY
 	default_ammo_type = /obj/item/cell/lasgun/lasrifle
 	allowed_ammo_types = list(/obj/item/cell/lasgun/lasrifle)
-	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_ENERGY|GUN_AMMO_COUNTER|GUN_AMMO_COUNT_BY_SHOTS_REMAINING|GUN_NO_PITCH_SHIFT_NEAR_EMPTY
+	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_ENERGY|GUN_AMMO_COUNTER|GUN_AMMO_COUNT_BY_SHOTS_REMAINING|GUN_NO_PITCH_SHIFT_NEAR_EMPTY|GUN_IFF
+
 	muzzle_flash_color = COLOR_TESLA_BLUE
 
 	rounds_per_shot = 100

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -121,7 +121,7 @@
 	muzzle_flash_color = COLOR_TESLA_BLUE
 
 	rounds_per_shot = 100
-	fire_delay = 3.5 SECONDS
+	fire_delay = 4 SECONDS
 	turret_flags = TURRET_INACCURATE
 	attachable_allowed = list(
 		/obj/item/attachable/flashlight,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

About The Pull Request
Tesla gun is a rarely used weapon, highly underestimated by marines. But in fact when it is used, it can have unexpectedly high impact. Current effects are:
- Skill block for xenos for LONG time
- Strong plasma drain with effect lasting for 10 seconds, draining 60% of your max plasma
- Slowdown, which usually makes difference between whether you are faster than marine or not
- All this with abysmally large effect range
- But also slow speed and firerate

This PR is trying to make tesla gun less painful for xenos and more fun for marines.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Before, one pew pew from marine could break Queen Screech assault by blocking skills of every xenos in large radius. Even more painful, it made possible to hunt xeno by having few marines by your side when you shoot the tesla to hamper xeno retreat who are slowed and cannot use skills to escape tesla's large effect radius.

Now the tesla has less one-time impact, but steadier and more reliable performance. It's not a xeno-bully weapon, but a disable weapon making beno retreat faster. Ammo efficiency improved to make it more viable. Added strong on-hit plasma drain to reward hits (before you'd be better off by NOT hitting the beno).

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

balance: Decreased plasma drain effect time from 10 to 2
balance: Decreased plasma regen stop time from 10 to 2
balance: Plasma drain now drains 10% per tick (from 6%)
balance: Removed stagger
balance: Increased ammo per cell from 4 to 6
added: on-hit plasma drain (30% of max)

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
