### PR TITLE
Add Seven Roundstart Xenomorph Tunnels in LV-624 

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -843,10 +843,13 @@ Every ship should have a believable and complete pipe system (ventilation, scrub
 
 #### Xenos related items (walls, weeds, silos, etc.)
 
-Everything related to xenos must be placed on map via a landmark, and not be directly added. This allows the map to be clean in HvH modes.
-Silos must be placed around the map for crash and hunt gamemode. A reasonable amount of turrets must be placed around the map, preferrably in caves and near silos.
+Everything related to xenos must be placed on map via a landmark, and not be directly added with the exception of tunnels. This allows the map to be clean in HvH modes. Silos must be placed around the map for crash and hunt gamemode. A reasonable amount of turrets must be placed around the map, preferrably in caves and near silos.
+
+Making tunnels into a landmark will not enable contributors to name the tunnels, thereby confusing xenomorph players on what tunnel to take. There must be at a total of 7 tunnels for xenomorphs: 4 to cover the map's corners (northwest, northeast, southwest, and southeast), 2 near known buildings that marines tranverse through, and 3 for caves. While 4+2+3 does not add up to 7 total tunnels, two corner tunnels can be inside caves.
+
 A reasonnable amount of weeds must be placed, near silos and turrets. You don't have to add resin walls or doors if you don't want to, but they add to the atmostphere.
-Adding corpse spawner also add to the atmospher, but they are not mandatory.
+
+Adding corpse spawner also add to the atmosphere, but they are not mandatory.
 
 #### Fog around silos
 

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -2623,6 +2623,12 @@
 /obj/effect/spawner/random/ammo/sidearm,
 /turf/open/floor/plating,
 /area/lv624/lazarus/tablefort)
+"aPx" = (
+/obj/structure/xeno/tunnel{
+	name = "Southeast tunnel"
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle1)
 "aPD" = (
 /obj/effect/decal/remains/human,
 /obj/item/ammo_casing,
@@ -4872,6 +4878,12 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/freezer,
 /area/lv624/lazarus/kitchen)
+"bNj" = (
+/obj/structure/xeno/tunnel{
+	name = "Northeast tunnel"
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1)
 "bNu" = (
 /turf/open/ground/river,
 /area/lv624/ground/sand7)
@@ -7029,6 +7041,12 @@
 	dir = 2
 	},
 /area/lv624/ground/caves/east1)
+"etu" = (
+/obj/structure/xeno/tunnel{
+	name = "Northwest tunnel"
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
 "etx" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -12941,6 +12959,12 @@
 	dir = 4
 	},
 /area/lv624/ground/jungle10)
+"lya" = (
+/obj/structure/xeno/tunnel{
+	name = "Southwest tunnel"
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/ruin)
 "lyj" = (
 /turf/closed/mineral/indestructible,
 /area/lv624/ground/caves/rock)
@@ -18294,6 +18318,13 @@
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/lazarus/quartstorage/outdoors)
+"rYx" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/xeno/tunnel{
+	name = "Hydro tunnel"
+	},
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle7)
 "rYQ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
@@ -22685,6 +22716,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle5)
+"wYO" = (
+/obj/structure/xeno/tunnel{
+	name = "Center tunnel"
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3)
 "wYW" = (
 /turf/open/floor/tile/red/full,
 /area/lv624/lazarus/security)
@@ -23643,6 +23680,12 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand2)
+"yaz" = (
+/obj/structure/xeno/tunnel{
+	name = "Fitness tunnel"
+	},
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
 "yaB" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/closed/wall/r_wall,
@@ -27242,7 +27285,7 @@ rHH
 kPr
 bgf
 vXW
-tnW
+lya
 lpu
 mcU
 kPr
@@ -28521,7 +28564,7 @@ xLJ
 xLJ
 xLJ
 xLJ
-abc
+etu
 abc
 abc
 mEN
@@ -45530,7 +45573,7 @@ kFx
 kFx
 aqo
 kFx
-kFx
+wYO
 jWv
 xLJ
 aen
@@ -48296,7 +48339,7 @@ vkA
 vkA
 wsU
 iJa
-aES
+yaz
 vUs
 kSt
 fkR
@@ -48472,7 +48515,7 @@ vMu
 vjE
 mPX
 aET
-dDC
+aES
 aES
 aRP
 kRJ
@@ -49650,7 +49693,7 @@ aWM
 arW
 arW
 arW
-jeR
+rYx
 eUY
 rGl
 tgs
@@ -58923,7 +58966,7 @@ mOs
 gCL
 gCL
 kau
-obT
+aPx
 sdC
 fuT
 sgf
@@ -60889,7 +60932,7 @@ xLJ
 aah
 aaD
 aah
-aah
+bNj
 xLJ
 xLJ
 xLJ


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

I also update the map contribution on guideline for tunnels.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Xenomorph's strength is mobility. They can swarm marines via tactical flanks and escape lethal engagements at a moment notice. Round start tunnels enable them to have better map dominance.

Xenomorphs used to have round start tunnels, then bad code forced maintainers to remove tunnels.

I start with LV-624 so that other maps don't die from map conflicts.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Add Seven Roundstart Xenomorph Tunnels in LV-624 
add: Add guideline for tunnels in the map contribution
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
