### PR TITLE
Some deployable weapon updates

### DIFF
--- a/code/datums/elements/deployable_item.dm
+++ b/code/datums/elements/deployable_item.dm
@@ -70,7 +70,7 @@
 			user.balloon_alert(user, "You are already doing something!")
 			return
 		user.balloon_alert(user, "You start deploying...")
-		user.dir = get_dir(user, location) //Face towards deploy location for ease of deploy.
+		user.setDir(get_dir(user, location)) //Face towards deploy location for ease of deploy.
 		var/newdir = user.dir //Save direction before the doafter for ease of deploy
 		if(!do_after(user, deploy_time, TRUE, item_to_deploy, BUSY_ICON_BUILD))
 			return

--- a/code/datums/elements/deployable_item.dm
+++ b/code/datums/elements/deployable_item.dm
@@ -55,10 +55,10 @@
 
 ///Handles the conversion of item into machine. Source is the Item to be deployed, user is who is deploying. If user is null, a direction must be set.
 /datum/element/deployable_item/proc/finish_deploy(obj/item/item_to_deploy, mob/user, turf/location, direction)
-	
+
 	var/direction_to_deploy
 	var/obj/deployed_machine
-	
+
 	if(user)
 		if(!ishuman(user) || CHECK_BITFIELD(item_to_deploy.flags_item, NODROP))
 			return
@@ -70,6 +70,8 @@
 			user.balloon_alert(user, "You are already doing something!")
 			return
 		user.balloon_alert(user, "You start deploying...")
+		user.dir = get_dir(user, location) //Face towards deploy location for ease of deploy.
+		var/newdir = user.dir //Save direction before the doafter for ease of deploy
 		if(!do_after(user, deploy_time, TRUE, item_to_deploy, BUSY_ICON_BUILD))
 			return
 
@@ -77,7 +79,7 @@
 
 		item_to_deploy.UnregisterSignal(user, list(COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEUP, COMSIG_MOB_MOUSEDRAG, COMSIG_KB_RAILATTACHMENT, COMSIG_KB_UNDERRAILATTACHMENT, COMSIG_KB_UNLOADGUN, COMSIG_KB_FIREMODE,  COMSIG_MOB_CLICK_RIGHT)) //This unregisters Signals related to guns, its for safety
 
-		direction_to_deploy = user.dir
+		direction_to_deploy = newdir
 
 	else
 		if(!direction)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -716,8 +716,10 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 		viewsize = zoom_viewsize
 
 	if(zoom) //If we are zoomed out, reset that parameter.
-		user.visible_message(span_notice("[user] looks up from [zoom_device]."),
-		span_notice("You look up from [zoom_device]."))
+		if(!TIMER_COOLDOWN_CHECK(user, COOLDOWN_ZOOM)) //If we are spamming the zoom, cut it out
+			user.visible_message(span_notice("[user] looks up from [zoom_device]."),
+			span_notice("You look up from [zoom_device]."))
+
 		zoom = FALSE
 		UnregisterSignal(user, COMSIG_ITEM_ZOOM)
 		onunzoom(user)
@@ -733,10 +735,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 			animate(user.client, 3*(tileoffset/7), pixel_x = 0, pixel_y = 0)
 		return
 
-	if(TIMER_COOLDOWN_CHECK(user, COOLDOWN_ZOOM)) //If we are spamming the zoom, cut it out
-		return
 	TIMER_COOLDOWN_START(user, COOLDOWN_ZOOM, 2 SECONDS)
-
 	if(SEND_SIGNAL(user, COMSIG_ITEM_ZOOM) &  COMSIG_ITEM_ALREADY_ZOOMED)
 		to_chat(user, span_warning("You are already looking through another zoom device.."))
 		return
@@ -745,8 +744,9 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 		user.client.view_size.add(viewsize)
 		change_zoom_offset(user, zoom_offset = tileoffset)
 
-	user.visible_message(span_notice("[user] peers through \the [zoom_device]."),
-	span_notice("You peer through \the [zoom_device]."))
+	if(!TIMER_COOLDOWN_CHECK(user, COOLDOWN_ZOOM))
+		user.visible_message(span_notice("[user] peers through \the [zoom_device]."),
+		span_notice("You peer through \the [zoom_device]."))
 	zoom = TRUE
 	RegisterSignal(user, COMSIG_ITEM_ZOOM, .proc/zoom_check_return)
 	onzoom(user)

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -630,6 +630,8 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	var/has_nightvision = FALSE
 	///boolean as to whether the attachment is currently giving nightvision
 	var/active_nightvision = FALSE
+	///True if the scope is supposed to reactiveate when a deployed gun is turned.
+	var/deployed_scope_rezoom = FALSE
 
 
 /obj/item/attachable/scope/marine
@@ -703,6 +705,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	icon_state = "sniperscope_invisible"
 	zoom_viewsize = 0
 	zoom_tile_offset = 3
+	deployed_scope_rezoom = TRUE
 
 /obj/item/attachable/scope/unremovable/tl102/nest
 	zoom_tile_offset = 6

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -492,8 +492,7 @@
 		if(!istype(attachable, /obj/item/weapon/gun))
 			continue
 		var/obj/item/weapon/gun/gun_attachable = attachable
-		var/chamber = in_chamber ? rounds_per_shot : 0
-		dat += gun_attachable.rounds ? "([gun_attachable.rounds + chamber]/[gun_attachable.max_rounds])" : "(Unloaded)"
+		dat += gun_attachable.rounds ? "([gun_attachable.rounds]/[gun_attachable.max_rounds])" : "(Unloaded)"
 
 	if(dat)
 		. += "[dat.Join(" ")]"


### PR DESCRIPTION

## About The Pull Request

the TL102 miniscope now rezooms in when you rotate.
I removed the spam delay on scopes for ease of use when rotating the deployable weapons.
deployables no longer check direction after deployment, brave broke this earlier

## Why It's Good For The Game
Fixes up some things.

## Changelog
:cl:
qol: The TL102 miniscope now rezooms in when you rotate.
fix: Deployables no longer check direction after deployment, but before.
/:cl:

