### PR TITLE
Standardization of Round Start CAS ammo

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -793,7 +793,7 @@ Any new map or map change must comply to these specifications.
 #### TGM Format & Map Merge
 
 New maps should be converted into the .tgm format before making a pull request. All edits to existing maps should be correctly map merged. This is done using the [Map Merge](https://tgstation13.org/wiki/Map_Merger) utility included in the repo to convert the file to TGM format.
-Likewise, you MUST run Map Merge prior to opening your PR when updating existing maps to minimize the change differences (even when using third party mapping programs such as StrongDMM).
+It is HIGHLY recommend to use third party mapping programs such as StrongDMM to make map changes easier.
 
 #### Variable Editing (Var-edits)
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -793,9 +793,7 @@ Any new map or map change must comply to these specifications.
 #### TGM Format & Map Merge
 
 New maps should be converted into the .tgm format before making a pull request. All edits to existing maps should be correctly map merged. This is done using the [Map Merge](https://tgstation13.org/wiki/Map_Merger) utility included in the repo to convert the file to TGM format.
-Likewise, you MUST run Map Merge prior to opening your PR when updating existing maps to minimize the change differences (even when using third party mapping programs such as FastDMM.)
-
-Failure to run Map Merge on a map after using third party mapping programs (such as FastDMM) greatly increases the risk of the map's key dictionary becoming corrupted by future edits after running map merge. Resolving the corruption issue involves rebuilding the map's key dictionary; id est rewriting all the keys contained within the map by reconverting it from BYOND to TGM format - which creates very large differences that ultimately delay the PR process and is extremely likely to cause merge conflicts with other pull requests.
+Likewise, you MUST run Map Merge prior to opening your PR when updating existing maps to minimize the change differences (even when using third party mapping programs such as StrongDMM).
 
 #### Variable Editing (Var-edits)
 
@@ -813,6 +811,24 @@ All maps should be 255x255 at most because of known issues with how BYOND behave
 
 Ais should be able to go everywhere on the map and it should be a single network if possible (two levels maps get a pass). Nodes can be placed up to 15 tiles apart, including diagonally. Any walls or lava between two nodes will block the link between them. Remember that ais are stupid, and that some obstacles are impossible to cross for them, so make their paths simple.
 
+#### Limited marine supplies in shipside maps
+
+Marine players are given limited supplies for preparation and deployment to enhance their gameplay while not sacrificing xenomorph players' fun. This line of thought follows the philosophy that all shipside maps are not chosen over another in consideration of supplies. For example: if marines choose Pillar of Spring over all other maps due to Pillar of Spring having more round start sentries and mortars, then mappers or contributors are obligated to eliminate the bias. While not an exhausive list, all shipside maps follow the same number of supplies:
+
+Chem lab:
+3 bluespace beakers
+
+CAS armament:
+6 30mm ammo crates
+2 banshees
+2 keepers
+2 widowmakers
+4 mini rockets
+2 GAU-21 30 mm cannons
+2 rocket pods
+2 minirocket pods
+
+This doesn't mean that mappers can't put extra supplies in planetside maps, though the extra supplies should be far away from landing zones to prevent marine players from favoring one map over another when considering supplies.
 #### Anti fob area system implemented
 
 Xenos should not be able to build near the fob before shutters are down. As such, wide enough areas around FOB must be placed. An area is set as non-buildable if it contains a shutter.
@@ -823,7 +839,7 @@ Every area must have an APC. A ground map must have roughly 10 generators, with 
 
 #### Connected pipenet
 
-Every ship should have a believable and complete pipe system (ventilation, scrubbers). All pipes must belong to the same network. No pipes ending nowhere. Pipes groundside are not mandatory, but they add to the atmosphere and are usefull to xeno. 
+Every ship should have a believable and complete pipe system (ventilation, scrubbers). All pipes must belong to the same network. No pipes ending nowhere. Pipes groundside are not mandatory, but they add to the atmosphere and are usefull to xeno.
 
 #### Xenos related items (walls, weeds, silos, etc.)
 
@@ -836,7 +852,7 @@ Adding corpse spawner also add to the atmospher, but they are not mandatory.
 
 Any silo placed on map must be protected by enough fog. This fog only appears in crash gamemode and is here to prevent marines to go near xenos spawn locations
 
-#### Intel and nuke disk computers 
+#### Intel and nuke disk computers
 
 There should be a reasonnable amount of intel computers placed in areas with apc. 3 nuke disk computer (yellow, red, blue) must be placed around the map. A nuke landmark has to be present as well somewhere.
 

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -4140,6 +4140,10 @@
 /obj/item/clothing/suit/replica,
 /turf/open/floor/mainship/red,
 /area/mainship/shipboard/firing_range)
+"nJ" = (
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "nK" = (
 /obj/effect/landmark/start/job/squadcorpsman,
 /turf/open/floor/mainship/cargo/arrow{
@@ -4952,6 +4956,10 @@
 /obj/structure/window/framed/mainship/requisitions,
 /turf/open/floor/plating,
 /area/mainship/command/corporateliaison)
+"qp" = (
+/obj/structure/ship_ammo/rocket/keeper,
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/hangar)
 "qq" = (
 /obj/structure/prop/mainship/name_stencil{
 	icon_state = "TGMC3"
@@ -6817,7 +6825,8 @@
 /obj/machinery/door_control/mainship/ammo{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
+/obj/structure/ship_ammo/heavygun,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "wJ" = (
 /obj/structure/table/reinforced,
@@ -9091,6 +9100,10 @@
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"Dy" = (
+/obj/structure/ship_ammo/minirocket,
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/hangar)
 "DA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -10037,6 +10050,10 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
+"FY" = (
+/obj/structure/dropship_equipment/weapon/minirocket_pod,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "FZ" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -21946,8 +21963,8 @@ fS
 VC
 OS
 iE
-dP
-dP
+qp
+qp
 sJ
 OS
 VC
@@ -22038,14 +22055,14 @@ Wu
 aD
 aZ
 VC
-VC
+FY
 VC
 aW
 VC
 OS
 jv
-VC
-VC
+mR
+mR
 jv
 OS
 VC
@@ -22136,14 +22153,14 @@ eC
 aW
 aZ
 VC
-VC
+nJ
 VC
 aW
 VC
 OS
 jw
-VC
-VC
+dP
+dP
 tk
 OS
 VC
@@ -22239,10 +22256,10 @@ cC
 aW
 VC
 OS
-pe
+Dy
 eC
 cD
-pe
+Dy
 OS
 VC
 iy
@@ -22533,7 +22550,7 @@ VC
 aW
 jq
 OS
-VC
+pe
 VC
 VC
 wI

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -38,7 +38,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "ah" = (
-/obj/structure/ship_ammo/heavygun,
+/obj/structure/ship_ammo/minirocket/illumination,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "ai" = (
@@ -65,10 +65,6 @@
 	},
 /obj/item/reagent_containers/jerrycan,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"al" = (
-/obj/structure/ship_ammo/minirocket/illumination,
-/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "am" = (
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -107,7 +103,7 @@
 	},
 /area/mainship/hallways/hangar)
 "at" = (
-/obj/structure/dropship_equipment/sentry_holder,
+/obj/structure/ship_ammo/heavygun,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "au" = (
@@ -115,11 +111,15 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname/mainship,
+/obj/structure/ship_ammo/rocket/widowmaker,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "aw" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
 /obj/structure/ship_ammo/rocket/widowmaker,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "az" = (
 /turf/closed/wall/mainship,
@@ -181,6 +181,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
+/obj/structure/ship_ammo/rocket/banshee,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "aL" = (
@@ -674,7 +675,7 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "cq" = (
-/obj/structure/ship_ammo/rocket/banshee,
+/obj/structure/dropship_equipment/weapon/minirocket_pod,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "cr" = (
@@ -3085,6 +3086,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
+/obj/structure/dropship_equipment/electronics/spotlights,
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
@@ -3310,9 +3312,8 @@
 	},
 /area/mainship/medical/lower_medical)
 "kG" = (
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
+/obj/structure/dropship_equipment/weapon/minirocket_pod,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "kH" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -3784,7 +3785,6 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
@@ -3837,11 +3837,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "ms" = (
-/obj/structure/dropship_equipment/weapon/heavygun,
-/obj/effect/decal/warning_stripes/thin,
-/turf/open/floor/mainship/orange{
-	dir = 4
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
 	},
+/obj/structure/ship_ammo/rocket/banshee,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "mt" = (
 /obj/machinery/light{
@@ -8993,8 +8993,11 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/surgery_hallway)
 "Cu" = (
-/obj/structure/closet/toolcloset,
-/turf/open/floor/mainship/cargo,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/structure/ship_ammo/rocket/keeper,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Cv" = (
 /obj/structure/cable,
@@ -9076,6 +9079,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
+"CI" = (
+/obj/structure/closet/toolcloset,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar)
 "CJ" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -10197,7 +10204,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Ge" = (
-/obj/structure/dropship_equipment/electronics/spotlights,
+/obj/structure/dropship_equipment/weapon/rocket_pod,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "Gf" = (
@@ -10319,7 +10326,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
 "Gv" = (
-/obj/structure/dropship_equipment/weapon/minirocket_pod,
+/obj/structure/dropship_equipment/weapon/heavygun,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "Gw" = (
@@ -12671,7 +12678,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_umbilical)
 "Nk" = (
-/obj/structure/dropship_equipment/weapon/rocket_pod,
+/obj/structure/ship_ammo/rocket/keeper,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "Nl" = (
@@ -14558,6 +14565,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"SS" = (
+/obj/machinery/light,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/hallways/hangar)
 "ST" = (
 /obj/item/tool/mop,
 /obj/machinery/light/small{
@@ -48530,12 +48546,12 @@ rc
 rc
 rc
 Pa
-Ge
-Ge
+kB
 Ge
 kB
+cq
 kB
-kB
+Gv
 az
 fL
 az
@@ -48788,11 +48804,11 @@ rc
 rc
 Pa
 kB
-kB
+Ge
 ap
+kG
 ap
-ap
-kB
+Gv
 az
 cu
 az
@@ -49049,7 +49065,7 @@ ak
 aJ
 an
 ag
-Gv
+kB
 az
 cu
 az
@@ -49303,8 +49319,8 @@ rc
 Pa
 aM
 aM
-ar
-ar
+aM
+aM
 Gg
 az
 az
@@ -49815,8 +49831,8 @@ Tm
 rc
 rc
 Pa
-al
-al
+at
+at
 at
 aA
 iB
@@ -50072,8 +50088,8 @@ Tm
 rc
 rc
 Pa
-al
-al
+at
+at
 at
 aA
 bH
@@ -50357,7 +50373,7 @@ bh
 bh
 bh
 gD
-kB
+CI
 az
 TE
 Bn
@@ -50588,8 +50604,8 @@ rc
 Pa
 ah
 ah
-ar
-ar
+ah
+ah
 bI
 az
 az
@@ -50844,10 +50860,10 @@ rc
 rc
 Pa
 au
-bw
+aw
 aK
-bw
-aB
+ms
+Cu
 Nk
 az
 fL
@@ -50871,7 +50887,7 @@ ke
 ke
 ke
 mj
-Np
+SS
 az
 gp
 ng
@@ -51100,8 +51116,8 @@ Tm
 rc
 rc
 Pa
-aw
-cq
+kB
+kB
 ap
 ap
 ap
@@ -51126,9 +51142,9 @@ iR
 jg
 KG
 lC
-kG
-ms
-Cu
+lC
+lC
+lC
 az
 EN
 ng

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -624,11 +624,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "acr" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -1047,11 +1047,11 @@
 /turf/open/floor/grass,
 /area/mainship/living/starboard_garden)
 "adz" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -1459,7 +1459,7 @@
 "anQ" = (
 /obj/structure/ship_ammo/heavygun,
 /obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "aop" = (
 /obj/structure/toilet{
@@ -2724,7 +2724,7 @@
 /area/mainship/living/commandbunks)
 "bbP" = (
 /obj/structure/ship_ammo/rocket/banshee,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "bbQ" = (
 /obj/effect/ai_node,
@@ -2745,11 +2745,11 @@
 /area/mainship/hallways/hangar)
 "bbX" = (
 /obj/structure/ship_ammo/rocket/widowmaker,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "bbZ" = (
 /obj/structure/ship_ammo/rocket/keeper,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "bca" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -3124,10 +3124,6 @@
 /obj/machinery/computer/security/wooden_tv,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
-"bga" = (
-/obj/structure/ship_ammo/minirocket,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "bgb" = (
 /turf/closed/wall/mainship,
 /area/mainship/hallways/hangar)
@@ -5726,10 +5722,7 @@
 /area/mainship/living/cryo_cells)
 "bCK" = (
 /obj/structure/ship_ammo/minirocket,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "bCL" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -9551,7 +9544,7 @@
 /area/mainship/hallways/port_hallway)
 "dZK" = (
 /obj/structure/ship_ammo/minirocket/illumination,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "ead" = (
 /turf/open/floor/mainship/mono,
@@ -11163,7 +11156,7 @@
 /area/mainship/hallways/port_hallway)
 "hhA" = (
 /obj/structure/ship_ammo/heavygun,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "hhG" = (
 /turf/open/floor/stairs/rampbottom{
@@ -12387,6 +12380,13 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
+"juB" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/effect/decal/warning_stripes/thin,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "jvm" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/mono,
@@ -12578,6 +12578,15 @@
 "jQu" = (
 /turf/open/floor/wood,
 /area/mainship/living/pilotbunks)
+"jQx" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "jQK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -13022,6 +13031,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/basketball)
+"kHG" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "kHU" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -14680,6 +14698,13 @@
 	dir = 4
 	},
 /area/mainship/command/cic)
+"npA" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thin,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "nqG" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/light{
@@ -16022,6 +16047,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/starboard_hallway)
+"pNB" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/effect/decal/warning_stripes/thin,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "pNG" = (
 /turf/open/shuttle/escapepod{
 	icon_state = "floor11"
@@ -41676,9 +41708,9 @@ bgb
 bbP
 bbP
 bbZ
-bbZ
-bga
-bCK
+jQx
+bdW
+bdW
 bgb
 eaL
 bbR
@@ -41930,11 +41962,11 @@ aaa
 aai
 tDH
 bgb
-lvI
-lvI
-lvI
-lvI
-bga
+xQX
+xQX
+xQX
+npA
+bCK
 bCK
 bgb
 lvI
@@ -42188,11 +42220,11 @@ aai
 tDH
 bgb
 acr
-bdW
-bdW
-bdW
-bga
-bga
+bea
+bea
+juB
+bCK
+bCK
 bgb
 bLs
 bbR
@@ -43730,9 +43762,9 @@ aai
 tDH
 bgb
 adz
-bea
-bea
-bea
+bdW
+bdW
+pNB
 dZK
 dZK
 bgb
@@ -43988,8 +44020,8 @@ rbR
 bgb
 bbX
 bbX
-bbX
-bbX
+bbZ
+npA
 dZK
 dZK
 bgb
@@ -44243,12 +44275,12 @@ aaa
 aai
 aak
 bgb
-lvI
-lvI
-lvI
-lvI
-dZK
-dZK
+xQX
+xQX
+xQX
+kHG
+bea
+bea
 bgb
 eaL
 bVJ


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

All shipsides shall spawn with the following:
6 30mm ammo crates
2 banshees
2 keepers
2 widowmakers
4 mini rockets
2 GAU-21 30 mm cannons
2 rocket pods
2 minirocket pods

Update map contribution to ensure that other contributors can read good practices on map PRs.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Theseus is the only shipside map that has the most CAS ammo compare to all shipside maps. It is the most beloved of all the CAS PO since they can boom boom more. This ensures that all CAS PO have the same ammo across shipside maps.

Long time ago, Theseus was made for high pop (whatever that meant). Only Big Bury is the dedicated high pop shipside, and even then Crash game mode doesn't exist after 30+ pop.

Theseus has
6 30mm ammo crates
2 banshees
2 keepers
4 widowmakers
6 mini rockets
2 GAU-21 30 mm cannons
2 rocket pods
2 minirocket pods

Meaning that Theseus is going to bomb the crap out of planetside. This is a nerf to Theseus and a buff to all other maps. You're welcome, CAS PO.

**NO SHIPSIDE SHOULD HAVE MORE OR LESS THAN EACH OTHER!!**

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: All shipsides shall spawn with the following:, 6 30mm ammo crates, 2 banshees, 2 keepers, 2 widowmakers, 4 mini rockets, 2 GAU-21 30 mm cannons, 2 rocket pods, 2 minirocket pods
code: update map contribution page to ensure that other contributors can read good practices on map PRs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
