### PR TITLE
Nerfs TAT AP shell

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1479,7 +1479,7 @@ datum/ammo/bullet/revolver/tp44
 	shell_speed = 4
 	damage = 150
 	penetration = 50
-	sundering = 55
+	sundering = 60
 
 /datum/ammo/rocket/atgun_shell/apcr/drop_nade(turf/T)
 	explosion(T, 0, 0, 1, 0)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1478,7 +1478,7 @@ datum/ammo/bullet/revolver/tp44
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING|AMMO_PASS_THROUGH_TURF|AMMO_PASS_THROUGH_MOVABLE
 	shell_speed = 4
 	damage = 150
-	penetration = 100
+	penetration = 50
 	sundering = 55
 
 /datum/ammo/rocket/atgun_shell/apcr/drop_nade(turf/T)


### PR DESCRIPTION
## About The Pull Request
Per title. Reduces penetration from 100 to 50, increases sunder from 55 to 60 _(at MJP's request)_.

## Why It's Good For The Game
AP pierces through walls, ignores armor due to having full penetration, and kills just a little bit over half a Xeno's armor _(inflicted in Sunder)_. TAT is currently very oppressive as a result; this PR aims to amend this by targeting the main offender.

## Changelog
:cl: Lewdcifer
balance: TAT AP penetration reduced from 100 > 50, sundering increased from 55 > 60.
/:cl: