### PR TITLE
Icy caves crash fixes & adjustments

### DIFF
--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -746,6 +746,11 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/crashed_ship)
+"cN" = (
+/obj/machinery/miner/damaged,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
 "cO" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -3047,6 +3052,12 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves/northern)
+"mS" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ1)
 "mV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -3892,6 +3903,10 @@
 "qC" = (
 /turf/closed/ice/thin/junction,
 /area/icy_caves/outpost/LZ2)
+"qE" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside)
 "qF" = (
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/tile/dark/brown2{
@@ -6466,6 +6481,10 @@
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
+"Bj" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
 "Bk" = (
 /turf/closed/ice/thin/corner{
 	dir = 8
@@ -6980,6 +6999,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/alienstuff)
+"DA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northwestmonorail)
 "DB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/singlePart{
@@ -7030,6 +7053,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"DN" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/corners{
+	dir = 9
+	},
+/area/icy_caves/outpost/LZ1)
 "DO" = (
 /obj/machinery/light{
 	dir = 8
@@ -7286,6 +7315,10 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/LZ1)
+"ER" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside)
 "ES" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -7475,6 +7508,10 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/medbay)
+"FH" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
 "FI" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -8146,10 +8183,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"Iq" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside/center)
 "Ir" = (
 /turf/closed/ice/thin/junction{
 	dir = 4
@@ -8263,6 +8296,11 @@
 	},
 /turf/open/floor/wood,
 /area/icy_caves/caves/underground_cafeteria)
+"IN" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northwestmonorail)
 "IO" = (
 /obj/item/stack/sandbags_empty{
 	amount = 25
@@ -8332,6 +8370,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
+"Jj" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/end{
+	dir = 1
+	},
+/area/icy_caves/caves)
 "Jk" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
@@ -10541,6 +10585,10 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/LZ1)
+"SC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/caves)
 "SD" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 4
@@ -10593,6 +10641,10 @@
 	dir = 4
 	},
 /area/icy_caves/caves/south)
+"SU" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/LZ1)
 "SV" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark,
@@ -10693,6 +10745,10 @@
 	dir = 1
 	},
 /area/icy_caves/caves/northern)
+"Tp" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall,
+/area/icy_caves/outpost/mining/west)
 "Tq" = (
 /obj/effect/decal/cleanable/blood/xtracks,
 /obj/structure/cable,
@@ -11167,10 +11223,6 @@
 /obj/structure/table,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"Vp" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside/center)
 "Vq" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -13035,20 +13087,20 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+cp
+cp
+cp
+cp
+cp
+cp
+cp
+cp
+cp
+cp
+cp
+cp
+cp
+cp
 qs
 uA
 TW
@@ -13191,7 +13243,7 @@ Yf
 MH
 MH
 Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -13204,7 +13256,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+cp
 qs
 ED
 qz
@@ -13347,7 +13399,7 @@ re
 re
 MH
 Yf
-Yf
+cp
 Yf
 Yf
 MH
@@ -13360,7 +13412,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+cp
 qy
 RC
 TM
@@ -13503,7 +13555,7 @@ WI
 WI
 WI
 MH
-Yf
+cp
 Yf
 Yf
 MH
@@ -13516,7 +13568,7 @@ MH
 MH
 MH
 MH
-DX
+DN
 AB
 zi
 TM
@@ -13659,7 +13711,7 @@ pa
 Si
 WI
 WI
-MH
+Jj
 MH
 MH
 MH
@@ -13672,7 +13724,7 @@ MH
 MH
 Uu
 Uu
-DX
+DN
 DX
 Sh
 sK
@@ -13815,20 +13867,20 @@ Tj
 SI
 SI
 SI
+qE
 SI
-SI
-SI
+ER
 SI
 SI
 WI
 WI
 WI
-WI
+FH
 WI
 WI
 Uu
 Uu
-DX
+DN
 Ml
 Tf
 TM
@@ -13971,11 +14023,11 @@ WI
 SI
 Ln
 SI
+qE
 SI
 SI
 SI
-SI
-SI
+ER
 AW
 WI
 XO
@@ -13984,7 +14036,7 @@ XO
 AW
 Uu
 Uu
-Uu
+SU
 Ml
 Tf
 TM
@@ -14127,7 +14179,7 @@ WI
 SI
 SI
 WI
-WI
+Bj
 WI
 WI
 SI
@@ -14140,7 +14192,7 @@ WI
 WI
 xn
 Uu
-Uu
+SU
 Uu
 Aq
 TM
@@ -14283,7 +14335,7 @@ WI
 SI
 SI
 WI
-pD
+cN
 WI
 WI
 SI
@@ -14296,7 +14348,7 @@ WI
 WI
 Uu
 Uu
-Uu
+SU
 Uu
 YH
 TM
@@ -14439,10 +14491,10 @@ WI
 SI
 SI
 WI
+Bj
 WI
 WI
-WI
-SI
+ER
 SI
 WI
 WI
@@ -14452,7 +14504,7 @@ WI
 WI
 Uu
 Uu
-Uu
+SU
 Ml
 Tf
 Tb
@@ -14595,9 +14647,9 @@ nx
 od
 lH
 nx
-xI
-xI
-xI
+Tp
+Tp
+Tp
 SI
 SI
 WI
@@ -14608,7 +14660,7 @@ MH
 WI
 Uu
 Uu
-Ml
+mS
 Ml
 Tf
 Ml
@@ -14753,7 +14805,7 @@ wW
 oI
 oZ
 oK
-xI
+Tp
 SI
 SI
 WI
@@ -14764,7 +14816,7 @@ Yf
 MH
 Uu
 Wo
-Uu
+SU
 UE
 TQ
 Uu
@@ -14909,18 +14961,18 @@ oI
 wW
 oI
 oU
-xI
-SI
-SI
-MH
-Yf
-Yf
-Yf
-qs
-qs
-Uu
-Uu
-Uu
+Tp
+qE
+qE
+Jj
+cp
+cp
+cp
+iS
+iS
+SU
+SU
+SU
 Uu
 TQ
 Uu
@@ -15223,7 +15275,7 @@ oI
 oU
 xI
 SI
-SI
+ER
 WI
 WI
 WI
@@ -16525,7 +16577,7 @@ cH
 in
 XV
 qI
-qI
+DA
 Cl
 Cl
 Cl
@@ -16840,7 +16892,7 @@ Cl
 Cl
 pE
 qA
-Px
+IN
 UU
 qI
 qI
@@ -17151,7 +17203,7 @@ Yf
 Yf
 XV
 qI
-qI
+DA
 qI
 XB
 XV
@@ -19630,7 +19682,7 @@ my
 my
 Iw
 DD
-Vp
+DD
 DD
 nM
 YQ
@@ -19783,10 +19835,10 @@ my
 my
 my
 my
-JW
+my
 my
 DD
-Iq
+DD
 DD
 nM
 YQ
@@ -19942,7 +19994,7 @@ DD
 my
 my
 DD
-Vp
+DD
 DD
 XH
 YQ
@@ -20094,7 +20146,7 @@ ND
 ND
 ND
 ND
-Vp
+DD
 my
 my
 DD
@@ -20253,7 +20305,7 @@ ND
 DD
 my
 my
-Vp
+DD
 DD
 DD
 qz
@@ -20565,7 +20617,7 @@ ND
 DD
 my
 my
-Vp
+DD
 DD
 DD
 qH
@@ -26484,7 +26536,7 @@ li
 li
 li
 DD
-Yl
+SC
 Yl
 TW
 XH
@@ -26952,7 +27004,7 @@ Pv
 Pv
 Sq
 Yl
-Yl
+SC
 Yl
 Ol
 Yf
@@ -27418,8 +27470,8 @@ Pv
 Sq
 Sq
 Yl
-Yl
-Yl
+SC
+SC
 Yl
 RO
 Pv
@@ -27729,7 +27781,7 @@ Sq
 Yl
 Yl
 Yl
-Yl
+SC
 Yl
 Yl
 Ol
@@ -27882,7 +27934,7 @@ Pv
 Yf
 Sq
 Yl
-Yl
+SC
 Yl
 Yl
 Yl
@@ -28041,7 +28093,7 @@ Yl
 Yl
 Yl
 Yl
