### PR TITLE
mini pepperball magazines should fit in pistol pouches the second

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -251,6 +251,7 @@
 		/obj/item/ammo_magazine/pistol,
 		/obj/item/ammo_magazine/revolver,
 		/obj/item/ammo_magazine/smg/standard_machinepistol,
+		/obj/item/ammo_magazine/rifle/pepperball/pepperball_mini,
 	)
 
 /obj/item/storage/pouch/magazine/pistol/large


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Mini pepperball mags are, as the name suggests, pretty mini, have low ammo and therefore run out of ammo quickly with it's mediocre fire rate. When I made the mini pepperball I did not consider how you store these mags. Since the mini pepperball is already pretty weak compared to other attachment options, ammo for it should at least be easy to carry around.
Note this does not allow regular pepperball to fit in pistol pouches.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Plasmapistol OP, ammo fits in pistol pouch.
Mini Pepperball weak, ammo does not fit in pistol pouch.
Curious.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: mini pepperball magazines now fit in pistol pouches
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
