### PR TITLE
Resolves some Defender action issues

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -330,7 +330,7 @@
 // ***************************************
 // *********** Regenerate Skin
 // ***************************************
-/datum/action/xeno_action/activable/regenerate_skin
+/datum/action/xeno_action/regenerate_skin
 	name = "Regenerate Skin"
 	action_icon_state = "regenerate_skin"
 	mechanics_text = "Regenerate your hard exoskeleton skin, restoring some health and removing all sunder."
@@ -341,15 +341,15 @@
 	keybind_flags = XACT_KEYBIND_USE_ABILITY
 	keybind_signal = COMSIG_XENOABILITY_REGENERATE_SKIN
 
-/datum/action/xeno_action/activable/regenerate_skin/on_cooldown_finish()
+/datum/action/xeno_action/regenerate_skin/on_cooldown_finish()
 	var/mob/living/carbon/xenomorph/X = owner
 	to_chat(X, span_notice("We feel we are ready to shred our skin and grow another."))
 	return ..()
 
-/datum/action/xeno_action/activable/regenerate_skin/action_activate()
+/datum/action/xeno_action/regenerate_skin/action_activate()
 	var/mob/living/carbon/xenomorph/defender/X = owner
 
-	if(!can_use_ability(src, TRUE))
+	if(!can_use_action(TRUE))
 		return fail_activate()
 
 	if(X.on_fire)
@@ -370,7 +370,7 @@
 // ***************************************
 // *********** Centrifugal force
 // ***************************************
-/datum/action/xeno_action/activable/centrifugal_force
+/datum/action/xeno_action/centrifugal_force
 	name = "Centrifugal force"
 	action_icon_state = "centrifugal_force"
 	mechanics_text = "Rapidly spin and hit all adjacent humans around you, knocking them away and down. Uses double plasma when crest is active."
@@ -385,14 +385,16 @@
 	///timer hash for the timer we use when spinning
 	var/spin_loop_timer
 
-/datum/action/xeno_action/activable/centrifugal_force/can_use_action(silent, override_flags)
+/datum/action/xeno_action/centrifugal_force/can_use_action(silent, override_flags)
+	if(spin_loop_timer)
+		return TRUE
 	. = ..()
 	var/mob/living/carbon/xenomorph/X = owner
 	if(X.crest_defense && X.plasma_stored < (plasma_cost * 2))
 		to_chat(X, span_xenowarning("We don't have enough plasma, we need [(plasma_cost * 2) - X.plasma_stored] more plasma!"))
 		return FALSE
 
-/datum/action/xeno_action/activable/centrifugal_force/action_activate()
+/datum/action/xeno_action/centrifugal_force/action_activate()
 	if(spin_loop_timer)
 		stop_spin()
 		return
@@ -409,7 +411,7 @@
 	RegisterSignal(owner, list(SIGNAL_ADDTRAIT(TRAIT_FLOORED), SIGNAL_ADDTRAIT(TRAIT_INCAPACITATED), SIGNAL_ADDTRAIT(TRAIT_IMMOBILE)), .proc/stop_spin)
 
 /// runs a spin, then starts the timer for a new spin if needed
-/datum/action/xeno_action/activable/centrifugal_force/proc/do_spin()
+/datum/action/xeno_action/centrifugal_force/proc/do_spin()
 	spin_loop_timer = null
 	var/mob/living/carbon/xenomorph/X = owner
 	X.spin(4, 1)
@@ -444,7 +446,7 @@
 	stop_spin()
 
 /// stops spin and unregisters all listeners
-/datum/action/xeno_action/activable/centrifugal_force/proc/stop_spin()
+/datum/action/xeno_action/centrifugal_force/proc/stop_spin()
 	SIGNAL_HANDLER
 	if(spin_loop_timer)
 		deltimer(spin_loop_timer)

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
@@ -50,7 +50,7 @@
 		/datum/action/xeno_action/fortify,
 		/datum/action/xeno_action/activable/forward_charge,
 		/datum/action/xeno_action/tail_sweep,
-		/datum/action/xeno_action/activable/regenerate_skin,
+		/datum/action/xeno_action/regenerate_skin,
 	)
 
 /datum/xeno_caste/defender/young
@@ -177,6 +177,6 @@
 		/datum/action/xeno_action/fortify,
 		/datum/action/xeno_action/activable/forward_charge,
 		/datum/action/xeno_action/tail_sweep,
-		/datum/action/xeno_action/activable/regenerate_skin,
-		/datum/action/xeno_action/activable/centrifugal_force,
+		/datum/action/xeno_action/regenerate_skin,
+		/datum/action/xeno_action/centrifugal_force,
 	)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Centrifugal Force and Regenerate Skin are both on-click trigger abilities that can never be selected. This makes them not /activable (the type for selectable abilities) and with that fixes the keybinds for both of them not working (alternatively could have been resolved via modifying what the keybinds do, but since they're not actually selectable this is a moot point.)

Additionally, allows Centrifugal force to actually be interrupted via retriggering, sometimes (this change just allows it to reach the check that can abort it which wasn't accounted for before, however the timer may not be existing at specific timings and therefore not interrupt it, which still leaves this somewhat inconsistant at times, but better than before)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good, probably.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The keybinds for Centrifugal Force and Regenerate Skin should work now.
fix: Retriggering Centrifugal Force to abort it while spinning should now work at least sometimes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
