### PR TITLE
Makes missing limbs bleed

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -86,10 +86,10 @@
 		var/blood_max = 0
 		for(var/l in limbs)
 			var/datum/limb/temp = l
-			if(!(temp.limb_status & LIMB_BLEEDING) || temp.limb_status & LIMB_ROBOT)
-				continue
 			if(temp.limb_status & LIMB_DESTROYED && !(temp.limb_status & LIMB_AMPUTATED))
 				blood_max += 5 //Yer missing a fucking limb.
+				continue
+			if(!(temp.limb_status & LIMB_BLEEDING) || temp.limb_status & LIMB_ROBOT)
 				continue
 			for(var/w in temp.wounds)
 				var/datum/wound/W = w


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Limbs skip bleeding if they aren't bleeding normally. Missing limbs are special cased instead of bleeding normally, so that check needs to go first.

## Why It's Good For The Game
bugfix

## Changelog
:cl:
fix: Removed limbs bleed properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
