### PR TITLE
More Playable King!

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -217,7 +217,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	desc = "Places a Psychic Echo chamber that tallhosts can detect, then after a summon time selects a random sister to take over the mind of the gravity manipulating King."
 	icon = "king"
 	flags_gamemode = ABILITY_DISTRESS
-	psypoint_cost = 1800
+	psypoint_cost = 600
 
 /datum/hive_upgrade/xenos/king/can_buy(mob/living/carbon/xenomorph/buyer, silent = TRUE)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

 A small rebalance on the Xeno King. Changed the psy points to make a King pod from 1800 to 600 (same as Silo) 

## Why It's Good For The Game

Since the King skills are a bit underwhelming compared to the costs to acquire him we are making the King more accessible. King in game and it is really cool, the problem is: It's not worth it. More playable xeno castes are always good in my opinion!

## Changelog
:cl:ZSpitfire

balance: reduced psy points cost for King pod

/:cl: