### PR TITLE
Fixes gens sometimes just not working and needing to be recorrupted.

### DIFF
--- a/code/modules/power/groundmap_geothermal.dm
+++ b/code/modules/power/groundmap_geothermal.dm
@@ -88,8 +88,9 @@
 	start_processing()
 
 /obj/machinery/power/geothermal/process()
-	if(corrupted && corruption_on && length(GLOB.humans_by_zlevel["2"]) > 0.2 * length(GLOB.alive_human_list))
-		SSpoints.add_psy_points("[corrupted]", GENERATOR_PSYCH_POINT_OUTPUT / GLOB.geothermal_generator_ammount)
+	if(corrupted && corruption_on)
+		if(length(GLOB.humans_by_zlevel["2"]) > 0.2 * length(GLOB.alive_human_list))
+			SSpoints.add_psy_points("[corrupted]", GENERATOR_PSYCH_POINT_OUTPUT / GLOB.geothermal_generator_ammount)
 		return
 	if(!is_on || buildstate || !anchored || !powernet) //Default logic checking
 		return PROCESS_KILL


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently, the way the check is setup, if corruption activates and not enough marines are on ground, it gets to the PROCESS_KILL bit and stops its processing, which does not restart unless recorrupted or fixed. This was triggered by the tad taking off for example, as this triggers gen corruption to activate and start processing, causes it to not see any marines on ground, and cancels processing due to that.

This PR makes it return whether or not there are enough marines on ground, preventing the PROCESS_KILL bit from being reached provided it is corrupted and has its corruption activated, which should avoid said issue. (Of course, it still checks for the required amount for providing the actual points.)

Fixes #9308 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Groundside corrupted gens should not have their point production break anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
