### PR TITLE
Ports TG's drop and pickup animations

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -652,6 +652,83 @@
 	if(SSmapping.configs[GROUND_MAP].environment_traits[MAP_COLD] && (flags_item_map_variant & ITEM_ICE_PROTECTION))
 		min_cold_protection_temperature = ICE_PLANET_MIN_COLD_PROTECTION_TEMPERATURE
 
+/**
+	Play small animation and jiggle when picking up an object
+ */
+
+/obj/item/proc/do_pickup_animation(atom/target)
+	set waitfor = FALSE
+	if(!istype(loc, /turf))
+		return
+	var/image/pickup_animation = image(icon = src, loc = loc, layer = layer + 0.1)
+	pickup_animation.plane = GAME_PLANE
+	pickup_animation.transform *= 0.75
+	pickup_animation.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+	var/turf/current_turf = get_turf(src)
+	var/direction
+	var/to_x = target.pixel_x
+	var/to_y = target.pixel_y
+
+	if(!QDELETED(current_turf) && !QDELETED(target))
+		direction = get_dir(current_turf, target)
+	if(direction & NORTH)
+		to_y += 32
+	else if(direction & SOUTH)
+		to_y -= 32
+	if(direction & EAST)
+		to_x += 32
+	else if(direction & WEST)
+		to_x -= 32
+	if(!direction)
+		to_y += 16
+	flick_overlay(pickup_animation, GLOB.clients, 6)
+	var/matrix/animation_matrix = new
+	animation_matrix.Turn(pick(-30, 30))
+	animate(pickup_animation, alpha = 175, pixel_x = to_x, pixel_y = to_y, time = 3, transform = animation_matrix, easing = CUBIC_EASING)
+	sleep(1)
+	animate(pickup_animation, alpha = 0, transform = matrix(), time = 1)
+
+/**
+	Play small animation and jiggle when dropping an object
+ */
+
+/obj/item/proc/do_drop_animation(atom/moving_from)
+	if(!istype(loc, /turf))
+		return
+
+	var/turf/current_turf = get_turf(src)
+	var/direction = get_dir(moving_from, current_turf)
+	var/from_x = moving_from.pixel_x
+	var/from_y = moving_from.pixel_y
+
+	if(direction & NORTH)
+		from_y -= 32
+	else if(direction & SOUTH)
+		from_y += 32
+	if(direction & EAST)
+		from_x -= 32
+	else if(direction & WEST)
+		from_x += 32
+	if(!direction)
+		from_y += 10
+		from_x += 6 * (prob(50) ? 1 : -1) //6 to the right or left, helps break up the straight upward move
+
+	//We're moving from these chords to our current ones
+	var/old_x = pixel_x
+	var/old_y = pixel_y
+	var/old_alpha = alpha
+	var/matrix/old_transform = transform
+	var/matrix/animation_matrix = new(old_transform)
+	animation_matrix.Turn(pick(-30, 30))
+	animation_matrix.Scale(0.7) // Shrink to start, end up normal sized
+
+	pixel_x = from_x
+	pixel_y = from_y
+	alpha = 0
+	transform = animation_matrix
+
+	// This is instant on byond's end, but to our clients this looks like a quick drop
+	animate(src, alpha = old_alpha, pixel_x = old_x, pixel_y = old_y, transform = old_transform, time = 3, easing = CUBIC_EASING)
 
 /obj/item/verb/verb_pickup()
 	set src in oview(1)
@@ -1008,7 +1085,6 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 // Returns TRUE on success, FALSE on failure.
 /obj/item/proc/use(used)
 	return !used
-
 
 // Plays item's usesound, if any.
 /obj/item/proc/play_tool_sound(atom/target, volume)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -652,13 +652,11 @@
 	if(SSmapping.configs[GROUND_MAP].environment_traits[MAP_COLD] && (flags_item_map_variant & ITEM_ICE_PROTECTION))
 		min_cold_protection_temperature = ICE_PLANET_MIN_COLD_PROTECTION_TEMPERATURE
 
-/**
-	Play small animation and jiggle when picking up an object
- */
 
+///Play small animation and jiggle when picking up an object
 /obj/item/proc/do_pickup_animation(atom/target)
 	set waitfor = FALSE
-	if(!istype(loc, /turf))
+	if(!isturf(loc))
 		return
 	var/image/pickup_animation = image(icon = src, loc = loc, layer = layer + 0.1)
 	pickup_animation.plane = GAME_PLANE
@@ -688,10 +686,8 @@
 	sleep(1)
 	animate(pickup_animation, alpha = 0, transform = matrix(), time = 1)
 
-/**
-	Play small animation and jiggle when dropping an object
- */
 
+///Play small animation and jiggle when dropping an object
 /obj/item/proc/do_drop_animation(atom/moving_from)
 	if(!istype(loc, /turf))
 		return

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -655,20 +655,18 @@
 
 ///Play small animation and jiggle when picking up an object
 /obj/item/proc/do_pickup_animation(atom/target)
-	set waitfor = FALSE
-	if(!isturf(loc))
+	if(!istype(loc, /turf))
 		return
 	var/image/pickup_animation = image(icon = src, loc = loc, layer = layer + 0.1)
 	pickup_animation.plane = GAME_PLANE
-	pickup_animation.transform *= 0.75
+	pickup_animation.transform.Scale(0.75)
 	pickup_animation.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+
 	var/turf/current_turf = get_turf(src)
-	var/direction
+	var/direction = get_dir(current_turf, target)
 	var/to_x = target.pixel_x
 	var/to_y = target.pixel_y
 
