### PR TITLE
Fix crusher primo advance

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -169,7 +169,7 @@
 /datum/action/xeno_action/activable/advance
 	name = "Rapid Advance"
 	action_icon_state = "crest_defense"
-	mechanics_text = "Fling an adjacent target over and behind you. Also works over barricades."
+	mechanics_text = "Charges up the crushers charge in place, then unleashes the full bulk of the crusher at the target location. Does not crush in diagonal directions."
 	ability_name = "rapid advance"
 	plasma_cost = 175
 	cooldown_timer = 30 SECONDS
@@ -198,11 +198,13 @@
 	X.set_canmove(TRUE)
 
 	var/datum/action/xeno_action/ready_charge/charge = X.actions_by_path[/datum/action/xeno_action/ready_charge]
+	var/aimdir = get_dir(X,A)
 	if(charge)
+		charge.do_stop_momentum(FALSE) //Reset charge so next_move_limit check_momentum() does not cuck us and 0 out steps_taken
 		charge.do_start_crushing()
 		charge.valid_steps_taken = charge.max_steps_buildup - 1
+		charge.charge_dir = aimdir //Set dir so check_momentum() does not cuck us
 	for(var/i=0 to get_dist(X, A))
-		var/aimdir = get_dir(X,A)
 		if(i % 2)
 			playsound(X, "alien_charge", 50)
 			new /obj/effect/temp_visual/xenomorph/afterimage(get_turf(X), X)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Crusher Advance in its current form is near useless because it does not "ram" things in its immediate path or put crusher in a full charge state during or after.

This PR seeks to remedy that. For a separate PR I am also debating lowering the very high plasma cost in light of the fact each tile covered by the ability now also depletes plasma as if you were full speed charging and stacking the costs. Perhaps keep the cost as is but leverage `agile_charge` to allow fun diagonal ramming just for the Advance path.

Here you can see it won't even touch a wooden table currently:
`We skid to a halt.`
![dreamseeker_32PEHSwwW6](https://user-images.githubusercontent.com/64715958/160573478-96a8177a-a880-4aa1-a891-49732490cf84.gif)

I added a readout for `valid_steps_taken` to visualize what was happening to the counter. As you can see currently it is way lower than it should be:
![dreamseeker_aPHc6cOVzJ](https://user-images.githubusercontent.com/64715958/160574247-bc9e8838-9966-4f77-9515-f6c75cbf741b.gif)

Here is the result of the fix:
`We crush wooden table! We ram Pene Dorn!`
![dreamseeker_UaCmPIggR8](https://user-images.githubusercontent.com/64715958/160574545-d9d4c4c7-75ff-4c67-9c77-3c9d0bc8058b.gif)

## Why It's Good For The Game

Fix good. Restores a primo ability to its intended strength.
Fixes #9641
## Changelog
:cl:
fix: Fixed Crusher Primo Rapid Advance not granting full charge or applying do_crush effects.
fix: Fixed a rare case of Rapid Advance causing signal registration errors.
spellcheck: Fixed Rapid Advance evolution menu description.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