-Yl
+SC
 Yl
 Yl
 Ol
@@ -28507,7 +28559,7 @@ Yl
 Yl
 Yl
 Yl
-Yl
+SC
 Yl
 Yl
 Ol
@@ -28659,7 +28711,7 @@ Gl
 Za
 Za
 Yl
-Yl
+SC
 Yl
 Yl
 Yl
@@ -28972,7 +29024,7 @@ QP
 Yl
 Yl
 Yl
-Yl
+SC
 Yl
 Yl
 Yl

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -271,6 +271,10 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
+"be" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/end,
+/area/icy_caves/caves/west)
 "bf" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -746,11 +750,6 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/crashed_ship)
-"cN" = (
-/obj/machinery/miner/damaged,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
 "cO" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -1743,6 +1742,11 @@
 	},
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"gY" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/west)
 "gZ" = (
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -2117,6 +2121,10 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ2)
+"iM" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/caves/west)
 "iN" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -2757,6 +2765,12 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/mining/west)
+"lI" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
+	dir = 6
+	},
+/area/icy_caves/caves/west)
 "lK" = (
 /obj/machinery/light{
 	dir = 8
@@ -3056,12 +3070,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves/northern)
-"mS" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singleEnd{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ1)
 "mV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -3126,6 +3134,12 @@
 	},
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/garage)
+"nk" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/corner{
+	dir = 4
+	},
+/area/icy_caves/caves/west)
 "nl" = (
 /turf/open/floor/tile/dark/yellow2,
 /area/icy_caves/outpost/LZ2)
@@ -3414,6 +3428,10 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"oC" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/single,
+/area/icy_caves/caves/west)
 "oD" = (
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 1
@@ -3584,6 +3602,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"pn" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/corner,
+/area/icy_caves/caves/west)
 "po" = (
 /turf/open/floor/tile/dark/purple2{
 	dir = 4
@@ -3911,10 +3933,6 @@
 "qC" = (
 /turf/closed/ice/thin/junction,
 /area/icy_caves/outpost/LZ2)
-"qE" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
 "qF" = (
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/tile/dark/brown2{
@@ -4636,6 +4654,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/purple/whitepurplefull,
 /area/icy_caves/caves/northwestmonorail/medbay)
+"tz" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/junction,
+/area/icy_caves/caves/west)
 "tA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/closed/wall/r_wall,
@@ -5350,6 +5372,12 @@
 	icon_state = "bright_clean2"
 	},
 /area/icy_caves/caves/northwestmonorail)
+"wr" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/corner{
+	dir = 1
+	},
+/area/icy_caves/caves/west)
 "ws" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/tile/dark,
@@ -5630,6 +5658,12 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
+"xB" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singlePart{
+	dir = 9
+	},
+/area/icy_caves/caves/west)
 "xE" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
@@ -5878,6 +5912,12 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"yL" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/corner{
+	dir = 1
+	},
+/area/icy_caves/caves/west)
 "yP" = (
 /turf/open/floor/tile/dark/red2,
 /area/icy_caves/caves/east)
@@ -6502,10 +6542,6 @@
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"Bj" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
 "Bk" = (
 /turf/closed/ice/thin/corner{
 	dir = 8
@@ -6571,6 +6607,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
+"BA" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/junction,
+/area/icy_caves/caves/west)
 "BB" = (
 /obj/structure/cryofeed,
 /turf/open/floor/podhatch/floor{
@@ -6842,6 +6882,12 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/LZ2)
+"CQ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleEnd{
+	dir = 4
+	},
+/area/icy_caves/caves/west)
 "CS" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 6
@@ -7074,12 +7120,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"DN" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/corners{
-	dir = 9
-	},
-/area/icy_caves/outpost/LZ1)
 "DO" = (
 /obj/machinery/light{
 	dir = 8
@@ -7336,10 +7376,6 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/LZ1)
-"ER" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
 "ES" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -7425,6 +7461,12 @@
 	},
 /turf/open/shuttle/dropship/seven,
 /area/space)
+"Fl" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/straight{
+	dir = 4
+	},
+/area/icy_caves/caves/west)
 "Fm" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -7529,10 +7571,6 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/medbay)
