### PR TITLE
King is now slightly less of a meme

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -217,7 +217,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	desc = "Places a Psychic Echo chamber that tallhosts can detect, then after a summon time selects a random sister to take over the mind of the gravity manipulating King."
 	icon = "king"
 	flags_gamemode = ABILITY_DISTRESS
-	psypoint_cost = 1800
+	psypoint_cost = 750
 
 /datum/hive_upgrade/xenos/king/can_buy(mob/living/carbon/xenomorph/buyer, silent = TRUE)
 	. = ..()
@@ -237,7 +237,6 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	var/obj/structure/resin/king_pod = new /obj/structure/resin/king_pod(get_turf(buyer), buyer.hivenumber)
 	log_game("[key_name(buyer)] has created a pod in [AREACOORD(buyer)]")
 	xeno_message("<B>[buyer] has created a king pod at [get_area(buyer)]. Defend it until the Queen Mother summons a king!</B>", hivenumber = buyer.hivenumber, target = king_pod, arrow_type = /obj/screen/arrow/leader_tracker_arrow)
-	priority_announce("WARNING: Psychic anomaly detected at [get_area(buyer)]. Assault of the area reccomended.", "TGMC Intel Division")
 	return ..()
 
 /datum/hive_upgrade/xenos/smart_minions


### PR DESCRIPTION
## About The Pull Request

King is now cheaper (750 points) and marines are no longer notified about it's summoning (but can still locate the pod).

## Why It's Good For The Game

King is a meme at 1800 points thanks to there being lots of other good options (primordials, silos, spawners, turret spam) so it's been made cheaper. 

Also there is no longer a priority announcement for King summoning because it's not that dangerous a caste and it will usually be randomly given to a xeno who dies with it in 2 mins because they don't know it sucks in combat. 

## Changelog
:cl:
balance: King is now cheaper (750 points) and marines are no longer notified about it's summoning (but can still locate the pod).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
