### PR TITLE
Spitter spits arent blocked by other xenos now

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2081,12 +2081,12 @@ datum/ammo/bullet/revolver/tp44
 /datum/ammo/xeno/acid/medium
 	name = "acid spatter"
 	damage = 30
-	flags_ammo_behavior = AMMO_XENO
+	flags_ammo_behavior = AMMO_XENO|AMMO_SKIPS_ALIENS
 
 /datum/ammo/xeno/acid/auto
 	name = "light acid spatter"
 	damage = 10
-	flags_ammo_behavior = AMMO_XENO
+	flags_ammo_behavior = AMMO_XENO|AMMO_SKIPS_ALIENS
 	spit_cost = 25
 	added_spit_delay = 0
 


### PR DESCRIPTION


## About The Pull Request

Xenos blocked the projectiles

## Why It's Good For The Game

Most xenos are melee and when they move around on the battle field while you are with them they will more often then not accidently block your shots. makes defenders shield thingy more useful

## Changelog
:cl:
balance: added ammo_skip_aliens to spitter spits
/:cl:


