### PR TITLE
Req crates no longer stay anchored when a supply drop fails

### DIFF
--- a/code/game/objects/machinery/squad_supply/supply_console.dm
+++ b/code/game/objects/machinery/squad_supply/supply_console.dm
@@ -156,17 +156,17 @@
 
 ///Make the supplies teleport
 /obj/machinery/computer/supplydrop_console/proc/fire_supplydrop(list/supplies, x_offset, y_offset)
-	if(QDELETED(supply_beacon))
-		visible_message("[icon2html(supply_pad, usr)] [span_warning("Launch aborted! Supply beacon signal lost.")]")
-		return
-
 	for(var/obj/C in supplies)
 		if(QDELETED(C))
 			supplies.Remove(C)
 			continue
 		if(C.loc != supply_pad.loc) //Crate no longer on pad somehow, abort.
 			supplies.Remove(C)
-			C.anchored = FALSE
+		C.anchored = FALSE //We need to un-anchor the crate after we're finished, even if it fails to send
+
+	if(QDELETED(supply_beacon))
+		visible_message("[icon2html(supply_pad, usr)] [span_warning("Launch aborted! Supply beacon signal lost.")]")
+		return
 
 	if(!supplies.len)
 		visible_message("[icon2html(supply_pad, usr)] [span_warning("Launch aborted! No deployable object detected on the drop pad.")]")
@@ -176,7 +176,6 @@
 	playsound(supply_beacon.drop_location,'sound/effects/phasein.ogg', 50, TRUE)
 	playsound(supply_pad.loc,'sound/effects/phasein.ogg', 50, TRUE)
 	for(var/obj/C in supplies)
-		C.anchored = FALSE
 		var/turf/TC = locate(supply_beacon.drop_location.x + x_offset, supply_beacon.drop_location.y + y_offset, supply_beacon.drop_location.z)
 		C.forceMove(TC)
 	supply_pad.visible_message("[icon2html(supply_pad, viewers(src))] [span_boldnotice("Supply drop teleported! Another launch will be available in one minute.")]")


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes issue [#7331](https://github.com/tgstation/TerraGov-Marine-Corps/issues/7331#issue-941184020)
The crate is now always unanchored after the console finishes sending (unless the crate was deleted) rather than only if the crate got moved or if it was sent successfully

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix good, this confused new ROs

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Req crates no longer stay anchored when a supply drop fails
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
