### PR TITLE
Teleporter buff cooldown

### DIFF
--- a/code/game/objects/structures/teleporter.dm
+++ b/code/game/objects/structures/teleporter.dm
@@ -62,7 +62,8 @@
 
 	do_sparks(5, TRUE, src)
 	playsound(loc,'sound/effects/phasein.ogg', 50, FALSE)
-	COOLDOWN_START(kit, teleport_cooldown, 20 SECONDS)
+	COOLDOWN_START(kit, teleport_cooldown, 2 SECONDS)
+	COOLDOWN_START(linked_kit, teleport_cooldown, 2 SECONDS)
 	if(powered())
 		use_power(TELEPORTING_COST * 200)
 	else


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Buff teleporter from 20 sec cooldown to 2 secs

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

It is easy rn to bypass the cooldown by stacking on teleporter, which is honestly janky.

Two solutions: 
- One object teleported at once, which is a major nerf to teleporter
- Cooldown being almost irrelevant. That's a buff, but also a QOL. 

I'd rather take the second option, teleporter is a strong tool for engineers and nerfing them like this would make it irrelevant.

Also, make the cooldown shared between the two teleporters, so you're not instantly teleported back by mistake

## Changelog
:cl:
balance: Teleporter cooldown severly reduced to 2 secs (rather than 20 secs)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