-"FH" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
 "FI" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -7759,6 +7797,11 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleT,
 /area/icy_caves/caves)
+"GB" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/west)
 "GD" = (
 /turf/open/floor/tile/dark/red2/corner{
 	dir = 1
@@ -8395,12 +8438,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
-"Jj" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/end{
-	dir = 1
-	},
-/area/icy_caves/caves)
 "Jk" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
@@ -8652,6 +8689,10 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"Ki" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/intersection,
+/area/icy_caves/caves/west)
 "Kj" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -9098,6 +9139,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"Mb" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice/thin/corner,
+/area/icy_caves/caves/west)
 "Mc" = (
 /turf/closed/shuttle/dropship2{
 	icon_state = "54"
@@ -9356,6 +9401,10 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
+"Na" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/west)
 "Nb" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail/hallway)
@@ -10771,10 +10820,6 @@
 	dir = 1
 	},
 /area/icy_caves/caves/northern)
-"Tp" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall,
-/area/icy_caves/outpost/mining/west)
 "Tq" = (
 /obj/effect/decal/cleanable/blood/xtracks,
 /obj/structure/cable,
@@ -11249,6 +11294,10 @@
 /obj/structure/table,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"Vp" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/west)
 "Vq" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -13099,24 +13148,6 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
 cp
 cp
 cp
@@ -13128,9 +13159,27 @@ cp
 cp
 cp
 cp
-cp
-cp
-cp
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
 qs
 uA
 TW
@@ -13255,7 +13304,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -13265,7 +13314,7 @@ Yf
 MH
 MH
 Yf
-Yf
+cp
 MH
 MH
 re
@@ -13273,7 +13322,7 @@ Yf
 MH
 MH
 Yf
-cp
+Yf
 Yf
 Yf
 Yf
@@ -13286,7 +13335,7 @@ Yf
 Yf
 Yf
 Yf
-cp
+Yf
 qs
 ED
 qz
@@ -13411,7 +13460,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -13421,7 +13470,7 @@ YI
 YI
 YI
 ZU
-ZU
+Na
 ZU
 GF
 re
@@ -13429,7 +13478,7 @@ re
 re
 MH
 Yf
-cp
+Yf
 Yf
 Yf
 MH
@@ -13442,7 +13491,7 @@ Yf
 Yf
 Yf
 Yf
-cp
+Yf
 qy
 RC
 TM
@@ -13567,7 +13616,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -13577,7 +13626,7 @@ ZU
 YI
 ZU
 ZU
-Wx
+iM
 Wx
 Bb
 WI
@@ -13585,7 +13634,7 @@ WI
 WI
 WI
 MH
-cp
+Yf
 Yf
 Yf
 MH
@@ -13598,7 +13647,7 @@ MH
 MH
 MH
 MH
-DN
+DX
 AB
 zi
 TM
@@ -13723,7 +13772,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+cp
 Yf
 Yf
 MH
@@ -13733,7 +13782,7 @@ ZU
 ZU
 gx
 ZU
-ZU
+Na
 ZU
 Bb
 WI
@@ -13741,7 +13790,7 @@ pa
 Si
 WI
 WI
-Jj
+MH
 MH
 MH
 MH
@@ -13754,7 +13803,7 @@ MH
 MH
 Uu
 Uu
-DN
+DX
 DX
 Sh
 sK
@@ -13879,7 +13928,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -13889,7 +13938,7 @@ ZU
 ZU
 ZU
 ZU
-ZU
+GB
 ZU
 Bb
 WI
@@ -13897,20 +13946,20 @@ Tj
 SI
 SI
 SI
-qE
 SI
-ER
+SI
+SI
 SI
 SI
 WI
 WI
 WI
-FH
+WI
 WI
 WI
 Uu
 Uu
-DN
+DX
 Ml
 Tf
 TM
@@ -14035,7 +14084,7 @@ Yf
 Yf
 Yf
 Yf
-Yf
+cp
 Yf
 Yf
 Yf
@@ -14045,7 +14094,7 @@ ez
 ZU
 ZU
 ZU
-ZU
+Na
 ZU
 Bb
 WI
@@ -14053,11 +14102,11 @@ WI
 SI
 Ln
 SI
-qE
 SI
 SI
 SI
-ER
+SI
+SI
 AW
 WI
 XO
@@ -14066,7 +14115,7 @@ XO
 AW
 Uu
 Uu
-SU
+Uu
 Ml
 Tf
 TM
@@ -14191,17 +14240,17 @@ bD
 Yf
 Yf
 Yf
+cp
 Yf
 Yf
 Yf
-Yf
 ZU
 ZU
 ZU
 ZU
 ZU
 ZU
-re
+dK
 re
 re
 WI
@@ -14209,7 +14258,7 @@ WI
 SI
 SI
 WI
-Bj
+WI
 WI
 WI
 SI
@@ -14222,7 +14271,7 @@ WI
 WI
 xn
 Uu
-SU
+Uu
 Uu
 Aq
 TM
@@ -14347,17 +14396,17 @@ bD
 Yf
 Yf
 Yf
-Yf
+cp
 Yf
 re
 re
 ZU
 ZU
-ZU
+Vp
 ZU
 Di
 Di
-lG
+kq
 lX
 lG
 WI
@@ -14365,7 +14414,7 @@ WI
 SI
 SI
 WI
-cN
+pD
 WI
 WI
 SI
@@ -14378,7 +14427,7 @@ WI
 WI
 Uu
 Uu
-SU
+Uu
 Uu
 YH
 TM
@@ -14503,7 +14552,7 @@ bh
 re
 re
 re
-re
+dK
 ZU
 ZU
 SF
@@ -14513,7 +14562,7 @@ ZU
 ZU
 Di
 Mg
-ec
+xB
 Vb
 eY
 mX
@@ -14521,10 +14570,10 @@ WI
 SI
 SI
 WI
-Bj
 WI
 WI
-ER
+WI
+SI
 SI
 WI
 WI
@@ -14534,7 +14583,7 @@ WI
 WI
 Uu
 Uu
-SU
+Uu
 Ml
 Tf
 Tb
@@ -14659,7 +14708,7 @@ TW
 dj
 Di
 XF
-DZ
+lI
 ZU
 ZU
 SF
@@ -14669,7 +14718,7 @@ ZU
 ZU
 RG
 ec
-fT
+oC
 xI
 xI
 xI
@@ -14677,9 +14726,9 @@ nx
 od
 lH
 nx
-Tp
-Tp
-Tp
+xI
+xI
+xI
 SI
 SI
 WI
@@ -14690,7 +14739,7 @@ MH
 WI
 Uu
 Uu
-mS
+Ml
 Ml
 Tf
 Ml
@@ -14815,17 +14864,17 @@ qz
 ZU
 gz
 ZU
-ZU
-ZU
-ez
-SF
-ZU
-ZU
-ez
+Na
 ZU
 ez
 SF
 ZU
+ZU
+ez
+ZU
+ez
+SF
+Na
 nO
 oI
 oI
@@ -14835,7 +14884,7 @@ wW
 oI
 oZ
 oK
-Tp
+xI
 SI
 SI
 WI
@@ -14971,7 +15020,7 @@ ZU
 ZU
 ZU
 ZU
-ZU
+Na
 ez
 ZU
 dx
@@ -14981,7 +15030,7 @@ Mg
 ZU
 ZU
 SF
-fT
+oC
 xI
 oJ
 au
@@ -14991,18 +15040,18 @@ oI
 wW
 oI
 oU
-Tp
-qE
-qE
-Jj
-cp
-cp
-cp
-iS
-iS
-SU
-SU
-SU
+xI
+SI
+SI
+MH
+Yf
+Yf
+Yf
+qs
+qs
+Uu
+Uu
+Uu
 Uu
 TQ
 Uu
@@ -15127,7 +15176,7 @@ ZU
 gx
 ZU
 ZU
-ez
+gY
 ZU
 Xu
 ho
@@ -15136,8 +15185,8 @@ Rj
 ec
 ZU
 ZU
-Di
-XF
+nk
+pn
 xI
 oK
 oI
@@ -15283,7 +15332,7 @@ gS
 ZU
 Qd
 ZU
-ZU
+Na
 dj
 Xu
 ho
