### PR TITLE
Crusher unique explosion handler removal

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/crusher.dm
@@ -18,13 +18,6 @@
 	old_x = -16
 	old_y = -3
 
-/mob/living/carbon/xenomorph/crusher/ex_act(severity)
-
-	flash_act()
-
-	if(severity == EXPLODE_DEVASTATE)
-		adjustBruteLoss(rand(200, 300), updating_health = TRUE)
-
 
 /mob/living/carbon/xenomorph/crusher/handle_special_state()
 	if(is_charging >= CHARGE_ON)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Crusher was the only xenos to have unique explosion handler, which overrides default behavior with 0 damage from light or heavy explosions, but doubled damage from devastating ones. This PR removes this handler. This code is likely a remainder from CM, since it wasn't ever changed by anybody.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes game more intuitive - game plays as you expect it to play. Crusher now can be damaged by nades, but is very resistant to them, as he still has tier 3 armor. He can also be damaged by all CAS weapons. For info - CAS machinegun and nades will deal 30 damage on average. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Removed ex act from crushher.dm
balance: crusher is no longer immune to some explosions
balance: crusher gets less damage from biggest explosions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
