### PR TITLE
Patches an area of incorrect weather on Big Red, plus minor tweaks

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -44592,10 +44592,10 @@ aaa
 aaa
 aaa
 aaa
-tzo
-tzo
-tzo
-ttW
+dCS
+dCS
+dCS
+buM
 hqP
 hqP
 hqP

--- a/_maps/modularmaps/big_red/bigredatmosvar3.dmm
+++ b/_maps/modularmaps/big_red/bigredatmosvar3.dmm
@@ -2,11 +2,21 @@
 "ac" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/outside/filtration_plant)
+"aj" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/s)
 "aO" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 1
 	},
 /area/bigredv2/outside/se)
+"by" = (
+/turf/open/floor{
+	dir = 1;
+	icon_state = "bot"
+	},
+/area/bigredv2/outside/s)
 "bz" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/se)
@@ -56,7 +66,7 @@
 	dir = 1;
 	icon_state = "asteroidfloor"
 	},
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
 "em" = (
 /turf/closed/wall,
 /area/bigredv2/outside/filtration_plant)
@@ -76,7 +86,7 @@
 	dir = 1;
 	icon_state = "bot"
 	},
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
 "eC" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
@@ -84,7 +94,7 @@
 	dir = 1;
 	icon_state = "asteroidfloor"
 	},
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
 "eD" = (
 /obj/effect/ai_node,
 /turf/open/floor{
@@ -115,21 +125,25 @@
 "fx" = (
 /obj/item/tool/pickaxe,
 /turf/open/floor,
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
 "gj" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
 "gl" = (
-/turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+/obj/machinery/light{
+	dir = 1
 	},
-/area/bigredv2/outside/filtration_plant)
+/turf/open/floor,
+/area/bigredv2/outside/s)
 "gL" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/se)
+"hn" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor,
+/area/bigredv2/outside/s)
 "ie" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -194,7 +208,10 @@
 "lK" = (
 /obj/item/tank/air,
 /turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/east)
+/area/bigredv2/outside/se)
+"mH" = (
+/turf/open/floor,
+/area/bigredv2/outside/s)
 "no" = (
 /obj/structure/sign/safety/vent,
 /turf/closed/wall/r_wall,
@@ -204,7 +221,7 @@
 	dir = 8;
 	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
 "nM" = (
 /obj/item/tank/air,
 /obj/effect/decal/cleanable/dirt,
@@ -221,7 +238,7 @@
 /area/bigredv2/outside/filtration_plant)
 "pg" = (
 /turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/east)
+/area/bigredv2/outside/se)
 "pN" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -246,10 +263,14 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
+"rk" = (
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/s)
 "rq" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/unmeltable,
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
 "rL" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -280,7 +301,7 @@
 "sc" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/east)
+/area/bigredv2/outside/se)
 "sk" = (
 /obj/structure/dispenser/oxygen,
 /turf/open/floor{
@@ -294,7 +315,7 @@
 "tv" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor,
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
 "tV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -367,7 +388,7 @@
 	pixel_y = 25
 	},
 /turf/open/floor,
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
 "xY" = (
 /obj/structure/cryofeed/right{
 	name = "\improper coolant feed"
@@ -394,6 +415,11 @@
 /obj/structure/table,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
+"zz" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/s)
 "zO" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -426,7 +452,7 @@
 	dir = 4;
 	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
 "AH" = (
 /obj/structure/cargo_container/ch_red{
 	dir = 4
@@ -435,7 +461,7 @@
 	dir = 1;
 	icon_state = "bot"
 	},
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
 "AZ" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor{
@@ -456,7 +482,10 @@
 	dir = 1;
 	icon_state = "bot"
 	},
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
+"BP" = (
+/turf/closed/wall/r_wall/unmeltable,
+/area/bigredv2/outside/s)
 "Cy" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/weed_node,
@@ -482,7 +511,7 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
 "Fe" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor{
@@ -507,14 +536,14 @@
 	dir = 1;
 	icon_state = "bot"
 	},
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
 "Go" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor{
 	dir = 4;
 	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
 "GD" = (
 /turf/open/floor/plating,
 /area/bigredv2/outside/filtration_plant)
@@ -524,7 +553,7 @@
 	dir = 4;
 	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
 "GW" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -553,7 +582,7 @@
 	dir = 4;
 	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
 "IJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -566,7 +595,7 @@
 "Jp" = (
 /obj/item/tank/air,
 /turf/open/floor,
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
 "Jv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -607,11 +636,11 @@
 	dir = 8;
 	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
 "KB" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/east)
+/area/bigredv2/outside/se)
 "KJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/unmeltable,
@@ -625,6 +654,9 @@
 /obj/effect/spawner/random/technology_scanner,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
+"Lx" = (
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/s)
 "LK" = (
 /obj/structure/largecrate/random,
 /turf/open/floor{
@@ -648,7 +680,7 @@
 	dir = 1;
 	icon_state = "bot"
 	},
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
 "MI" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -673,7 +705,7 @@
 	dir = 1;
 	icon_state = "asteroidfloor"
 	},
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
 "Ny" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 5
@@ -683,7 +715,7 @@
 /obj/structure/dispenser/oxygen,
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/east)
+/area/bigredv2/outside/se)
 "OK" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -720,7 +752,7 @@
 "QP" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/east)
+/area/bigredv2/outside/se)
 "QY" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
@@ -792,7 +824,7 @@
 	dir = 1;
 	icon_state = "asteroidfloor"
 	},
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
 "Vn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -818,7 +850,7 @@
 	dir = 8;
 	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/s)
 "WA" = (
 /obj/machinery/light{
 	dir = 1
@@ -865,6 +897,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/bigredv2/outside/filtration_plant)
+"ZD" = (
+/obj/machinery/light,
+/turf/open/floor,
+/area/bigredv2/outside/s)
 
 (1,1,1) = {"
 em
@@ -883,7 +919,7 @@ Ff
 Ff
 Ff
 Ff
-gl
+eH
 AZ
 eH
 eH
@@ -910,15 +946,15 @@ Ff
 ac
 ac
 Ff
-gl
-gl
-gl
+eH
+eH
+eH
 Nv
-gl
-gl
-gl
+eH
+eH
+eH
 ek
-Ff
+BP
 "}
 (3,1,1) = {"
 rU
@@ -945,7 +981,7 @@ AF
 Is
 Go
 Is
-tm
+Lx
 "}
 (4,1,1) = {"
 rU
@@ -965,14 +1001,14 @@ kj
 ze
 tm
 xW
-HM
-HM
-AC
-Jy
-AC
-HM
-HM
-tm
+mH
+mH
+hn
+aj
+hn
+mH
+mH
+Lx
 "}
 (5,1,1) = {"
 em
@@ -991,15 +1027,15 @@ HM
 Jy
 Mj
 tm
-UL
-AC
-AC
-AC
-HM
-Ht
-Ht
-eE
-tm
+gl
+hn
+hn
+hn
+mH
+by
+by
+ZD
+Lx
 "}
 (6,1,1) = {"
 bZ
@@ -1018,15 +1054,15 @@ Ht
 Ht
 cB
 Rj
-HM
-AC
-AC
-QY
-HM
-Ht
+mH
+hn
+hn
+zz
+mH
+by
 Mx
-HM
-Ff
+mH
+BP
 "}
 (7,1,1) = {"
 IJ
@@ -1045,7 +1081,7 @@ LK
 Ht
 HM
 Rj
-HM
+mH
 Ea
 tv
 tv
@@ -1072,15 +1108,15 @@ Ht
 LK
 HM
 Rj
-HM
+mH
 tv
-HM
-HM
-HM
-Ht
+mH
+mH
+mH
+by
 AH
-HM
-Ff
+mH
+BP
 "}
 (9,1,1) = {"
 de
@@ -1099,15 +1135,15 @@ Ht
 Gh
 cB
 Rj
-HM
+mH
 tv
-HM
-cB
+mH
+rk
 Jp
 Gn
-Ht
-eE
-tm
+by
+ZD
+Lx
 "}
 (10,1,1) = {"
 AC
@@ -1126,15 +1162,15 @@ HM
 HM
 eE
 tm
-UL
+gl
 tv
-Jy
+aj
 fx
-HM
-Ht
-Ht
-HM
-tm
+mH
+by
+by
+mH
+Lx
 "}
 (11,1,1) = {"
 ze
@@ -1153,15 +1189,15 @@ Ff
 ux
 ux
 Ff
-HM
+mH
 tv
-HM
-HM
-HM
-Jy
-HM
-HM
-tm
+mH
+mH
+mH
+aj
+mH
+mH
+Lx
 "}
 (12,1,1) = {"
 jl
@@ -1188,7 +1224,7 @@ nG
 Ws
 nG
 nG
-tm
+Lx
 "}
 (13,1,1) = {"
 GD
@@ -1207,15 +1243,15 @@ KJ
 wk
 wk
 Ff
-gl
+eH
 UV
-gl
+eH
 eC
-gl
-gl
-gl
+eH
+eH
+eH
 ek
-tm
+Lx
 "}
 (14,1,1) = {"
 yG
@@ -1242,7 +1278,7 @@ AF
 Is
 Is
 Is
-em
+Rb
 "}
 (15,1,1) = {"
 qp

--- a/_maps/modularmaps/big_red/bigredcheckpointsouthvar1.dmm
+++ b/_maps/modularmaps/big_red/bigredcheckpointsouthvar1.dmm
@@ -6,7 +6,7 @@
 /turf/closed/wall,
 /area/bigredv2/outside/se)
 "k" = (
-/turf/open/floor/gcircuit,
+/turf/open/floor/podhatch/floor,
 /area/bigredv2/outside/se)
 "s" = (
 /obj/effect/decal/cleanable/dirt,
@@ -27,7 +27,7 @@
 	},
 /area/bigredv2/outside/se)
 "E" = (
-/turf/open/floor/gcircuit,
+/turf/open/floor/podhatch/floor,
 /area/bigredv2/caves/rock)
 "I" = (
 /turf/closed/wall,

--- a/_maps/modularmaps/big_red/bigredcheckpointsouthvar3.dmm
+++ b/_maps/modularmaps/big_red/bigredcheckpointsouthvar3.dmm
@@ -59,7 +59,7 @@
 "k" = (
 /obj/structure/filingcabinet,
 /obj/structure/cable,
-/turf/open/floor/gcircuit,
+/turf/open/floor/podhatch/floor,
 /area/bigredv2/outside/southcheckpoint)
 "l" = (
 /obj/item/trash/sosjerky,
@@ -71,7 +71,7 @@
 /area/bigredv2/outside/southcheckpoint)
 "m" = (
 /obj/structure/table/mainship,
-/turf/open/floor/gcircuit,
+/turf/open/floor/podhatch/floor,
 /area/bigredv2/outside/southcheckpoint)
 "n" = (
 /obj/machinery/door/airlock/mainship/security/glass{
@@ -113,7 +113,7 @@
 /area/bigredv2/outside/southcheckpoint)
 "u" = (
 /obj/structure/inflatable,
-/turf/open/floor/gcircuit,
+/turf/open/floor/podhatch/floor,
 /area/bigredv2/outside/southcheckpoint)
 "v" = (
 /obj/structure/rack,
@@ -125,7 +125,7 @@
 "w" = (
 /obj/structure/table/mainship,
 /obj/effect/spawner/random/technology_scanner,
-/turf/open/floor/gcircuit,
+/turf/open/floor/podhatch/floor,
 /area/bigredv2/outside/southcheckpoint)
 "z" = (
 /obj/machinery/power/apc{
@@ -141,7 +141,7 @@
 /obj/machinery/computer/security/wooden_tv{
 	dir = 8
 	},
-/turf/open/floor/gcircuit,
+/turf/open/floor/podhatch/floor,
 /area/bigredv2/outside/southcheckpoint)
 "B" = (
 /obj/structure/table/mainship,
@@ -169,7 +169,7 @@
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/southcheckpoint)
 "H" = (
-/turf/open/floor/gcircuit,
+/turf/open/floor/podhatch/floor,
 /area/bigredv2/outside/southcheckpoint)
 "I" = (
 /obj/structure/window/framed/colony/reinforced,
@@ -203,13 +203,13 @@
 /area/bigredv2/outside/southcheckpoint)
 "Q" = (
 /obj/structure/largecrate,
-/turf/open/floor/gcircuit,
+/turf/open/floor/podhatch/floor,
 /area/bigredv2/outside/southcheckpoint)
 "R" = (
 /obj/structure/table/mainship,
 /obj/item/ashtray/bronze,
 /obj/item/trash/cigbutt/cigarbutt,
-/turf/open/floor/gcircuit,
+/turf/open/floor/podhatch/floor,
 /area/bigredv2/outside/southcheckpoint)
 "S" = (
 /obj/structure/table/mainship,
@@ -247,7 +247,7 @@
 /area/bigredv2/outside/southcheckpoint)
 "Y" = (
 /obj/structure/closet/secure_closet/marshal,
-/turf/open/floor/gcircuit,
+/turf/open/floor/podhatch/floor,
 /area/bigredv2/outside/southcheckpoint)
 
 (1,1,1) = {"

--- a/_maps/modularmaps/big_red/bigredofficevar2.dmm
+++ b/_maps/modularmaps/big_red/bigredofficevar2.dmm
@@ -1,6 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ak" = (
 /obj/effect/spawner/random/gun,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/sterile,
 /area/bigredv2/outside/office_complex)
 "aB" = (
@@ -24,13 +25,14 @@
 /obj/effect/decal/tracks/wheels/bloody{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "aU" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
@@ -39,13 +41,17 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/blue/full,
 /area/bigredv2/outside/office_complex)
+"bc" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/c)
 "bf" = (
 /obj/structure/window_frame/mainship/white,
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/bigredv2/outside/office_complex)
 "bg" = (
-/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/icefloor,
 /area/bigredv2/outside/c)
 "bj" = (
@@ -109,7 +115,7 @@
 /area/bigredv2/outside/office_complex)
 "bQ" = (
 /obj/structure/cable,
-/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/mainship/orange/full,
 /area/bigredv2/outside/office_complex)
 "bW" = (
@@ -121,10 +127,13 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/corpsespawner/marine/engineer,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/mainship/tcomms,
 /area/bigredv2/outside/office_complex)
 "bX" = (
-/obj/structure/window/framed/mainship/hull/canterbury,
+/obj/structure/window/framed/mainship,
 /turf/open/floor/plating,
 /area/bigredv2/outside/office_complex)
 "cj" = (
@@ -175,6 +184,18 @@
 /obj/effect/spawner/random/ammo,
 /turf/open/floor/mainship/orange/full,
 /area/bigredv2/outside/office_complex)
+"dv" = (
+/obj/machinery/door/poddoor/mainship/open,
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/mainship/mono,
+/area/bigredv2/outside/office_complex)
+"dK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/bigredv2/outside/e)
 "dP" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/red/redtaupecorner{
@@ -193,13 +214,14 @@
 	},
 /area/bigredv2/outside/e)
 "ea" = (
-/obj/structure/razorwire,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/bigredv2/outside/office_complex)
 "ek" = (
 /obj/effect/decal/cleanable/blood/drip,
-/obj/effect/landmark/corpsespawner/security,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/corpsespawner/marine,
 /turf/open/floor/plating/plating_catwalk,
 /area/bigredv2/outside/office_complex)
 "eq" = (
@@ -216,7 +238,7 @@
 /area/bigredv2/outside/office_complex)
 "eK" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/red/redtaupecorner,
+/turf/open/floor/plating/icefloor,
 /area/bigredv2/outside/office_complex)
 "eN" = (
 /obj/structure/window_frame/mainship/white,
@@ -224,6 +246,7 @@
 /area/bigredv2/outside/office_complex)
 "fs" = (
 /obj/item/stack/sheet/plasteel,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/stripesquare,
 /area/bigredv2/outside/office_complex)
 "fG" = (
@@ -251,6 +274,7 @@
 /area/bigredv2/outside/office_complex)
 "gR" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/stripesquare,
 /area/bigredv2/outside/office_complex)
 "gW" = (
@@ -260,6 +284,7 @@
 "ha" = (
 /obj/item/stack/sheet/plasteel,
 /obj/effect/spawner/random/gun,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/bigredv2/outside/office_complex)
 "hs" = (
@@ -305,6 +330,13 @@
 	dir = 8
 	},
 /turf/open/floor/mainship/cargo,
+/area/bigredv2/outside/office_complex)
+"ju" = (
+/obj/effect/decal/tracks/wheels/bloody{
+	dir = 4
+	},
+/obj/item/shard,
+/turf/open/floor/plating/plating_catwalk,
 /area/bigredv2/outside/office_complex)
 "jD" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -357,6 +389,7 @@
 /obj/effect/decal/tracks/wheels/bloody{
 	dir = 10
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/bigredv2/outside/office_complex)
 "lp" = (
@@ -371,7 +404,7 @@
 "ls" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/stationary/crashmode,
-/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "lM" = (
@@ -415,6 +448,7 @@
 	dir = 1
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating,
 /area/bigredv2/outside/office_complex)
 "nc" = (
@@ -423,10 +457,12 @@
 /area/bigredv2/outside/office_complex)
 "ng" = (
 /obj/machinery/autodoc_console,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/sterile,
 /area/bigredv2/outside/office_complex)
 "nC" = (
-/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/bigredv2/outside/office_complex)
 "nX" = (
@@ -437,13 +473,14 @@
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "oo" = (
-/obj/structure/window/reinforced/toughened,
+/obj/item/shard,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/red{
 	dir = 1
 	},
 /area/bigredv2/outside/office_complex)
 "ow" = (
-/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/mainship/mono,
 /area/bigredv2/outside/office_complex)
 "oF" = (
@@ -465,12 +502,18 @@
 /obj/structure/bed/chair/office/light,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
+"ps" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 4
+	},
+/area/bigredv2/outside/c)
 "pA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/tile/red/redtaupecorner,
+/turf/open/floor/plating/icefloor,
 /area/bigredv2/outside/office_complex)
 "pC" = (
 /obj/structure/bed/chair/dropship/passenger,
@@ -512,10 +555,8 @@
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/bigredv2/outside/c)
 "qN" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/red/redtaupecorner{
 	dir = 8
 	},
@@ -544,8 +585,7 @@
 /obj/item/radio/intercom{
 	dir = 4;
 	freerange = 1;
-	name = "General Listening Channel";
-	pixel_y = -28
+	name = "General Listening Channel"
 	},
 /obj/structure/closet/secure_closet/guncabinet/lmg,
 /turf/open/floor/mainship/blue{
@@ -553,13 +593,7 @@
 	},
 /area/bigredv2/outside/office_complex)
 "si" = (
-/obj/machinery/door/window{
-	dir = 2
-	},
-/obj/structure/window/reinforced/toughened{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/mainship/red{
 	dir = 1
 	},
@@ -616,6 +650,10 @@
 /obj/item/clothing/head/beret/jan,
 /turf/open/floor/tile/whiteyellow/full,
 /area/bigredv2/outside/office_complex)
+"tP" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/icefloor,
+/area/bigredv2/outside/office_complex)
 "tR" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall,
@@ -670,7 +708,7 @@
 /obj/effect/decal/tracks/wheels/bloody{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/blood,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/bigredv2/outside/office_complex)
@@ -701,6 +739,7 @@
 "vL" = (
 /obj/effect/spawner/random/gun,
 /obj/effect/spawner/random/ammo,
+/obj/item/shard,
 /turf/open/floor/mainship/red{
 	dir = 4
 	},
@@ -711,7 +750,7 @@
 	},
 /area/bigredv2/outside/office_complex)
 "vS" = (
-/obj/structure/window/framed/mainship/white/canterbury,
+/obj/structure/window/framed/mainship/white,
 /turf/open/floor/plating,
 /area/bigredv2/outside/office_complex)
 "vX" = (
@@ -753,6 +792,11 @@
 /obj/machinery/bioprinter/stocked,
 /turf/open/floor/mainship/sterile/dark,
 /area/bigredv2/outside/office_complex)
+"xe" = (
+/obj/item/stack/sheet/metal,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/bigredv2/outside/office_complex)
 "xf" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/asteroidfloor,
@@ -768,6 +812,7 @@
 /obj/machinery/door/poddoor/mainship/open{
 	dir = 1
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating,
 /area/bigredv2/outside/office_complex)
 "xU" = (
@@ -826,11 +871,21 @@
 /obj/structure/cable,
 /turf/open/floor/mainship,
 /area/bigredv2/outside/office_complex)
+"zg" = (
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating,
+/area/bigredv2/outside/office_complex)
 "zi" = (
 /obj/machinery/door/poddoor/mainship/open,
 /obj/effect/decal/tracks/wheels/bloody{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/mainship/mono,
 /area/bigredv2/outside/office_complex)
 "zG" = (
@@ -865,7 +920,7 @@
 /area/bigredv2/outside/office_complex)
 "AQ" = (
 /obj/item/stack/sheet/metal,
-/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/blood,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile,
 /area/bigredv2/outside/office_complex)
@@ -948,7 +1003,7 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
-/turf/open/floor,
+/turf/open/floor/plating/icefloor,
 /area/bigredv2/outside/office_complex)
 "EA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -988,7 +1043,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "Fv" = (
@@ -1010,7 +1065,7 @@
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 8
 	},
-/obj/effect/landmark/corpsespawner/security,
+/obj/effect/landmark/corpsespawner/marine,
 /turf/open/floor/mainship/mono,
 /area/bigredv2/outside/office_complex)
 "FJ" = (
@@ -1018,7 +1073,7 @@
 /obj/effect/decal/tracks/wheels/bloody{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/blood,
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/bigredv2/outside/office_complex)
@@ -1033,6 +1088,7 @@
 /obj/item/clipboard,
 /obj/item/pinpointer,
 /obj/machinery/vending/nanomed,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/blue,
 /area/bigredv2/outside/office_complex)
 "FR" = (
@@ -1050,7 +1106,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/bigredv2/outside/office_complex)
 "FV" = (
-/turf/closed/wall/mainship/white/canterbury,
+/turf/closed/wall/mainship/white,
 /area/bigredv2/outside/office_complex)
 "Gf" = (
 /obj/structure/bed/chair/dropship/passenger,
@@ -1089,7 +1145,7 @@
 /area/bigredv2/outside/office_complex)
 "Iy" = (
 /obj/structure/cable,
-/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/blood,
 /obj/effect/decal/tracks/wheels/bloody{
 	dir = 1
 	},
@@ -1128,8 +1184,13 @@
 	name = "General Listening Channel";
 	pixel_y = -28
 	},
-/obj/effect/landmark/corpsespawner/security,
+/obj/effect/landmark/corpsespawner/marine/corpsman,
 /turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/outside/office_complex)
+"JC" = (
+/obj/effect/spawner/random/gun,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
 /area/bigredv2/outside/office_complex)
 "JK" = (
 /obj/machinery/autolathe,
@@ -1140,6 +1201,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/ammo,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/bigredv2/outside/office_complex)
 "JW" = (
@@ -1149,15 +1211,20 @@
 /obj/effect/ai_node,
 /turf/open/floor,
 /area/bigredv2/outside/c)
+"JY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/icefloor,
+/area/bigredv2/outside/office_complex)
 "Ks" = (
 /obj/structure/bed/chair/dropship/passenger,
 /obj/machinery/vending/nanomed,
-/obj/effect/landmark/corpsespawner/security,
+/obj/effect/landmark/corpsespawner/marine,
 /turf/open/floor/mainship/sterile,
 /area/bigredv2/outside/office_complex)
 "Kz" = (
 /obj/machinery/door/poddoor/mainship/open,
-/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/mainship/mono,
 /area/bigredv2/outside/office_complex)
 "Lx" = (
@@ -1192,11 +1259,8 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/office_complex)
 "ME" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/item/stack/sheet/plasteel,
-/turf/open/floor/tile/red/redtaupecorner,
+/turf/open/floor/plating/icefloor,
 /area/bigredv2/outside/office_complex)
 "MJ" = (
 /obj/structure/table,
@@ -1267,9 +1331,7 @@
 "OS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
-/turf/open/floor/tile/red/redtaupecorner{
-	dir = 8
-	},
+/turf/open/floor/plating/icefloor,
 /area/bigredv2/outside/office_complex)
 "OX" = (
 /obj/docking_port/stationary/crashmode,
@@ -1281,6 +1343,7 @@
 /area/bigredv2/outside/e)
 "PJ" = (
 /obj/item/shard,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/bigredv2/outside/office_complex)
 "PN" = (
@@ -1300,7 +1363,7 @@
 /obj/effect/decal/tracks/wheels/bloody{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
@@ -1347,18 +1410,32 @@
 "Qw" = (
 /obj/item/stack/sheet/metal,
 /obj/item/ammo_casing,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/bigredv2/outside/office_complex)
 "Qy" = (
 /obj/item/shard,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/blue{
 	dir = 4
 	},
 /area/bigredv2/outside/office_complex)
+"QF" = (
+/turf/open/floor/plating/icefloor,
+/area/bigredv2/outside/se)
 "QL" = (
+/obj/effect/landmark/corpsespawner/marine,
+/obj/effect/decal/cleanable/blood{
+	dir = 1
+	},
 /turf/open/floor/mainship/blue{
 	dir = 8
 	},
+/area/bigredv2/outside/office_complex)
+"QM" = (
+/obj/item/stack/sheet/metal,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk,
 /area/bigredv2/outside/office_complex)
 "Ra" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1403,6 +1480,7 @@
 /obj/effect/decal/tracks/wheels/bloody{
 	dir = 10
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/bigredv2/outside/office_complex)
 "SY" = (
@@ -1442,7 +1520,7 @@
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/bigredv2/outside/e)
 "Uz" = (
-/turf/closed/wall/mainship/outer/canterbury,
+/turf/closed/wall/mainship,
 /area/bigredv2/outside/office_complex)
 "US" = (
 /obj/structure/table/mainship,
@@ -1494,10 +1572,19 @@
 "Wm" = (
 /turf/open/floor,
 /area/bigredv2/outside/c)
+"Wn" = (
+/obj/item/stack/sheet/metal,
+/obj/item/shard,
+/turf/open/floor/mainship/mono,
+/area/bigredv2/outside/office_complex)
 "Ws" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/se)
+"Wv" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/icefloor,
+/area/bigredv2/outside/office_complex)
 "Wz" = (
 /obj/structure/window_frame/mainship,
 /obj/item/shard,
@@ -1519,9 +1606,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/tile/red/redtaupecorner{
-	dir = 4
-	},
+/turf/open/floor/plating/icefloor,
 /area/bigredv2/outside/office_complex)
 "Xf" = (
 /turf/open/floor/marking/asteroidwarning{
@@ -1535,6 +1620,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
+"Xt" = (
+/turf/open/floor/plating,
+/area/bigredv2/outside/office_complex)
 "Xu" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/red/redtaupecorner{
@@ -1546,6 +1634,7 @@
 	dir = 1
 	},
 /obj/effect/spawner/random/gun,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/bigredv2/outside/office_complex)
 "XJ" = (
@@ -1593,6 +1682,10 @@
 	dir = 8
 	},
 /area/bigredv2/outside/office_complex)
+"Yp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/whiteyellow/full,
+/area/bigredv2/outside/office_complex)
 "Yr" = (
 /turf/open/floor/mainship/mono,
 /area/bigredv2/outside/office_complex)
@@ -1628,6 +1721,7 @@
 /area/bigredv2/outside/office_complex)
 "Zw" = (
 /obj/structure/bed/chair/dropship/passenger,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/bigredv2/outside/office_complex)
 "ZA" = (
@@ -1648,6 +1742,7 @@
 /area/bigredv2/outside/office_complex)
 "ZD" = (
 /obj/machinery/door/poddoor/mainship/open,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/mainship/mono,
 /area/bigredv2/outside/office_complex)
 "ZJ" = (
@@ -1661,7 +1756,7 @@ sB
 Tz
 AR
 Yc
-Yc
+AR
 mI
 AR
 mI
@@ -1677,7 +1772,7 @@ Yc
 Yc
 AR
 Xf
-sB
+Dc
 sB
 "}
 (2,1,1) = {"
@@ -1707,12 +1802,12 @@ sB
 "}
 (3,1,1) = {"
 qL
-sB
+Dc
 oU
 Uz
 Uz
 Kz
-ZD
+dv
 ZD
 Uz
 TD
@@ -1728,7 +1823,7 @@ qx
 Uz
 Qd
 sB
-sB
+Dc
 "}
 (4,1,1) = {"
 qL
@@ -1752,7 +1847,7 @@ nC
 AS
 Uz
 Ys
-sB
+Dc
 sB
 "}
 (5,1,1) = {"
@@ -1777,7 +1872,7 @@ jD
 eI
 Uz
 Ys
-sB
+bc
 sB
 "}
 (6,1,1) = {"
@@ -1838,13 +1933,13 @@ wl
 Uz
 MN
 zb
+ea
 Yr
-Yr
-Yr
+ea
 iB
 LE
 iS
-uh
+JC
 iB
 iS
 iS
@@ -1852,7 +1947,7 @@ LE
 Yh
 Nk
 xx
-wF
+JY
 OX
 "}
 (9,1,1) = {"
@@ -1876,7 +1971,7 @@ bu
 LM
 ha
 MP
-xx
+zg
 OS
 kc
 "}
@@ -1897,7 +1992,7 @@ Vc
 FF
 Yr
 gN
-LE
+Wn
 hs
 Lx
 iY
@@ -1913,7 +2008,7 @@ XQ
 Uz
 LE
 tF
-LE
+xe
 hT
 Sv
 vw
@@ -1927,8 +2022,8 @@ Jt
 We
 Uz
 Uz
-Tx
-Tx
+wF
+Wv
 "}
 (12,1,1) = {"
 Uz
@@ -1946,14 +2041,14 @@ uZ
 Yr
 PT
 PT
-tF
+ju
 ow
 sx
 SE
 Uz
 Qd
-Tx
-Fp
+wF
+QF
 "}
 (13,1,1) = {"
 sB
@@ -1972,12 +2067,12 @@ cp
 Uz
 vX
 uL
-uk
+QM
 ek
 vX
 Uz
 Ys
-uC
+Xt
 Ws
 "}
 (14,1,1) = {"
@@ -1990,9 +2085,9 @@ fs
 Qr
 lp
 Uz
+ea
 Yr
-Yr
-Yr
+ea
 Yr
 Uz
 SE
@@ -2002,12 +2097,12 @@ jK
 SE
 Uz
 Ys
-Tx
+Wv
 Bv
 "}
 (15,1,1) = {"
 rt
-rt
+ps
 oU
 Uz
 Uz
@@ -2027,7 +2122,7 @@ mh
 Ow
 Uz
 Ja
-uC
+Xt
 Ws
 "}
 (16,1,1) = {"
@@ -2045,14 +2140,14 @@ Uz
 Uz
 Uz
 Uz
+tP
+tP
 Uz
 Uz
 Uz
 Uz
 Uz
-Uz
-Uz
-Tx
+wF
 Ws
 "}
 (17,1,1) = {"
@@ -2060,7 +2155,7 @@ jX
 yK
 Pn
 br
-br
+xf
 tE
 Nz
 Gt
@@ -2069,9 +2164,9 @@ oF
 oF
 RN
 Tx
-vO
+wF
 pA
-Tx
+wF
 Tx
 Tx
 Tx
@@ -2182,7 +2277,7 @@ Ws
 "}
 (22,1,1) = {"
 wi
-jZ
+dK
 br
 br
 Tx
@@ -2194,11 +2289,11 @@ mv
 ls
 IE
 Tx
-vO
+wF
 Rd
 Tx
 Ty
-by
+Yp
 pX
 ud
 Mn
@@ -2215,7 +2310,7 @@ mv
 mv
 oR
 Cj
-mv
+oR
 Am
 IE
 Tx
@@ -2226,7 +2321,7 @@ yB
 by
 ud
 ud
-by
+Yp
 lM
 Ws
 "}
@@ -2273,7 +2368,7 @@ vO
 Hj
 by
 by
-ud
+pX
 pX
 Ra
 Ij
@@ -2282,13 +2377,13 @@ Fp
 "}
 (26,1,1) = {"
 dT
-jZ
+dK
 br
 NB
 br
+xf
 br
-br
-br
+xf
 Tx
 MJ
 vG

--- a/code/game/objects/effects/landmarks/corpsespawner.dm
+++ b/code/game/objects/effects/landmarks/corpsespawner.dm
@@ -375,4 +375,4 @@
 	corpsegloves = /obj/item/clothing/gloves/latex
 	corpseshoes = /obj/item/clothing/shoes/marine
 	corpsepocket1 = /obj/item/tweezers
-	corpsepocket2 = /obj/item/glasses
+	corpsepocket2 = /obj/item/clothing/glasses/meson

--- a/code/game/objects/effects/landmarks/corpsespawner.dm
+++ b/code/game/objects/effects/landmarks/corpsespawner.dm
@@ -339,3 +339,40 @@
 	corpseid = 1
 	corpseidjob = "Private Security Officer"
 	corpseidaccess = "101"
+
+/////////////////Marine//////////////////////
+
+/obj/effect/landmark/corpsespawner/marine
+	name = "Marine"
+	corpseuniform = /obj/item/clothing/under/marine/standard
+	corpsesuit = /obj/item/clothing/suit/modular/xenonauten/light
+	corpseback = /obj/item/storage/backpack/satchel
+	corpsemask = /obj/item/clothing/mask/rebreather
+	corpsehelmet = /obj/item/clothing/head/modular/marine/m10x
+	corpsegloves = /obj/item/clothing/gloves/marine
+	corpseshoes = /obj/item/clothing/shoes/marine
+	corpsepocket1 = /obj/item/tool/lighter/zippo
+
+/obj/effect/landmark/corpsespawner/marine/engineer
+	name = "Marine Engineer"
+	corpseuniform = /obj/item/clothing/under/marine/standard
+	corpsesuit = /obj/item/clothing/suit/modular/xenonauten/light
+	corpseback = /obj/item/storage/backpack/marine/engineerpack
+	corpsemask = /obj/item/clothing/mask/gas/tactical
+	corpsehelmet = /obj/item/clothing/head/beret/eng
+	corpsegloves = /obj/item/clothing/gloves/marine/insulated
+	corpseshoes = /obj/item/clothing/shoes/marine
+	corpsebelt = /obj/item/storage/belt/utility/full
+	corpsepocket1 = /obj/item/flashlight
+
+/obj/effect/landmark/corpsespawner/marine/corpsman
+	name = "Marine Corpsman"
+	corpseuniform = /obj/item/clothing/under/marine/corpsman
+	corpsesuit = /obj/item/clothing/suit/modular/xenonauten/light
+	corpseback = /obj/item/storage/backpack/corpsman
+	corpsemask = /obj/item/clothing/mask/gas
+	corpsehelmet = /obj/item/clothing/head/helmet/marine/corpsman
+	corpsegloves = /obj/item/clothing/gloves/latex
+	corpseshoes = /obj/item/clothing/shoes/marine
+	corpsepocket1 = /obj/item/tweezers
+	corpsepocket2 = /obj/item/glasses


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Apparently an area on Big Red has an incorrect area assignment causing wonky visual effects when it comes to weather.
![unknown](https://user-images.githubusercontent.com/49290523/159824235-528e0d3f-649a-475c-8c54-72127b3c4160.png)

This PR removes that and makes yet more changes to the Crashedbury variation of offices, namely making it so the walls aren't indestructible and adding marine corpses inside instead of security.

## Why It's Good For The Game

Just some more minor tweaks requested on Discord, I live to make tiny changes.

## Changelog
:cl:
add: New marine corpse spawners for use by mappers.
balance: The crashed Canterbury variation in Big Red no longer has indestructible walls.
fix: Fixed an incorrect area in Big Red causing weather to look weird.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
