### PR TITLE
Lowers the cost of feast for gorger, and cooldown

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -380,7 +380,7 @@
 	name = "Feast"
 	action_icon_state = "feast"
 	mechanics_text = "Enter a state of rejuvenation. During this time you use a small amount of blood and heal. You can cancel this early."
-	cooldown_timer = 180 SECONDS
+	cooldown_timer = 0 SECONDS
 	plasma_cost = 0
 	keybind_signal = COMSIG_XENOABILITY_FEAST
 	keybind_flags = XACT_KEYBIND_USE_ABILITY
@@ -392,9 +392,9 @@
 		return FALSE
 	if(owner_xeno.has_status_effect(STATUS_EFFECT_XENO_FEAST))
 		return TRUE
-	if(owner_xeno.plasma_stored < owner_xeno.xeno_caste.feast_plasma_drain * 10)
+	if(owner_xeno.plasma_stored < owner_xeno.xeno_caste.feast_plasma_drain * 6.5)
 		if(!silent)
-			to_chat(owner_xeno, span_notice("Not enough to begin a feast. We need [owner_xeno.xeno_caste.feast_plasma_drain * 10] blood."))
+			to_chat(owner_xeno, span_notice("Not enough to begin a feast. We need [owner_xeno.xeno_caste.feast_plasma_drain * 6.5] blood."))
 		return FALSE
 
 /datum/action/xeno_action/activable/feast/use_ability(atom/A)

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -380,7 +380,7 @@
 	name = "Feast"
 	action_icon_state = "feast"
 	mechanics_text = "Enter a state of rejuvenation. During this time you use a small amount of blood and heal. You can cancel this early."
-	cooldown_timer = 0 SECONDS
+	cooldown_timer = 30 SECONDS
 	plasma_cost = 0
 	keybind_signal = COMSIG_XENOABILITY_FEAST
 	keybind_flags = XACT_KEYBIND_USE_ABILITY

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -380,7 +380,7 @@
 	name = "Feast"
 	action_icon_state = "feast"
 	mechanics_text = "Enter a state of rejuvenation. During this time you use a small amount of blood and heal. You can cancel this early."
-	cooldown_timer = 30 SECONDS
+	cooldown_timer = 100 SECONDS
 	plasma_cost = 0
 	keybind_signal = COMSIG_XENOABILITY_FEAST
 	keybind_flags = XACT_KEYBIND_USE_ABILITY


### PR DESCRIPTION
## About The Pull Request

Feast used to be 200 blood/plasma now its 130 blood/plasma to activate.

## Why It's Good For The Game

Gorger is a bullet sponge shielder support caste, that being said 90% of the time it wont have the required blood to activate its feast as it will need to heal and make shields for the hive which is more beneficial so its not seen much.

This will allow the ability to be used more and grant gorger more bullet sponge soaking as a target for marines.

This will help gorger's survivability and presence on the field more so with marines constant additions of weapons and to fine tune itself as the main support for the hive.

feast also had a cooldown of 180 which is terrible for use.

## Changelog
:cl:
balance: feast now cheaper 
balance: feast cooldown now 100 for starters instead of 180
/:cl:


