### PR TITLE
Add fire extinguishers in Alamo

### DIFF
--- a/_maps/shuttles/alamo.dmm
+++ b/_maps/shuttles/alamo.dmm
@@ -574,9 +574,27 @@
 	icon_state = "26"
 	},
 /area/shuttle/dropship/alamo)
+"iV" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 4
+	},
+/obj/structure/closet/walllocker/hydrant/extinguisher{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/floor,
+/area/shuttle/dropship/alamo)
 "vw" = (
 /obj/structure/dropship_piece/one/engine/leftbottom,
 /turf/template_noop,
+/area/shuttle/dropship/alamo)
+"yA" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 8
+	},
+/obj/structure/closet/walllocker/hydrant/extinguisher{
+	dir = 8
+	},
+/turf/open/shuttle/dropship/floor,
 /area/shuttle/dropship/alamo)
 "Dp" = (
 /turf/open/shuttle/dropship/ten,
@@ -685,7 +703,7 @@ aS
 bo
 aI
 bx
-aI
+iV
 bl
 aI
 bX
@@ -702,7 +720,7 @@ aK
 bj
 aN
 bd
-aN
+yA
 aN
 bj
 Dp
@@ -748,7 +766,7 @@ aK
 bl
 aI
 be
-aI
+iV
 aI
 bl
 Dp
@@ -777,7 +795,7 @@ aS
 bq
 aN
 bd
-aN
+yA
 bj
 aN
 ca


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Alamo has four fire-safety lockers, or essentially fire extinguishers, so that marines are safe and secured knowing that hopefully someone will extinguish fire really fast.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fire bad, Alamo safe, Alamo good. I'm surprised that the fire-safety lockers don't get used as much despite being super useful. It's neat have around and shouldn't be limited to Magmoor.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Add fire extinguishers in Alamo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
