### PR TITLE
Changes the T-25 Smartrifle to cost 29 points instead of 30

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -148,7 +148,7 @@ GLOBAL_LIST_INIT(smartgunner_gear_listed_products, list(
 	/obj/item/clothing/glasses/night/m56_goggles = list(CAT_ESS, "M26 head mounted sight", 0, "white"),
 	/obj/item/weapon/gun/rifle/standard_smartmachinegun = list(CAT_LEDSUP, "T-29 Smartmachinegun", 29 , "white"), //If a smartgunner buys T-29, then they will have 16 points to purchase 4 T-29 drums
 	/obj/item/ammo_magazine/standard_smartmachinegun = list(CAT_LEDSUP, "T-29 Smartmachinegun ammo", 4 , "black"),
-	/obj/item/weapon/gun/rifle/standard_smartrifle = list(CAT_LEDSUP, "T-25 smartrifle", 30 , "white"),
+	/obj/item/weapon/gun/rifle/standard_smartrifle = list(CAT_LEDSUP, "T-25 smartrifle", 29 , "white"),
 	/obj/item/ammo_magazine/rifle/standard_smartrifle = list(CAT_LEDSUP, "T-25 smartrifle magazine", 2 , "black"),
 	/obj/item/ammo_magazine/packet/t25 = list(CAT_LEDSUP, "T-25 smartrifle ammo box", 6 , "black"),
 	))


### PR DESCRIPTION
## About The Pull Request

This PR makes the T-25 Smartrifle cost 29 points instead of 30 in the Equipment Rack, like the T-29 does.

## Why It's Good For The Game

I'm a T-29 user personally, if only because it's more familiar to me as an ex-CM smartgunner, but I think it's annoying to have the leftover point when using the T-25. I considered changing the prices of the other items around, but I'd imagine that would end up misbalancing it far more. For instance, if I made the ammo box cost 5 points, you could buy a whole other magazine *but still have the leftover point*, while if I made the magazine cost 1 point, you could get 3 mags and 2 ammo boxes, which doesn't seem that bad to me, but I can see why other people would find it such.

## Changelog
:cl:
balance: Makes the T-25 Smartrifle cost 29 points from the Smartgunner Equipment Rack instead of 30. Now, what to do with the extra point?
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
