### PR TITLE
Dragunov Special Ammo

### DIFF
--- a/code/__DEFINES/calibers.dm
+++ b/code/__DEFINES/calibers.dm
@@ -51,6 +51,7 @@
 #define CALIBER_86X70 "8.6x70mm"
 #define CALIBER_10X99 "10x99mm"
 #define CALIBER_762X54 "7.62x54mm Rimmed" //SVD and mosin
+#define CALIBER_762X54_plus "7.62.54mm Rimmed" //SVD only
 #define CALIBER_557 ".557/440" //Martini Henry
 #define CALIBER_RAILGUN "rail projectile"
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -971,6 +971,16 @@ datum/ammo/bullet/revolver/tp44
 	penetration = 35
 	sundering = 15
 
+/datum/ammo/bullet/sniper/svd_special //Different ammo with new special tips. Mosin cannot load these.
+	name ="hollow point sniper bullet"
+	handful_icon_state = "crude sniper bullet"
+	hud_state = "minigun"
+	handful_amount = 5
+	damage = 95
+	penetration = 30
+	sundering = 0
+	damage_falloff = 0.5
+
 /datum/ammo/bullet/sniper/martini
 	name = "crude heavy sniper bullet"
 	handful_icon_state = "crude heavy sniper bullet"

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -285,10 +285,14 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	reload_sound = 'sound/weapons/guns/interact/svd_reload.ogg'
 	cocked_sound = 'sound/weapons/guns/interact/svd_cocked.ogg'
 	default_ammo_type = /obj/item/ammo_magazine/sniper/svd
-	allowed_ammo_types = list(/obj/item/ammo_magazine/sniper/svd)
+	allowed_ammo_types = list(
+		/obj/item/ammo_magazine/sniper/svd,
+		/obj/item/ammo_magazine/sniper/svd_special,
+	)
 	attachable_allowed = list(
 		/obj/item/attachable/reddot,
 		/obj/item/attachable/verticalgrip,
+		/obj/item/attachable/angledgrip,
 		/obj/item/attachable/gyro,
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/bipod,

--- a/code/modules/projectiles/magazines/shotguns.dm
+++ b/code/modules/projectiles/magazines/shotguns.dm
@@ -62,6 +62,16 @@ one type of shotgun ammo, but I think it helps in referencing it. ~N
 	w_class = WEIGHT_CLASS_SMALL // CAN throw it in your pocket, friend.
 	icon_state_mini = "mosin"
 
+/obj/item/ammo_magazine/rifle/bolt/softpoint
+	name = "box of SP 7.62x54mmR rifle rounds"
+	desc = "A box filled with soft-point rifle bullets."
+	icon_state = "7.62"
+	default_ammo = /datum/ammo/bullet/sniper/svd_special
+	caliber = CALIBER_762X54_plus
+	max_rounds = 20
+	w_class = WEIGHT_CLASS_SMALL
+	icon_state_mini = "mosin"
+
 /obj/item/ammo_magazine/rifle/martini
 	name = "box of .557/440 rifle rounds"
 	desc = "A box filled with rifle bullets."

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -55,7 +55,14 @@
 	max_rounds = 10
 	icon_state_mini = "mag_rifle"
 
-
+/obj/item/ammo_magazine/sniper/svd_special //Different magazine with special ammo.
+	name = "\improper Special SVD magazine (7.62x54mmR)"
+	desc = "A large caliber magazine for the SVD sniper rifle. This one has Soft-Point markings."
+	caliber = CALIBER_762X54_plus
+	icon_state = "svd"
+	default_ammo = /datum/ammo/bullet/sniper/svd_special
+	max_rounds = 10
+	icon_state_mini = "mag_rifle"
 
 //tx8 magazines
 

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1228,12 +1228,16 @@ Imports
 /datum/supply_packs/imports/dragunov
 	name = "SVD Dragunov Sniper"
 	contains = list(/obj/item/weapon/gun/rifle/sniper/svd)
-	cost = 15
+	cost = 20
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/imports/dragunov/ammo
 	name = "SVD Dragunov Sniper Ammo"
 	contains = list(/obj/item/ammo_magazine/sniper/svd)
+	cost = 2
+/datum/supply_packs/imports/dragunov/ammo_special
+	name = "SVD Dragunov Sniper Soft-Point Ammo"
+	contains = list(/obj/item/ammo_magazine/sniper/svd_special)
 	cost = 5
 	available_against_xeno_only = TRUE
 


### PR DESCRIPTION
## About The Pull Request

Made to compete with https://github.com/tgstation/TerraGov-Marine-Corps/pull/9846 .

Adds a new magazine with special tipped ammo (soft-point ammo) that does more damage, costs 5 req points. Normal magazines are cheaper, and the SVD Dragunov is 20 points instead of 15.
Also it adds angled grip because the longer ranged scope adds more delay than the medium ranged scope which adds delay, and it's only fair with the req price of the weapon.
## Why It's Good For The Game

( People malded over #9846 so I made this, for the same reasons. )
Sniper has always been a worse niche when it comes to a good player's arsenal. There is no good sniper weapon at the moment.
A sniper should be playable other than by NPCs.
This should allow for the meta to change over from shotgun to sniper more nicely.
It's an alternate ammo thing that is req-locked, and since the weapon can be found in starter crates, I might change the randomization, but it definitely won't two-shot rounies even with special ammo.
It doesn't make the dragunov good in close quarters since you can't attach bayonet nor pb with it, but it certainly has an effect on frontlining, so even NPCs can kill an ancient shrike in 6 or 7 shots (7 or 8 shots with regular ammo), which was something of a skill issue before.

## Changelog
:cl:
balance: Dragunov now costs 20 points, it's magazines now cost 2 points. 
balance: New ammo that uses special tipped rounds for the Dragunov can be ordered from req for 5 points, they provide higher damage but no sunder and more falloff.
/:cl:
