### PR TITLE
Fixes razorwire duplication exploit, adds ability to blacklist medical chems

### DIFF
--- a/code/game/objects/machinery/sleeper.dm
+++ b/code/game/objects/machinery/sleeper.dm
@@ -282,7 +282,10 @@
 		if(beaker)
 			if(beaker.reagents.total_volume < beaker.reagents.maximum_volume)
 				for(var/datum/reagent/x in occupant.reagents.reagent_list)
-					occupant.reagents.trans_to(beaker, 10)
+					if(x.medbayblacklist)
+						occupant.reagents.remove_reagent(x.type, 1000)
+					else
+						occupant.reagents.trans_to(beaker, 10)
 
 
 	updateUsrDialog()
@@ -367,6 +370,10 @@
 
 /obj/machinery/sleeper/proc/toggle_filter()
 	if(!occupant)
+		filtering = 0
+		return
+	if(ismonkey(occupant))
+		to_chat(usr, span_scanner("Unknown biological subject detected, dialysis not available. Please contact a licensed supplier for further assistance."))
 		filtering = 0
 		return
 	if(filtering)

--- a/code/game/objects/machinery/sleeper.dm
+++ b/code/game/objects/machinery/sleeper.dm
@@ -62,7 +62,7 @@
 	else
 		var/mob/living/occupant = connected.occupant
 		dat += "<font color='#487553'><B>Occupant Statistics:</B></FONT><BR>"
-		if (occupant)
+		if(occupant)
 			var/t1
 			dat += text("<B>Name: [occupant.name]</B><BR>")
 			switch(occupant.stat)
@@ -75,6 +75,16 @@
 				else
 			dat += text("[]\tHealth %: [] ([])</FONT><BR>", (occupant.health > 50 ? "<font color='#487553'>" : "<font color='#b54646'>"), occupant.health, t1)
 			if(ishuman(occupant))
+				if(connected.filtering)
+					dat += "<A href='?src=\ref[src];togglefilter=1'>Stop Dialysis</A><BR>"
+				else
+					dat += "<HR><A href='?src=\ref[src];togglefilter=1'>Start Dialysis</A><BR>"
+				if(connected.stasis)
+					dat += "<HR><A href='?src=\ref[src];togglestasis=1'>Deactivate Cryostasis</A><BR><HR>"
+				else
+					dat += "<HR><A href='?src=\ref[src];togglestasis=1'>Activate Cryostasis</A><BR><HR>"
+			else
+				dat += "<HR>Dialysis Disabled - Non-human present.<BR><HR>"
 				var/mob/living/carbon/human/patient = occupant
 				var/pulse = patient.handle_pulse()
 				dat += text("[]\t-Pulse, bpm: []</FONT><BR>", (pulse == PULSE_NONE || pulse == PULSE_THREADY ? "<font color='#b54646'>" : "<font color='#487553'>"), patient.get_pulse(GETPULSE_TOOL))
@@ -89,28 +99,9 @@
 					dat += " <a href ='?src=\ref[src];chemical=[chemical];amount=[amount]'>[amount] units</a>"
 				dat += "<br>"
 			dat += "<A href='?src=\ref[src];refresh=1'>Refresh Meter Readings</A><BR>"
-			if(connected.beaker)
-				dat += "<HR><A href='?src=\ref[src];removebeaker=1'>Remove Beaker</A><BR>"
-				if(ishuman(occupant))
-					if(connected.filtering)
-						dat += "<A href='?src=\ref[src];togglefilter=1'>Stop Dialysis</A><BR>"
-						dat += "Output Beaker has [connected.beaker.reagents.maximum_volume - connected.beaker.reagents.total_volume] units of free space remaining<BR><HR>"
-					else
-						dat += "<HR><A href='?src=\ref[src];togglefilter=1'>Start Dialysis</A><BR>"
-						dat += "Output Beaker has [connected.beaker.reagents.maximum_volume - connected.beaker.reagents.total_volume] units of free space remaining<BR><HR>"
-					if(connected.stasis)
-						dat += "<HR><A href='?src=\ref[src];togglestasis=1'>Deactivate Cryostasis</A><BR><HR>"
-					else
-						dat += "<HR><A href='?src=\ref[src];togglestasis=1'>Activate Cryostasis</A><BR><HR>"
-				else
-					dat += "<HR>Dialysis Disabled - Non-human present.<BR><HR>"
-
-			else
-				dat += "<HR>No Dialysis Output Beaker is present.<BR><HR>"
 			dat += "<HR><A href='?src=\ref[src];ejectify=1'>Eject Patient</A>"
 		else
 			dat += "The sleeper is empty."
-
 	var/datum/browser/popup = new(user, "sleeper", "<div align='center'>Sleeper Console</div>", 400, 670)
 	popup.set_content(dat)
 	popup.open()
@@ -123,16 +114,16 @@
 
 	if(href_list["chemical"] && connected && connected.occupant)
 		var/datum/reagent/R = text2path(href_list["chemical"])
-		if (connected.occupant.stat == DEAD)
+		if(connected.occupant.stat == DEAD)
 			to_chat(usr, span_warning("This person has no life for to preserve anymore."))
+		else if(ismonkey(connected.occupant))
+			to_chat(usr, span_scanner("Unknown biological subject detected, chemical injection not available. Please contact a licensed supplier for further assistance."))	
 		else if(!(R in connected.available_chemicals))
 			message_admins("[ADMIN_TPMONTY(usr)] has tried to inject an invalid chem with the sleeper. Looks like an exploit attempt, or a bug.")
 		else
 			var/amount = text2num(href_list["amount"])
 			if(amount == 5 || amount == 10)
 				connected.inject_chemical(usr, R, amount)
-	if (href_list["removebeaker"])
-		connected.remove_beaker()
 	if (href_list["togglefilter"])
 		connected.toggle_filter()
 	if (href_list["togglestasis"])
@@ -166,7 +157,6 @@
 	var/mob/living/carbon/human/occupant = null
 	var/available_chemicals = list(/datum/reagent/medicine/inaprovaline = "Inaprovaline", /datum/reagent/toxin/sleeptoxin = "Soporific", /datum/reagent/medicine/paracetamol = "Paracetamol", /datum/reagent/medicine/bicaridine = "Bicaridine", /datum/reagent/medicine/kelotane = "Kelotane", /datum/reagent/medicine/dylovene = "Dylovene", /datum/reagent/medicine/dexalin = "Dexalin", /datum/reagent/medicine/tricordrazine = "Tricordrazine", /datum/reagent/medicine/spaceacillin = "Spaceacillin")
 	var/amounts = list(5, 10)
-	var/obj/item/reagent_containers/glass/beaker = null
 	var/filtering = FALSE
 	var/stasis = FALSE
 	var/obj/machinery/sleep_console/connected
@@ -178,7 +168,6 @@
 
 /obj/machinery/sleeper/Initialize()
 	. = ..()
-	beaker = new /obj/item/reagent_containers/glass/beaker/large()
 	if(orient == "RIGHT")
 		icon_state = "sleeper_0-r"
 	RegisterSignal(src, COMSIG_MOVABLE_SHUTTLE_CRUSH, .proc/shuttle_crush)
@@ -261,11 +250,6 @@
 			popup.open(FALSE)
 		break
 
-
-/obj/machinery/sleeper/handle_atom_del(atom/movable/AM)
-	if(AM == beaker)
-		beaker = null
-
 /obj/machinery/sleeper/process()
 	if (machine_stat & (NOPOWER|BROKEN))
 		if(occupant)
@@ -279,13 +263,8 @@
 	occupant?.adjustOxyLoss(-occupant.getOxyLoss()) // keep them breathing, pretend they get IV dexalinplus
 
 	if(filtering)
-		if(beaker)
-			if(beaker.reagents.total_volume < beaker.reagents.maximum_volume)
-				for(var/datum/reagent/x in occupant.reagents.reagent_list)
-					if(x.medbayblacklist)
-						occupant.reagents.remove_reagent(x.type, 1000)
-					else
-						occupant.reagents.trans_to(beaker, 10)
+		for(var/datum/reagent/x in occupant.reagents.reagent_list)
+			occupant.reagents.remove_reagent(x.type, 10)
 
 
 	updateUsrDialog()
@@ -293,19 +272,6 @@
 
 /obj/machinery/sleeper/attackby(obj/item/I, mob/user, params)
 	. = ..()
-
-	if(istype(I, /obj/item/reagent_containers/glass))
-		if(beaker)
-			to_chat(user, span_warning("The sleeper has a beaker already."))
-			return
-
-		if(!user.transferItemToLoc(I, src))
-			return
-
-		beaker = I
-		user.visible_message("[user] adds \a [I] to \the [src]!", "You add \a [I] to \the [src]!")
-		updateUsrDialog()
-		return
 
 	if(istype(I, /obj/item/healthanalyzer) && occupant) //Allows us to use the analyzer on the occupant without taking him out.
 		var/obj/item/healthanalyzer/J = I
@@ -439,10 +405,6 @@
 		to_chat(user, text("[]\t -Burn Severity %: []</font>", (occupant.getFireLoss() < 60 ? "<font color='#487553'> " : "<font color='#b54646'> "), occupant.getFireLoss()))
 		to_chat(user, span_notice("Expected time till occupant can safely awake: (note: If health is below 20% these times are inaccurate)"))
 		to_chat(user, span_notice("\t [occupant.AmountUnconscious() * 0.1] second\s (if around 1 or 2 the sleeper is keeping them asleep.)"))
-		if(beaker)
-			to_chat(user, span_notice("\t Dialysis Output Beaker has [beaker.reagents.maximum_volume - beaker.reagents.total_volume] of free space remaining."))
-		else
-			to_chat(user, span_notice("No Dialysis Output Beaker loaded."))
 	else
 		to_chat(user, span_notice("There is no one inside!"))
 
@@ -468,18 +430,6 @@
 		return
 
 	go_out()
-
-
-/obj/machinery/sleeper/verb/remove_beaker()
-	set name = "Remove Beaker"
-	set category = "Object"
-	set src in oview(1)
-	if(usr.stat != 0)
-		return
-	if(beaker)
-		filtering = FALSE
-		beaker.loc = usr.loc
-		beaker = null
 
 /obj/machinery/sleeper/relaymove(mob/user)
 	if(user.incapacitated(TRUE))

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -237,7 +237,7 @@
 		if(istype(I, /obj/item/reagent_containers/glass/bucket))
 			to_chat(user, span_warning("That's too big to fit!"))
 			return
-		
+
 		beaker =  I
 		
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -224,6 +224,12 @@
 	. = ..()
 
 	if(istype(I, /obj/item/reagent_containers/glass))
+		
+		for(var/datum/reagent/X in I.reagents.reagent_list)
+			if(X.medbayblacklist)
+				to_chat(user, span_warning("The cryo cell's automatic safety features beep softly, they must have detected a harmful substance in the beaker."))
+				return
+
 		if(beaker)
 			to_chat(user, span_warning("A beaker is already loaded into the machine."))
 			return
@@ -231,10 +237,12 @@
 		if(istype(I, /obj/item/reagent_containers/glass/bucket))
 			to_chat(user, span_warning("That's too big to fit!"))
 			return
-
+		
 		beaker =  I
+		
 
 		var/reagentnames = ""
+
 		for(var/datum/reagent/R in beaker.reagents.reagent_list)
 			reagentnames += ", [R.name]"
 

--- a/code/modules/reagents/holder.dm
+++ b/code/modules/reagents/holder.dm
@@ -504,11 +504,9 @@
 /datum/reagents/proc/reaction(atom/A, method=TOUCH, volume_modifier=1, show_message = 1)
 	var/react_type
 	if(isliving(A))
-		var/mob/living/L = A
-		if (L.stat == DEAD)
-			return
 		react_type = "LIVING"
 		if(method == INGEST)
+			var/mob/living/L = A
 			L.taste(src)
 	else if (isturf(A))
 		react_type = "TURF"
@@ -521,9 +519,11 @@
 		var/datum/reagent/R = reagent
 		switch(react_type)
 			if("LIVING")
+				var/mob/living/L = A
+				if(!R.reactinmob && L.stat == DEAD)
+					return
 				var/touch_protection = 0
 				if(method == VAPOR)
-					var/mob/living/L = A
 					touch_protection = CLAMP01(1 -  L.get_permeability_protection())
 				R.reaction_mob(A, method, R.volume * volume_modifier, show_message, touch_protection)
 			if("TURF")

--- a/code/modules/reagents/holder.dm
+++ b/code/modules/reagents/holder.dm
@@ -504,9 +504,11 @@
 /datum/reagents/proc/reaction(atom/A, method=TOUCH, volume_modifier=1, show_message = 1)
 	var/react_type
 	if(isliving(A))
+		var/mob/living/L = A
+		if (L.stat == DEAD)
+			return
 		react_type = "LIVING"
 		if(method == INGEST)
-			var/mob/living/L = A
 			L.taste(src)
 	else if (isturf(A))
 		react_type = "TURF"

--- a/code/modules/reagents/holder.dm
+++ b/code/modules/reagents/holder.dm
@@ -520,7 +520,7 @@
 		switch(react_type)
 			if("LIVING")
 				var/mob/living/L = A
-				if(!R.reactinmob && L.stat == DEAD)
+				if(!R.reactindeadmob && L.stat == DEAD)
 					return
 				var/touch_protection = 0
 				if(method == VAPOR)

--- a/code/modules/reagents/holder.dm
+++ b/code/modules/reagents/holder.dm
@@ -204,6 +204,8 @@
 	else
 		if(!target.reagents)
 			return
+		if(!isliving(target))
+			return	
 		R = target.reagents
 
 	if(amount < 0)

--- a/code/modules/reagents/holder.dm
+++ b/code/modules/reagents/holder.dm
@@ -204,8 +204,6 @@
 	else
 		if(!target.reagents)
 			return
-		if(!isliving(target))
-			return	
 		R = target.reagents
 
 	if(amount < 0)

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -322,6 +322,11 @@
 			to_chat(user, "Something is already loaded into the machine.")
 			return
 
+		for(var/datum/reagent/X in I.reagents.reagent_list)
+			if(X.medbayblacklist)
+				to_chat(user, span_warning("The chemical dispenser's automatic safety features beep softly, they must have detected a harmful substance in the beaker."))
+				return
+
 		if(I.is_open_container())
 			if(!user.transferItemToLoc(I, src))
 				return

--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -49,6 +49,10 @@
 	. = ..()
 
 	if(istype(I,/obj/item/reagent_containers) && I.is_open_container())
+		for(var/datum/reagent/X in I.reagents.reagent_list)
+			if(X.medbayblacklist)
+				to_chat(user, span_warning("The chem master's automatic safety features beep softly, they must have detected a harmful substance in the beaker."))
+				return
 		if(beaker)
 			to_chat(user, span_warning("A beaker is already loaded into the machine."))
 			return

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -61,6 +61,8 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/effect_str = 1
 	///Used for certain chems we don't want being extracted via dialysis or being used in cryo, makes all important medical machines (dispenser, cryo etc...) refuse to interact with the reagent
 	var/medbayblacklist = FALSE
+	///If true allow foam and smoke to transfer reagent into mobs
+	var/reactinmob = TRUE
 
 /datum/reagent/New()
 	. = ..()

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -61,8 +61,8 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/effect_str = 1
 	///Used for certain chems we don't want being extracted via dialysis or being used in cryo, makes all important medical machines (dispenser, cryo etc...) refuse to interact with the reagent
 	var/medbayblacklist = FALSE
-	///If true allow foam and smoke to transfer reagent into mobs
-	var/reactinmob = TRUE
+	///If true allow foam and smoke to transfer reagent into dead mobs
+	var/reactindeadmob = TRUE
 
 /datum/reagent/New()
 	. = ..()

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -59,6 +59,8 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/trait_flags = NONE
 	///Affects the strength of reagent effects
 	var/effect_str = 1
+	///Used for certain chems we don't want being extracted via dialysis or being used in cryo, makes all important medical machines (dispenser, cryo etc...) refuse to interact with the reagent
+	var/medbayblacklist = FALSE
 
 /datum/reagent/New()
 	. = ..()

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -442,6 +442,7 @@
 	color = "#535E66" // rgb: 83, 94, 102
 	custom_metabolism = REAGENTS_METABOLISM * 5
 	medbayblacklist = TRUE
+	reactinmob = FALSE
 
 /datum/reagent/toxin/nanites/on_mob_add(mob/living/L, metabolism)
 	to_chat(L, span_userdanger("Your body begins to twist and deform! Get out of the razorburn!"))

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -442,7 +442,7 @@
 	color = "#535E66" // rgb: 83, 94, 102
 	custom_metabolism = REAGENTS_METABOLISM * 5
 	medbayblacklist = TRUE
-	reactinmob = FALSE
+	reactindeadmob = FALSE
 
 /datum/reagent/toxin/nanites/on_mob_add(mob/living/L, metabolism)
 	to_chat(L, span_userdanger("Your body begins to twist and deform! Get out of the razorburn!"))

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -441,6 +441,7 @@
 	reagent_state = LIQUID
 	color = "#535E66" // rgb: 83, 94, 102
 	custom_metabolism = REAGENTS_METABOLISM * 5
+	medbayblacklist = TRUE
 
 /datum/reagent/toxin/nanites/on_mob_add(mob/living/L, metabolism)
 	to_chat(L, span_userdanger("Your body begins to twist and deform! Get out of the razorburn!"))


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Acts as an alternative to https://github.com/tgstation/TerraGov-Marine-Corps/pull/9820

You had to know this was coming.
Right now the game suffers from a small group of players who have figured out how to duplicate razorburn and then microdose it. 
This PR patches the current methods being used and adds some future protections against this sort of thing.

To start off, reagents no longer transfer to dead mobs, this was being used to gas large groups of dead monkeys with nanites.
Sleepers no longer perform dialysis on monkeys at all, this was being used to transfer the nanite reagent to beakers.

I'm going to answer some questions here to save time.
Q. But what if they just start gassing live humans to extract nanite reagent?
A. Sleepers now purge any chemicals instead of removing them to a beaker.
Q. I've heard you can use cryo to duplicate chems, won't they just use that?
A. Blacklisting a chemical means cryo won't accept it either.
Q. If I _did_ get it, could I use it in a custom mix?
A. Medical machinery will refuse beakers with blacklisted reagents, no turning your pilfered 60u bottle of nanites into 10 6u beakers so groundside can be filled with razorwire. 
Q. Can I work with a blacklisted reagent at all?
A. Not if I have anything to say about it.

## Why It's Good For The Game

Razorwire spam has become an issue again lately, along with chemical duplication in general. Removing it will probably help our flagging xeno winrates and prevent more abuse. 
If this system has no holes in it, it can be rolled out to any other reagent that we don't want players touching.

## Changelog
:cl:
add: Added a system to blacklist chemicals from being used in medbay.
balance: Razorburn nanites are now a blacklisted chemical.
balance: You can no longer use the sleeper to give monkeys dialysis.
balance: Dead mobs no longer accumulate smoke or foam reagents.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
