### PR TITLE
Fixes AT gun APHE chain explosions

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1472,10 +1472,6 @@ datum/ammo/bullet/revolver/tp44
 /datum/ammo/rocket/atgun_shell/drop_nade(turf/T)
 	explosion(T, 0, 2, 3, 2)
 
-/datum/ammo/rocket/atgun_shell/on_hit_turf(turf/T, obj/projectile/P)
-	if(T == P.original_target_turf)	//Only detonate at the target, not on wall passes.
-		return ..()
-
 /datum/ammo/rocket/atgun_shell/apcr
 	name = "tungsten penetrator"
 	hud_state = "shell_he"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1472,6 +1472,10 @@ datum/ammo/bullet/revolver/tp44
 /datum/ammo/rocket/atgun_shell/drop_nade(turf/T)
 	explosion(T, 0, 2, 3, 2)
 
+/datum/ammo/rocket/atgun_shell/on_hit_turf(turf/T, obj/projectile/P)
+	if(T == P.original_target_turf)	//Only detonate at the target, not on wall passes.
+		return ..()
+
 /datum/ammo/rocket/atgun_shell/apcr
 	name = "tungsten penetrator"
 	hud_state = "shell_he"

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -569,7 +569,8 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 
 /obj/projectile/proc/scan_a_turf(turf/turf_to_scan, cardinal_move)
 	if(turf_to_scan.density) //Handle wall hit.
-		ammo.on_hit_turf(turf_to_scan, src)
+		if((ammo.flags_ammo_behavior & (AMMO_EXPLOSIVE|AMMO_PASS_THROUGH_TURF)) != (AMMO_EXPLOSIVE|AMMO_PASS_THROUGH_TURF))
+			ammo.on_hit_turf(turf_to_scan, src)
 		turf_to_scan.bullet_act(src)
 		return !(ammo.flags_ammo_behavior & AMMO_PASS_THROUGH_TURF)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Basically, the way explosive (rocket) ammo works is that on_turf_hit, it explodes, which generally works all fine since a rocket doesn't tend to pass through walls. Hoowever, when there is say, a shell that passes through walls and is explosive, said code causes issues, namely exploding on every closed turf (mainly walls) and stacking explosions, amping its lethality to questionable levels. ~~This resolves this problem via only calling on_turf_hit()'s drop_nade() if said turf is the original intended target, as that is the only situation where it *should* explode on hitting a turf (since hitting xenos or whatever else is handled in the other on_hit procs and it doesn't pass through mobs / simillar anymore)~~

Instead of what I did before, I instead resorted to having ammo not do on_hit_turf except for the final (clicked target) turf if it has both explosive and pass_turf as flags, due to the previous implementation still causing dual explosions on the final turf. (I.. guess I could turn it into a seperate flag if wanted? It's just too oddly specific to really be worth making it its own bitflag which is why I did it this way)
Feel free to suggest alternatives if you can think of a cleaner way of doing this, or if you do want me to turn it into a flag.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: APHE only explodes when it hits something that stops its movement, not when passing through walls on its way there.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
