### PR TITLE
Removes blink debuff when wraith is in phase shift

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -509,6 +509,9 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 
 	new /obj/effect/temp_visual/wraith_warp(get_turf(teleporter))
 
+	if(owner.status_flags & INCORPOREAL) //No debuff while in phase shift
+		return
+
 	for(var/mob/living/living_target in range(1, teleporter.loc))
 
 		if(living_target.stat == DEAD)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Alternative to or to be merged with https://github.com/tgstation/TerraGov-Marine-Corps/pull/9904
Wraith can still blink in phase shift, it just won't apply the debuff on anything

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Unkillable + no counter + actually pretty severe debuffs, even with eyeblur removal
Blink debuffs probably wouldn't be that strong without phase shift (you can't apply them on standing targets since debuffs are only applied on same tile as wraith now, instead of 3x3), but do whatever

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Blink debuff no longer applies while the wraith is in phase shift
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