-	if(!QDELETED(current_turf) && !QDELETED(target))
-		direction = get_dir(current_turf, target)
 	if(direction & NORTH)
 		to_y += 32
 	else if(direction & SOUTH)
@@ -678,14 +676,16 @@
 	else if(direction & WEST)
 		to_x -= 32
 	if(!direction)
-		to_y += 16
-	flick_overlay(pickup_animation, GLOB.clients, 6)
-	var/matrix/animation_matrix = new
-	animation_matrix.Turn(pick(-30, 30))
-	animate(pickup_animation, alpha = 175, pixel_x = to_x, pixel_y = to_y, time = 3, transform = animation_matrix, easing = CUBIC_EASING)
-	sleep(1)
-	animate(pickup_animation, alpha = 0, transform = matrix(), time = 1)
+		to_y += 10
+		pickup_animation.pixel_x += 6 * (prob(50) ? 1 : -1) //6 to the right or left, helps break up the straight upward move
 
+	flick_overlay(pickup_animation, GLOB.clients, 4)
+	var/matrix/animation_matrix = new(pickup_animation.transform)
+	animation_matrix.Turn(pick(-30, 30))
+	animation_matrix.Scale(0.65)
+
+	animate(pickup_animation, alpha = 175, pixel_x = to_x, pixel_y = to_y, time = 3, transform = animation_matrix, easing = CUBIC_EASING)
+	animate(alpha = 0, transform = matrix().Scale(0.7), time = 1)
 
 ///Play small animation and jiggle when dropping an object
 /obj/item/proc/do_drop_animation(atom/moving_from)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -655,7 +655,7 @@
 
 ///Play small animation and jiggle when picking up an object
 /obj/item/proc/do_pickup_animation(atom/target)
-	if(!istype(loc, /turf))
+	if(!isturf(loc))
 		return
 	var/image/pickup_animation = image(icon = src, loc = loc, layer = layer + 0.1)
 	pickup_animation.plane = GAME_PLANE

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -689,7 +689,7 @@
 
 ///Play small animation and jiggle when dropping an object
 /obj/item/proc/do_drop_animation(atom/moving_from)
-	if(!istype(loc, /turf))
+	if(!isturf(loc))
 		return
 
 	var/turf/current_turf = get_turf(src)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -43,8 +43,7 @@
 	Returns TRUE on success.
 */
 /mob/proc/put_in_l_hand(obj/item/W)
-	if(isturf(W.loc))
-		W.do_pickup_animation(src)
+	W.do_pickup_animation(src)
 	if(status_flags & INCORPOREAL) // INCORPOREAL things don't have hands
 		return FALSE
 	if(lying_angle)
@@ -72,8 +71,7 @@
 	Returns TRUE on success.
 */
 /mob/proc/put_in_r_hand(obj/item/W)
-	if(isturf(W.loc))
-		W.do_pickup_animation(src)
+	W.do_pickup_animation(src)
 	if(status_flags & INCORPOREAL) // INCORPOREAL things don't have hands
 		return FALSE
 	if(lying_angle)
@@ -132,9 +130,7 @@
 	Returns TURE if it was able to put the thing into one of our hands.
 */
 /mob/proc/put_in_hands(obj/item/W, del_on_fail = FALSE)
-	log_world("Putting[W] in hands")
-	if(isturf(W.loc))
-		W.do_pickup_animation(src)
+	W.do_pickup_animation(src)
 	if(status_flags & INCORPOREAL) // INCORPOREAL things don't have hands
 		return FALSE
 	if(!W)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -43,6 +43,8 @@
 	Returns TRUE on success.
 */
 /mob/proc/put_in_l_hand(obj/item/W)
+	if(isturf(W.loc))
+		W.do_pickup_animation(src)
 	if(status_flags & INCORPOREAL) // INCORPOREAL things don't have hands
 		return FALSE
 	if(lying_angle)
@@ -70,6 +72,8 @@
 	Returns TRUE on success.
 */
 /mob/proc/put_in_r_hand(obj/item/W)
+	if(isturf(W.loc))
+		W.do_pickup_animation(src)
 	if(status_flags & INCORPOREAL) // INCORPOREAL things don't have hands
 		return FALSE
 	if(lying_angle)
@@ -128,6 +132,9 @@
 	Returns TURE if it was able to put the thing into one of our hands.
 */
 /mob/proc/put_in_hands(obj/item/W, del_on_fail = FALSE)
+	log_world("Putting[W] in hands")
+	if(isturf(W.loc))
+		W.do_pickup_animation(src)
 	if(status_flags & INCORPOREAL) // INCORPOREAL things don't have hands
 		return FALSE
 	if(!W)
@@ -156,7 +163,6 @@
 	if(stat == CONSCIOUS && isturf(loc))
 		return drop_held_item()
 	return FALSE
-
 
 /**
 	Drops the item in our left hand.
@@ -217,11 +223,13 @@
 	if(.)
 		I.pixel_x = initial(I.pixel_x) + rand(-6,6)
 		I.pixel_y = initial(I.pixel_y) + rand(-6,6)
+	I.do_drop_animation(src)
 
 /**
  * For when the item will be immediately placed in a loc other than the ground.
 */
 /mob/proc/transferItemToLoc(obj/item/I, atom/newloc, force = FALSE)
+	I.do_drop_animation(src)
 	return UnEquip(I, force, newloc)
 
 /**


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.
TG has simple little animations for picking up items and dropping them, this PR ports them.

## Why It's Good For The Game

It looks fancy and lets you see who's picking up what.

## Changelog
:cl:
add: Ported TG's animation effects for dropping and picking up items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
