### PR TITLE
Tweak Minerva and PoS for FCDR to have loadout vendor and change poster's positions

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -356,6 +356,7 @@
 	dir = 5
 	},
 /obj/effect/ai_node,
+/obj/structure/sign/poster,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "be" = (
@@ -1110,6 +1111,13 @@
 /obj/structure/window/framed/mainship/requisitions,
 /turf/open/floor/plating,
 /area/mainship/squads/req)
+"dB" = (
+/obj/machinery/door/airlock/mainship/command/CPToffice{
+	dir = 2
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/commandbunks)
 "dC" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -1780,6 +1788,7 @@
 	},
 /obj/effect/ai_node,
 /obj/structure/cable,
+/obj/structure/sign/poster,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "fI" = (
@@ -3981,16 +3990,11 @@
 /turf/closed/wall/mainship/research/containment/wall/west,
 /area/mainship/medical/medical_science)
 "ni" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/structure/sign/poster{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet{
-	icon_state = "carpetside"
-	},
-/area/mainship/living/bridgebunks)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/starboard_hull)
 "nj" = (
 /turf/open/floor/mainship/research/containment/floor2{
 	dir = 9
@@ -4180,9 +4184,9 @@
 /area/mainship/living/cryo_cells)
 "nP" = (
 /obj/structure/sign/poster{
-	dir = 8
+	dir = 1
 	},
-/turf/closed/wall/mainship,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "nQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -4971,6 +4975,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"qv" = (
+/obj/structure/cable,
+/turf/open/floor/carpet{
+	dir = 1;
+	icon_state = "carpetside"
+	},
+/area/mainship/living/bridgebunks)
 "qw" = (
 /obj/machinery/power/apc/mainship,
 /turf/closed/wall/mainship,
@@ -7469,6 +7480,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/general)
+"yH" = (
+/obj/structure/bed/chair/comfy/beige{
+	dir = 4
+	},
+/obj/effect/landmark/start/job/staffofficer,
+/turf/open/floor/carpet,
+/area/mainship/living/bridgebunks)
 "yI" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 8;
@@ -9541,9 +9559,12 @@
 /turf/open/floor/mainship/silver,
 /area/mainship/medical/medical_science)
 "EQ" = (
-/obj/docking_port/stationary/marine_dropship/crash_target,
-/turf/closed/wall/mainship,
-/area/mainship/living/commandbunks)
+/obj/machinery/camera/autoname/mainship,
+/obj/structure/sign/poster{
+	dir = 1
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "ER" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/numbertwobunks)
@@ -9930,46 +9951,21 @@
 /area/mainship/living/evacuation)
 "FL" = (
 /obj/structure/table/woodentable,
-/obj/item/clipboard{
-	pixel_x = 5
-	},
-/obj/item/paper,
-/obj/item/tool/pen,
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/mainship/living/bridgebunks)
-"FN" = (
-/turf/open/floor/mainship/purple{
-	dir = 4
-	},
-/area/mainship/squads/general)
-"FO" = (
-/obj/structure/bed,
-/obj/item/bedsheet/captain,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/landmark/start/job/staffofficer,
-/turf/open/floor/wood,
-/area/mainship/living/bridgebunks)
-"FP" = (
-/obj/structure/table/woodentable,
 /obj/item/storage/fancy/cigar,
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
-"FQ" = (
-/obj/structure/closet/secure_closet/captain,
-/turf/open/floor/carpet{
-	dir = 9;
-	icon_state = "carpetside"
+"FN" = (
+/turf/open/floor/mainship/purple{
+	dir = 4
 	},
+/area/mainship/squads/general)
+"FO" = (
+/turf/open/floor/wood,
 /area/mainship/living/commandbunks)
-"FS" = (
+"FP" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
 	},
@@ -9982,7 +9978,7 @@
 	icon_state = "carpetside"
 	},
 /area/mainship/living/commandbunks)
-"FT" = (
+"FQ" = (
 /obj/structure/table/mainship,
 /obj/structure/paper_bin{
 	pixel_y = 5
@@ -9994,10 +9990,22 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
-"FU" = (
+"FS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/poster{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
+"FT" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hop,
 /obj/effect/landmark/start/job/fieldcommander,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
+"FU" = (
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "FV" = (
@@ -10243,6 +10251,7 @@
 /obj/item/fuelCell/full,
 /obj/item/assembly/prox_sensor,
 /obj/item/fuelCell/full,
+/obj/structure/sign/poster,
 /turf/open/floor/mainship/orange{
 	dir = 10
 	},
@@ -10267,30 +10276,31 @@
 /turf/open/floor/wood,
 /area/mainship/living/bridgebunks)
 "GH" = (
-/obj/structure/bed/fancy,
-/obj/item/bedsheet/captain,
-/obj/effect/landmark/start/job/captain,
-/turf/open/floor/wood,
-/area/mainship/living/commandbunks)
-"GI" = (
-/turf/open/floor/carpet{
-	dir = 10;
-	icon_state = "carpetside"
-	},
-/area/mainship/living/commandbunks)
-"GJ" = (
 /obj/structure/cable,
 /turf/open/floor/carpet{
 	dir = 6;
 	icon_state = "carpetside"
 	},
 /area/mainship/living/commandbunks)
-"GK" = (
+"GI" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
-"GM" = (
+"GJ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
+"GK" = (
 /obj/machinery/marine_selector/clothes/commander,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
+"GM" = (
+/obj/machinery/vending/uniform_supply,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "GN" = (
@@ -10490,9 +10500,7 @@
 	},
 /area/mainship/living/briefing)
 "Hp" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
+/obj/structure/sign/poster,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "Hq" = (
@@ -10627,12 +10635,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "HO" = (
-/obj/machinery/door/airlock/mainship/command/CPToffice{
-	dir = 2
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/commandbunks)
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "HP" = (
 /obj/machinery/door/airlock/mainship/command/FCDRquarters{
 	dir = 2
@@ -11040,6 +11050,8 @@
 /obj/structure/bed/chair/comfy/beige{
 	dir = 4
 	},
+/obj/effect/landmark/start/job/staffofficer,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/mainship/living/bridgebunks)
 "Jc" = (
@@ -11072,10 +11084,10 @@
 /turf/open/floor/carpet,
 /area/mainship/living/bridgebunks)
 "Ji" = (
-/obj/structure/cable,
 /obj/structure/bed/chair/comfy/beige{
 	dir = 8
 	},
+/obj/effect/landmark/start/job/staffofficer,
 /turf/open/floor/carpet,
 /area/mainship/living/bridgebunks)
 "Jk" = (
@@ -11086,6 +11098,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/structure/bed/chair/comfy/beige{
+	dir = 8
+	},
+/obj/effect/landmark/start/job/staffofficer,
 /turf/open/floor/carpet{
 	dir = 4;
 	icon_state = "carpetside"
@@ -11333,6 +11349,19 @@
 /obj/effect/decal/warning_stripes/thick,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
+"JW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/sign/poster{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/port_hull)
 "JX" = (
 /obj/structure/sign/vacuum,
 /turf/closed/wall/mainship/outer,
@@ -11389,18 +11418,9 @@
 	},
 /area/mainship/living/bridgebunks)
 "Ke" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/structure/cable,
-/turf/open/floor/carpet{
-	icon_state = "carpetside"
-	},
-/area/mainship/living/bridgebunks)
+/obj/docking_port/stationary/marine_dropship/crash_target,
+/turf/closed/wall/mainship,
+/area/mainship/living/commandbunks)
 "Kf" = (
 /obj/machinery/door_control/mainship/req{
 	dir = 4;
@@ -11493,11 +11513,12 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "Kv" = (
-/obj/structure/sign/poster{
-	dir = 8
+/obj/structure/closet/secure_closet/captain,
+/turf/open/floor/carpet{
+	dir = 9;
+	icon_state = "carpetside"
 	},
-/turf/closed/wall/mainship/outer,
-/area/mainship/hallways/hangar)
+/area/mainship/living/commandbunks)
 "Kw" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
 	dir = 1;
@@ -12019,7 +12040,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
 /obj/machinery/light,
-/obj/effect/landmark/start/job/staffofficer,
 /turf/open/floor/wood,
 /area/mainship/living/bridgebunks)
 "Mb" = (
@@ -12387,11 +12407,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "Nj" = (
-/obj/structure/sign/poster{
-	dir = 8
-	},
-/turf/closed/wall/mainship,
-/area/mainship/living/evacuation)
+/obj/effect/landmark/start/job/captain,
+/obj/structure/bed/fancy,
+/obj/item/bedsheet/captain,
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "Nk" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 8
@@ -14037,11 +14057,11 @@
 	},
 /area/mainship/engineering/engineering_workshop)
 "Sl" = (
-/obj/structure/sign/poster{
-	dir = 4
+/turf/open/floor/carpet{
+	dir = 10;
+	icon_state = "carpetside"
 	},
-/turf/closed/wall/mainship,
-/area/mainship/squads/general)
+/area/mainship/living/commandbunks)
 "Sm" = (
 /obj/structure/rack,
 /obj/item/stack/rods{
@@ -14221,6 +14241,12 @@
 	dir = 10
 	},
 /area/mainship/command/cic)
+"SU" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/general)
 "SV" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/marine_card,
@@ -15260,12 +15286,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cryo_cells)
 "VW" = (
-/obj/structure/cable,
-/turf/open/floor/carpet{
-	dir = 1;
-	icon_state = "carpetside"
-	},
-/area/mainship/living/bridgebunks)
+/obj/machinery/loadout_vendor,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "VX" = (
 /obj/machinery/light{
 	dir = 4
@@ -18640,7 +18663,7 @@ gN
 gP
 gP
 gN
-Nj
+gN
 gN
 gN
 gP
@@ -19741,7 +19764,7 @@ vw
 vw
 vw
 gQ
-Le
+JW
 fD
 XE
 hr
@@ -20013,10 +20036,10 @@ co
 co
 co
 DX
-EM
-EM
-EM
-EM
+EO
+EO
+EO
+EO
 EM
 IW
 EM
@@ -20111,10 +20134,10 @@ Av
 aw
 Sf
 DZ
-EM
+EO
 FL
-GF
-EM
+Nj
+EO
 Ia
 IX
 JY
@@ -20209,10 +20232,10 @@ cs
 cs
 cs
 Ea
-EM
+Ke
 FO
-GG
-HN
+FO
+EO
 lK
 IY
 Ka
@@ -20308,8 +20331,8 @@ YC
 KO
 Ed
 EO
-EO
-EO
+Kv
+Sl
 EO
 Ic
 IZ
@@ -20405,13 +20428,13 @@ BI
 aw
 ZR
 Eg
-EQ
+EO
 FP
 GH
-EO
-Ie
+dB
+qv
 Ja
-ni
+Kc
 EM
 GF
 LZ
@@ -20492,7 +20515,7 @@ pr
 qC
 kT
 kq
-tp
+FS
 uJ
 vw
 vw
@@ -20509,7 +20532,7 @@ GI
 EO
 Ie
 Je
-ni
+Kc
 HN
 GG
 Ma
@@ -20602,10 +20625,10 @@ BJ
 CI
 Ei
 EO
-FS
-GJ
-HO
-VW
+EO
+EO
+EO
+Ie
 Ji
 Kc
 EM
@@ -20699,13 +20722,13 @@ ty
 ty
 ty
 Ej
-EO
+ER
 FT
 GK
-EO
+ER
 Ic
 IZ
-Ke
+Kc
 EM
 GF
 LZ
@@ -20798,11 +20821,11 @@ BN
 ty
 Ek
 ER
-ER
-ER
+FU
+VW
 ER
 Ie
-Ja
+yH
 Kc
 HN
 GG
@@ -22522,7 +22545,7 @@ XE
 VS
 VS
 VS
-Kv
+VS
 VS
 VS
 VS
@@ -26176,7 +26199,7 @@ mD
 lw
 sr
 sr
-Sl
+sr
 sr
 sr
 sr
@@ -26191,7 +26214,7 @@ sr
 sr
 sr
 sr
-Sl
+sr
 sr
 sr
 sr
@@ -26274,7 +26297,7 @@ pW
 rk
 sr
 sX
-uq
+GJ
 sX
 sr
 ta
@@ -26371,11 +26394,11 @@ mE
 pX
 mE
 sr
-sY
+nP
 us
 AC
 sr
-tc
+nP
 tc
 yJ
 Pl
@@ -26571,7 +26594,7 @@ sr
 ut
 qm
 sr
-tc
+nP
 tc
 yG
 zZ
@@ -26583,7 +26606,7 @@ tc
 zZ
 fj
 sr
-IB
+SU
 JJ
 KM
 sr
@@ -26681,7 +26704,7 @@ tc
 Ae
 CT
 sr
-nP
+sr
 sr
 sr
 sr
@@ -26943,7 +26966,7 @@ YB
 XE
 XE
 Hr
-WD
+ni
 fv
 QM
 gI
@@ -27253,7 +27276,7 @@ oU
 mE
 mE
 sr
-sY
+EQ
 us
 tc
 sr
@@ -27352,7 +27375,7 @@ qh
 rr
 sr
 tf
-ux
+HO
 tf
 sr
 ta
@@ -27450,7 +27473,7 @@ lw
 lw
 sr
 sr
-nP
+sr
 sr
 sr
 sr

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -5058,9 +5058,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "qp" = (
-/obj/structure/toilet,
 /obj/machinery/light{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
@@ -6113,10 +6112,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/port_missiles)
 "tL" = (
-/obj/machinery/photocopier,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/mirror,
+/obj/structure/sink,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "tM" = (
@@ -6307,6 +6304,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/photocopier,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "un" = (
@@ -8878,6 +8876,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "Cb" = (
@@ -9731,11 +9732,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "Eo" = (
-/obj/structure/sink{
-	dir = 8
-	},
-/obj/structure/mirror{
-	dir = 8
+/obj/structure/toilet{
+	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
@@ -40142,7 +40140,7 @@ sV
 sV
 Mb
 Mb
-Ox
+tL
 qp
 Et
 uV
@@ -40398,7 +40396,7 @@ tb
 Qu
 sV
 Ca
-tL
+Ox
 Ox
 Ox
 Ox

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -1334,7 +1334,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_umbilical)
 "er" = (
-/obj/machinery/vending/nanomed,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -3635,6 +3634,10 @@
 "lG" = (
 /turf/closed/wall/mainship,
 /area/mainship/command/telecomms)
+"lH" = (
+/obj/machinery/marine_selector/clothes/commander,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "lJ" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
@@ -5055,8 +5058,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "qp" = (
-/obj/structure/sink,
-/obj/structure/mirror,
+/obj/structure/toilet,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "qq" = (
@@ -6135,14 +6140,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "tO" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/shower{
+	dir = 4;
+	pixel_y = -3
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
+/obj/machinery/door/window,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/numbertwobunks)
 "tP" = (
 /obj/structure/cable,
@@ -6563,23 +6566,31 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/port_missiles)
 "vh" = (
-/obj/machinery/marine_selector/clothes/commander,
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
+/obj/effect/landmark/start/job/fieldcommander,
 /turf/open/floor/carpet{
 	dir = 10;
 	icon_state = "carpetside"
 	},
 /area/mainship/living/numbertwobunks)
 "vi" = (
-/obj/structure/bed,
-/obj/item/bedsheet/hop,
-/obj/effect/landmark/start/job/fieldcommander,
 /turf/open/floor/carpet{
 	dir = 6;
 	icon_state = "carpetside"
 	},
 /area/mainship/living/numbertwobunks)
 "vj" = (
-/obj/structure/bookcase,
+/obj/item/binoculars,
+/obj/item/storage/briefcase,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/head/bowlerhat{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/staff/gentcane{
+	pixel_x = 5
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "vk" = (
@@ -7139,9 +7150,8 @@
 /turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/firing_range)
 "wP" = (
-/obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/area/mainship/living/numbertwobunks)
 "wQ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -8836,6 +8846,10 @@
 /obj/item/clipboard{
 	pixel_x = 5
 	},
+/obj/structure/paper_bin{
+	pixel_y = 5
+	},
+/obj/item/tool/pen,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "BX" = (
@@ -9192,11 +9206,15 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "CZ" = (
-/obj/structure/sign/poster{
-	dir = 8
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
-/turf/closed/wall/mainship,
-/area/mainship/squads/req)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "Db" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
@@ -9705,12 +9723,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "Eo" = (
-/obj/machinery/shower{
-	dir = 4;
-	pixel_y = -3
+/obj/structure/sink{
+	dir = 8
 	},
-/obj/machinery/door/window,
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/mirror{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "Ep" = (
 /obj/machinery/light/small{
@@ -9739,14 +9758,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
 "Et" = (
-/obj/structure/flora/pottedplant/twentytwo,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/machinery/door/airlock/mainship/generic/bathroom{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "Eu" = (
@@ -9796,11 +9813,14 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "EC" = (
-/obj/structure/table/mainship,
-/obj/structure/paper_bin{
-	pixel_y = 5
+/obj/structure/flora/pottedplant/twentytwo,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/item/tool/pen,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/light,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "ED" = (
@@ -11464,10 +11484,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "JG" = (
-/obj/structure/bed/chair/office/dark,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "JH" = (
@@ -13063,11 +13079,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "Ou" = (
-/obj/structure/sign/poster{
-	dir = 4
-	},
-/turf/closed/wall/mainship/outer,
-/area/mainship/hull/lower_hull)
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "Ov" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -13654,8 +13668,13 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "Qm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "Qn" = (
@@ -13737,19 +13756,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "Qv" = (
-/obj/structure/table/mainship,
-/obj/item/clothing/head/bowlerhat{
-	pixel_x = -4;
-	pixel_y = 8
+/obj/structure/bed/chair/office/dark{
+	dir = 4
 	},
-/obj/item/staff/gentcane{
-	pixel_x = 5
-	},
-/obj/item/storage/fancy/cigarettes/lady_finger{
-	pixel_y = 5
-	},
-/obj/item/clothing/tie/red,
-/obj/item/megaphone,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "Qw" = (
@@ -13921,10 +13930,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "QX" = (
@@ -14364,15 +14373,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Sp" = (
-/obj/machinery/door/airlock/mainship/command/FCDRquarters{
-	dir = 2
-	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "Sr" = (
 /obj/structure/disposalpipe/segment/corner{
@@ -14534,11 +14537,8 @@
 /turf/open/floor/mainship/ntlogo,
 /area/mainship/squads/general)
 "SP" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/toilet,
-/turf/open/floor/mainship/mono,
+/obj/machinery/vending/nanomed,
+/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "SQ" = (
 /obj/structure/disposalpipe/segment/corner,
@@ -14795,7 +14795,7 @@
 	},
 /area/mainship/command/self_destruct)
 "TM" = (
-/obj/structure/flora/pottedplant/twentyone,
+/obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "TN" = (
@@ -14956,13 +14956,8 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "Uw" = (
-/obj/machinery/door/airlock/mainship/generic/bathroom{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/turf/open/floor/mainship/mono,
+/obj/machinery/loadout_vendor,
+/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "Ux" = (
 /obj/structure/noticeboard,
@@ -15588,6 +15583,16 @@
 /obj/effect/decal/warning_stripes/box/small,
 /turf/open/floor/mainship/black/full,
 /area/mainship/living/cafeteria_starboard)
+"Wm" = (
+/obj/item/reagent_containers/food/drinks/flask/barflask,
+/obj/item/megaphone,
+/obj/item/clothing/tie/red,
+/obj/item/storage/fancy/cigarettes/lady_finger{
+	pixel_y = 5
+	},
+/obj/structure/table/woodentable,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "Wn" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/black{
@@ -15624,14 +15629,8 @@
 	},
 /area/mainship/shipboard/starboard_missiles)
 "Wt" = (
-/obj/structure/table/mainship,
-/obj/item/storage/briefcase,
-/obj/item/clipboard{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/food/drinks/flask/barflask,
-/obj/item/binoculars,
 /obj/machinery/light,
+/obj/structure/flora/pottedplant/twentyone,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "Wu" = (
@@ -16035,7 +16034,6 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/upper_engineering)
 "XD" = (
-/obj/machinery/door/firedoor/mainship,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -16483,13 +16481,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "YR" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/mainship/command/FCDRquarters{
+	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers{
-	dir = 8
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "YS" = (
@@ -37018,7 +37017,7 @@ rc
 Qc
 Qc
 XX
-Ou
+ad
 XX
 Qc
 Qc
@@ -39877,8 +39876,8 @@ Ec
 fu
 fu
 WW
-bZ
-Ox
+Mb
+tO
 Eo
 Ox
 ZQ
@@ -40137,7 +40136,7 @@ Mb
 Mb
 Ox
 qp
-Ox
+Et
 uV
 vi
 tp
@@ -40393,8 +40392,8 @@ sV
 Ca
 tL
 Ox
-SP
-Uw
+Ox
+Ox
 tM
 vj
 tp
@@ -40649,9 +40648,9 @@ Zt
 sV
 um
 tM
+wP
 Ox
-Ox
-Ox
+Ou
 er
 TM
 tp
@@ -41164,8 +41163,8 @@ sV
 ZM
 BV
 EC
-tO
 Ox
+SP
 JG
 Qv
 tp
@@ -41420,11 +41419,11 @@ Zt
 sV
 sW
 ut
-ut
-Et
+CZ
 Ox
-Ox
-Ox
+Uw
+lH
+Wm
 tp
 Rr
 OI
@@ -41680,8 +41679,8 @@ Ox
 Ox
 Ox
 Ox
-xE
-xY
+Ox
+Ox
 tp
 Ka
 OI
@@ -47299,7 +47298,7 @@ kM
 qG
 qG
 qG
-CZ
+qG
 qG
 qG
 NS
@@ -49867,7 +49866,7 @@ kM
 kM
 kM
 XD
-wP
+kM
 kM
 kM
 kM

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -6142,6 +6142,7 @@
 	pixel_y = -3
 	},
 /obj/machinery/door/window,
+/obj/structure/window/reinforced/tinted,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/numbertwobunks)
 "tP" = (

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -6480,9 +6480,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "uV" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/open/floor/carpet{
 	dir = 5;
 	icon_state = "carpetside"
@@ -6797,6 +6794,7 @@
 /obj/machinery/firealarm{
 	dir = 4
 	},
+/obj/structure/sign/poster,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "vR" = (
@@ -7933,6 +7931,16 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"yZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "zb" = (
 /obj/machinery/alarm,
 /turf/open/floor/mainship/mono,
@@ -40394,7 +40402,7 @@ tL
 Ox
 Ox
 Ox
-tM
+yZ
 vj
 tp
 rE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

FCDR now has loadout vendors in all shipside maps except Sulaco. Waiting on you, Derrick, for the Sulaco map change.

In PoS, I change up his bunk to ensure that he has armament vendor, clothing vendor, armor vendor, and loadout vendor.

In Minerva, due to constraints, I have to change up SO, captain, and FC's bunk to give room for FC's loadout vendor and a clothing vendor.

For posters, I change some poster's positions in both maps for aesthetics and visual reasons.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I overheard that FCDR has a loadout vendor in his bunk. I had to check all the shipside maps, which wasn't too hard, to see which map, and surely enough, it was Theseus that had loadout vendor. Of all the shipside maps, Theseus has FCDR not running to marine prep like a peasant.

As par usual of me, I ensure that all shipside maps, except Sulaco since Derrick has his hands on that, have at least a loadout vendor.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: All FCDR bunks now have at least a loadout vendor in all shipside maps except Sulaco
fix: poster positions in Minerva and PoS
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