@@ -15292,7 +15341,7 @@ ec
 ZU
 ZU
 gx
-da
+BA
 DK
 xI
 oU
@@ -15305,7 +15354,7 @@ oI
 oU
 xI
 SI
-ER
+SI
 WI
 WI
 WI
@@ -15439,7 +15488,7 @@ dE
 EB
 ZU
 ZU
-ZU
+Na
 ZU
 Xu
 Om
@@ -15448,7 +15497,7 @@ VB
 eb
 ZU
 ZU
-do
+Fl
 fT
 xI
 oK
@@ -15595,7 +15644,7 @@ dw
 dE
 EB
 ZU
-ZU
+Na
 gx
 ZU
 Xu
@@ -15604,7 +15653,7 @@ Om
 xP
 eb
 ZU
-gz
+wr
 XF
 xI
 iJ
@@ -15751,7 +15800,7 @@ gA
 XJ
 dE
 Sn
-ez
+gY
 ZU
 ez
 ZU
@@ -15760,7 +15809,7 @@ EB
 ZU
 ZU
 ez
-ZU
+Na
 do
 xI
 xI
@@ -15907,16 +15956,16 @@ hn
 dx
 Di
 VB
-XF
+pn
 ZU
 ZU
 ZU
-lj
-ZU
-gx
-EB
-EB
-ez
+tz
+Na
+GB
+Mb
+Mb
+gY
 SF
 XO
 XO
@@ -16063,11 +16112,11 @@ hn
 gz
 Jg
 Om
-Jg
+Ki
 eb
 ZU
 BQ
-lj
+tz
 Bw
 ZU
 ZU
@@ -16219,11 +16268,11 @@ hn
 Xu
 DK
 gS
-gz
+wr
 eb
 ZU
 ZU
-lj
+tz
 fz
 fz
 ZU
@@ -16375,11 +16424,11 @@ Rj
 Mg
 YI
 Bw
-EB
+Mb
 ZU
 ZU
 ZU
-dE
+yL
 Sn
 xa
 dE
@@ -16531,11 +16580,11 @@ Rj
 Rj
 XJ
 dE
-Sn
-dw
-ZU
-ZU
-Di
+be
+CQ
+Na
+Na
+nk
 VB
 XF
 ZU

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -2059,6 +2059,10 @@
 /obj/item/reagent_containers/food/snacks/applecakeslice,
 /turf/open/floor/wood,
 /area/icy_caves/caves/underground_cafeteria)
+"iw" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/outside/center)
 "ix" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -2340,7 +2344,7 @@
 /area/icy_caves/outpost/LZ2)
 "jS" = (
 /obj/machinery/miner/damaged,
-/turf/open/floor/plating/ground/snow/layer1,
+/turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/outside/center)
 "jT" = (
 /obj/machinery/landinglight/ds1{
@@ -3232,6 +3236,10 @@
 "nI" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ2)
+"nJ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside/center)
 "nK" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/tile/dark,
@@ -5474,6 +5482,10 @@
 	},
 /turf/open/shuttle/escapepod/plain,
 /area/space)
+"wU" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside/center)
 "wW" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
@@ -6017,6 +6029,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail/hallway)
+"zs" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/ice_rock/singleT,
+/area/icy_caves/caves)
 "zu" = (
 /obj/machinery/door/airlock/multi_tile/mainship/secdoor,
 /turf/open/floor/prison{
@@ -6090,6 +6106,11 @@
 	icon_state = "103"
 	},
 /area/icy_caves/caves/northwestmonorail)
+"zJ" = (
+/obj/effect/landmark/corpsespawner/colonist,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside/center)
 "zK" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -8253,6 +8274,10 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
+"IE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside/center)
 "IG" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -9229,6 +9254,11 @@
 	},
 /turf/open/floor/cult,
 /area/icy_caves/caves/chapel)
+"MG" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/research)
 "MH" = (
 /turf/closed/ice/thin/end{
 	dir = 1
@@ -9715,10 +9745,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ2)
-"OM" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice_rock/singleEnd,
-/area/icy_caves/caves)
 "ON" = (
 /obj/machinery/door/airlock/multi_tile/mainship/personalglass{
 	name = "\improper Xenbiology Airlock"
@@ -12040,6 +12066,10 @@
 	},
 /turf/open/shuttle/escapepod/plain,
 /area/icy_caves/caves/northwestmonorail)
+"YC" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/r_wall,
+/area/icy_caves/outpost/research)
 "YE" = (
 /obj/structure/bed/chair,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -26829,14 +26859,14 @@ yE
 my
 xm
 xE
-li
-DD
-li
-DD
-li
-li
-vh
-li
+iw
+wU
+iw
+wU
+iw
+iw
+zJ
+iw
 li
 li
 ow
@@ -26846,10 +26876,10 @@ ow
 VU
 aG
 Sq
-Sq
-Yl
-Yl
-Yl
+oF
+wD
+wD
+wD
 Ol
 bD
 Yf
@@ -26985,14 +27015,14 @@ ro
 li
 HA
 my
-li
-ow
-li
+iw
+DD
+DD
 jS
-li
-li
+IE
+DD
 ow
-ow
+nJ
 ow
 ow
 ow
@@ -27002,10 +27032,10 @@ bX
 aI
 Pv
 Pv
-Sq
+oF
 Yl
 SC
-Yl
+wD
 Ol
 Yf
 Yf
@@ -27141,13 +27171,13 @@ ro
 li
 HA
 my
+wU
 DD
-ow
-li
-ow
-ow
-ow
-ow
+DD
+DD
+DD
+DD
+Yl
 Ay
 Mr
 ss
@@ -27159,8 +27189,8 @@ DP
 DP
 oF
 oF
-wD
-wD
+Yl
+Yl
 RO
 Ol
 Yf
@@ -27297,16 +27327,16 @@ Tc
 li
 HA
 my
-li
-li
-li
-li
-ow
-ow
-ow
-Mr
-VU
-VU
+iw
+DD
+IE
+DD
+DD
+IE
+Yl
+Yl
+Yl
+SC
 aI
 pq
 eY
@@ -27453,19 +27483,19 @@ dk
 rJ
 HA
 my
-li
-li
-li
-li
+iw
+DD
+DD
+DD
 ow
 VU
 VU
-Mr
-qH
-WS
-oW
-oW
-oW
+SC
+Yl
+Yl
+Yl
+Yl
+Yl
 Pv
 Sq
 Sq
@@ -27609,20 +27639,20 @@ tH
 Mh
 kK
 IS
-Mh
-tH
-tH
-qz
-VU
-qH
+MG
+YC
+YC
+Mr
+ss
+zs
 yZ
-OM
-XH
-Vb
-Yf
-Yf
-Sq
-Sq
+Yl
+Yl
+Yl
+Yl
+SC
+Yl
+Yl
 Yl
 Yl
 Yl
@@ -27775,9 +27805,9 @@ ko
 TW
 bF
 Pv
-Yf
-Sq
-Sq
+Yl
+Yl
+Yl
 Yl
 Yl
 Yl
@@ -27931,8 +27961,8 @@ Ay
 oW
 Pv
 Pv
-Yf
-Sq
+Yl
+Yl
 Yl
 SC
 Yl
@@ -28708,8 +28738,8 @@ nI
 nI
 nI
 Gl
-Za
-Za
+Yl
+Yl
 Yl
 SC
 Yl
@@ -28864,9 +28894,9 @@ nI
 nI
 wa
 Gl
-Za
-Za
-Za
+Yl
+Yl
+Yl
 Yl
 Yl
 Yl


### PR DESCRIPTION


## About The Pull Request

removes some stuff and fixes some stuff

## Why It's Good For The Game

Red disk was more or less a free disk for marines, so added a silo and fog area west of it in the miner building behind the icy walls to prevent undefendable camping meaning xenos only got a few fog spots to shoot from giving marines a chance.

green disk had marines hard camping it so fixes that by extending the fog  upward rather then closer to the disk giving xenos a place to attack from two areas.

blue disk well a bit tricky i think its more or less an issue of skill and its already pretty far so i aint touching it

there was also that silo south of dorms which had no fog and stuff so i deleted that

## Changelog
:cl:
balance: fog and silo changes
/:cl:


