### PR TITLE
Praetorian bomb resist 1 on all maturities

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -30,7 +30,7 @@
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER|CASTE_CAN_BECOME_KING
 
 	// *** Defense *** //
-	soft_armor = list("melee" = 30, "bullet" = 35, "laser" = 35, "energy" = 35, "bomb" = XENO_BOMB_RESIST_0, "bio" = 28, "rad" = 28, "fire" = 35, "acid" = 28)
+	soft_armor = list("melee" = 30, "bullet" = 35, "laser" = 35, "energy" = 35, "bomb" = XENO_BOMB_RESIST_1, "bio" = 28, "rad" = 28, "fire" = 35, "acid" = 28)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.3 SECONDS
@@ -81,7 +81,7 @@
 	upgrade_threshold = TIER_THREE_MATURE_THRESHOLD
 
 	// *** Defense *** //
-	soft_armor = list("melee" = 35, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_0, "bio" = 33, "rad" = 33, "fire" = 40, "acid" = 33)
+	soft_armor = list("melee" = 35, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_1, "bio" = 33, "rad" = 33, "fire" = 40, "acid" = 33)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.2 SECONDS
@@ -115,7 +115,7 @@
 	upgrade_threshold = TIER_THREE_ELDER_THRESHOLD
 
 	// *** Defense *** //
-	soft_armor = list("melee" = 40, "bullet" = 45, "laser" = 45, "energy" = 45, "bomb" = XENO_BOMB_RESIST_0, "bio" = 35, "rad" = 35, "fire" = 45, "acid" = 35)
+	soft_armor = list("melee" = 40, "bullet" = 45, "laser" = 45, "energy" = 45, "bomb" = XENO_BOMB_RESIST_1, "bio" = 35, "rad" = 35, "fire" = 45, "acid" = 35)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.1 SECONDS


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. Previously prae got XENO_BOMB_RESIST_0 on all maturities except for ancient. Now it has XENO_BOMB_RESIST_1 on all maturities.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Prae is front- or second-line T3 xeno. XENO_BOMB_RESIST_0 means you can gib it instantly with direct hit of CAS missile, mortar HE, explosive vest. XENO_BOMB_RESIST_1 means you will deal 170 damage (50% health) instead. Increase in armor also means less damage, slowdown and stagger from nades. You will still need 4 nades to kill Elder Prae, before or after the change. But Prae will have some more chances to NOT get stunlocked. Getting ancient on T3 takes abysmal amount of time, during which you can suddenly pop.

Pros: 
- Little harder to bully a front/second T3 with nades.
- Deaths from mortar/CAS/other DEVA explosions are now more of your fault. If you die this means you exposed yourself to this stuff while damaged. Bad beno.

Cons:
- Little harder to bully a front/second T3 with nades.
- CAS is little more useless now. (Planning to make it better, later)
- Less funny benos pop.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: increased Prae bomb resist from 0 to 1 on Young, Mature, Elder.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
