### PR TITLE
Fix crusher rapid advance forcing 8 directions

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -209,6 +209,7 @@
 			playsound(X, "alien_charge", 50)
 			new /obj/effect/temp_visual/xenomorph/afterimage(get_turf(X), X)
 		X.Move(get_step(X, aimdir), aimdir)
+		aimdir = get_dir(X,A)
 	succeed_activate()
 	add_cooldown()
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Someone *cough* in their last PR didn't account for direction needing recalculation each step which is required to advance to all the red arrow destinations:
![dreamseeker_30UpkpaGrY](https://user-images.githubusercontent.com/64715958/161169719-4d819aff-e8ad-4476-b713-d62e83a184e5.png)

## Why It's Good For The Game

Fix.

## Changelog
:cl:
fix: Fixed Crusher Rapid Advance forcing 8 directions only.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
