### PR TITLE
Preweeds Chigusa + minor changes and fixes

### DIFF
--- a/_maps/map_files/desertdam/desertdam.dmm
+++ b/_maps/map_files/desertdam/desertdam.dmm
@@ -121,10 +121,6 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
-"aaI" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/water_treatment_two/lobby)
 "aaJ" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -1169,12 +1165,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/dam_interior/south_tunnel)
-"afD" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
-	},
-/area/desert_dam/exterior/landing/landing_pad_three_external)
 "afE" = (
 /obj/structure/platform_decoration{
 	dir = 4
@@ -1319,16 +1309,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_labs)
-"agA" = (
-/obj/machinery/door/poddoor/mainship/open{
-	dir = 1;
-	name = "\improper Containment Lock"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "agB" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -2072,6 +2052,14 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
+"ajv" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "floor_plate"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
 "ajw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -2654,12 +2642,6 @@
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_biology)
-"alv" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 5
-	},
-/area/desert_dam/exterior/valley/valley_civilian)
 "aly" = (
 /obj/structure/closet/crate,
 /obj/item/storage/fancy/vials,
@@ -4801,13 +4783,6 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/valley/valley_labs)
-"asu" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/east_wing_hallway)
 "asv" = (
 /obj/machinery/door/airlock/mainship/security/glass{
 	dir = 1;
@@ -5976,6 +5951,11 @@
 /obj/structure/flora/desert/bush,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/east_caves)
+"awm" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/interior/caves/central_caves)
 "awn" = (
 /obj/structure/stairs/seamless/platform{
 	dir = 8
@@ -6219,6 +6199,16 @@
 	icon_state = "whiteblue"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_lobby)
+"axd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "freezerfloor"
+	},
+/area/desert_dam/building/cafeteria/cold_room)
 "axe" = (
 /turf/open/floor{
 	dir = 8;
@@ -6605,12 +6595,6 @@
 	icon_state = "blue"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_RND)
-"ayD" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached1"
-	},
-/area/desert_dam/exterior/valley/valley_mining)
 "ayE" = (
 /obj/structure/closet/secure_closet/RD,
 /turf/open/floor/prison{
@@ -6845,12 +6829,6 @@
 	icon_state = "whitepurple"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
-"azr" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
 "azs" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/dam_interior/western_dam_cave)
@@ -7014,6 +6992,10 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_wilderness)
+"azY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_hydro)
 "azZ" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
@@ -7360,6 +7342,14 @@
 	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/interior/caves/temple)
+"aBS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_two/hallway)
 "aBT" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -7493,6 +7483,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/desert_dam/exterior/valley/tradeship)
+"aCA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
 "aCB" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 2;
@@ -7968,6 +7965,16 @@
 /obj/structure/platform_decoration,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"aEk" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "aEl" = (
 /obj/structure/platform,
 /obj/structure/platform{
@@ -7989,6 +7996,12 @@
 "aEq" = (
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"aEr" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "aEs" = (
 /obj/machinery/door/poddoor/mainship/indestructible{
 	id = "medstorage3"
@@ -8149,6 +8162,12 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"aFg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "aFh" = (
 /obj/machinery/light{
 	dir = 4
@@ -8236,6 +8255,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/desert_dam/building/medical/break_room)
+"aFK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "green"
+	},
+/area/desert_dam/building/dorms/hallway_westwing)
 "aFM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/autodoc,
@@ -8425,6 +8450,12 @@
 	dir = 6
 	},
 /area/desert_dam/interior/caves/central_caves)
+"aGS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement3"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "aGT" = (
 /obj/structure/table,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -9047,6 +9078,11 @@
 	icon_state = "cement_sunbleached18"
 	},
 /area/desert_dam/exterior/valley/valley_medical)
+"aKw" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/interior/caves/central_caves)
 "aKy" = (
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 1
@@ -10019,6 +10055,11 @@
 	icon_state = "cement_sunbleached2"
 	},
 /area/desert_dam/exterior/valley/valley_medical)
+"aOa" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/building/administration/meetingrooom)
 "aOc" = (
 /obj/structure/cable,
 /turf/closed/wall,
@@ -10180,13 +10221,6 @@
 	icon_state = "rasputin15"
 	},
 /area/shuttle/tri_trans2/alpha)
-"aOZ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "whitepurple"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "aPa" = (
 /obj/structure/bed/chair/dropship/passenger,
 /obj/structure/cable,
@@ -10233,16 +10267,6 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/river/riverside_central_north)
-"aPj" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/control_room)
 "aPk" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/exterior/valley/valley_wilderness)
@@ -10477,6 +10501,12 @@
 	icon_state = "floor11"
 	},
 /area/shuttle/tri_trans2/alpha)
+"aQC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/workshop)
 "aQD" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal2"
@@ -10740,6 +10770,15 @@
 	dir = 4
 	},
 /area/desert_dam/interior/caves/east_caves)
+"aRW" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/flora/rock/pile/alt3,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "aRX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -10788,6 +10827,12 @@
 	icon_state = "cement_sunbleached19"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
+"aSi" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
 "aSj" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal2"
@@ -10984,6 +11029,12 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"aTi" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_medical_south)
 "aTj" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -11032,11 +11083,9 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/warehouse/loading)
 "aTw" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached18"
-	},
-/area/desert_dam/exterior/valley/valley_northwest)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "aTx" = (
 /obj/structure/largecrate,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -11404,6 +11453,10 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"aVl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "aVm" = (
 /turf/closed/wall/r_wall,
 /area/desert_dam/building/administration/office)
@@ -11494,6 +11547,11 @@
 	icon_state = "carpet7-3"
 	},
 /area/desert_dam/building/administration/office)
+"aVL" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "aVM" = (
 /obj/structure/window/framed/prison/reinforced,
 /turf/open/floor/plating,
@@ -12123,13 +12181,6 @@
 /obj/structure/rack,
 /turf/open/floor/prison,
 /area/desert_dam/building/water_treatment_two/hallway)
-"aYh" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal3"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/north_valley_dam)
 "aYj" = (
 /turf/open/floor/prison{
 	dir = 4;
@@ -12324,6 +12375,10 @@
 /obj/structure/closet/secure_closet/detective,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/marshals_office)
+"aYQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "aYS" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8
@@ -13142,6 +13197,15 @@
 	icon_state = "cement14"
 	},
 /area/desert_dam/interior/dam_interior/north_tunnel_entrance)
+"bbS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/west_wing_hallway)
 "bbT" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal2"
@@ -13253,6 +13317,17 @@
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
+"bcv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull"
+	},
+/area/desert_dam/building/medical/emergency_room)
 "bcA" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -13452,6 +13527,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/desert_dam/building/administration/meetingrooom)
+"bdl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/security/warden)
 "bdm" = (
 /obj/machinery/power/apc{
 	start_charge = 0
@@ -13699,14 +13778,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_northwest)
-"bem" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/building/hydroponics/hydroponics_storage)
 "ben" = (
 /obj/machinery/landinglight/ds1/delaytwo{
 	dir = 1
@@ -14029,6 +14100,13 @@
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
+"bfv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "kitchen"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "bfw" = (
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
@@ -14210,12 +14288,18 @@
 /turf/open/floor/plating,
 /area/desert_dam/building/water_treatment_one/breakroom)
 "bge" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "darkred2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/desert_dam/building/security/prison)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bgf" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -14299,6 +14383,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_two/hallway)
+"bgv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "bgz" = (
 /turf/open/floor/wood,
 /area/desert_dam/building/security/courtroom)
@@ -14720,10 +14810,6 @@
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/bar_valley_dam)
-"biv" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/valley_wilderness)
 "biw" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -15281,11 +15367,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_wilderness)
-"bkF" = (
-/obj/structure/bed/chair,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/security/execution_chamber)
 "bkG" = (
 /obj/item/ammo_magazine/revolver/cmb,
 /obj/structure/table/woodentable,
@@ -15391,6 +15472,12 @@
 	icon_state = "red"
 	},
 /area/desert_dam/building/security/lobby)
+"blb" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/administration/control_room)
 "blc" = (
 /obj/machinery/landinglight/ds2/delaytwo,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -16544,6 +16631,13 @@
 	icon_state = "blue"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
+"bpH" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/desert_dam/building/medical/garage)
 "bpI" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -17699,19 +17793,6 @@
 	icon_state = "grimy"
 	},
 /area/desert_dam/building/bar/bar)
-"bup" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "yellow"
-	},
-/area/desert_dam/building/hydroponics/hydroponics)
-"bus" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 5
-	},
-/area/desert_dam/exterior/valley/bar_valley_dam)
 "but" = (
 /obj/structure/window/framed/wood/reinforced,
 /turf/open/floor/plating,
@@ -18080,6 +18161,11 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
+"bvW" = (
+/obj/effect/landmark/excavation_site_spawner,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_medical)
 "bvX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -19035,6 +19121,16 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
+"bzB" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
 "bzC" = (
 /obj/structure/platform_decoration{
 	dir = 4
@@ -19383,13 +19479,6 @@
 	icon_state = "catwalk-255"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
-"bAX" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal12"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_medical)
 "bAZ" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/desert_dam/exterior/valley/valley_mining)
@@ -19608,6 +19697,10 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/courtroom)
+"bBT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/administration/overseer_office)
 "bBU" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -20011,7 +20104,7 @@
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "bDC" = (
-/obj/machinery/floodlight,
+/obj/machinery/computer/nuke_disk_generator/blue,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "green"
@@ -20438,11 +20531,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
-"bFe" = (
-/obj/effect/landmark/excavation_site_spawner,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_medical)
 "bFf" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
@@ -20762,11 +20850,6 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/atmos_storage)
-"bGm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "bGn" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
 	icon_state = "cement12"
@@ -21318,6 +21401,14 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
+"bIi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/warehouse/warehouse)
 "bIl" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -21616,15 +21707,6 @@
 	icon_state = "white"
 	},
 /area/desert_dam/interior/dam_interior/lobby)
-"bJs" = (
-/obj/structure/bed/chair/wood/normal{
-	dir = 1
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/carpet{
-	icon_state = "carpetside"
-	},
-/area/desert_dam/building/administration/meetingrooom)
 "bJt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21864,12 +21946,6 @@
 	icon_state = "cement4"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
-"bKu" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
-	},
-/area/desert_dam/exterior/valley/valley_labs)
 "bKv" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -22201,10 +22277,6 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
-"bLG" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/valley_wilderness)
 "bLK" = (
 /obj/structure/cable,
 /obj/structure/bed/chair/office/light{
@@ -22806,6 +22878,12 @@
 	icon_state = "darkredcorners2"
 	},
 /area/desert_dam/building/security/armory)
+"bNW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "bNY" = (
 /turf/closed/wall/r_wall/chigusa,
 /area/desert_dam/interior/dam_interior/workshop)
@@ -22930,10 +23008,6 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
-"bOy" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
-/area/desert_dam/building/security/marshals_office)
 "bOz" = (
 /obj/structure/stairs{
 	dir = 4
@@ -23145,18 +23219,22 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
+"bPy" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/primary_tool_storage)
 "bPz" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor{
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/prison)
-"bPB" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "whitepurplecorner"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "bPC" = (
 /obj/structure/table,
 /obj/machinery/computer/security{
@@ -23244,6 +23322,12 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
+"bPQ" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "bPR" = (
 /obj/machinery/power/apc{
 	start_charge = 0
@@ -23355,14 +23439,6 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
-"bQh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/medical/break_room)
 "bQj" = (
 /obj/machinery/light{
 	dir = 4
@@ -23662,10 +23738,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/river/riverside_central_north)
-"bRu" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "bRv" = (
 /turf/open/floor{
 	dir = 5;
@@ -24467,6 +24539,16 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"bUw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/primary_tool_storage)
 "bUy" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal2"
@@ -25003,13 +25085,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/south_valley_dam)
-"bWl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/interior/dam_interior/north_tunnel)
 "bWm" = (
 /obj/structure/platform{
 	dir = 8
@@ -25097,12 +25172,6 @@
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
-"bWI" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
-	},
-/area/desert_dam/exterior/valley/valley_civilian)
 "bWJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -25649,6 +25718,13 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/disposals)
+"bYA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkred2"
+	},
+/area/desert_dam/building/security/prison)
 "bYB" = (
 /obj/structure/rack,
 /obj/item/flashlight,
@@ -26021,15 +26097,6 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/north_wing_hallway)
-"bZB" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/obj/effect/decal/sandytile,
-/obj/effect/decal/sandytile,
-/turf/open/floor{
-	dir = 4;
-	icon_state = "whiteyellowfull"
-	},
-/area/desert_dam/interior/caves/temple)
 "bZC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
@@ -26512,13 +26579,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
-"cbp" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "cement_sunbleached2"
-	},
-/area/desert_dam/exterior/valley/valley_medical)
 "cbq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -27425,10 +27485,6 @@
 	icon_state = "cement_sunbleached17"
 	},
 /area/desert_dam/exterior/valley/valley_medical)
-"cfd" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/bar_valley_dam)
 "cfe" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock{
 	dir = 4
@@ -27512,6 +27568,10 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
+"cfG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "cfI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -27724,13 +27784,6 @@
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
-"cgX" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "darkyellowcorners2"
-	},
-/area/desert_dam/interior/dam_interior/engine_east_wing)
 "cgY" = (
 /turf/open/floor/plating{
 	dir = 10;
@@ -28321,12 +28374,6 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/substation/west)
-"cjJ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/lobby)
 "cjK" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -28790,6 +28837,10 @@
 	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/filtration_a)
+"clp" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "clq" = (
 /obj/machinery/door/airlock/mainship/maint{
 	name = "\improper Lab Maintenance";
@@ -28817,6 +28868,10 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/warehouse/breakroom)
+"clu" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "clw" = (
 /turf/open/floor/prison{
 	dir = 1;
@@ -29337,12 +29392,6 @@
 	icon_state = "whitepurple"
 	},
 /area/desert_dam/building/medical/chemistry)
-"cnI" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "warning"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_west_entrance)
 "cnJ" = (
 /obj/machinery/smartfridge/chemistry,
 /turf/closed/wall,
@@ -29659,12 +29708,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_civilian)
-"cpa" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/security/prison)
 "cpc" = (
 /obj/structure/largecrate,
 /turf/open/floor/prison{
@@ -29866,6 +29909,12 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/north_wing_hallway)
+"cpP" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/interior/caves/central_caves)
 "cpR" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -30821,6 +30870,13 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"ctH" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "ctO" = (
 /obj/structure/desertdam/decals/road/stop{
 	dir = 4;
@@ -30934,6 +30990,13 @@
 "cuh" = (
 /turf/closed/wall/r_wall,
 /area/desert_dam/building/medical/north_wing_hallway)
+"cui" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
 "cuk" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8;
@@ -31186,15 +31249,6 @@
 /obj/machinery/computer/med_data,
 /turf/open/floor/wood,
 /area/desert_dam/building/medical/CMO)
-"cvm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/dorms/hallway_westwing)
 "cvn" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached13"
@@ -31247,6 +31301,13 @@
 	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
+"cvA" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "cvB" = (
 /obj/structure/table,
 /obj/item/folder/black_random,
@@ -31716,10 +31777,6 @@
 	icon_state = "delivery"
 	},
 /area/desert_dam/interior/dam_interior/south_tunnel)
-"cxf" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/interior/lab_northeast/east_lab_RND)
 "cxg" = (
 /obj/item/weapon/gun/shotgun/double,
 /turf/open/floor/cult,
@@ -31849,6 +31906,11 @@
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/desert_dam/building/medical/surgery_observation)
+"cxF" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_medical)
 "cxH" = (
 /turf/open/floor/prison{
 	icon_state = "whitegreencorner"
@@ -32090,6 +32152,12 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/wood,
 /area/desert_dam/building/medical/CMO)
+"cyy" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkred2"
+	},
+/area/desert_dam/building/security/deathrow)
 "cyB" = (
 /obj/structure/desertdam/decals/loose_sand_overlay{
 	dir = 9
@@ -32226,12 +32294,6 @@
 	icon_state = "asteroidfloor"
 	},
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
-"czm" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached4"
-	},
-/area/desert_dam/exterior/valley/valley_hydro)
 "czo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
@@ -33238,12 +33300,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_civilian)
-"cCK" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/cavetodirt{
-	dir = 6
-	},
-/area/desert_dam/exterior/valley/valley_hydro)
 "cCL" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -33288,6 +33344,15 @@
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/valley_cargo)
+"cCX" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/decal/sandytile,
+/obj/effect/decal/sandytile,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
+/area/desert_dam/interior/caves/temple)
 "cDb" = (
 /obj/machinery/landinglight/ds2/delaytwo,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -33442,6 +33507,15 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/surgery_room_two)
+"cDw" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "freezerfloor"
+	},
+/area/desert_dam/building/security/prison)
 "cDy" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -33531,6 +33605,10 @@
 	},
 /turf/open/ground/coast,
 /area/desert_dam/exterior/river/riverside_east)
+"cDQ" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/interior/caves/central_caves)
 "cDR" = (
 /obj/structure/platform_decoration{
 	dir = 4
@@ -33557,6 +33635,10 @@
 	icon_state = "asteroidplating"
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"cDW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "cDX" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached1"
@@ -34394,6 +34476,14 @@
 "cGD" = (
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
+"cGE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "cGG" = (
 /obj/machinery/landinglight/ds2{
 	dir = 4
@@ -34576,6 +34666,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/valley/valley_cargo)
+"cHm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "cHn" = (
 /obj/machinery/landinglight/ds2/delaytwo{
 	dir = 8
@@ -35450,6 +35547,14 @@
 "cKx" = (
 /turf/open/floor/prison,
 /area/desert_dam/building/medical/virology_isolation)
+"cKB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/warehouse/loading)
 "cKC" = (
 /obj/machinery/light{
 	dir = 4
@@ -35530,6 +35635,13 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/virology_wing)
+"cKJ" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "cKL" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -35607,6 +35719,14 @@
 "cLu" = (
 /turf/closed/wall/r_wall,
 /area/desert_dam/building/medical/virology_wing)
+"cLC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "cLG" = (
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/warehouse/warehouse)
@@ -36922,12 +37042,6 @@
 "cQx" = (
 /turf/closed/wall/wood,
 /area/desert_dam/building/bar/bar_restroom)
-"cQy" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 6
-	},
-/area/desert_dam/exterior/valley/valley_northwest)
 "cQz" = (
 /obj/machinery/door/airlock/mainship/generic{
 	name = "\improper Toilet Unit"
@@ -37095,12 +37209,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
-"cRe" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 9
-	},
-/area/desert_dam/exterior/valley/valley_civilian)
 "cRg" = (
 /turf/open/floor/prison{
 	dir = 8;
@@ -37165,6 +37273,10 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"cRx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/medical/break_room)
 "cRB" = (
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached15"
@@ -37359,6 +37471,10 @@
 	icon_state = "red"
 	},
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
+"cSt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/cafeteria/loading)
 "cSu" = (
 /turf/open/floor/prison{
 	icon_state = "darkyellowcorners2"
@@ -37480,6 +37596,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
+"cSY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 5
+	},
+/area/desert_dam/interior/caves/temple)
 "cTa" = (
 /obj/machinery/door/poddoor/mainship/open{
 	dir = 4;
@@ -37673,6 +37795,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
+"cTZ" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal4"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "cUb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -37997,12 +38126,6 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
 /area/desert_dam/building/hydroponics/hydroponics_breakroom)
-"cVW" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "whitepurplecorner"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "cVX" = (
 /obj/structure/platform{
 	dir = 1
@@ -38011,6 +38134,12 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_south)
+"cWa" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement1"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "cWb" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal9"
@@ -38143,13 +38272,6 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/valley_mining)
-"cWQ" = (
-/obj/machinery/landinglight/ds2/delaythree,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
-	},
-/area/desert_dam/exterior/landing/landing_pad_three_external)
 "cWW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -38609,6 +38731,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"cZI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached13"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "cZK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -38641,12 +38769,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_northwing)
-"dab" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 10
-	},
-/area/desert_dam/exterior/valley/valley_medical_south)
 "dak" = (
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached20"
@@ -38754,15 +38876,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/cafeteria/cold_room)
-"daS" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/engine_west_wing)
 "daT" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal1"
@@ -39058,28 +39171,15 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
-"dbR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "cell_stripe"
-	},
-/area/desert_dam/building/warehouse/warehouse)
-"dbS" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_wilderness)
 "dbT" = (
 /obj/item/stool,
 /turf/open/floor/plating,
 /area/desert_dam/building/warehouse/loading)
 "dbV" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "darkyellow2"
-	},
-/area/desert_dam/interior/dam_interior/engine_east_wing)
+/turf/open/floor/prison/bright_clean,
+/area/desert_dam/interior/east_engineering)
 "dbY" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
@@ -39285,6 +39385,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
+"dcT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
 "dcV" = (
 /obj/structure/closet/crate/hydroponics/prespawned,
 /obj/machinery/light{
@@ -39365,6 +39471,14 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
+"ddj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "yellow"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
 "ddm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40426,13 +40540,6 @@
 	icon_state = "asteroidfloor"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
-"dig" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "dil" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -40566,6 +40673,12 @@
 /obj/structure/table/woodentable,
 /turf/open/floor/wood,
 /area/desert_dam/building/administration/office)
+"djp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "djq" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -40892,13 +41005,14 @@
 	icon_state = "cement_sunbleached2"
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
-"dlr" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal2"
-	},
+"dlk" = (
+/obj/structure/disposalpipe/segment,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/south_valley_dam)
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/west_wing_hallway)
 "dlu" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -41124,6 +41238,13 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/cafeteria/loading)
+"dmT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/desert_dam/building/substation/northeast)
 "dnn" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal2"
@@ -41150,12 +41271,23 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"dnC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkred2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_security_armory)
 "dnD" = (
 /obj/structure/platform,
 /turf/open/ground/coast{
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_south)
+"dnG" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "dnN" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 5
@@ -41166,6 +41298,15 @@
 	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/valley/valley_medical)
+"dnS" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/carpet{
+	icon_state = "carpetside"
+	},
+/area/desert_dam/building/administration/meetingrooom)
 "dod" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached12"
@@ -41364,14 +41505,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-"dqc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/building/warehouse/loading)
 "dqd" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
@@ -41410,6 +41543,13 @@
 "dqp" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/desert_dam/building/water_treatment_one)
+"dqr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "dqs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -41660,6 +41800,13 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/prison,
 /area/desert_dam/building/water_treatment_one/garage)
+"dsN" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal3"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "dsO" = (
 /obj/structure/rack,
 /turf/open/floor/prison{
@@ -41697,17 +41844,12 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
-"dth" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
+"dtg" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/cafeteria/loading)
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "dto" = (
 /obj/structure/table,
 /turf/open/floor/prison,
@@ -41785,6 +41927,17 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_south)
+"duf" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"duj" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/valley_cargo)
 "dun" = (
 /obj/machinery/computer/med_data/laptop,
 /obj/structure/table/woodentable,
@@ -42108,14 +42261,10 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/dorms/restroom)
-"dwt" = (
-/obj/effect/decal/cleanable/dirt,
+"dwq" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/auxilary_tool_storage)
+/turf/open/floor/wood,
+/area/desert_dam/building/medical/CMO)
 "dww" = (
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 6
@@ -42284,13 +42433,6 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
-"dxQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/dorms/hallway_westwing)
 "dxR" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/donut,
@@ -42556,12 +42698,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_northwing)
-"dzt" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached18"
-	},
-/area/desert_dam/exterior/valley/valley_hydro)
 "dzx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -42621,6 +42757,20 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
+"dzY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkred2"
+	},
+/area/desert_dam/building/security/southern_hallway)
 "dAd" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/chips,
@@ -42680,12 +42830,6 @@
 	icon_state = "white"
 	},
 /area/desert_dam/building/water_treatment_one/breakroom)
-"dAy" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached1"
-	},
-/area/desert_dam/exterior/valley/valley_northwest)
 "dAA" = (
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/filtration_a)
@@ -42737,6 +42881,15 @@
 	icon_state = "green"
 	},
 /area/desert_dam/building/dorms/hallway_northwing)
+"dAM" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "dAW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -42901,14 +43054,6 @@
 	icon_state = "blue"
 	},
 /area/desert_dam/building/dorms/pool)
-"dBF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/building/administration/hallway)
 "dBJ" = (
 /obj/machinery/computer/pod/old{
 	name = "Personal Computer"
@@ -43055,6 +43200,14 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"dCu" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
 "dCw" = (
 /obj/structure/table/mainship,
 /obj/item/spacecash/c10,
@@ -43074,6 +43227,12 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/disposals)
+"dCA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/building/substation/southwest)
 "dCB" = (
 /obj/structure/table/woodentable,
 /turf/open/floor/wood,
@@ -43146,6 +43305,13 @@
 	icon_state = "whitepurple"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
+"dCR" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkbrown2"
+	},
+/area/desert_dam/building/warehouse/loading)
 "dCU" = (
 /obj/structure/platform{
 	dir = 1
@@ -43218,10 +43384,6 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/emergency_room)
-"dDs" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/desert_dam/interior/caves/central_caves)
 "dDv" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/welding,
@@ -43264,6 +43426,10 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
+"dDF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/interior/dam_interior/south_tunnel)
 "dDJ" = (
 /turf/open/floor/prison{
 	dir = 8;
@@ -43302,6 +43468,13 @@
 	icon_state = "yellow"
 	},
 /area/desert_dam/building/hydroponics/hydroponics)
+"dDS" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal1"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_mining)
 "dDZ" = (
 /obj/structure/toilet{
 	dir = 8
@@ -43311,6 +43484,11 @@
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/water_treatment_one/breakroom)
+"dEa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/cult,
+/area/desert_dam/building/bar/bar)
 "dEb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
@@ -43385,6 +43563,12 @@
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/cafeteria/cold_room)
+"dEC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "dED" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -43394,6 +43578,21 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_one/hallway)
+"dEE" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_2"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_medical_south)
+"dEM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/dorms/restroom)
 "dEW" = (
 /obj/structure/platform{
 	dir = 1
@@ -43556,6 +43755,12 @@
 	icon_state = "kitchen"
 	},
 /area/desert_dam/building/dorms/restroom)
+"dFY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "dGa" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/candy,
@@ -43568,12 +43773,6 @@
 	icon_state = "kitchen"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
-"dGr" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 6
-	},
-/area/desert_dam/exterior/valley/bar_valley_dam)
 "dGv" = (
 /obj/structure/platform,
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
@@ -43811,11 +44010,6 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/warehouse/breakroom)
-"dIb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/interior/dam_interior/engine_west_wing)
 "dIj" = (
 /turf/open/floor/plating{
 	dir = 1;
@@ -43877,6 +44071,13 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"dIx" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "dIz" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -44071,11 +44272,10 @@
 	icon_state = "blue"
 	},
 /area/desert_dam/building/dorms/pool)
-"dJp" = (
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 6
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+"dJu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/lab_northeast/east_lab_workshop)
 "dJA" = (
 /obj/structure/platform{
 	dir = 8
@@ -45698,18 +45898,10 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/emergency_room)
-"dQW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
+"dQU" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached4"
-	},
-/area/desert_dam/exterior/valley/valley_medical)
+/turf/open/floor/bcircuit,
+/area/desert_dam/interior/dam_interior/tech_storage)
 "dQX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
@@ -46826,6 +47018,11 @@
 	icon_state = "yellow"
 	},
 /area/desert_dam/building/hydroponics/hydroponics)
+"dUI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/dorms/hallway_northwing)
 "dUJ" = (
 /obj/effect/landmark/start/job/survivor,
 /obj/effect/decal/cleanable/dirt,
@@ -47149,10 +47346,6 @@
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/prison,
 /area/desert_dam/building/water_treatment_one/control_room)
-"dVQ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/desert_dam/exterior/valley/north_valley_dam)
 "dVS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47771,11 +47964,6 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/dorms/restroom)
-"dYA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "dYC" = (
 /obj/structure/table,
 /obj/item/radio,
@@ -47907,13 +48095,6 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/dorms/pool)
-"dZH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached10"
-	},
-/area/desert_dam/exterior/valley/valley_medical_south)
 "dZL" = (
 /turf/open/ground/river{
 	name = "pool"
@@ -48005,6 +48186,14 @@
 	icon_state = "wood"
 	},
 /area/desert_dam/building/dorms/hallway_westwing)
+"eaD" = (
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/flora/rock/pile/alt3,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "eaG" = (
 /obj/structure/table/woodentable,
 /obj/structure/paper_bin,
@@ -48531,12 +48720,6 @@
 	icon_state = "cell_stripe"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
-"edk" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 9
-	},
-/area/desert_dam/interior/caves/central_caves)
 "edo" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -48556,14 +48739,6 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/administration/hallway)
-"edH" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/building/water_treatment_one/hallway)
 "edJ" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "\improper Water Treatment Foyer"
@@ -48663,12 +48838,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_one/hallway)
-"edW" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 4
-	},
-/area/desert_dam/exterior/valley/valley_hydro)
 "eed" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 2;
@@ -48680,13 +48849,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/water_treatment_one/breakroom)
-"een" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_cargo)
 "eeo" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -48868,6 +49030,11 @@
 /obj/structure/flora/tree/joshua,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"eff" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "efl" = (
 /obj/machinery/door/airlock/mainship/generic{
 	name = "\improper Toilet Unit"
@@ -48920,19 +49087,13 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/south_valley_dam)
-"egT" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/valley/south_valley_dam)
-"eha" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal2"
+"ehb" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_4"
 	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_medical)
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "ehg" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal3"
@@ -48952,15 +49113,6 @@
 	dir = 10
 	},
 /area/desert_dam/exterior/valley/valley_medical)
-"ehW" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "eiI" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison{
@@ -48968,11 +49120,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_storage)
-"eiK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "eiP" = (
 /obj/effect/ai_node,
 /turf/open/ground/jungle{
@@ -49006,11 +49153,6 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
-"ejV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
-/area/desert_dam/exterior/valley/valley_telecoms)
 "ekf" = (
 /obj/structure/lattice{
 	layer = 2.9
@@ -49038,18 +49180,32 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/interior/caves/temple)
-"ekF" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal3"
-	},
+"eky" = (
+/obj/structure/cable,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_medical)
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/warehouse/warehouse)
+"ekA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "floor_plate"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
 "ekH" = (
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached9"
 	},
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"ekP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached2"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "ekQ" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal3"
@@ -49077,13 +49233,6 @@
 	icon_state = "bluecorner"
 	},
 /area/desert_dam/building/administration/hallway)
-"elx" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal1"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/landing/landing_pad_three_external)
 "elz" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -49092,25 +49241,10 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/administration/hallway)
-"elD" = (
+"emn" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "freezerfloor"
-	},
-/area/desert_dam/building/water_treatment_one/breakroom)
-"elG" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	dir = 1;
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/lab_northwest/west_lab_xenoflora)
-"elW" = (
-/obj/structure/flora/tree/joshua,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_cargo)
+/turf/open/floor/prison,
+/area/desert_dam/building/medical/virology_isolation)
 "emv" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -49137,40 +49271,18 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/valley/valley_cargo)
-"eni" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "darkredcorners2"
-	},
-/area/desert_dam/building/security/deathrow)
 "enk" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 6
 	},
 /area/desert_dam/interior/caves/central_caves)
-"enE" = (
+"enA" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/desert_dam/building/substation/northeast)
-"eoa" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal7"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached13"
 	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/south_valley_dam)
-"eou" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
-"epq" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "dark2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_west_entrance)
+/area/desert_dam/exterior/valley/valley_labs)
 "epG" = (
 /obj/structure/table,
 /turf/open/floor/prison{
@@ -49186,34 +49298,25 @@
 	dir = 5
 	},
 /area/desert_dam/interior/east_engineering)
-"epQ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 9
-	},
-/area/desert_dam/exterior/landing/landing_pad_three_external)
 "eqo" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_biology)
-"eqG" = (
-/obj/effect/decal/cleanable/dirt,
+"eqr" = (
+/obj/structure/cable,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
 	},
-/area/desert_dam/exterior/valley/valley_labs)
-"erw" = (
-/obj/structure/platform{
+/area/desert_dam/building/medical/treatment_room)
+"ert" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 4
 	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt{
-	dir = 1
-	},
-/area/desert_dam/exterior/river/riverside_central_north)
+/area/desert_dam/exterior/valley/valley_medical_south)
 "erz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49254,6 +49357,19 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_east)
+"etD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/virology_isolation)
+"etO" = (
+/obj/structure/flora/desert/grass/heavy{
+	icon_state = "heavygrass_3"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_cargo)
 "etY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
@@ -49313,15 +49429,18 @@
 	dir = 9
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
+"euS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/interior/dam_interior/workshop)
 "euX" = (
 /obj/structure/desertdam/decals/loose_sand_overlay,
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/east_caves)
-"eva" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/north_valley_dam)
 "evd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -49339,6 +49458,13 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
+"evh" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/building/cafeteria/loading)
 "evl" = (
 /obj/structure/largecrate/random,
 /obj/effect/spawner/random/trash,
@@ -49346,12 +49472,36 @@
 	icon_state = "whiteblue"
 	},
 /area/desert_dam/building/medical/medsecure)
+"evo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement3"
+	},
+/area/desert_dam/interior/dam_interior/northwestern_tunnel)
+"evF" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkred2"
+	},
+/area/desert_dam/building/security/southern_hallway)
 "evU" = (
 /obj/structure/flora/desert/cactus{
 	icon_state = "cactus_8"
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_civilian)
+"evV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "ewp" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -49359,11 +49509,6 @@
 /obj/vehicle/train/cargo/trolley,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"ewA" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/substation/northeast)
 "ewD" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/valley/valley_cargo)
@@ -49373,6 +49518,13 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_east)
+"ewU" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/building/hydroponics/hydroponics_loading)
 "ewX" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -49383,19 +49535,27 @@
 	icon_state = "cement_sunbleached18"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"exv" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
+"exC" = (
+/obj/structure/flora/desert/cactus{
+	icon_state = "cactus_8"
 	},
-/area/desert_dam/building/water_treatment_one/garage)
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "exD" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached18"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"exE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "exO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -49411,6 +49571,12 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/desert_dam/building/warehouse/warehouse)
+"exX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/treatment_room)
 "eyb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -49448,13 +49614,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/desert_dam/building/bar/bar)
-"ezy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
-/area/desert_dam/building/bar/backroom)
 "ezI" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal1"
@@ -49509,23 +49668,43 @@
 /obj/effect/decal/cleanable/liquid_fuel,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/water_treatment_one/garage)
+"eCY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/north_wing_hallway)
 "eDb" = (
 /obj/structure/closet/secure_closet/atmos_personal,
 /turf/open/floor/prison/blue,
 /area/desert_dam/interior/east_engineering)
+"eDq" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
+"eDy" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_labs)
+"eDB" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "eDC" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached11"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
-"eDH" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached13"
-	},
-/area/desert_dam/exterior/valley/north_valley_dam)
 "eDL" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_8"
@@ -49533,6 +49712,17 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"eDN" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_wilderness)
+"eDO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "eDQ" = (
 /obj/structure/table,
 /turf/open/floor/prison,
@@ -49552,34 +49742,39 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_medical_south)
-"eEl" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 8
+"eEm" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "vault"
 	},
-/area/desert_dam/exterior/valley/valley_wilderness)
+/area/desert_dam/building/substation/northeast)
 "eEp" = (
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/office)
+"eEt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitegreencorner"
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
 "eEA" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"eFm" = (
+"eFr" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
-"eFC" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal2"
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowcorner"
 	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_mining)
+/area/desert_dam/interior/dam_interior/break_room)
 "eFM" = (
 /obj/structure/platform{
 	dir = 1
@@ -49635,6 +49830,27 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"eHB" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"eHS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
+"eHT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "eHU" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -49647,24 +49863,15 @@
 /obj/structure/cable,
 /turf/open/floor/bcircuit,
 /area/desert_dam/interior/dam_interior/engine_room)
+"eIG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/west_tunnel)
 "eIH" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock{
 	dir = 4
 	},
 /area/desert_dam/interior/caves/east_caves)
-"eIJ" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_civilian)
 "eIL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -49679,12 +49886,6 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_south)
-"eJp" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/cafeteria/loading)
 "eJM" = (
 /obj/machinery/landinglight/ds2,
 /obj/effect/ai_node,
@@ -49692,13 +49893,6 @@
 	icon_state = "cement_sunbleached2"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"eJS" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating{
-	dir = 1;
-	icon_state = "warnplate"
-	},
-/area/desert_dam/building/medical/garage)
 "eKa" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -49715,6 +49909,14 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_biology)
+"eKI" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement1"
+	},
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "eKN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
@@ -49758,6 +49960,13 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/administration/hallway)
+"eMI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/medical/lobby)
 "eMP" = (
 /obj/structure/desertdam/decals/road/stop{
 	dir = 1;
@@ -49766,6 +49975,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_cargo)
+"eNd" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/north_valley_dam)
 "eNe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
@@ -49835,18 +50051,6 @@
 	icon_state = "cement_sunbleached13"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
-"ePp" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
-"ePr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached18"
-	},
-/area/desert_dam/exterior/valley/valley_medical)
 "ePQ" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -49858,6 +50062,26 @@
 "ePU" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge,
 /area/desert_dam/interior/dam_interior/western_dam_cave)
+"eQg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
+"eQv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/emergency_room)
 "eRf" = (
 /obj/structure/table/woodentable,
 /obj/effect/ai_node,
@@ -49882,6 +50106,25 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/emergency_room)
+"eRN" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
+"eSc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/valley/valley_telecoms)
+"eSt" = (
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "eSw" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner{
 	dir = 4
@@ -49892,10 +50135,6 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"eTw" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/medical/break_room)
 "eUi" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -49923,20 +50162,6 @@
 /obj/effect/ai_node,
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/valley/valley_labs)
-"eUJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement4"
-	},
-/area/desert_dam/interior/dam_interior/central_tunnel)
 "eUR" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 2;
@@ -49962,21 +50187,16 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_two/equipment)
-"eWm" = (
+"eWh" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached1"
-	},
-/area/desert_dam/exterior/valley/valley_hydro)
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_mining)
 "eWG" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached4"
 	},
-/area/desert_dam/exterior/valley/valley_telecoms)
-"eWZ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_telecoms)
 "eXb" = (
 /obj/effect/decal/warning_stripes{
@@ -50018,11 +50238,29 @@
 	icon_state = "floor_plate"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"eYe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/area/desert_dam/exterior/valley/valley_telecoms)
+"eYq" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/security/southern_hallway)
 "eYF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"eYK" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "eYU" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable,
@@ -50042,35 +50280,25 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
-"eZO" = (
+"eZf" = (
+/obj/structure/cable,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
+/turf/open/floor{
+	dir = 1;
+	icon_state = "whitegreen"
 	},
-/area/desert_dam/exterior/valley/valley_mining)
-"eZX" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
-	},
+/area/desert_dam/building/lab_northwest/west_lab_xenoflora)
+"faU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/desert_dam/exterior/landing/landing_pad_three_external)
-"faP" = (
-/obj/structure/flora/desert/cactus/multiple{
-	icon_state = "cacti_10"
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
 	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "fbp" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/cafeteria/loading)
-"fbr" = (
-/obj/structure/flora/desert/grass,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "fbt" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -50084,13 +50312,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_crashsite)
-"fbO" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 6;
-	icon_state = "darkpurple2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "fcj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -50100,6 +50321,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
+"fck" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_6"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "fcx" = (
 /obj/machinery/floodlight/landing,
 /obj/structure/desertdam/decals/loose_sand_overlay{
@@ -50118,12 +50346,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/bcircuit,
 /area/desert_dam/interior/dam_interior/tech_storage)
-"fcX" = (
+"fdd" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 1
+/turf/open/floor{
+	icon_state = "dark"
 	},
-/area/desert_dam/exterior/valley/valley_crashsite)
+/area/desert_dam/building/church)
 "fdf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/mono,
@@ -50134,24 +50362,11 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
-"fdD" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal2"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_civilian)
 "fdL" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner2{
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_east)
-"feq" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/dorms/restroom)
 "fev" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -50161,12 +50376,12 @@
 	icon_state = "white"
 	},
 /area/desert_dam/building/water_treatment_one/breakroom)
-"feO" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 8
+"few" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
 	},
-/area/desert_dam/exterior/valley/valley_crashsite)
+/area/desert_dam/building/cafeteria/loading)
 "feS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -50183,16 +50398,6 @@
 	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
-"feX" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/hydroponics/hydroponics_breakroom)
 "ffh" = (
 /obj/machinery/door/airlock/mainship/security/glass{
 	dir = 1;
@@ -50204,10 +50409,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/security/office)
-"ffq" = (
+"ffr" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/desert_dam/interior/lab_northeast/east_lab_biology)
+/turf/open/floor/prison,
+/area/desert_dam/building/dorms/hallway_northwing)
 "ffA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -50223,10 +50430,6 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/building/substation/northeast)
-"ffF" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/landing/landing_pad_three_external)
 "fgb" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -50262,6 +50465,24 @@
 /obj/item/flashlight,
 /turf/open/floor/mainship/mono,
 /area/desert_dam/exterior/valley/tradeship)
+"fgT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"fhc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_labs)
+"fhh" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "yellow"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
 "fhl" = (
 /obj/machinery/landinglight/ds2/delaythree{
 	dir = 1
@@ -50283,25 +50504,12 @@
 	icon_state = "whiteblue"
 	},
 /area/desert_dam/building/medical/medsecure)
-"fhI" = (
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "fif" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal1"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
-"fir" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/building/dorms/restroom)
 "fiw" = (
 /obj/structure/flora/rock/pile/alt2,
 /obj/docking_port/stationary/crashmode,
@@ -50320,25 +50528,25 @@
 	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/interior/caves/temple)
+"fjd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/warehouse/breakroom)
+"fjI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 5
+	},
+/area/desert_dam/interior/caves/east_caves)
 "fjS" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 4
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
-"fkj" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "white"
-	},
-/area/desert_dam/interior/dam_interior/lobby)
-"fkp" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
-	},
-/area/desert_dam/building/security/evidence)
 "fkJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
@@ -50346,13 +50554,6 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/building/medical/virology_isolation)
-"fkY" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal1"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_civilian)
 "flu" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -50364,13 +50565,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/tech_storage)
-"fmn" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal1"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/interior/dam_interior/south_tunnel)
 "fmt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -50381,24 +50575,25 @@
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/water_treatment_two/equipment)
-"fmC" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 8
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
 "fnb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached11"
 	},
 /area/desert_dam/exterior/valley/valley_medical)
-"fnp" = (
+"foa" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached18"
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowcorner"
 	},
-/area/desert_dam/exterior/valley/south_valley_dam)
+/area/desert_dam/building/water_treatment_one/breakroom)
+"fob" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
+	},
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "fof" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -50435,13 +50630,6 @@
 	icon_state = "cement_sunbleached9"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
-"fpw" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating{
-	dir = 9;
-	icon_state = "warnplate"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "fpJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50465,10 +50653,6 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/security/staffroom)
-"fqn" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/desert_dam/exterior/valley/valley_wilderness)
 "fqI" = (
 /obj/structure/table,
 /turf/open/floor{
@@ -50481,12 +50665,24 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/tradeship)
+"fqQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/dorms/hallway_westwing)
 "fqR" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"fqU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/water_treatment_two/lobby)
 "frg" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge{
 	icon_state = "shallow_water_clean"
@@ -50504,13 +50700,6 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
-"fsE" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/valley/valley_mining)
 "fsW" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -50520,11 +50709,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-"fsX" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "fsZ" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison,
@@ -50538,15 +50722,6 @@
 	icon_state = "cement_sunbleached18"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
-"fte" = (
-/obj/machinery/landinglight/ds2{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached1"
-	},
-/area/desert_dam/exterior/landing/landing_pad_three_external)
 "ftp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -50570,10 +50745,43 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/staffroom)
+"fug" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "kitchen"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "fut" = (
 /obj/effect/ai_node,
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/valley/valley_labs)
+"fuw" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal1"
+	},
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_labs)
+"fuC" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal8"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
+"fuF" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/building/water_treatment_one/garage)
 "fuL" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -50584,6 +50792,13 @@
 	icon_state = "vault"
 	},
 /area/desert_dam/building/security/prison)
+"fva" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/desert_dam/building/lab_northwest/west_lab_xenoflora)
 "fvc" = (
 /obj/machinery/door/poddoor/shutters/opened,
 /obj/structure/cable,
@@ -50604,6 +50819,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/warehouse/loading)
+"fwb" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "fwg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -50622,10 +50843,12 @@
 	dir = 9
 	},
 /area/desert_dam/interior/caves/temple)
-"fwI" = (
+"fww" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/desert_dam/interior/lab_northeast/east_lab_maintenence)
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "fwJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -50667,13 +50890,6 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
-"fxV" = (
-/obj/structure/flora/desert/grass{
-	icon_state = "lightgrass_3"
-	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "fxY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -50683,13 +50899,11 @@
 	icon_state = "whitegreencorner"
 	},
 /area/desert_dam/building/medical/west_wing_hallway)
-"fyo" = (
+"fyg" = (
+/obj/machinery/light,
 /obj/effect/landmark/weed_node,
-/turf/open/floor{
-	dir = 8;
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/lab_northwest/west_lab_xenoflora)
+/turf/open/floor/wood,
+/area/desert_dam/building/medical/break_room)
 "fyq" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
@@ -50717,6 +50931,13 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/cafeteria/loading)
+"fzw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/desert_dam/building/church)
 "fzA" = (
 /obj/machinery/floodlight/landing,
 /obj/machinery/landinglight/ds2/delayone{
@@ -50739,17 +50960,16 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/tradeship)
-"fAr" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/desert_dam/interior/caves/central_caves)
-"fAx" = (
-/obj/effect/decal/cleanable/dirt,
+"fBc" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_northwest)
+"fBC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
 	},
-/area/desert_dam/exterior/valley/valley_telecoms)
+/area/desert_dam/exterior/valley/valley_wilderness)
 "fBX" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison{
@@ -50818,6 +51038,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/central_tunnel)
+"fDf" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/bcircuit,
+/area/desert_dam/interior/dam_interior/engine_room)
 "fDi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -50840,34 +51064,19 @@
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"fDo" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_labs)
-"fDw" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement13"
+"fDr" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal2"
 	},
-/area/desert_dam/interior/dam_interior/south_tunnel)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_mining)
 "fDL" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal2"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
-"fDS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/desert_dam/building/cafeteria/backroom)
-"fDV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/cult,
-/area/desert_dam/building/bar/bar)
 "fEf" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -50879,11 +51088,6 @@
 	dir = 6
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"fEO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison/bright_clean,
-/area/desert_dam/interior/east_engineering)
 "fEQ" = (
 /obj/structure/desertdam/decals/road/stop{
 	dir = 4;
@@ -50901,12 +51105,6 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/surgery_room_one)
-"fFU" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/dorms/hallway_northwing)
 "fFY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -50964,12 +51162,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_two/equipment)
-"fHH" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 4
-	},
-/area/desert_dam/interior/dam_interior/western_dam_cave)
 "fHT" = (
 /obj/structure/flora/rock/alt2{
 	name = "rock"
@@ -51009,13 +51201,6 @@
 	icon_state = "cement_sunbleached13"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"fJM" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal1"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_mining)
 "fKd" = (
 /obj/structure/cable,
 /turf/closed/wall{
@@ -51045,10 +51230,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/security/northern_hallway)
-"fKq" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
-/area/desert_dam/building/bar/backroom)
 "fKt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/desertdam/decals/road/edge{
@@ -51066,6 +51247,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_two/equipment)
+"fKB" = (
+/obj/structure/table,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "dark2"
+	},
+/area/desert_dam/building/administration/archives)
 "fLB" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -51073,6 +51261,19 @@
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/medical/break_room)
+"fLF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
+"fLL" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_2"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "fLY" = (
 /obj/machinery/light{
 	dir = 1
@@ -51106,12 +51307,16 @@
 "fMJ" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/north_tunnel_entrance)
-"fOT" = (
+"fNN" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached11"
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/auxilary_tool_storage)
+"fOA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
 	},
-/area/desert_dam/exterior/valley/valley_medical)
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "fOW" = (
 /obj/structure/cable,
 /turf/open/floor/prison,
@@ -51149,19 +51354,19 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
-"fPr" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "darkbrown2"
-	},
-/area/desert_dam/building/warehouse/loading)
 "fPt" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached18"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"fPv" = (
+/obj/structure/desertdam/decals/road/stop{
+	icon_state = "stop_decal5"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "fPy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -51171,10 +51376,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics)
-"fPF" = (
+"fQy" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/bar/bar_restroom)
 "fQD" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison,
@@ -51198,19 +51406,6 @@
 	dir = 6
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"fQY" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 5
-	},
-/area/desert_dam/exterior/valley/valley_labs)
-"fRs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "fRy" = (
 /obj/structure/stairs/seamless/platform/alt{
 	dir = 4
@@ -51232,13 +51427,6 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"fRR" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "whitegreenfull"
-	},
-/area/desert_dam/building/water_treatment_one/floodgate_control)
 "fRX" = (
 /obj/effect/landmark/weed_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -51283,10 +51471,6 @@
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
-"fSM" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt,
-/area/desert_dam/exterior/valley/valley_civilian)
 "fSP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51299,12 +51483,6 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
-"fSV" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/building/warehouse/breakroom)
 "fTa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/shower{
@@ -51338,19 +51516,40 @@
 /obj/item/book/manual/engineering_guide,
 /turf/open/floor/mainship/mono,
 /area/desert_dam/exterior/valley/tradeship)
+"fTL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/central_tunnel)
+"fTP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/hydroponics/hydroponics_storage)
+"fTX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
 "fUc" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"fUB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/east_wing_hallway)
 "fUE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -51362,6 +51561,20 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"fVl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "fVv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -51380,18 +51593,6 @@
 	icon_state = "dark"
 	},
 /area/desert_dam/building/church)
-"fVX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached4"
-	},
-/area/desert_dam/exterior/valley/valley_medical)
-"fVZ" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_cargo)
 "fWm" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -51404,6 +51605,21 @@
 	},
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_mining)
+"fWP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkred2"
+	},
+/area/desert_dam/building/security/southern_hallway)
+"fWX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/building/security/prison)
 "fXu" = (
 /obj/machinery/landinglight/ds2/delaytwo{
 	dir = 4
@@ -51472,6 +51688,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/tech_storage)
+"fZf" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
+"fZw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/river/riverside_south)
 "fZA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -51495,10 +51723,14 @@
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
 /area/desert_dam/building/administration/hallway)
-"gaj" = (
+"gah" = (
+/obj/structure/cable,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/hydroponics/hydroponics_storage)
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_one/equipment)
 "gak" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison{
@@ -51514,32 +51746,29 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics)
-"gau" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_security_armory)
 "gaw" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/lab_northeast/east_lab_RND)
-"gbl" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 5
+"gbL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/desert_dam/exterior/valley/valley_crashsite)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_one/hallway)
 "gbQ" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"gbS" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "gbX" = (
 /obj/machinery/light,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -51563,11 +51792,6 @@
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/cafeteria/backroom)
-"gcn" = (
-/obj/structure/flora/tree/joshua,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "gcG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/stationary/crashmode,
@@ -51596,15 +51820,6 @@
 	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/valley/bar_valley_dam)
-"get" = (
-/obj/structure/table,
-/obj/item/storage/box/lightstick,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "darkyellow2"
-	},
-/area/desert_dam/interior/dam_interior/engine_east_wing)
 "gez" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -51612,10 +51827,12 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
-"geT" = (
+"geS" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
-/area/desert_dam/building/administration/overseer_office)
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "geZ" = (
 /obj/structure/platform_decoration{
 	dir = 4
@@ -51646,12 +51863,19 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/cafeteria/loading)
-"ggq" = (
+"ggi" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement4"
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
 	},
-/area/desert_dam/interior/dam_interior/northeastern_tunnel)
+/area/desert_dam/building/administration/hallway)
+"ggs" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/valley/valley_cargo)
 "ggy" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal3"
@@ -51669,17 +51893,10 @@
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_excavation)
-"ggW" = (
+"ghw" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/desert_dam/interior/dam_interior/north_tunnel)
-"ghD" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal2"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/river/riverside_east)
+/turf/open/floor/prison,
+/area/desert_dam/building/hydroponics/hydroponics_storage)
 "ghH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -51705,10 +51922,17 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_security_armory)
-"giq" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/interior/caves/central_caves)
+"ghW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
+"giH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/exterior/valley/valley_medical_south)
 "giL" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/prison,
@@ -51746,6 +51970,10 @@
 	icon_state = "cement1"
 	},
 /area/desert_dam/interior/dam_interior/western_dam_cave)
+"gjs" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "gjC" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -51782,20 +52010,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/mono,
 /area/desert_dam/exterior/valley/tradeship)
+"gku" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/desert_dam/exterior/valley/valley_labs)
 "gkB" = (
 /obj/structure/largecrate/machine/bodyscanner,
 /turf/open/floor{
 	icon_state = "whiteblue"
 	},
 /area/desert_dam/building/medical/medsecure)
-"gli" = (
-/obj/effect/decal/cleanable/dirt,
+"gkO" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
 	},
-/area/desert_dam/interior/dam_interior/smes_main)
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "glx" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -51808,19 +52039,13 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
-"gmE" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
-"gmL" = (
+"glU" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor{
-	dir = 1;
-	icon_state = "warning"
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "floor_plate"
 	},
-/area/desert_dam/interior/lab_northeast/east_lab_west_entrance)
+/area/desert_dam/interior/dam_interior/hanger)
 "gmZ" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	dir = 2;
@@ -51840,6 +52065,13 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/water_treatment_one/lobby)
+"gnY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/building/substation/northeast)
 "goi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -51858,6 +52090,17 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_northwest)
+"goJ" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "kitchen"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "goO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -51867,28 +52110,20 @@
 	icon_state = "yellowcorner"
 	},
 /area/desert_dam/building/hydroponics/hydroponics)
-"goQ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 4
-	},
-/area/desert_dam/exterior/valley/valley_cargo)
 "goZ" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/valley/valley_hydro)
-"gpr" = (
+"gpg" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached4"
+	icon_state = "cement_sunbleached1"
 	},
-/area/desert_dam/exterior/valley/valley_mining)
-"gpu" = (
-/obj/machinery/light,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "red"
+/area/desert_dam/exterior/valley/valley_labs)
+"gpA" = (
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
 	},
-/area/desert_dam/building/security/northern_hallway)
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "gpP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -51899,16 +52134,20 @@
 	dir = 9
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
+"gqc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/hangar_storage)
 "gqq" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_cargo)
-"gqS" = (
+"gqD" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement4"
+/turf/open/floor/prison{
+	icon_state = "darkbrown2"
 	},
-/area/desert_dam/interior/dam_interior/west_tunnel)
+/area/desert_dam/building/warehouse/loading)
 "grm" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -51926,15 +52165,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
-"grC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
+"grD" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "bright_clean"
+	icon_state = "whitegreenfull"
 	},
-/area/desert_dam/interior/dam_interior/lobby)
+/area/desert_dam/interior/east_engineering)
 "grJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -51961,17 +52198,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
-"gta" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/interior/caves/central_caves)
-"gtF" = (
+"gsU" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "whitepurple"
+/turf/open/floor{
+	icon_state = "freezerfloor"
 	},
-/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
+/area/desert_dam/building/cafeteria/cold_room)
 "guw" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/effect/landmark/lv624/fog_blocker,
@@ -51983,20 +52216,14 @@
 	dir = 5
 	},
 /area/desert_dam/interior/caves/central_caves)
-"guO" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
-/area/desert_dam/building/medical/break_room)
+"gvm" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/interior/caves/central_caves)
 "gvo" = (
 /turf/open/floor/plating,
 /area/desert_dam/exterior/landing/landing_pad_two)
-"gvt" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/south_valley_dam)
 "gvG" = (
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 5
@@ -52008,14 +52235,6 @@
 	dir = 5
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
-"gvT" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/building/warehouse/warehouse)
 "gvY" = (
 /obj/structure/platform{
 	dir = 8
@@ -52042,14 +52261,13 @@
 	icon_state = "vault"
 	},
 /area/desert_dam/building/security/prison)
-"gwO" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal1"
-	},
-/obj/effect/ai_node,
+"gwI" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_labs)
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "blue"
+	},
+/area/desert_dam/building/administration/hallway)
 "gwU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -52059,15 +52277,6 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
-"gwX" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/building/administration/hallway)
 "gxl" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -52080,15 +52289,20 @@
 	icon_state = "cement4"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
-"gyo" = (
-/obj/effect/decal/cleanable/dirt,
+"gyi" = (
+/obj/structure/table,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/hydroponics/hydroponics_storage)
-"gyI" = (
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "kitchen"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
+"gyl" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/desert_dam/building/medical/garage)
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "gzn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -52099,16 +52313,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/warehouse/loading)
-"gzs" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "cell_stripe"
-	},
-/area/desert_dam/interior/dam_interior/hanger)
 "gzC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/lv624/fog_blocker,
@@ -52139,31 +52343,31 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"gBf" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/lobby)
-"gBx" = (
+"gBJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
+	dir = 8;
+	icon_state = "sterile_white"
 	},
-/area/desert_dam/building/medical/morgue)
+/area/desert_dam/building/medical/primary_storage)
 "gCg" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /turf/open/floor/prison,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
-"gCm" = (
+"gCr" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached14"
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
 	},
-/area/desert_dam/exterior/landing/landing_pad_three_external)
+/area/desert_dam/exterior/valley/valley_telecoms)
+"gCH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/desert_dam/interior/dam_interior/lobby)
 "gCL" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison,
@@ -52179,6 +52383,11 @@
 	icon_state = "whiteyellowfull"
 	},
 /area/desert_dam/interior/caves/temple)
+"gCU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_cargo)
 "gDi" = (
 /obj/structure/cable,
 /turf/open/floor{
@@ -52186,22 +52395,21 @@
 	icon_state = "whiteyellowcorner"
 	},
 /area/desert_dam/interior/dam_interior/break_room)
-"gDq" = (
+"gDK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
-	icon_state = "bright_clean2"
+	dir = 10;
+	icon_state = "bright_clean"
 	},
-/area/desert_dam/building/dorms/restroom)
-"gDs" = (
-/obj/structure/window/framed/colony/reinforced,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/desert_dam/building/administration/meetingrooom)
-"gDG" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/exterior/valley/south_valley_dam)
+/area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "gDW" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -52229,13 +52437,6 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_medical_south)
-"gFa" = (
-/obj/structure/table/reinforced,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "darkpurple2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "gFm" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -52253,20 +52454,6 @@
 	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
-"gFA" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 5
-	},
-/area/desert_dam/exterior/valley/valley_hydro)
-"gFB" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "darkyellow2"
-	},
-/area/desert_dam/interior/dam_interior/hanger)
 "gFE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -52336,6 +52523,34 @@
 	dir = 9
 	},
 /area/desert_dam/exterior/valley/tradeship)
+"gHq" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_5"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/bar_valley_dam)
+"gHw" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/substation/northeast)
+"gHx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/desert_dam/interior/east_engineering)
+"gHP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "gHU" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -52345,12 +52560,6 @@
 "gIF" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
-"gIL" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 8
-	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "gIR" = (
 /obj/docking_port/stationary/crashmode,
@@ -52379,6 +52588,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"gJq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "gJu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -52388,12 +52602,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/deathrow)
-"gJH" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement1"
-	},
-/area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "gJM" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -52403,18 +52611,21 @@
 "gJP" = (
 /turf/closed/wall,
 /area/desert_dam/exterior/valley/valley_medical_south)
+"gKl" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "whiteblue"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_lobby)
 "gKw" = (
 /obj/effect/ai_node,
 /turf/open/ground/river/desertdam/clean/shallow_edge{
 	icon_state = "shallow_water_clean"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
-"gKz" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 10
-	},
-/area/desert_dam/interior/dam_interior/western_dam_cave)
 "gKT" = (
 /obj/structure/bed/chair,
 /obj/structure/cable,
@@ -52445,21 +52656,6 @@
 	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
-"gMI" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 4
-	},
-/area/desert_dam/interior/caves/central_caves)
-"gMR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/building/administration/hallway)
 "gNq" = (
 /obj/structure/table,
 /obj/item/tool/pen,
@@ -52483,6 +52679,13 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"gNG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "cell_stripe"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
 "gNO" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -52499,12 +52702,6 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/medical/surgery_observation)
-"gOn" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement4"
-	},
-/area/desert_dam/exterior/valley/valley_wilderness)
 "gOB" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
@@ -52521,13 +52718,31 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
-"gPJ" = (
+"gOQ" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal2"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_labs)
+"gPb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkbrown2"
+	},
+/area/desert_dam/interior/dam_interior/disposals)
+"gPv" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
-	dir = 4;
-	icon_state = "darkyellow2"
+	dir = 10;
+	icon_state = "floor_plate"
 	},
-/area/desert_dam/interior/dam_interior/hanger)
+/area/desert_dam/exterior/valley/valley_northwest)
 "gQm" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -52536,13 +52751,6 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
-"gRj" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "E"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_civilian)
 "gRl" = (
 /obj/structure/window/framed/colony,
 /obj/structure/cable,
@@ -52557,22 +52765,37 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/north_valley_dam)
-"gSr" = (
-/obj/effect/decal/cleanable/dirt,
+"gSC" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_wilderness)
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_west_wing)
+"gSF" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached11"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"gSG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 6;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/treatment_room)
 "gSJ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_northwest)
-"gSR" = (
+"gST" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
-	dir = 1;
-	icon_state = "cell_stripe"
+	dir = 10;
+	icon_state = "whitegreenfull"
 	},
-/area/desert_dam/building/warehouse/warehouse)
+/area/desert_dam/building/water_treatment_one/floodgate_control)
 "gSZ" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -52582,10 +52805,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"gTa" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/desert_dam/exterior/valley/valley_cargo)
 "gTc" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner2{
 	dir = 1
@@ -52615,18 +52834,10 @@
 	icon_state = "floor_plate"
 	},
 /area/desert_dam/building/security/evidence)
-"gTX" = (
+"gUi" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 5
-	},
+/turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/dam_interior/western_dam_cave)
-"gUt" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached13"
-	},
-/area/desert_dam/exterior/valley/valley_medical)
 "gUv" = (
 /obj/machinery/floodlight/landing,
 /obj/machinery/landinglight/ds2/delayone{
@@ -52648,13 +52859,6 @@
 	},
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/interior/dam_interior/west_tunnel)
-"gUJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
 /area/desert_dam/interior/dam_interior/west_tunnel)
 "gVx" = (
 /obj/effect/ai_node,
@@ -52691,10 +52895,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
-"gWL" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/valley_civilian)
 "gWR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -52769,6 +52969,16 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+"gYM" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "blue"
+	},
+/area/desert_dam/building/administration/hallway)
 "gYP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -52781,14 +52991,6 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/east_caves)
-"gZs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement4"
-	},
-/area/desert_dam/interior/dam_interior/workshop)
 "gZL" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -52825,21 +53027,9 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_loading)
-"haZ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 9
-	},
-/area/desert_dam/exterior/valley/valley_wilderness)
 "hbr" = (
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/riverside_central_south)
-"hbw" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached4"
-	},
-/area/desert_dam/exterior/valley/valley_civilian)
 "hbx" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -52852,33 +53042,48 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_northwing)
+"hbC" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "hbR" = (
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/desert_dam/building/bar/backroom)
-"hcs" = (
+"hbV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
+"hcL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
+	icon_state = "whitegreen"
 	},
-/area/desert_dam/building/warehouse/loading)
+/area/desert_dam/building/medical/virology_wing)
 "hdd" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt{
 	dir = 8
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
-"hdr" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+"hdw" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement1"
+/turf/open/floor{
+	icon_state = "darkyellow2"
 	},
-/area/desert_dam/interior/dam_interior/central_tunnel)
+/area/desert_dam/building/substation/northeast)
 "hdR" = (
 /obj/structure/cable,
 /turf/open/floor{
@@ -52903,24 +53108,13 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/interior/caves/central_caves)
-"hfk" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 9
+"hfg" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E"
 	},
-/area/desert_dam/exterior/valley/valley_northwest)
-"hfr" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/cave/rock{
-	dir = 4
-	},
-/area/desert_dam/interior/caves/east_caves)
-"hfH" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_workshop)
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "hga" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -52948,10 +53142,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/lab_northeast/east_lab_excavation)
-"hgR" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/substation/west)
+"hgQ" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "hgV" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -52972,13 +53169,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
-"hhe" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal10"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_wilderness)
 "hhj" = (
 /obj/structure/stairs/seamless/platform/alt{
 	dir = 8
@@ -52987,6 +53177,15 @@
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"hhF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/warehouse/warehouse)
+"hhL" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/area/desert_dam/exterior/valley/north_valley_dam)
 "hhT" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -53000,10 +53199,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics)
-"hin" = (
+"hik" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
-/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached15"
+	},
+/area/desert_dam/exterior/valley/valley_cargo)
 "his" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	id = "northpath1"
@@ -53014,18 +53215,12 @@
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"hiF" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "E"
-	},
-/obj/machinery/door/poddoor/mainship/open{
-	dir = 2;
-	id = "dam_stormlock_north2";
-	name = "\improper Storm Lock"
-	},
+"hiw" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/interior/dam_interior/south_tunnel)
+/turf/open/floor/prison{
+	icon_state = "darkpurple2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_RND)
 "hiH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -53052,36 +53247,12 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
-"hjR" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/building/water_treatment_two/control_room)
 "hjS" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/valley_medical_south)
-"hjX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/building/administration/hallway)
 "hjZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -53107,13 +53278,6 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
-"hkq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/desert_dam/interior/dam_interior/workshop)
 "hkv" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -53125,10 +53289,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/courtroom)
-"hlh" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/desert_dam/interior/dam_interior/west_tunnel)
 "hlj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor{
@@ -53178,12 +53338,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/cafeteria/loading)
-"hnz" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
-	},
-/area/desert_dam/exterior/valley/valley_northwest)
 "hnJ" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -53209,6 +53363,10 @@
 	icon_state = "whiteyellowfull"
 	},
 /area/desert_dam/interior/caves/temple)
+"hpd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_hydro)
 "hpe" = (
 /obj/effect/landmark/weed_node,
 /obj/structure/cable,
@@ -53233,13 +53391,6 @@
 	icon_state = "whiteyellowfull"
 	},
 /area/desert_dam/interior/caves/temple)
-"hpN" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal12"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_mining)
 "hpP" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -53263,6 +53414,17 @@
 	icon_state = "swallc3"
 	},
 /area/shuttle/tri_trans1/alpha)
+"hqD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached2"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
+"hqR" = (
+/obj/structure/flora/desert/grass,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "hqT" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached1"
@@ -53291,12 +53453,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"hrO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_wilderness)
 "hsb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53309,6 +53465,12 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
+"hsn" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "hso" = (
 /obj/structure/cable,
 /turf/open/floor/prison,
@@ -53355,14 +53517,6 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
-"hte" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "kitchen"
-	},
-/area/desert_dam/building/cafeteria/cafeteria)
 "htG" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -53372,17 +53526,13 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"htY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+"htO" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal10"
 	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/hangar_storage)
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/south_valley_dam)
 "huq" = (
 /obj/machinery/landinglight/ds1{
 	dir = 4
@@ -53396,13 +53546,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/warehouse/warehouse)
-"huF" = (
+"huN" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/building/medical/lobby)
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/tech_storage)
 "huZ" = (
 /obj/structure/cable,
 /turf/closed/wall,
@@ -53412,6 +53560,14 @@
 	icon_state = "cement_sunbleached17"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"hvo" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement3"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "hvv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor/prison{
@@ -53427,12 +53583,12 @@
 /obj/structure/bed/chair/office/light,
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"hvY" = (
+"hvW" = (
+/obj/structure/cable,
+/obj/structure/cable,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached10"
-	},
-/area/desert_dam/exterior/valley/valley_wilderness)
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "hwc" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached4"
@@ -53453,6 +53609,13 @@
 	},
 /turf/open/floor/wood,
 /area/desert_dam/building/medical/break_room)
+"hwo" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/building/hydroponics/hydroponics_loading)
 "hwy" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal3"
@@ -53466,13 +53629,6 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
-"hwN" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "kitchen"
-	},
-/area/desert_dam/building/cafeteria/cafeteria)
 "hwS" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 1
@@ -53531,13 +53687,6 @@
 	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"hyl" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "hyv" = (
 /obj/structure/cable,
 /turf/closed/wall{
@@ -53557,18 +53706,40 @@
 "hyG" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge,
 /area/desert_dam/exterior/river/riverside_central_south)
-"hzz" = (
+"hyJ" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 9
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
 	},
+/area/desert_dam/exterior/valley/valley_hydro)
+"hyN" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal6"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
+"hyZ" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/warehouse/breakroom)
 "hzL" = (
 /obj/effect/ai_node,
 /turf/open/ground/coast{
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_south)
+"hzS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "hAv" = (
 /obj/item/stack/sheet/mineral/sandstone{
 	amount = 50
@@ -53599,13 +53770,6 @@
 	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"hAQ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating{
-	dir = 6;
-	icon_state = "warnplate"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "hBr" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached3"
@@ -53615,12 +53779,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/desert_dam/building/substation/northeast)
-"hBL" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement1"
-	},
-/area/desert_dam/interior/dam_interior/workshop)
 "hBR" = (
 /turf/open/floor{
 	dir = 5;
@@ -53660,13 +53818,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
-"hCT" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating{
-	dir = 8;
-	icon_state = "warnplate"
+"hCC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/desert_dam/interior/lab_northeast/east_lab_containment)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/cafeteria/loading)
 "hDc" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner,
 /area/desert_dam/exterior/river/riverside_south)
@@ -53698,6 +53860,10 @@
 /obj/docking_port/stationary/marine_dropship/lz2,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/landing/landing_pad_two)
+"hEv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/north_valley_dam)
 "hES" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -53753,10 +53919,6 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
-"hFZ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/landing/landing_pad_three_external)
 "hGl" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
@@ -53766,12 +53928,6 @@
 	icon_state = "floor_plate"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
-"hGv" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "wood"
-	},
-/area/desert_dam/building/dorms/hallway_westwing)
 "hGD" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -53799,6 +53955,13 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/desert_dam/building/medical/virology_wing)
+"hGY" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "hHc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -53819,17 +53982,18 @@
 	dir = 5
 	},
 /area/desert_dam/interior/caves/central_caves)
+"hHy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/cafeteria/loading)
 "hHK" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"hIS" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
-	},
-/area/desert_dam/exterior/valley/valley_northwest)
 "hIT" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
@@ -53880,13 +54044,26 @@
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/security/southern_hallway)
-"hKf" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
+"hKM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_civilian)
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/administration/hallway)
+"hKP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/desert_dam/exterior/valley/valley_labs)
+"hKS" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "hKV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -53916,12 +54093,6 @@
 	icon_state = "warning"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
-"hLY" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "cement_sunbleached2"
-	},
-/area/desert_dam/exterior/valley/valley_labs)
 "hMc" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached13"
@@ -53942,14 +54113,29 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
-"hML" = (
-/obj/structure/platform,
-/obj/structure/platform{
-	dir = 4
+"hMF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/dorms/hallway_westwing)
+"hMU" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal2"
 	},
-/obj/structure/flora/rock/pile/alt3,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/desert_dam/exterior/valley/valley_crashsite)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
+"hMZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
+"hNk" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "hNn" = (
 /obj/structure/rack,
 /obj/item/storage/surgical_tray,
@@ -53962,12 +54148,6 @@
 	icon_state = "whiteblue"
 	},
 /area/desert_dam/building/medical/medsecure)
-"hNs" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
-	},
-/area/desert_dam/exterior/valley/north_valley_dam)
 "hNJ" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
 /obj/machinery/door/poddoor/shutters/mainship{
@@ -53976,11 +54156,13 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"hNK" = (
-/obj/effect/decal/cleanable/dirt,
+"hNP" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/dorms/hallway_northwing)
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkredcorners2"
+	},
+/area/desert_dam/building/security/deathrow)
 "hOc" = (
 /obj/structure/stairs/seamless/platform/alt{
 	dir = 8
@@ -54047,6 +54229,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"hPF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/water_treatment_one/garage)
 "hQa" = (
 /obj/machinery/landinglight/ds1/delayone,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -54060,6 +54246,20 @@
 "hQr" = (
 /turf/closed/wall/r_wall/chigusa,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"hQt" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/warehouse/loading)
+"hQB" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/interior/dam_interior/south_tunnel)
 "hQD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -54111,6 +54311,21 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
+"hRF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+"hRM" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"hRQ" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_9"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_civilian)
 "hSr" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal2"
@@ -54120,21 +54335,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"hSv" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_plate"
-	},
-/area/desert_dam/interior/dam_interior/hanger)
-"hSy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/shower{
-	pixel_y = 18
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/freezer,
-/area/desert_dam/interior/east_engineering)
 "hSB" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/structure/cable,
@@ -54190,6 +54390,12 @@
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"hUr" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "hUz" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -54250,6 +54456,15 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/wood,
 /area/desert_dam/building/administration/overseer_office)
+"hWK" = (
+/obj/structure/flora/desert/grass,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_medical)
+"hXk" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/substation/northeast)
 "hXz" = (
 /obj/machinery/landinglight/ds2/delayone{
 	dir = 1
@@ -54283,12 +54498,13 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/administration/hallway)
-"hXL" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 5
+"hXI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "cell_stripe"
 	},
-/area/desert_dam/interior/caves/central_caves)
+/area/desert_dam/building/warehouse/loading)
 "hXS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -54303,37 +54519,24 @@
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"hXY" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/valley_hydro)
 "hYc" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached9"
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
-"hYe" = (
+"hYv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/south_valley_dam)
+"hYL" = (
+/obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
+	dir = 8;
 	icon_state = "sterile_white"
 	},
-/area/desert_dam/interior/dam_interior/north_tunnel)
-"hYK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/auxilary_tool_storage)
+/area/desert_dam/building/bar/bar_restroom)
 "hYO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -54350,12 +54553,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
-"hYS" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "greencorner"
-	},
-/area/desert_dam/building/telecommunication)
 "hZm" = (
 /obj/machinery/landinglight/ds2/delaythree{
 	dir = 1
@@ -54364,6 +54561,15 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"hZr" = (
+/obj/structure/table,
+/obj/item/storage/box/lightstick,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "hZv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -54388,12 +54594,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
-"hZZ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement4"
-	},
-/area/desert_dam/interior/dam_interior/south_tunnel)
 "iaW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/stationary/crashmode,
@@ -54406,13 +54606,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_storage)
-"iby" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/valley/valley_medical)
 "ibE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -54450,13 +54643,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
-"icl" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "darkredcorners2"
-	},
-/area/desert_dam/building/security/southern_hallway)
 "ico" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -54468,11 +54654,6 @@
 	icon_state = "kitchen"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
-"icq" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/desert_dam/interior/dam_interior/south_tunnel)
 "icK" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_6"
@@ -54487,22 +54668,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"icZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/interior/dam_interior/north_tunnel)
 "idg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
-"idm" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/interior/dam_interior/engine_room)
-"idp" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/building/cafeteria/loading)
 "idI" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -54510,16 +54686,17 @@
 	icon_state = "blue"
 	},
 /area/desert_dam/building/administration/hallway)
-"idM" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "idP" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
+"idW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull"
+	},
+/area/desert_dam/building/medical/virology_wing)
 "iej" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -54543,25 +54720,19 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/disposals)
-"ift" = (
+"igh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "darkbrown2"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement3"
 	},
-/area/desert_dam/building/warehouse/loading)
+/area/desert_dam/interior/dam_interior/north_tunnel)
 "igw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
-"igC" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal5"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_medical)
 "igP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -54569,27 +54740,17 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/atmos_storage)
-"igV" = (
-/obj/structure/bed/chair{
-	dir = 8
+"igS" = (
+/obj/effect/decal/sandytile,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
 	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "kitchen"
-	},
-/area/desert_dam/building/cafeteria/cafeteria)
+/area/desert_dam/interior/caves/temple)
 "igY" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
-"iha" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal2"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_wilderness)
 "ihe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -54607,10 +54768,16 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_one/hallway)
-"ihJ" = (
+"ihv" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/valley_northwest)
+/turf/open/floor/wood,
+/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
+"ihT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "yellow"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
 "ihU" = (
 /turf/open/floor/plating/catwalk,
 /area/desert_dam/exterior/river/riverside_central_north)
@@ -54641,6 +54808,13 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/tech_storage)
+"ijg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
 "ijn" = (
 /obj/machinery/landinglight/ds2{
 	dir = 1
@@ -54649,6 +54823,12 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"ijV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "iki" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54667,6 +54847,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/desert_dam/interior/caves/central_caves)
+"iky" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "ikA" = (
 /obj/structure/desertdam/decals/road/stop{
 	icon_state = "stop_decal5"
@@ -54695,25 +54879,12 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/bar_valley_dam)
-"ilf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	dir = 8;
-	icon_state = "carpet13-5"
-	},
-/area/desert_dam/building/church)
 "ilz" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal1"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
-"ims" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
-/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "imz" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -54735,13 +54906,20 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics)
-"imS" = (
+"imU" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
+/turf/open/floor/plating/ground/dirt{
+	dir = 8
 	},
-/area/desert_dam/building/medical/west_wing_hallway)
+/area/desert_dam/exterior/river/riverside_east)
+"imY" = (
+/obj/structure/desertdam/decals/road/stop{
+	icon_state = "stop_decal5"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "ini" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -54758,16 +54936,18 @@
 	dir = 1
 	},
 /area/desert_dam/interior/east_engineering)
-"inm" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/security/warden)
 "inQ" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal8"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"ior" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement1"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
 "ioB" = (
 /turf/open/floor/plating/ground/dirt{
 	dir = 8
@@ -54790,9 +54970,12 @@
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
 "ipF" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/desert_dam/exterior/valley/valley_medical)
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "ipY" = (
 /obj/machinery/door/poddoor/shutters/mainship/open{
 	dir = 2;
@@ -54805,6 +54988,13 @@
 /obj/item/trash/liquidfood,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
+"iqu" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_mining)
 "iqz" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -54816,6 +55006,40 @@
 	},
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_northwest)
+"irv" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt{
+	dir = 1
+	},
+/area/desert_dam/exterior/river/riverside_central_north)
+"irw" = (
+/obj/structure/platform,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"irP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/exterior/valley/valley_cargo)
+"irX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/valley_medical)
+"isd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "ist" = (
 /obj/structure/flora/desert/cactus/multiple{
 	icon_state = "cacti_9"
@@ -54826,10 +55050,21 @@
 /obj/machinery/camera/autoname/lz_camera,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/landing/landing_pad_one)
+"isQ" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "isZ" = (
 /obj/structure/shuttle/engine/propulsion/burst/left,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/tradeship)
+"itq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "itQ" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/catwalk,
@@ -54848,25 +55083,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
-"ivM" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/primary_tool_storage)
 "iwh" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 4
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
-"iwn" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/interior/dam_interior/south_tunnel)
 "iwv" = (
 /obj/machinery/landinglight/ds2/delaythree{
 	dir = 8
@@ -54892,47 +55113,20 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_south)
-"ixF" = (
-/obj/structure/cable,
+"iwY" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "red"
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet13-5"
 	},
-/area/desert_dam/building/security/northern_hallway)
+/area/desert_dam/building/church)
 "ixM" = (
 /obj/structure/flora/rock/alt2{
 	name = "rock"
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_cargo)
-"ixT" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
-"ixU" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 1
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
-"ixW" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
-"iyd" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/cafeteria/loading)
 "iyj" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/mainship/orange{
@@ -54971,13 +55165,14 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/virology_wing)
-"iAH" = (
+"iAS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
-	dir = 4;
-	icon_state = "greencorner"
+	dir = 8;
+	icon_state = "sterile_white"
 	},
-/area/desert_dam/building/telecommunication)
+/area/desert_dam/building/medical/treatment_room)
 "iBL" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 4
@@ -54995,26 +55190,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
-"iCl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "white"
-	},
-/area/desert_dam/building/medical/chemistry)
-"iDm" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal3"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_mining)
 "iDr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/stationary/crashmode,
@@ -55039,46 +55214,11 @@
 "iDQ" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"iDR" = (
-/obj/structure/platform,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 8
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
-"iEi" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/security/southern_hallway)
-"iEs" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/building/hydroponics/hydroponics)
 "iEI" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
 	},
 /area/desert_dam/interior/dam_interior/western_dam_cave)
-"iEO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached4"
-	},
-/area/desert_dam/exterior/valley/valley_labs)
 "iFE" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
@@ -55096,12 +55236,6 @@
 	icon_state = "cement4"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
-"iFX" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 8
-	},
-/area/desert_dam/exterior/valley/valley_northwest)
 "iGb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -55121,6 +55255,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/medical/virology_isolation)
+"iGf" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/interior/caves/central_caves)
 "iGx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -55133,10 +55273,12 @@
 	dir = 9
 	},
 /area/desert_dam/exterior/valley/bar_valley_dam)
-"iGD" = (
+"iGE" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/desert_dam/interior/dam_interior/south_tunnel)
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "iGK" = (
 /obj/structure/flora/desert/grass,
 /obj/structure/cable,
@@ -55163,6 +55305,10 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_northwest)
+"iHi" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/interior/lab_northeast/east_lab_maintenence)
 "iHq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -55172,43 +55318,14 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/dorms/pool)
-"iHs" = (
-/obj/structure/table,
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "dark2"
-	},
-/area/desert_dam/building/administration/archives)
 "iHt" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall/unmeltable,
 /area/desert_dam/interior/east_engineering)
-"iHL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal2"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_mining)
-"iHP" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	dir = 4;
-	icon_state = "darkyellow2"
-	},
-/area/desert_dam/building/substation/northeast)
 "iIq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor/prison,
 /area/desert_dam/building/medical/virology_isolation)
-"iIN" = (
-/obj/structure/flora/desert/grass{
-	icon_state = "lightgrass_9"
-	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "iJq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -55244,11 +55361,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/staffroom)
-"iLp" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "iLB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -55258,13 +55370,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/security/lobby)
-"iLG" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "darkred2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_security_armory)
 "iLP" = (
 /obj/structure/flora/rock/pile/alt2,
 /obj/effect/ai_node,
@@ -55280,14 +55385,6 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
-"iMn" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "iMq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -55295,12 +55392,6 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_northwing)
-"iMt" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 1
-	},
-/area/desert_dam/exterior/valley/bar_valley_dam)
 "iML" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -55315,34 +55406,18 @@
 	icon_state = "cement3"
 	},
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
-"iMQ" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal4"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_cargo)
 "iNd" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
-"iNE" = (
+"iNN" = (
+/obj/structure/cable,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
 	},
-/area/desert_dam/building/medical/morgue)
-"iNH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/hangar_storage)
+/area/desert_dam/exterior/valley/valley_mining)
 "iNT" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating{
@@ -55362,10 +55437,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/bar_valley_dam)
-"iOl" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
-/area/desert_dam/exterior/landing/landing_pad_three_external)
 "iOv" = (
 /obj/structure/platform{
 	dir = 4
@@ -55375,6 +55446,13 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
+"iOQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached13"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "iOV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -55382,42 +55460,34 @@
 	icon_state = "dark"
 	},
 /area/desert_dam/building/church)
-"iPd" = (
+"iPf" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached13"
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
 	},
-/area/desert_dam/exterior/valley/valley_civilian)
-"iPs" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	dir = 4;
-	icon_state = "whiteyellowcorner"
-	},
-/area/desert_dam/interior/dam_interior/break_room)
+/area/desert_dam/exterior/valley/valley_telecoms)
 "iPK" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"iPV" = (
-/obj/effect/ai_node,
+"iPY" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/valley_crashsite)
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
+"iQc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_cargo)
 "iQk" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
-"iQI" = (
-/obj/structure/flora/desert/cactus/multiple{
-	icon_state = "cacti_12"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_labs)
 "iRn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -55431,6 +55501,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/armory)
+"iRN" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/security/execution_chamber)
 "iRO" = (
 /turf/closed/mineral,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
@@ -55449,17 +55523,6 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
-"iRY" = (
-/obj/machinery/light,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "whitepurple"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
-"iSk" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "iSu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -55479,15 +55542,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/security/northern_hallway)
-"iSV" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "whitegreenfull"
-	},
-/area/desert_dam/interior/east_engineering)
 "iTK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/stationary/crashmode,
@@ -55495,17 +55549,19 @@
 	icon_state = "cement3"
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
-"iTR" = (
+"iUf" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached13"
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
 	},
-/area/desert_dam/exterior/valley/valley_cargo)
-"iTX" = (
-/obj/structure/cable,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"iUm" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/hydroponics/hydroponics_loading)
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
 "iUL" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -55519,14 +55575,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"iVc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/building/water_treatment_two/hallway)
 "iVA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55545,6 +55593,12 @@
 	icon_state = "catwalk-255"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
+"iVE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/interior/caves/central_caves)
 "iVH" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
@@ -55565,6 +55619,10 @@
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+"iVX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_labs)
 "iVZ" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
@@ -55582,18 +55640,38 @@
 	icon_state = "cement_sunbleached18"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"iWI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/interior/dam_interior/workshop)
 "iWM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor{
 	icon_state = "wood"
 	},
 /area/desert_dam/building/dorms/hallway_northwing)
+"iWX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement1"
+	},
+/area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "iWY" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 8
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"iXg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "iXh" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached2"
@@ -55624,12 +55702,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_mining)
-"iYa" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/river/riverside_south)
 "iYn" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -55645,33 +55717,43 @@
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/interior/dam_interior/disposals)
-"iYC" = (
-/obj/structure/flora/desert/grass{
-	icon_state = "lightgrass_9"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_civilian)
 "iYI" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached18"
 	},
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"iYZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 9
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "iZh" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/cafeteria/loading)
+"iZr" = (
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 2;
+	id = "dam_shutter_hangar";
+	name = "\improper Hangar Lock"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
 "iZC" = (
 /turf/open/floor/asteroidfloor,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"jac" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+"iZJ" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/interior/dam_interior/auxilary_tool_storage)
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "jam" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave{
@@ -55695,6 +55777,16 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/security/staffroom)
+"jbc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/warehouse/breakroom)
 "jbx" = (
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "tile"
@@ -55705,6 +55797,15 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/hangar_storage)
+"jcb" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "asteroidplating"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "jco" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
@@ -55724,15 +55825,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
-"jcz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/cafeteria/cafeteria)
 "jcL" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall,
@@ -55759,15 +55851,17 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_two/hallway)
-"jds" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 9
-	},
-/area/desert_dam/interior/caves/east_caves)
 "jdv" = (
 /turf/open/floor/plating/catwalk,
 /area/desert_dam/exterior/river/riverside_east)
+"jdz" = (
+/obj/structure/table,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
+/area/desert_dam/building/security/prison)
 "jdB" = (
 /obj/structure/flora/desert/cactus/multiple{
 	icon_state = "cacti_9"
@@ -55794,33 +55888,12 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_south)
-"jet" = (
+"jfr" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/building/water_treatment_two/equipment)
-"jeW" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 1
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
-"jeX" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/desert_dam/interior/dam_interior/northeastern_tunnel)
-"jfs" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 8
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "jfz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
@@ -55841,13 +55914,6 @@
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
-"jfQ" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal4"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/north_valley_dam)
 "jgr" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal5"
@@ -55888,16 +55954,15 @@
 	icon_state = "whiteblue"
 	},
 /area/desert_dam/building/medical/medsecure)
-"jhw" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "jhJ" = (
 /obj/structure/table,
 /obj/effect/landmark/dropship_console_spawn_lz2,
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"jhU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "jii" = (
 /obj/structure/table,
 /obj/item/tool/extinguisher,
@@ -55926,34 +55991,43 @@
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
-"jjx" = (
+"jjn" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached4"
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 5
 	},
-/area/desert_dam/exterior/valley/valley_telecoms)
+/area/desert_dam/interior/dam_interior/western_dam_cave)
 "jjJ" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/desert_dam/building/medical/east_wing_hallway)
-"jjS" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_wilderness)
 "jjV" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/lab_northeast/east_lab_excavation)
+"jkc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/bar/bar)
+"jke" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "kitchen"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
+"jkg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "jkk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55967,12 +56041,6 @@
 	icon_state = "cement4"
 	},
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
-"jkG" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
-	},
-/area/desert_dam/exterior/valley/valley_mining)
 "jlg" = (
 /obj/structure/cable,
 /obj/structure/prop/mainship/brokengen,
@@ -55986,6 +56054,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_telecoms)
+"jlD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "floor_marked"
+	},
+/area/desert_dam/building/hydroponics/hydroponics_storage)
 "jlP" = (
 /obj/structure/flora/desert/grass/heavy{
 	icon_state = "heavygrass_5"
@@ -56023,6 +56099,19 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
+"jmY" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_11"
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"jnp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "whitepurple"
+	},
+/area/desert_dam/building/medical/chemistry)
 "jnu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -56033,19 +56122,6 @@
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_RND)
-"jny" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "white"
-	},
-/area/desert_dam/building/lab_northwest/west_lab_xenoflora)
-"jnD" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "blue"
-	},
-/area/desert_dam/building/administration/control_room)
 "jnF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -56080,6 +56156,18 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
+"joK" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"joU" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal2"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "jpa" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached14"
@@ -56091,6 +56179,13 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"jpp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "darkpurple2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "jpH" = (
 /obj/structure/bed/alien,
 /obj/item/bedsheet/brown,
@@ -56104,33 +56199,17 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
+"jpX" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal8"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/south_valley_dam)
 "jqa" = (
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/east_engineering)
-"jqe" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 1
-	},
-/area/desert_dam/exterior/valley/valley_telecoms)
-"jqm" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 1
-	},
-/area/desert_dam/exterior/valley/valley_cargo)
-"jqs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/warehouse/warehouse)
-"jqv" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_medical)
 "jqH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -56158,22 +56237,13 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/warehouse/warehouse)
-"jri" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N"
-	},
+"jrI" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "asteroidplating"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
 	},
-/area/desert_dam/exterior/valley/valley_crashsite)
-"jrk" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/building/hydroponics/hydroponics_loading)
+/area/desert_dam/exterior/valley/valley_mining)
 "jrV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
@@ -56191,17 +56261,23 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/warehouse/loading)
+"jsr" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "jsv" = (
 /obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
-"jsC" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached4"
+"jsJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
 	},
-/area/desert_dam/exterior/valley/valley_crashsite)
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "jsN" = (
 /obj/structure/platform{
 	dir = 1
@@ -56232,11 +56308,10 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_biology)
-"jtt" = (
+"jtC" = (
+/obj/structure/platform,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 5
-	},
+/turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "jun" = (
 /obj/structure/cable,
@@ -56267,6 +56342,12 @@
 	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
+"jvl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 6
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "jvs" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
@@ -56278,13 +56359,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_wilderness)
-"jvM" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "darkyellow2"
-	},
-/area/desert_dam/interior/dam_interior/hangar_storage)
 "jvZ" = (
 /obj/structure/platform{
 	dir = 1
@@ -56300,21 +56374,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/staffroom)
-"jwL" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "whitegreenfull"
-	},
-/area/desert_dam/interior/east_engineering)
-"jwO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/emergency_room)
 "jwY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -56323,12 +56382,10 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
-"jxr" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "darkred2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_security_armory)
+"jxd" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/interior/caves/central_caves)
 "jxv" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
@@ -56337,6 +56394,13 @@
 	icon_state = "blue"
 	},
 /area/desert_dam/building/administration/control_room)
+"jxH" = (
+/obj/structure/platform,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt{
+	dir = 8
+	},
+/area/desert_dam/exterior/river/riverside_east)
 "jxV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -56345,49 +56409,28 @@
 	icon_state = "white"
 	},
 /area/desert_dam/interior/dam_interior/break_room)
-"jyf" = (
-/obj/structure/bed,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "wood"
-	},
-/area/desert_dam/building/dorms/hallway_northwing)
-"jyh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/building/hydroponics/hydroponics)
 "jyo" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/indestructible,
 /area/desert_dam/exterior/rock)
-"jyu" = (
+"jyw" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "whitepurplecorner"
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached9"
 	},
-/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
-"jyA" = (
-/obj/machinery/light,
+/area/desert_dam/exterior/valley/valley_telecoms)
+"jyZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "blue"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
 	},
-/area/desert_dam/building/administration/hallway)
+/area/desert_dam/exterior/valley/valley_labs)
 "jze" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/prison{
@@ -56401,18 +56444,6 @@
 	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
-"jzw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "yellowcorner"
-	},
-/area/desert_dam/building/hydroponics/hydroponics)
-"jzJ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/valley_mining)
 "jzR" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -56422,6 +56453,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/courtroom)
+"jzW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 6
+	},
+/area/desert_dam/interior/dam_interior/western_dam_cave)
 "jAl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -56444,22 +56481,25 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_one/lobby)
+"jAI" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "jBg" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 6
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
-"jBl" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "whitegreencorner"
-	},
-/area/desert_dam/building/medical/east_wing_hallway)
 "jBp" = (
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 9
 	},
 /area/desert_dam/interior/caves/temple)
+"jCz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "jCQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -56474,15 +56514,17 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"jDx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 6
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "jDy" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/desert_dam/building/water_treatment_one/floodgate_control)
-"jDB" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
-/area/desert_dam/building/medical/break_room)
 "jDV" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -56490,12 +56532,21 @@
 	icon_state = "cell_stripe"
 	},
 /area/desert_dam/building/warehouse/loading)
-"jEA" = (
+"jEc" = (
+/obj/structure/flora/tree/joshua,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 5
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_cargo)
+"jEv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/desert_dam/interior/caves/temple)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "jED" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -56524,14 +56575,22 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_hydro)
-"jFg" = (
+"jFs" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_telecoms)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_hydro)
 "jFG" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall,
 /area/desert_dam/building/substation/central)
+"jFI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
 "jFK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -56563,12 +56622,19 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/security/holding)
-"jGD" = (
+"jGP" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor{
-	icon_state = "freezerfloor"
+	icon_state = "wood"
 	},
-/area/desert_dam/building/security/prison)
+/area/desert_dam/building/security/southern_hallway)
+"jGU" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "jHu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -56581,6 +56647,18 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_hydro)
+"jHA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "grimy"
+	},
+/area/desert_dam/building/bar/bar)
+"jHC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "jHO" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison{
@@ -56606,13 +56684,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/office)
-"jIm" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal9"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_medical_south)
 "jIo" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -56648,10 +56719,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/desert_dam/building/hydroponics/hydroponics_storage)
-"jIJ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt,
-/area/desert_dam/exterior/valley/valley_labs)
 "jJa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -56660,28 +56727,24 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_westwing)
+"jJc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "jJy" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
-"jJP" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/desert_dam/building/substation/northeast)
 "jKe" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_wilderness)
-"jKo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/water_treatment_one/garage)
 "jKr" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 8
@@ -56703,6 +56766,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/north_tunnel)
+"jKE" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "jLd" = (
 /obj/machinery/light{
 	dir = 8
@@ -56756,22 +56825,29 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"jMz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
 "jMC" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
 	},
 /area/desert_dam/exterior/valley/valley_labs)
+"jMD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "jML" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal12"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"jMQ" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/desert_dam/interior/caves/central_caves)
 "jMT" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -56807,25 +56883,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_northwest)
-"jNx" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 1
-	},
-/area/desert_dam/exterior/valley/valley_civilian)
-"jNz" = (
-/obj/structure/table/reinforced,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_biology)
-"jND" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 5
-	},
-/area/desert_dam/interior/caves/central_caves)
 "jNF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -56840,14 +56897,13 @@
 /obj/structure/flora/rock/pile/alt,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
-"jNT" = (
+"jOb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/security/southern_hallway)
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
 "jOe" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached12"
@@ -56859,12 +56915,13 @@
 	icon_state = "cement_sunbleached13"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
-"jOu" = (
+"jON" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 8
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
 	},
-/area/desert_dam/exterior/valley/valley_telecoms)
+/area/desert_dam/exterior/valley/valley_mining)
 "jOP" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -56890,20 +56947,13 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"jPm" = (
-/obj/effect/decal/cleanable/dirt,
+"jPi" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison/sterilewhite,
-/area/desert_dam/interior/east_engineering)
-"jPn" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "E"
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitepurplecorner"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_civilian)
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "jPV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
@@ -56933,42 +56983,37 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
-"jQG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
+"jRe" = (
+/obj/structure/flora/desert/cactus{
+	icon_state = "cactus_7"
 	},
-/area/desert_dam/building/water_treatment_one/control_room)
-"jQI" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison/sterilewhite,
-/area/desert_dam/interior/east_engineering)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "jRv" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor{
 	icon_state = "wood"
 	},
 /area/desert_dam/building/dorms/hallway_westwing)
-"jRx" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal4"
+"jRA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
 	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/south_valley_dam)
-"jRB" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_civilian)
+/area/desert_dam/interior/dam_interior/south_tunnel)
 "jSk" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+"jSl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "jSv" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -57018,14 +57063,12 @@
 	icon_state = "cement2"
 	},
 /area/desert_dam/interior/dam_interior/west_tunnel)
-"jUv" = (
-/obj/structure/cable,
+"jUg" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
 	},
-/area/desert_dam/interior/dam_interior/engine_west_wing)
+/area/desert_dam/exterior/valley/north_valley_dam)
 "jUV" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached11"
@@ -57070,6 +57113,24 @@
 	icon_state = "cell_stripe"
 	},
 /area/desert_dam/building/warehouse/loading)
+"jWF" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"jWY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "jXc" = (
 /turf/open/floor/plating/catwalk,
 /area/desert_dam/exterior/river/riverside_south)
@@ -57092,25 +57153,16 @@
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/valley_cargo)
+"jXP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/medical/lobby)
 "jYe" = (
 /turf/closed/wall/r_wall,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"jYg" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
-"jYh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "jYx" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_11"
@@ -57132,6 +57184,10 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"jYT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/exterior/valley/south_valley_dam)
 "jZr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -57151,20 +57207,39 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
-"kaB" = (
-/obj/effect/ai_node,
+"kaJ" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "cult"
-	},
-/area/desert_dam/building/church)
-"kbf" = (
-/obj/structure/flora/desert/grass/heavy{
-	icon_state = "heavygrass_4"
-	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
+"kaS" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_medical)
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+"kaT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_west_entrance)
+"kbl" = (
+/obj/structure/flora/desert/grass,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"kbp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitepurple"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
+"kbq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkbrown2"
+	},
+/area/desert_dam/building/warehouse/loading)
 "kbA" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal3"
@@ -57172,16 +57247,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
-"kbB" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "darkred2"
-	},
-/area/desert_dam/building/security/southern_hallway)
 "kbX" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached13"
@@ -57194,12 +57259,6 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/substation/southwest)
-"kch" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/desert_dam/interior/dam_interior/north_tunnel)
 "kcm" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -57277,12 +57336,6 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
-"kdW" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement3"
-	},
-/area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "kea" = (
 /obj/structure/cable,
 /turf/open/floor/prison,
@@ -57306,6 +57359,25 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/desert_dam/building/administration/office)
+"keP" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull"
+	},
+/area/desert_dam/interior/east_engineering)
+"keR" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_mining)
+"kfa" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave/rock{
+	dir = 4
+	},
+/area/desert_dam/interior/caves/east_caves)
 "kfe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -57333,20 +57405,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_telecoms)
-"kfz" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/building/hydroponics/hydroponics)
-"kfD" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/east_wing_hallway)
 "kfQ" = (
 /obj/structure/cable,
 /turf/open/floor{
@@ -57360,6 +57418,29 @@
 	dir = 10
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"kgg" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached2"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
+"kgS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_workshop)
+"khd" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "khq" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -57386,33 +57467,33 @@
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"kiP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/xeno_resin_door,
+"kiy" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/administration/meetingrooom)
+"kiB" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement12"
+	icon_state = "cement4"
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
+"kja" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal4"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_cargo)
 "kjf" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall/r_wall,
 /area/desert_dam/building/dorms/pool)
-"kjJ" = (
+"kjH" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/warehouse/loading)
-"kjU" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal8"
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
 	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_civilian)
+/area/desert_dam/exterior/valley/valley_cargo)
 "kkm" = (
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 10
@@ -57425,12 +57506,6 @@
 "kln" = (
 /turf/open/ground/river/desertdam/clean/shallow,
 /area/desert_dam/exterior/river/riverside_central_south)
-"klF" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 1
-	},
-/area/desert_dam/interior/caves/central_caves)
 "klS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -57440,13 +57515,14 @@
 	icon_state = "kitchen"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
-"kmc" = (
+"kma" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
-	dir = 4;
-	icon_state = "cell_stripe"
+	dir = 10;
+	icon_state = "bright_clean"
 	},
-/area/desert_dam/building/warehouse/loading)
+/area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "kmo" = (
 /obj/structure/platform{
 	dir = 1
@@ -57455,6 +57531,20 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_east)
+"kmG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "yellow"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
+"kno" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/building/substation/northeast)
 "knw" = (
 /obj/machinery/door/window{
 	dir = 1
@@ -57473,10 +57563,10 @@
 	icon_state = "greencorner"
 	},
 /area/desert_dam/building/telecommunication)
-"koi" = (
+"kos" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/desert_dam/exterior/valley/valley_wilderness)
+/turf/open/floor/wood,
+/area/desert_dam/building/bar/bar)
 "koZ" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -57504,30 +57594,6 @@
 /obj/item/stack/sheet/wood,
 /turf/open/floor/wood,
 /area/desert_dam/interior/caves/central_caves)
-"kpG" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/treatment_room)
-"kpQ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/west_wing_hallway)
-"kqk" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/valley/valley_hydro)
 "kqw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57574,36 +57640,24 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
-"krh" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	dir = 8;
-	icon_state = "darkyellow2"
-	},
-/area/desert_dam/building/security/prison)
-"krp" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "cult"
-	},
-/area/desert_dam/building/church)
 "kry" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"krG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/medical/surgery_room_two)
 "krW" = (
 /obj/structure/table,
 /obj/machinery/faxmachine,
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"ksz" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 1
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
 "ksF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -57641,30 +57695,13 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
-"ktV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/building/water_treatment_two/control_room)
-"kul" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached13"
-	},
-/area/desert_dam/exterior/valley/valley_labs)
-"kuD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+"kum" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal1"
 	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/dorms/hallway_northwing)
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "kuR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -57749,13 +57786,6 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_medical)
-"kwX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached4"
-	},
-/area/desert_dam/exterior/valley/valley_hydro)
 "kxg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57809,18 +57839,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_civilian)
-"kyu" = (
-/obj/machinery/door/poddoor/mainship/open{
-	dir = 2;
-	id = "dam_shutter_hangar";
-	name = "\improper Hangar Lock"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/hanger)
 "kzc" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
@@ -57828,10 +57846,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"kzl" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/darkish,
-/area/desert_dam/interior/caves/temple)
 "kzp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/ai_node,
@@ -57872,6 +57886,10 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_east_entrance)
+"kzJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/north_valley_dam)
 "kzM" = (
 /obj/structure/sink{
 	dir = 8;
@@ -57922,6 +57940,16 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
+"kAC" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/west_wing_hallway)
 "kAJ" = (
 /obj/structure/table/reinforced/prison{
 	color = "#6b675e"
@@ -57933,12 +57961,9 @@
 	},
 /area/desert_dam/interior/caves/temple)
 "kAO" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement4"
-	},
-/area/desert_dam/interior/dam_interior/north_tunnel)
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/interior/dam_interior/south_tunnel_entrance)
 "kBb" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -57956,27 +57981,32 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
+"kBw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
+"kBI" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal1"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
+"kBZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/warehouse/loading)
 "kCb" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 9
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"kCr" = (
+"kCj" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/interior/lab_northeast/east_lab_workshop)
-"kCu" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/north_valley_dam)
-"kCz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
 	},
-/area/desert_dam/building/medical/primary_storage)
+/area/desert_dam/exterior/valley/valley_mining)
 "kDu" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -57984,6 +58014,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/warehouse/loading)
+"kDN" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
 "kDW" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -58004,11 +58040,20 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/virology_wing)
-"kEx" = (
+"kEy" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
 /obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/desert_dam/exterior/valley/valley_crashsite)
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
+"kEG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/primary_tool_storage)
 "kEX" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -58022,9 +58067,15 @@
 	},
 /area/desert_dam/interior/dam_interior/workshop)
 "kFe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
-/area/desert_dam/building/medical/CMO)
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_lobby)
 "kFk" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt{
@@ -58038,13 +58089,11 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
-"kFL" = (
+"kFQ" = (
+/obj/structure/cable,
 /obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 9
-	},
-/area/desert_dam/interior/caves/central_caves)
+/turf/open/floor/prison,
+/area/desert_dam/building/cafeteria/loading)
 "kFV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -58064,12 +58113,45 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"kGC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/north_valley_dam)
 "kGF" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
+"kHf" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
+"kHk" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/northwestern_tunnel)
+"kHl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/virology_wing)
+"kHC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "kHF" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -58083,6 +58165,13 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical_south)
+"kHS" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal11"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "kIi" = (
 /turf/open/ground/coast{
 	dir = 8
@@ -58099,6 +58188,19 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_mining)
+"kIB" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal1"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/landing/landing_pad_three_external)
+"kIK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "kIM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -58116,6 +58218,13 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/desert_dam/building/water_treatment_one/floodgate_control)
+"kJh" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitepurplecorner"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "kJk" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -58126,27 +58235,19 @@
 /obj/effect/ai_node,
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river_mouth/southern)
-"kJL" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "E"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/north_valley_dam)
 "kJP" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal2"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
-"kKQ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached18"
+"kKN" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
 	},
-/area/desert_dam/exterior/valley/valley_wilderness)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "kKT" = (
 /obj/machinery/light{
 	dir = 1
@@ -58186,12 +58287,6 @@
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/security/southern_hallway)
-"kMn" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 1
-	},
-/area/desert_dam/interior/dam_interior/western_dam_cave)
 "kMv" = (
 /obj/structure/cable,
 /obj/effect/decal/warning_stripes/thin{
@@ -58201,6 +58296,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/desert_dam/exterior/valley/tradeship)
+"kMz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "kMF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58230,20 +58331,12 @@
 	icon_state = "kitchen"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
-"kND" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
+"kOg" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "darkred2"
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 10
 	},
-/area/desert_dam/building/security/southern_hallway)
+/area/desert_dam/interior/caves/temple)
 "kOL" = (
 /obj/structure/flora/rock/alt3{
 	name = "rock"
@@ -58258,6 +58351,17 @@
 	dir = 9
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
+"kOP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/hangar_storage)
 "kOS" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -58265,6 +58369,13 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
+"kPc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/warehouse/loading)
 "kPt" = (
 /obj/structure/flora/rock/alt{
 	name = "rock"
@@ -58294,17 +58405,6 @@
 	name = "reinforced metal wall"
 	},
 /area/desert_dam/interior/dam_interior/west_tunnel)
-"kPX" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/desert_dam/exterior/landing/landing_pad_three_external)
-"kQa" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "kQt" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal3"
@@ -58323,6 +58423,18 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
+"kQv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "kQy" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -58407,6 +58519,13 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"kSx" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal3"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/north_valley_dam)
 "kSG" = (
 /obj/machinery/door/airlock/sandstone{
 	density = 0;
@@ -58424,16 +58543,30 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
-"kTd" = (
+"kSN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
 /area/desert_dam/exterior/valley/valley_mining)
 "kTi" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 6
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"kTy" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_civilian)
+"kTT" = (
+/obj/structure/desertdam/decals/road/stop{
+	dir = 1;
+	icon_state = "stop_decal5"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "kUz" = (
 /obj/structure/table,
 /turf/open/floor{
@@ -58455,19 +58588,6 @@
 	icon_state = "cement1"
 	},
 /area/desert_dam/interior/dam_interior/north_tunnel)
-"kUO" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal4"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_medical)
-"kUX" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
-	},
-/area/desert_dam/exterior/valley/valley_medical_south)
 "kUY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58496,17 +58616,6 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/building/water_treatment_one/floodgate_control)
-"kVu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/virology_wing)
 "kVw" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal9"
@@ -58561,21 +58670,6 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
-"kWM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/building/water_treatment_one/hallway)
 "kXl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -58604,21 +58698,6 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/hangar_storage)
-"kXM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/medical/treatment_room)
-"kXO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/building/administration/hallway)
 "kXU" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner{
 	dir = 4
@@ -58633,10 +58712,13 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_south)
-"kYc" = (
+"kYv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/security/execution_chamber)
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/desert_dam/building/dorms/hallway_northwing)
 "kYL" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -58650,16 +58732,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_cargo)
-"kZj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/warehouse/breakroom)
 "kZm" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -58673,6 +58745,17 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_biology)
+"kZo" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitepurplecorner"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
+"kZv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/building/water_treatment_one/garage)
 "kZJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -58681,18 +58764,17 @@
 /obj/effect/ai_node,
 /turf/open/floor/carpet,
 /area/desert_dam/building/warehouse/breakroom)
-"kZN" = (
+"lai" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 10
+/turf/open/floor/plating,
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+"laE" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal4"
 	},
-/area/desert_dam/exterior/valley/bar_valley_dam)
-"lag" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement4"
-	},
-/area/desert_dam/exterior/valley/valley_wilderness)
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/north_valley_dam)
 "laO" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -58707,13 +58789,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
-"lbg" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/building/cafeteria/loading)
 "lbk" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
@@ -58757,23 +58832,30 @@
 /obj/structure/flora/rock/pile,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_northwest)
-"lcC" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 6
-	},
-/area/desert_dam/interior/dam_interior/western_dam_cave)
 "lcY" = (
 /obj/structure/flora/rock/alt2{
 	name = "rock"
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/central_caves)
+"lda" = (
+/obj/machinery/landinglight/ds2/delaytwo{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "ldx" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock{
 	dir = 4
 	},
 /area/desert_dam/interior/dam_interior/western_dam_cave)
+"ldM" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "ldU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58821,6 +58903,18 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
+"lfd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/administration/hallway)
 "lfg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
@@ -58835,12 +58929,6 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
-"lgt" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "lgD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
@@ -58859,6 +58947,13 @@
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_medical_south)
+"lhC" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/medical/break_room)
 "lhH" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
@@ -58877,6 +58972,10 @@
 	icon_state = "cement4"
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
+"lhL" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "lib" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -58916,12 +59015,29 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"ljj" = (
+"ljf" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
+/turf/open/floor/plating/ground/dirt{
+	dir = 10
 	},
-/area/desert_dam/exterior/valley/valley_hydro)
+/area/desert_dam/interior/dam_interior/western_dam_cave)
+"ljh" = (
+/obj/effect/landmark/excavation_site_spawner,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"ljC" = (
+/obj/structure/closet/secure_closet/scientist,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkpurple2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
+"ljP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "ljW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -58931,17 +59047,20 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_two/lobby)
-"lly" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/interior/caves/central_caves)
 "llO" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
 	icon_state = "cement7"
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
+"llV" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/desert_dam/exterior/valley/tradeship)
 "lmf" = (
 /turf/open/floor,
 /area/storage/testroom)
@@ -58969,6 +59088,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
+"lmt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "lmR" = (
 /obj/structure/cable,
 /turf/open/floor/prison,
@@ -58976,13 +59101,6 @@
 "lmV" = (
 /turf/closed/wall/r_wall,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"lnw" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 5;
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/lobby)
 "lnD" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
@@ -58994,6 +59112,18 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/building/medical/garage)
+"lnY" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"log" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "lop" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -59021,13 +59151,6 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/surgery_room_two)
-"loy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/cafeteria/loading)
 "lpe" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -59038,14 +59161,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/lobby)
-"lpf" = (
-/obj/structure/table,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "kitchen"
-	},
-/area/desert_dam/building/cafeteria/cafeteria)
 "lpj" = (
 /obj/effect/turf_underlay/tiles/dark2,
 /turf/closed/shuttle{
@@ -59056,30 +59171,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/desert_dam/building/substation/southwest)
-"lpq" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "E"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_medical)
-"lpx" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/building/cafeteria/loading)
-"lpA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement4"
-	},
-/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "lpD" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_2"
@@ -59154,13 +59245,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"lqN" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_labs)
 "lqX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -59178,42 +59262,12 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_civilian)
-"lrF" = (
-/obj/structure/platform,
-/obj/structure/platform{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 8
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
-"lrM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/valley/valley_hydro)
 "lrR" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 8
 	},
 /area/desert_dam/exterior/valley/valley_mining)
-"lrV" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "lrY" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_8"
@@ -59227,6 +59281,18 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_workshop)
+"lsw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull"
+	},
+/area/desert_dam/interior/east_engineering)
 "lsE" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_4"
@@ -59241,6 +59307,12 @@
 	name = "reinforced metal wall"
 	},
 /area/desert_dam/building/water_treatment_two/hallway)
+"lsK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached19"
+	},
+/area/desert_dam/exterior/valley/valley_cargo)
 "ltx" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -59257,13 +59329,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
-"lum" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "whitepurple"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "luo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
@@ -59280,12 +59345,6 @@
 	icon_state = "cement12"
 	},
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
-"luQ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "dark"
-	},
-/area/desert_dam/building/church)
 "luT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -59313,6 +59372,14 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"lvE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/administration/hallway)
 "lvK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -59350,6 +59417,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
+"lxR" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkbrown2"
+	},
+/area/desert_dam/building/warehouse/loading)
 "lxT" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal9"
@@ -59381,6 +59455,11 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"lyH" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/interior/caves/central_caves)
 "lyM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -59390,6 +59469,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/armory)
+"lze" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
 "lzj" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/mainship/engineering/free_access{
@@ -59404,14 +59489,15 @@
 	icon_state = "cement1"
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
-"lzF" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/desert_dam/exterior/valley/valley_crashsite)
-"lzM" = (
+"lzW" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_medical)
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "kitchen"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "lzZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -59430,6 +59516,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_cargo)
+"lAy" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "lAR" = (
 /obj/structure/flora/rock/alt{
 	name = "rock"
@@ -59470,24 +59564,21 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
-"lCe" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 5
-	},
-/area/desert_dam/exterior/valley/valley_medical)
 "lCm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor{
 	icon_state = "white"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_lobby)
-"lCp" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "wood"
+"lCo" = (
+/obj/machinery/landinglight/ds2{
+	dir = 4
 	},
-/area/desert_dam/building/security/southern_hallway)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "lCs" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 9
@@ -59497,19 +59588,23 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_telecoms)
-"lCQ" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal4"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_civilian)
 "lCX" = (
 /obj/effect/ai_node,
 /turf/open/ground/coast/corner{
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/valley_labs)
+"lCZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/lab_northeast/east_lab_containment)
+"lDk" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/medical/chemistry)
 "lDp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -59523,10 +59618,6 @@
 	dir = 8
 	},
 /area/desert_dam/interior/caves/east_caves)
-"lDE" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/desert_dam/interior/dam_interior/central_tunnel)
 "lDT" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_3"
@@ -59539,6 +59630,13 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"lEw" = (
+/obj/structure/flora/desert/grass/heavy{
+	icon_state = "heavygrass_4"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_medical)
 "lET" = (
 /obj/effect/ai_node,
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner2{
@@ -59560,12 +59658,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
-"lFs" = (
-/obj/structure/cable,
-/obj/structure/cable,
+"lFA" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "lFE" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/desert_dam/interior/east_engineering)
@@ -59574,14 +59672,12 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/interior/caves/central_caves)
-"lFR" = (
-/obj/effect/decal/cleanable/dirt,
+"lFS" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
 	},
-/area/desert_dam/building/warehouse/warehouse)
+/area/desert_dam/exterior/valley/valley_northwest)
 "lGp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -59593,20 +59689,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_storage)
-"lGq" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/engine_east_wing)
-"lGv" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_labs)
 "lGy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -59633,6 +59715,23 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_cargo)
+"lHr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/warehouse/breakroom)
+"lHx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull"
+	},
+/area/desert_dam/building/medical/treatment_room)
 "lHW" = (
 /obj/effect/landmark/weed_node,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -59652,12 +59751,6 @@
 /obj/machinery/microwave,
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"lIV" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_wilderness)
 "lIY" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -59670,10 +59763,6 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/treatment_room)
-"lJC" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_northwest)
 "lJD" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -59688,6 +59777,12 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"lJU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 9
+	},
+/area/desert_dam/interior/caves/east_caves)
 "lKf" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -59707,10 +59802,13 @@
 "lKL" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
-"lKX" = (
+"lLy" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/interior/dam_interior/central_tunnel)
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "lLB" = (
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 5
@@ -59736,6 +59834,18 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical_south)
+"lNn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkbrown2"
+	},
+/area/desert_dam/interior/dam_interior/disposals)
 "lNu" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/bar_valley_dam)
@@ -59762,26 +59872,20 @@
 	dir = 5
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
-"lPp" = (
-/obj/structure/desertdam/decals/road/stop{
-	icon_state = "stop_decal5"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_civilian)
 "lPy" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
-"lPH" = (
+"lQC" = (
+/obj/structure/cable,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
 	},
-/area/desert_dam/exterior/landing/landing_pad_three_external)
+/area/desert_dam/interior/dam_interior/engine_west_wing)
 "lQM" = (
 /obj/structure/stairs/seamless/platform{
 	dir = 8
@@ -59795,13 +59899,20 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/central_caves)
-"lRq" = (
+"lRo" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor{
-	dir = 4;
-	icon_state = "whiteyellowcorner"
+	icon_state = "freezerfloor"
 	},
-/area/desert_dam/building/water_treatment_one/breakroom)
+/area/desert_dam/interior/dam_interior/break_room)
+"lRy" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/north_wing_hallway)
 "lRH" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/marking/asteroidwarning{
@@ -59828,19 +59939,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_security_armory)
-"lSE" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt{
-	dir = 8
-	},
-/area/desert_dam/exterior/valley/valley_medical)
-"lSN" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "darkbrown2"
-	},
-/area/desert_dam/building/warehouse/loading)
 "lSX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -59859,22 +59957,6 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
-"lTf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/interior/dam_interior/control_room)
-"lTm" = (
-/obj/effect/decal/cleanable/liquid_fuel,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_crashsite)
-"lTo" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 6
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
 "lTI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
@@ -59891,13 +59973,6 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
-"lUc" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "whitegreenfull"
-	},
-/area/desert_dam/building/medical/virology_wing)
 "lUk" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/prison{
@@ -59937,6 +60012,13 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/warehouse/breakroom)
+"lVV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowcorner"
+	},
+/area/desert_dam/interior/dam_interior/break_room)
 "lVW" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -59944,12 +60026,12 @@
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "lWc" = (
-/obj/structure/flora/desert/grass/heavy{
-	icon_state = "heavygrass_3"
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
 	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
+/area/desert_dam/exterior/valley/valley_northwest)
 "lWj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
@@ -59960,23 +60042,39 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+"lWn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
+"lWr" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_lobby)
 "lWS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor{
 	icon_state = "white"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_lobby)
-"lXX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+"lXG" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
 	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
+/area/desert_dam/interior/caves/central_caves)
+"lYd" = (
+/obj/effect/decal/sandytile,
+/obj/effect/decal/sandytile,
+/obj/effect/decal/sandytile,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
 	},
-/area/desert_dam/building/hydroponics/hydroponics)
+/area/desert_dam/interior/caves/temple)
 "lYm" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal8"
@@ -59989,12 +60087,6 @@
 	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
-"lYs" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 10
-	},
-/area/desert_dam/exterior/valley/valley_wilderness)
 "lYv" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_4"
@@ -60010,12 +60102,6 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_south)
-"lYK" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 1
-	},
-/area/desert_dam/interior/caves/central_caves)
 "lYW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -60027,17 +60113,6 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
-"lZb" = (
-/obj/machinery/door/poddoor/mainship/open{
-	dir = 4;
-	id = "dam_checkpoint_north";
-	name = "\improper Checkpoint Lock"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "warning"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_west_entrance)
 "lZG" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 1
@@ -60058,12 +60133,6 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"lZW" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement15"
-	},
-/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "mae" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -60076,12 +60145,6 @@
 	dir = 4
 	},
 /area/desert_dam/interior/caves/temple)
-"maC" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached4"
-	},
-/area/desert_dam/interior/caves/central_caves)
 "maI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -60090,6 +60153,12 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_northwing)
+"mbe" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
 "mbl" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -60097,47 +60166,63 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/water_treatment_one/garage)
-"mbK" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/floor/tile/darkish,
-/area/desert_dam/interior/caves/temple)
-"mct" = (
-/obj/structure/platform{
-	dir = 8
-	},
+"mbH" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
-"mdJ" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
+"mcy" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_wilderness)
+/area/desert_dam/interior/dam_interior/south_tunnel)
+"mcI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
+"mcO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement13"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
+"mcQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating{
+	dir = 4;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "mdP" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal9"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
-"mdQ" = (
+"mdW" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_4"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_civilian)
+"men" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
+"meA" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
-	dir = 1;
-	icon_state = "whitegreen"
+	icon_state = "sterile_white"
 	},
-/area/desert_dam/building/medical/virology_wing)
-"mev" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement3"
-	},
-/area/desert_dam/exterior/valley/valley_wilderness)
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "meI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -60171,6 +60256,11 @@
 	icon_state = "dark"
 	},
 /area/desert_dam/building/security/interrogation)
+"mfH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "mfK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60207,12 +60297,6 @@
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/interior/caves/central_caves)
-"mhP" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "mhU" = (
 /obj/structure/rack,
 /turf/open/floor/prison{
@@ -60235,46 +60319,44 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/surgery_room_two)
-"mjg" = (
+"miS" = (
+/obj/structure/cable,
+/obj/structure/cable,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
 	},
-/area/desert_dam/exterior/valley/valley_civilian)
+/area/desert_dam/building/warehouse/warehouse)
+"miU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "mjl" = (
 /obj/effect/ai_node,
 /turf/open/ground/coast{
 	dir = 4
 	},
 /area/desert_dam/exterior/river/riverside_central_north)
+"mjv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
 "mjy" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 9
 	},
 /area/desert_dam/interior/caves/temple)
-"mkm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
+"mkr" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached18"
-	},
-/area/desert_dam/exterior/valley/south_valley_dam)
-"mkx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/primary_tool_storage)
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "mkJ" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_4"
@@ -60305,22 +60387,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"mly" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "freezerfloor"
-	},
-/area/desert_dam/building/cafeteria/cold_room)
-"mlF" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
-	},
-/area/desert_dam/exterior/valley/valley_hydro)
 "mlS" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal3"
@@ -60328,13 +60394,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"mmp" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "whitegreenfull"
-	},
-/area/desert_dam/building/medical/treatment_room)
 "mmz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -60373,12 +60432,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
-"mno" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 9
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
 "mnA" = (
 /obj/machinery/floodlight,
 /obj/machinery/camera/autoname/mainship,
@@ -60387,6 +60440,12 @@
 	icon_state = "green"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
+"mnJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/exterior/valley/valley_cargo)
 "mnN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60406,6 +60465,13 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/building/water_treatment_two/floodgate_control)
+"mog" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "cult"
+	},
+/area/desert_dam/building/church)
 "moj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -60421,29 +60487,19 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_medical_south)
-"moS" = (
+"moT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/building/dorms/restroom)
-"mpj" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/closed/wall,
-/area/desert_dam/building/dorms/pool)
-"mpV" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "kitchen"
+	icon_state = "bright_clean"
 	},
-/area/desert_dam/building/cafeteria/cafeteria)
+/area/desert_dam/building/water_treatment_two/equipment)
+"mpj" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/wall,
+/area/desert_dam/building/dorms/pool)
 "mqn" = (
 /obj/machinery/power/smes/buildable{
 	capacity = 1e+006;
@@ -60451,6 +60507,10 @@
 	},
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_northwest)
+"mqs" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/south_valley_dam)
 "mqF" = (
 /obj/machinery/landinglight/ds2/delaythree,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -60459,10 +60519,11 @@
 /area/desert_dam/exterior/landing/landing_pad_two_external)
 "mqQ" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "cement_sunbleached15"
+/turf/open/floor{
+	dir = 5;
+	icon_state = "vault"
 	},
-/area/desert_dam/exterior/valley/valley_medical)
+/area/desert_dam/building/security/prison)
 "mqT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/decal/cleanable/dirt,
@@ -60475,12 +60536,14 @@
 "mrg" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner2,
 /area/desert_dam/exterior/river_mouth/southern)
-"mrl" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "grimy"
+"mro" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
-/area/desert_dam/building/bar/bar)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_mining)
 "mrx" = (
 /obj/structure/flora/tree/joshua,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -60501,12 +60564,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/hanger)
-"mrY" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement1"
-	},
-/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "msC" = (
 /obj/machinery/door/airlock/mainship/engineering{
 	dir = 2;
@@ -60522,6 +60579,19 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river_mouth/southern)
+"msV" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"mta" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
 "mtd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -60548,12 +60618,14 @@
 	},
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"mtt" = (
+"mtr" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "cement_sunbleached15"
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
 	},
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/building/medical/west_wing_hallway)
 "mtC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -60568,6 +60640,12 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/central_caves)
+"muO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
 "mvg" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
@@ -60577,13 +60655,6 @@
 	icon_state = "cell_stripe"
 	},
 /area/desert_dam/building/warehouse/warehouse)
-"mvk" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal7"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_labs)
 "mvl" = (
 /obj/structure/flora/rock/alt3{
 	name = "rock"
@@ -60609,12 +60680,40 @@
 /obj/structure/bed/chair/office/light,
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"mwr" = (
+"mvT" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor{
-	icon_state = "freezerfloor"
+	icon_state = "white"
 	},
-/area/desert_dam/interior/dam_interior/break_room)
+/area/desert_dam/building/water_treatment_one/breakroom)
+"mvW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkpurple2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
+"mws" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/interior/caves/central_caves)
+"mwz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
+"mwO" = (
+/obj/machinery/landinglight/ds2/delaytwo,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
+"mwR" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "mwS" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	id = "port_authority2"
@@ -60622,17 +60721,6 @@
 /obj/structure/window/framed/chigusa,
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"mxi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	dir = 8;
-	icon_state = "darkbrown2"
-	},
-/area/desert_dam/interior/dam_interior/disposals)
 "mxn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -60641,12 +60729,14 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_northwing)
-"mxx" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached18"
+"mxC" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal5"
 	},
-/area/desert_dam/exterior/valley/valley_mining)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "myi" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
@@ -60687,12 +60777,6 @@
 	icon_state = "cement_sunbleached13"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
-"myZ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 8
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
 "mzj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -60717,6 +60801,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"mzB" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/west_wing_hallway)
 "mzH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -60726,18 +60817,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_two/lobby)
-"mzI" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached13"
-	},
-/area/desert_dam/exterior/valley/valley_wilderness)
-"mzT" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 8
-	},
-/area/desert_dam/exterior/valley/valley_labs)
 "mzU" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash,
@@ -60770,21 +60849,12 @@
 	icon_state = "delivery"
 	},
 /area/desert_dam/interior/dam_interior/north_tunnel)
-"mBk" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "mBs" = (
 /obj/structure/cable,
 /turf/open/floor{
 	icon_state = "white"
 	},
 /area/desert_dam/building/medical/garage)
-"mBu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_cargo)
 "mBA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -60795,29 +60865,24 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_storage)
-"mCm" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
 "mCu" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal7"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
-"mCF" = (
+"mCW" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/interior/dam_interior/hanger)
-"mCI" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "white"
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
 	},
-/area/desert_dam/interior/lab_northeast/east_lab_lobby)
+/area/desert_dam/exterior/valley/valley_northwest)
+"mDe" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached11"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "mDz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -60843,6 +60908,18 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_cargo)
+"mDW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "mEf" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached10"
@@ -60942,6 +61019,19 @@
 	icon_state = "cement_sunbleached10"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
+"mFE" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"mFX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkred2"
+	},
+/area/desert_dam/building/security/southern_hallway)
 "mGn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60956,12 +61046,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/courtroom)
-"mGA" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached18"
-	},
-/area/desert_dam/exterior/valley/valley_medical)
 "mGG" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean,
@@ -60982,22 +61066,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"mHl" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/interior/caves/central_caves)
-"mIa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "whitegreenfull"
-	},
-/area/desert_dam/interior/east_engineering)
 "mIs" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
@@ -61015,6 +61083,11 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_medical_south)
+"mIQ" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/lab_northeast/east_lab_RND)
 "mIS" = (
 /obj/structure/table,
 /obj/structure/paper_bin,
@@ -61022,6 +61095,16 @@
 /obj/effect/spawner/random/powercell,
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"mJE" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitepurple"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "mJT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison,
@@ -61036,12 +61119,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
-"mJZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_medical)
 "mKm" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 4
@@ -61061,17 +61138,12 @@
 "mKs" = (
 /turf/closed/mineral,
 /area/desert_dam/exterior/valley/valley_telecoms)
-"mKy" = (
-/obj/structure/platform{
-	dir = 1
+"mKF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
 	},
-/obj/structure/platform{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 8
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
+/area/desert_dam/exterior/river/riverside_east)
 "mKO" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/effect/ai_node,
@@ -61104,6 +61176,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"mLV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
 "mLW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61117,13 +61195,6 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/valley/bar_valley_dam)
-"mMn" = (
-/obj/structure/flora/desert/grass{
-	icon_state = "lightgrass_3"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_medical_south)
 "mMy" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -61161,12 +61232,6 @@
 "mNk" = (
 /turf/closed/wall/r_wall,
 /area/desert_dam/exterior/valley/bar_valley_dam)
-"mNm" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt{
-	dir = 8
-	},
-/area/desert_dam/exterior/river/riverside_east)
 "mNA" = (
 /obj/machinery/landinglight/ds1/delaythree{
 	dir = 4
@@ -61185,18 +61250,16 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
-"mNT" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached1"
+"mOd" = (
+/obj/machinery/light{
+	dir = 8
 	},
-/area/desert_dam/exterior/valley/valley_medical_south)
-"mOb" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 10
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreen"
 	},
-/area/desert_dam/exterior/valley/south_valley_dam)
+/area/desert_dam/building/medical/east_wing_hallway)
 "mOk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -61206,47 +61269,35 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
-"mPa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+"mOr" = (
+/obj/machinery/iv_drip,
+/obj/machinery/door_control{
+	id = "medstorage3";
+	name = "Medical Secure Shutters"
 	},
+/turf/open/floor{
+	icon_state = "whiteblue"
+	},
+/area/desert_dam/building/medical/medsecure)
+"mPc" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "kitchen"
+/turf/open/floor/plating{
+	icon_state = "warnplate"
 	},
-/area/desert_dam/building/cafeteria/cafeteria)
-"mPg" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached18"
-	},
-/area/desert_dam/exterior/valley/valley_civilian)
+/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "mPo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/desert_dam/interior/dam_interior/workshop)
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/interior/dam_interior/north_tunnel)
 "mPt" = (
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/detective)
-"mPE" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/desert_dam/exterior/valley/valley_wilderness)
-"mPU" = (
-/obj/machinery/light,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
-/area/desert_dam/building/medical/break_room)
 "mQb" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -61274,13 +61325,12 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
-"mQO" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating{
-	dir = 1;
-	icon_state = "warnplate"
+"mQH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
 	},
-/area/desert_dam/exterior/valley/valley_crashsite)
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "mQQ" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_11"
@@ -61305,12 +61355,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
-"mRQ" = (
-/obj/effect/landmark/weed_node,
+"mRJ" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached13"
+	icon_state = "cement_sunbleached12"
 	},
-/area/desert_dam/exterior/valley/north_valley_dam)
+/area/desert_dam/exterior/valley/valley_crashsite)
 "mSb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -61321,13 +61372,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_one/hallway)
-"mSc" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/medical/surgery_room_two)
 "mSg" = (
 /obj/structure/bed/chair/dropship/passenger,
 /obj/machinery/light{
@@ -61404,13 +61448,6 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/north_wing_hallway)
-"mTJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "wood"
-	},
-/area/desert_dam/building/dorms/hallway_northwing)
 "mTL" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/dirttosand,
@@ -61431,12 +61468,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"mUq" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 8
-	},
-/area/desert_dam/interior/caves/central_caves)
 "mUw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -61444,12 +61475,12 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/treatment_room)
-"mUE" = (
+"mUZ" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "red"
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
 	},
-/area/desert_dam/interior/lab_northeast/east_lab_west_entrance)
+/area/desert_dam/exterior/valley/valley_medical)
 "mVe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -61459,6 +61490,13 @@
 	icon_state = "darkredcorners2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_security_armory)
+"mVp" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal9"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/south_valley_dam)
 "mVz" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -61469,22 +61507,17 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
+"mVN" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/interior/caves/central_caves)
 "mVO" = (
 /obj/structure/flora/rock/alt3{
 	name = "rock"
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_northwest)
-"mWg" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "blue"
-	},
-/area/desert_dam/building/administration/hallway)
 "mWC" = (
 /obj/structure/platform{
 	dir = 1
@@ -61506,26 +61539,6 @@
 	dir = 10
 	},
 /area/desert_dam/exterior/valley/valley_mining)
-"mXK" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "blue"
-	},
-/area/desert_dam/building/administration/hallway)
-"mYn" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "whitepurple"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
-"mYq" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "white"
-	},
-/area/desert_dam/building/medical/garage)
 "mYS" = (
 /obj/structure/table,
 /turf/open/floor/prison,
@@ -61542,18 +61555,6 @@
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
-"mZk" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement15"
-	},
-/area/desert_dam/exterior/valley/valley_wilderness)
-"nac" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "green"
-	},
-/area/desert_dam/building/dorms/hallway_northwing)
 "nah" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -61578,14 +61579,11 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
-"naT" = (
+"naR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_marked"
-	},
-/area/desert_dam/building/hydroponics/hydroponics_storage)
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "ncd" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
@@ -61597,6 +61595,23 @@
 "ncm" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
+"ncs" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"ncN" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_two/control_room)
 "ndj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -61605,6 +61620,27 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/west_tunnel)
+"nds" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/dorms/hallway_northwing)
+"ndB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/security/southern_hallway)
 "ndI" = (
 /turf/open/floor/prison,
 /area/desert_dam/interior/east_engineering)
@@ -61627,10 +61663,6 @@
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"ndW" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/tile/darkish,
-/area/desert_dam/interior/caves/temple)
 "neg" = (
 /obj/effect/ai_node,
 /turf/open/floor{
@@ -61690,38 +61722,13 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
-"ngy" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal4"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_mining)
-"ngA" = (
-/obj/machinery/landinglight/ds2/delaytwo{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached1"
-	},
-/area/desert_dam/exterior/landing/landing_pad_three_external)
-"ngH" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/interior/dam_interior/west_tunnel)
-"nhj" = (
+"ngV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached10"
 	},
-/area/desert_dam/interior/dam_interior/central_tunnel)
+/area/desert_dam/exterior/valley/valley_medical_south)
 "nil" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached13"
@@ -61739,12 +61746,6 @@
 	icon_state = "cement_sunbleached13"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
-"niZ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "cement_sunbleached9"
-	},
-/area/desert_dam/exterior/valley/valley_mining)
 "njb" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -61752,6 +61753,13 @@
 "nje" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/valley/valley_northwest)
+"njh" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_telecoms)
 "nji" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
@@ -61764,6 +61772,10 @@
 	dir = 10
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"njw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_labs)
 "njF" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand,
@@ -61778,20 +61790,25 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
-"nkf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_wilderness)
 "nkB" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_civilian)
+"nkG" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal3"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_labs)
+"nkY" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "nla" = (
 /obj/structure/table/mainship,
 /obj/item/clothing/suit/storage/hazardvest,
@@ -61831,6 +61848,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/interior/east_engineering)
+"nlY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/lobby)
 "nmc" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
@@ -61851,30 +61874,36 @@
 	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/valley/valley_medical_south)
+"nmz" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal7"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_labs)
 "nmW" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 4
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
-"nmZ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/dorms/hallway_westwing)
 "nnb" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/desert_dam/interior/dam_interior/hanger)
+"nnl" = (
+/obj/structure/desertdam/decals/loose_sand_overlay{
+	dir = 9
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "nns" = (
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 1
 	},
 /area/desert_dam/interior/dam_interior/western_dam_cave)
-"nny" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
-	},
-/area/desert_dam/exterior/valley/north_valley_dam)
 "nnA" = (
 /obj/structure/table,
 /obj/effect/spawner/random/toolbox,
@@ -61898,19 +61927,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_wilderness)
-"nol" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal11"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_wilderness)
-"noo" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached14"
-	},
-/area/desert_dam/exterior/valley/valley_hydro)
 "noC" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/catwalk,
@@ -61954,13 +61970,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_crashsite)
-"npV" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_plate"
-	},
-/area/desert_dam/exterior/valley/valley_northwest)
 "nqc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -61976,10 +61985,13 @@
 	icon_state = "cement_sunbleached10"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
-"nqK" = (
+"nqP" = (
+/obj/machinery/light,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/valley_cargo)
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "nrb" = (
 /obj/structure/table,
 /obj/machinery/faxmachine,
@@ -62002,12 +62014,6 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/administration/control_room)
-"nrI" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement3"
-	},
-/area/desert_dam/interior/dam_interior/central_tunnel)
 "nrN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -62040,20 +62046,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_mining)
-"nsh" = (
-/obj/effect/decal/cleanable/dirt,
+"nsT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
+"nsV" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
-	dir = 1;
-	icon_state = "yellow"
+	icon_state = "sterile_white"
 	},
-/area/desert_dam/building/hydroponics/hydroponics)
-"nsP" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/desert_dam/interior/dam_interior/west_tunnel)
+/area/desert_dam/interior/dam_interior/workshop)
 "ntb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -62111,13 +62115,15 @@
 	icon_state = "cement4"
 	},
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
-"nuM" = (
+"nvf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating{
-	dir = 8;
-	icon_state = "warnplate"
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
 	},
-/area/desert_dam/interior/lab_northeast/east_lab_biology)
+/area/desert_dam/building/cafeteria/cafeteria)
 "nvj" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_4"
@@ -62148,6 +62154,11 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/west_wing_hallway)
+"nwg" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "nwI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -62159,12 +62170,6 @@
 	icon_state = "cement_sunbleached13"
 	},
 /area/desert_dam/exterior/valley/valley_medical_south)
-"nxh" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 6
-	},
-/area/desert_dam/exterior/valley/valley_medical_south)
 "nxq" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -62172,6 +62177,10 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/emergency_room)
+"nxT" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "nxU" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal1"
@@ -62196,14 +62205,10 @@
 	icon_state = "rasputin3"
 	},
 /area/shuttle/tri_trans1/alpha)
-"nyM" = (
-/obj/structure/cable,
+"nyk" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_plate"
-	},
-/area/desert_dam/interior/dam_interior/west_tunnel)
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "nza" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -62221,16 +62226,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_crashsite)
-"nzq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	dir = 4;
-	icon_state = "whiteyellowfull"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_lobby)
 "nzH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -62273,13 +62268,6 @@
 /obj/structure/sign/safety/hazard,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"nAI" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 6;
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/treatment_room)
 "nAZ" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/xeno_resin_wall,
@@ -62358,10 +62346,6 @@
 	icon_state = "white"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_lobby)
-"nDe" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/interior/caves/central_caves)
 "nDh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -62404,13 +62388,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/substation/central)
-"nDW" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal3"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/landing/landing_pad_three_external)
 "nEo" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
@@ -62418,21 +62395,25 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/west_tunnel)
-"nEV" = (
+"nEv" = (
+/obj/structure/flora/rock/pile/alt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement3"
-	},
-/area/desert_dam/exterior/valley/valley_wilderness)
-"nFd" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison/bright_clean,
-/area/desert_dam/interior/east_engineering)
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "nFh" = (
 /obj/structure/showcase/yaut,
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/interior/caves/temple)
+"nFq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_one/hallway)
 "nFr" = (
 /obj/machinery/floodlight/landing,
 /turf/open/floor{
@@ -62447,12 +62428,26 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/security/lobby)
+"nFX" = (
+/obj/structure/desertdam/decals/road/stop{
+	icon_state = "stop_decal5"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "nGb" = (
 /obj/machinery/landinglight/ds1{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"nGj" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
+	},
+/area/desert_dam/interior/caves/central_caves)
 "nGA" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
@@ -62465,36 +62460,6 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_south)
-"nHc" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached4"
-	},
-/area/desert_dam/exterior/valley/valley_civilian)
-"nHe" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/interior/lab_northeast/east_lab_maintenence)
-"nHr" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/interior/lab_northeast/east_lab_RND)
-"nHw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/east_wing_hallway)
 "nHz" = (
 /obj/machinery/door/airlock/mainship/engineering,
 /obj/structure/cable,
@@ -62516,12 +62481,12 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/north_wing_hallway)
-"nHU" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached14"
+"nIa" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
 	},
-/area/desert_dam/exterior/valley/valley_crashsite)
+/area/desert_dam/interior/caves/central_caves)
 "nIf" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -62529,6 +62494,12 @@
 	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
+"nIp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/primary_tool_storage)
 "nIt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62565,14 +62536,21 @@
 	icon_state = "kitchen"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
+"nJk" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkbrowncorners2"
+	},
+/area/desert_dam/building/warehouse/warehouse)
 "nJw" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_labs)
-"nJy" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/valley_crashsite)
+"nKc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/south_valley_dam)
 "nKf" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
@@ -62595,28 +62573,22 @@
 	icon_state = "vault"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
-"nKP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+"nKW" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/building/water_treatment_two/equipment)
-"nKS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/building/hydroponics/hydroponics)
+/turf/open/floor/prison,
+/area/desert_dam/building/water_treatment_one/lobby)
 "nLd" = (
 /obj/structure/flora/rock/pile/alt,
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/central_caves)
+"nLp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/administration/hallway)
 "nLt" = (
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/tradeship)
@@ -62630,25 +62602,26 @@
 	},
 /turf/open/floor/wood,
 /area/desert_dam/building/medical/break_room)
-"nLS" = (
+"nMg" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor{
-	dir = 5;
-	icon_state = "whiteyellow"
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
 	},
-/area/desert_dam/interior/lab_northeast/east_lab_lobby)
+/area/desert_dam/exterior/valley/valley_cargo)
+"nMu" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/desert_dam/building/security/northern_hallway)
 "nMx" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached18"
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"nMz" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 1
-	},
-/area/desert_dam/exterior/valley/valley_hydro)
 "nMM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -62672,14 +62645,6 @@
 	icon_state = "floor_marked"
 	},
 /area/desert_dam/building/cafeteria/loading)
-"nMT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "nMW" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -62716,24 +62681,6 @@
 	icon_state = "wood"
 	},
 /area/desert_dam/building/dorms/hallway_westwing)
-"nNN" = (
-/obj/effect/landmark/excavation_site_spawner,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
-"nOn" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	dir = 1;
-	icon_state = "warning"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_east_entrance)
-"nOo" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached18"
-	},
-/area/desert_dam/exterior/valley/north_valley_dam)
 "nOE" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison{
@@ -62741,12 +62688,17 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
-"nPz" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "white"
+"nPb" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
 	},
-/area/desert_dam/building/water_treatment_one/breakroom)
+/area/desert_dam/exterior/valley/valley_wilderness)
+"nPw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/engine_west_wing)
 "nPH" = (
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 4
@@ -62767,12 +62719,6 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
-"nQv" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached1"
-	},
-/area/desert_dam/exterior/valley/north_valley_dam)
 "nQx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -62785,12 +62731,16 @@
 /obj/item/instrument/guitar,
 /turf/open/floor/mainship/mono,
 /area/desert_dam/exterior/valley/tradeship)
-"nQQ" = (
+"nQR" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached1"
+/turf/open/floor/prison,
+/area/desert_dam/interior/lab_northeast/east_lab_RND)
+"nRu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "freezerfloor"
 	},
-/area/desert_dam/exterior/valley/valley_labs)
+/area/desert_dam/building/water_treatment_one/breakroom)
 "nRC" = (
 /obj/machinery/light{
 	dir = 1
@@ -62817,6 +62767,12 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
+"nRS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "cult"
+	},
+/area/desert_dam/building/church)
 "nRT" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -62841,13 +62797,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_mining)
-"nSm" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/desert_dam/building/administration/hallway)
 "nSy" = (
 /obj/structure/flora/rock/alt2{
 	name = "rock"
@@ -62869,6 +62818,13 @@
 	dir = 8
 	},
 /area/desert_dam/building/medical/office2)
+"nSZ" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal4"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_mining)
 "nTa" = (
 /obj/structure/table,
 /obj/effect/spawner/random/toolbox,
@@ -62878,6 +62834,10 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+"nTg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "nTk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62899,13 +62859,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
-"nTx" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "cell_stripe"
-	},
-/area/desert_dam/interior/dam_interior/hanger)
 "nTF" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/structure/stairs/seamless,
@@ -62920,10 +62873,19 @@
 	dir = 9
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"nUJ" = (
+"nTY" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/south_valley_dam)
+/turf/open/floor/plating/ground/dirt{
+	dir = 1
+	},
+/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
+"nUE" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal3"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "nUW" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 4
@@ -62943,27 +62905,11 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"nVD" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_wilderness)
-"nVV" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/substation/northeast)
 "nWL" = (
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 4
 	},
 /area/desert_dam/interior/caves/temple)
-"nWN" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/treatment_room)
 "nWR" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -62978,13 +62924,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"nXl" = (
-/obj/machinery/landinglight/ds2/delaytwo,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
-	},
-/area/desert_dam/exterior/landing/landing_pad_three_external)
 "nXt" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -63025,6 +62964,12 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/administration/control_room)
+"nYv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "nYJ" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -63039,18 +62984,25 @@
 	dir = 5
 	},
 /area/desert_dam/exterior/valley/tradeship)
-"nZr" = (
+"nZT" = (
+/obj/structure/toilet,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "cement_sunbleached15"
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
 	},
-/area/desert_dam/exterior/valley/valley_hydro)
-"oab" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 10
+/area/desert_dam/building/warehouse/breakroom)
+"oag" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/desert_dam/interior/east_engineering)
+"oaj" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached13"
 	},
-/area/desert_dam/exterior/valley/valley_wilderness)
+/area/desert_dam/exterior/valley/north_valley_dam)
 "oap" = (
 /obj/structure/window/reinforced/toughened{
 	dir = 4
@@ -63082,6 +63034,12 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+"obt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "obW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -63090,13 +63048,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/medical/virology_isolation)
-"ocC" = (
-/obj/structure/flora/desert/grass{
-	icon_state = "lightgrass_2"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_medical_south)
 "odn" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached14"
@@ -63131,19 +63082,15 @@
 /obj/structure/window/framed/chigusa,
 /turf/closed/wall/r_wall/chigusa,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"oeE" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/desert_dam/exterior/valley/valley_crashsite)
-"oeU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "darkbrown2"
+"odY" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
 	},
-/area/desert_dam/building/warehouse/loading)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "oeV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -63159,14 +63106,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/valley/valley_telecoms)
-"ogq" = (
+"ofz" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/interior/dam_interior/south_tunnel)
-"ogG" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/interior/dam_interior/atmos_storage)
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "ogI" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	id = "northpath1"
@@ -63176,26 +63121,43 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"ohO" = (
+"ohA" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "freezerfloor"
+	},
+/area/desert_dam/building/hydroponics/hydroponics_breakroom)
+"ohI" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "darkbrown2"
-	},
-/area/desert_dam/building/warehouse/loading)
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "oit" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
-"oiX" = (
+"oiB" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 5
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement1"
 	},
-/area/desert_dam/interior/caves/east_caves)
+/area/desert_dam/interior/dam_interior/central_tunnel)
+"oiH" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"oiY" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "ojD" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -63209,6 +63171,10 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/tradeship)
+"ojV" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/interior/caves/central_caves)
 "okE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -63268,6 +63234,21 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
+"omv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/dorms/hallway_westwing)
+"omP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "onj" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal1"
@@ -63275,27 +63256,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
-"onF" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "whitepurplecorner"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "onL" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/interior/caves/temple)
-"ool" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"onM" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal5"
 	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/warehouse/breakroom)
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "oow" = (
 /obj/machinery/landinglight/ds2/delaytwo{
 	dir = 8
@@ -63323,12 +63294,6 @@
 	icon_state = "cement_sunbleached13"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
-"opc" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/building/administration/control_room)
 "opG" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/valley/valley_crashsite)
@@ -63357,6 +63322,22 @@
 	icon_state = "cement_sunbleached9"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"oqG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_telecoms)
+"oqS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/interior/dam_interior/northwestern_tunnel)
+"oqV" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "ord" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -63387,6 +63368,14 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
+"otg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_two/lobby)
 "otn" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal6"
@@ -63414,20 +63403,22 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"ouf" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
-	},
+"ouv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "darkyellow2"
-	},
-/area/desert_dam/interior/dam_interior/hanger)
+/turf/open/floor/prison,
+/area/desert_dam/building/warehouse/warehouse)
 "ouG" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"ouJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "ovA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -63446,6 +63437,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"ovV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached11"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
+"owm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/engine_west_wing)
 "owP" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -63465,14 +63469,6 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/north_wing_hallway)
-"oxA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/cafeteria/cafeteria)
 "oxL" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -63482,6 +63478,10 @@
 	icon_state = "redcorner"
 	},
 /area/desert_dam/building/security/northern_hallway)
+"oyb" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/interior/dam_interior/north_tunnel)
 "oyf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -63495,24 +63495,59 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"oyn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "oyq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
 /area/desert_dam/exterior/valley/tradeship)
-"oyL" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal7"
+"oyD" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E"
+	},
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 2;
+	id = "dam_stormlock_north2";
+	name = "\improper Storm Lock"
 	},
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_civilian)
+/area/desert_dam/interior/dam_interior/south_tunnel)
+"oyL" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_3"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_medical_south)
+"oyP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/building/substation/northeast)
 "oze" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
+"ozg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/primary_tool_storage)
+"ozk" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "ozu" = (
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
@@ -63520,6 +63555,20 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"ozx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/auxilary_tool_storage)
+"ozG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/dorms/hallway_westwing)
 "ozV" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	dir = 2;
@@ -63533,6 +63582,16 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"oAq" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "kitchen"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "oAM" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal2"
@@ -63552,11 +63611,24 @@
 	},
 /turf/open/floor/bcircuit,
 /area/desert_dam/interior/dam_interior/smes_main)
+"oBx" = (
+/obj/structure/flora/desert/cactus{
+	icon_state = "cactus_4"
+	},
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "oBK" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
+"oBM" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "green"
+	},
+/area/desert_dam/building/dorms/hallway_northwing)
 "oBR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -63570,13 +63642,6 @@
 	icon_state = "greencorner"
 	},
 /area/desert_dam/building/telecommunication)
-"oCm" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/medical/break_room)
 "oCv" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison{
@@ -63584,13 +63649,10 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_one/equipment)
-"oCD" = (
-/obj/effect/decal/cleanable/dirt,
+"oCL" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement1"
-	},
-/area/desert_dam/interior/dam_interior/west_tunnel)
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_medical)
 "oCQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -63628,6 +63690,10 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+"oEw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/building/hydroponics/hydroponics_loading)
 "oEC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -63636,10 +63702,6 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/administration/hallway)
-"oEI" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/water_treatment_one/hallway)
 "oEU" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -63650,10 +63712,6 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_biology)
-"oEW" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/landing/landing_pad_three_external)
 "oFf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -63664,11 +63722,25 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/security/northern_hallway)
+"oFq" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_2"
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "oFQ" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached10"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"oFS" = (
+/obj/structure/flora/desert/cactus/multiple{
+	icon_state = "cacti_10"
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "oGa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -63678,22 +63750,29 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
-"oGC" = (
-/obj/structure/platform,
-/obj/structure/flora/rock/pile/alt3,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/desert_dam/exterior/valley/valley_crashsite)
-"oGE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
+"oGz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/desert_dam/interior/dam_interior/west_tunnel)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
 "oGQ" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"oGT" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "oHf" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -63756,15 +63835,6 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_crashsite)
-"oJZ" = (
-/obj/structure/platform{
-	dir = 4
-	},
-/obj/structure/flora/rock/pile/alt3,
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 8
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
 "oKn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -63780,41 +63850,43 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
+"oKB" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "kitchen"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "oKG" = (
 /obj/structure/desertdam/decals/road/stop{
 	icon_state = "stop_decal5"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
-"oKQ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement13"
-	},
-/area/desert_dam/interior/dam_interior/west_tunnel)
-"oLc" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
-	},
-/area/desert_dam/exterior/valley/valley_telecoms)
 "oLz" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"oLE" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_labs)
-"oLR" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "oLT" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"oLX" = (
+/obj/effect/ai_node,
+/obj/effect/decal/sandytile,
+/obj/effect/decal/sandytile,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
+/area/desert_dam/interior/caves/temple)
+"oMe" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_northwest)
 "oMw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
@@ -63862,10 +63934,6 @@
 	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
-"oNT" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
-/area/desert_dam/exterior/valley/north_valley_dam)
 "oNX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -63895,23 +63963,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/dam_interior/south_tunnel)
-"oOy" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/warehouse/breakroom)
 "oOD" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/bar_valley_dam)
-"oOG" = (
-/obj/structure/bed/chair,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
-/area/desert_dam/building/security/courtroom)
 "oOO" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -63933,13 +63988,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"oPp" = (
-/obj/structure/flora/pottedplant,
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "whiteblue"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_lobby)
 "oPz" = (
 /obj/machinery/power/monitor{
 	name = "Core Power Monitoring"
@@ -63970,24 +64018,16 @@
 	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
-"oQK" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached4"
-	},
-/area/desert_dam/exterior/valley/south_valley_dam)
-"oRf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/cafeteria/loading)
 "oRg" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_3"
 	},
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"oRk" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/water_treatment_two/hallway)
 "oRs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -64001,6 +64041,15 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/virology_isolation)
+"oRZ" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/north_valley_dam)
 "oSo" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
@@ -64011,10 +64060,6 @@
 	},
 /turf/open/ground/river/desertdam/clean/shallow,
 /area/desert_dam/exterior/river/riverside_central_south)
-"oSG" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_civilian)
 "oSY" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/effect/ai_node,
@@ -64039,12 +64084,6 @@
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"oTj" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
 "oTm" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -64068,6 +64107,10 @@
 	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"oTR" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/security/prison)
 "oTZ" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -64090,6 +64133,13 @@
 	icon_state = "bluecorner"
 	},
 /area/desert_dam/building/administration/hallway)
+"oUE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "oVo" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -64111,13 +64161,24 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"oWj" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
+"oVR" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_wilderness)
+"oVV" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal1"
 	},
-/area/desert_dam/interior/dam_interior/auxilary_tool_storage)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/interior/dam_interior/south_tunnel)
+"oWj" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/security/courtroom)
 "oWr" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -64141,12 +64202,6 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
-"oXG" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/virology_isolation)
 "oXK" = (
 /obj/effect/landmark/weed_node,
 /obj/structure/cable,
@@ -64171,24 +64226,11 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/administration/hallway)
-"oYj" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_plate"
-	},
-/area/desert_dam/interior/dam_interior/west_tunnel)
 "oYW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/desert_dam/building/warehouse/breakroom)
-"oZd" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 6
-	},
-/area/desert_dam/interior/caves/temple)
 "oZg" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -64212,11 +64254,26 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/west_wing_hallway)
+"oZy" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "oZz" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/valley_medical_south)
+"oZF" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/west_wing_hallway)
 "oZJ" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -64233,12 +64290,6 @@
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/bar_valley_dam)
-"paI" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached4"
-	},
-/area/desert_dam/exterior/valley/valley_medical)
 "paV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -64247,10 +64298,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_two/hallway)
-"paZ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/north_valley_dam)
 "pba" = (
 /obj/structure/flora/tree/joshua,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -64272,20 +64319,23 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/central_tunnel)
-"pbV" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached1"
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
-"pcp" = (
-/obj/structure/desertdam/decals/road/stop{
-	dir = 1;
-	icon_state = "stop_decal5"
-	},
+"pbT" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_wilderness)
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
+	},
+/area/desert_dam/exterior/valley/valley_mining)
+"pcf" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/lab_northwest/west_lab_xenoflora)
+"pcx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "pcA" = (
 /obj/structure/flora/rock/pile/alt,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -64315,19 +64365,12 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_east)
-"pdj" = (
-/obj/effect/decal/cleanable/liquid_fuel,
+"pdk" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached11"
+/turf/open/floor{
+	icon_state = "freezerfloor"
 	},
-/area/desert_dam/exterior/valley/valley_hydro)
-"pdp" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/river/riverside_east)
+/area/desert_dam/building/security/prison)
 "pdV" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -64359,13 +64402,6 @@
 	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
-"peU" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "greencorner"
-	},
-/area/desert_dam/building/telecommunication)
 "peV" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 2;
@@ -64379,6 +64415,12 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"peX" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "pft" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -64400,23 +64442,29 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/security/northern_hallway)
+"pfU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "blue"
+	},
+/area/desert_dam/building/administration/hallway)
 "pfV" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 5
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
-"pgv" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/warehouse/breakroom)
 "pgN" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 5
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"pgR" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "phh" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -64456,6 +64504,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
+"phT" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal4"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "phV" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/box/matches,
@@ -64485,18 +64540,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/bcircuit,
 /area/desert_dam/interior/dam_interior/smes_main)
-"pjm" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_medical)
-"pjq" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "pjv" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -64546,11 +64589,22 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"pkL" = (
-/obj/structure/flora/desert/grass,
+"pkR" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/bar_valley_dam)
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/hydroponics/hydroponics_breakroom)
+"pkU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "pkY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -64568,16 +64622,18 @@
 	icon_state = "cement_sunbleached18"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
-"ple" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
-	},
-/area/desert_dam/exterior/valley/valley_medical)
 "plo" = (
 /obj/structure/flora/desert/grass,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_labs)
+"plG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "cell_stripe"
+	},
+/area/desert_dam/building/warehouse/warehouse)
 "plK" = (
 /obj/machinery/light{
 	dir = 4
@@ -64619,6 +64675,13 @@
 	dir = 9
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"pmz" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal1"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_labs)
 "pmG" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -64636,12 +64699,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_wilderness)
-"pnH" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached1"
-	},
-/area/desert_dam/exterior/valley/valley_telecoms)
 "pnK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64660,18 +64717,18 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
-"poo" = (
-/obj/effect/decal/sandytile,
-/turf/open/floor{
-	dir = 4;
-	icon_state = "whiteyellowfull"
-	},
-/area/desert_dam/interior/caves/temple)
 "poP" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 5
 	},
 /area/desert_dam/exterior/valley/valley_labs)
+"ppl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/hydroponics/hydroponics_breakroom)
 "ppp" = (
 /obj/structure/flora/tree/joshua,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -64707,23 +64764,6 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/virology_isolation)
-"pqa" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/interior/dam_interior/west_tunnel)
-"pqi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "kitchen"
-	},
-/area/desert_dam/building/cafeteria/cafeteria)
 "pqj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -64755,6 +64795,12 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
+"pra" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "prz" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_3"
@@ -64823,17 +64869,22 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
+"ptr" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "cell_stripe"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
 "ptH" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_6"
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"ptK" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_wilderness)
 "ptU" = (
 /turf/open/ground/coast,
 /area/desert_dam/exterior/river/riverside_east)
@@ -64848,6 +64899,20 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
+"pul" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"puo" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
 "puu" = (
 /obj/structure/platform{
 	dir = 8
@@ -64864,13 +64929,22 @@
 	icon_state = "cement_sunbleached11"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
-"pva" = (
+"puM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
-	icon_state = "whitegreen"
+	dir = 10;
+	icon_state = "bright_clean"
 	},
-/area/desert_dam/building/medical/north_wing_hallway)
+/area/desert_dam/interior/dam_interior/smes_main)
+"puQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal2"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_mining)
 "pvs" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/south_valley_dam)
@@ -64881,6 +64955,12 @@
 	icon_state = "whitepurple"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
+"pvG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "pvZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64905,10 +64985,6 @@
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/security/southern_hallway)
-"pwF" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/water_treatment_one/garage)
 "pwL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64925,6 +65001,20 @@
 /obj/structure/largecrate/random,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/tradeship)
+"pwV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_west_entrance)
+"pwW" = (
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_telecoms)
 "pxa" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -64945,22 +65035,16 @@
 	dir = 9
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
-"pxl" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached4"
-	},
-/area/desert_dam/exterior/valley/valley_wilderness)
 "pxm" = (
 /obj/machinery/computer/area_atmos/area,
 /turf/open/floor/prison/blue{
 	dir = 4
 	},
 /area/desert_dam/interior/east_engineering)
-"pxr" = (
-/obj/structure/platform,
+"pxn" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/cave,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "pxw" = (
 /obj/structure/cable,
@@ -64969,6 +65053,12 @@
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"pxQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "pxR" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached18"
@@ -64991,22 +65081,10 @@
 "pys" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_medical_south)
-"pyy" = (
-/obj/effect/decal/cleanable/dirt,
+"pyN" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached1"
-	},
-/area/desert_dam/exterior/valley/valley_mining)
-"pzh" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "whitegreenfull"
-	},
-/area/desert_dam/interior/east_engineering)
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/interior/dam_interior/western_dam_cave)
 "pzq" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -65021,13 +65099,11 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
-"pzE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/cafeteria/cafeteria)
+"pzG" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "pAf" = (
 /obj/structure/sink{
 	dir = 1;
@@ -65050,14 +65126,6 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/virology_wing)
-"pAA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/building/administration/hallway)
 "pAK" = (
 /turf/open/floor/marking/asteroidwarning,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
@@ -65077,6 +65145,16 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/valley/north_valley_dam)
+"pCl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
+"pCq" = (
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "pDd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
@@ -65152,12 +65230,6 @@
 	dir = 5
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
-"pEA" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement4"
-	},
-/area/desert_dam/exterior/valley/valley_northwest)
 "pEK" = (
 /obj/machinery/door/poddoor/mainship/open{
 	dir = 8;
@@ -65189,10 +65261,6 @@
 	icon_state = "cement_sunbleached9"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"pEZ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/desert_dam/interior/dam_interior/western_dam_cave)
 "pFb" = (
 /obj/structure/platform{
 	dir = 1
@@ -65201,12 +65269,6 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_south)
-"pFh" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "whitepurple"
-	},
-/area/desert_dam/building/medical/chemistry)
 "pFj" = (
 /obj/structure/table,
 /obj/item/storage/fancy/vials,
@@ -65261,12 +65323,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_northwing)
-"pHV" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement4"
-	},
-/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "pHY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -65277,6 +65333,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+"pIf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/north_tunnel)
 "pIg" = (
 /obj/structure/table,
 /turf/open/floor/prison{
@@ -65284,6 +65347,12 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/warehouse/breakroom)
+"pIt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "pIv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65296,6 +65365,13 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
+"pIy" = (
+/obj/structure/flora/desert/grass/heavy{
+	icon_state = "heavygrass_5"
+	},
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "pIN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -65334,6 +65410,27 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river_mouth/southern)
+"pJF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 10
+	},
+/area/desert_dam/interior/dam_interior/western_dam_cave)
+"pJQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
+"pJS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/administration/hallway)
 "pJW" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_2"
@@ -65365,11 +65462,6 @@
 /obj/machinery/power/smes/preset,
 /turf/open/floor/mainship/mono,
 /area/desert_dam/exterior/valley/tradeship)
-"pKP" = (
-/obj/structure/stairs/seamless,
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/desert_dam/interior/caves/temple)
 "pLj" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
@@ -65381,10 +65473,6 @@
 	dir = 5
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
-"pLv" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
-/area/desert_dam/building/water_treatment_one/hallway)
 "pLT" = (
 /obj/structure/platform{
 	dir = 8
@@ -65413,18 +65501,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/east_engineering)
-"pML" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+"pMO" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal3"
 	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/desert_dam/building/security/prison)
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_mining)
 "pMQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
@@ -65438,12 +65521,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"pNd" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "darkyellow2"
-	},
-/area/desert_dam/building/substation/southwest)
 "pNG" = (
 /obj/structure/xenoautopsy/tank/broken,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -65456,27 +65533,30 @@
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
-"pPs" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "E"
-	},
+"pPt" = (
+/obj/structure/table/reinforced,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
-	dir = 4;
-	icon_state = "darkyellow2"
+	icon_state = "darkpurple2"
 	},
-/area/desert_dam/interior/dam_interior/hanger)
-"pQJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
+"pQe" = (
+/obj/structure/platform_decoration{
+	dir = 4
 	},
-/area/desert_dam/exterior/valley/valley_mining)
-"pQK" = (
+/turf/open/floor/plating/ground/dirt,
+/area/desert_dam/exterior/valley/valley_labs)
+"pQh" = (
+/obj/machinery/pipedispenser,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
-/area/desert_dam/interior/dam_interior/hangar_storage)
+/area/desert_dam/interior/east_engineering)
+"pQm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "pQS" = (
 /obj/structure/platform,
 /turf/open/ground/river/desertdam/clean/shallow_edge{
@@ -65503,10 +65583,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
-"pRz" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/bcircuit,
-/area/desert_dam/interior/dam_interior/tech_storage)
+"pRF" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "pRU" = (
 /obj/structure/platform{
 	dir = 4
@@ -65516,13 +65596,6 @@
 	icon_state = "cement_sunbleached13"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
-"pSd" = (
-/obj/structure/flora/desert/grass{
-	icon_state = "lightgrass_11"
-	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "pSj" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -65543,29 +65616,21 @@
 	icon_state = "wood"
 	},
 /area/desert_dam/building/water_treatment_one/hallway)
-"pTo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/building/water_treatment_two/lobby)
 "pTU" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
-"pUg" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_mining)
 "pUl" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_2"
 	},
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"pUo" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/landing/landing_pad_three)
 "pUy" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -65614,12 +65679,6 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/valley/valley_crashsite)
-"pVC" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement4"
-	},
-/area/desert_dam/exterior/valley/valley_telecoms)
 "pVF" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -65676,18 +65735,37 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"pWx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/medical/break_room)
 "pWG" = (
 /obj/effect/ai_node,
 /turf/open/floor{
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/lab_northwest/west_lab_xenoflora)
+"pWK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitepurplecorner"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "pWZ" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal7"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"pXc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_cargo)
 "pXd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -65703,6 +65781,20 @@
 /obj/effect/ai_node,
 /turf/open/ground/river/desertdam/clean/shallow_edge,
 /area/desert_dam/exterior/river/riverside_south)
+"pYw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/hangar_storage)
+"pYB" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/building/medical/garage)
 "pYK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -65710,12 +65802,6 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_biology)
-"pYW" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt{
-	dir = 8
-	},
-/area/desert_dam/exterior/valley/north_valley_dam)
 "pZm" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -65734,13 +65820,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_security_armory)
-"pZM" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal1"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_labs)
 "qab" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -65761,23 +65840,22 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-"qau" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/primary_tool_storage)
+"qar" = (
+/obj/machinery/miner/damaged/platinum,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/desert_dam/interior/caves/temple)
 "qaA" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/valley/valley_telecoms)
-"qaY" = (
+"qaB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached14"
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
 	},
-/area/desert_dam/exterior/valley/north_valley_dam)
+/area/desert_dam/building/medical/morgue)
 "qba" = (
 /obj/machinery/door/airlock/mainship/engineering{
 	dir = 2;
@@ -65834,15 +65912,6 @@
 /obj/structure/cable,
 /turf/closed/wall/r_wall/chigusa,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"qcC" = (
-/obj/structure/table,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/water_treatment_one/garage)
-"qdJ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_cargo)
 "qdS" = (
 /turf/open/floor/plating/ground/desertdam/grate{
 	icon_state = "catwalk-255"
@@ -65862,6 +65931,13 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"qel" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/medical/morgue)
 "qet" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -65879,10 +65955,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/interior/caves/east_caves)
-"qex" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/water_treatment_one/lobby)
 "qey" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -65906,10 +65978,6 @@
 	icon_state = "kitchen"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
-"qfp" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/interior/dam_interior/western_dam_cave)
 "qfF" = (
 /obj/structure/table,
 /obj/item/assembly/infra,
@@ -65933,51 +66001,47 @@
 /obj/structure/flora/bush,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_hydro)
-"qgf" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
-	},
-/area/desert_dam/exterior/valley/valley_northwest)
-"qgs" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
-	},
+"qgO" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/building/water_treatment_one/garage)
-"qgA" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
+/area/desert_dam/building/cafeteria/loading)
+"qgV" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
 	},
-/area/desert_dam/building/security/northern_hallway)
+/area/desert_dam/exterior/valley/valley_crashsite)
 "qho" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_8"
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_medical_south)
-"qhy" = (
+"qhw" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"qhz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating{
+	icon_state = "warnplate"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
+"qhT" = (
 /obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/interior/caves/central_caves)
+"qic" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_crashsite)
-"qic" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal10"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/south_valley_dam)
-"qie" = (
-/obj/machinery/light,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/cafeteria/cafeteria)
 "qix" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
@@ -66001,27 +66065,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/desert_dam/building/medical/break_room)
-"qiT" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 9
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
-"qjq" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/building/substation/southwest)
-"qjM" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/west_wing_hallway)
 "qjT" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/donkpocket,
@@ -66035,12 +66078,6 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating,
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
-"qkl" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/desert_dam/interior/dam_interior/south_tunnel)
 "qkJ" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
@@ -66048,16 +66085,6 @@
 /obj/item/stack/sheet/wood,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
-"qkP" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement1"
-	},
-/area/desert_dam/exterior/valley/valley_wilderness)
-"qkW" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_wilderness)
 "qkY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -66066,24 +66093,16 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/north_wing_hallway)
-"qlg" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached4"
-	},
-/area/desert_dam/exterior/valley/valley_labs)
 "qlr" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"qlP" = (
+"qlX" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/valley/valley_telecoms)
+/turf/open/floor/prison,
+/area/desert_dam/building/medical/break_room)
 "qmg" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -66094,12 +66113,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
-"qmC" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/cafeteria/cafeteria)
 "qmG" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/ai_node,
@@ -66121,21 +66134,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
-"qmS" = (
-/obj/effect/decal/cleanable/dirt,
+"qmV" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor{
-	dir = 4;
-	icon_state = "whiteyellowcorner"
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
 	},
-/area/desert_dam/interior/dam_interior/break_room)
-"qmT" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal8"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/south_valley_dam)
+/area/desert_dam/building/medical/virology_isolation)
 "qnk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -66177,15 +66182,6 @@
 	icon_state = "cement_sunbleached11"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
-"qph" = (
-/obj/effect/decal/sandytile,
-/obj/effect/decal/sandytile,
-/obj/effect/decal/sandytile,
-/turf/open/floor{
-	dir = 4;
-	icon_state = "whiteyellowfull"
-	},
-/area/desert_dam/interior/caves/temple)
 "qpt" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 9
@@ -66215,12 +66211,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"qqL" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached14"
-	},
-/area/desert_dam/exterior/valley/valley_labs)
 "qqR" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
@@ -66234,19 +66224,31 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
-"qqV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "whitegreenfull"
+"qqY" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
-/area/desert_dam/interior/east_engineering)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "qre" = (
 /obj/structure/largecrate/supply/explosives/mortar_flare,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/tradeship)
+"qrn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "greencorner"
+	},
+/area/desert_dam/building/telecommunication)
 "qrp" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -66254,13 +66256,6 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
-"qrw" = (
-/obj/structure/flora/desert/grass{
-	icon_state = "lightgrass_11"
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "qrD" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -66268,6 +66263,16 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
+"qrK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/north_tunnel)
+"qsf" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached15"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "qsq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -66278,6 +66283,20 @@
 	icon_state = "cement4"
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
+"qsX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreencorner"
+	},
+/area/desert_dam/building/medical/west_wing_hallway)
+"qtd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 6;
+	icon_state = "darkpurple2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "qtf" = (
 /obj/structure/bed/chair,
 /obj/effect/ai_node,
@@ -66292,6 +66311,10 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/disposals)
+"qtU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/hanger)
 "que" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -66307,15 +66330,22 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/west_tunnel)
-"quM" = (
-/obj/structure/cable,
-/obj/structure/cable,
+"quN" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_medical)
+"quO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached15"
 	},
-/area/desert_dam/building/warehouse/warehouse)
+/area/desert_dam/exterior/valley/valley_civilian)
+"qve" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement1"
+	},
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "qvf" = (
 /obj/structure/platform{
 	dir = 8
@@ -66324,6 +66354,17 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"qvn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_containment)
+"qvp" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/interior/caves/central_caves)
 "qvP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -66336,25 +66377,18 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/medical/virology_wing)
-"qwf" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/interior/dam_interior/workshop)
-"qwm" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/north_wing_hallway)
 "qwp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/south_tunnel)
+"qwA" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal2"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "qwK" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave{
@@ -66370,6 +66404,13 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/north_wing_hallway)
+"qwN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "grimy"
+	},
+/area/desert_dam/building/bar/bar)
 "qwZ" = (
 /obj/structure/bed/chair,
 /obj/effect/landmark/start/job/survivor,
@@ -66394,17 +66435,18 @@
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_labs)
+"qyb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/security/southern_hallway)
 "qyh" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/valley/valley_hydro)
-"qyz" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal2"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_labs)
 "qyD" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/prison,
@@ -66416,6 +66458,14 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/security/staffroom)
+"qyI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_one/control_room)
 "qyL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/effect/ai_node,
@@ -66432,6 +66482,15 @@
 	icon_state = "cement_sunbleached19"
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
+"qzE" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/engine_west_wing)
 "qzH" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -66453,13 +66512,16 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
-"qAG" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_mining)
 "qAI" = (
 /turf/closed/mineral,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"qAW" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_11"
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "qBh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -66478,6 +66540,12 @@
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"qBy" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
+	},
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "qBH" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison{
@@ -66485,10 +66553,12 @@
 	icon_state = "floor_plate"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
-"qBV" = (
+"qBJ" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/desert_dam/exterior/valley/valley_mining)
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "qCr" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -66524,34 +66594,18 @@
 	icon_state = "cement_sunbleached18"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
-"qDi" = (
-/obj/effect/landmark/excavation_site_spawner,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_hydro)
-"qDp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/desert_dam/interior/dam_interior/north_tunnel)
 "qDM" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
-"qED" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
+"qDN" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
 	},
-/area/desert_dam/building/cafeteria/cafeteria)
+/area/desert_dam/exterior/valley/valley_mining)
 "qEJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -66570,14 +66624,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
-"qFb" = (
-/obj/structure/cable,
+"qEW" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 6
 	},
-/area/desert_dam/building/warehouse/loading)
+/area/desert_dam/interior/caves/temple)
 "qFd" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
@@ -66593,10 +66645,6 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/disposals)
-"qFg" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/desert_dam/interior/caves/central_caves)
 "qFh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -66616,6 +66664,34 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/administration/hallway)
+"qFY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached13"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
+"qGm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
+"qGu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_hydro)
+"qGP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 1
+	},
+/area/desert_dam/interior/dam_interior/western_dam_cave)
 "qHn" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_medical_south)
@@ -66667,13 +66743,6 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"qJb" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "darkyellow2"
-	},
-/area/desert_dam/building/substation/southwest)
 "qJc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -66690,14 +66759,6 @@
 "qJq" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/valley/south_valley_dam)
-"qJt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/medical/lobby)
 "qJA" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/interior/dam_interior/western_dam_cave)
@@ -66713,13 +66774,6 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_biology)
-"qKy" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal3"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_labs)
 "qKA" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 1
@@ -66731,24 +66785,23 @@
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/valley_medical_south)
-"qLm" = (
+"qLo" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
-	dir = 1;
-	icon_state = "whitegreen"
+	icon_state = "sterile_white"
 	},
-/area/desert_dam/building/medical/treatment_room)
-"qLs" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 10
-	},
-/area/desert_dam/exterior/valley/valley_hydro)
+/area/desert_dam/building/cafeteria/cafeteria)
 "qLD" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/darkish,
 /area/desert_dam/interior/caves/temple)
+"qLL" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/north_tunnel)
 "qLT" = (
 /obj/structure/showcase{
 	desc = "An ancient, dusty tomb with strange alien writing. It's best not to touch it.";
@@ -66785,22 +66838,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_cargo)
-"qNx" = (
-/obj/effect/decal/cleanable/dirt,
+"qNE" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement3"
+/turf/open/floor/tile/darkish,
+/area/desert_dam/interior/caves/temple)
+"qNG" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
 	},
-/area/desert_dam/interior/dam_interior/northwestern_tunnel)
-"qNC" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"qNV" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/building/warehouse/warehouse)
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/building/warehouse/loading)
 "qOn" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -66819,41 +66870,34 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/emergency_room)
-"qOG" = (
-/obj/effect/ai_node,
+"qOt" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached11"
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
 	},
-/area/desert_dam/exterior/valley/valley_mining)
+/area/desert_dam/interior/lab_northeast/east_lab_workshop)
 "qPe" = (
 /obj/machinery/floodlight/landing,
 /turf/open/floor{
 	icon_state = "asteroidplating"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"qPj" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal9"
-	},
+"qPw" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/south_valley_dam)
-"qPA" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/desert_dam/interior/dam_interior/western_dam_cave)
+"qPx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
 	},
-/area/desert_dam/exterior/valley/valley_labs)
+/area/desert_dam/exterior/valley/valley_mining)
 "qPC" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"qQd" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
-/area/desert_dam/exterior/valley/valley_telecoms)
 "qQe" = (
 /obj/structure/cable,
 /obj/effect/decal/warning_stripes/thin,
@@ -66861,16 +66905,32 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/mono,
 /area/desert_dam/exterior/valley/tradeship)
+"qQf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "qQg" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
-"qQl" = (
+"qQs" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/desert_dam/interior/dam_interior/northeastern_tunnel)
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "floor_plate"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
 "qQG" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -66900,26 +66960,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_security_armory)
-"qSa" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal1"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_wilderness)
-"qSg" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal3"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_civilian)
-"qSo" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 10
-	},
-/area/desert_dam/interior/caves/temple)
 "qSs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -66929,12 +66969,6 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/west_wing_hallway)
-"qSv" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "yellow"
-	},
-/area/desert_dam/building/hydroponics/hydroponics)
 "qSO" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge{
 	dir = 4
@@ -66970,27 +67004,23 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"qTD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/workshop)
 "qTQ" = (
 /obj/structure/fence,
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/cavetodirt,
 /area/desert_dam/interior/caves/east_caves)
-"qTV" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 4
-	},
-/area/desert_dam/interior/caves/central_caves)
 "qTY" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached6"
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
-"qUc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_medical)
 "qUd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/weed_node,
@@ -66998,22 +67028,17 @@
 	icon_state = "cement14"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
-"qUC" = (
-/obj/structure/flora/desert/grass{
-	icon_state = "lightgrass_6"
+"qUl" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal4"
 	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "qUE" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_cargo)
-"qUF" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "qUI" = (
 /obj/structure/platform{
 	dir = 1
@@ -67025,6 +67050,13 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_south)
+"qUL" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/desert_dam/exterior/valley/valley_labs)
 "qVj" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -67102,6 +67134,17 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/river/riverside_east)
+"qYf" = (
+/obj/structure/stairs/cornerdark/seamless,
+/obj/structure/platform_decoration,
+/turf/open/floor/plating,
+/area/desert_dam/interior/lab_northeast/east_lab_containment)
+"qYk" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "qYn" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -67131,6 +67174,11 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/interior/caves/east_caves)
+"qZa" = (
+/obj/structure/table/woodentable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/carpet,
+/area/desert_dam/building/administration/meetingrooom)
 "qZq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -67154,11 +67202,23 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_wilderness)
+"rac" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "raC" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 4
 	},
 /area/desert_dam/exterior/valley/valley_medical_south)
+"raH" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal3"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/south_valley_dam)
 "raL" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -67172,12 +67232,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/detective)
-"rcs" = (
+"rcb" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 8
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
 	},
-/area/desert_dam/exterior/valley/valley_mining)
+/area/desert_dam/exterior/valley/valley_medical)
 "rcY" = (
 /obj/structure/cable,
 /turf/open/floor/prison,
@@ -67188,20 +67248,12 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/river/riverside_south)
-"rdV" = (
-/obj/structure/platform,
+"rdO" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt{
-	dir = 8
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
 	},
-/area/desert_dam/exterior/river/riverside_east)
-"rea" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	dir = 4;
-	icon_state = "whiteyellowfull"
-	},
-/area/desert_dam/building/security/prison)
+/area/desert_dam/building/dorms/restroom)
 "reY" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -67217,18 +67269,20 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/interior/caves/temple)
-"rfs" = (
+"rfr" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/interior/lab_northeast/east_lab_east_entrance)
-"rfE" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
 	},
-/obj/effect/decal/cleanable/dirt,
+/area/desert_dam/building/medical/break_room)
+"rft" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_mining)
+/turf/open/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_entrance)
 "rfQ" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating,
@@ -67255,27 +67309,16 @@
 	dir = 10
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
-"rgK" = (
-/obj/structure/desertdam/decals/loose_sand_overlay,
+"rgI" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/valley/valley_labs)
-"rhc" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_cargo)
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_civilian)
 "rhr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/security/staffroom)
-"ric" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/desert_dam/building/cafeteria/backroom)
 "riy" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge{
 	dir = 4
@@ -67325,23 +67368,14 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/warehouse/breakroom)
-"rjY" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
+"rkf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/shower{
+	pixel_y = 18
 	},
-/area/desert_dam/exterior/valley/valley_medical)
-"rkl" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/interior/dam_interior/western_dam_cave)
-"rkm" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/desert_dam/building/security/prison)
+/turf/open/floor/freezer,
+/area/desert_dam/interior/east_engineering)
 "rko" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -67354,6 +67388,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"rkH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "rlk" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -67386,28 +67426,28 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/valley/tradeship)
-"rlN" = (
-/obj/structure/flora/desert/cactus{
-	icon_state = "cactus_4"
-	},
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "rlU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/desert_dam/building/cafeteria/loading)
-"rlV" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement3"
-	},
-/area/desert_dam/interior/dam_interior/south_tunnel)
 "rmj" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/east_caves)
+"rms" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"rmE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "rmM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -67416,6 +67456,12 @@
 	icon_state = "cement15"
 	},
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
+"rmU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached11"
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "rmX" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -67430,6 +67476,15 @@
 	icon_state = "white"
 	},
 /area/desert_dam/building/lab_northwest/west_lab_xenoflora)
+"rny" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/medical/lobby)
 "rnA" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
@@ -67440,27 +67495,6 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/virology_wing)
-"roA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/primary_tool_storage)
-"roD" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "whiteblue"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_lobby)
 "roU" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/south_tunnel)
@@ -67510,17 +67544,32 @@
 	icon_state = "bluecorner"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
+"rro" = (
+/obj/machinery/light,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitepurple"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "rrw" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/interior/caves/east_caves)
-"rrY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
+"rrL" = (
+/obj/structure/toilet{
+	dir = 8
 	},
-/area/desert_dam/interior/dam_interior/workshop)
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "freezerfloor"
+	},
+/area/desert_dam/building/hydroponics/hydroponics_breakroom)
+"rsc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "freezerfloor"
+	},
+/area/desert_dam/building/cafeteria/cold_room)
 "rsn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -67529,6 +67578,36 @@
 	icon_state = "vault"
 	},
 /area/desert_dam/building/security/prison)
+"rsu" = (
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 4;
+	id = "dam_checkpoint_north";
+	name = "\improper Checkpoint Lock"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_west_entrance)
+"rsx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement1"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
+"rsD" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal3"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
+"rsI" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "rsY" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal2"
@@ -67536,15 +67615,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"rtn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/engine_room)
 "rtA" = (
 /obj/effect/ai_node,
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/riverside_central_south)
-"rtL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/interior/east_engineering)
 "rtX" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal3"
@@ -67556,14 +67634,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/west_tunnel)
-"rvB" = (
-/obj/structure/flora/desert/cactus{
-	icon_state = "cactus_8"
-	},
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "rvL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -67587,35 +67657,64 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/catwalk,
 /area/desert_dam/exterior/river/riverside_south)
-"rwW" = (
+"rxj" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "cement_sunbleached9"
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
 	},
-/area/desert_dam/exterior/valley/valley_telecoms)
+/area/desert_dam/exterior/valley/valley_crashsite)
 "rxm" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_cargo)
+"rxn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/medical/west_wing_hallway)
+"rxy" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal2"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/south_valley_dam)
+"rxE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/bar/backroom)
 "rxL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/workshop)
-"rxO" = (
+"rxN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor{
-	dir = 5;
-	icon_state = "vault"
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
 	},
-/area/desert_dam/building/security/prison)
+/area/desert_dam/interior/dam_interior/hanger)
 "rxU" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock{
 	dir = 4
 	},
 /area/desert_dam/interior/dam_interior/western_dam_cave)
+"ryq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreencorner"
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
 "ryv" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -67670,11 +67769,6 @@
 	icon_state = "cement1"
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
-"rzl" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/valley_wilderness)
 "rzB" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_9"
@@ -67696,10 +67790,30 @@
 	icon_state = "white"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_lobby)
-"rAC" = (
+"rAi" = (
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"rAn" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal2"
+	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_cargo)
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/river/riverside_east)
+"rAv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "rAM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -67715,20 +67829,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
-"rAT" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal6"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_labs)
-"rAW" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/interior/dam_interior/west_tunnel)
 "rAX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -67751,6 +67851,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/cafeteria/loading)
+"rBy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/lobby)
 "rBR" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -67768,6 +67877,12 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
+"rCk" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement13"
+	},
+/area/desert_dam/interior/dam_interior/south_tunnel)
 "rCp" = (
 /obj/structure/platform,
 /obj/effect/decal/cleanable/dirt,
@@ -67800,36 +67915,18 @@
 	icon_state = "cement4"
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
-"rDd" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached11"
-	},
-/area/desert_dam/exterior/valley/valley_civilian)
 "rDe" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_mining)
-"rDw" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "cement_sunbleached2"
-	},
-/area/desert_dam/exterior/valley/valley_medical)
-"rEa" = (
+"rEd" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
-	icon_state = "darkred2"
+	icon_state = "whitepurplecorner"
 	},
-/area/desert_dam/building/security/southern_hallway)
-"rEb" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement4"
-	},
-/area/desert_dam/interior/dam_interior/northwestern_tunnel)
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "rEm" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -67844,12 +67941,33 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/south_tunnel)
+"rEs" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/security/prison)
 "rEH" = (
 /obj/structure/table,
 /turf/open/floor{
 	icon_state = "whiteyellow"
 	},
 /area/desert_dam/building/water_treatment_one/breakroom)
+"rET" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached13"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
+"rFa" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "cell_stripe"
+	},
+/area/desert_dam/building/warehouse/warehouse)
 "rFg" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -67868,6 +67986,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"rFX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached10"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "rGw" = (
 /obj/machinery/door/airlock/mainship/maint{
 	name = "\improper Atmospheric Storage"
@@ -67882,6 +68006,10 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
+"rGV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/substation/west)
 "rGX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -67923,13 +68051,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"rHB" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/hydroponics/hydroponics_breakroom)
 "rHN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -67952,19 +68073,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"rIa" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 10
-	},
-/area/desert_dam/interior/caves/central_caves)
-"rIv" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal4"
-	},
+"rIx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_wilderness)
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_one/hallway)
 "rJp" = (
 /obj/machinery/door/airlock/mainship/engineering,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
@@ -67976,6 +68093,13 @@
 "rJC" = (
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/building/water_treatment_one)
+"rJF" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached11"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "rJK" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal1"
@@ -68000,16 +68124,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_cargo)
+"rKX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/warehouse/breakroom)
 "rLs" = (
 /turf/open/ground/river/desertdam/clean/shallow,
 /area/desert_dam/exterior/river_mouth/southern)
-"rLu" = (
-/obj/structure/flora/desert/grass{
-	icon_state = "lightgrass_4"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/bar_valley_dam)
 "rLz" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/interior/dam_interior/west_tunnel)
@@ -68061,13 +68184,6 @@
 "rOw" = (
 /turf/open/floor/wood/broken,
 /area/desert_dam/interior/caves/central_caves)
-"rOJ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating{
-	dir = 8;
-	icon_state = "warnplate"
-	},
-/area/desert_dam/building/substation/northeast)
 "rOW" = (
 /obj/structure/cable,
 /turf/closed/mineral,
@@ -68083,10 +68199,6 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
-"rPc" = (
-/obj/machinery/miner/damaged/platinum,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/desert_dam/interior/caves/temple)
 "rPm" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
@@ -68098,12 +68210,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
-"rPq" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached14"
-	},
-/area/desert_dam/exterior/valley/valley_mining)
 "rPE" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
@@ -68111,14 +68217,6 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
-"rPY" = (
-/obj/structure/closet/secure_closet/scientist,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "darkpurple2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "rQo" = (
 /obj/machinery/door/poddoor/shutters/mainship/open{
 	id = null;
@@ -68160,25 +68258,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/southern_hallway)
-"rRc" = (
-/obj/structure/desertdam/decals/loose_sand_overlay{
-	dir = 9
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/valley/valley_labs)
-"rRF" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached11"
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
-"rRT" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
-/area/desert_dam/building/bar/bar)
 "rSc" = (
 /obj/structure/platform{
 	dir = 1
@@ -68200,14 +68279,6 @@
 	icon_state = "cement3"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
-"rSO" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/desert_dam/building/substation/northeast)
 "rSV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
@@ -68221,31 +68292,36 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"rTi" = (
+"rTg" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
 	},
-/area/desert_dam/exterior/valley/valley_telecoms)
-"rTD" = (
+/area/desert_dam/exterior/valley/valley_wilderness)
+"rTk" = (
+/obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "dark"
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
 	},
-/area/desert_dam/building/church)
+/area/desert_dam/building/hydroponics/hydroponics)
 "rTI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/desert_dam/building/administration/office)
-"rTJ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
+"rTN" = (
+/obj/structure/desertdam/decals/loose_sand_overlay{
+	dir = 9
 	},
-/area/desert_dam/exterior/landing/landing_pad_three_external)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "rTW" = (
 /obj/structure/window/reinforced/toughened{
 	dir = 8
@@ -68273,13 +68349,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
-"rVG" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_medical)
 "rVH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68292,6 +68361,12 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
+"rVV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "rWa" = (
 /obj/machinery/camera/autoname/lz_camera,
 /turf/open/floor/plating,
@@ -68299,18 +68374,12 @@
 "rWp" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner,
 /area/desert_dam/exterior/river_mouth/southern)
-"rWy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
+"rWz" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
 	},
-/area/desert_dam/building/administration/hallway)
+/area/desert_dam/exterior/valley/valley_wilderness)
 "rWV" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison{
@@ -68318,6 +68387,13 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/virology_wing)
+"rXd" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal3"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "rXh" = (
 /obj/machinery/floodlight/landing,
 /obj/structure/desertdam/decals/loose_sand_overlay{
@@ -68332,6 +68408,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/north_tunnel)
+"rXu" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal1"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "rXC" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
@@ -68344,6 +68427,14 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"rXR" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "rXX" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -68359,32 +68450,21 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/staffroom)
-"rYj" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
-/area/desert_dam/building/administration/office)
 "rYr" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 5
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"rYL" = (
-/obj/effect/decal/cleanable/dirt,
+"rYx" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement1"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached13"
 	},
-/area/desert_dam/interior/dam_interior/central_tunnel)
+/area/desert_dam/exterior/valley/north_valley_dam)
 "rYO" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/mainship/mono,
 /area/desert_dam/exterior/valley/tradeship)
-"rYS" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
-	},
-/area/desert_dam/exterior/valley/south_valley_dam)
 "rYT" = (
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison{
@@ -68397,17 +68477,6 @@
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"rZo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/security/southern_hallway)
 "rZP" = (
 /obj/structure/largecrate/random,
 /obj/effect/ai_node,
@@ -68416,13 +68485,6 @@
 	icon_state = "floor_marked"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_loading)
-"rZT" = (
-/obj/structure/toilet,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/building/warehouse/breakroom)
 "rZU" = (
 /obj/structure/desertdam/decals/road/stop{
 	icon_state = "stop_decal5"
@@ -68430,6 +68492,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"rZX" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal10"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "rZY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -68438,6 +68507,19 @@
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/security/southern_hallway)
+"sal" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
+	},
+/area/desert_dam/interior/caves/central_caves)
+"sav" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "saT" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -68452,12 +68534,28 @@
 	icon_state = "cement_sunbleached11"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"sbf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/hangar_storage)
 "sbp" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
+"sbB" = (
+/obj/structure/desertdam/decals/loose_sand_overlay,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "sbP" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -68471,6 +68569,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"scW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "sdm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -68478,23 +68582,28 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_northwing)
+"sdt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/lobby)
 "sdu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
+"sdC" = (
+/obj/structure/bed/chair,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/security/courtroom)
 "sdX" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 1
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"sen" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "whitegreencorner"
-	},
-/area/desert_dam/building/medical/east_wing_hallway)
 "seD" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 6
@@ -68507,10 +68616,23 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/west_tunnel)
+"seT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating{
+	dir = 9;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "sff" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
 /area/desert_dam/exterior/valley/valley_labs)
+"sfk" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached9"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "sfs" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -68520,11 +68642,10 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/treatment_room)
-"sfE" = (
+"sfv" = (
 /obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/interior/caves/central_caves)
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/area/desert_dam/exterior/valley/valley_telecoms)
 "sfP" = (
 /obj/structure/toilet{
 	dir = 1
@@ -68536,6 +68657,25 @@
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"sfQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
+"sfT" = (
+/obj/structure/platform,
+/obj/structure/flora/rock/pile/alt3,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"sfW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "sgc" = (
 /obj/effect/ai_node,
 /turf/open/ground/river/desertdam/clean/shallow,
@@ -68570,15 +68710,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_security_armory)
-"sgG" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "freezerfloor"
-	},
-/area/desert_dam/building/hydroponics/hydroponics_breakroom)
 "sgQ" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal3"
@@ -68643,6 +68774,16 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"shZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
+"siu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/building/cafeteria/backroom)
 "siy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -68658,10 +68799,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"siS" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_medical_south)
 "ska" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -68681,6 +68818,13 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
+"skm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitepurple"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "skr" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -68697,13 +68841,12 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/lobby)
-"slb" = (
+"sln" = (
 /obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 1
+	dir = 6
 	},
-/area/desert_dam/exterior/valley/valley_crashsite)
+/area/desert_dam/exterior/valley/valley_medical_south)
 "slB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -68722,13 +68865,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
-"slU" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal4"
+"slS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_labs)
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
 "slX" = (
 /obj/structure/bed/alien{
 	color = "#aba9a9"
@@ -68768,12 +68915,21 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"smw" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/south_tunnel)
 "smY" = (
 /obj/structure/flora/desert/grass/heavy{
 	icon_state = "heavygrass_6"
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_labs)
+"snq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "snr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -68820,16 +68976,6 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
-"soj" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "whitepurple"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "soE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -68839,13 +68985,13 @@
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/water_treatment_two/equipment)
-"soL" = (
-/obj/structure/flora/desert/grass{
-	icon_state = "lightgrass_2"
-	},
+"soH" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/bar_valley_dam)
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/desert_dam/building/dorms/hallway_westwing)
 "soS" = (
 /obj/structure/stairs/seamless/platform{
 	dir = 1
@@ -68867,13 +69013,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
-"spM" = (
-/obj/structure/flora/desert/grass{
-	icon_state = "lightgrass_5"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/bar_valley_dam)
 "sqe" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -68893,6 +69032,10 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_medical)
+"sqI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/building/medical/garage)
 "sqQ" = (
 /obj/machinery/landinglight/ds2{
 	dir = 4
@@ -68917,19 +69060,17 @@
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
-"srP" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_crashsite)
-"srZ" = (
-/obj/structure/toilet{
-	dir = 4
-	},
+"srn" = (
+/obj/structure/flora/pottedplant,
 /obj/effect/landmark/weed_node,
 /turf/open/floor{
-	icon_state = "freezerfloor"
+	icon_state = "whiteblue"
 	},
-/area/desert_dam/building/security/prison)
+/area/desert_dam/interior/lab_northeast/east_lab_lobby)
+"srx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/bar/backroom)
 "ssn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68955,22 +69096,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_one/garage)
-"sti" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	dir = 1;
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/lab_northwest/west_lab_xenoflora)
-"stE" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 9
-	},
-/area/desert_dam/exterior/valley/valley_wilderness)
 "stQ" = (
 /obj/effect/decal/medical_decals{
 	icon_state = "docstriping"
@@ -69003,6 +69128,13 @@
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_lobby)
+"suY" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal4"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/south_valley_dam)
 "svo" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -69027,12 +69159,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/valley/south_valley_dam)
-"svN" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/grate{
-	icon_state = "catwalk-255"
-	},
-/area/desert_dam/exterior/river/riverside_central_north)
 "svV" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -69049,19 +69175,13 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_workshop)
-"swM" = (
-/obj/structure/flora/desert/grass{
-	icon_state = "lightgrass_2"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/landing/landing_pad_three_external)
-"swQ" = (
+"swT" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
-	icon_state = "darkpurple2"
+	dir = 1;
+	icon_state = "whitepurplecorner"
 	},
-/area/desert_dam/interior/lab_northeast/east_lab_RND)
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "swV" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -69102,12 +69222,6 @@
 	icon_state = "asteroidfloor"
 	},
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
-"syc" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached14"
-	},
-/area/desert_dam/exterior/valley/valley_telecoms)
 "syi" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -69125,13 +69239,6 @@
 	dir = 5
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"syL" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating{
-	dir = 10;
-	icon_state = "warnplate"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "syM" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
@@ -69142,6 +69249,20 @@
 	dir = 9
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"szi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "szv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -69157,14 +69278,6 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
-"sAb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "darkred2"
-	},
-/area/desert_dam/building/security/southern_hallway)
 "sAm" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt{
@@ -69188,37 +69301,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_cargo)
-"sAH" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
-	},
-/area/desert_dam/exterior/valley/south_valley_dam)
-"sAW" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "E"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/building/hydroponics/hydroponics_loading)
-"sBv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "cement_sunbleached9"
-	},
-/area/desert_dam/exterior/valley/valley_northwest)
-"sBK" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_hydro)
-"sBX" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "darkpurple2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "sCa" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
@@ -69241,6 +69323,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/valley/valley_telecoms)
+"sCN" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "sDf" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/prison,
@@ -69251,17 +69339,23 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"sDJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "floor_plate"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
 "sEm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/desert_dam/building/bar/bar)
-"sFc" = (
+"sEw" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "darkyellow2"
-	},
-/area/desert_dam/building/substation/northeast)
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "sFe" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -69269,21 +69363,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
-"sFw" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "darkpurple2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_biology)
-"sFG" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/hanger)
 "sFH" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -69311,43 +69390,56 @@
 	icon_state = "yellow"
 	},
 /area/desert_dam/building/hydroponics/hydroponics)
+"sGm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "sGH" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_hydro)
-"sGI" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/medical/virology_isolation)
 "sGQ" = (
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 10
 	},
 /area/desert_dam/interior/caves/temple)
+"sGW" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/desert_dam/interior/caves/central_caves)
+"sGX" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/interior/caves/central_caves)
+"sHb" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal12"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "sHc" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
 "sHr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/interior/dam_interior/tech_storage)
-"sHG" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/bcircuit,
-/area/desert_dam/interior/dam_interior/engine_room)
-"sHI" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "whitepurple"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "sHL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -69357,40 +69449,16 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/lobby)
-"sIf" = (
+"sIp" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 10
+/turf/open/floor{
+	icon_state = "dark2"
 	},
-/area/desert_dam/exterior/valley/valley_cargo)
-"sIA" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached11"
-	},
-/area/desert_dam/exterior/valley/valley_hydro)
-"sIB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "kitchen"
-	},
-/area/desert_dam/building/cafeteria/cafeteria)
+/area/desert_dam/interior/lab_northeast/east_lab_west_entrance)
 "sIE" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/east_caves)
-"sIL" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "yellow"
-	},
-/area/desert_dam/building/hydroponics/hydroponics)
 "sIY" = (
 /obj/effect/landmark/weed_node,
 /obj/structure/cable,
@@ -69402,27 +69470,57 @@
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+"sJn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkred2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_security_armory)
+"sJH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "greencorner"
+	},
+/area/desert_dam/building/telecommunication)
+"sJM" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/tile/darkish,
+/area/desert_dam/interior/caves/temple)
 "sJS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/prison,
 /area/desert_dam/interior/lab_northeast/east_lab_workshop)
+"sJV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/interior/lab_northeast/east_lab_maintenence)
 "sJZ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/wall/r_wall,
 /area/desert_dam/exterior/rock)
+"sKb" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/dorms/restroom)
+"sKh" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_medical_south)
 "sKl" = (
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 9
 	},
 /area/desert_dam/interior/dam_interior/western_dam_cave)
-"sKy" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating{
-	icon_state = "warnplate"
-	},
-/area/desert_dam/exterior/valley/valley_telecoms)
 "sKJ" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -69442,12 +69540,29 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
-"sLQ" = (
+"sLB" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkbrown2"
 	},
-/area/desert_dam/exterior/valley/valley_civilian)
+/area/desert_dam/building/warehouse/warehouse)
+"sLF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "kitchen"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
+"sMs" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_one/hallway)
 "sMu" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
@@ -69463,23 +69578,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
-"sMP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/engine_east_wing)
-"sMR" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/desert_dam/exterior/valley/bar_valley_dam)
 "sNj" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
@@ -69495,14 +69593,30 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/building/substation/northeast)
-"sOL" = (
+"sOA" = (
+/obj/structure/cable,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/water_treatment_two/hallway)
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
+"sOF" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/building/cafeteria/loading)
 "sOR" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/dam_interior/north_tunnel)
+"sOS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitepurplecorner"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "sPA" = (
 /obj/structure/platform{
 	dir = 1
@@ -69514,12 +69628,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/north_tunnel_entrance)
-"sPY" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_civilian)
 "sQb" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -69536,25 +69644,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
-"sQv" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/desert_dam/exterior/valley/valley_crashsite)
-"sRa" = (
+"sQR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "whitegreenfull"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
 	},
-/area/desert_dam/building/medical/emergency_room)
-"sRr" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/south_valley_dam)
+/area/desert_dam/interior/dam_interior/north_tunnel)
 "sRu" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -69590,20 +69686,6 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
-"sSA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/lobby)
-"sSL" = (
-/obj/structure/flora/desert/grass/heavy{
-	icon_state = "heavygrass_3"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_cargo)
 "sTc" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_6"
@@ -69625,12 +69707,11 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
-"sTE" = (
+"sUh" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/grate{
-	icon_state = "catwalk-255"
-	},
-/area/desert_dam/exterior/river/riverside_central_south)
+/turf/open/floor/wood,
+/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "sUA" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
@@ -69647,6 +69728,12 @@
 "sVq" = (
 /turf/closed/mineral/indestructible,
 /area/desert_dam/exterior/rock)
+"sVz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
 "sWv" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -69670,12 +69757,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/cafeteria/loading)
-"sWV" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "darkred2"
-	},
-/area/desert_dam/building/security/deathrow)
 "sXh" = (
 /obj/effect/landmark/start/job/xenomorph,
 /obj/effect/landmark/start/job/xenomorph,
@@ -69707,10 +69788,6 @@
 "sYf" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/valley/valley_medical_south)
-"sYj" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_civilian)
 "sYo" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
@@ -69740,20 +69817,27 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"sZx" = (
+"sZz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "sterile_white"
 	},
-/area/desert_dam/interior/dam_interior/northeastern_tunnel)
+/area/desert_dam/building/cafeteria/cafeteria)
 "sZM" = (
 /obj/structure/flora/rock{
 	name = "rock"
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_civilian)
+"sZS" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_labs)
 "sZV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -69770,10 +69854,6 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/interior/caves/central_caves)
-"tad" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/desert_dam/exterior/valley/valley_hydro)
 "tai" = (
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -69786,13 +69866,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"taq" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/bar/bar_restroom)
 "tat" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/desertdam/decals/road/edge{
@@ -69802,13 +69875,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
-"tau" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "grimy"
-	},
-/area/desert_dam/building/bar/bar)
 "taC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -69830,22 +69896,30 @@
 	icon_state = "cement3"
 	},
 /area/desert_dam/interior/dam_interior/south_tunnel)
-"taQ" = (
-/obj/structure/morgue{
-	dir = 8
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/building/medical/morgue)
 "tbc" = (
 /obj/machinery/landinglight/ds2/delaytwo,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"tbi" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
+"tbT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached11"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "tcj" = (
 /obj/structure/cable,
 /turf/closed/wall/wood,
@@ -69889,6 +69963,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
+"tcY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/shuttle/dropship{
+	icon_state = "rasputin3"
+	},
+/area/shuttle/tri_trans2/alpha)
 "tdf" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -69919,14 +69999,6 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
-"teg" = (
-/obj/structure/table,
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	dir = 4;
-	icon_state = "whiteyellowfull"
-	},
-/area/desert_dam/building/security/prison)
 "teq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/ai_node,
@@ -69935,27 +70007,26 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
-"teC" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
+"tew" = (
+/obj/structure/bed,
+/obj/machinery/light{
+	dir = 1
 	},
-/area/desert_dam/building/bar/bar_restroom)
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/desert_dam/building/dorms/hallway_northwing)
 "teR" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/interior/caves/temple)
-"tfo" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
+"teZ" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_mining)
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "tfs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -69964,6 +70035,20 @@
 	icon_state = "cement1"
 	},
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
+"tfQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/auxilary_tool_storage)
+"tgH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "thd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -69983,12 +70068,15 @@
 /obj/item/stack/sheet/wood,
 /turf/open/floor/plating/catwalk,
 /area/desert_dam/exterior/river/riverside_south)
-"thF" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached18"
+"thG" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
-/area/desert_dam/exterior/valley/valley_labs)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/warehouse/warehouse)
 "tib" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal8"
@@ -70002,13 +70090,12 @@
 	icon_state = "dark"
 	},
 /area/desert_dam/building/church)
-"tio" = (
-/obj/effect/decal/cleanable/dirt,
+"tiN" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
 	},
-/area/desert_dam/interior/lab_northeast/east_lab_workshop)
+/area/desert_dam/exterior/valley/valley_telecoms)
 "tiR" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -70053,19 +70140,18 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/warehouse/loading)
-"tkX" = (
+"tkY" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
-	icon_state = "darkredfull2"
+	icon_state = "bright_clean2"
 	},
-/area/desert_dam/building/security/deathrow)
-"tlh" = (
-/obj/structure/desertdam/decals/road/stop{
-	icon_state = "stop_decal5"
-	},
+/area/desert_dam/building/dorms/restroom)
+"tll" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_civilian)
+/turf/open/floor/prison,
+/area/desert_dam/interior/east_engineering)
 "tlu" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -70074,6 +70160,13 @@
 	icon_state = "cell_stripe"
 	},
 /area/desert_dam/building/warehouse/loading)
+"tma" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal7"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/south_valley_dam)
 "tmh" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -70116,21 +70209,18 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
-"tnx" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/desert_dam/exterior/landing/landing_pad_three)
-"tnz" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "darkyellow2"
-	},
-/area/desert_dam/interior/dam_interior/smes_backup)
 "tnH" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/execution_chamber)
+"tnP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whiteyellow"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_lobby)
 "tnS" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal1"
@@ -70153,10 +70243,6 @@
 	icon_state = "whiteblue"
 	},
 /area/desert_dam/building/medical/medsecure)
-"toM" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/interior/dam_interior/south_tunnel_entrance)
 "toP" = (
 /obj/structure/flora/desert/grass/heavy{
 	icon_state = "heavygrass_3"
@@ -70164,13 +70250,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/central_caves)
-"toU" = (
-/obj/effect/decal/cleanable/dirt,
+"toT" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "freezerfloor"
+/turf/open/floor/prison{
+	icon_state = "whitepurple"
 	},
-/area/desert_dam/building/cafeteria/cold_room)
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "tpf" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 2;
@@ -70202,19 +70287,6 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/exterior/valley/valley_cargo)
-"tqt" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "darkyellow2"
-	},
-/area/desert_dam/interior/dam_interior/engine_west_wing)
-"tqu" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating{
-	icon_state = "warnplate"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "tqQ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -70227,18 +70299,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/desert_dam/building/cafeteria/backroom)
-"trA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "trV" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -70289,6 +70349,13 @@
 	dir = 6
 	},
 /area/desert_dam/interior/caves/east_caves)
+"tsU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "ttd" = (
 /obj/machinery/light,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -70302,6 +70369,14 @@
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/security/southern_hallway)
+"ttC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/desert_dam/building/security/prison)
 "ttR" = (
 /obj/effect/ai_node,
 /turf/open/floor{
@@ -70338,30 +70413,24 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-"tuk" = (
+"tuM" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 5
+	dir = 1
 	},
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/valley/valley_hydro)
 "tuO" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 5
 	},
 /area/desert_dam/interior/dam_interior/western_dam_cave)
-"tvb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+"tuV" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor{
-	dir = 8;
-	icon_state = "darkbrown2"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement1"
 	},
-/area/desert_dam/interior/dam_interior/disposals)
+/area/desert_dam/interior/dam_interior/south_tunnel)
 "tvf" = (
 /obj/structure/platform{
 	dir = 1
@@ -70371,25 +70440,10 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
-"tvD" = (
-/obj/structure/platform,
-/obj/structure/platform{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 8
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
 "tvM" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 4
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
-"twd" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 10
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "twm" = (
@@ -70427,12 +70481,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
-"twX" = (
+"twZ" = (
 /obj/effect/landmark/weed_node,
-/turf/open/shuttle/dropship{
-	icon_state = "rasputin3"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement3"
 	},
-/area/shuttle/tri_trans2/alpha)
+/area/desert_dam/interior/dam_interior/south_tunnel)
 "txc" = (
 /obj/structure/platform_decoration{
 	dir = 4
@@ -70449,34 +70503,39 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"txl" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 4
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
-"txx" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "white"
-	},
-/area/desert_dam/exterior/valley/valley_telecoms)
 "txF" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"txG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/south_tunnel)
 "txN" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_northwest)
+"txU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement3"
+	},
+/area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "tyc" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"tye" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal9"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical_south)
 "tyO" = (
 /obj/structure/platform{
 	dir = 8
@@ -70511,6 +70570,13 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
+"tzT" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_2"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "tAs" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached18"
@@ -70522,13 +70588,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
-"tAN" = (
-/obj/structure/desertdam/decals/road/stop{
-	icon_state = "stop_decal5"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_medical)
 "tBa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -70539,11 +70598,14 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/building/medical/emergency_room)
-"tBl" = (
+"tBo" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/interior/caves/central_caves)
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull"
+	},
+/area/desert_dam/interior/east_engineering)
 "tBs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -70587,22 +70649,26 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/lobby)
-"tCI" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement1"
-	},
-/area/desert_dam/interior/dam_interior/south_tunnel)
-"tDG" = (
+"tCP" = (
+/obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
-/area/desert_dam/building/security/prison)
+/area/desert_dam/building/hydroponics/hydroponics_loading)
 "tDH" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
+"tDJ" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"tEk" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/interior/caves/central_caves)
 "tEz" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/ai_node,
@@ -70661,6 +70727,17 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
+"tGm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/north_tunnel_entrance)
+"tGo" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/treatment_room)
 "tGK" = (
 /obj/structure/flora/bush,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -70678,11 +70755,13 @@
 	icon_state = "cement_sunbleached9"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"tIh" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
+"tHL" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "tIq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -70699,12 +70778,6 @@
 	icon_state = "cement14"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
-"tIT" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/valley/valley_wilderness)
 "tIU" = (
 /obj/structure/table/mainship,
 /obj/effect/spawner/random/toolbox,
@@ -70744,13 +70817,14 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_civilian)
-"tKh" = (
+"tKs" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 8
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
 	},
-/area/desert_dam/exterior/valley/valley_crashsite)
+/area/desert_dam/building/hydroponics/hydroponics)
 "tKB" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -70766,13 +70840,6 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/security/staffroom)
-"tKO" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "green"
-	},
-/area/desert_dam/building/dorms/hallway_westwing)
 "tLj" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -70797,12 +70864,6 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_east)
-"tLL" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "cement_sunbleached2"
-	},
-/area/desert_dam/exterior/valley/valley_medical_south)
 "tLN" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -70813,11 +70874,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/hanger)
-"tMA" = (
-/obj/machinery/pipedispenser,
+"tMN" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/interior/east_engineering)
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 4
+	},
+/area/desert_dam/interior/dam_interior/western_dam_cave)
 "tMX" = (
 /obj/machinery/door/poddoor/mainship/open{
 	dir = 4;
@@ -70853,6 +70915,26 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_northwest)
+"tOQ" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
+	},
+/area/desert_dam/building/security/evidence)
+"tPd" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
+"tPh" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "tPi" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison{
@@ -70886,10 +70968,16 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"tQz" = (
+"tQF" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/desert_dam/interior/dam_interior/north_tunnel)
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/desert_dam/exterior/valley/valley_hydro)
+"tRc" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "tRn" = (
 /obj/structure/flora/desert/cactus{
 	icon_state = "cactus_4"
@@ -70901,10 +70989,6 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/landing/landing_pad_one)
-"tRN" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/hydroponics/hydroponics_loading)
 "tRQ" = (
 /obj/structure/desertdam/decals/loose_sand_overlay,
 /obj/effect/ai_node,
@@ -70928,6 +71012,12 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/west_tunnel)
+"tSq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "tSG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -70979,26 +71069,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/alt,
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
-"tUx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "whitegreencorner"
-	},
-/area/desert_dam/building/medical/west_wing_hallway)
 "tUF" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
 	},
 /area/desert_dam/exterior/valley/bar_valley_dam)
-"tUN" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/building/hydroponics/hydroponics)
 "tUS" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -71009,12 +71084,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
-"tUZ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
-	},
-/area/desert_dam/exterior/valley/valley_mining)
 "tVs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -71051,12 +71120,19 @@
 	icon_state = "kitchen"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
-"tXG" = (
+"tXA" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached1"
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkredcorners2"
 	},
-/area/desert_dam/exterior/valley/valley_medical)
+/area/desert_dam/building/security/southern_hallway)
+"tXB" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/desert_dam/building/medical/chemistry)
 "tXJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -71120,20 +71196,12 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_south)
-"uac" = (
-/obj/structure/platform{
+"tZY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
 	dir = 1
 	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_telecoms)
-"uaw" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "blue"
-	},
-/area/desert_dam/building/administration/hallway)
+/area/desert_dam/exterior/valley/valley_crashsite)
 "uax" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -71175,16 +71243,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
-"ubd" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_plate"
-	},
-/area/desert_dam/interior/dam_interior/hanger)
 "ubh" = (
 /obj/machinery/light{
 	dir = 8
@@ -71196,20 +71254,14 @@
 /obj/item/tool/hand_labeler,
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"ubq" = (
+"ubj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
-"ubK" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_medical)
 "ubV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/mineral,
@@ -71250,10 +71302,23 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
+"udC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
 "uee" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall{
 	name = "reinforced metal wall"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"uek" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "uet" = (
@@ -71284,12 +71349,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/courtroom)
-"ufK" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 10
-	},
-/area/desert_dam/exterior/valley/valley_telecoms)
 "ufL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -71314,18 +71373,12 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/tradeship)
-"ugs" = (
+"uhy" = (
 /obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 5
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
-"uht" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "wood"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "uhI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -71359,6 +71412,12 @@
 	},
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/hanger)
+"ujd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "ujl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -71370,6 +71429,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics)
+"ujL" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_cargo)
 "ujO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -71380,6 +71446,20 @@
 	icon_state = "warning"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+"ukb" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/valley_cargo)
+"ukq" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
 "ukB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -71391,6 +71471,16 @@
 	icon_state = "cement_sunbleached2"
 	},
 /area/desert_dam/exterior/valley/valley_cargo)
+"ull" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/control_room)
+"ume" = (
+/obj/structure/flora/tree/joshua,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "uml" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -71416,23 +71506,13 @@
 	icon_state = "kitchen"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
-"umD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_plate"
+"umK" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal7"
 	},
-/area/desert_dam/interior/dam_interior/hanger)
-"umZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/lobby)
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "unt" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/mainship/mono,
@@ -71469,12 +71549,13 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"upU" = (
+"uqb" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 5
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
 	},
-/area/desert_dam/exterior/landing/landing_pad_three_external)
+/area/desert_dam/building/substation/southwest)
 "uqe" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -71482,6 +71563,10 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/bar/bar_restroom)
+"uqk" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "uqm" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/prison{
@@ -71493,25 +71578,25 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_crashsite)
-"uqF" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 10
+"uqy" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached11"
 	},
-/area/desert_dam/exterior/valley/valley_crashsite)
+/area/desert_dam/exterior/valley/valley_mining)
 "uqK" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"urb" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating{
-	dir = 1;
-	icon_state = "warnplate"
+"ure" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt{
+	dir = 1
 	},
-/area/desert_dam/exterior/valley/valley_crashsite)
+/area/desert_dam/exterior/river/riverside_central_north)
 "urw" = (
 /obj/structure/desertdam/decals/loose_sand_overlay{
 	dir = 9
@@ -71520,12 +71605,6 @@
 	icon_state = "cement_sunbleached2"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"urz" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 6
-	},
-/area/desert_dam/interior/caves/central_caves)
 "urD" = (
 /obj/machinery/door/airlock/mainship/security/glass{
 	name = "\improper Security Armoury"
@@ -71538,6 +71617,16 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_security_armory)
+"urH" = (
+/obj/machinery/door/airlock/mainship/generic{
+	dir = 2;
+	name = "\improper Toilet Unit"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "urU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -71559,10 +71648,6 @@
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/valley/valley_cargo)
-"utd" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_medical_south)
 "ute" = (
 /obj/structure/desertdam/decals/road/stop{
 	icon_state = "stop_decal5"
@@ -71584,14 +71669,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
-"utA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached11"
-	},
-/area/desert_dam/exterior/valley/valley_mining)
 "utB" = (
 /obj/structure/flora/desert/cactus/multiple{
 	icon_state = "cacti_10"
@@ -71607,6 +71684,17 @@
 /obj/structure/fence,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"utU" = (
+/obj/machinery/landinglight/ds2/delaythree,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
+"uuh" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/security/courtroom)
 "uuq" = (
 /obj/docking_port/stationary/marine_dropship/lz1,
 /turf/open/floor/plating,
@@ -71642,6 +71730,11 @@
 	dir = 6
 	},
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
+"uvB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "uvP" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -71650,13 +71743,6 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/interior/lab_northeast/east_lab_RND)
-"uwd" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "white"
-	},
-/area/desert_dam/building/lab_northwest/west_lab_xenoflora)
 "uwC" = (
 /obj/machinery/computer/nuke_disk_generator/green,
 /obj/machinery/light,
@@ -71708,17 +71794,20 @@
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/cafeteria/backroom)
+"uyE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/north_valley_dam)
 "uyW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/interior/east_engineering)
-"uzr" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "whitepurple"
+"uzd" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
 	},
-/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
+/area/desert_dam/exterior/valley/valley_crashsite)
 "uzw" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/prison{
@@ -71749,6 +71838,10 @@
 "uAo" = (
 /turf/open/floor/plating/ground/mars/cavetodirt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"uAs" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical_south)
 "uAO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -71794,28 +71887,26 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
-"uBY" = (
+"uCD" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt{
-	dir = 1
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkbrown2"
 	},
-/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
+/area/desert_dam/building/warehouse/loading)
 "uCF" = (
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/dam_interior/south_tunnel)
-"uDw" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/desert_dam/exterior/valley/valley_telecoms)
-"uDD" = (
+"uDW" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached1"
+	icon_state = "cement_sunbleached4"
 	},
-/area/desert_dam/exterior/landing/landing_pad_three_external)
+/area/desert_dam/exterior/valley/south_valley_dam)
 "uEy" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/phoron{
@@ -71826,23 +71917,6 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
-"uFc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/building/hydroponics/hydroponics)
-"uFt" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "whitepurplecorner"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "uFF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/atmos_personal,
@@ -71871,14 +71945,6 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/administration/hallway)
-"uGG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "darkred2"
-	},
-/area/desert_dam/building/security/southern_hallway)
 "uGL" = (
 /obj/item/stack/sheet/mineral/sandstone,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -71913,10 +71979,26 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/building/medical/emergency_room)
+"uHT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "uHV" = (
 /obj/effect/ai_node,
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/riverside_south)
+"uIg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
+"uIx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_mining)
 "uJf" = (
 /obj/machinery/landinglight/ds1/delaythree,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -71940,12 +72022,6 @@
 	icon_state = "vault"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
-"uJC" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 4
-	},
-/area/desert_dam/exterior/valley/valley_labs)
 "uJK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -71972,6 +72048,12 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
+"uKc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "uKn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
@@ -71979,13 +72061,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_one/garage)
-"uKt" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "darkbrown2"
-	},
-/area/desert_dam/building/warehouse/warehouse)
 "uKw" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/chigusa,
@@ -72007,23 +72082,22 @@
 	icon_state = "delivery"
 	},
 /area/desert_dam/interior/dam_interior/south_tunnel)
-"uLz" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/east_wing_hallway)
-"uLI" = (
+"uLH" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/valley_medical)
-"uME" = (
+/area/desert_dam/exterior/valley/valley_mining)
+"uLX" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 4
+/turf/open/floor/prison{
+	icon_state = "red"
 	},
-/area/desert_dam/exterior/valley/valley_medical_south)
+/area/desert_dam/interior/lab_northeast/east_lab_west_entrance)
+"uMB" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "uMG" = (
 /obj/structure/platform{
 	dir = 1
@@ -72060,6 +72134,12 @@
 	icon_state = "cement_sunbleached11"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"uNG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_medical_south)
 "uOe" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -72073,20 +72153,6 @@
 	},
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner,
 /area/desert_dam/exterior/river/riverside_east)
-"uPw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/primary_tool_storage)
-"uPA" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/desert_dam/interior/dam_interior/central_tunnel)
 "uPF" = (
 /obj/effect/ai_node,
 /turf/open/floor{
@@ -72094,12 +72160,6 @@
 	icon_state = "vault"
 	},
 /area/desert_dam/building/substation/northeast)
-"uPI" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached1"
-	},
-/area/desert_dam/exterior/valley/valley_civilian)
 "uPS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72134,14 +72194,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/bar/bar)
-"uRq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
+"uQK" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
 	},
-/area/desert_dam/building/cafeteria/cafeteria)
+/area/desert_dam/interior/caves/central_caves)
 "uRx" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/prison{
@@ -72171,20 +72229,24 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/security/northern_hallway)
-"uSb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/desert_dam/interior/dam_interior/central_tunnel)
-"uTe" = (
-/obj/machinery/light{
-	dir = 8
-	},
+"uSs" = (
+/obj/structure/bed/chair,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
-/area/desert_dam/interior/dam_interior/engine_room)
+/area/desert_dam/building/security/execution_chamber)
+"uSI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/desert_dam/building/security/observation)
+"uTh" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/substation/southwest)
 "uTo" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -72192,12 +72254,15 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
-"uUz" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
+"uTY" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
 	},
-/area/desert_dam/interior/caves/central_caves)
+/area/desert_dam/building/dorms/restroom)
 "uVK" = (
 /obj/item/tool/pickaxe,
 /obj/effect/decal/remains/human,
@@ -72229,15 +72294,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-"uWo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
+"uWt" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
+	dir = 8;
+	icon_state = "blue"
 	},
-/area/desert_dam/building/water_treatment_one/hallway)
+/area/desert_dam/building/administration/control_room)
 "uWx" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -72246,18 +72309,6 @@
 	icon_state = "greencorner"
 	},
 /area/desert_dam/building/telecommunication)
-"uWH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/building/water_treatment_two/hallway)
 "uWO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -72272,12 +72323,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
-"uXd" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt{
-	dir = 1
-	},
-/area/desert_dam/exterior/valley/north_valley_dam)
 "uXk" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -72302,6 +72347,14 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"uXt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "uXv" = (
 /obj/structure/cable,
 /turf/open/floor/prison,
@@ -72321,6 +72374,12 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/building/medical/emergency_room)
+"uYi" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "dark2"
+	},
+/area/desert_dam/building/administration/archives)
 "uYm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -72353,11 +72412,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
-"uYI" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "uZm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -72388,25 +72442,12 @@
 	icon_state = "bluecorner"
 	},
 /area/desert_dam/building/administration/hallway)
-"uZK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
+"vah" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement12"
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
 	},
-/area/desert_dam/exterior/valley/valley_wilderness)
-"vac" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached1"
-	},
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "vaA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -72416,12 +72457,6 @@
 	},
 /turf/open/floor/wood,
 /area/desert_dam/building/bar/bar)
-"vaB" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "darkred2"
-	},
-/area/desert_dam/building/security/warden)
 "vaN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -72456,12 +72491,13 @@
 	icon_state = "cement_sunbleached11"
 	},
 /area/desert_dam/exterior/valley/valley_medical)
-"vbS" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 5
+"vbX" = (
+/obj/machinery/light,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "red"
 	},
-/area/desert_dam/exterior/valley/valley_wilderness)
+/area/desert_dam/building/security/northern_hallway)
 "vco" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -72479,20 +72515,23 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/west_tunnel)
-"vcE" = (
-/turf/open/floor/tile/darkish,
-/area/desert_dam/interior/caves/temple)
 "vcQ" = (
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"vde" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 9
+"vdg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/area/desert_dam/exterior/valley/bar_valley_dam)
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/desert_dam/building/security/prison)
 "vdZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -72528,12 +72567,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
-"vey" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 6
-	},
-/area/desert_dam/exterior/valley/valley_mining)
 "vez" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -72551,18 +72584,6 @@
 	icon_state = "cement_sunbleached20"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
-"vfa" = (
-/obj/structure/flora/desert/grass{
-	icon_state = "lightgrass_4"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_civilian)
-"vfe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/warehouse/warehouse)
 "vfS" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -72570,20 +72591,12 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
-"vgd" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N"
-	},
+"vfZ" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_medical)
-"vge" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
 	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_wilderness)
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "vgi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -72611,14 +72624,6 @@
 	icon_state = "grimy"
 	},
 /area/desert_dam/building/bar/bar)
-"vgA" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/mainship/mono,
-/area/desert_dam/exterior/valley/tradeship)
 "vgF" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/desert_dam/interior/caves/east_caves)
@@ -72631,10 +72636,6 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
-"vhb" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_hydro)
 "vhf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -72645,6 +72646,12 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/dorms/pool)
+"vhm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
 "vhs" = (
 /obj/structure/table,
 /turf/open/floor{
@@ -72666,12 +72673,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/detective)
-"viU" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 5
-	},
-/area/desert_dam/exterior/valley/north_valley_dam)
 "viV" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -72693,13 +72694,12 @@
 /obj/effect/spawner/random/tool,
 /turf/open/floor/prison,
 /area/desert_dam/interior/east_engineering)
-"vjC" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "cement_sunbleached2"
+"vjB" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
 	},
-/area/desert_dam/exterior/valley/valley_hydro)
+/area/desert_dam/exterior/valley/valley_wilderness)
 "vjX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -72715,13 +72715,6 @@
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/lobby)
-"vki" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/lobby)
 "vks" = (
@@ -72753,13 +72746,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/armory)
-"vlH" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal3"
+"vmk" = (
+/obj/structure/platform{
+	dir = 1
 	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_wilderness)
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "vmm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -72771,6 +72768,13 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/virology_isolation)
+"vmI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
 "vmL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
@@ -72784,26 +72788,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
-"vnn" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 4
-	},
-/area/desert_dam/exterior/valley/valley_wilderness)
-"vnr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/building/administration/control_room)
-"vnx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
 "vnT" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
@@ -72827,27 +72811,32 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/valley/valley_cargo)
+"voj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/administration/hallway)
 "voI" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner2{
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
-"voW" = (
-/obj/effect/ai_node,
-/obj/effect/decal/sandytile,
-/obj/effect/decal/sandytile,
-/turf/open/floor{
-	dir = 4;
-	icon_state = "whiteyellowfull"
-	},
-/area/desert_dam/interior/caves/temple)
-"vpa" = (
+"voK" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
+	dir = 4;
+	icon_state = "whitegreencorner"
 	},
-/area/desert_dam/interior/dam_interior/hanger)
+/area/desert_dam/building/medical/west_wing_hallway)
 "vpv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -72858,6 +72847,14 @@
 	icon_state = "kitchen"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
+"vpx" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "vpz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -72865,9 +72862,22 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"vpD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/engine_west_wing)
 "vpQ" = (
 /obj/structure/flora/desert/grass,
 /turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_civilian)
+"vqk" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_civilian)
 "vqt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -72891,27 +72901,46 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/central_caves)
-"vrz" = (
+"vrr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/interior/caves/central_caves)
+/turf/open/floor/plating,
+/area/desert_dam/building/cafeteria/backroom)
+"vrO" = (
+/obj/machinery/landinglight/ds2/delaytwo{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "vrY" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 9
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"vse" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/desert_dam/interior/dam_interior/western_dam_cave)
-"vsw" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "freezerfloor"
+"vsb" = (
+/obj/structure/morgue{
+	dir = 8
 	},
-/area/desert_dam/building/cafeteria/cold_room)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/medical/morgue)
+"vsF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_two/equipment)
 "vsQ" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge,
 /area/desert_dam/exterior/river/riverside_east)
@@ -72919,6 +72948,32 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/central_caves)
+"vtv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
+"vtN" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/interior/caves/central_caves)
+"vtT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_two/control_room)
 "vul" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/valley/valley_cargo)
@@ -72946,13 +73001,19 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical_south)
-"vwc" = (
+"vuP" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
-	dir = 1;
-	icon_state = "whitepurplecorner"
+	icon_state = "whitegreen"
 	},
-/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+/area/desert_dam/building/medical/east_wing_hallway)
+"vuW" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal4"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_labs)
 "vwr" = (
 /obj/machinery/landinglight/ds1/delaythree{
 	dir = 1
@@ -72989,6 +73050,13 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/building/medical/treatment_room)
+"vwV" = (
+/obj/machinery/light,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "blue"
+	},
+/area/desert_dam/building/administration/hallway)
 "vxa" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
@@ -73001,13 +73069,6 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/west_tunnel)
-"vxh" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
 "vxt" = (
 /obj/effect/landmark/start/job/survivor,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -73018,13 +73079,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/water_treatment_one/breakroom)
-"vxN" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/valley/valley_medical)
 "vxT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -73040,13 +73094,6 @@
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"vyp" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating{
-	dir = 4;
-	icon_state = "warnplate"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "vyt" = (
 /obj/structure/flora/rock/pile/alt,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -73083,6 +73130,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"vzy" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_3"
+	},
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "vzF" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -73090,23 +73144,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_mining)
-"vzU" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "whitepurple"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
-"vzY" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/building/dorms/restroom)
 "vAi" = (
 /obj/machinery/door/airlock/mainship/security/glass{
 	name = "\improper Security Office"
@@ -73124,32 +73161,13 @@
 	dir = 6
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
-"vAC" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_telecoms)
-"vAG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
+"vAM" = (
+/obj/structure/table/reinforced,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
-	dir = 8;
-	icon_state = "whitegreen"
+	icon_state = "bright_clean2"
 	},
-/area/desert_dam/building/medical/west_wing_hallway)
-"vAK" = (
-/obj/machinery/iv_drip,
-/obj/machinery/door_control{
-	id = "medstorage3";
-	name = "Medical Secure Shutters"
-	},
-/turf/open/floor{
-	icon_state = "whiteblue"
-	},
-/area/desert_dam/building/medical/medsecure)
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "vBp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -73169,17 +73187,16 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
-"vBU" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/cafeteria/cafeteria)
 "vCe" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"vCh" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement15"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "vCp" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -73194,6 +73211,13 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
+"vCF" = (
+/obj/structure/flora/desert/grass/heavy{
+	icon_state = "heavygrass_3"
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "vCV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor/prison{
@@ -73209,18 +73233,6 @@
 	icon_state = "cement_sunbleached2"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"vDy" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached6"
-	},
-/area/desert_dam/exterior/valley/valley_telecoms)
-"vDD" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/dirt,
-/area/desert_dam/exterior/valley/valley_labs)
 "vDE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -73236,6 +73248,12 @@
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
+"vDQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "vDS" = (
 /obj/effect/ai_node,
 /turf/open/floor{
@@ -73243,6 +73261,24 @@
 	icon_state = "whiteyellowfull"
 	},
 /area/desert_dam/building/security/prison)
+"vEm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_two/hallway)
+"vER" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
 "vEU" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -73259,6 +73295,13 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
+"vFH" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "vFJ" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -73268,6 +73311,12 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river_mouth/southern)
+"vFM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/cafeteria/loading)
 "vFS" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison{
@@ -73299,10 +73348,6 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/central_caves)
-"vGM" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_wilderness)
 "vGO" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -73328,24 +73373,6 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
-"vHu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached4"
-	},
-/area/desert_dam/exterior/valley/valley_medical)
-"vHX" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_hydro)
 "vIa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -73361,12 +73388,25 @@
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/prison,
 /area/desert_dam/building/water_treatment_two/lobby)
+"vIl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "vIx" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"vIR" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/desert_dam/building/administration/hallway)
 "vJB" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
@@ -73386,13 +73426,10 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
-"vJZ" = (
+"vKa" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/virology_isolation)
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/valley_medical)
 "vKb" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -73470,14 +73507,17 @@
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"vMn" = (
-/obj/effect/decal/cleanable/dirt,
+"vLO" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_cargo)
+"vMn" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
 	},
-/area/desert_dam/interior/dam_interior/central_tunnel)
+/area/desert_dam/exterior/valley/valley_crashsite)
 "vMp" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
@@ -73489,12 +73529,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
+"vMq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkredfull2"
+	},
+/area/desert_dam/building/security/deathrow)
 "vMx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
+"vMI" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal12"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_mining)
 "vML" = (
 /obj/structure/cable,
 /turf/open/floor{
@@ -73504,17 +73557,13 @@
 "vMQ" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/interior/dam_interior/western_dam_cave)
-"vMZ" = (
-/obj/structure/flora/desert/grass{
-	icon_state = "lightgrass_2"
+"vNw" = (
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
-"vNC" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/building/warehouse/loading)
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/engine_room)
 "vNT" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal3"
@@ -73532,23 +73581,12 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/emergency_room)
-"vOs" = (
-/obj/structure/table/woodentable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/carpet,
-/area/desert_dam/building/administration/meetingrooom)
 "vOx" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached2"
 	},
 /area/desert_dam/exterior/valley/valley_medical)
-"vOC" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "green"
-	},
-/area/desert_dam/building/dorms/hallway_westwing)
 "vOI" = (
 /obj/structure/cable,
 /obj/structure/stairs/seamless/platform,
@@ -73556,6 +73594,12 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
+"vOU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached2"
+	},
+/area/desert_dam/exterior/valley/valley_medical_south)
 "vOX" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -73599,6 +73643,19 @@
 	icon_state = "whiteyellowfull"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_lobby)
+"vPV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "vQd" = (
 /obj/structure/desertdam/decals/loose_sand_overlay{
 	dir = 9
@@ -73608,6 +73665,12 @@
 	icon_state = "cement_sunbleached2"
 	},
 /area/desert_dam/exterior/valley/valley_cargo)
+"vQu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "vQM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -73626,12 +73689,12 @@
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"vRP" = (
+"vRD" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
 	},
-/area/desert_dam/exterior/valley/valley_labs)
+/area/desert_dam/exterior/valley/south_valley_dam)
 "vRR" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -73644,14 +73707,6 @@
 	icon_state = "cement_sunbleached19"
 	},
 /area/desert_dam/exterior/valley/bar_valley_dam)
-"vSZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/medical/west_wing_hallway)
 "vTk" = (
 /obj/structure/bed/chair,
 /obj/effect/ai_node,
@@ -73672,46 +73727,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
-"vUk" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal5"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_medical)
-"vUm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement3"
-	},
-/area/desert_dam/interior/dam_interior/north_tunnel)
-"vUz" = (
+"vTT" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "darkyellow2"
 	},
-/area/desert_dam/interior/dam_interior/primary_tool_storage)
+/area/desert_dam/interior/dam_interior/smes_backup)
 "vUI" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_civilian)
-"vUQ" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
-"vVm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+"vVk" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
+	icon_state = "red"
 	},
-/area/desert_dam/building/medical/lobby)
+/area/desert_dam/interior/lab_northeast/east_lab_east_entrance)
 "vVn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -73740,10 +73773,6 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
-"vWl" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_medical)
 "vWw" = (
 /obj/machinery/landinglight/ds2{
 	dir = 8
@@ -73752,10 +73781,6 @@
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"vWx" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
-/area/desert_dam/building/administration/meetingrooom)
 "vWI" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -73779,6 +73804,19 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_security_armory)
+"vXc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitepurplecorner"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+"vXd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "vXl" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached11"
@@ -73804,30 +73842,25 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/north_tunnel)
-"vYa" = (
-/obj/structure/cable,
+"vYd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
 	},
-/area/desert_dam/building/water_treatment_one/equipment)
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "vYm" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
-"vYD" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/interior/dam_interior/central_tunnel)
-"vYE" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "cement_sunbleached15"
-	},
-/area/desert_dam/exterior/valley/valley_civilian)
 "vYZ" = (
 /obj/structure/rack,
 /obj/item/tool/pickaxe/drill,
@@ -73855,37 +73888,23 @@
 	},
 /area/desert_dam/interior/dam_interior/lobby)
 "vZM" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 4
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal3"
 	},
-/area/desert_dam/exterior/valley/valley_northwest)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "vZV" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 6
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"waa" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/smes_main)
 "wai" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached16"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
-"wan" = (
-/obj/structure/platform{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 8
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
 "wav" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_9"
@@ -73909,6 +73928,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"waT" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "waU" = (
 /obj/machinery/landinglight/ds2/delaytwo{
 	dir = 1
@@ -73917,20 +73943,19 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"waW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
-/area/desert_dam/building/bar/bar)
 "wba" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/catwalk,
 /area/desert_dam/exterior/river/riverside_east)
-"wbl" = (
-/obj/effect/decal/cleanable/dirt,
+"wbu" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/building/water_treatment_one/garage)
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/lobby)
 "wbv" = (
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached2"
@@ -73952,10 +73977,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
-"wcA" = (
+"wcF" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/bar_valley_dam)
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "wcO" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall,
@@ -73994,6 +74019,21 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
+"wfw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/lobby)
+"wfH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/medical/lobby)
 "wgd" = (
 /obj/structure/platform_decoration{
 	dir = 4
@@ -74008,12 +74048,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
-"wgk" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 1
-	},
-/area/desert_dam/exterior/landing/landing_pad_three_external)
 "wgp" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "\improper Research Hallway"
@@ -74044,10 +74078,12 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/bar/bar_restroom)
-"whn" = (
+"whd" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/valley_labs)
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "whC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -74055,30 +74091,12 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/engine_room)
-"whD" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/north_valley_dam)
 "whJ" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 10
 	},
 /area/desert_dam/interior/caves/temple)
-"wib" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/engine_west_wing)
-"wie" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/building/hydroponics/hydroponics_loading)
 "win" = (
 /obj/structure/stairs/seamless/platform/alt{
 	dir = 4
@@ -74087,15 +74105,6 @@
 	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
-"wiB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/building/hydroponics/hydroponics)
 "wiX" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
@@ -74103,26 +74112,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
-"wjc" = (
-/obj/effect/decal/cleanable/liquid_fuel,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_crashsite)
-"wjn" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "kitchen"
-	},
-/area/desert_dam/building/cafeteria/cafeteria)
 "wjr" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
+"wjt" = (
+/turf/open/floor/tile/darkish,
+/area/desert_dam/interior/caves/temple)
 "wjv" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -74142,18 +74139,6 @@
 	icon_state = "floor_marked"
 	},
 /area/desert_dam/building/cafeteria/loading)
-"wjN" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/cafeteria/loading)
-"wjV" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached13"
-	},
-/area/desert_dam/exterior/valley/valley_medical)
 "wkt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -74168,16 +74153,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_one/hallway)
-"wkv" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/desert_dam/interior/dam_interior/northwestern_tunnel)
-"wkI" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "wkM" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -74188,6 +74163,10 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
+"wlb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/tile/darkish,
+/area/desert_dam/interior/caves/temple)
 "wlc" = (
 /obj/structure/flora/tree/joshua,
 /obj/effect/landmark/excavation_site_spawner,
@@ -74206,10 +74185,28 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/administration/hallway)
+"wly" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/desert_dam/building/church)
 "wlX" = (
 /obj/vehicle/train/cargo/engine,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"wmr" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
 "wmJ" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached3"
@@ -74221,13 +74218,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
-"wnJ" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 6
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
 "wnV" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
@@ -74245,6 +74235,17 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
+"wos" = (
+/obj/effect/landmark/excavation_site_spawner,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_hydro)
+"woS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "woT" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -74293,6 +74294,13 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
+"wra" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_9"
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "wrj" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -74330,13 +74338,10 @@
 "wsw" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"wsS" = (
-/obj/structure/platform{
-	dir = 8
-	},
+"wsB" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt,
-/area/desert_dam/exterior/valley/valley_labs)
+/turf/open/floor/prison,
+/area/desert_dam/building/water_treatment_one/hallway)
 "wtl" = (
 /obj/structure/stairs/seamless,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -74375,29 +74380,10 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/security/northern_hallway)
-"wut" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/interior/dam_interior/central_tunnel)
 "wuz" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_medical_south)
-"wuG" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "kitchen"
-	},
-/area/desert_dam/building/cafeteria/cafeteria)
 "wuJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -74406,13 +74392,18 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_storage)
-"wvB" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
+"wvw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_civilian)
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "wvK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -74420,42 +74411,15 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/interior/east_engineering)
-"wvM" = (
+"wvZ" = (
 /obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached6"
 	},
-/area/desert_dam/exterior/valley/valley_crashsite)
-"wvY" = (
-/obj/structure/stairs/cornerdark/seamless,
-/obj/structure/platform_decoration,
-/turf/open/floor/plating,
-/area/desert_dam/interior/lab_northeast/east_lab_containment)
+/area/desert_dam/exterior/valley/valley_telecoms)
 "wwd" = (
 /turf/closed/wall/r_wall,
 /area/desert_dam/interior/dam_interior/hanger)
-"wwQ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/medical/chemistry)
-"wwY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/cafeteria/cafeteria)
 "wxc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -74465,6 +74429,13 @@
 	icon_state = "floor_marked"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_loading)
+"wxi" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 5;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/lobby)
 "wxk" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -74481,6 +74452,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/bar/backroom)
+"wxK" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached2"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "wya" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -74516,6 +74494,11 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+"wzk" = (
+/obj/structure/table,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/water_treatment_one/garage)
 "wzl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -74525,12 +74508,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/south_tunnel)
-"wzn" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "dark2"
-	},
-/area/desert_dam/building/administration/archives)
 "wzq" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -74556,30 +74533,12 @@
 "wAC" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"wAE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
+"wAG" = (
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached12"
 	},
-/area/desert_dam/exterior/valley/valley_civilian)
-"wBa" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached4"
-	},
-/area/desert_dam/exterior/valley/north_valley_dam)
-"wBc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_medical)
+/area/desert_dam/interior/caves/central_caves)
 "wBs" = (
 /obj/effect/landmark/nuke_spawn,
 /turf/open/floor/prison{
@@ -74587,6 +74546,16 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/substation/southwest)
+"wBM" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached13"
+	},
+/area/desert_dam/exterior/valley/valley_cargo)
+"wBY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/valley_telecoms)
 "wCa" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -74622,13 +74591,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
-"wCR" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "freezerfloor"
-	},
-/area/desert_dam/building/hydroponics/hydroponics_breakroom)
 "wCZ" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	id = "port_authority1"
@@ -74654,6 +74616,10 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/west_wing_hallway)
+"wDU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/bright_clean,
+/area/desert_dam/interior/east_engineering)
 "wDY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -74672,12 +74638,11 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_westwing)
-"wFj" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached11"
-	},
-/area/desert_dam/exterior/valley/valley_mining)
+"wEN" = (
+/obj/structure/stairs/seamless,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/desert_dam/interior/caves/temple)
 "wFv" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/tile/red/whitered{
@@ -74697,6 +74662,15 @@
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"wGt" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
 "wGx" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -74726,12 +74700,12 @@
 	icon_state = "whiteyellow"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_lobby)
-"wIN" = (
+"wId" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "dark"
+/turf/open/floor/plating/ground/dirt{
+	dir = 1
 	},
-/area/desert_dam/building/security/observation)
+/area/desert_dam/exterior/valley/north_valley_dam)
 "wJs" = (
 /obj/structure/closet/crate/medical,
 /obj/effect/decal/cleanable/dirt,
@@ -74739,6 +74713,13 @@
 	icon_state = "whiteblue"
 	},
 /area/desert_dam/building/medical/medsecure)
+"wJu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating{
+	dir = 6;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "wJz" = (
 /turf/closed/wall,
 /area/desert_dam/exterior/valley/valley_mining)
@@ -74772,6 +74753,16 @@
 	icon_state = "floor_plate"
 	},
 /area/desert_dam/building/security/lobby)
+"wKT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/desert_dam/building/lab_northwest/west_lab_xenoflora)
+"wKV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/interior/caves/central_caves)
 "wLA" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -74805,13 +74796,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/desert_dam/interior/caves/central_caves)
-"wMn" = (
-/obj/structure/flora/desert/cactus{
-	icon_state = "cactus_7"
-	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "wMo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor{
@@ -74831,12 +74815,6 @@
 "wMF" = (
 /turf/closed/wall/mainship,
 /area/desert_dam/exterior/valley/tradeship)
-"wNl" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "red"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_east_entrance)
 "wNs" = (
 /turf/closed/shuttle{
 	icon_state = "swallc4"
@@ -74867,6 +74845,21 @@
 /obj/structure/window_frame/wood,
 /turf/open/floor/wood/broken,
 /area/desert_dam/interior/caves/central_caves)
+"wNS" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/lab_northwest/west_lab_xenoflora)
+"wNT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/water_treatment_one/garage)
 "wNW" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -74910,6 +74903,10 @@
 	dir = 10
 	},
 /area/desert_dam/exterior/valley/valley_medical)
+"wPB" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_cargo)
 "wPH" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -74923,6 +74920,12 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
+"wPY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "wQc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -74964,13 +74967,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
-"wRx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "darkbrown2"
-	},
-/area/desert_dam/building/warehouse/loading)
 "wRR" = (
 /obj/structure/flora/desert/grass,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -75000,19 +74996,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_mining)
-"wSi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached13"
-	},
-/area/desert_dam/exterior/valley/valley_medical)
-"wSm" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
-	},
-/area/desert_dam/exterior/valley/valley_medical)
 "wSt" = (
 /obj/structure/cryofeed/right{
 	name = "\improper coolant feed"
@@ -75071,6 +75054,10 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"wTI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/valley_mining)
 "wTJ" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -75123,28 +75110,16 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_northwing)
-"wUq" = (
+"wUR" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 6
-	},
-/area/desert_dam/exterior/valley/valley_medical)
-"wUC" = (
-/obj/machinery/door/airlock/mainship/generic{
-	dir = 2;
-	name = "\improper Toilet Unit"
-	},
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
+"wVk" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/cafeteria/cafeteria)
-"wVo" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/valley/valley_hydro)
+/turf/open/floor/wood,
+/area/desert_dam/building/administration/office)
 "wVs" = (
 /obj/effect/ai_node,
 /turf/open/floor{
@@ -75158,14 +75133,6 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/west_tunnel)
-"wVK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/desert_dam/interior/dam_interior/central_tunnel)
 "wWi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -75181,13 +75148,6 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_south)
-"wWx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "white"
-	},
-/area/desert_dam/building/water_treatment_one/breakroom)
 "wWZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -75195,10 +75155,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/lab_northeast/east_lab_east_entrance)
-"wYq" = (
+"wYL" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
-/area/desert_dam/interior/dam_interior/north_tunnel_entrance)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "wYS" = (
 /obj/structure/flora/tree/joshua,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -75207,19 +75168,21 @@
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/plating,
 /area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+"wZH" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull"
+	},
+/area/desert_dam/interior/east_engineering)
 "wZM" = (
 /obj/structure/flora/tree/joshua,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 5
 	},
 /area/desert_dam/exterior/valley/valley_labs)
-"wZU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
-	},
-/area/desert_dam/exterior/valley/valley_mining)
 "xab" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/prison,
@@ -75242,10 +75205,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/security/northern_hallway)
-"xar" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/desert_dam/exterior/valley/valley_wilderness)
+"xas" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "xaB" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -75274,12 +75239,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
-"xbk" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt{
-	dir = 1
-	},
-/area/desert_dam/exterior/river/riverside_central_north)
 "xbr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -75289,22 +75248,22 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/west_wing_hallway)
-"xbQ" = (
+"xbO" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
+	icon_state = "cement_sunbleached15"
 	},
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/valley/valley_medical)
+"xcg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached11"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "xcX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor/wood,
 /area/desert_dam/building/administration/office)
-"xdg" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 6
-	},
-/area/desert_dam/exterior/valley/valley_cargo)
 "xdh" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal1"
@@ -75340,13 +75299,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_security_armory)
-"xeo" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
-/area/desert_dam/building/security/courtroom)
 "xet" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -75432,6 +75384,18 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/chemistry)
+"xgV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached13"
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
+"xgZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "xhl" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
@@ -75445,6 +75409,12 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_wilderness)
+"xhx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "xhA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -75457,6 +75427,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/south_tunnel)
+"xhP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
 "xhQ" = (
 /obj/effect/ai_node,
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner{
@@ -75474,36 +75450,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
-"xif" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/hanger)
-"xin" = (
-/obj/machinery/landinglight/ds2/delaytwo{
-	dir = 8
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
-	},
-/area/desert_dam/exterior/landing/landing_pad_three_external)
 "xix" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
-"xiz" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
-	},
-/area/desert_dam/exterior/valley/valley_northwest)
 "xiB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -75512,11 +75464,6 @@
 	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
-"xiV" = (
-/obj/structure/flora/rock/pile/alt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "xjb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -75525,15 +75472,19 @@
 	icon_state = "floor_marked"
 	},
 /area/desert_dam/building/cafeteria/loading)
-"xjz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+"xjg" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
 	},
-/area/desert_dam/building/water_treatment_one/hallway)
+/area/desert_dam/exterior/valley/valley_crashsite)
+"xjr" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "xjC" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison,
@@ -75543,13 +75494,6 @@
 /obj/structure/cable,
 /turf/open/floor/bcircuit,
 /area/desert_dam/interior/dam_interior/smes_main)
-"xjS" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal1"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_medical)
 "xjY" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
@@ -75557,19 +75501,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
-"xke" = (
-/obj/structure/flora/desert/grass/heavy{
-	icon_state = "heavygrass_5"
-	},
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
-"xkJ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt{
-	dir = 10
-	},
-/area/desert_dam/interior/dam_interior/western_dam_cave)
 "xkN" = (
 /obj/machinery/microwave,
 /obj/structure/table/mainship,
@@ -75589,6 +75520,10 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/break_room)
+"xlk" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/desert_dam/interior/dam_interior/western_dam_cave)
 "xlx" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -75611,6 +75546,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"xme" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/administration/control_room)
 "xmw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -75632,24 +75574,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/interior/caves/temple)
-"xmN" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
-	},
-/area/desert_dam/exterior/valley/bar_valley_dam)
 "xmX" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
-"xnf" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 5
-	},
-/area/desert_dam/exterior/valley/valley_wilderness)
 "xnv" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
@@ -75675,6 +75605,12 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
+"xoC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
 "xoL" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -75758,11 +75694,18 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
-"xsd" = (
-/obj/structure/flora/desert/grass,
+"xrU" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_medical)
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkred2"
+	},
+/area/desert_dam/building/security/southern_hallway)
+"xrX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/security/marshals_office)
 "xsQ" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -75785,12 +75728,36 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
+"xtG" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "xud" = (
 /obj/machinery/landinglight/ds1,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"xun" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/lab_northeast/east_lab_east_entrance)
+"xuV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/hydroponics/hydroponics_storage)
+"xvf" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "xvi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -75824,25 +75791,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_one/lobby)
-"xvu" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 10
-	},
-/area/desert_dam/interior/caves/central_caves)
 "xvz" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_2"
 	},
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"xvC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "xvJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -75852,16 +75806,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
-"xvK" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/east_wing_hallway)
 "xvS" = (
 /obj/machinery/landinglight/ds1/delaytwo,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -75881,12 +75825,6 @@
 	icon_state = "whiteyellowcorner"
 	},
 /area/desert_dam/interior/dam_interior/break_room)
-"xws" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 6
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
 "xwG" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -75903,6 +75841,13 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/administration/control_room)
+"xyy" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/interior/dam_interior/west_tunnel)
 "xyC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -75915,6 +75860,13 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"xzb" = (
+/obj/structure/flora/desert/cactus/multiple{
+	icon_state = "cacti_12"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_labs)
 "xzc" = (
 /obj/structure/table,
 /turf/open/floor{
@@ -75933,6 +75885,12 @@
 	icon_state = "bluecorner"
 	},
 /area/desert_dam/building/dorms/pool)
+"xzE" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "xzM" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -75960,28 +75918,11 @@
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/warehouse/warehouse)
-"xAf" = (
-/obj/structure/platform{
-	dir = 1
-	},
-/obj/structure/platform{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 8
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
 "xAB" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/desert_dam/building/administration/control_room)
-"xAW" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement1"
-	},
-/area/desert_dam/interior/dam_interior/west_tunnel)
 "xBb" = (
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 6
@@ -76012,6 +75953,18 @@
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/security/prison)
+"xBT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/primary_tool_storage)
 "xCf" = (
 /obj/structure/stairs/seamless/platform{
 	dir = 8
@@ -76036,6 +75989,18 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
+"xCq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "xCI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -76046,6 +76011,10 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/virology_isolation)
+"xCV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/hydroponics/hydroponics_loading)
 "xDf" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -76054,6 +76023,12 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_south)
+"xDo" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/desert_dam/building/dorms/hallway_westwing)
 "xDD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -76065,35 +76040,40 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/dorms/restroom)
+"xEk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/desert_dam/building/medical/chemistry)
 "xEl" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
-"xEQ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "darkyellow2"
-	},
-/area/desert_dam/interior/dam_interior/primary_tool_storage)
-"xEX" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal3"
+"xEw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_medical)
-"xEY" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/desert_dam/building/dorms/hallway_westwing)
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
 "xFk" = (
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 6
@@ -76103,18 +76083,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/mainship/blue,
 /area/desert_dam/exterior/valley/tradeship)
-"xFn" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/valley/north_valley_dam)
-"xFs" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 1
-	},
-/area/desert_dam/exterior/valley/valley_mining)
 "xFu" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -76127,18 +76095,6 @@
 	},
 /turf/open/floor/wood,
 /area/desert_dam/interior/caves/central_caves)
-"xFR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "xFV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall/r_wall,
@@ -76156,6 +76112,13 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"xGw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating{
+	dir = 10;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "xGA" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
 /obj/structure/disposalpipe/segment,
@@ -76166,6 +76129,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
+"xGO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement3"
+	},
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "xGT" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -76184,17 +76153,20 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_one/hallway)
-"xHE" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "whitegreencorner"
-	},
-/area/desert_dam/building/medical/west_wing_hallway)
 "xHP" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/interior/caves/temple)
+"xIl" = (
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 1;
+	name = "\improper Containment Lock"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "xIy" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_8"
@@ -76259,6 +76231,16 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/desert_dam/interior/caves/temple)
+"xKf" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/grate{
+	icon_state = "catwalk-255"
+	},
+/area/desert_dam/exterior/river/riverside_central_south)
+"xKt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/water_treatment_one/hallway)
 "xKY" = (
 /obj/structure/platform{
 	dir = 8
@@ -76268,6 +76250,14 @@
 	icon_state = "cement_sunbleached13"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"xLg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/primary_tool_storage)
 "xLp" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -76281,10 +76271,10 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/security/northern_hallway)
-"xLF" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/random/dirt,
+"xLz" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "xLK" = (
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -76302,15 +76292,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/bar_valley_dam)
-"xLU" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/west_wing_hallway)
 "xMd" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -76330,14 +76311,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/river/riverside_central_north)
-"xMs" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "xMy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -76382,6 +76355,13 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
+"xNb" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "xNj" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -76420,11 +76400,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/riverside_east)
-"xOM" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "xPA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/desertdam/decals/road/edge{
@@ -76438,6 +76413,33 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
+"xQa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
+"xQk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/desert_dam/building/water_treatment_one/breakroom)
+"xQw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"xQG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkbrown2"
+	},
+/area/desert_dam/building/warehouse/loading)
 "xQQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -76469,14 +76471,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/lab_northeast/east_lab_maintenence)
-"xRz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/engine_west_wing)
 "xRI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -76484,10 +76478,6 @@
 	},
 /turf/open/floor/wood,
 /area/desert_dam/building/medical/CMO)
-"xSK" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
-/area/desert_dam/building/security/courtroom)
 "xTh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -76498,17 +76488,21 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
+"xTk" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "xTz" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 8
 	},
 /area/desert_dam/interior/caves/central_caves)
-"xTN" = (
+"xUJ" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 5
-	},
-/area/desert_dam/exterior/valley/valley_cargo)
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "xUM" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -76545,14 +76539,6 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
-"xVH" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/west_wing_hallway)
 "xVI" = (
 /obj/structure/cable,
 /obj/structure/stairs/seamless/platform{
@@ -76562,12 +76548,12 @@
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
-"xWh" = (
+"xVY" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	icon_state = "whitepurplecorner"
+/turf/open/floor/plating/ground/desertdam/grate{
+	icon_state = "catwalk-255"
 	},
-/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
+/area/desert_dam/exterior/river/riverside_central_north)
 "xWm" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -76599,21 +76585,17 @@
 	icon_state = "cement12"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
-"xXb" = (
-/obj/structure/desertdam/decals/road/edge{
-	icon_state = "road_edge_decal3"
-	},
+"xWL" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/south_valley_dam)
-"xXh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/area/desert_dam/exterior/landing/landing_pad_three_external)
+"xXl" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
 	},
-/area/desert_dam/interior/dam_interior/engine_east_wing)
+/area/desert_dam/building/water_treatment_one/garage)
 "xXq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -76624,12 +76606,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-"xXL" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "white"
-	},
-/area/desert_dam/building/medical/chemistry)
 "xXT" = (
 /obj/structure/flora/rock/alt3{
 	name = "rock"
@@ -76656,20 +76632,37 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/administration/lobby)
-"xYT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor{
-	icon_state = "dark"
+"xYK" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_3"
 	},
-/area/desert_dam/building/church)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "xZe" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"xZO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "kitchen"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
+"yak" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/interior/caves/central_caves)
 "ybg" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -76677,15 +76670,14 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_wilderness)
-"ybk" = (
-/obj/structure/desertdam/decals/loose_sand_overlay{
-	dir = 9
+"ybh" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
 	},
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
+/area/desert_dam/interior/lab_northeast/east_lab_security_armory)
 "ybx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -76700,6 +76692,13 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
+"ybB" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/security/northern_hallway)
 "ybJ" = (
 /obj/structure/closet/crate/solar,
 /obj/effect/decal/cleanable/dirt,
@@ -76713,13 +76712,12 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
-"yck" = (
+"ybU" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
-	dir = 1;
-	icon_state = "darkbrowncorners2"
+	icon_state = "darkred2"
 	},
-/area/desert_dam/building/warehouse/warehouse)
+/area/desert_dam/building/security/warden)
 "ycr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -76735,6 +76733,13 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"yde" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
 "ydw" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating{
@@ -76742,17 +76747,12 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/building/medical/garage)
-"ydV" = (
+"ydA" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "whitepurplecorner"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement1"
 	},
-/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
-"yeb" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+/area/desert_dam/interior/dam_interior/workshop)
 "yei" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -76769,12 +76769,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_cargo)
-"yfb" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 6
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
 "yfq" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal3"
@@ -76786,6 +76780,18 @@
 /obj/effect/ai_node,
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner2,
 /area/desert_dam/exterior/valley/valley_labs)
+"yfI" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/desert_dam/interior/caves/central_caves)
+"yfM" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement15"
+	},
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "ygb" = (
 /obj/structure/platform{
 	dir = 1
@@ -76819,14 +76825,6 @@
 	name = "reinforced metal wall"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
-"yhl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "yhu" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -76872,19 +76870,31 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/north_wing_hallway)
-"yiM" = (
-/obj/structure/flora/desert/grass{
-	icon_state = "lightgrass_3"
-	},
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "yiP" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"yiW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
+"yje" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached9"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
+"yjA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "greencorner"
+	},
+/area/desert_dam/building/telecommunication)
 "yjN" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -76916,19 +76926,13 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
-"ykj" = (
-/obj/effect/decal/cleanable/dirt,
+"ykD" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
 	},
-/area/desert_dam/exterior/valley/valley_mining)
-"ykw" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "cement_sunbleached19"
-	},
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/building/security/prison)
 "ykK" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -76974,10 +76978,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/south_valley_dam)
-"ylW" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/interior/caves/central_caves)
 "yma" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -78497,7 +78497,7 @@ dTs
 bUd
 aia
 bUe
-xkJ
+ljf
 bUg
 dTs
 dTs
@@ -78597,7 +78597,7 @@ jOV
 mFm
 ekk
 gbQ
-iOl
+nTg
 cBS
 wAC
 wAC
@@ -78731,7 +78731,7 @@ dTs
 dTs
 bUg
 bUg
-xkJ
+ljf
 bUg
 bUg
 bPO
@@ -78833,7 +78833,7 @@ hQr
 dTs
 jPc
 cBS
-hFZ
+mkr
 wAC
 dTs
 dTs
@@ -78923,8 +78923,8 @@ dTs
 qJA
 qJA
 qJA
-pEZ
-pEZ
+xlk
+xlk
 qJA
 qJA
 qJA
@@ -78945,7 +78945,7 @@ dTs
 dTs
 qJA
 qJA
-pEZ
+xlk
 dTs
 dTs
 dTs
@@ -78957,9 +78957,9 @@ dTs
 dTs
 dTs
 bUg
-xkJ
+ljf
 bUg
-xkJ
+ljf
 bUg
 dTs
 dTs
@@ -78967,7 +78967,7 @@ bUg
 ahn
 bUg
 bUg
-xkJ
+ljf
 bUg
 bPO
 bPO
@@ -78983,7 +78983,7 @@ dTs
 dTs
 dTs
 ceA
-eWZ
+oqG
 ceA
 dTs
 dTs
@@ -78996,14 +78996,14 @@ dTs
 dTs
 ceA
 ceA
-eWZ
+oqG
 ceA
 dTs
 dTs
 dTs
 dTs
 dTs
-eWZ
+oqG
 ceA
 ceA
 dTs
@@ -79154,14 +79154,14 @@ dTs
 dTs
 dTs
 qJA
-fHH
-pEZ
+tMN
+xlk
 qJA
 nPH
 qJA
 nns
 qJA
-lcC
+jzW
 qJA
 nns
 sKl
@@ -79193,7 +79193,7 @@ azs
 bUg
 bUg
 bUg
-xkJ
+ljf
 bUg
 bUg
 bUg
@@ -79225,7 +79225,7 @@ ceA
 ceA
 ceA
 ceA
-eWZ
+oqG
 ceA
 ceA
 ceA
@@ -79239,14 +79239,14 @@ ceA
 ceA
 ceA
 ceA
-eWZ
+oqG
 ceA
 ceA
 ceA
 cIe
 ceA
-eWZ
-eWZ
+oqG
+oqG
 ceG
 jZZ
 dTs
@@ -79281,7 +79281,7 @@ cjH
 czA
 dTs
 dTs
-nqK
+wPB
 cwB
 cwB
 cwB
@@ -79300,7 +79300,7 @@ qjT
 hQr
 dTs
 jPc
-afD
+pJQ
 dTs
 dTs
 dTs
@@ -79317,7 +79317,7 @@ dTs
 dTs
 wAC
 wAC
-hFZ
+mkr
 wAC
 wAC
 dTs
@@ -79385,7 +79385,7 @@ qJA
 ejB
 nPH
 nPH
-pEZ
+xlk
 ejB
 ldx
 qJA
@@ -79394,14 +79394,14 @@ qJA
 qJA
 ejB
 qJA
-pEZ
+xlk
 qJA
 qJA
 qJA
-vse
+qPw
 qJA
 nPH
-pEZ
+xlk
 qJA
 yiv
 qJA
@@ -79412,7 +79412,7 @@ dTs
 dTs
 dTs
 ejB
-gTX
+jjn
 qJA
 qJA
 qJA
@@ -79475,7 +79475,7 @@ beO
 beO
 aUu
 ceA
-eWZ
+oqG
 ceA
 ceA
 bRG
@@ -79519,7 +79519,7 @@ oOP
 doE
 doE
 doE
-qdJ
+iQc
 qbx
 dTs
 dTs
@@ -79649,12 +79649,12 @@ qJA
 qJA
 ldx
 qJA
-pEZ
+xlk
 qJA
 ejB
 qJA
 qJA
-kMn
+qGP
 bPO
 azs
 azs
@@ -79740,7 +79740,7 @@ kEX
 cjH
 cjH
 ctw
-iAH
+qrn
 cuA
 cuA
 knM
@@ -79786,7 +79786,7 @@ uPY
 uPY
 uPY
 uPY
-oEW
+jhU
 uPY
 rYr
 kRZ
@@ -79850,10 +79850,10 @@ aQU
 wTE
 xND
 nns
-pEZ
+xlk
 qJA
 nPH
-pEZ
+xlk
 qJA
 dTs
 dTs
@@ -79871,7 +79871,7 @@ dTs
 qJA
 dww
 qJA
-pEZ
+xlk
 qJA
 nns
 qJA
@@ -79881,16 +79881,16 @@ dTs
 qJA
 qJA
 qJA
-pEZ
+xlk
 qJA
 qJA
 hgy
 qJA
-pEZ
+xlk
 yiv
 qJA
 bPO
-qfp
+gUi
 azs
 bRM
 aQK
@@ -79920,12 +79920,12 @@ ceA
 aRy
 aSL
 ceA
-eWZ
+oqG
 ceA
 ceA
 ceA
 ceA
-eWZ
+oqG
 ceA
 ceA
 cjO
@@ -79952,7 +79952,7 @@ cjO
 cjO
 tDH
 ceA
-eWZ
+oqG
 ceG
 dTs
 dTs
@@ -79965,7 +79965,7 @@ cgm
 cgn
 cgY
 cih
-hgR
+rGV
 cgm
 ckv
 hOq
@@ -79977,7 +79977,7 @@ cmZ
 cqd
 cuB
 eEb
-hYS
+yjA
 cvF
 cxR
 dHa
@@ -80005,9 +80005,9 @@ gOB
 gbQ
 cRE
 uPY
-upU
+jsJ
 kTi
-oEW
+jhU
 uPY
 wQK
 jPc
@@ -80016,7 +80016,7 @@ qbg
 pAK
 cBS
 uPY
-oEW
+jhU
 wQK
 uPY
 uPY
@@ -80113,13 +80113,13 @@ qJA
 qJA
 qJA
 qJA
-kMn
+qGP
 qJA
 sKl
 dTs
 dTs
 qJA
-kMn
+qGP
 qJA
 qJA
 qJA
@@ -80130,13 +80130,13 @@ bKc
 aTQ
 cxj
 iWa
-qfp
+gUi
 dTs
 dTs
 azs
-qfp
+gUi
 azs
-qfp
+gUi
 azs
 azs
 bPO
@@ -80203,7 +80203,7 @@ cih
 cjI
 cqa
 oBW
-iAH
+qrn
 cqd
 cqd
 cqd
@@ -80217,7 +80217,7 @@ kkH
 cQm
 doE
 doE
-qdJ
+iQc
 doE
 doE
 cQm
@@ -80232,11 +80232,11 @@ kRZ
 kTi
 uPY
 uPY
-oEW
+jhU
 iXh
 gbQ
 gbQ
-iOl
+nTg
 cBS
 uPY
 uPY
@@ -80254,7 +80254,7 @@ uPY
 uPY
 cuL
 mUm
-elx
+kIB
 jML
 uPY
 uPY
@@ -80323,12 +80323,12 @@ dTs
 dTs
 dTs
 ejB
-pEZ
+xlk
 qJA
 qJA
 qJA
 qJA
-pEZ
+xlk
 qJA
 qJA
 qJA
@@ -80339,12 +80339,12 @@ dTs
 dTs
 dTs
 dTs
-pEZ
+xlk
 ejB
 qJA
 qqj
 qJA
-pEZ
+xlk
 yiv
 ejB
 qJA
@@ -80385,8 +80385,8 @@ ceA
 ceA
 axk
 ceA
-jjx
-oLc
+fwb
+fZf
 ceA
 ceA
 acs
@@ -80408,7 +80408,7 @@ bBS
 bgz
 bgz
 bgz
-xSK
+uuh
 aTZ
 aTZ
 aTZ
@@ -80416,13 +80416,13 @@ ceA
 ceA
 cjO
 bQN
-txx
+geS
 bUR
 cjO
-qlP
+jMD
 cjO
 ceA
-jqe
+iPf
 dTs
 dTs
 dTs
@@ -80440,11 +80440,11 @@ uWx
 cni
 cni
 cni
-peU
+sJH
 cni
-peU
+sJH
 cqa
-hYS
+yjA
 cwy
 cjH
 cjH
@@ -80464,12 +80464,12 @@ njv
 aKY
 cGu
 cGu
-rTJ
+mcI
 cGu
 cGu
 gbQ
 gbQ
-iOl
+nTg
 gbQ
 gbQ
 cGu
@@ -80481,11 +80481,11 @@ cGu
 gbQ
 gbQ
 gbQ
-iOl
+nTg
 gbQ
 cGu
 cES
-gCm
+kMz
 dsE
 tmE
 tmE
@@ -80493,7 +80493,7 @@ sFU
 uPY
 qeM
 uPY
-wgk
+nsT
 wAC
 dTs
 dTs
@@ -80558,12 +80558,12 @@ dTs
 dTs
 qqj
 hgy
-pEZ
-gKz
+xlk
+pJF
 qJA
 mTa
 qJA
-gKz
+pJF
 qJA
 dTs
 dTs
@@ -80577,7 +80577,7 @@ dTs
 qJA
 qJA
 qJA
-pEZ
+xlk
 nPH
 mTa
 qJA
@@ -80604,7 +80604,7 @@ dTs
 dTs
 dTs
 vMQ
-rkl
+pyN
 iEI
 dTs
 dTs
@@ -80636,10 +80636,10 @@ bou
 bsb
 aUe
 bgz
-oOG
+sdC
 bKf
 bBS
-xSK
+uuh
 bKf
 bLe
 bgz
@@ -80662,7 +80662,7 @@ dTs
 dTs
 dTs
 aIP
-vAC
+pwW
 cgm
 cgm
 chb
@@ -80701,7 +80701,7 @@ cGG
 cGG
 cFI
 cFS
-fte
+lCo
 nVC
 cGG
 cFS
@@ -80711,7 +80711,7 @@ cGS
 cDV
 cEZ
 cFc
-ngA
+vrO
 cFS
 cGG
 cFc
@@ -80922,7 +80922,7 @@ dTs
 dTs
 dTs
 vul
-elW
+jEc
 cTD
 cYZ
 doE
@@ -80957,7 +80957,7 @@ cBS
 kzc
 tmE
 tmE
-nDW
+rXd
 uPY
 uPY
 uPY
@@ -81087,7 +81087,7 @@ ceA
 ceA
 aQc
 beO
-qQd
+sfv
 aSL
 ceA
 ceA
@@ -81107,7 +81107,7 @@ bgz
 bgz
 bzW
 mGv
-xSK
+uuh
 bgz
 ufq
 bgz
@@ -81132,16 +81132,16 @@ cjO
 cjO
 kzQ
 ceA
-eWZ
+oqG
 ceA
 ceA
 ceA
-eWZ
+oqG
 gez
 uOe
 cjO
 ceA
-eWZ
+oqG
 ceA
 ceA
 cjO
@@ -81166,7 +81166,7 @@ dTs
 cDM
 cDY
 cDY
-tnx
+pUo
 cDY
 cDY
 wMF
@@ -81187,7 +81187,7 @@ wMF
 wMF
 rfQ
 cML
-afD
+pJQ
 dsE
 tmE
 tmE
@@ -81344,7 +81344,7 @@ bgz
 bgz
 bgz
 bKZ
-xSK
+uuh
 bMZ
 bNO
 aTZ
@@ -81352,14 +81352,14 @@ ceA
 vVF
 cjO
 cjO
-qlP
+jMD
 cjO
 oIk
-qlP
+jMD
 cjO
 ceA
 ceA
-eWZ
+oqG
 ceA
 tDH
 cjO
@@ -81397,7 +81397,7 @@ cUA
 doE
 dTs
 dTs
-nXl
+mwO
 cDY
 wMF
 qMp
@@ -81429,7 +81429,7 @@ sFU
 uPY
 uPY
 uPY
-epQ
+mQH
 wAC
 dTs
 dTs
@@ -81490,7 +81490,7 @@ bhN
 bik
 bwX
 biZ
-mCF
+qtU
 bwX
 bhT
 bhT
@@ -81500,13 +81500,13 @@ bhT
 bwX
 bhT
 biZ
-gPJ
+aCA
 bhT
 bhT
 bwX
 biZ
 bsr
-mCF
+qtU
 afh
 dTs
 dTs
@@ -81530,7 +81530,7 @@ aLY
 aLY
 aLY
 bLW
-gZs
+iWI
 bVf
 bLW
 aLY
@@ -81553,7 +81553,7 @@ aSK
 cvr
 aPR
 aRy
-qQd
+sfv
 dzh
 aSL
 cjO
@@ -81573,7 +81573,7 @@ bsl
 aUe
 bgz
 bKf
-oOG
+sdC
 bBS
 bgz
 bKf
@@ -81620,9 +81620,9 @@ cjO
 cxt
 qbx
 cwB
-xdg
+kjH
 doE
-qdJ
+iQc
 cyB
 cTG
 cTG
@@ -81648,7 +81648,7 @@ pmo
 wMF
 fqM
 knw
-vgA
+llV
 oMM
 kMv
 kMe
@@ -81661,7 +81661,7 @@ xWn
 tmE
 sFU
 uPY
-oEW
+jhU
 lpD
 fRI
 dTs
@@ -81726,11 +81726,11 @@ bjx
 bjx
 tFX
 bjx
-pPs
+puo
 bjx
 bjx
 blw
-pPs
+puo
 bjx
 tFX
 bjx
@@ -81752,16 +81752,16 @@ bCe
 bCP
 bzh
 bFG
-pQK
+gqc
 bzi
 bJb
 bKm
 byo
 bLW
-qwf
+nsV
 bLW
 bLW
-qwf
+nsV
 bLW
 bLW
 bMW
@@ -81789,7 +81789,7 @@ aPR
 aRy
 sCK
 dzh
-oLc
+fZf
 cjO
 ceA
 ceA
@@ -81818,16 +81818,16 @@ bgz
 aTZ
 ceA
 ceA
-eWZ
+oqG
 ceA
 cjO
-fAx
+gCr
 bUT
 bUT
 ceA
 ceA
 gpY
-ufK
+yiW
 ceA
 cjO
 cjO
@@ -81846,7 +81846,7 @@ crm
 ciF
 ciF
 chv
-eWZ
+oqG
 aRy
 dzh
 beO
@@ -81965,16 +81965,16 @@ biE
 bjk
 blx
 bhP
-hSv
+glU
 bhP
 bhP
 bhP
 bhP
-hSv
+glU
 bhP
 bhA
 bst
-mCF
+qtU
 agP
 buI
 bhu
@@ -82001,7 +82001,7 @@ hmF
 bMW
 bVf
 bLW
-qwf
+nsV
 bUX
 bLU
 dTs
@@ -82022,7 +82022,7 @@ cvr
 aXd
 aRy
 dzh
-qQd
+sfv
 ekS
 cjO
 ceA
@@ -82039,7 +82039,7 @@ bom
 oFf
 bsb
 aTZ
-xeo
+oWj
 bKf
 bKf
 bBS
@@ -82188,10 +82188,10 @@ aQU
 wTE
 bhe
 bdD
-hSv
+glU
 bhP
 bhP
-hSv
+glU
 bhP
 bhP
 biE
@@ -82206,7 +82206,7 @@ bhP
 bhP
 asR
 bhP
-ubd
+qQs
 bst
 bhT
 bsr
@@ -82225,7 +82225,7 @@ bzi
 bJd
 bzi
 bMw
-qwf
+nsV
 bME
 bLW
 bNZ
@@ -82284,17 +82284,17 @@ bsp
 bKN
 bLd
 bLL
-lCp
+jGP
 bNE
 bRz
-krh
+fWX
 bVA
-rxO
+ttC
 bSz
 cak
 caR
 bNE
-srZ
+cDw
 bNE
 cdG
 bNE
@@ -82366,7 +82366,7 @@ uPY
 uPY
 uPY
 uPY
-wgk
+nsT
 dTs
 dTs
 acu
@@ -82452,12 +82452,12 @@ jbV
 bTA
 bVj
 bzi
-pQK
+gqc
 bzi
 kXK
 bzi
 bzi
-pQK
+gqc
 bMw
 bLW
 mhU
@@ -82508,15 +82508,15 @@ ycr
 bsm
 aUS
 bld
-wIN
+uSI
 bwH
 bwH
 aUS
 emv
 nYe
-rEa
+mFX
 bsp
-lCp
+jGP
 bLd
 bLd
 bNE
@@ -82566,7 +82566,7 @@ cZb
 cZb
 csG
 cOj
-oEW
+jhU
 cDK
 cDY
 qMp
@@ -82690,18 +82690,18 @@ bzk
 bzk
 lBM
 bVo
-jvM
+pYw
 bzk
 bMw
 bLW
 bLW
 cvf
 cvf
-rrY
+qTD
 cvf
 cCh
 gxo
-hkq
+euS
 bLW
 bLW
 bUY
@@ -82755,15 +82755,15 @@ bLM
 bLd
 bNE
 bRD
-rkm
+mqQ
 bWM
 bSz
-rxO
+ttC
 bTn
-rkm
+mqQ
 cdt
-jGD
-jGD
+pdk
+pdk
 cdN
 bNE
 dTs
@@ -82981,7 +82981,7 @@ bml
 bml
 aUS
 ttf
-jNT
+qyb
 bIX
 bNE
 bNF
@@ -83002,7 +83002,7 @@ cdN
 bNE
 dTs
 cjO
-uac
+njh
 aRy
 aSL
 cfC
@@ -83035,7 +83035,7 @@ cZb
 csG
 doE
 uPY
-cWQ
+utU
 cDY
 cDY
 cDY
@@ -83059,11 +83059,11 @@ wMF
 wMF
 rfQ
 waU
-afD
+pJQ
 dsE
 ozv
 tmE
-nDW
+rXd
 prz
 lpD
 wQK
@@ -83143,17 +83143,17 @@ bjz
 bhP
 bhP
 brD
-gFB
+mta
 bhT
 buD
 bhz
 bhz
-kyu
+iZr
 bSg
 bSg
 bSg
 bVQ
-iNH
+sbf
 bSg
 bSg
 omj
@@ -83164,7 +83164,7 @@ bzm
 clY
 wOt
 bLY
-hBL
+ydA
 bLY
 bLY
 xbg
@@ -83191,7 +83191,7 @@ kfo
 aWf
 aPR
 aRy
-ejV
+eYe
 sCK
 ekS
 cjO
@@ -83224,7 +83224,7 @@ bQu
 bNE
 bSb
 eXh
-rxO
+ttC
 bYT
 bYT
 iJA
@@ -83267,7 +83267,7 @@ cZb
 cZb
 cZb
 csG
-qdJ
+iQc
 tTv
 aLy
 cDY
@@ -83399,7 +83399,7 @@ bLW
 kFa
 bLW
 bLW
-qwf
+nsV
 bLW
 kFa
 gxo
@@ -83453,7 +83453,7 @@ qet
 bIW
 bNF
 bOD
-tDG
+oTR
 bOD
 bNE
 bSn
@@ -83461,11 +83461,11 @@ bTo
 bSz
 bYT
 bYT
-rkm
+mqQ
 bYl
 bNE
 chd
-jGD
+pdk
 bcM
 bNE
 dTs
@@ -83511,7 +83511,7 @@ cFP
 cGa
 cGQ
 cFe
-xin
+lda
 cGa
 cGQ
 cFe
@@ -83533,7 +83533,7 @@ snZ
 vPD
 sFU
 uPY
-oEW
+jhU
 prz
 nTW
 wAC
@@ -83593,7 +83593,7 @@ aQU
 xWm
 bdD
 bhP
-hSv
+glU
 bhP
 bhP
 bhP
@@ -83607,7 +83607,7 @@ bhP
 bhP
 bhP
 bhP
-hSv
+glU
 biG
 bhP
 bhA
@@ -83625,7 +83625,7 @@ bBj
 bBj
 bFK
 phP
-htY
+kOP
 bJf
 bKo
 bMw
@@ -83700,7 +83700,7 @@ cbI
 bNE
 ciK
 ciK
-jGD
+pdk
 bNE
 dTs
 dTs
@@ -83720,7 +83720,7 @@ ceA
 cjO
 kzQ
 aUh
-eWZ
+oqG
 ceA
 cjO
 kZd
@@ -83740,7 +83740,7 @@ uPY
 aLK
 cDX
 cDX
-uDD
+jSl
 cDX
 cDX
 cDX
@@ -83749,16 +83749,16 @@ cDX
 cDX
 cDX
 cDX
-uDD
+jSl
 cES
 cDX
 cDX
 cDX
 cDX
-uDD
+jSl
 cDX
 cDX
-uDD
+jSl
 cDX
 cES
 cRB
@@ -83768,7 +83768,7 @@ tmE
 sFU
 uPY
 uPY
-swM
+fLL
 fRI
 dTs
 dTs
@@ -83827,12 +83827,12 @@ aQU
 xWm
 bdD
 bhP
-hSv
+glU
 hGl
 bhP
-hSv
+glU
 bhP
-hSv
+glU
 cAx
 bjk
 blx
@@ -83864,7 +83864,7 @@ bJf
 bKp
 byo
 bMa
-qwf
+nsV
 mOk
 bLW
 bOM
@@ -83895,8 +83895,8 @@ aXf
 aZN
 dzh
 hiH
-ejV
-oLc
+eYe
+fZf
 cjO
 aoj
 aUf
@@ -83998,7 +83998,7 @@ mUm
 mUm
 ueR
 tmE
-ffF
+xWL
 sFU
 lpD
 pMX
@@ -84067,11 +84067,11 @@ bim
 bim
 bim
 bim
-ouf
+bzB
 bim
 bhS
 bim
-ouf
+bzB
 bim
 bim
 bim
@@ -84155,24 +84155,24 @@ bGD
 bsT
 bNG
 bOG
-cpa
+rEs
 bOG
 bNG
 cal
 cal
 bXO
-rxO
+ttC
 bSz
-pML
+vdg
 cak
 bTm
-krh
+fWX
 bTm
 csh
 bNE
 dTs
 jZZ
-uDw
+wBY
 aRy
 aSL
 lCI
@@ -84330,7 +84330,7 @@ bBw
 luw
 bzt
 bzt
-ehW
+kHk
 bzt
 bzt
 bzt
@@ -84361,10 +84361,10 @@ aSK
 cvr
 aXd
 aRy
-qQd
+sfv
 sCK
 sCK
-oLc
+fZf
 cjO
 aoj
 aND
@@ -84421,13 +84421,13 @@ dTs
 dTs
 dTs
 cuy
-jOu
+aEr
 cjO
 cxq
 cxQ
-qdJ
+iQc
 doE
-qdJ
+iQc
 crv
 cTD
 cYZ
@@ -84532,7 +84532,7 @@ nOE
 bhz
 biI
 bhz
-vpa
+vmI
 bhz
 nOE
 bhz
@@ -84547,25 +84547,25 @@ bhz
 fKl
 bhz
 bhz
-sFG
+ukq
 bhz
 qJc
 bhz
-vpa
+vmI
 byq
 bzr
 bzr
-qNx
+evo
 euJ
 bTE
-kdW
+txU
 bzr
 oze
 jlY
 iMM
 bzr
 bTE
-qNx
+evo
 euJ
 bTE
 bTE
@@ -84574,7 +84574,7 @@ cyU
 cyU
 kcL
 cEs
-mPo
+aQC
 cEs
 gJb
 kFa
@@ -84622,12 +84622,12 @@ rZY
 bGH
 bJH
 bNF
-bge
+bYA
 bOJ
-bge
+bYA
 bNF
 bSX
-rkm
+mqQ
 bYl
 bZH
 cai
@@ -84659,7 +84659,7 @@ dTs
 cjO
 cxr
 cwz
-qdJ
+iQc
 doE
 doE
 gNP
@@ -84703,7 +84703,7 @@ tTd
 tTd
 mHb
 uPY
-oEW
+jhU
 uPY
 dTs
 dTs
@@ -84770,10 +84770,10 @@ bhz
 bhz
 bhz
 bhz
-vpa
+vmI
 bhz
 bhz
-vpa
+vmI
 bhz
 bhz
 bhz
@@ -84787,7 +84787,7 @@ buD
 bhz
 bhz
 bhz
-gJH
+iWX
 bWY
 cXG
 oze
@@ -84802,11 +84802,11 @@ bWY
 mvg
 mvg
 bwU
-gJH
+iWX
 bLY
 bLY
 bLY
-hBL
+ydA
 bLY
 cGy
 cEs
@@ -84848,7 +84848,7 @@ pfC
 bsb
 aWK
 bqh
-fkp
+tOQ
 bpN
 bDE
 aWK
@@ -84896,7 +84896,7 @@ oZk
 czv
 doE
 doE
-fVZ
+vLO
 cTD
 cYZ
 doE
@@ -84924,16 +84924,16 @@ cVH
 cWn
 cNo
 aMI
-eZX
+kKN
 deU
 vcQ
-lPH
+isd
 aMT
 daw
 lmV
 uPY
 uPY
-oEW
+jhU
 uPY
 uPY
 uPY
@@ -85024,7 +85024,7 @@ bKM
 bSh
 bzt
 bBw
-wkv
+oqS
 xri
 bzt
 bzt
@@ -85038,7 +85038,7 @@ mDA
 bzt
 bzt
 bRj
-qwf
+nsV
 bLW
 bLW
 bLW
@@ -85065,7 +85065,7 @@ aPR
 aRy
 dzh
 dzh
-qQd
+sfv
 aSL
 cjO
 aoj
@@ -85087,7 +85087,7 @@ bBb
 bDE
 aWK
 ttf
-rZo
+ndB
 bIW
 bNF
 bPz
@@ -85095,7 +85095,7 @@ bPK
 bRx
 bNE
 bTh
-rea
+ykD
 bYm
 bNE
 bTh
@@ -85103,7 +85103,7 @@ leP
 bYm
 bNE
 bTh
-rea
+ykD
 bYm
 bNE
 dTs
@@ -85112,7 +85112,7 @@ daZ
 sVo
 mfa
 gNP
-qdJ
+iQc
 qbx
 czA
 dTs
@@ -85128,7 +85128,7 @@ dTs
 dTs
 vul
 cxT
-qdJ
+iQc
 doE
 cDc
 cTD
@@ -85154,7 +85154,7 @@ gHj
 huv
 cxu
 sAq
-quM
+miS
 hJT
 cXD
 aMI
@@ -85163,7 +85163,7 @@ deV
 vcQ
 vcQ
 aMU
-kPX
+jCz
 utN
 uPY
 uPY
@@ -85235,7 +85235,7 @@ bjx
 bjx
 bjx
 bjx
-pPs
+puo
 bjx
 bjx
 bjx
@@ -85296,7 +85296,7 @@ aUA
 aUM
 aWE
 aPR
-pVC
+vQu
 bqd
 bqd
 dzh
@@ -85334,7 +85334,7 @@ bTj
 bNE
 bTj
 leP
-teg
+jdz
 bNE
 bTj
 bUV
@@ -85348,7 +85348,7 @@ cYZ
 doE
 cNQ
 doE
-jqm
+mnJ
 dTs
 dTs
 dTs
@@ -85395,12 +85395,12 @@ aMI
 bjE
 aMJ
 vcQ
-lPH
+isd
 aNe
 bjE
 utN
 uPY
-oEW
+jhU
 uPY
 uPY
 dTs
@@ -85472,7 +85472,7 @@ bhP
 bhP
 mKW
 mKW
-hSv
+glU
 bhP
 bhP
 bhP
@@ -85486,7 +85486,7 @@ bhA
 xVF
 bhT
 buD
-vpa
+vmI
 bin
 bhu
 bzv
@@ -85517,11 +85517,11 @@ gwU
 bLW
 bXS
 djY
-tvb
+lNn
 duP
 duP
 dLd
-mxi
+gPb
 dNm
 bXQ
 dTs
@@ -85582,7 +85582,7 @@ cYZ
 doE
 qUE
 doE
-xTN
+ukb
 czA
 dTs
 dTs
@@ -85623,7 +85623,7 @@ cLI
 cLO
 cUZ
 cVH
-gvT
+eky
 aMw
 aMI
 dbc
@@ -85633,7 +85633,7 @@ vcQ
 aNm
 dbc
 utN
-oEW
+jhU
 uPY
 uPY
 dTs
@@ -85701,7 +85701,7 @@ ams
 bhP
 bhP
 azI
-hSv
+glU
 bhP
 jTF
 bhP
@@ -85709,11 +85709,11 @@ bhP
 bhP
 bhP
 mKW
-hSv
+glU
 bhP
 bhP
 bhP
-hSv
+glU
 bhP
 bhP
 bhA
@@ -85725,7 +85725,7 @@ bxb
 bhu
 bzw
 bzt
-rEb
+log
 mvg
 bzr
 bEg
@@ -85789,10 +85789,10 @@ brY
 bFm
 aYd
 bDL
-rZo
+ndB
 bJK
 bLa
-uGG
+xrU
 bLa
 bsS
 bsp
@@ -85800,13 +85800,13 @@ bLO
 btX
 bNf
 bNL
-icl
+tXA
 lDp
 bNf
 bNL
 bLO
 btX
-rEa
+mFX
 bsp
 cQm
 cGI
@@ -85932,7 +85932,7 @@ xMI
 aiZ
 aoE
 cck
-hSv
+glU
 mKW
 bhP
 mKW
@@ -85951,7 +85951,7 @@ bhP
 bhP
 bhP
 bhA
-gFB
+mta
 bsu
 buD
 bhz
@@ -86089,7 +86089,7 @@ cLQ
 cLI
 cLI
 cLO
-dbR
+plG
 cVI
 cOB
 cXD
@@ -86147,7 +86147,7 @@ dTs
 dTs
 bDO
 iNZ
-pEA
+uKc
 kBc
 apz
 aql
@@ -86173,7 +86173,7 @@ bhQ
 bhP
 bhP
 bhQ
-hSv
+glU
 bhP
 bhQ
 bhP
@@ -86195,7 +86195,7 @@ bzy
 bzt
 bwc
 bwT
-mhP
+hNk
 bzt
 bxY
 bGV
@@ -86236,7 +86236,7 @@ aFx
 axk
 ceA
 aRy
-oLc
+fZf
 ceA
 ceA
 aVB
@@ -86259,10 +86259,10 @@ aYd
 bDL
 bGL
 bJM
-kbB
+evF
 bLb
 bJM
-iEi
+eYq
 nNs
 nNs
 bNd
@@ -86295,7 +86295,7 @@ cZb
 csG
 doE
 doE
-qdJ
+iQc
 doE
 cTD
 ewD
@@ -86325,12 +86325,12 @@ cLI
 cLO
 cUY
 cVI
-gvT
+eky
 cXD
 cYC
 dbe
 ddL
-qNC
+thG
 aMQ
 aNo
 aNK
@@ -86362,7 +86362,7 @@ dTs
 dTs
 ars
 apa
-xiz
+cvA
 axZ
 dTs
 dTs
@@ -86396,21 +86396,21 @@ dTs
 dTs
 dTs
 axZ
-cQy
+lmt
 aiZ
 aoE
 cck
 bhT
 bhP
-umD
-hSv
+sDJ
+glU
 bhP
 bhP
 mKW
 mKW
 bhP
 mKW
-hSv
+glU
 bhP
 bhP
 bhP
@@ -86458,7 +86458,7 @@ cti
 vmL
 wVJ
 vmL
-oGE
+mjv
 aJJ
 vmL
 ahp
@@ -86466,7 +86466,7 @@ vZj
 aSK
 cvr
 aPR
-pVC
+vQu
 axk
 ceA
 aRy
@@ -86514,7 +86514,7 @@ svo
 mWC
 daZ
 cxU
-sIf
+irP
 doE
 doE
 doE
@@ -86621,7 +86621,7 @@ apz
 aqg
 aqg
 asa
-npV
+gPv
 bDO
 dTs
 dTs
@@ -86634,7 +86634,7 @@ aiZ
 aiZ
 aoE
 cck
-nTx
+gNG
 bhP
 bhP
 nji
@@ -86648,15 +86648,15 @@ bhP
 mKW
 bhR
 bhP
-umD
+sDJ
 bhR
 bhP
 bhP
-gzs
+ptr
 bEO
 bIh
 bJt
-xif
+rxN
 bON
 bhu
 bsi
@@ -86714,7 +86714,7 @@ awM
 awM
 awM
 awM
-ixF
+nMu
 bqA
 oFf
 bsb
@@ -86725,7 +86725,7 @@ bBd
 bFw
 aYd
 bDL
-kND
+dzY
 bIX
 bIX
 bJU
@@ -86747,10 +86747,10 @@ bBL
 bBL
 dTs
 doE
-jqm
+mnJ
 czA
 cwz
-qdJ
+iQc
 doE
 cTC
 cUl
@@ -86761,7 +86761,7 @@ dlM
 cZb
 cZb
 csG
-sSL
+etO
 doE
 cJd
 cJd
@@ -86771,7 +86771,7 @@ cJd
 cJd
 doE
 qUE
-qdJ
+iQc
 cTD
 cYZ
 dTs
@@ -86827,7 +86827,7 @@ dsl
 dsl
 dsl
 dsl
-aTw
+pra
 axZ
 apa
 kBb
@@ -86849,7 +86849,7 @@ dTs
 dTs
 dTs
 iNZ
-pEA
+uKc
 kBc
 apz
 aql
@@ -86915,7 +86915,7 @@ bRc
 bRX
 bRk
 bUr
-oCD
+rsx
 cLX
 kxg
 cOo
@@ -86951,7 +86951,7 @@ axF
 bpq
 diO
 wuq
-gpu
+vbX
 aYd
 bbo
 bzd
@@ -86968,7 +86968,7 @@ bNI
 bQC
 bSB
 bWA
-vaB
+ybU
 bJU
 bBO
 bYs
@@ -86985,7 +86985,7 @@ czA
 dTs
 dTs
 cwz
-qdJ
+iQc
 cTC
 dlb
 cMJ
@@ -87000,7 +87000,7 @@ czv
 cJd
 cOd
 coi
-xYT
+wly
 cPi
 cJd
 doE
@@ -87034,7 +87034,7 @@ dbi
 dbi
 deY
 dfA
-vfe
+hhF
 cXD
 bvA
 dTs
@@ -87098,20 +87098,20 @@ dTs
 dTs
 dTs
 vAr
-lJC
+oMe
 axY
-aTw
+pra
 fSe
 bhP
 bhP
 bhP
 bhP
-hSv
+glU
 bhP
 bhP
 mKW
 bhP
-hSv
+glU
 mKW
 bhP
 bhP
@@ -87148,19 +87148,19 @@ bPX
 tdf
 bRY
 bOR
-pqa
+mLV
 bTG
 bTG
 xeQ
 bZc
 bTG
-ngH
+wGt
 bTG
 ddP
-gUJ
+jOb
 dKz
 bTG
-gUJ
+jOb
 bTG
 bYC
 cio
@@ -87171,13 +87171,13 @@ aPR
 aFx
 aPu
 ceA
-jjx
+fwb
 aSL
 ceA
 ceA
 aVM
 aXZ
-bOy
+xrX
 bes
 bkG
 bmX
@@ -87200,7 +87200,7 @@ bJV
 bMs
 bNJ
 bNi
-inm
+bdl
 bWA
 cfN
 bJU
@@ -87233,7 +87233,7 @@ cru
 doE
 cJd
 coi
-rTD
+fzw
 fVP
 coi
 cJd
@@ -87264,7 +87264,7 @@ cVH
 vDE
 cXK
 cYJ
-jqs
+ouv
 cXK
 deZ
 cXK
@@ -87296,11 +87296,11 @@ aPD
 iqK
 aau
 aoE
-ihJ
+fBc
 apa
 kBb
 axZ
-ihJ
+fBc
 axZ
 nmW
 apu
@@ -87338,7 +87338,7 @@ fPt
 sqe
 eHU
 bhP
-hSv
+glU
 bhP
 bhP
 bhP
@@ -87349,17 +87349,17 @@ mKW
 mKW
 bhP
 bhP
-hSv
+glU
 bhP
 bhP
-hSv
+glU
 bhP
 bhA
 bEO
 bDo
 bJt
 bLx
-vpa
+vmI
 cwr
 bpJ
 bAr
@@ -87390,12 +87390,12 @@ bWT
 bTG
 bTI
 bTG
-pqa
+mLV
 bTG
 bTI
 bTG
 bTG
-pqa
+mLV
 bTI
 cio
 cfl
@@ -87408,7 +87408,7 @@ ceA
 aRy
 aSL
 ceA
-eWZ
+oqG
 aVM
 aZM
 aZM
@@ -87444,7 +87444,7 @@ car
 bBL
 ccY
 hUM
-sWV
+cyy
 cPF
 bBL
 dTs
@@ -87463,7 +87463,7 @@ dlM
 cZb
 cZb
 csG
-qdJ
+iQc
 cJd
 cJd
 cJd
@@ -87532,7 +87532,7 @@ aau
 aoE
 axZ
 apa
-xiz
+cvA
 brB
 axZ
 vAr
@@ -87540,11 +87540,11 @@ aiZ
 aiZ
 aiZ
 aiZ
-lJC
+oMe
 brB
 apu
 apu
-vZM
+xhx
 vAr
 aiZ
 aiZ
@@ -87559,7 +87559,7 @@ aqg
 asa
 aiZ
 aiZ
-lJC
+oMe
 aiZ
 aiZ
 dTs
@@ -87646,24 +87646,24 @@ ceA
 aVM
 aZM
 aZM
-bOy
+xrX
 aZM
 jIo
 aVM
 bpe
 bou
-qgA
+ybB
 bom
 bsQ
 btX
 bvH
 bBe
-sAb
+fWP
 bBe
 fwg
 bHg
 bKh
-rEa
+mFX
 bJV
 bNi
 bNi
@@ -87699,15 +87699,15 @@ cZb
 csG
 doE
 cJe
-luQ
+fdd
 cOe
 iOV
 tif
 coi
-luQ
+fdd
 cJe
 doE
-qdJ
+iQc
 cTD
 cYZ
 dTs
@@ -87720,14 +87720,14 @@ boP
 lFb
 clj
 bvA
-yck
+nJk
 cmS
 mvi
 cMd
 cLI
 cLI
 cLO
-gSR
+rFa
 cVI
 vDE
 cXM
@@ -87771,7 +87771,7 @@ gjl
 mZc
 mZc
 mZc
-qgf
+lWc
 mZc
 mZc
 byi
@@ -87795,7 +87795,7 @@ eKa
 ipB
 ipB
 uBs
-hnz
+ouJ
 bgN
 bgN
 bgN
@@ -87870,7 +87870,7 @@ cwq
 bkj
 aSK
 aPR
-pVC
+vQu
 axk
 ceA
 aRy
@@ -87900,7 +87900,7 @@ bKK
 bIX
 bKO
 bNi
-inm
+bdl
 bQH
 bTw
 bWB
@@ -88003,7 +88003,7 @@ aSC
 aau
 aOc
 akz
-dAy
+xjr
 kYL
 alp
 alp
@@ -88014,10 +88014,10 @@ avC
 ame
 afy
 jCY
-hIS
+fLF
 ame
 ame
-xbQ
+wPY
 ame
 oZJ
 aoE
@@ -88031,7 +88031,7 @@ ame
 gGO
 kYL
 kYL
-vac
+vFH
 kYL
 gLB
 kYL
@@ -88107,7 +88107,7 @@ aPR
 aFx
 axk
 ceA
-jjx
+fwb
 ekS
 ceA
 axF
@@ -88174,7 +88174,7 @@ cPe
 cNU
 cPk
 cJd
-qdJ
+iQc
 doE
 cTD
 cYZ
@@ -88203,8 +88203,8 @@ cYC
 dbe
 ddL
 deW
-uKt
-vfe
+sLB
+hhF
 cXD
 bvA
 dTs
@@ -88243,7 +88243,7 @@ aiZ
 acW
 aqy
 aja
-lJC
+oMe
 aiZ
 aiZ
 vYm
@@ -88261,8 +88261,8 @@ aqg
 asa
 aoE
 ame
-lJC
-hfk
+oMe
+jHC
 aja
 aiZ
 aqy
@@ -88294,7 +88294,7 @@ brG
 bsy
 btp
 uPS
-oWj
+ozx
 bxf
 bys
 bLz
@@ -88352,10 +88352,10 @@ bnC
 bnC
 cjO
 cjO
-qlP
+jMD
 ccm
-syc
-qlP
+tiN
+jMD
 aNH
 aTy
 boq
@@ -88378,10 +88378,10 @@ bGx
 bZu
 car
 bBL
-eni
+hNP
 hUM
 cKX
-tkX
+vMq
 bBL
 dTs
 dTs
@@ -88394,7 +88394,7 @@ dTs
 dTs
 dTs
 vul
-qdJ
+iQc
 cUl
 cZb
 cZb
@@ -88412,7 +88412,7 @@ doE
 doE
 cTD
 cYZ
-qdJ
+iQc
 dTs
 dTs
 boP
@@ -88494,15 +88494,15 @@ aqg
 aqg
 asa
 aoE
-xbQ
+wPY
 aqy
 axZ
 axZ
-iFX
+mCW
 dTs
 dTs
 axZ
-iFX
+mCW
 ars
 dTs
 dTs
@@ -88523,10 +88523,10 @@ bni
 bnM
 boA
 bDi
-bGm
+naR
 boA
 boA
-mBk
+fNN
 uPS
 bMc
 bMc
@@ -88540,7 +88540,7 @@ gWW
 bWa
 bBD
 bAt
-hYe
+qLL
 bDK
 brQ
 bpJ
@@ -88578,7 +88578,7 @@ ceA
 aRy
 qTY
 beO
-rTi
+ozk
 beO
 beO
 beO
@@ -88627,7 +88627,7 @@ dTs
 dTs
 dTs
 czA
-gTa
+duj
 doE
 cUl
 cvJ
@@ -88704,16 +88704,16 @@ hBR
 aPF
 aRc
 aau
-ihJ
+fBc
 aja
 aVI
 azf
 jxv
 aYu
-jnD
+uWt
 aYu
 aZx
-jnD
+uWt
 aWk
 fJx
 bdE
@@ -88758,13 +88758,13 @@ bnN
 fUE
 bEo
 rSy
-jac
+tfQ
 rSy
 rSy
 ngn
 gYc
 bMc
-oWj
+ozx
 bvY
 bJj
 kUJ
@@ -88816,7 +88816,7 @@ bqd
 bqd
 qTY
 qTY
-vDy
+wvZ
 qTY
 qTY
 qTY
@@ -88844,7 +88844,7 @@ cyH
 cJr
 bNw
 bZJ
-kYc
+iRN
 caZ
 bZJ
 qZq
@@ -88872,12 +88872,12 @@ cJd
 cNY
 cOn
 cOD
-ilf
+iwY
 cNv
 cPm
 cJd
 doE
-qdJ
+iQc
 cTD
 cYZ
 doE
@@ -88886,7 +88886,7 @@ dTs
 boP
 boP
 boP
-fSV
+rKX
 uAO
 cna
 bvA
@@ -88898,7 +88898,7 @@ cLG
 cOF
 cLO
 cUY
-lFR
+bIi
 cOB
 cXD
 bvA
@@ -88956,7 +88956,7 @@ aWl
 baR
 aWM
 aiZ
-aTw
+pra
 apz
 aqg
 ahk
@@ -89035,7 +89035,7 @@ bOX
 bOX
 bOX
 cdR
-uPA
+dtg
 cxc
 pbH
 aWE
@@ -89043,16 +89043,16 @@ aPR
 aFx
 axk
 ceA
-eWZ
+oqG
 bft
 rFg
 ceA
 cjO
-rwW
+jyw
 bqd
 bqd
 bqd
-pnH
+pkU
 bqd
 aTU
 cjO
@@ -89082,7 +89082,7 @@ tnH
 kea
 kea
 fof
-kYc
+iRN
 bZw
 dTs
 dTs
@@ -89118,7 +89118,7 @@ doE
 doE
 dTs
 boP
-rZT
+nZT
 boR
 bNb
 lVK
@@ -89240,7 +89240,7 @@ blI
 sOR
 bAv
 bwe
-qDp
+mPo
 bHT
 bJh
 bDK
@@ -89261,7 +89261,7 @@ qsq
 cuo
 psu
 aUp
-lKX
+wcF
 dTs
 dTs
 dTs
@@ -89345,10 +89345,10 @@ cNv
 cOn
 cJe
 doE
-qdJ
+iQc
 cTD
 cYZ
-qdJ
+iQc
 doE
 dTs
 boP
@@ -89411,7 +89411,7 @@ dTs
 aVI
 aNu
 aWl
-vnr
+xme
 aWl
 aYw
 afa
@@ -89430,10 +89430,10 @@ aql
 ara
 ahz
 aoE
-lJC
+oMe
 aiZ
 brB
-ihJ
+fBc
 dTs
 dTs
 dTs
@@ -89490,11 +89490,11 @@ dTs
 dTs
 dTs
 bOX
-ubq
+tSq
 bVY
 cuq
-wut
-lKX
+fTL
+wcF
 aUp
 dTs
 dTs
@@ -89508,13 +89508,13 @@ cxc
 bQb
 aSK
 aPR
-pVC
+vQu
 axk
 ceA
 ceA
 grm
 ceA
-eWZ
+oqG
 ceA
 bVK
 bqi
@@ -89563,7 +89563,7 @@ dTs
 dTs
 dTs
 czA
-gTa
+duj
 doE
 cUl
 cZb
@@ -89605,15 +89605,15 @@ fvC
 cYy
 cZv
 cZv
-fPr
+dCR
 cZv
 dfB
 dfI
 dfI
 dfI
-kjJ
+kBZ
 dfI
-ift
+gqD
 cZB
 dTs
 dTs
@@ -89650,14 +89650,14 @@ dJL
 bdE
 afe
 bdE
-vnr
+xme
 kRF
 aWl
 aYS
-opc
+blb
 baR
 aWM
-lJC
+oMe
 aoE
 apz
 jco
@@ -89737,7 +89737,7 @@ dTs
 dTs
 bOX
 cdR
-uPA
+dtg
 cxc
 cfP
 aWE
@@ -89758,7 +89758,7 @@ bZv
 brq
 bBf
 ceA
-eWZ
+oqG
 aNH
 jba
 aOC
@@ -89780,7 +89780,7 @@ cyH
 cJt
 bNw
 bZM
-bkF
+uSs
 cba
 bZJ
 gXX
@@ -89805,12 +89805,12 @@ cZb
 csG
 cJe
 coi
-rTD
+fzw
 coi
 cOS
 cPg
 coi
-luQ
+fdd
 coi
 cJe
 rxm
@@ -89820,7 +89820,7 @@ doE
 cOj
 doE
 qUE
-qdJ
+iQc
 bpY
 bPE
 dHR
@@ -89843,7 +89843,7 @@ cZx
 cXa
 cXa
 cXa
-oeU
+uCD
 cZx
 cZx
 cZx
@@ -89923,7 +89923,7 @@ bhu
 blZ
 bmm
 bmF
-sHr
+huN
 bDe
 bDj
 bEy
@@ -89931,7 +89931,7 @@ xeM
 uRx
 blZ
 btt
-hYK
+gDK
 bMc
 bxk
 brF
@@ -89958,7 +89958,7 @@ dTs
 dTs
 afd
 jBg
-ubq
+tSq
 bVp
 cuq
 moj
@@ -89989,7 +89989,7 @@ brr
 bFt
 ceA
 bZK
-jFg
+eSc
 bFt
 wEo
 ceA
@@ -90050,15 +90050,15 @@ cJe
 doE
 cTD
 cYZ
-qdJ
+iQc
 doE
-qdJ
+iQc
 doE
 doE
 bpY
 bPE
 dHR
-pgv
+fjd
 pIg
 cps
 bpY
@@ -90068,9 +90068,9 @@ cOi
 cOW
 cUz
 cVo
-dqc
+cKB
 xhA
-ift
+gqD
 cVN
 cIp
 dep
@@ -90136,7 +90136,7 @@ aiZ
 beD
 beU
 bfp
-tuk
+lFS
 axZ
 dTs
 dTs
@@ -90159,7 +90159,7 @@ bmn
 xjC
 bCA
 bnU
-pRz
+dQU
 fcD
 xeM
 bEC
@@ -90175,9 +90175,9 @@ dTs
 blI
 blI
 bUq
-kAO
+sQR
 bBP
-hYe
+qLL
 bAt
 bDK
 brQ
@@ -90194,12 +90194,12 @@ aWy
 cNe
 cOP
 bVp
-uSb
+ipF
 psu
 bYE
 bZf
 bZV
-mwr
+lRo
 kzM
 cbi
 caC
@@ -90212,14 +90212,14 @@ cvr
 aPR
 aFx
 axk
-jOu
+aEr
 cwl
 ceA
-eWZ
+oqG
 ceA
 aUh
 can
-jFg
+eSc
 bFu
 ceA
 can
@@ -90288,7 +90288,7 @@ doE
 doE
 doE
 doE
-qdJ
+iQc
 bpY
 bPJ
 ddg
@@ -90458,7 +90458,7 @@ bFt
 vVF
 can
 brr
-sKy
+qhz
 ceA
 fWm
 aNH
@@ -90486,7 +90486,7 @@ bZw
 bZw
 cdH
 bZJ
-kYc
+iRN
 bZw
 dTs
 dTs
@@ -90500,7 +90500,7 @@ dTs
 czA
 vul
 doE
-qdJ
+iQc
 cUl
 qNk
 dvo
@@ -90512,7 +90512,7 @@ cOb
 cOX
 cOb
 cOb
-krp
+nRS
 cJd
 cJd
 vul
@@ -90536,9 +90536,9 @@ cOi
 cOW
 adY
 cVi
-dqc
+cKB
 xhA
-wRx
+xQG
 cVN
 dca
 deq
@@ -90547,7 +90547,7 @@ dfp
 cVi
 cIq
 cjf
-vNC
+qNV
 cOi
 cOi
 cZB
@@ -90601,15 +90601,15 @@ aqg
 asa
 aoE
 ame
-lJC
+oMe
 aiZ
 aiZ
 aqz
-lJC
+oMe
 goG
 brB
 apu
-vZM
+xhx
 dTs
 dTs
 dTs
@@ -90625,7 +90625,7 @@ dTs
 blZ
 bmp
 xjC
-sHr
+huN
 bnU
 bnU
 fcD
@@ -90659,7 +90659,7 @@ bOY
 bOY
 bOY
 bOY
-nhj
+evV
 cOL
 cbh
 cur
@@ -90688,7 +90688,7 @@ cwl
 ceA
 can
 bud
-sKy
+qhz
 ceA
 bZK
 brr
@@ -90743,7 +90743,7 @@ doE
 cJe
 cOb
 cOv
-kaB
+mog
 cOb
 cOv
 cOb
@@ -90762,7 +90762,7 @@ brL
 qZM
 rJY
 prX
-oOy
+hyZ
 lcd
 fRE
 cJc
@@ -90774,12 +90774,12 @@ tkt
 xhA
 cWj
 cVN
-dqc
+cKB
 cIq
 cIq
 cIq
 cIq
-dqc
+cKB
 dgp
 cOi
 cOi
@@ -90820,7 +90820,7 @@ aXL
 aYj
 edz
 bsE
-nSm
+vIR
 aZP
 aZS
 aZT
@@ -90842,7 +90842,7 @@ aiZ
 aiZ
 aiZ
 aiZ
-lJC
+oMe
 aiZ
 axY
 dTs
@@ -90859,7 +90859,7 @@ dTs
 blZ
 bmq
 bCf
-sHr
+huN
 bnV
 bnV
 bnV
@@ -90867,7 +90867,7 @@ sDf
 brM
 blZ
 btv
-oWj
+ozx
 mJW
 hYP
 hYP
@@ -90875,10 +90875,10 @@ hYP
 twW
 bUs
 bWa
-vUm
+igh
 bWa
 bUm
-ggW
+qrK
 btD
 bJi
 vXJ
@@ -90889,14 +90889,14 @@ bML
 bOh
 bPa
 bWh
-nrI
+xGO
 bWh
 cGr
 cGr
 cGr
 iTK
 dam
-wVK
+jJc
 psu
 bYE
 bYE
@@ -90912,7 +90912,7 @@ qqR
 qwp
 aEI
 aEx
-hZZ
+hQB
 dTs
 dTs
 dTs
@@ -90992,7 +90992,7 @@ cTG
 cTG
 cUB
 brL
-pgv
+fjd
 rQU
 cnc
 con
@@ -91105,7 +91105,7 @@ bvY
 bvY
 bvY
 bMc
-dwt
+kma
 bvY
 bMc
 cbT
@@ -91125,7 +91125,7 @@ bQa
 bXa
 cCT
 cCT
-rYL
+oiB
 cCT
 lzE
 cCT
@@ -91238,10 +91238,10 @@ cME
 cOi
 adY
 cVi
-dqc
+cKB
 jsl
 cYz
-hcs
+kPc
 cIq
 cIq
 cIq
@@ -91295,7 +91295,7 @@ buN
 buN
 buJ
 buJ
-sBv
+yje
 aoG
 apz
 aqg
@@ -91342,11 +91342,11 @@ byu
 byu
 boB
 bLz
-hYe
+qLL
 bwe
-kch
+icZ
 bAt
-bWl
+pIf
 cfr
 bAt
 bDK
@@ -91364,7 +91364,7 @@ bQc
 bOY
 pqj
 cbh
-uSb
+ipF
 psu
 bTt
 bZh
@@ -91441,21 +91441,21 @@ cUl
 dVb
 crz
 csG
-qdJ
+iQc
 doE
 cJd
 cOx
-krp
+nRS
 cOb
 cPj
 cJd
-goQ
+nMg
 oOP
 doE
 doE
-qdJ
+iQc
 doE
-qdJ
+iQc
 ixM
 cQm
 doE
@@ -91515,11 +91515,11 @@ dTs
 dTs
 aVm
 cQs
-rYj
+wVk
 rTI
 aWq
 aXL
-mXK
+pfU
 pwL
 pDA
 aYX
@@ -91609,7 +91609,7 @@ cbW
 ccE
 bTt
 mAZ
-qkl
+jRA
 qqR
 bJE
 aEH
@@ -91662,7 +91662,7 @@ eOD
 eOD
 eOD
 eOD
-tad
+tQF
 eOD
 eOD
 dTs
@@ -91684,8 +91684,8 @@ sYa
 cOb
 cJd
 doE
-qdJ
-qdJ
+iQc
+iQc
 doE
 doE
 doE
@@ -91696,8 +91696,8 @@ doE
 bpY
 cat
 dHR
-ool
-pgv
+lHr
+fjd
 cps
 bpY
 cIt
@@ -91707,7 +91707,7 @@ cOi
 adY
 cZB
 cVO
-qFb
+hQt
 cWj
 cWW
 cVN
@@ -91893,17 +91893,17 @@ dNS
 dNS
 eOD
 eOD
-tad
+tQF
 eOD
 eOD
-tad
+tQF
 eOD
 eOD
 dTs
 dTs
 dTs
 czA
-xdg
+kjH
 doE
 cUl
 cZb
@@ -91918,7 +91918,7 @@ cJd
 cJd
 cJd
 doE
-qdJ
+iQc
 tCb
 doE
 doE
@@ -91929,7 +91929,7 @@ cQm
 doE
 boP
 caw
-kZj
+jbc
 cne
 cou
 cqh
@@ -91940,7 +91940,7 @@ cME
 cOi
 adY
 cZB
-hcs
+kPc
 fvC
 cWj
 cVN
@@ -91953,7 +91953,7 @@ cIq
 cVN
 cIq
 cIq
-hcs
+kPc
 cZB
 cZB
 cZB
@@ -91989,7 +91989,7 @@ djg
 aXL
 aYm
 pwL
-pAA
+lvE
 aZb
 aWY
 bff
@@ -92032,7 +92032,7 @@ dTs
 dTs
 dTs
 dTs
-tQz
+oyb
 bmf
 brP
 qyN
@@ -92070,7 +92070,7 @@ qIf
 bOY
 bTt
 bZk
-qmS
+eFr
 wLE
 dMC
 dMC
@@ -92158,7 +92158,7 @@ doE
 doE
 doE
 doE
-qdJ
+iQc
 cQm
 boP
 boP
@@ -92177,14 +92177,14 @@ cVi
 cIq
 xhA
 cYA
-ohO
+kbq
 cZz
 deR
-ohO
+kbq
 cZz
 cZz
 cZz
-ohO
+kbq
 cZz
 cZv
 cZv
@@ -92301,7 +92301,7 @@ bRy
 bOY
 lhI
 fCZ
-ubq
+tSq
 bYE
 bZl
 dEb
@@ -92311,7 +92311,7 @@ bZX
 ccH
 bTt
 mAZ
-qkl
+jRA
 qqR
 bJE
 aEH
@@ -92320,7 +92320,7 @@ aFy
 aEI
 aEx
 cvv
-iGD
+txG
 dTs
 dTs
 dTs
@@ -92358,7 +92358,7 @@ dTs
 dTs
 eOD
 eOD
-tad
+tQF
 eOD
 eOD
 eOD
@@ -92423,13 +92423,13 @@ cVN
 cVN
 cVN
 cIq
-hcs
+kPc
 cIq
-hcs
+kPc
 xhA
 cIq
 cIq
-ift
+gqD
 cZB
 acu
 "}
@@ -92465,7 +92465,7 @@ dJP
 xYE
 bbj
 bbC
-lJC
+oMe
 akz
 aNp
 aNp
@@ -92485,7 +92485,7 @@ aql
 ara
 asa
 aoE
-hfk
+jHC
 axZ
 dTs
 dTs
@@ -92533,7 +92533,7 @@ cDU
 cGA
 bRy
 cOP
-eUJ
+szi
 fCZ
 bOY
 bYE
@@ -92541,7 +92541,7 @@ bZm
 dEb
 dKs
 dEb
-iPs
+lVV
 ccE
 bTt
 mAZ
@@ -92600,7 +92600,7 @@ eOD
 eOD
 eOD
 eOD
-tad
+tQF
 eOD
 dTs
 czA
@@ -92612,9 +92612,9 @@ cZb
 cZb
 csG
 doE
-qdJ
+iQc
 doE
-iMQ
+kja
 cZb
 cNw
 iaW
@@ -92687,7 +92687,7 @@ aVm
 duV
 aWw
 aWq
-rYj
+wVk
 aXL
 aYl
 aYH
@@ -92702,11 +92702,11 @@ bbC
 aiZ
 aiZ
 aiZ
-lJC
+oMe
 aiZ
 ame
 ame
-xbQ
+wPY
 ame
 ame
 ame
@@ -92720,7 +92720,7 @@ aqg
 asa
 aoE
 brB
-ihJ
+fBc
 axZ
 dTs
 dTs
@@ -92772,7 +92772,7 @@ fCZ
 bOY
 bYE
 bZn
-iPs
+lVV
 dEb
 dEb
 dEb
@@ -92837,7 +92837,7 @@ eOD
 eOD
 eOD
 uAo
-gTa
+duj
 doE
 doE
 rxm
@@ -92877,7 +92877,7 @@ cOi
 cUz
 jDV
 cVP
-oeU
+uCD
 cXa
 cZx
 dcb
@@ -92888,7 +92888,7 @@ cXa
 cXa
 cZx
 cZx
-lSN
+lxR
 cZx
 cZx
 cZx
@@ -92947,7 +92947,7 @@ bdg
 bdg
 bdf
 udu
-bKu
+rmE
 pUO
 cGD
 cGD
@@ -93013,7 +93013,7 @@ dNk
 kUz
 bYE
 yll
-qkl
+jRA
 qqR
 bJE
 aEI
@@ -93037,7 +93037,7 @@ cQx
 cQx
 cQN
 uax
-taq
+fQy
 cQx
 dTs
 dTs
@@ -93092,7 +93092,7 @@ dvo
 dvo
 csG
 doE
-qdJ
+iQc
 doE
 doE
 cQm
@@ -93113,7 +93113,7 @@ tzc
 cVU
 cVN
 cIq
-hcs
+kPc
 dcc
 cIq
 tng
@@ -93130,7 +93130,7 @@ cZB
 aOW
 iUL
 aOW
-kmc
+hXI
 cZB
 cZB
 acu
@@ -93157,7 +93157,7 @@ aVm
 aVm
 aVm
 aVm
-mWg
+gYM
 edz
 qVk
 hga
@@ -93173,7 +93173,7 @@ buM
 bcq
 bdf
 bdB
-geT
+bBT
 bdC
 beE
 bdC
@@ -93231,13 +93231,13 @@ bHc
 bQg
 bHa
 cFx
-qau
+ozg
 bOq
 bPx
 bOY
 rCC
 fCZ
-ubq
+tSq
 bYE
 bYE
 bTt
@@ -93307,7 +93307,7 @@ dTs
 dTs
 cHl
 doE
-qdJ
+iQc
 doE
 cUl
 cZb
@@ -93315,15 +93315,15 @@ cZb
 cZb
 cZb
 cZb
-rhc
+pXc
 cZb
-rhc
+pXc
 cZb
 cZb
 cZb
 cKd
 cZb
-mBu
+gCU
 csG
 doE
 doE
@@ -93344,18 +93344,18 @@ cNj
 cOi
 cUz
 tzc
-wRx
+xQG
 cIq
 cIq
 cIq
 dcc
 cIq
-hcs
+kPc
 cVU
 dfL
 cIq
 dfL
-hcs
+kPc
 dfL
 cZB
 dTs
@@ -93396,13 +93396,13 @@ erz
 oYa
 giT
 pXd
-gMR
-dBF
+pJS
+hKM
 bbU
 giT
 buY
 wln
-kXO
+nLp
 bsE
 aZc
 bdg
@@ -93449,7 +93449,7 @@ dTs
 dTs
 bxq
 bxr
-ggq
+mbH
 cbl
 bFP
 bGX
@@ -93461,7 +93461,7 @@ bMe
 bMM
 bNn
 bOk
-xEQ
+kEG
 bHW
 bHa
 cFy
@@ -93474,7 +93474,7 @@ qFk
 uAh
 uAh
 bZp
-vMn
+ubj
 dfS
 dfS
 oCV
@@ -93487,12 +93487,12 @@ aEI
 aEI
 aEx
 cvv
-iGD
+txG
 roU
 cir
 adt
 adx
-fKq
+srx
 buA
 adt
 dTs
@@ -93504,7 +93504,7 @@ dTs
 cQx
 cQG
 cQQ
-teC
+hYL
 cQQ
 cQx
 dTs
@@ -93527,7 +93527,7 @@ dTs
 dTs
 eOD
 tjX
-tad
+tQF
 eOD
 eOD
 eOD
@@ -93562,7 +93562,7 @@ cTc
 csE
 xBc
 doE
-qdJ
+iQc
 cQm
 cQm
 boP
@@ -93597,7 +93597,7 @@ cZB
 cbK
 aPa
 wzq
-twX
+tcY
 aRm
 cbK
 cZB
@@ -93637,7 +93637,7 @@ buX
 bbD
 hXF
 elz
-gwX
+ggi
 elz
 bzJ
 bAE
@@ -93649,7 +93649,7 @@ bdC
 bfy
 bdg
 udu
-bKu
+rmE
 pUO
 cGD
 cGD
@@ -93657,9 +93657,9 @@ amt
 vzj
 aeA
 aeA
-fDo
+fhc
 poP
-whn
+njw
 dTs
 dTs
 bkU
@@ -93670,7 +93670,7 @@ bms
 sPL
 bms
 boH
-wYq
+tGm
 bmf
 brQ
 bsC
@@ -93685,22 +93685,22 @@ dTs
 bxr
 bDb
 cbl
-lgt
+fOA
 bPx
 bHW
 bJm
-qau
-qau
+ozg
+ozg
 bHa
 bMN
-qau
+ozg
 bHa
 ciT
 ciT
-uPw
+xLg
 cFA
 cGs
-ivM
+bPy
 cAq
 bTJ
 bWg
@@ -93709,7 +93709,7 @@ bWh
 cGr
 cGr
 cGr
-lDE
+cfG
 fCZ
 cGr
 bWh
@@ -93737,7 +93737,7 @@ adw
 adw
 cQx
 cQG
-taq
+fQy
 uqe
 cQQ
 cQx
@@ -93781,14 +93781,14 @@ cUl
 cZb
 cZb
 csG
-ykw
+lsK
 cJo
 daU
 cJQ
 cJQ
 cJX
 cJQ
-rAC
+ggs
 daU
 daU
 cKi
@@ -93862,7 +93862,7 @@ aXQ
 aYq
 aYo
 aYX
-uaw
+gwI
 aZw
 aZw
 aZw
@@ -93879,7 +93879,7 @@ bBi
 dKc
 beH
 bfa
-geT
+bBT
 hWz
 bdg
 udu
@@ -93939,7 +93939,7 @@ bPx
 bOY
 cun
 clU
-hdr
+eKI
 dNl
 dNl
 dNl
@@ -93955,7 +93955,7 @@ cfQ
 cgB
 cgB
 qHO
-icq
+smw
 dTs
 dTs
 adt
@@ -94000,14 +94000,14 @@ eOD
 uRz
 eOD
 eOD
-cCK
+jvl
 ibU
 ibU
-hXY
+qGu
 ibU
 dTs
 dTs
-gTa
+duj
 doE
 doE
 doE
@@ -94019,7 +94019,7 @@ cTC
 cJo
 daU
 daU
-rAC
+ggs
 cJX
 daU
 daU
@@ -94082,13 +94082,13 @@ ach
 ahH
 awK
 aGA
-sti
+wNS
 aIf
 aIf
 rmY
 rmY
 aIf
-jny
+wKT
 aLM
 aWY
 aWY
@@ -94103,7 +94103,7 @@ aZC
 aZC
 aZC
 idI
-rWy
+lfd
 bsE
 bsE
 bbX
@@ -94126,7 +94126,7 @@ vCE
 ajK
 aeA
 aeA
-fDo
+fhc
 poP
 mKm
 asq
@@ -94152,10 +94152,10 @@ dTs
 qqS
 bxr
 bDg
-wkI
+cDW
 cts
 bHa
-qau
+ozg
 xYo
 cqu
 ciT
@@ -94170,16 +94170,16 @@ ciT
 bTc
 bTP
 bHc
-ubq
+tSq
 bOY
 bQc
 bOY
 bOY
-ubq
+tSq
 bOY
 bOY
 bOY
-ubq
+tSq
 bOY
 bOY
 mAZ
@@ -94194,23 +94194,23 @@ oOu
 dTs
 adt
 adz
-ezy
+rxE
 bOB
 adt
 ced
-rRT
+kos
 cQR
 cpq
 cBX
 cPX
-rRT
+kos
 cij
 cij
 iqz
 cij
 adw
 lNu
-wcA
+ldM
 lNu
 dTs
 dTs
@@ -94257,7 +94257,7 @@ daU
 daU
 daU
 daU
-rAC
+ggs
 daU
 cKi
 cTC
@@ -94318,7 +94318,7 @@ adV
 aGz
 aHm
 aIf
-uwd
+fva
 aJr
 aJr
 rmY
@@ -94339,7 +94339,7 @@ aZC
 idI
 xeH
 bsE
-kXO
+nLp
 aZb
 bdf
 bdf
@@ -94394,7 +94394,7 @@ wPI
 bHa
 ciT
 ciT
-roA
+xBT
 bJm
 bOm
 bHc
@@ -94463,10 +94463,10 @@ dTs
 dTs
 eOD
 eOD
-cCK
+jvl
 ibU
 ibU
-hXY
+qGu
 ibU
 ibU
 ibU
@@ -94495,10 +94495,10 @@ cJZ
 daU
 cKi
 cTC
-qdJ
+iQc
 cKr
 qUE
-qdJ
+iQc
 cTC
 cUl
 yeU
@@ -94533,7 +94533,7 @@ cZB
 cbK
 aPp
 aQs
-twX
+tcY
 aRr
 cbK
 cZB
@@ -94556,7 +94556,7 @@ aIf
 aJr
 aJr
 aIf
-jny
+wKT
 aLN
 aWY
 aWY
@@ -94585,7 +94585,7 @@ ahh
 ahh
 ahh
 udu
-bKu
+rmE
 pUO
 akN
 uWT
@@ -94618,7 +94618,7 @@ bxq
 aTF
 aTF
 aTF
-lgt
+fOA
 bDg
 cbm
 bxr
@@ -94646,7 +94646,7 @@ dTs
 aUp
 raY
 afd
-vYD
+aYQ
 afd
 jBg
 bOY
@@ -94711,7 +94711,7 @@ dTs
 dTs
 czA
 cGi
-qdJ
+iQc
 doE
 cUl
 cZb
@@ -94811,10 +94811,10 @@ bsJ
 bsE
 bsE
 bsE
-kXO
+nLp
 aYk
 aZA
-hLY
+hqD
 ajg
 bfB
 bfJ
@@ -94850,12 +94850,12 @@ bqP
 bxr
 byv
 bxr
-lgt
+fOA
 bxr
 bxr
 bDg
 cbm
-fRs
+meA
 bPx
 fPp
 wPI
@@ -94867,7 +94867,7 @@ ckL
 bOo
 bHc
 bQg
-mkx
+bUw
 ciT
 bTe
 bLq
@@ -94883,7 +94883,7 @@ dTs
 dTs
 bOY
 bOY
-ubq
+tSq
 afC
 xnv
 cfj
@@ -94935,7 +94935,7 @@ dTs
 ibU
 ibU
 ibU
-hXY
+qGu
 dTs
 dTs
 dTs
@@ -94949,7 +94949,7 @@ doE
 doE
 cUl
 cvJ
-een
+ujL
 csG
 cTC
 cJo
@@ -95019,7 +95019,7 @@ ach
 axn
 aGA
 aHn
-jny
+wKT
 aIM
 aJs
 aJs
@@ -95035,14 +95035,14 @@ aWY
 aZC
 aZY
 bav
-wzn
-wzn
+uYi
+uYi
 aZC
 eln
 byA
 btH
 qxs
-kXO
+nLp
 bAn
 dJZ
 dKb
@@ -95052,7 +95052,7 @@ adO
 aii
 bfC
 bfK
-nQQ
+gpg
 mTR
 pUO
 edN
@@ -95093,7 +95093,7 @@ cbU
 bPx
 fPp
 wPI
-uPw
+xLg
 dDD
 bMj
 ghH
@@ -95283,7 +95283,7 @@ aZw
 aZw
 aZR
 ahh
-vRP
+bgv
 ahh
 bfL
 iVN
@@ -95317,12 +95317,12 @@ aUl
 bqU
 bvr
 bxt
-mrY
+qve
 bSP
 bSP
 bSP
 bDc
-jeX
+ijV
 cbU
 bPx
 bIb
@@ -95352,7 +95352,7 @@ dTs
 dTs
 dTs
 qKe
-iwn
+dDF
 xnv
 cfj
 wzl
@@ -95491,25 +95491,25 @@ aIf
 aIN
 aJu
 aJu
-elG
+eZf
 aIf
 aIf
 aMa
-hLY
+hqD
 ajg
-qqL
+pxQ
 dTs
 dTs
 aZC
 baa
 baw
 aZY
-iHs
+fKB
 aZC
 buZ
-hjX
+voj
 bsE
-jyA
+vwV
 bcT
 bcT
 bcT
@@ -95526,9 +95526,9 @@ edN
 edN
 edN
 dzU
-hLY
+hqD
 ajg
-kul
+enA
 ooW
 ooW
 ooW
@@ -95599,22 +95599,22 @@ dTs
 adw
 ahW
 foP
-tau
+qwN
 ceb
 ceO
 cil
 nza
-fDV
+dEa
 cKl
 wtS
-rRT
+kos
 cvt
 cRa
 cxi
 cij
 adw
 lyw
-wcA
+ldM
 eHi
 cTs
 lNu
@@ -95648,7 +95648,7 @@ dTs
 vul
 doE
 doE
-qdJ
+iQc
 cUl
 cvJ
 crz
@@ -95668,7 +95668,7 @@ cTC
 doE
 cKr
 doE
-qdJ
+iQc
 cTC
 dUO
 dVb
@@ -95727,7 +95727,7 @@ aJu
 aJu
 aLb
 aIf
-jny
+wKT
 aMb
 adO
 mFD
@@ -95743,7 +95743,7 @@ aZC
 buO
 pwL
 bsE
-nSm
+vIR
 bcU
 bdi
 bdG
@@ -95789,23 +95789,23 @@ aTF
 qqS
 aTF
 bxr
-lpA
+bge
 cbm
 cbU
 bGX
 bIc
 dFb
-qau
+ozg
 ciT
 bHa
 vjo
-uPw
+xLg
 ciT
 cyT
 ciT
 ciT
 ciT
-vUz
+nIp
 bLq
 dTs
 dTs
@@ -95826,7 +95826,7 @@ cfj
 cfS
 cgz
 aEx
-hZZ
+hQB
 dTs
 dTs
 dTs
@@ -95836,12 +95836,12 @@ aYW
 ylg
 cRt
 eLH
-waW
+jkc
 ezr
 cil
 cFL
 iqz
-rRT
+kos
 cij
 cij
 cij
@@ -95853,7 +95853,7 @@ eHi
 dod
 lNu
 lNu
-wcA
+ldM
 mTj
 dTs
 dTs
@@ -95869,7 +95869,7 @@ dTs
 dTs
 dTs
 ibU
-hXY
+qGu
 ibU
 ibU
 ibU
@@ -95899,7 +95899,7 @@ daU
 cKf
 cKi
 cTC
-qdJ
+iQc
 cKr
 tLl
 tLl
@@ -95955,7 +95955,7 @@ adN
 adE
 aGz
 aHr
-jny
+wKT
 aIN
 fqI
 abI
@@ -96025,7 +96025,7 @@ aTF
 bxr
 bWc
 cbm
-sZx
+rAv
 bPx
 bHW
 ckQ
@@ -96053,7 +96053,7 @@ dTs
 dTs
 dTs
 qKe
-iwn
+dDF
 qKe
 xnv
 cfj
@@ -96079,9 +96079,9 @@ cij
 cxi
 cQT
 cxi
-rRT
+kos
 but
-wcA
+ldM
 lNu
 eHi
 dod
@@ -96089,7 +96089,7 @@ lNu
 xLS
 lNu
 lNu
-pkL
+hqR
 lNu
 aFQ
 aHh
@@ -96114,12 +96114,12 @@ dTs
 dTs
 ibU
 oXw
-vhb
+azY
 tLl
 tLl
 bYV
 aEq
-sBK
+hpd
 fdk
 hOK
 cJp
@@ -96148,7 +96148,7 @@ mbl
 dto
 dto
 dtp
-pwF
+hPF
 dxW
 dsJ
 dTs
@@ -96191,7 +96191,7 @@ aGA
 aHs
 aIf
 aIO
-fyo
+pcf
 aJw
 aIL
 aIf
@@ -96228,7 +96228,7 @@ edN
 edN
 gIR
 dzU
-thF
+uHT
 aeA
 akv
 dTs
@@ -96256,7 +96256,7 @@ dTs
 aGP
 soU
 aTF
-lgt
+fOA
 bWc
 qXy
 ctt
@@ -96264,7 +96264,7 @@ bHb
 bHa
 ckT
 ciT
-uPw
+xLg
 ciT
 ghH
 ckL
@@ -96319,7 +96319,7 @@ lNu
 lNu
 eHi
 dod
-spM
+gHq
 lNu
 lNu
 lNu
@@ -96341,7 +96341,7 @@ oXw
 tLl
 tLl
 jfA
-vhb
+azY
 fCr
 ibU
 ibU
@@ -96356,21 +96356,21 @@ sLx
 wya
 fdk
 hqp
-iTR
+wBM
 cRL
 cRL
-iTR
+wBM
 cRL
 cRL
-iTR
+wBM
 cRL
 cRL
 cRL
-mtt
+hik
 doE
 cKr
 tLl
-vhb
+azY
 hOK
 bYV
 sLx
@@ -96432,7 +96432,7 @@ aIf
 aLN
 aGz
 adZ
-qlg
+pQm
 ajL
 anE
 aeA
@@ -96519,7 +96519,7 @@ aDn
 aEa
 cEn
 acw
-iwn
+dDF
 aBX
 cvv
 roU
@@ -96555,7 +96555,7 @@ cTr
 dod
 cTh
 lNu
-wcA
+ldM
 xeD
 lNu
 lNu
@@ -96569,9 +96569,9 @@ dTs
 dTs
 cqn
 aFQ
-vhb
+azY
 tLl
-qDi
+wos
 tLl
 tLl
 tLl
@@ -96613,7 +96613,7 @@ dVj
 wJQ
 dVA
 chD
-qgs
+fuF
 chD
 dWf
 dtp
@@ -96662,12 +96662,12 @@ aIf
 aJr
 aJr
 aIf
-jny
+wKT
 aLN
 aGz
 aeA
 vCE
-bKu
+rmE
 aeA
 dTs
 aZC
@@ -96769,7 +96769,7 @@ dTs
 adw
 ahW
 bum
-mrl
+jHA
 ceb
 ceN
 cij
@@ -96779,7 +96779,7 @@ cFL
 coq
 cQD
 cil
-rRT
+kos
 cij
 cij
 but
@@ -96813,10 +96813,10 @@ tLl
 tLl
 tLl
 tLl
-vhb
+azY
 tLl
 tLl
-vhb
+azY
 tLl
 tLl
 bYV
@@ -96851,7 +96851,7 @@ dtr
 ibV
 ciG
 dtp
-qcC
+wzk
 dyb
 bgd
 nDN
@@ -96891,7 +96891,7 @@ aig
 aza
 aGz
 aHm
-jny
+wKT
 rmY
 aJr
 aJr
@@ -96907,7 +96907,7 @@ dTs
 dTs
 dTs
 aeq
-whn
+njw
 aew
 pba
 ahh
@@ -96916,11 +96916,11 @@ ajK
 gjQ
 bcT
 bdn
-vWx
+kiy
 beg
-vOs
+qZa
 bew
-bJs
+dnS
 bfq
 bcT
 bfL
@@ -96983,7 +96983,7 @@ aEa
 aCF
 wRU
 aCU
-yhl
+tgH
 aEb
 cEv
 aSW
@@ -97017,17 +97017,17 @@ cij
 cij
 adw
 adw
-rLu
+ehb
 xLS
 eHi
 dod
 lDT
-soL
+tzT
 kWh
 lNu
 lNu
 lNu
-toM
+kAO
 aHj
 cqn
 nxZ
@@ -97080,7 +97080,7 @@ glx
 dVj
 wJQ
 dVB
-wbl
+kZv
 dVE
 eCK
 dWg
@@ -97088,7 +97088,7 @@ dtp
 dto
 dyb
 bgk
-elD
+nRu
 dAn
 dyb
 dTs
@@ -97195,7 +97195,7 @@ cBa
 tJx
 bWc
 cbm
-fRs
+meA
 bHd
 bIe
 cnv
@@ -97362,7 +97362,7 @@ aHt
 aIg
 aKZ
 aIf
-jny
+wKT
 aIM
 aIg
 aLO
@@ -97377,7 +97377,7 @@ dTs
 dTs
 aew
 aeA
-fDo
+fhc
 ahh
 vCE
 ajL
@@ -97399,7 +97399,7 @@ hZV
 ali
 dzU
 vzj
-fQY
+eDO
 aeq
 dTs
 dTs
@@ -97423,15 +97423,15 @@ bpM
 bwf
 kQu
 snr
-dIb
+nPw
 bAz
 cBa
-hyl
+waT
 bWc
 cbm
 bxr
 bHd
-qQl
+lhL
 bIf
 bKz
 bxq
@@ -97458,13 +97458,13 @@ aDC
 nBv
 suJ
 suJ
-lFs
+hvW
 cEv
 bgn
 cAN
 cAP
 bha
-pHV
+vXd
 ncm
 dTs
 dTs
@@ -97472,10 +97472,10 @@ dTs
 dTs
 wgv
 uzC
-cfd
+gjs
 wgv
 wgv
-cfd
+gjs
 pXe
 cTr
 oKn
@@ -97490,7 +97490,7 @@ lNu
 eHi
 dZF
 iGC
-cfd
+gjs
 pXe
 tyc
 vqt
@@ -97550,7 +97550,7 @@ aLX
 dsJ
 dtt
 dtp
-jKo
+wNT
 dWi
 dtp
 dxY
@@ -97603,7 +97603,7 @@ aGA
 aGA
 xzR
 vCE
-bKu
+rmE
 poP
 dTs
 dTs
@@ -97689,7 +97689,7 @@ igw
 aDs
 cZK
 aDD
-dYA
+gJq
 acw
 byr
 suJ
@@ -97716,10 +97716,10 @@ qbp
 lNu
 lNu
 lNu
-wcA
+ldM
 iOa
 lNu
-wcA
+ldM
 olG
 eHi
 dod
@@ -97827,16 +97827,16 @@ ahY
 aAB
 aQn
 aQn
-vDD
+pQe
 ahh
 ahF
 ajK
 ahh
-vRP
+bgv
 dTs
 dTs
 aeA
-qlg
+pQm
 ajL
 aeA
 dTs
@@ -97864,7 +97864,7 @@ ahh
 vzj
 pUO
 edN
-oLE
+iVX
 dzU
 vzj
 aeA
@@ -97897,7 +97897,7 @@ bzH
 tJx
 bWc
 cbm
-lgt
+fOA
 bHd
 bIf
 bIf
@@ -97933,13 +97933,13 @@ jgX
 cyD
 bha
 cCG
-eFm
+kaJ
 dTs
 dTs
 dTs
 wgv
 wgv
-sMR
+sEw
 lNu
 lNu
 mTj
@@ -98059,12 +98059,12 @@ acF
 acF
 anB
 sff
-jIJ
+gku
 ahC
-rRc
+nnl
 ahh
 vCE
-bKu
+rmE
 ahh
 dTs
 dTs
@@ -98081,7 +98081,7 @@ baI
 aiu
 akB
 aeA
-iEO
+jyZ
 ajL
 amg
 bcT
@@ -98091,10 +98091,10 @@ bcU
 bcT
 bcU
 bcU
-gDs
+aOa
 bcT
 bfN
-vRP
+bgv
 vzj
 pUO
 hZV
@@ -98123,10 +98123,10 @@ dTs
 dTs
 bpM
 bwi
-wib
+owm
 bSc
 bEF
-daS
+qzE
 bpO
 byx
 bYG
@@ -98134,8 +98134,8 @@ cbm
 bFP
 bHd
 bIf
-qQl
-qQl
+lhL
+lhL
 bxq
 dTs
 dTs
@@ -98151,7 +98151,7 @@ aCt
 aCx
 aEa
 aCJ
-ims
+sUh
 aCI
 aCI
 aEa
@@ -98176,7 +98176,7 @@ wgv
 pXe
 xeD
 lNu
-wcA
+ldM
 lNu
 lNu
 ekH
@@ -98226,11 +98226,11 @@ hBr
 hBr
 hBr
 hBr
-ljj
+woS
 hBr
 hBr
 hBr
-ljj
+woS
 cYP
 pxw
 oAV
@@ -98243,23 +98243,23 @@ sYo
 rkC
 spa
 ovJ
-vjC
+kgg
 oAV
 oAV
 oAV
 oAV
 gFy
 dsJ
-pwF
+hPF
 dVL
 gGo
 dVL
-exv
+xXl
 ebD
 dyb
 dty
 dWH
-elD
+nRu
 dwl
 dyb
 dTs
@@ -98295,10 +98295,10 @@ ahF
 ajg
 abV
 abV
-eqG
+dqr
 ajg
 ajc
-bKu
+rmE
 dTs
 dTs
 dTs
@@ -98333,12 +98333,12 @@ vzj
 pUO
 edN
 edN
-qKy
+nkG
 vzj
 hDT
 aeA
 aeA
-fQY
+eDO
 dTs
 dTs
 dTs
@@ -98387,11 +98387,11 @@ aEa
 aCL
 aCI
 aCI
-hin
+ihv
 aEb
 cEv
 aSW
-uBY
+nTY
 acw
 acw
 czk
@@ -98453,13 +98453,13 @@ aEq
 fdk
 cWy
 peQ
-sIA
+ovV
 cYQ
-eWm
+shZ
 peQ
 peQ
 peQ
-eWm
+shZ
 aqf
 aqf
 peQ
@@ -98468,9 +98468,9 @@ peQ
 aAC
 wFK
 gdW
-wVo
+qBJ
 gdW
-wVo
+qBJ
 gdW
 hOK
 bYV
@@ -98526,7 +98526,7 @@ dTs
 dTs
 ahh
 aLv
-nQQ
+gpg
 aii
 aby
 aii
@@ -98538,10 +98538,10 @@ dTs
 dTs
 aew
 plo
-qlg
+pQm
 aji
 ajg
-qPA
+uIg
 ajg
 ajg
 ajg
@@ -98554,17 +98554,17 @@ ajc
 ajg
 ooW
 ooW
-kul
+enA
 ooW
 ooW
-kul
+enA
 ooW
 ooW
 ooW
-kul
+enA
 ooW
 ajM
-slU
+vuW
 cGD
 cGD
 dzU
@@ -98591,15 +98591,15 @@ dTs
 dTs
 bpM
 bwk
-xRz
+vpD
 fZA
-wib
+owm
 bSR
 bzH
-hyl
+waT
 bDg
 cbm
-lgt
+fOA
 bHf
 bHf
 bHf
@@ -98767,7 +98767,7 @@ iVN
 uRH
 hVT
 ybA
-thF
+uHT
 xof
 dTs
 aeq
@@ -98780,11 +98780,11 @@ aii
 aii
 iFE
 aii
-nQQ
+gpg
 aii
 aii
 alX
-nQQ
+gpg
 ajL
 iVN
 uRH
@@ -98863,7 +98863,7 @@ dTs
 tUF
 ekH
 btm
-xmN
+lFA
 tyc
 wyR
 kry
@@ -98881,7 +98881,7 @@ lNu
 lNu
 lNu
 lNu
-soL
+tzT
 rzE
 tyc
 lwC
@@ -98922,24 +98922,24 @@ oKG
 aEq
 fdk
 hOK
-lrM
+qGm
 tLl
 tLl
-vHX
+jFs
 tLl
 gdW
 cWy
 oQx
 gdW
-wVo
+qBJ
 gdW
 dgK
 qQg
 gdW
 tLl
-vhb
+azY
 tLl
-vhb
+azY
 hOK
 bYV
 aEq
@@ -98954,7 +98954,7 @@ dqe
 dqe
 edO
 dus
-kWM
+gbL
 dVH
 dus
 dyb
@@ -98992,14 +98992,14 @@ dTs
 dTs
 dTs
 axq
-vRP
+bgv
 pUO
 edN
 cGD
 dzU
 pUO
 edN
-oLE
+iVX
 dzU
 vzj
 xof
@@ -99043,7 +99043,7 @@ cGD
 dzU
 blM
 kWb
-paZ
+kzJ
 dTs
 dTs
 dTs
@@ -99087,7 +99087,7 @@ aCl
 aCJ
 aEa
 aCN
-hin
+ihv
 aCL
 aDq
 aEa
@@ -99095,7 +99095,7 @@ dTs
 dTs
 dTs
 oGQ
-kZN
+iXg
 ekH
 dod
 tyc
@@ -99110,7 +99110,7 @@ dTs
 dTs
 wgv
 wgv
-sMR
+sEw
 lNu
 lDT
 qHF
@@ -99146,7 +99146,7 @@ cOH
 dkJ
 lql
 cRg
-qJb
+uqb
 cOH
 aRO
 bYV
@@ -99157,7 +99157,7 @@ aEq
 fdk
 hOK
 cYT
-vhb
+azY
 tLl
 tLl
 daF
@@ -99185,21 +99185,21 @@ dpw
 dqf
 dqf
 dqf
-pLv
+xKt
 edO
 dus
 wkt
 dtx
-oEI
+wsB
 eeq
 dyY
-nPz
+mvT
 bBN
 qmG
 dAq
 eeC
 neg
-elD
+nRu
 pAf
 dyb
 dTs
@@ -99228,7 +99228,7 @@ dTs
 ane
 aaF
 pUO
-oLE
+iVX
 edN
 dzU
 pUO
@@ -99236,7 +99236,7 @@ cGD
 edN
 dzU
 vzj
-rgK
+sbB
 dTs
 dTs
 dTs
@@ -99275,7 +99275,7 @@ wnE
 biJ
 cGD
 dzU
-nOo
+sVz
 bhi
 cMI
 bkZ
@@ -99293,7 +99293,7 @@ dTs
 bpM
 bRd
 daB
-jUv
+lQC
 fZA
 bEG
 bAD
@@ -99301,11 +99301,11 @@ cBa
 tJx
 bDg
 caF
-lZW
+yfM
 bPv
 ckd
 ckX
-fkj
+gCH
 cnw
 bLr
 dTs
@@ -99337,7 +99337,7 @@ jmd
 eft
 sCf
 iYI
-bus
+vfZ
 wgv
 dTs
 dTs
@@ -99348,7 +99348,7 @@ pij
 lNu
 kWh
 lNu
-wcA
+ldM
 lNu
 iGK
 tyc
@@ -99362,7 +99362,7 @@ tUF
 lNu
 lNu
 lNu
-wcA
+ldM
 iGC
 tUF
 pal
@@ -99402,18 +99402,18 @@ des
 daI
 dbr
 dgL
-kfz
+dCu
 diG
 daF
 daF
 tLl
-vhb
+azY
 hOK
 bYV
 sLx
 sms
 fdk
-dzt
+vIl
 dhs
 dpx
 dqg
@@ -99429,7 +99429,7 @@ edT
 dWw
 pWg
 fev
-wWx
+xQk
 ebO
 dyb
 dAn
@@ -99465,10 +99465,10 @@ pUO
 cGD
 cGD
 dzU
-slU
+vuW
 cGD
 cGD
-qKy
+nkG
 vzj
 xof
 wZM
@@ -99479,7 +99479,7 @@ dTs
 dTs
 dTs
 mKm
-uJC
+hKP
 xzR
 aeA
 qxv
@@ -99510,9 +99510,9 @@ biK
 uWT
 bjo
 blM
-eva
+uyE
 kWb
-paZ
+kzJ
 dTs
 dTs
 dTs
@@ -99529,13 +99529,13 @@ bVa
 daB
 joI
 fZA
-wib
+owm
 bAD
 bzH
-hyl
+waT
 cbj
 ctu
-lgt
+fOA
 bHf
 cQO
 clS
@@ -99564,7 +99564,7 @@ dTs
 dTs
 dTs
 dTs
-sMR
+sEw
 iYI
 tyc
 wyR
@@ -99572,12 +99572,12 @@ kry
 sCf
 iYI
 lNu
-iMt
+vah
 dTs
 dTs
 dTs
 pXe
-wcA
+ldM
 lNu
 lNu
 xeD
@@ -99592,13 +99592,13 @@ sCf
 qKA
 lAR
 wgv
-dGr
+qBy
 xeD
 lNu
 lNu
 lNu
 qKA
-sMR
+sEw
 lNu
 iGC
 dTs
@@ -99630,7 +99630,7 @@ tLl
 dbu
 dbn
 dbq
-tUN
+cui
 daK
 dTP
 dTP
@@ -99694,11 +99694,11 @@ ads
 aKh
 aqb
 ane
-vRP
+bgv
 pUO
 vqR
 vqR
-rAT
+hyN
 mCu
 vqR
 vqR
@@ -99732,11 +99732,11 @@ aeA
 aeA
 aeA
 aeA
-fDo
+fhc
 qxv
-fDo
+fhc
 aeA
-fDo
+fhc
 ahF
 ajK
 pUO
@@ -99779,7 +99779,7 @@ bLr
 iwh
 iwh
 nue
-nUJ
+mqs
 pLm
 iwh
 iwh
@@ -99829,10 +99829,10 @@ pij
 lNu
 lNu
 lyw
-wcA
+ldM
 iGC
 wgv
-cfd
+gjs
 cvH
 dTs
 dTs
@@ -99845,7 +99845,7 @@ dTs
 dTs
 dMV
 cPJ
-qjq
+uTh
 cRi
 kbY
 cSu
@@ -99860,13 +99860,13 @@ fdk
 hOK
 cYT
 tLl
-vhb
+azY
 dbu
 dbn
 dbq
 eew
 dTP
-nKS
+tKs
 dTP
 daK
 dUA
@@ -99890,12 +99890,12 @@ doH
 doH
 doH
 eby
-uWo
+nFq
 ecl
 dus
 eeq
 dzb
-wWx
+xQk
 dWE
 dWN
 rEH
@@ -99940,7 +99940,7 @@ otn
 uRH
 uRH
 uRH
-pZM
+pmz
 uRH
 hVT
 uRH
@@ -99950,21 +99950,21 @@ uRH
 uRH
 uRH
 uRH
-gwO
+fuw
 uRH
 uRH
-pZM
+pmz
 uRH
 agT
-mvk
+nmz
 cGD
 cGD
 dzU
 agw
-fDo
+fhc
 sgi
 aiQ
-mzT
+eDB
 adj
 adj
 adj
@@ -99972,7 +99972,7 @@ jMC
 aeA
 smY
 vCE
-bKu
+rmE
 vTR
 boc
 aox
@@ -99980,11 +99980,11 @@ bjo
 blM
 bhi
 bkw
-viU
+aSi
 bkZ
 dTs
 bkZ
-paZ
+kzJ
 bkZ
 dTs
 dTs
@@ -100015,10 +100015,10 @@ dCt
 dCt
 dCt
 dCt
-egT
+vhm
 cNW
 tWC
-nUJ
+mqs
 bUt
 bVs
 bWj
@@ -100030,7 +100030,7 @@ pLm
 dTs
 dTs
 wgv
-cfd
+gjs
 pXe
 lNu
 iYI
@@ -100057,10 +100057,10 @@ tyc
 eft
 jmd
 sCf
-wcA
+ldM
 lNu
 lNu
-wcA
+ldM
 cAW
 iGC
 cvH
@@ -100099,7 +100099,7 @@ dbu
 dbn
 dbq
 dTP
-nKS
+tKs
 dUg
 dDQ
 dbs
@@ -100167,11 +100167,11 @@ aaV
 cGD
 abq
 cGD
-oLE
+iVX
 edN
 cGD
 cGD
-oLE
+iVX
 acR
 cGD
 cGD
@@ -100204,7 +100204,7 @@ dTs
 dTs
 bkZ
 bgP
-eva
+uyE
 bhF
 bhZ
 bir
@@ -100220,12 +100220,12 @@ bkZ
 bkZ
 bmu
 bhk
-xFn
+dcT
 bhk
 cBa
 bqV
 brU
-tqt
+gSC
 bqV
 bqV
 btG
@@ -100240,12 +100240,12 @@ bEE
 oVo
 oVo
 tCF
-grC
+rBy
 tCF
 tCF
 bMm
 euG
-rYS
+vRD
 hpw
 hpw
 pTU
@@ -100259,7 +100259,7 @@ bWk
 cNW
 cNW
 cNW
-nUJ
+mqs
 cNW
 pLm
 iwh
@@ -100274,10 +100274,10 @@ kry
 sCf
 coE
 pal
-wcA
+ldM
 lNu
 mTj
-dGr
+qBy
 lNu
 lNu
 pal
@@ -100292,10 +100292,10 @@ rFU
 jMT
 sCf
 lNu
-wcA
+ldM
 lNu
 lNu
-vde
+fob
 wgv
 wgv
 dTs
@@ -100316,7 +100316,7 @@ cOH
 cQr
 cRi
 kbY
-pNd
+dCA
 cTi
 tLl
 bYV
@@ -100325,13 +100325,13 @@ wya
 oKG
 aEq
 fdk
-dzt
+vIl
 cYT
 tLl
-vhb
+azY
 dbu
 dbn
-sIL
+kmG
 daK
 dTP
 deu
@@ -100343,7 +100343,7 @@ deu
 dbn
 dbu
 tLl
-vhb
+azY
 hOK
 bYV
 aEq
@@ -100354,7 +100354,7 @@ cXh
 eaU
 dqi
 dqS
-qex
+nKW
 dqV
 edO
 dus
@@ -100363,7 +100363,7 @@ dVT
 dus
 dyb
 ebE
-nPz
+mvT
 dAq
 dBV
 dCJ
@@ -100411,25 +100411,25 @@ edN
 cGD
 tAt
 cGD
-oLE
+iVX
 tAt
 cGD
 cGD
-lGv
+sZS
 cGD
 cGD
 tAt
 cGD
-oLE
+iVX
 tAt
 cGD
 agV
 cGD
 cGD
-oLE
+iVX
 dzU
 aeA
-fDo
+fhc
 aiQ
 aeq
 dTs
@@ -100437,7 +100437,7 @@ dTs
 dTs
 dTs
 bkZ
-dVQ
+kGC
 bhi
 bhF
 bhZ
@@ -100445,14 +100445,14 @@ bir
 boc
 biP
 bjo
-nOo
+sVz
 bhi
-eva
+uyE
 bhi
 kWb
 hsN
 bmu
-xFn
+dcT
 bmL
 bob
 boI
@@ -100472,7 +100472,7 @@ vZn
 bZi
 cbq
 bFT
-umZ
+wbu
 ckh
 ckh
 lpe
@@ -100561,13 +100561,13 @@ aEq
 fdk
 hOK
 cYT
-vhb
+azY
 tLl
 daF
 dbn
 dcg
 dTP
-iEs
+rTk
 deu
 dbn
 dbq
@@ -100589,15 +100589,15 @@ hOK
 dqW
 dqT
 dqV
-qex
+nKW
 edO
-oEI
+wsB
 dVY
 ecn
 ecy
 dyb
 dze
-lRq
+foa
 dAq
 dBW
 dCK
@@ -100637,7 +100637,7 @@ abv
 abz
 cGD
 cGD
-oLE
+iVX
 tBD
 fDL
 oqy
@@ -100650,7 +100650,7 @@ fDL
 fDL
 fDL
 fDL
-qyz
+gOQ
 fDL
 fDL
 fDL
@@ -100677,13 +100677,13 @@ bhF
 bhZ
 bir
 boc
-kCu
+hEv
 bjo
 blM
 bhi
 bhi
 bhi
-eva
+uyE
 bhi
 bhk
 bmL
@@ -100692,15 +100692,15 @@ aAo
 bju
 bpP
 bpP
-xRz
+vpD
 bEG
-xRz
+vpD
 que
 bEG
 jQw
 bpP
 bEG
-xRz
+vpD
 bpP
 bCw
 bDl
@@ -100714,7 +100714,7 @@ crI
 bPv
 dCt
 dCt
-qPj
+mVp
 fif
 fif
 tSK
@@ -100828,7 +100828,7 @@ edL
 eaw
 ebW
 eco
-oEI
+wsB
 dyb
 dyb
 eeq
@@ -100879,9 +100879,9 @@ aiQ
 ade
 jMC
 aeA
-iQI
+xzb
 aeA
-fDo
+fhc
 ajg
 ajg
 ajg
@@ -100906,9 +100906,9 @@ dTs
 dTs
 dTs
 bhj
-eva
+uyE
 bhF
-nny
+xoC
 bir
 biN
 bje
@@ -101029,7 +101029,7 @@ gdW
 dUL
 jOe
 cYT
-vhb
+azY
 dbu
 daG
 dbp
@@ -101097,7 +101097,7 @@ dTs
 dTs
 dTs
 ane
-hzz
+iYZ
 aaN
 eRn
 fDL
@@ -101122,15 +101122,15 @@ dTs
 dTs
 aeA
 aeA
-fDo
+fhc
 agw
 hDT
 vzj
-slU
+vuW
 cGD
 cGD
 dzU
-fDo
+fhc
 akv
 dTs
 dTs
@@ -101149,12 +101149,12 @@ biP
 bjo
 bhF
 bit
-hNs
+mbe
 bit
 azM
 azM
 azM
-oNT
+hhL
 azM
 bod
 boJ
@@ -101184,7 +101184,7 @@ bHm
 dCt
 naH
 ozu
-gvt
+nKc
 bRr
 ozu
 ozu
@@ -101267,20 +101267,20 @@ tLl
 dbu
 daG
 dbq
-uFc
+fTX
 dTP
 dTP
 dTP
 dTP
-wiB
+eHS
 dUD
 dUG
 daK
-qSv
+ihT
 dbn
 dbu
 tLl
-dzt
+vIl
 bYV
 aEq
 aEq
@@ -101289,14 +101289,14 @@ xqQ
 fdk
 hOK
 dqW
-qex
+nKW
 gnt
 dqV
 edO
 fMa
 bnn
 bHj
-xjz
+rIx
 edU
 rko
 rko
@@ -101396,7 +101396,7 @@ dwd
 bqY
 bqY
 bsG
-gli
+puM
 sgr
 bwo
 bxz
@@ -101415,7 +101415,7 @@ dwW
 dwX
 bMn
 bHm
-egT
+vhm
 naH
 ozu
 ozu
@@ -101494,7 +101494,7 @@ tLl
 mAm
 tLl
 gdW
-kwX
+xQa
 jOe
 cYT
 tLl
@@ -101569,7 +101569,7 @@ dTs
 ahh
 ahh
 ahh
-vRP
+bgv
 ahh
 ahh
 soS
@@ -101616,12 +101616,12 @@ biN
 bje
 bjo
 bhG
-nQv
+kDN
 bib
 bib
 bib
 bib
-nQv
+kDN
 bib
 bib
 bod
@@ -101635,7 +101635,7 @@ kvx
 rHf
 fGR
 byD
-aPj
+wmr
 bZS
 bZS
 fsW
@@ -101647,7 +101647,7 @@ ckm
 cnr
 bKD
 bJz
-tnz
+vTT
 bRO
 dCt
 naH
@@ -101659,14 +101659,14 @@ ozu
 xsS
 mfK
 dCt
-egT
+vhm
 dCt
 dCt
-egT
+vhm
 dCt
 dCt
 dCt
-egT
+vhm
 bic
 biu
 jbx
@@ -101744,8 +101744,8 @@ dfT
 eDQ
 fMI
 dTP
-jzw
-bup
+sfQ
+fhh
 dbu
 gdW
 hOK
@@ -101762,12 +101762,12 @@ dsb
 dsA
 dqm
 dus
-edH
+sMs
 ecr
 dus
 dOg
 dzf
-vYa
+gah
 dzg
 dzf
 dCL
@@ -101803,7 +101803,7 @@ dTs
 dTs
 adD
 adD
-wsS
+qUL
 aQn
 abY
 aci
@@ -101844,7 +101844,7 @@ dTs
 dTs
 bhj
 bhF
-nny
+xoC
 bir
 boc
 biP
@@ -101889,7 +101889,7 @@ ozu
 ozu
 bRr
 ozu
-gvt
+nKc
 xsS
 mfK
 dCt
@@ -101968,7 +101968,7 @@ pnK
 dTK
 eeP
 daK
-kfz
+dCu
 nqc
 eew
 ddR
@@ -102044,7 +102044,7 @@ acj
 acp
 acy
 ahC
-jIJ
+gku
 dTs
 dTs
 dTs
@@ -102082,7 +102082,7 @@ bhZ
 bir
 biO
 bjf
-kJL
+oRZ
 bjf
 bjf
 bjq
@@ -102101,7 +102101,7 @@ bFY
 bFY
 bFY
 oAX
-gli
+puM
 fpg
 nTa
 bAG
@@ -102119,7 +102119,7 @@ cuW
 bRO
 dCt
 naH
-gvt
+nKc
 ozu
 bRr
 uml
@@ -102187,13 +102187,13 @@ dTs
 cPL
 dTA
 dTA
-wCR
+ohA
 cSA
 cPL
 cTM
 cTO
 cUF
-rHB
+ppl
 cVV
 lwm
 eGM
@@ -102226,8 +102226,8 @@ fCB
 hOK
 dqW
 het
-qex
-qex
+nKW
+nKW
 dqm
 dus
 dWa
@@ -102298,7 +102298,7 @@ ahh
 ahh
 pUO
 aht
-lqN
+eDy
 dzU
 ahh
 dTs
@@ -102310,7 +102310,7 @@ dTs
 bhk
 bhk
 bhk
-xFn
+dcT
 bhF
 bhZ
 bir
@@ -102320,7 +102320,7 @@ bjr
 biP
 biP
 bjr
-kCu
+hEv
 aox
 atM
 aox
@@ -102351,7 +102351,7 @@ bJz
 jmX
 cuW
 bRO
-egT
+vhm
 naH
 ozu
 ozu
@@ -102424,7 +102424,7 @@ cQw
 wDY
 cSB
 cTj
-feX
+pkR
 mvz
 cUG
 cTN
@@ -102437,7 +102437,7 @@ gdW
 dbu
 dTQ
 dbs
-lXX
+slS
 daK
 ddT
 dex
@@ -102559,7 +102559,7 @@ biQ
 bmg
 aox
 biP
-aYh
+kSx
 blM
 btc
 bpV
@@ -102667,7 +102667,7 @@ cWy
 peQ
 ass
 jOe
-vhb
+azY
 daF
 daH
 dbq
@@ -102676,14 +102676,14 @@ dTP
 daK
 daK
 daK
-tUN
+cui
 daK
 fMI
 daK
-qSv
+ihT
 djt
 daF
-vhb
+azY
 hOK
 bYV
 aEq
@@ -102703,7 +102703,7 @@ ect
 dqo
 dpB
 dzj
-vYa
+gah
 dzg
 bgq
 dCL
@@ -102775,11 +102775,11 @@ dTs
 bXh
 aiW
 bXg
-pYW
+muO
 akJ
 akS
 alr
-wBa
+lze
 cEl
 lPy
 bit
@@ -102787,12 +102787,12 @@ bit
 bit
 bit
 bit
-hNs
+mbe
 bit
 cdC
 aui
 bki
-whD
+eNd
 vNT
 blM
 btc
@@ -102800,15 +102800,15 @@ bpW
 vFS
 bra
 lmq
-waa
+ijg
 pGZ
 bOr
-waa
+ijg
 btc
 bzN
 bTb
 bST
-lTf
+ull
 bSf
 cbP
 bGb
@@ -102826,9 +102826,9 @@ ozu
 bRr
 uml
 vgm
-xXb
+raH
 mfK
-egT
+vhm
 dCt
 dCt
 dsk
@@ -102887,7 +102887,7 @@ dTs
 dTs
 dTs
 cPL
-sgG
+rrL
 cPL
 cQA
 cPL
@@ -102895,19 +102895,19 @@ cPL
 cTO
 cUs
 cTO
-rHB
+ppl
 cVV
 gdW
 gdW
-czm
+pgR
 jOe
 tLl
 dbu
 daG
-sIL
+kmG
 gcb
 dTP
-nKS
+tKs
 daK
 daK
 dUb
@@ -103018,7 +103018,7 @@ jvg
 bib
 ani
 bib
-nQv
+kDN
 bib
 bib
 bib
@@ -103054,10 +103054,10 @@ bLE
 bHm
 bHm
 dCt
-qic
+htO
 oAM
 oAM
-qmT
+jpX
 ozu
 ozu
 xsS
@@ -103128,14 +103128,14 @@ cPL
 cPL
 cTP
 iKk
-rHB
+ppl
 cVq
 cPL
 vuu
 gdW
 hqp
 jOe
-vhb
+azY
 dbu
 daG
 dbt
@@ -103158,13 +103158,13 @@ aEq
 aEq
 fdk
 hOK
-vhb
+azY
 dpB
 dNX
 dVw
 dNY
 dOa
-jQG
+qyI
 dVO
 dWe
 ecv
@@ -103258,7 +103258,7 @@ bhk
 bhk
 bhk
 blM
-jfQ
+laE
 biP
 biP
 bjo
@@ -103286,7 +103286,7 @@ bHm
 bRO
 bRO
 bHm
-egT
+vhm
 dCt
 blO
 nil
@@ -103495,27 +103495,27 @@ blM
 bir
 bki
 bje
-aYh
+kSx
 blM
 bhk
 bhi
 bTR
-eva
+uyE
 bhi
 btQ
 bvi
 whC
 bvi
-uTe
+vNw
 bvi
 bvi
-idm
+rtn
 bvi
 bwu
 bEQ
 bvi
 bHq
-idm
+rtn
 btQ
 cNW
 cNW
@@ -103594,12 +103594,12 @@ dTI
 dTI
 cPL
 cTl
-rHB
+ppl
 iKk
 cUH
 hOA
 cVV
-vhb
+azY
 gdW
 hqp
 sbP
@@ -103609,10 +103609,10 @@ daF
 daG
 dcj
 dTP
-wiB
+eHS
 dUj
 daG
-nsh
+ddj
 dTZ
 aMs
 diK
@@ -103752,13 +103752,13 @@ bHr
 bvi
 btQ
 dCt
-egT
+vhm
 dCt
 dCt
 chz
 ciE
 cie
-fnp
+vER
 aFo
 aFo
 aFo
@@ -103848,7 +103848,7 @@ deu
 dUp
 dUv
 dTP
-jyh
+xEw
 deu
 dbn
 dbu
@@ -103960,11 +103960,11 @@ aKO
 agm
 auH
 blM
-svN
+xVY
 cyP
-svN
+xVY
 cyP
-nOo
+sVz
 bYf
 aea
 aea
@@ -103994,9 +103994,9 @@ hbr
 cif
 qDb
 aFo
-sTE
+xKf
 wrl
-sTE
+xKf
 mfK
 chA
 hbr
@@ -104025,7 +104025,7 @@ lYE
 dGA
 dGA
 dHA
-iYa
+fZw
 dfc
 dgF
 jrV
@@ -104062,7 +104062,7 @@ dTs
 dTs
 cPL
 cTn
-rHB
+ppl
 kuR
 cTO
 cVs
@@ -104077,7 +104077,7 @@ dbu
 daG
 dbq
 dTP
-tUN
+cui
 dUh
 dUH
 dbr
@@ -104100,11 +104100,11 @@ kpb
 syO
 dhA
 ego
-vhb
+azY
 tLl
 syO
 jKr
-qLs
+hMZ
 tLl
 lwm
 hqp
@@ -104210,7 +104210,7 @@ slB
 bAK
 bAK
 bAK
-sHG
+fDf
 bwv
 aFo
 aAs
@@ -104264,7 +104264,7 @@ wiX
 ukB
 ukB
 sgQ
-vxN
+dIx
 tjV
 tjV
 tjV
@@ -104298,7 +104298,7 @@ cPL
 cTo
 cTO
 ecI
-rHB
+ppl
 cTO
 cVV
 tLl
@@ -104306,7 +104306,7 @@ tLl
 tJI
 jOe
 tLl
-vhb
+azY
 dbu
 daG
 dbq
@@ -104331,7 +104331,7 @@ hOK
 tLl
 tLl
 syO
-hXY
+qGu
 ibU
 jKr
 jKr
@@ -104382,7 +104382,7 @@ dTs
 dTs
 aWZ
 aWZ
-xbk
+ure
 mim
 mim
 bXi
@@ -104428,7 +104428,7 @@ bXn
 bXn
 bXv
 blM
-svN
+xVY
 cyP
 cyP
 cyP
@@ -104462,7 +104462,7 @@ cld
 cig
 qDb
 aFo
-sTE
+xKf
 aFo
 aFo
 mfK
@@ -104536,7 +104536,7 @@ hOA
 cPL
 cPL
 tLl
-vhb
+azY
 syi
 xmX
 tLl
@@ -104546,11 +104546,11 @@ daG
 dbq
 daK
 daK
-nKS
+tKs
 dTP
 dTP
 dTP
-jyh
+xEw
 deu
 dbn
 dbu
@@ -104618,7 +104618,7 @@ dTs
 mim
 mim
 mim
-xbk
+ure
 kFk
 bXi
 aZg
@@ -104635,12 +104635,12 @@ aZg
 aZg
 aZg
 bXz
-tIT
+vDQ
 aXW
-vge
+hbC
 aWB
 aZk
-tIT
+vDQ
 bZs
 bXn
 bXn
@@ -104669,7 +104669,7 @@ vNT
 blM
 bhk
 bhk
-xFn
+dcT
 bhk
 kvj
 btQ
@@ -104688,11 +104688,11 @@ bHv
 bIu
 btQ
 dCt
-egT
+vhm
 dCt
 dCt
 dCt
-egT
+vhm
 dCt
 qDb
 naH
@@ -104725,18 +104725,18 @@ dTs
 dTs
 tWE
 cdw
-lzM
+quN
 cdw
 ciU
 cfw
-qUc
+ghW
 idg
 chr
 ciU
 cdw
 cdw
 cdw
-lzM
+quN
 cdw
 ceo
 tjV
@@ -104796,7 +104796,7 @@ aEq
 aEq
 fdk
 hOK
-vhb
+azY
 iNd
 dqp
 dqp
@@ -104807,7 +104807,7 @@ rJC
 rJC
 dqp
 dqp
-hXY
+qGu
 lwm
 qck
 jOe
@@ -104855,7 +104855,7 @@ fIK
 ard
 asy
 fIK
-erw
+irv
 adu
 bWq
 aIG
@@ -104902,7 +104902,7 @@ bje
 bjo
 blM
 bhk
-xFn
+dcT
 bhk
 bhk
 bhk
@@ -104929,7 +104929,7 @@ dCt
 dCt
 dCt
 qDb
-jRx
+suY
 uml
 ddt
 xsS
@@ -104948,7 +104948,7 @@ dTs
 dTs
 dTs
 rwf
-vAK
+mOr
 jhp
 uBx
 evl
@@ -104957,7 +104957,7 @@ aDX
 rwf
 dTs
 cOk
-wUq
+mUZ
 nXt
 coJ
 coI
@@ -104967,7 +104967,7 @@ dPY
 idg
 hwy
 ciU
-lzM
+quN
 cdw
 cdw
 cdw
@@ -105002,12 +105002,12 @@ dTs
 ibU
 goZ
 tLl
-vhb
+azY
 tLl
 tLl
 hqp
 jOe
-vhb
+azY
 ego
 daF
 daF
@@ -105047,7 +105047,7 @@ qck
 jOe
 gdW
 ebP
-nMz
+tuM
 ibU
 dTs
 dTs
@@ -105090,7 +105090,7 @@ aRi
 aRH
 aPP
 aPP
-tIT
+vDQ
 aPP
 aPP
 aPP
@@ -105132,14 +105132,14 @@ bXv
 blM
 bir
 biP
-kCu
+hEv
 bjo
 blM
 bhk
 bhk
 bhk
 bhk
-xFn
+dcT
 btQ
 bvj
 ujO
@@ -105159,7 +105159,7 @@ dCt
 dCt
 dCt
 dCt
-egT
+vhm
 dCt
 dCt
 qDb
@@ -105233,7 +105233,7 @@ dTs
 dTs
 dTs
 dTs
-hXY
+qGu
 oXw
 tLl
 tLl
@@ -105319,22 +105319,22 @@ dTs
 dTs
 dTs
 cTE
-tIT
+vDQ
 aOk
 aaS
 aXU
-mzI
+qFY
 aXU
 aXU
-mzI
+qFY
 aXU
 aXU
 aXU
-mzI
+qFY
 aXU
 agg
 aXU
-mzI
+qFY
 aXU
 aXU
 aif
@@ -105399,7 +105399,7 @@ cie
 qDb
 aFo
 aFo
-sTE
+xKf
 aFo
 mfK
 chA
@@ -105431,15 +105431,15 @@ nTI
 nTI
 ciU
 cfw
-vWl
+sGm
 ibE
 nTp
 ilz
 ilz
-xjS
+kum
 cix
 ciU
-lzM
+quN
 ceo
 tjV
 pFb
@@ -105489,7 +105489,7 @@ wuJ
 xqf
 dTY
 dTY
-gaj
+ghw
 cXz
 gdW
 hOK
@@ -105566,7 +105566,7 @@ dTs
 dTs
 dTs
 bRg
-kKQ
+fBC
 aPP
 aaB
 abZ
@@ -105574,7 +105574,7 @@ abZ
 abZ
 amM
 buj
-qkW
+ljP
 aZk
 aXv
 bRg
@@ -105598,10 +105598,10 @@ bXn
 bXn
 bXv
 blM
-svN
+xVY
 cyP
 cyP
-svN
+xVY
 blM
 bZs
 bXn
@@ -105733,7 +105733,7 @@ wya
 fdk
 hOK
 tLl
-nMz
+tuM
 dpC
 rJC
 rJC
@@ -105790,7 +105790,7 @@ aow
 apx
 arf
 arf
-lZb
+rsu
 aow
 asB
 aow
@@ -105810,7 +105810,7 @@ aCp
 buj
 buj
 aZk
-kKQ
+fBC
 bdc
 euN
 oBK
@@ -105865,7 +105865,7 @@ cld
 cld
 cig
 qDb
-sTE
+xKf
 aFo
 aFo
 aFo
@@ -105902,10 +105902,10 @@ cfw
 iAf
 uYD
 chu
-mJZ
+dEC
 idg
 dPY
-xEX
+rsD
 ciU
 cdw
 ceo
@@ -105942,7 +105942,7 @@ ioB
 dsU
 dkb
 hqp
-sIA
+ovV
 rpQ
 xML
 aqf
@@ -105953,7 +105953,7 @@ eiI
 dTX
 dcn
 dcn
-bem
+fTP
 uur
 prI
 prI
@@ -105977,7 +105977,7 @@ rJC
 rJC
 rJC
 dqp
-hXY
+qGu
 lwm
 hqp
 jOe
@@ -106021,7 +106021,7 @@ dTs
 dTs
 dTs
 aow
-gmL
+pwV
 asx
 asx
 asA
@@ -106035,11 +106035,11 @@ dTs
 dTs
 dTs
 aXv
-tIT
+vDQ
 aXW
 buj
 buj
-qkW
+ljP
 aCp
 aWa
 aWB
@@ -106047,7 +106047,7 @@ aZk
 aXv
 bRg
 wjr
-bLG
+xUJ
 dTs
 dTs
 dTs
@@ -106092,17 +106092,17 @@ bHv
 bIu
 btQ
 dCt
-egT
+vhm
 dCt
 dCt
-egT
+vhm
 dCt
 dCt
 qDb
 naH
 ozu
 ozu
-xXb
+raH
 mfK
 chA
 hbr
@@ -106131,7 +106131,7 @@ tWE
 cdw
 cdw
 coJ
-mGA
+eHT
 cfw
 ciu
 idg
@@ -106177,21 +106177,21 @@ dtX
 dkc
 hqp
 rpQ
-pdj
+rJF
 aqf
 jOe
 gdW
 cXz
-gyo
+xuV
 dTY
 dTY
-naT
+jlD
 dUq
 dTX
 lUO
 dUq
 dUq
-gaj
+ghw
 cXz
 gdW
 hOK
@@ -106217,7 +106217,7 @@ hqp
 jOe
 gdW
 viV
-nMz
+tuM
 dTs
 dTs
 dTs
@@ -106258,11 +106258,11 @@ aow
 aqK
 asx
 asx
-cnI
+kaT
 asC
 atp
 aud
-mUE
+uLX
 aow
 dTs
 dTs
@@ -106278,7 +106278,7 @@ aCQ
 buj
 buj
 aZk
-kKQ
+fBC
 aeE
 bgH
 bgH
@@ -106300,13 +106300,13 @@ bXn
 bXn
 bXv
 blM
-jfQ
+laE
 bki
 bje
 vNT
 blM
 bhk
-xFn
+dcT
 bhk
 bhk
 bhk
@@ -106331,7 +106331,7 @@ dCt
 dCt
 dCt
 dCt
-egT
+vhm
 qDb
 naH
 uml
@@ -106368,12 +106368,12 @@ cdw
 ciU
 cfw
 dPY
-qUc
+ghW
 cht
 poi
 qEJ
 poi
-bAX
+sHb
 aKv
 cdw
 ceo
@@ -106413,7 +106413,7 @@ cWy
 peQ
 peQ
 aqf
-mlF
+rVV
 gdW
 dck
 dcY
@@ -106434,7 +106434,7 @@ sLx
 wya
 fdk
 hOK
-vhb
+azY
 tLl
 gdW
 dqp
@@ -106537,12 +106537,12 @@ blM
 bir
 biP
 biP
-aYh
+kSx
 blM
 bhk
 bhk
 bhk
-xFn
+dcT
 bhk
 btQ
 bvj
@@ -106562,14 +106562,14 @@ btQ
 dCt
 dCt
 dCt
-egT
+vhm
 dCt
 dCt
 dCt
 qDb
 naH
 ozu
-gvt
+nKc
 xsS
 mfK
 chA
@@ -106598,7 +106598,7 @@ dTs
 dTs
 tWE
 cdw
-lzM
+quN
 ciU
 cfw
 cge
@@ -106729,7 +106729,7 @@ pjI
 asA
 asG
 nfU
-epq
+sIp
 avq
 aow
 dTs
@@ -106738,14 +106738,14 @@ dTs
 dTs
 aXv
 aPP
-rIv
+qUl
 buj
 buj
 buj
-pcp
+kTT
 ybg
 aWB
-vlH
+dsN
 bRg
 aXY
 dTs
@@ -106770,7 +106770,7 @@ fGT
 blM
 cyP
 cyP
-svN
+xVY
 cyP
 blM
 bYJ
@@ -106839,11 +106839,11 @@ dPY
 dPY
 rZU
 idg
-mJZ
+dEC
 dPY
 chr
 aKv
-lzM
+quN
 ceo
 tjV
 cgq
@@ -106878,10 +106878,10 @@ djx
 dtY
 gdW
 gdW
-wVo
+qBJ
 gdW
 hqp
-mlF
+rVV
 gdW
 dck
 dck
@@ -106920,7 +106920,7 @@ xmX
 gdW
 ebP
 iNd
-hXY
+qGu
 dTs
 dTs
 dTs
@@ -107068,13 +107068,13 @@ gNO
 cOk
 wOZ
 ciU
-kUO
+cTZ
 dPY
 dPY
 gNv
 icM
 cdc
-eha
+qwA
 ciy
 ciU
 nXt
@@ -107126,7 +107126,7 @@ thd
 dfj
 haK
 dfj
-tRN
+xCV
 dda
 dkI
 cUj
@@ -107205,10 +107205,10 @@ awd
 dTs
 dTs
 aHO
-tIT
+vDQ
 aaC
 aXC
-iha
+joU
 aXC
 aCQ
 buj
@@ -107226,7 +107226,7 @@ dTs
 dTs
 dTs
 dTs
-xFn
+dcT
 bhk
 bhk
 bhk
@@ -107236,7 +107236,7 @@ bXi
 aZg
 bXz
 blM
-svN
+xVY
 cyP
 cyP
 cyP
@@ -107269,7 +107269,7 @@ clf
 hbr
 cif
 qDb
-sTE
+xKf
 aFo
 wrl
 aFo
@@ -107289,10 +107289,10 @@ cdv
 dTs
 dTs
 cOk
-rjY
+rcb
 chZ
 civ
-rjY
+rcb
 dTs
 dTs
 dTs
@@ -107348,7 +107348,7 @@ dnD
 drg
 cZc
 gdW
-czm
+pgR
 jOe
 gdW
 cZc
@@ -107381,7 +107381,7 @@ rJC
 rJC
 dqp
 dqp
-hXY
+qGu
 lwm
 hqp
 jOe
@@ -107435,8 +107435,8 @@ qrp
 azp
 awd
 awd
-yeb
-fhI
+hRF
+pCq
 dTs
 dTs
 aPP
@@ -107446,7 +107446,7 @@ abZ
 abZ
 amM
 buj
-qkW
+ljP
 aZk
 dTs
 cTE
@@ -107463,17 +107463,17 @@ dTs
 bgP
 biw
 bmL
-hNs
+mbe
 bjs
 bjJ
-uXd
+wId
 mim
 bXA
 blM
 bir
 biP
 biP
-aYh
+kSx
 blM
 bhl
 bhk
@@ -107534,7 +107534,7 @@ dTs
 dTs
 dTs
 dTs
-ipF
+vKa
 ciU
 dPR
 dPY
@@ -107588,7 +107588,7 @@ gdW
 cZc
 dde
 ddY
-iTX
+tCP
 wxc
 dea
 pbC
@@ -107657,7 +107657,7 @@ dTs
 dTs
 dTs
 dTs
-jYg
+kaS
 jnY
 ayK
 ayZ
@@ -107666,14 +107666,14 @@ xEl
 xEl
 xEl
 obs
-jyu
+vXc
 axS
 axS
 axt
-dJp
+gpA
 lKL
 dTs
-tIT
+vDQ
 aXW
 buj
 buj
@@ -107739,7 +107739,7 @@ oXx
 qDb
 naH
 ozu
-gvt
+nKc
 xsS
 mfK
 cuR
@@ -107755,10 +107755,10 @@ dLK
 caH
 cdw
 cej
-lzM
+quN
 cdw
 caH
-paI
+obt
 civ
 caH
 dTs
@@ -107771,12 +107771,12 @@ cer
 xqW
 ciU
 cfw
-mJZ
+dEC
 idg
 ute
 dPY
 dPY
-mJZ
+dEC
 pUR
 aaY
 cdw
@@ -107814,7 +107814,7 @@ ghQ
 lwj
 nlb
 cle
-wVo
+qBJ
 gdW
 hqp
 jOe
@@ -107827,7 +107827,7 @@ rza
 dea
 dcN
 wRi
-wie
+oEw
 dhZ
 eeV
 xqQ
@@ -107849,7 +107849,7 @@ rJC
 rJC
 rJC
 dpC
-hXY
+qGu
 lwm
 qck
 jOe
@@ -107904,21 +107904,21 @@ ayZ
 ayZ
 azk
 tPi
-jYg
+kaS
 dTs
 dTs
 aPP
 aXW
 buj
-qkW
+ljP
 buj
 aCp
-qkW
+ljP
 buj
 aZk
 dTs
 aeE
-bLG
+xUJ
 aOg
 dTs
 dTs
@@ -107928,7 +107928,7 @@ dTs
 dTs
 dTs
 bkZ
-dVQ
+kGC
 bhi
 bhF
 bhZ
@@ -107938,10 +107938,10 @@ bie
 bie
 blg
 blM
-jfQ
+laE
 biP
 biP
-aYh
+kSx
 blM
 bhk
 cpu
@@ -107966,7 +107966,7 @@ btQ
 cNW
 dCt
 euG
-rYS
+vRD
 hpw
 hpw
 hpw
@@ -107987,20 +107987,20 @@ hbr
 hyG
 dLL
 caH
-lzM
+quN
 cdw
 aDV
 aMD
 caH
 cib
-mqQ
+xbO
 caH
 cer
 aFG
 cer
 cer
 xqW
-lzM
+quN
 cdw
 cdw
 coK
@@ -108013,7 +108013,7 @@ cdc
 cdc
 ciy
 cib
-gUt
+cZI
 cjT
 cjT
 cjT
@@ -108024,10 +108024,10 @@ cEg
 cEg
 lnT
 cEg
-gyI
+sqI
 cIz
 cCc
-rjY
+rcb
 caH
 caH
 caH
@@ -108051,14 +108051,14 @@ dnD
 gdW
 gdW
 hqp
-mlF
+rVV
 gdW
 gdW
 dda
 ddZ
 jsv
 wxc
-tRN
+xCV
 hAB
 dhZ
 wRi
@@ -108073,7 +108073,7 @@ xqQ
 fdk
 hOK
 iNd
-hXY
+qGu
 dpC
 rJC
 rJC
@@ -108090,7 +108090,7 @@ jOe
 gdW
 mMy
 fHZ
-edW
+pIt
 ibU
 ibU
 dTs
@@ -108126,7 +108126,7 @@ dTs
 dTs
 dTs
 dTs
-jYg
+kaS
 ayK
 ayZ
 xEl
@@ -108165,12 +108165,12 @@ bkZ
 pCf
 bhi
 bhF
-oNT
+hhL
 bit
 bjM
 bjM
 bjM
-mRQ
+rYx
 bju
 bir
 biP
@@ -108188,7 +108188,7 @@ bwx
 bxK
 awA
 bzQ
-get
+hZr
 bAM
 bsd
 wyS
@@ -108205,7 +108205,7 @@ hqT
 hqT
 hqT
 shm
-jRx
+suY
 uml
 vgm
 xsS
@@ -108234,12 +108234,12 @@ ilz
 ilz
 ilz
 ilz
-xjS
+kum
 ilz
 ilz
 ilz
 qVN
-qUc
+ghW
 ciu
 cht
 ilz
@@ -108254,7 +108254,7 @@ poi
 fKt
 cCd
 cDf
-gyI
+sqI
 cDf
 cDf
 cDf
@@ -108290,7 +108290,7 @@ gdW
 gdW
 dde
 dea
-tRN
+xCV
 wyJ
 dea
 hAB
@@ -108327,10 +108327,10 @@ tLl
 eLU
 fCr
 ibU
-hXY
+qGu
 ibU
 ibU
-hXY
+qGu
 ibU
 dTs
 dTs
@@ -108368,10 +108368,10 @@ ayZ
 axQ
 azc
 azc
-vwc
+jPi
 ayZ
 ayZ
-mYn
+toT
 dTs
 dTs
 dTs
@@ -108442,7 +108442,7 @@ fif
 tSK
 ozu
 ozu
-xXb
+raH
 mfK
 bVE
 dCt
@@ -108463,7 +108463,7 @@ ciu
 ciu
 ciu
 cda
-vWl
+sGm
 ciu
 cda
 ciu
@@ -108471,17 +108471,17 @@ ciu
 cda
 dPY
 dPY
-lpq
+hfg
 dPY
 ciu
 dPY
 ibE
 cda
-vWl
+sGm
 dPY
 slN
 ciu
-mJZ
+dEC
 lFc
 ibE
 dPY
@@ -108490,17 +108490,17 @@ cCd
 cDf
 cDf
 cDf
-gyI
+sqI
 cDf
 cHx
 cIB
 cEf
 cdw
 sqi
-ple
+whd
 cMN
 cid
-lSE
+omP
 cgr
 hzL
 dTs
@@ -108521,13 +108521,13 @@ gdW
 tJI
 aqf
 hBr
-noo
+fww
 ddc
 dea
 dea
 ddY
 dea
-jrk
+hwo
 uYz
 rPp
 dhZ
@@ -108540,7 +108540,7 @@ sLx
 hjm
 fdk
 hOK
-gFA
+hyJ
 ibU
 dqp
 rJC
@@ -108631,46 +108631,46 @@ dTs
 dTs
 dTs
 bkZ
-dVQ
+kGC
 bhF
-oNT
+hhL
 bhZ
 bir
-kCu
+hEv
 biP
 biP
 blN
-kCu
+hEv
 biP
 biP
 bjo
 kBt
 bit
-qaY
+jUg
 bre
 dvO
 pqt
 gYE
 pqt
 pqt
-xXh
+cLC
 pqt
-xXh
+cLC
 qYC
 pqt
-xXh
+cLC
 uWf
 aKl
 brf
-lGq
+fgT
 brf
 bre
 euG
-rYS
+vRD
 nqm
 kVU
 naH
-gvt
+nKc
 ozu
 ozu
 bRr
@@ -108679,7 +108679,7 @@ ozu
 xsS
 mfK
 bVE
-egT
+vhm
 duy
 mEu
 bnh
@@ -108690,7 +108690,7 @@ vsQ
 dLQ
 ccP
 cdy
-wSm
+kHC
 ceX
 cfw
 ciu
@@ -108726,7 +108726,7 @@ cDf
 cDf
 cDf
 cDf
-eJS
+pYB
 cDf
 cCc
 cdw
@@ -108929,20 +108929,20 @@ ceY
 cfw
 ciu
 ciu
-vUk
+onM
 cdc
 cdc
-eha
+qwA
 cdc
 cdc
 cdc
-eha
+qwA
 cdc
 cdc
 ppI
 cdc
 cdc
-eha
+qwA
 cfA
 sML
 fEQ
@@ -108952,11 +108952,11 @@ ctO
 ntj
 ctO
 ctO
-igC
+mxC
 dTM
 aBV
 cDf
-gyI
+sqI
 cDf
 cDf
 cDf
@@ -108991,13 +108991,13 @@ dIw
 gdW
 gdW
 dde
-tRN
+xCV
 dea
 dfk
-tRN
+xCV
 vMp
 xjY
-sAW
+ewU
 dgT
 eeW
 aEq
@@ -109029,7 +109029,7 @@ gdW
 gdW
 gdW
 gdW
-wVo
+qBJ
 gdW
 gdW
 gdW
@@ -109066,7 +109066,7 @@ apD
 arL
 arL
 lse
-hfH
+qOt
 arL
 avy
 arJ
@@ -109102,7 +109102,7 @@ dTs
 bhj
 bhF
 azM
-nny
+xoC
 bir
 biP
 biP
@@ -109112,7 +109112,7 @@ biQ
 biQ
 biQ
 bnt
-nOo
+sVz
 gHU
 gHU
 diL
@@ -109139,7 +109139,7 @@ hwc
 kVU
 ngo
 oAM
-dlr
+rxy
 oAM
 inQ
 ozu
@@ -109160,7 +109160,7 @@ dLZ
 caH
 caH
 caH
-kUO
+cTZ
 ciu
 ciu
 chr
@@ -109182,7 +109182,7 @@ ciu
 dPY
 dPY
 ciu
-qUc
+ghW
 ciu
 xOb
 idg
@@ -109194,14 +109194,14 @@ cEh
 cEh
 ydw
 cEh
-gyI
+sqI
 cDf
 cDf
 dnP
 hrk
 jXq
 caH
-rjY
+rcb
 caH
 dTs
 dTs
@@ -109223,12 +109223,12 @@ cZc
 gdW
 gdW
 gdW
-wVo
+qBJ
 dda
 deb
 dea
 dea
-tRN
+xCV
 rAP
 dea
 dea
@@ -109252,7 +109252,7 @@ gdW
 gdW
 tLl
 tLl
-vhb
+azY
 tLl
 lwm
 hqp
@@ -109297,7 +109297,7 @@ dTs
 dTs
 ajz
 apZ
-kCr
+dJu
 arL
 wQc
 atQ
@@ -109343,7 +109343,7 @@ tKB
 ggy
 ati
 auo
-eDH
+oaj
 iif
 iif
 lYn
@@ -109368,14 +109368,14 @@ bDx
 bDx
 bDx
 cNW
-egT
+vhm
 hwc
 kVU
 mdP
 fif
 fif
 fif
-eoa
+tma
 ozu
 ozu
 xsS
@@ -109424,7 +109424,7 @@ chr
 pdV
 cCe
 mBs
-mYq
+bpH
 fCD
 cFT
 cGU
@@ -109478,7 +109478,7 @@ fdk
 hOK
 viV
 vuu
-vhb
+azY
 tLl
 gdW
 wRX
@@ -109538,7 +109538,7 @@ auj
 arL
 avA
 arJ
-lum
+exE
 ayZ
 ayZ
 azp
@@ -109557,7 +109557,7 @@ dTs
 dTs
 dTs
 bgH
-lYs
+iGE
 bRg
 bRg
 bRg
@@ -109592,7 +109592,7 @@ bwA
 bxL
 bsN
 brf
-sMP
+vYd
 bBH
 brh
 aff
@@ -109630,11 +109630,11 @@ ceo
 cdw
 cfw
 ciu
-vWl
+sGm
 chr
 chZ
 vXl
-fOT
+mDe
 civ
 ciR
 bdh
@@ -109644,12 +109644,12 @@ clH
 cmt
 dPj
 ciR
-mGA
+eHT
 csH
 dPZ
-eha
+qwA
 cdc
-eha
+qwA
 cdc
 cdc
 dPZ
@@ -109666,10 +109666,10 @@ cGV
 cIC
 cCc
 cdw
-lzM
+quN
 cdw
 cdw
-lzM
+quN
 dTs
 dTs
 dTs
@@ -109690,7 +109690,7 @@ nlb
 cjS
 dtY
 gdW
-vhb
+azY
 tLl
 dde
 dea
@@ -109718,7 +109718,7 @@ gdW
 hqp
 jOe
 gdW
-wVo
+qBJ
 gdW
 gdW
 gdW
@@ -109729,12 +109729,12 @@ gdW
 gdW
 gdW
 gdW
-wVo
+qBJ
 gdW
 gdW
 gdW
 gdW
-wVo
+qBJ
 hqp
 jOe
 gdW
@@ -109768,7 +109768,7 @@ arB
 arL
 atj
 cRj
-tio
+kgS
 arL
 avy
 arJ
@@ -109801,7 +109801,7 @@ dTs
 dTs
 dTs
 dTs
-oYj
+ekA
 vGm
 aCP
 ari
@@ -109832,15 +109832,15 @@ brh
 bDz
 igP
 bFa
-ogG
+pul
 bIy
 bDx
 cNW
 dCt
-oQK
+uDW
 kVU
 naH
-gvt
+nKc
 ozu
 ozu
 bRr
@@ -109849,7 +109849,7 @@ ozu
 xsS
 mfK
 bVE
-egT
+vhm
 dCU
 dKA
 mEu
@@ -109859,7 +109859,7 @@ kMb
 vsQ
 dLP
 bPi
-rjY
+rcb
 ceo
 cdw
 cfw
@@ -109874,7 +109874,7 @@ ciR
 bGP
 ckA
 dOS
-wwQ
+lDk
 cmu
 coM
 ciR
@@ -109887,9 +109887,9 @@ cjT
 cjT
 cjT
 dPS
-wSi
+iOQ
 dPS
-mqQ
+xbO
 cCf
 cCg
 cCg
@@ -109928,12 +109928,12 @@ bLk
 tLl
 dda
 dea
-tRN
+xCV
 dea
-tRN
+xCV
 dea
 dea
-tRN
+xCV
 dea
 dda
 gdW
@@ -109960,7 +109960,7 @@ hGN
 qck
 jOe
 gdW
-wVo
+qBJ
 lwX
 dtE
 lwX
@@ -109999,7 +109999,7 @@ dTs
 dTs
 ajz
 arC
-kCr
+dJu
 ckK
 cRj
 auj
@@ -110012,7 +110012,7 @@ ayZ
 azp
 avG
 wZp
-fPF
+lai
 axL
 ayx
 aCr
@@ -110038,7 +110038,7 @@ dTs
 biy
 bbV
 aCP
-nsP
+jMz
 bjO
 bkk
 bky
@@ -110060,12 +110060,12 @@ brh
 bxN
 tui
 brf
-sMP
+vYd
 bBI
 brh
 bDA
 igP
-ogG
+pul
 bFa
 bIy
 bDx
@@ -110079,7 +110079,7 @@ oAM
 oAM
 inQ
 ozu
-gvt
+nKc
 xsS
 mfK
 bVE
@@ -110100,13 +110100,13 @@ cfw
 cge
 pjv
 chr
-paI
+obt
 vXl
 dnP
 ceY
 ciR
 bLu
-wwQ
+lDk
 dYp
 xgw
 ckB
@@ -110172,7 +110172,7 @@ dda
 dda
 gdW
 hqp
-mlF
+rVV
 bYV
 aEq
 aEq
@@ -110192,7 +110192,7 @@ peQ
 peQ
 qix
 qck
-nZr
+qsf
 gdW
 gdW
 lwX
@@ -110270,14 +110270,14 @@ dTs
 dTs
 dTs
 dTs
-nyM
+ajv
 aCP
 bZc
 bjO
 bkj
 bkj
 blj
-oYj
+ekA
 biy
 dTs
 dTs
@@ -110292,10 +110292,10 @@ dTs
 dTs
 brh
 bcW
-cgX
+tsU
 awB
 bxQ
-dbV
+xQw
 brh
 bDB
 ebg
@@ -110304,14 +110304,14 @@ bFa
 bIz
 bDx
 fyq
-egT
+vhm
 fpu
 hqT
 nil
 nil
 nil
 pTU
-jRx
+suY
 uml
 vgm
 xsS
@@ -110330,7 +110330,7 @@ bVz
 caH
 ceo
 cdw
-kUO
+cTZ
 ciu
 ciu
 chr
@@ -110355,7 +110355,7 @@ cwH
 cwH
 cvN
 crC
-qJt
+wfH
 dPT
 cBd
 cCg
@@ -110395,15 +110395,15 @@ gdW
 tLl
 tLl
 tLl
-vhb
+azY
 tLl
 tLl
 tLl
 tLl
-vhb
+azY
 tLl
 tLl
-wVo
+qBJ
 gdW
 hqp
 jOe
@@ -110418,7 +110418,7 @@ qck
 jOe
 gFK
 lwm
-kqk
+sOA
 lwm
 lwm
 lwm
@@ -110439,7 +110439,7 @@ dtE
 gdW
 hqp
 jOe
-wVo
+qBJ
 iNd
 dTs
 dTs
@@ -110463,7 +110463,7 @@ afG
 afH
 afK
 alc
-hCT
+qvn
 agI
 afG
 arE
@@ -110551,7 +110551,7 @@ ozu
 xsS
 mfK
 bVD
-egT
+vhm
 bXo
 ptU
 mEu
@@ -110561,7 +110561,7 @@ kMb
 kMb
 vsQ
 dLW
-rjY
+rcb
 cen
 cdw
 cfw
@@ -110574,9 +110574,9 @@ ciR
 cjn
 cjU
 ckE
-xXL
+tXB
 ntb
-pFh
+jnp
 coO
 cpA
 cjV
@@ -110587,7 +110587,7 @@ dPT
 dPT
 dQp
 crD
-vki
+eMI
 crD
 dQC
 ctQ
@@ -110655,7 +110655,7 @@ gdW
 gdW
 gdW
 gdW
-wVo
+qBJ
 dxe
 dxe
 xlx
@@ -110670,7 +110670,7 @@ dAA
 dGv
 bNu
 dtE
-wVo
+qBJ
 hqp
 jOe
 gdW
@@ -110705,7 +110705,7 @@ bYD
 kIM
 cRj
 atk
-hfH
+qOt
 atQ
 awG
 ayM
@@ -110740,12 +110740,12 @@ dTs
 dTs
 vGm
 aCP
-nsP
+jMz
 bjO
 bkk
 bky
 blj
-oYj
+ekA
 biy
 dTs
 dTs
@@ -110766,7 +110766,7 @@ fpJ
 dTs
 brh
 mnA
-ogG
+pul
 bFa
 wTP
 bIB
@@ -110802,7 +110802,7 @@ cfw
 cge
 cgL
 chr
-paI
+obt
 civ
 ciS
 cjn
@@ -110817,9 +110817,9 @@ cqr
 dPG
 csJ
 ctR
-qJt
+wfH
 dPT
-vVm
+rny
 dQs
 dQs
 dQy
@@ -110828,7 +110828,7 @@ dQJ
 cBe
 cCi
 cCi
-jwO
+eQv
 dRm
 uHN
 dSf
@@ -110896,7 +110896,7 @@ kVg
 dzm
 eyF
 dxe
-wVo
+qBJ
 lwX
 bNu
 cmQ
@@ -110945,7 +110945,7 @@ arJ
 ayO
 ebT
 ayZ
-mYn
+toT
 avG
 dTs
 dTs
@@ -111048,7 +111048,7 @@ cnH
 coQ
 cpC
 cjV
-vki
+eMI
 crD
 skA
 dQh
@@ -111119,7 +111119,7 @@ tLl
 gdW
 gdW
 gdW
-wVo
+qBJ
 cFf
 ghQ
 dHg
@@ -111127,7 +111127,7 @@ gdW
 din
 hUT
 dWy
-fRR
+gST
 dWK
 din
 gdW
@@ -111247,7 +111247,7 @@ dTs
 dTs
 dTs
 qDb
-jRx
+suY
 ozu
 ozu
 xsS
@@ -111268,7 +111268,7 @@ ceo
 cdw
 cfw
 ciu
-vWl
+sGm
 chr
 chZ
 civ
@@ -111290,7 +111290,7 @@ lib
 cwI
 cxA
 wOy
-lnw
+wxi
 vkf
 dQK
 cBf
@@ -111351,16 +111351,16 @@ hlu
 viV
 tLl
 gdW
-wVo
+qBJ
 gdW
 gdW
 cFf
 ghQ
 dHg
-wVo
+qBJ
 din
 fVJ
-fRR
+gST
 iXE
 dWK
 din
@@ -111445,7 +111445,7 @@ auu
 aCR
 bjO
 bkk
-rAW
+xyy
 blj
 ctg
 dTs
@@ -111484,7 +111484,7 @@ qDb
 naH
 ozu
 ozu
-xXb
+raH
 mfK
 dCt
 dCt
@@ -111505,11 +111505,11 @@ cge
 cgL
 chr
 chZ
-ple
+whd
 ciS
 cjq
 cjq
-iCl
+xEk
 clI
 clI
 cnG
@@ -111517,9 +111517,9 @@ coO
 cpA
 cjV
 crF
-gBf
+wfw
 dQd
-cjJ
+nlY
 cvP
 cwJ
 cwK
@@ -111662,7 +111662,7 @@ avG
 dTs
 pxa
 pxa
-nVD
+jfr
 pxa
 vit
 wDA
@@ -111672,16 +111672,16 @@ pnG
 wjr
 dTs
 dTs
-bLG
+xUJ
 oBK
 wrs
 aPk
-mPE
+rTg
 aXW
 buj
 buj
 aZk
-gqS
+udC
 auu
 biy
 biy
@@ -111735,7 +111735,7 @@ caH
 cen
 cdw
 cfw
-vWl
+sGm
 ciu
 chr
 chZ
@@ -111745,7 +111745,7 @@ cjr
 cjq
 ckH
 clI
-xXL
+tXB
 dPa
 coR
 cpD
@@ -111756,11 +111756,11 @@ eud
 ctS
 cvQ
 cwK
-huF
+jXP
 cxZ
 crF
 sHL
-sSA
+sdt
 cBg
 cCg
 cDn
@@ -111818,13 +111818,13 @@ fdk
 lwm
 viV
 tLl
-wVo
+qBJ
 gdW
 fhm
-wVo
+qBJ
 gdW
 gdW
-wVo
+qBJ
 fhm
 dxe
 xJG
@@ -111840,7 +111840,7 @@ dtE
 lwX
 lwX
 lwX
-wVo
+qBJ
 dKB
 cGT
 cGT
@@ -111866,7 +111866,7 @@ aiz
 aiz
 ahr
 aju
-nMT
+cGE
 ahr
 anO
 akO
@@ -111891,10 +111891,10 @@ ebT
 ayZ
 ayZ
 azx
-jyu
+vXc
 avH
 bRg
-ptK
+eDN
 pnG
 bRg
 dTs
@@ -111905,7 +111905,7 @@ vit
 pxa
 fgl
 noc
-rzl
+isQ
 jKe
 mTL
 aAu
@@ -111914,10 +111914,10 @@ bgr
 aXW
 nrl
 buj
-vlH
+dsN
 aCP
 bUr
-hlh
+eIG
 bZc
 avZ
 jLd
@@ -111949,13 +111949,13 @@ dTs
 iwh
 nue
 qDb
-jRx
+suY
 ozu
 ozu
 xsS
 mfK
 bVE
-egT
+vhm
 dEl
 tiZ
 eDR
@@ -111965,7 +111965,7 @@ kMb
 kMb
 vsQ
 dLX
-rjY
+rcb
 ceo
 cdw
 cfw
@@ -112067,13 +112067,13 @@ din
 dxe
 dxe
 gdW
-wVo
+qBJ
 gdW
 bVk
 bVk
 bVk
 gdW
-wVo
+qBJ
 gdW
 cCb
 rWp
@@ -112107,12 +112107,12 @@ azv
 bRT
 bZU
 aoW
-ixW
+xtG
 bZU
 bZU
 ayr
 ayr
-lrV
+dAM
 ayr
 ayr
 hGF
@@ -112134,7 +112134,7 @@ dTs
 dTs
 dTs
 dTs
-lYs
+iGE
 bRg
 bRg
 bRg
@@ -112155,7 +112155,7 @@ bTI
 bZc
 avZ
 aCP
-nsP
+jMz
 avZ
 avc
 awq
@@ -112201,29 +112201,29 @@ vsQ
 dLX
 caH
 ceo
-lzM
+quN
 cfw
 cge
 cgL
 chr
-fVX
+oUE
 vXl
 ceX
 cjs
 dOj
 dOu
 dOl
-xHE
+qsX
 cnK
 cjX
 cmx
 cqt
-tUx
+voK
 dQG
 mMG
 dQg
 cnK
-imS
+rxn
 cmx
 cqt
 dOj
@@ -112234,7 +112234,7 @@ cCj
 cDp
 dRg
 dRm
-sRa
+bcv
 dSj
 dSv
 cCf
@@ -112386,11 +112386,11 @@ aZk
 atI
 avm
 bUr
-xAW
+ior
 avm
 bUr
 bUr
-oKQ
+mcO
 bUr
 bUr
 bzV
@@ -112398,7 +112398,7 @@ bzV
 bzV
 bzV
 bzV
-qkP
+cWa
 bzV
 aBJ
 bzV
@@ -112413,7 +112413,7 @@ aBG
 uXp
 aVY
 aBG
-fDw
+rCk
 bID
 aBY
 shm
@@ -112437,19 +112437,19 @@ caH
 ceo
 cdw
 cfw
-vWl
+sGm
 lZM
 chr
 chZ
 fnb
-ple
+whd
 cjt
-vSZ
+mtr
 dOv
 xbr
 dOG
 dOG
-vAG
+bbS
 dPk
 dPr
 dPH
@@ -112593,9 +112593,9 @@ avG
 ayP
 ayZ
 ayZ
-cVW
+rEd
 avH
-lag
+kiB
 azu
 dTs
 dTs
@@ -112610,7 +112610,7 @@ bRg
 bRg
 dfr
 bgH
-koi
+nyk
 bRg
 bgr
 aXW
@@ -112627,7 +112627,7 @@ abZ
 abZ
 abZ
 abZ
-qSa
+rXu
 abZ
 abZ
 abZ
@@ -112636,14 +112636,14 @@ abZ
 abZ
 aBK
 abZ
-qSa
+rXu
 abZ
 abZ
-qSa
+rXu
 bJD
 duq
 bJD
-fmn
+oVV
 bJD
 bJD
 bJD
@@ -112651,10 +112651,10 @@ bJD
 duq
 bJD
 fif
-eoa
+tma
 ozu
 ozu
-xXb
+raH
 mfK
 bVE
 dCt
@@ -112692,11 +112692,11 @@ nCr
 csP
 dNW
 csP
-xVH
+dlk
 cyb
 dQA
 dNW
-xLU
+oZF
 cBj
 cCl
 cCl
@@ -112848,7 +112848,7 @@ aOg
 bRg
 bgr
 aXW
-qkW
+ljP
 buj
 buj
 aBn
@@ -112876,13 +112876,13 @@ azZ
 buj
 bJE
 duw
-ogq
+mcy
 bJE
 bIF
 bJE
-ogq
+mcy
 bIF
-hiF
+oyD
 bJE
 ssy
 ozu
@@ -112891,7 +112891,7 @@ ozu
 xsS
 mfK
 bVD
-egT
+vhm
 dAB
 mEu
 bnh
@@ -112914,10 +112914,10 @@ civ
 cjs
 cjZ
 ckN
-qjM
+mzB
 ckN
 ckN
-kpQ
+kAC
 cpG
 cqw
 crK
@@ -113048,7 +113048,7 @@ dTs
 dTs
 dTs
 dTs
-nHe
+sJV
 aqC
 aqC
 aqC
@@ -113058,7 +113058,7 @@ dTs
 dTs
 dTs
 avG
-lum
+exE
 ayZ
 ayZ
 azp
@@ -113081,7 +113081,7 @@ bRg
 bRg
 cTE
 bgr
-rIv
+qUl
 buj
 azN
 aCj
@@ -113089,18 +113089,18 @@ aBr
 aBx
 aCj
 aAa
-lIV
+wUR
 aCj
 aAa
-lIV
+wUR
 aCj
 aAa
 aCj
 aCj
-mdJ
+odY
 aCj
 aCj
-mdJ
+odY
 aCj
 aAU
 aBQ
@@ -113121,7 +113121,7 @@ bJE
 svy
 ozu
 ozu
-gvt
+nKc
 xsS
 mfK
 bVE
@@ -113144,7 +113144,7 @@ cgN
 cht
 ilz
 cix
-mGA
+eHT
 cjv
 cka
 cka
@@ -113285,7 +113285,7 @@ dTs
 axT
 aqC
 aqC
-fwI
+iHi
 aqC
 aqJ
 dTs
@@ -113297,7 +113297,7 @@ ayZ
 ayZ
 azp
 avG
-lag
+kiB
 azu
 bRg
 gvR
@@ -113335,7 +113335,7 @@ aXC
 aXC
 aXC
 aXC
-iha
+joU
 aXC
 aXC
 aXC
@@ -113353,7 +113353,7 @@ bIH
 ntP
 bIH
 oAM
-qmT
+jpX
 ozu
 byV
 xsS
@@ -113372,7 +113372,7 @@ dLZ
 caH
 ceo
 cdw
-kUO
+cTZ
 ciu
 cgN
 chu
@@ -113403,9 +113403,9 @@ cBl
 cCm
 ctW
 cEy
-qLm
+tGo
 cGg
-kpG
+eqr
 cHc
 cEG
 cJC
@@ -113508,7 +113508,7 @@ ahr
 agQ
 kqZ
 amr
-trA
+kQv
 akO
 dFM
 aCr
@@ -113572,14 +113572,14 @@ byZ
 byZ
 byZ
 byZ
-nEV
+aGS
 byZ
 byZ
 byZ
 aZm
 bID
 cEX
-rlV
+twZ
 taH
 bJF
 bJF
@@ -113591,9 +113591,9 @@ naH
 uml
 vgm
 xsS
-mkm
+oGz
 bVE
-egT
+vhm
 uMG
 ptU
 mEu
@@ -113603,26 +113603,26 @@ kMb
 vsQ
 dLQ
 dLZ
-rjY
+rcb
 ceo
 cdw
 cfw
 cge
 cgM
-tAN
+nFX
 ciu
 chr
 ciU
 cjv
 jPV
-gBx
+qaB
 naz
 vaN
 dPb
 cka
 cpI
 qTq
-pva
+eCY
 crM
 ctX
 cuZ
@@ -113632,7 +113632,7 @@ dQt
 cye
 uKJ
 kLA
-kCz
+gBJ
 uKJ
 cCn
 ctW
@@ -113734,7 +113734,7 @@ ajy
 afN
 afN
 cTd
-wvY
+qYf
 agH
 aNk
 qIk
@@ -113752,7 +113752,7 @@ avK
 awH
 awI
 aCr
-fwI
+iHi
 aqC
 avG
 axW
@@ -113795,7 +113795,7 @@ cTE
 bRg
 bRg
 pnG
-vGM
+nxT
 dTs
 dTs
 bRg
@@ -113809,14 +113809,14 @@ cTE
 bRg
 bRg
 ahV
-fqn
+teZ
 roU
 aBp
 cFj
 cFj
 cFj
 cFj
-tCI
+tuV
 cFj
 aBp
 aCc
@@ -113846,7 +113846,7 @@ cgN
 chu
 ciu
 chr
-mGA
+eHT
 cjv
 dOn
 dOx
@@ -113874,7 +113874,7 @@ cEz
 cEB
 dRJ
 nBZ
-kXM
+iAS
 cIF
 cHJ
 sgs
@@ -113973,7 +113973,7 @@ afG
 amR
 fcj
 ahr
-bRu
+lCZ
 kqZ
 amr
 aoP
@@ -113981,7 +113981,7 @@ akO
 eNU
 aug
 aun
-nHr
+mIQ
 auq
 ucW
 awJ
@@ -114029,7 +114029,7 @@ bRg
 bRg
 iLP
 aeE
-eEl
+xzE
 dTs
 dTs
 dTs
@@ -114054,10 +114054,10 @@ aBH
 ceQ
 bID
 aCe
-sAH
+xhP
 naH
 ozu
-gvt
+nKc
 xsS
 mfK
 bVD
@@ -114074,7 +114074,7 @@ bii
 caH
 cen
 cdw
-kUO
+cTZ
 ciu
 cgN
 chu
@@ -114216,7 +114216,7 @@ dCO
 aug
 aun
 auq
-cxf
+nQR
 auq
 afo
 aCr
@@ -114263,14 +114263,14 @@ bRg
 cTE
 bRg
 dfr
-biv
+aTw
 dTs
 dTs
 dTs
 dTs
 bgH
 bgH
-lYs
+iGE
 bRg
 cTE
 qZW
@@ -114297,13 +114297,13 @@ bUF
 bVF
 dCt
 dCt
-pdp
+mKF
 aWH
 kMb
 kMb
 kMb
 aWH
-pdp
+mKF
 aWH
 caH
 ciu
@@ -114314,7 +114314,7 @@ cgM
 chu
 ciu
 chr
-mGA
+eHT
 cjv
 cke
 ckO
@@ -114345,7 +114345,7 @@ dSm
 cHc
 cEG
 cJF
-mmp
+lHx
 eBZ
 cLV
 cJA
@@ -114388,7 +114388,7 @@ cko
 cCH
 cto
 cto
-qSg
+nUE
 rjq
 cko
 cko
@@ -114437,7 +114437,7 @@ agQ
 agQ
 agQ
 agQ
-bRu
+lCZ
 agQ
 fcj
 aiz
@@ -114460,7 +114460,7 @@ avG
 ayd
 ayj
 ayj
-uht
+xgZ
 avH
 ayK
 ayZ
@@ -114489,15 +114489,15 @@ byZ
 byZ
 byZ
 byZ
-fqn
+teZ
 cTE
 bRg
 bRg
 bRg
 bRg
 aeE
-biv
-biv
+aTw
+aTw
 dTs
 dTs
 dTs
@@ -114509,7 +114509,7 @@ bRg
 bRg
 cTE
 bRg
-haZ
+rkH
 aam
 dTs
 dTs
@@ -114544,7 +114544,7 @@ ilz
 ilz
 cfz
 ciu
-wBc
+qQf
 chu
 ciu
 chr
@@ -114556,7 +114556,7 @@ dOI
 tBR
 ckc
 cka
-qwm
+lRy
 dPt
 pif
 crR
@@ -114685,8 +114685,8 @@ auh
 auq
 auq
 avM
-cxf
-swQ
+nQR
+hiw
 aCr
 aqC
 aqC
@@ -114717,7 +114717,7 @@ aAh
 aPk
 aPk
 aPk
-fqn
+teZ
 bRg
 bRg
 bRg
@@ -114730,7 +114730,7 @@ mrC
 bRg
 aeE
 gDW
-biv
+aTw
 dTs
 dTs
 dTs
@@ -114738,8 +114738,8 @@ dTs
 dTs
 dTs
 gDW
-biv
-oab
+aTw
+nPb
 bRg
 cTE
 bRg
@@ -114754,7 +114754,7 @@ dTs
 dTs
 dTs
 dTs
-sRr
+hYv
 qJq
 qDb
 naH
@@ -114763,7 +114763,7 @@ ozu
 ozu
 bUH
 ozu
-gvt
+nKc
 ssy
 bbF
 jdv
@@ -114773,7 +114773,7 @@ kMb
 jdv
 bbF
 biz
-vWl
+sGm
 ciu
 cda
 ciu
@@ -114784,10 +114784,10 @@ cdc
 ciy
 ciU
 cjv
-iNE
+qel
 ckc
 ckc
-iNE
+qel
 dPb
 cka
 yiG
@@ -114814,7 +114814,7 @@ cHc
 cIH
 cJG
 cKx
-sGI
+emn
 cJG
 cMQ
 cNE
@@ -114853,7 +114853,7 @@ pys
 pys
 aKm
 cUc
-lCQ
+phT
 cto
 cto
 crW
@@ -114881,11 +114881,11 @@ dTs
 cxm
 aKm
 aKm
-sYj
+rgI
 aKm
 aKm
 aKm
-cRe
+hbV
 dTs
 dTs
 dTs
@@ -114922,7 +114922,7 @@ avN
 auq
 axE
 aCr
-fwI
+iHi
 aqC
 avG
 axW
@@ -114937,7 +114937,7 @@ azp
 avG
 dTs
 bgH
-bLG
+xUJ
 aYz
 bRg
 bRg
@@ -114952,9 +114952,9 @@ ftw
 aPk
 bRg
 bRg
-vGM
-vGM
-vGM
+nxT
+nxT
+nxT
 bRg
 nly
 bgr
@@ -114963,7 +114963,7 @@ aFz
 aFz
 bfh
 ccK
-ylW
+qvp
 dTs
 dTs
 dTs
@@ -114973,14 +114973,14 @@ dTs
 dTs
 dTs
 dTs
-biv
-oab
-vGM
-dbS
-vbS
-ylW
-ylW
-ylW
+aTw
+nPb
+nxT
+oVR
+sCN
+qvp
+qvp
+qvp
 dTs
 dTs
 dTs
@@ -114992,7 +114992,7 @@ pvs
 svJ
 qDb
 naH
-gvt
+nKc
 ozu
 ozu
 bUI
@@ -115009,17 +115009,17 @@ bbF
 bjh
 ciu
 ciu
-rVG
+tHL
 lZM
 ciu
 jMw
 chr
-rDw
+ekP
 cel
 ceY
 cjv
 ckg
-taQ
+vsb
 ckg
 ckg
 ckg
@@ -115053,7 +115053,7 @@ cNa
 cMR
 cNF
 cNF
-oXG
+etD
 cMP
 dTs
 dTs
@@ -115083,7 +115083,7 @@ lpN
 pys
 wuz
 vyt
-utd
+sKh
 pys
 aKm
 cUc
@@ -115095,7 +115095,7 @@ lJD
 ewX
 cEV
 aKm
-vfa
+mdW
 cJl
 aKm
 qeu
@@ -115153,7 +115153,7 @@ aug
 aur
 auq
 awe
-cxf
+nQR
 axE
 aCr
 aqC
@@ -115177,16 +115177,16 @@ bRg
 cTE
 bgr
 aXW
-jjS
+sHr
 aWB
 aZk
 bij
-fqn
+teZ
 aPk
 bRg
-vGM
-stE
-eEl
+nxT
+oZy
+xzE
 dTs
 dTs
 mgg
@@ -115196,8 +115196,8 @@ vte
 aFz
 aFz
 aGI
-tBl
-ylW
+mws
+qvp
 dTs
 dTs
 dTs
@@ -115208,14 +115208,14 @@ dTs
 dTs
 dTs
 dTs
-biv
-oab
+aTw
+nPb
 bRg
 vte
 aGI
 lMc
-tBl
-ylW
+mws
+qvp
 dTs
 dTs
 dTs
@@ -115224,7 +115224,7 @@ dTs
 dTs
 pvs
 qJq
-fnp
+vER
 naH
 bSl
 bSl
@@ -115239,7 +115239,7 @@ jdv
 jdv
 jdv
 jdv
-ghD
+rAn
 bbT
 cdc
 cdc
@@ -115275,10 +115275,10 @@ cyk
 cyk
 cyk
 cEF
-qLm
+tGo
 dRM
 cHc
-nWN
+exX
 cIH
 cJG
 vJB
@@ -115309,11 +115309,11 @@ dTs
 dTs
 qHn
 qHn
-nxh
+sln
 pys
 icK
 qho
-utd
+sKh
 eEh
 pys
 pys
@@ -115321,7 +115321,7 @@ pys
 mmU
 cko
 cUc
-lCQ
+phT
 cpR
 cET
 crW
@@ -115343,16 +115343,16 @@ dTs
 dTs
 dTs
 dTs
-gWL
+kTy
 cwu
 cux
-sYj
+rgI
 aKm
 aKm
 aKm
 cEU
 cUK
-cRe
+hbV
 dTs
 dTs
 dTs
@@ -115386,7 +115386,7 @@ api
 aug
 jnu
 auq
-cxf
+nQR
 auq
 axE
 aCr
@@ -115396,7 +115396,7 @@ avG
 aye
 ayl
 ayv
-uht
+xgZ
 avH
 ayO
 ayZ
@@ -115418,19 +115418,19 @@ bij
 bRg
 qZW
 bRg
-stE
+oZy
 dTs
 dTs
 dTs
 dTs
-rIa
-maC
-uUz
-mHl
-mHl
+qhT
+uQK
+wAG
+ojV
+ojV
 snO
-ylW
-ylW
+qvp
+qvp
 dTs
 dTs
 dTs
@@ -115443,13 +115443,13 @@ dTs
 dTs
 dTs
 dTs
-xar
+uqk
 aFz
 aFz
 aGg
 ccK
 ccK
-ylW
+qvp
 dTs
 dTs
 dTs
@@ -115488,7 +115488,7 @@ ciV
 cjw
 cjw
 ckR
-oCm
+rfr
 cmB
 cnN
 cjy
@@ -115528,7 +115528,7 @@ iGe
 cRQ
 cPM
 cAe
-uME
+ert
 raC
 qHn
 qHn
@@ -115557,7 +115557,7 @@ cvn
 cvx
 cCH
 cto
-oSG
+kBw
 crW
 lJD
 cko
@@ -115583,7 +115583,7 @@ aKm
 cJl
 cPz
 aKm
-sYj
+rgI
 aKm
 aKm
 ctm
@@ -115607,10 +115607,10 @@ afK
 afK
 agI
 afG
-fpw
+seT
 afK
 afK
-syL
+xGw
 afG
 aqF
 anX
@@ -115648,7 +115648,7 @@ aXW
 blT
 buj
 aZk
-lag
+kiB
 bRg
 bRg
 aeE
@@ -115657,7 +115657,7 @@ xGe
 xGe
 xGe
 xGe
-jMQ
+aKw
 nMW
 mhJ
 vrk
@@ -115677,7 +115677,7 @@ xGe
 xGe
 xGe
 xGe
-jMQ
+aKw
 vrk
 vrk
 vrk
@@ -115693,7 +115693,7 @@ dTs
 dTs
 egS
 qDb
-jRx
+suY
 ozu
 ozu
 ozu
@@ -115712,12 +115712,12 @@ ccO
 caH
 cen
 cdw
-kUO
+cTZ
 ciu
 ciu
-ekF
+vZM
 chZ
-ple
+whd
 ciV
 cjx
 xkY
@@ -115736,7 +115736,7 @@ cvW
 cwQ
 cxE
 cym
-mSc
+krG
 czc
 cAt
 miO
@@ -115765,7 +115765,7 @@ cAe
 pys
 pys
 xrh
-uME
+ert
 qHn
 qHn
 qHn
@@ -115775,7 +115775,7 @@ dTs
 dTs
 qHn
 kcP
-utd
+sKh
 pys
 mQQ
 pys
@@ -115784,18 +115784,18 @@ hXE
 pys
 cAe
 tLA
-jIm
+tye
 vuF
 vuF
 daT
 daT
-oyL
+umK
 cto
 cto
 crW
 lJD
 cko
-sYj
+rgI
 aKm
 aKm
 aKm
@@ -115839,7 +115839,7 @@ afG
 afI
 akW
 akW
-tqu
+mPc
 amn
 afI
 akW
@@ -115891,7 +115891,7 @@ dTs
 dTs
 dTs
 dTs
-lzF
+clp
 aHb
 uXk
 aBk
@@ -115910,17 +115910,17 @@ dTs
 dTs
 dTs
 dTs
-qhy
-wnJ
+oiH
+rxj
 aBk
 aBk
-qiT
-qhy
-qhy
+xjg
+oiH
+oiH
 dTs
 dTs
 dTs
-fsX
+mwR
 vCe
 dTs
 dTs
@@ -115932,7 +115932,7 @@ ozu
 byV
 ozu
 xsS
-oQK
+uDW
 hhj
 dEX
 mEu
@@ -115956,7 +115956,7 @@ ciV
 cjx
 hFL
 cjx
-oCm
+rfr
 cmB
 cnN
 cjy
@@ -115989,7 +115989,7 @@ cHL
 cMU
 cNH
 dAl
-oXG
+etD
 cJG
 cJG
 cJG
@@ -116010,9 +116010,9 @@ gJP
 sYf
 pys
 pys
-utd
+sKh
 pys
-utd
+sKh
 pys
 pys
 lhu
@@ -116034,7 +116034,7 @@ aKm
 aKm
 aKm
 aKm
-sYj
+rgI
 cpZ
 cwu
 dTs
@@ -116046,13 +116046,13 @@ dTs
 cwu
 cux
 csa
-sYj
+rgI
 aKm
 aKm
 nkB
 aKm
 aKm
-sYj
+rgI
 kON
 dTs
 dTs
@@ -116081,10 +116081,10 @@ eiP
 agL
 afG
 aqH
-vzU
+rXR
 aoP
 akO
-gtF
+kbp
 aCr
 aCr
 aCr
@@ -116092,7 +116092,7 @@ aCr
 aCr
 aCr
 aCr
-fwI
+iHi
 aqC
 aqC
 axT
@@ -116113,7 +116113,7 @@ bRg
 cTE
 alW
 aXW
-nkf
+jEv
 buj
 aZk
 bij
@@ -116125,13 +116125,13 @@ dTs
 dTs
 dTs
 dTs
-lzF
+clp
 xsQ
 aHA
 aGq
 aBk
 aBk
-jeW
+hUr
 dTs
 dTs
 dTs
@@ -116143,23 +116143,23 @@ dTs
 dTs
 dTs
 dTs
-qhy
-xws
+oiH
+tRc
 aBk
 aBk
 aBk
-ksz
+qYk
 dTs
 dTs
 dTs
 dTs
 dTs
-qhy
-qUF
-qhy
+oiH
+eff
+oiH
 dTs
 dTs
-mOb
+iUm
 qDb
 ngo
 oAM
@@ -116179,7 +116179,7 @@ bcY
 bPi
 caH
 ceo
-lzM
+quN
 cfw
 cge
 cgL
@@ -116214,7 +116214,7 @@ cEE
 dRq
 dRP
 cHg
-nAI
+gSG
 cHL
 cIK
 cIK
@@ -116235,7 +116235,7 @@ cFK
 pys
 pys
 pys
-utd
+sKh
 pys
 pys
 pys
@@ -116244,7 +116244,7 @@ dco
 kcP
 pys
 pys
-ocC
+dEE
 pys
 pys
 rzB
@@ -116259,7 +116259,7 @@ cto
 cUP
 cto
 cto
-oSG
+kBw
 crW
 lJD
 cko
@@ -116312,7 +116312,7 @@ afG
 afJ
 iNT
 all
-hAQ
+wJu
 afG
 aqI
 bAR
@@ -116359,48 +116359,48 @@ dTs
 dTs
 dTs
 dTs
-lzF
+clp
 aHb
 aHA
 aBk
 imz
 niK
 uGU
-txl
-qhy
+qNG
+oiH
 dTs
 dTs
-txl
-txl
+qNG
+qNG
 dTs
 dTs
 dTs
 dTs
 dTs
-xws
+tRc
 aBk
 aBk
 imz
 aBk
-ksz
+qYk
 dTs
 dTs
 dTs
 dTs
-fsX
+mwR
 oLT
 vCe
-fsX
+mwR
 dTs
 dTs
 qJq
 hwc
 hpw
-rYS
+vRD
 hpw
 hpw
 hpw
-sAH
+xhP
 dCt
 dEl
 mEu
@@ -116416,13 +116416,13 @@ ceo
 cdw
 cfw
 ciu
-vWl
+sGm
 chr
 chZ
 civ
 ciV
 cjz
-bQh
+pWx
 ckS
 clQ
 cmC
@@ -116455,7 +116455,7 @@ cIK
 cLm
 cHL
 cMW
-vJZ
+qmV
 vmm
 oRT
 cPN
@@ -116464,16 +116464,16 @@ obW
 cRR
 cPM
 cAe
-utd
+sKh
 pys
 pys
 pys
 moI
-mMn
+oyL
 pys
 wYS
-utd
-utd
+sKh
+sKh
 wTk
 pys
 pys
@@ -116481,15 +116481,15 @@ boY
 pys
 pys
 pys
-utd
+sKh
 pys
 cAe
-tLL
+vOU
 tSa
 kHJ
 lNg
 lNg
-fdD
+hMU
 cVA
 cto
 cto
@@ -116497,26 +116497,26 @@ cto
 crW
 vBK
 cvw
-sYj
+rgI
 cqT
 aKm
-sYj
+rgI
 aKm
 aKm
 aKm
 aKm
-alv
+nYv
 cwu
 dTs
 dTs
 dTs
 ctn
 cux
-sYj
+rgI
 aKm
 aKm
 aKm
-iYC
+hRQ
 aKm
 fCL
 aKm
@@ -116577,7 +116577,7 @@ dTs
 dTs
 bRg
 aiS
-hrO
+ohI
 ajE
 ajm
 akc
@@ -116593,38 +116593,38 @@ dTs
 dTs
 dTs
 dTs
-lzF
+clp
 dsX
 srf
 aBk
 aBk
 oTm
 oTm
-jhw
-gbl
-txl
-xws
+nwg
+eYK
+qNG
+tRc
 oTm
 oTm
-gbl
+eYK
 dTs
 dTs
 dTs
-xws
-jhw
+tRc
+nwg
 aBk
 igY
 aBk
 pmt
-qhy
+oiH
 dTs
 dTs
 dTs
 dTs
-qhy
+oiH
 mTi
 weZ
-qhy
+oiH
 dTs
 dTs
 qJq
@@ -116659,7 +116659,7 @@ cjA
 dOq
 cki
 clR
-eTw
+qlX
 cnP
 coU
 dPm
@@ -116677,7 +116677,7 @@ cwS
 cwS
 cwS
 cwS
-xvK
+mOd
 cEH
 dRs
 dRR
@@ -116734,7 +116734,7 @@ coc
 aKm
 aKm
 cmJ
-sYj
+rgI
 aKm
 aKm
 aKm
@@ -116743,7 +116743,7 @@ aKm
 pfV
 ctn
 cux
-sYj
+rgI
 aKm
 aKm
 aKm
@@ -116793,7 +116793,7 @@ dTs
 dTs
 dTs
 aqC
-fwI
+iHi
 aqC
 aqC
 axT
@@ -116815,7 +116815,7 @@ ajm
 ajm
 ajr
 akc
-nkf
+jEv
 buj
 aZk
 bij
@@ -116827,11 +116827,11 @@ dTs
 dTs
 dTs
 dTs
-lzF
+clp
 dsX
 srf
-vUQ
-iLp
+hRM
+iZJ
 oTm
 oTm
 oTm
@@ -116840,25 +116840,25 @@ oTm
 imz
 oTm
 oTm
-jhw
+nwg
 oTm
-gbl
-xws
+eYK
+tRc
 oTm
 aBk
 imz
 aBk
 aBk
-ksz
-qhy
+qYk
+oiH
 dTs
 dTs
 dTs
 dTs
-qhy
-gbS
+oiH
+iky
 vCe
-qhy
+oiH
 dTs
 dTs
 dTs
@@ -116866,7 +116866,7 @@ pvs
 abk
 adi
 abU
-gDG
+jYT
 abO
 abO
 abk
@@ -116887,7 +116887,7 @@ iAf
 pjv
 chr
 chZ
-ple
+whd
 ciW
 cjB
 eyb
@@ -116933,7 +116933,7 @@ diY
 cPM
 cAe
 pys
-utd
+sKh
 pys
 yil
 cdM
@@ -117030,7 +117030,7 @@ xWA
 aqC
 aqC
 gZL
-nHe
+sJV
 dTs
 dTs
 dTs
@@ -117044,14 +117044,14 @@ dTs
 dTs
 bRg
 bRg
-hhe
+rZX
 ajo
 ajF
 ajF
 aCQ
 blT
 buj
-vlH
+dsN
 bij
 bRg
 aXY
@@ -117061,14 +117061,14 @@ dTs
 dTs
 dTs
 dTs
-lzF
+clp
 dsX
 srf
 aBk
 aBk
 aGH
 wQM
-ybk
+rTN
 aAq
 aGH
 aGH
@@ -117083,16 +117083,16 @@ aBk
 aBk
 aBk
 aBk
-slb
+uek
 dTs
 dTs
 dTs
 dTs
 dTs
-qhy
+oiH
 mTi
 vCe
-xws
+tRc
 oTm
 dTs
 dTs
@@ -117102,7 +117102,7 @@ adk
 agf
 abU
 abU
-gDG
+jYT
 abo
 dEW
 kMb
@@ -117172,30 +117172,30 @@ pys
 pys
 pys
 pys
-utd
+sKh
 pys
 pys
-utd
+sKh
 wTk
 pys
-utd
+sKh
 ist
 pys
 pys
 pys
-utd
+sKh
 cAe
 pwf
 ojD
 tSa
 acD
 lAT
-siS
+uAs
 cto
 cUP
 cto
 cto
-jRB
+vqk
 crW
 pmG
 xwG
@@ -117214,7 +117214,7 @@ vDG
 cok
 cok
 cok
-sLQ
+ujd
 cok
 cok
 cok
@@ -117223,7 +117223,7 @@ cok
 iQk
 cvw
 cmJ
-jNx
+oyn
 dTs
 dTs
 dTs
@@ -117252,7 +117252,7 @@ dTs
 akL
 akL
 bAR
-trA
+kQv
 akO
 api
 akL
@@ -117289,7 +117289,7 @@ aZk
 bij
 bRg
 bRg
-xnf
+rWz
 xGe
 dTs
 dTs
@@ -117317,17 +117317,17 @@ aBk
 oTm
 oTm
 aCG
-qhy
+oiH
 dTs
 dTs
 dTs
 dTs
-qhy
-qhy
+oiH
+oiH
 mTi
 tFc
 aBk
-jhw
+nwg
 dTs
 dTs
 dTs
@@ -117350,12 +117350,12 @@ bVz
 caH
 ceo
 cdw
-kUO
+cTZ
 ciu
 ciu
 chr
 chZ
-ple
+whd
 ciW
 cjD
 fLB
@@ -117369,20 +117369,20 @@ bZx
 pBn
 csT
 cub
-asu
+jFI
 cwd
 cwV
 cxH
 cvg
 cze
-asu
+jFI
 cvg
 cvg
-asu
+jFI
 cvg
 cwd
 dRy
-nHw
+vtv
 cHj
 cHL
 cHL
@@ -117402,12 +117402,12 @@ cMP
 cAe
 pys
 pys
-utd
+sKh
 pys
 rzB
 pys
 pys
-utd
+sKh
 pys
 pys
 gJP
@@ -117421,7 +117421,7 @@ jsg
 cAe
 gEK
 hFC
-kUX
+uNG
 kHJ
 lNg
 lNg
@@ -117442,17 +117442,17 @@ cod
 cod
 cod
 cod
-uPI
+pvG
 qoS
 xwG
-rDd
+rmU
 cod
 cod
 cod
 cod
 cod
 cod
-uPI
+pvG
 mEf
 mEf
 coc
@@ -117513,7 +117513,7 @@ dTs
 bRg
 bRg
 aXW
-gSr
+uvB
 ajm
 ajr
 akc
@@ -117529,14 +117529,14 @@ dTs
 dTs
 dTs
 dTs
-xws
+tRc
 gcW
 aGc
 mZj
 aGw
 aGw
 aGw
-gmE
+uMB
 gJM
 aGw
 aGw
@@ -117546,19 +117546,19 @@ aGw
 aGw
 aHU
 wQM
-oTj
-vUQ
+uzd
+hRM
 oTm
 oTm
-ixU
-qhy
+hsn
+oiH
 dTs
 dTs
 dTs
-qhy
-qhy
+oiH
+oiH
 hUz
-qhy
+oiH
 dzH
 imz
 oTm
@@ -117568,7 +117568,7 @@ dTs
 abk
 adm
 abU
-gDG
+jYT
 abO
 aVE
 abo
@@ -117586,7 +117586,7 @@ ceo
 cdw
 cfw
 cge
-vgd
+xNb
 chr
 chZ
 civ
@@ -117649,7 +117649,7 @@ dTs
 dTs
 xVE
 xVE
-dab
+giH
 pys
 mmU
 abJ
@@ -117662,7 +117662,7 @@ vuF
 daT
 coZ
 cto
-oSG
+kBw
 cto
 crY
 daT
@@ -117673,7 +117673,7 @@ cFH
 cmN
 coc
 aKm
-sYj
+rgI
 aKm
 aKm
 aKm
@@ -117689,7 +117689,7 @@ aKm
 aKm
 cmU
 mEf
-vYE
+quO
 aKm
 ctm
 dTs
@@ -117714,7 +117714,7 @@ aah
 anV
 ajO
 ajO
-aOZ
+skm
 ajO
 amG
 ajO
@@ -117728,9 +117728,9 @@ ajO
 ajO
 ajO
 ajO
-onF
+kJh
 akO
-gtF
+kbp
 akL
 dTs
 dTs
@@ -117749,7 +117749,7 @@ bRg
 aXW
 ajm
 ajm
-gSr
+uvB
 akc
 blT
 buj
@@ -117770,7 +117770,7 @@ uNF
 aGE
 aGE
 yiP
-pbV
+bPQ
 aGc
 vGO
 aGc
@@ -117779,17 +117779,17 @@ vGO
 aGc
 vGO
 aGc
-gmE
+uMB
 aGw
 mZj
 aHU
 aBk
 uGU
-qhy
+oiH
 dTs
 dTs
 dTs
-txl
+qNG
 aJV
 aJV
 aEV
@@ -117818,7 +117818,7 @@ bVz
 caH
 ceo
 cdw
-kUO
+cTZ
 ciu
 ciu
 chr
@@ -117851,7 +117851,7 @@ czf
 dRj
 dRy
 dSc
-kfD
+vuP
 cHN
 cIN
 cJI
@@ -117868,7 +117868,7 @@ twm
 cLu
 cAe
 pys
-utd
+sKh
 pys
 pys
 pys
@@ -117891,7 +117891,7 @@ hFC
 hFC
 tSa
 acD
-siS
+uAs
 lAT
 cto
 cUP
@@ -117899,11 +117899,11 @@ cto
 cto
 cto
 cto
-gRj
+ctH
 cto
 cto
 cto
-qSg
+nUE
 cmN
 coc
 aKm
@@ -117959,7 +117959,7 @@ hFS
 aoJ
 aoJ
 aoJ
-iMn
+vpx
 aoJ
 aoJ
 apT
@@ -117987,7 +117987,7 @@ aXC
 aCQ
 aaM
 aWB
-vlH
+dsN
 bij
 aPP
 aPP
@@ -118004,7 +118004,7 @@ srf
 aBk
 aBk
 aGH
-oTj
+uzd
 fEf
 aGE
 saV
@@ -118013,29 +118013,29 @@ aGE
 aGE
 aGE
 wCa
-pbV
+bPQ
 flu
 aGc
 aHA
 imz
 aBk
 sym
-txl
-txl
-xws
-jhw
+qNG
+qNG
+tRc
+nwg
 aBk
 igY
 iBV
 ltx
 dzO
-fsX
+mwR
 dTs
 dTs
 dTs
 abk
 afw
-gDG
+jYT
 abU
 abO
 aVR
@@ -118059,12 +118059,12 @@ chr
 chZ
 civ
 ciW
-jDB
+cRx
 dOr
 dOD
 dOM
 dOY
-jDB
+cRx
 coU
 yiG
 bZx
@@ -118128,7 +118128,7 @@ acD
 lAT
 lAT
 cto
-tlh
+fPv
 cto
 cto
 cto
@@ -118137,10 +118137,10 @@ cnU
 cto
 cto
 cto
-qSg
+nUE
 cmN
 coc
-sYj
+rgI
 duC
 oVs
 dwF
@@ -118225,10 +118225,10 @@ aZk
 bij
 byZ
 byZ
-nEV
+aGS
 sKT
 bAO
-gmE
+uMB
 mZj
 aGw
 aGw
@@ -118247,7 +118247,7 @@ awv
 aGT
 aHJ
 aHV
-oTj
+uzd
 aGH
 aHb
 aHA
@@ -118255,14 +118255,14 @@ aBk
 aBk
 imz
 aBk
-iLp
+iZJ
 aBk
 imz
 oTm
 aBk
 aBk
 ltx
-ksz
+qYk
 dTs
 dTs
 dTs
@@ -118287,7 +118287,7 @@ caH
 cdw
 cdw
 cfw
-pjm
+lLy
 pjv
 chr
 chZ
@@ -118319,7 +118319,7 @@ dyW
 itT
 cEM
 qMf
-fUB
+pCl
 cHO
 cIP
 cJK
@@ -118335,10 +118335,10 @@ cQB
 cQB
 cLu
 cAe
-utd
+sKh
 pys
 pys
-utd
+sKh
 fCf
 dTs
 dTs
@@ -118356,7 +118356,7 @@ cAe
 cAe
 vdZ
 xyC
-dZH
+ngV
 qKF
 kHJ
 lNg
@@ -118364,7 +118364,7 @@ lNg
 cmb
 cmb
 cmb
-fdD
+hMU
 cmb
 cmb
 cmb
@@ -118377,7 +118377,7 @@ coc
 aKm
 duC
 dvD
-mTJ
+kYv
 dxf
 kEe
 iMq
@@ -118389,7 +118389,7 @@ dFf
 eaA
 eaH
 dBo
-tKO
+soH
 gYP
 pEL
 nNI
@@ -118417,7 +118417,7 @@ ahd
 alE
 azv
 akO
-bPB
+kZo
 ajP
 ajP
 alE
@@ -118449,7 +118449,7 @@ bRg
 bRg
 pnG
 aXW
-hrO
+ohI
 ajU
 buj
 aCp
@@ -118462,7 +118462,7 @@ rzf
 bzV
 pLj
 bAP
-pbV
+bPQ
 aGE
 flu
 aGE
@@ -118489,15 +118489,15 @@ aBk
 aBk
 imz
 aBk
-vUQ
+hRM
 fHT
 aBk
 aBk
 aBk
-rvB
+exC
 ltx
-ksz
-qhy
+qYk
+oiH
 dTs
 dTs
 dTs
@@ -118518,7 +118518,7 @@ dJT
 dTs
 dTs
 caH
-lzM
+quN
 cdw
 cfw
 ciu
@@ -118531,7 +118531,7 @@ cjG
 dOr
 dCw
 dOO
-guO
+lhC
 cjG
 coU
 yiG
@@ -118588,7 +118588,7 @@ dTs
 qHn
 cAe
 dvj
-dZH
+ngV
 xyC
 xyC
 hFC
@@ -118615,7 +118615,7 @@ dwF
 duC
 dXC
 mxn
-nac
+oBM
 dBo
 dZR
 eaA
@@ -118667,7 +118667,7 @@ amr
 aoP
 azv
 api
-eou
+pcx
 dqd
 dTs
 dTs
@@ -118696,7 +118696,7 @@ aPP
 aPP
 xFu
 byY
-vUQ
+hRM
 aBk
 aCG
 oit
@@ -118704,10 +118704,10 @@ aBk
 aHb
 aHA
 dzO
-twd
+oqV
 dTs
 dTs
-twd
+oqV
 aKC
 xsQ
 aHA
@@ -118725,15 +118725,15 @@ imz
 oTm
 oTm
 oTm
-vUQ
+hRM
 oTm
 oTm
 aBk
 ltx
-gbl
-qhy
-qhy
-kEx
+eYK
+oiH
+oiH
+pxn
 oTm
 dTs
 dTs
@@ -118757,9 +118757,9 @@ cdw
 cfw
 ciu
 ciu
-ekF
+vZM
 chZ
-ple
+whd
 ciW
 dOh
 dAW
@@ -118774,7 +118774,7 @@ dPN
 crM
 cue
 cvl
-kFe
+dwq
 cxb
 cug
 cug
@@ -118794,9 +118794,9 @@ cHO
 cKF
 cHO
 cHN
-mdQ
+kHl
 cIP
-kVu
+hcL
 cLp
 cPP
 cLu
@@ -118826,13 +118826,13 @@ xyC
 nmw
 nmw
 nmw
-mNT
+aTi
 nmw
 nmw
 cod
 cod
 cod
-uPI
+pvG
 cod
 cod
 coc
@@ -118853,12 +118853,12 @@ dXZ
 dBo
 dZR
 eaA
-hGv
+xDo
 eaA
 eaH
 dBo
 dGC
-xEY
+fqQ
 dHE
 dBr
 dBr
@@ -118932,27 +118932,27 @@ xGe
 dTs
 oTm
 oTm
-ksz
-lzF
-vUQ
-jsC
-azr
+qYk
+clp
+hRM
+lnY
+uhy
 dTs
 dTs
 dTs
 dTs
-lzF
+clp
 oTm
 aHb
 uXk
 aBk
 oTm
-ybk
+rTN
 wQM
 wQM
 wQM
-jsC
-ixT
+lnY
+mRJ
 wQM
 wQM
 wQM
@@ -118962,17 +118962,17 @@ oTm
 aBk
 oTm
 oTm
-xke
+pIy
 jSx
 oTm
 ufP
-txl
-xws
+qNG
+tRc
 oTm
 oTm
 aGH
 wbv
-nHU
+miU
 dTs
 dTs
 czT
@@ -119000,7 +119000,7 @@ dOh
 hwl
 dOh
 cjG
-mPU
+fyg
 cjy
 cpM
 bZA
@@ -119075,7 +119075,7 @@ abt
 cto
 crW
 cmN
-bWI
+xvf
 aKm
 duC
 oVs
@@ -119087,13 +119087,13 @@ dZf
 dBr
 dZS
 dFf
-hGv
+xDo
 eaz
 eaz
 dBr
 dGC
 wEG
-vOC
+aFK
 dBr
 dEr
 dFf
@@ -119115,15 +119115,15 @@ dTs
 dTs
 dTs
 afP
-rPY
+ljC
 aiI
 aAi
 als
 ajY
 ann
-sFw
+mvW
 alt
-sBX
+jpp
 afP
 dTs
 dTs
@@ -119150,15 +119150,15 @@ dTs
 dTs
 bRg
 bRg
-gSr
+uvB
 buj
 buj
 buj
 aaC
 abD
 aXC
-nol
-lag
+kHS
+kiB
 bRg
 aeE
 dTs
@@ -119166,7 +119166,7 @@ xGe
 dTs
 dTs
 dTs
-ksz
+qYk
 dTs
 imz
 aHb
@@ -119177,10 +119177,10 @@ dTs
 dTs
 dTs
 oTm
-jsC
-azr
-vUQ
-ybk
+lnY
+uhy
+hRM
+rTN
 wQM
 wQM
 wQM
@@ -119269,7 +119269,7 @@ cLp
 cPQ
 cQC
 bnA
-qAG
+keR
 bjV
 cTp
 bjV
@@ -119313,13 +119313,13 @@ coc
 aKm
 duC
 dvD
-mTJ
+kYv
 dxf
 kEe
 pHI
 dXZ
 dFU
-hGv
+xDo
 dFf
 smh
 dFf
@@ -119366,7 +119366,7 @@ dTs
 dTs
 akL
 amr
-trA
+kQv
 azv
 api
 xzM
@@ -119388,7 +119388,7 @@ bgC
 bgC
 bgC
 bgC
-mev
+hvo
 bzR
 byZ
 byZ
@@ -119405,7 +119405,7 @@ dTs
 qzH
 aHb
 aHA
-ksz
+qYk
 dTs
 dTs
 dTs
@@ -119416,7 +119416,7 @@ aHA
 aBk
 lVW
 wQM
-xAf
+vmk
 azU
 azU
 geZ
@@ -119424,7 +119424,7 @@ fOY
 azU
 azU
 azU
-lrF
+rAi
 wQM
 wQM
 oTm
@@ -119456,18 +119456,18 @@ dTs
 dTs
 caH
 wqK
-ubK
+nkY
 ciu
 ciu
 chr
 chZ
-tXG
+aFg
 cjT
 cjT
 cjT
 cjT
 cjT
-gUt
+cZI
 cjT
 vXl
 cjT
@@ -119486,7 +119486,7 @@ cpx
 wFv
 wFv
 cDy
-uLz
+yde
 dRA
 dRZ
 iLT
@@ -119507,7 +119507,7 @@ bjV
 ppp
 bjV
 bjV
-xFs
+qPx
 dTs
 dTs
 dTs
@@ -119532,17 +119532,17 @@ dcw
 deB
 dSq
 dcw
-qmC
-qie
+qLo
+nqP
 dbK
 aKm
 aKm
 cUc
 cCH
-oSG
+kBw
 cto
 crW
-hbw
+lWn
 coc
 aKm
 duC
@@ -119556,7 +119556,7 @@ dBr
 dZT
 dFf
 dFf
-hGv
+xDo
 dFf
 dBr
 eaP
@@ -119603,7 +119603,7 @@ amr
 aoP
 azv
 api
-eou
+pcx
 dTs
 dTs
 dTs
@@ -119616,17 +119616,17 @@ dTs
 dTs
 dTs
 dTs
-lag
+kiB
 awE
 bzV
 bzV
 bzV
 bzV
-qkP
+cWa
 bzV
 bzV
 bzV
-mZk
+vCh
 dTs
 dTs
 dTs
@@ -119639,7 +119639,7 @@ oLT
 agC
 aHb
 uXk
-ksz
+qYk
 dTs
 dTs
 dTs
@@ -119652,25 +119652,25 @@ aGH
 wQM
 aSM
 azT
-fmC
+hKS
 aJY
 azT
 aKA
-myZ
-fmC
+xas
+hKS
 aPn
 wQM
 wQM
 oTm
-vUQ
-vUQ
+hRM
+hRM
 oTm
-jhw
-vUQ
-iLp
-mQO
-pjq
-iSk
+nwg
+hRM
+iZJ
+hGY
+wYL
+pRF
 bmB
 aMf
 ucZ
@@ -119690,7 +119690,7 @@ dTs
 dTs
 caH
 ciU
-kUO
+cTZ
 cge
 pjv
 chr
@@ -119698,14 +119698,14 @@ ciU
 cdw
 cdw
 cdw
-jqv
+cxF
 cdw
 cdw
 cdw
 cdw
-mGA
+eHT
 caH
-vHu
+vPV
 oWr
 cdw
 dTs
@@ -119723,7 +119723,7 @@ cDy
 cEJ
 kXq
 dSc
-jBl
+eEt
 cHO
 cIU
 cJM
@@ -119758,10 +119758,10 @@ dao
 dao
 dcw
 dqt
-pzE
+hzS
 cWp
 cWp
-wjn
+oAq
 dgY
 dgY
 cWp
@@ -119770,7 +119770,7 @@ cWp
 dcw
 cZu
 aKm
-sYj
+rgI
 cUc
 cCH
 cto
@@ -119789,7 +119789,7 @@ dAD
 dBo
 dZR
 eaA
-hGv
+xDo
 eaA
 eaA
 dBo
@@ -119873,11 +119873,11 @@ mTi
 aEV
 aHb
 aHA
-gbl
-qhy
+eYK
+oiH
 dTs
 dTs
-xws
+tRc
 oTm
 aHb
 uXk
@@ -119892,19 +119892,19 @@ aKy
 sDw
 aKA
 aKA
-pxr
+jtC
 aGH
 aGH
-vUQ
+hRM
 aBk
 imz
 oTm
 oTm
 aBk
 qzH
-mQO
-iSk
-eiK
+hGY
+pRF
+mfH
 aTq
 aUO
 ucZ
@@ -119921,12 +119921,12 @@ vsQ
 dLP
 bxS
 mQZ
-rdV
+jxH
 caH
 ciU
 cfw
 ciu
-vWl
+sGm
 chr
 ciU
 cdw
@@ -119941,7 +119941,7 @@ aMz
 caH
 kwO
 civ
-lzM
+quN
 dTs
 dTs
 dTs
@@ -119964,7 +119964,7 @@ cHL
 cHL
 cLq
 rGX
-lUc
+idW
 cMb
 cMb
 cOQ
@@ -119972,7 +119972,7 @@ cPT
 cQC
 bnA
 bjV
-qAG
+keR
 bjV
 bjV
 dnN
@@ -120018,7 +120018,7 @@ oVs
 dwF
 duC
 dym
-kuD
+nds
 dAD
 dBo
 dZR
@@ -120052,7 +120052,7 @@ ajV
 akY
 aln
 aln
-fbO
+qtd
 amH
 als
 wpx
@@ -120064,12 +120064,12 @@ afP
 aoM
 ape
 ape
-nuM
+gkO
 apw
 afP
 amr
 aoP
-dig
+kHf
 api
 akL
 dTs
@@ -120088,7 +120088,7 @@ bij
 axh
 bRg
 dTs
-oeE
+tDJ
 oTm
 aBk
 aeo
@@ -120104,12 +120104,12 @@ dTs
 dTs
 dTs
 ccJ
-xiV
+nEv
 aHb
 aHA
 imz
-gbl
-xws
+eYK
+tRc
 oTm
 oTm
 oTm
@@ -120119,7 +120119,7 @@ aBk
 wQM
 wQM
 aSM
-myZ
+xas
 aKA
 aJE
 iRQ
@@ -120129,14 +120129,14 @@ aKA
 aPn
 aGH
 aGH
-iLp
+iZJ
 aBk
-qUC
+fck
 aBk
 aBk
 iBV
-jhw
-mQO
+nwg
+hGY
 aMf
 aMo
 aMg
@@ -120162,7 +120162,7 @@ cfw
 ciu
 ciu
 chr
-mGA
+eHT
 cdw
 cdw
 cdw
@@ -120230,7 +120230,7 @@ mQC
 dAg
 dFh
 dHo
-hte
+sLF
 dDK
 dAk
 cYK
@@ -120248,7 +120248,7 @@ cmN
 coc
 aKm
 duC
-jyf
+tew
 iWM
 dxf
 kEe
@@ -120257,12 +120257,12 @@ dAD
 dBo
 dZR
 eaA
-hGv
+xDo
 eaC
 eaC
 dBo
 dGC
-cvm
+omv
 pEL
 nNI
 tsO
@@ -120296,7 +120296,7 @@ alI
 alI
 aoI
 aoN
-ffq
+mwz
 nmc
 apg
 apy
@@ -120322,27 +120322,27 @@ bij
 axh
 dTs
 dTs
-qUF
-twd
+eff
+oqV
 aBk
 aGZ
 fHT
 aBk
-ksz
+qYk
 dTs
 dTs
 dTs
 dTs
 dTs
 dTs
-qhy
+oiH
 mTi
 aEV
 aBk
 aHb
 vGO
 aGw
-gmE
+uMB
 aGw
 aGw
 qCr
@@ -120357,7 +120357,7 @@ aKA
 aKA
 aKA
 aKA
-myZ
+xas
 aKA
 aKA
 aPn
@@ -120370,7 +120370,7 @@ oTm
 aHz
 aBk
 oTm
-mQO
+hGY
 aMf
 aMp
 aMf
@@ -120391,7 +120391,7 @@ dJT
 dLQ
 dLZ
 caH
-ePr
+jWY
 cfw
 cge
 cgL
@@ -120399,7 +120399,7 @@ chr
 dBN
 dnP
 civ
-xsd
+hWK
 coI
 aMz
 aMB
@@ -120408,7 +120408,7 @@ aNh
 aMz
 caH
 kwO
-ple
+whd
 dTs
 dTs
 dTs
@@ -120466,10 +120466,10 @@ dFk
 dAG
 dDK
 dDK
-mpV
+goJ
 dFk
 dgb
-qmC
+qLo
 dbK
 aKm
 aKm
@@ -120478,7 +120478,7 @@ cCH
 abt
 cto
 crW
-hbw
+lWn
 coc
 aKm
 duC
@@ -120486,7 +120486,7 @@ dvE
 dwF
 duC
 dym
-kuD
+nds
 dAD
 dBo
 jRv
@@ -120556,27 +120556,27 @@ bij
 axh
 dTs
 dTs
-qUF
-lzF
+eff
+clp
 oTm
 oTm
-iLp
+iZJ
 aFN
-gbl
+eYK
 dTs
 dTs
 dTs
 dTs
 dTs
 dTs
-qhy
-lTo
+oiH
+ncs
 aBk
 aBk
 aHb
 aGc
 aGE
-pbV
+bPQ
 fHr
 flu
 aGE
@@ -120588,12 +120588,12 @@ lVW
 wQM
 aSM
 aJY
-myZ
+xas
 sDw
 iWY
 aKA
 sDw
-myZ
+xas
 aPn
 aGH
 aGH
@@ -120601,16 +120601,16 @@ oTm
 oTm
 oTm
 oTm
-vUQ
-yiM
-lWc
-mQO
+hRM
+vzy
+vCF
+hGY
 aMf
 aMq
 hJX
 aMg
 aTr
-vnx
+sav
 dEW
 kMb
 kMb
@@ -120627,18 +120627,18 @@ dLZ
 caH
 ciU
 cfw
-vWl
+sGm
 ciu
 cht
 ilz
 cix
 ciU
 cdw
-lzM
+quN
 aMz
 sNT
 rcY
-ewA
+gHw
 aNI
 aNZ
 pen
@@ -120659,7 +120659,7 @@ cDA
 cEM
 uYs
 dSc
-kfD
+vuP
 cub
 cIX
 cJN
@@ -120673,12 +120673,12 @@ dTs
 dTs
 xPG
 bnA
-qAG
+keR
 bjV
 jdB
 bjV
 bjV
-qAG
+keR
 dnN
 bqp
 dTs
@@ -120694,7 +120694,7 @@ qCu
 dao
 deC
 dcw
-jcz
+nvf
 dDK
 dgY
 uVX
@@ -120706,7 +120706,7 @@ dDK
 dcw
 cZu
 aKm
-sYj
+rgI
 cUc
 cCH
 cpR
@@ -120766,7 +120766,7 @@ afP
 aoO
 apq
 apq
-vyp
+mcQ
 apS
 afP
 amx
@@ -120789,23 +120789,23 @@ bRg
 bij
 axh
 dTs
-qhy
-qUF
+oiH
+eff
 ccJ
 aBk
-vUQ
+hRM
 aBk
 aBk
 aBk
-ksz
+qYk
 dTs
 dTs
 dTs
 dTs
 dTs
-lzF
-vUQ
-vUQ
+clp
+hRM
+hRM
 oTm
 dsX
 srf
@@ -120822,7 +120822,7 @@ wQM
 wQM
 aSM
 aKA
-myZ
+xas
 aKA
 aKA
 doT
@@ -120831,16 +120831,16 @@ aKy
 aJN
 xyH
 aGH
-vUQ
+hRM
 aBk
 aBk
 aBk
 aBk
 iBV
 aBk
-mQO
-lTm
-oLR
+hGY
+xLz
+joK
 aMf
 aMf
 aTr
@@ -120860,12 +120860,12 @@ dLQ
 ccP
 cdy
 civ
-kUO
+cTZ
 ciu
 ciu
 chu
 ciu
-ekF
+vZM
 ciU
 cdw
 cdw
@@ -120890,7 +120890,7 @@ cAI
 cBF
 cBG
 cDA
-sen
+ryq
 cEM
 dSc
 cHj
@@ -120924,7 +120924,7 @@ dao
 dao
 tKc
 oMw
-ric
+siu
 dao
 deD
 dcw
@@ -120932,7 +120932,7 @@ mmz
 cWp
 cWp
 dHl
-mPa
+xZO
 tXg
 dHl
 dHl
@@ -120965,7 +120965,7 @@ jfz
 dDJ
 dGE
 wEG
-nmZ
+hMF
 dIl
 dJm
 dBC
@@ -120989,9 +120989,9 @@ aiI
 rYT
 alI
 amo
-jNz
+vAM
 amo
-jNz
+vAM
 qKx
 alI
 ajY
@@ -121021,23 +121021,23 @@ dTs
 dTs
 dTs
 bij
-uZK
+mDW
 dTs
-qhy
+oiH
 vCe
 njF
 gIF
 oTm
-nNN
+ljh
 aBk
 aCG
-qhy
+oiH
 dTs
 dTs
 dTs
 dTs
 dTs
-lzF
+clp
 aEY
 gJM
 qCr
@@ -121055,10 +121055,10 @@ aBk
 wQM
 wQM
 aSM
-fmC
+hKS
 aKA
 aKA
-fcX
+tZY
 aKA
 aJY
 iRQ
@@ -121072,8 +121072,8 @@ aBk
 aBk
 imz
 aBk
-urb
-srP
+hgQ
+aVl
 aMg
 aMf
 bmB
@@ -121097,7 +121097,7 @@ civ
 cfw
 cge
 pjv
-tAN
+nFX
 ciu
 chr
 ciU
@@ -121143,7 +121143,7 @@ xGe
 dTs
 blt
 bjV
-qAG
+keR
 bjV
 bjV
 bjV
@@ -121168,10 +121168,10 @@ dGa
 dHI
 ums
 ums
-wuG
+lzW
 dVo
 cYK
-qmC
+qLo
 cZu
 aKm
 cUL
@@ -121192,11 +121192,11 @@ maI
 hby
 dBp
 bAi
-dxQ
+ozG
 eal
 hCl
 dav
-dxQ
+ozG
 hCl
 ebc
 jQv
@@ -121232,7 +121232,7 @@ ahe
 aiE
 afP
 aoM
-nuM
+gkO
 ape
 ape
 apw
@@ -121257,56 +121257,56 @@ dTs
 bij
 axh
 dTs
-qhy
+oiH
 vCe
 aEV
 oTm
-fbr
+kbl
 oTm
-vUQ
-ugs
-qhy
+hRM
+qgV
+oiH
 dTs
 dTs
 dTs
 dTs
 dTs
-xws
+tRc
 aHb
 vGO
 aGE
 aGE
 aGo
 oTm
-ksz
-qhy
-twd
+qYk
+oiH
+oqV
 aBk
 wCO
 aHb
 aGc
 mZj
-gmE
+uMB
 pWn
 wCv
 mWI
 aKg
 aJY
 aJY
-sQv
+rsI
 aKA
 aKA
 aPn
 lVW
 wQM
 oTm
-ksz
-idM
-twd
+qYk
+jKE
+oqV
 oTm
 igY
 aBk
-urb
+hgQ
 aMf
 aMf
 aMf
@@ -121325,7 +121325,7 @@ kMb
 vsQ
 aUn
 bXy
-rdV
+jxH
 caH
 ciU
 cfw
@@ -121334,18 +121334,18 @@ ciu
 chu
 ciu
 chr
-mGA
+eHT
 cdw
-kbf
+lEw
 aMz
 aNb
-nVV
+hXk
 aNh
 aMz
 aMz
-dQW
+eQg
 civ
-rjY
+rcb
 cdv
 dTs
 dTs
@@ -121390,17 +121390,17 @@ dTs
 dTs
 dao
 daN
-ric
+siu
 gcf
 uyn
 dao
 deF
 dqt
-uRq
+uXt
 dxT
 dGD
 cYK
-pqi
+fug
 ico
 dSr
 dWA
@@ -121408,7 +121408,7 @@ dHo
 dWO
 dbK
 dbK
-mjg
+gyl
 lJD
 dWV
 dXb
@@ -121488,23 +121488,23 @@ dTs
 dTs
 dTs
 dTs
-gOn
-kiP
+vjB
+gHP
 dTs
-qhy
-uYI
+oiH
+pzG
 akb
 oTm
-pSd
+jmY
 aGr
 aBk
 imz
-gbl
-qhy
+eYK
+oiH
 dTs
 dTs
 dTs
-qhy
+oiH
 oTm
 aHb
 aHA
@@ -121513,31 +121513,31 @@ oTm
 dzO
 dTs
 dTs
-qhy
-qhy
+oiH
+oiH
 aBk
 aBk
 fEf
 aGE
 aGE
-pbV
+bPQ
 fRy
 aIj
-fcX
+tZY
 npN
 sDw
 iWY
 aKA
-myZ
+xas
 aKA
-iDR
+irw
 aGH
 aGH
 dzO
-qhy
+oiH
 dTs
 dTs
-twd
+oqV
 imz
 aBk
 adK
@@ -121595,7 +121595,7 @@ cAG
 cEM
 cEM
 dSc
-kfD
+vuP
 cub
 cIX
 cJN
@@ -121625,7 +121625,7 @@ dTs
 dao
 daN
 dbx
-fDS
+vrr
 dof
 dao
 deG
@@ -121639,7 +121639,7 @@ ums
 dFk
 dFk
 dFk
-pzE
+hzS
 dcw
 cZu
 cko
@@ -121692,26 +121692,26 @@ alt
 alt
 alt
 alt
-sFw
+mvW
 akZ
 qKx
 als
 alI
 alI
-agA
+xIl
 aoN
 apg
 apg
-ffq
+mwz
 apy
 afP
 amx
 alV
 bfT
-kQa
+jGU
 msC
 vPy
-rSO
+eEm
 atV
 avU
 aIw
@@ -121725,7 +121725,7 @@ dTs
 bij
 prG
 aBk
-ugs
+qgV
 dzH
 aBk
 aBk
@@ -121734,11 +121734,11 @@ aGp
 aBk
 qzH
 aBk
-gbl
+eYK
 dTs
 dTs
-qhy
-xws
+oiH
+tRc
 oTm
 aHb
 aHA
@@ -121748,12 +121748,12 @@ dTs
 dTs
 dTs
 dTs
-qhy
-twd
+oiH
+oqV
 oTm
-vUQ
-vUQ
-iLp
+hRM
+hRM
+iZJ
 wQM
 wQM
 aSM
@@ -121767,17 +121767,17 @@ aKA
 aEf
 aGH
 aGH
-ksz
-fsX
+qYk
+mwR
 dTs
 dTs
-qhy
+oiH
 agC
 aBk
 adK
 bln
 uqo
-wjc
+dnG
 aMf
 aHb
 aGc
@@ -121795,7 +121795,7 @@ dLQ
 mQZ
 dLZ
 caH
-mGA
+eHT
 cfw
 cge
 cgL
@@ -121814,7 +121814,7 @@ aNC
 cbD
 civ
 caH
-bFe
+bvW
 cdv
 cOk
 cOk
@@ -121846,11 +121846,11 @@ dTs
 dTs
 dTs
 bqp
-jzJ
+uLH
 blt
 bjV
 bjV
-qAG
+keR
 dnN
 dTs
 dTs
@@ -121865,12 +121865,12 @@ dao
 dbK
 dyT
 ftp
-hwN
+bfv
 dDK
 dDK
 ico
 ico
-hwN
+bfv
 dJV
 dJi
 dDK
@@ -121880,7 +121880,7 @@ cmM
 oRs
 dWW
 cto
-oSG
+kBw
 cUP
 cto
 crW
@@ -121890,7 +121890,7 @@ dXX
 duC
 dxj
 dXy
-kuD
+nds
 dXY
 dBr
 dBr
@@ -121971,7 +121971,7 @@ aBk
 oTm
 dTs
 dTs
-lzF
+clp
 oTm
 oTm
 dsX
@@ -121982,26 +121982,26 @@ dTs
 dTs
 dTs
 dTs
-qhy
-lzF
+oiH
+clp
 oTm
 aBk
 aBk
 aBk
 wQM
-wvM
-mKy
-oJZ
-wan
+mFE
+jWF
+aRW
+qhw
 jpm
 htb
-wan
-wan
-wan
-tvD
-mCm
+qhw
+qhw
+qhw
+eSt
+iUf
 aGH
-ksz
+qYk
 dTs
 dTs
 dTs
@@ -122026,7 +122026,7 @@ kMb
 kMb
 vsQ
 dLQ
-mNm
+imU
 dLZ
 caH
 ciU
@@ -122034,16 +122034,16 @@ cfw
 ciu
 lZM
 chu
-vWl
+sGm
 chr
 ciU
 cdw
 aNr
 aMz
-rOJ
+gnY
 auc
 atm
-rOJ
+gnY
 aNC
 cbD
 civ
@@ -122051,7 +122051,7 @@ caH
 cdw
 cdw
 cdv
-uLI
+oCL
 cOk
 dTs
 dTs
@@ -122085,7 +122085,7 @@ bqp
 blt
 bjV
 bjV
-qAG
+keR
 brj
 dTs
 dTs
@@ -122096,7 +122096,7 @@ dby
 sTg
 dqu
 dvf
-uRq
+uXt
 ddi
 ftp
 dCe
@@ -122111,14 +122111,14 @@ lqr
 hav
 hav
 gFE
-wAE
+men
 cCH
 bQD
 cET
 cUP
 cto
 crW
-nHc
+eDq
 dXr
 rLV
 dXx
@@ -122174,14 +122174,14 @@ afP
 afP
 afP
 amx
-jYh
+xCq
 hpe
 anv
 aIw
 asW
-jJP
+dmT
 atV
-sFc
+hdw
 aIw
 dTs
 dTs
@@ -122203,9 +122203,9 @@ aGH
 lVW
 aGH
 oTm
-gbl
-txl
-xws
+eYK
+qNG
+tRc
 oTm
 oTm
 dsX
@@ -122229,12 +122229,12 @@ wQM
 wQM
 aID
 aIW
-wvM
+mFE
 wQM
 wQM
 wQM
-oTj
-oTj
+uzd
+uzd
 dTs
 dTs
 dTs
@@ -122265,12 +122265,12 @@ dLZ
 caH
 ciU
 cfw
-vWl
+sGm
 ciu
-vUk
+onM
 cdc
 ciy
-mGA
+eHT
 cdw
 cdw
 aMz
@@ -122280,12 +122280,12 @@ aNB
 auA
 aMz
 cbD
-ple
+whd
 caH
 cdw
 owP
 cdw
-lzM
+quN
 cdv
 cOk
 dTs
@@ -122316,7 +122316,7 @@ dTs
 dTs
 dTs
 bqp
-qBV
+wTI
 bjV
 bjV
 bjV
@@ -122324,7 +122324,7 @@ dnN
 dTs
 dTs
 bqp
-vey
+pbT
 daO
 dbz
 cOG
@@ -122357,7 +122357,7 @@ dXs
 cvx
 dXy
 dXA
-hNK
+dUI
 xfT
 dAD
 dBt
@@ -122399,7 +122399,7 @@ bfj
 bmy
 alI
 ajY
-gFa
+pPt
 afP
 dTs
 dTs
@@ -122436,7 +122436,7 @@ aAF
 aKj
 aDZ
 aGH
-vUQ
+hRM
 imz
 aBk
 oTm
@@ -122445,7 +122445,7 @@ oTm
 aHb
 aHA
 iBV
-ksz
+qYk
 dTs
 dTs
 dTs
@@ -122459,13 +122459,13 @@ imz
 oTm
 aGW
 wQM
-wvM
+mFE
 wQM
-jsC
-azr
+lnY
+uhy
 wQM
 wQM
-wvM
+mFE
 wQM
 aGH
 aBk
@@ -122476,7 +122476,7 @@ dTs
 dTs
 ccJ
 imz
-oTj
+uzd
 aGH
 aGH
 aGH
@@ -122497,16 +122497,16 @@ caH
 abg
 aqw
 caH
-mGA
+eHT
 cfw
 ciu
 ciu
 chr
-rDw
+ekP
 cjT
 ceY
 cdw
-lzM
+quN
 aMz
 aMz
 aMz
@@ -122521,7 +122521,7 @@ cdw
 cdw
 coI
 cdw
-lCe
+irX
 cer
 cer
 cer
@@ -122554,7 +122554,7 @@ bqp
 blt
 tRn
 kIu
-qAG
+keR
 dnN
 dTs
 hVA
@@ -122575,7 +122575,7 @@ ums
 dbK
 dbK
 dbK
-hwN
+bfv
 dcw
 cZu
 cko
@@ -122585,7 +122585,7 @@ dWZ
 dWZ
 cUP
 cto
-qSg
+nUE
 cUc
 dXt
 dXw
@@ -122598,7 +122598,7 @@ dBu
 dBy
 dwm
 bJX
-feq
+rdO
 dFi
 dFW
 dFW
@@ -122630,7 +122630,7 @@ dTs
 afP
 ajY
 aiI
-xFR
+wvw
 alI
 ajY
 aob
@@ -122647,7 +122647,7 @@ bfT
 apj
 aIw
 asY
-iHP
+kno
 aub
 avV
 aIw
@@ -122662,7 +122662,7 @@ bij
 axh
 oTm
 ajC
-xOM
+msV
 aGH
 alj
 azT
@@ -122670,22 +122670,22 @@ nrg
 aJY
 aEf
 aGH
-vUQ
+hRM
 aBk
 aBk
-wMn
+jRe
 oTm
 oTm
 dsX
 aHA
 aCG
-qhy
+oiH
 dTs
 dTs
 dTs
 dTs
 dTs
-kEx
+pxn
 aBk
 imz
 aBk
@@ -122699,19 +122699,19 @@ aHb
 aHA
 aBk
 aBk
-iLp
+iZJ
 aBk
 aBk
 aBk
-ksz
+qYk
 dTs
 dTs
 dTs
 dTs
-nJy
-jfs
-tKh
-feO
+clu
+eHB
+rms
+xTk
 rlk
 dTs
 dTs
@@ -122733,31 +122733,31 @@ civ
 caH
 ciU
 csH
-eha
+qwA
 cdc
 ciy
 ciU
 caH
-rjY
+rcb
 caH
 xCj
 caH
 caH
-rjY
+rcb
 caH
 caH
 caH
 cbD
 civ
 xCj
-rjY
+rcb
 caH
 caH
 caH
 caH
 caH
 caH
-iby
+oiY
 caH
 bnA
 emI
@@ -122795,15 +122795,15 @@ fSD
 bjV
 daO
 dbB
-oxA
+sZz
 dri
 dxN
-qmC
+qLo
 dUt
-hte
+sLF
 dgY
 dgY
-hwN
+bfv
 ums
 ums
 dDK
@@ -122817,7 +122817,7 @@ dHm
 dWW
 dXe
 dXg
-lPp
+imY
 cto
 crW
 cUc
@@ -122827,7 +122827,7 @@ dim
 dxl
 dXy
 sdm
-nac
+oBM
 dBv
 dBy
 dDa
@@ -122875,7 +122875,7 @@ dTs
 dTs
 dTs
 apW
-uzr
+cHm
 alV
 bfT
 apj
@@ -122896,10 +122896,10 @@ bij
 axh
 oTm
 oTm
-xOM
+msV
 aGH
 alj
-sQv
+rsI
 aBw
 azT
 aEf
@@ -122913,18 +122913,18 @@ oTm
 aHb
 aHA
 aEX
-qhy
+oiH
 dTs
 dTs
 dTs
 dTs
 dTs
-lzF
+clp
 oTm
-ePp
-vUQ
-fbr
-fbr
+aVL
+hRM
+kbl
+kbl
 aHR
 aBk
 aBk
@@ -122933,12 +122933,12 @@ xsQ
 iDy
 aBk
 aBk
-vUQ
+hRM
 aBk
 iBV
 aBk
-gbl
-fsX
+eYK
+mwR
 dTs
 nzm
 mTi
@@ -122975,11 +122975,11 @@ cjT
 cjT
 aNj
 aNj
-gUt
+cZI
 cjT
 cjT
 cjT
-gUt
+cZI
 cjT
 cbF
 cbG
@@ -122987,7 +122987,7 @@ cbH
 cbH
 cbH
 cbH
-wjV
+rET
 cbH
 cbH
 cbH
@@ -123007,7 +123007,7 @@ bWD
 bWJ
 bWJ
 bXM
-eZO
+jkg
 dTs
 dTs
 dTs
@@ -123039,12 +123039,12 @@ dDK
 dDK
 dIm
 eGt
-sIB
+jke
 vIa
 dDK
-hte
+sLF
 dDK
-pzE
+hzS
 dqt
 dvm
 dHm
@@ -123115,7 +123115,7 @@ bfT
 anD
 aIw
 aIw
-enE
+oyP
 auA
 auA
 aIw
@@ -123138,27 +123138,27 @@ aJY
 aJY
 bpI
 aEv
-gmE
+uMB
 aGw
 aGw
 aGw
 mZj
-gmE
+uMB
 aGc
 uXk
 uGU
-fsX
-qhy
+mwR
+oiH
 dTs
 dTs
 dTs
-qhy
-lzF
+oiH
+clp
 oTm
 aBk
 aHC
 aBk
-vUQ
+hRM
 aBk
 oTm
 aBk
@@ -123172,8 +123172,8 @@ kOL
 aBk
 aBk
 aBk
-gbl
-qhy
+eYK
+oiH
 mTi
 ccJ
 aBk
@@ -123230,14 +123230,14 @@ bnA
 mzj
 bnA
 bnA
-eZO
+jkg
 wqI
 yhu
-eZO
+jkg
 bnA
 bnA
 bnA
-mxx
+sfW
 kVw
 bZN
 wRY
@@ -123260,7 +123260,7 @@ jYx
 bjV
 bjV
 dzE
-qAG
+keR
 daO
 dbD
 dqs
@@ -123269,7 +123269,7 @@ dbK
 dcw
 dUt
 dcw
-wjn
+oAq
 cWp
 cWp
 ums
@@ -123281,14 +123281,14 @@ dcw
 dcw
 cZu
 cko
-mPg
+kIK
 cCH
 dWZ
 dWZ
 cUP
 cto
 crW
-mPg
+kIK
 cko
 aKm
 dim
@@ -123300,7 +123300,7 @@ dBx
 dBy
 dDa
 hCb
-feq
+rdO
 dBy
 dBy
 dBy
@@ -123343,9 +123343,9 @@ apW
 apW
 apW
 alO
-ydV
+pWK
 alV
-kQa
+jGU
 aiH
 anG
 aJd
@@ -123363,7 +123363,7 @@ bzV
 bzV
 alW
 oTm
-jhw
+nwg
 dZl
 lVW
 alj
@@ -123372,27 +123372,27 @@ hLq
 nDi
 aEj
 aEw
-pbV
+bPQ
 wCa
 aGE
 aGE
 aGE
-pbV
+bPQ
 aGE
 feU
-faP
+oFS
 uGU
-qhy
-qhy
+oiH
+oiH
 dTs
 dTs
-qhy
-wnJ
+oiH
+rxj
 aBk
 aGr
 aBk
 imz
-vUQ
+hRM
 aHS
 imz
 aBk
@@ -123406,7 +123406,7 @@ oTm
 aBk
 aBk
 aBk
-vUQ
+hRM
 uGU
 aKE
 aKQ
@@ -123450,7 +123450,7 @@ dCZ
 gYv
 giL
 ndI
-rtL
+tll
 dBk
 kdQ
 aTG
@@ -123486,7 +123486,7 @@ dTs
 dTs
 bjV
 dTs
-jzJ
+uLH
 fSD
 bjV
 bjV
@@ -123497,7 +123497,7 @@ bjV
 bjV
 daO
 dbE
-oxA
+sZz
 drY
 dUe
 dcw
@@ -123520,7 +123520,7 @@ cCH
 dXe
 dXg
 cUP
-oSG
+kBw
 crW
 cUc
 cko
@@ -123564,13 +123564,13 @@ dTs
 dTs
 dTs
 apW
-uzr
+cHm
 amz
-jYh
+xCq
 ant
 amz
 aiH
-sHI
+mJE
 akj
 akj
 akj
@@ -123597,13 +123597,13 @@ bRg
 bRg
 qzH
 aBk
-vUQ
+hRM
 ltx
 aGH
 alj
 aKA
 lEv
-sQv
+rsI
 aEf
 wQM
 wQM
@@ -123617,10 +123617,10 @@ aBk
 imz
 aBk
 ufP
-qhy
+oiH
 dTs
 dTs
-lzF
+clp
 oTm
 aBk
 aBk
@@ -123637,7 +123637,7 @@ aBk
 aBk
 oTm
 oTm
-vUQ
+hRM
 oTm
 oTm
 oTm
@@ -123665,36 +123665,36 @@ kMb
 dMq
 xCj
 caH
-rjY
+rcb
 caH
 caH
 caH
 caH
-cbp
+wxK
 cel
 cel
-wSm
+kHC
 cel
 fnb
-fOT
+mDe
 ceX
 aQd
 aPc
 wfg
 wfg
-jwL
+grD
 wfg
 jze
 aPc
 aOH
 aTM
 aVr
-ktV
+vtT
 bgW
 bho
 aTM
 aYg
-sOL
+oRk
 bdb
 bfS
 bgl
@@ -123704,7 +123704,7 @@ paa
 bgl
 bgl
 bnA
-eZO
+jkg
 bFF
 bWL
 bTW
@@ -123744,15 +123744,15 @@ ums
 tXg
 dHi
 dxT
-lpf
+gyi
 dcw
 cZu
 aKm
 cko
-mPg
+kIK
 cCH
 dWZ
-oSG
+kBw
 cUP
 cto
 crW
@@ -123772,7 +123772,7 @@ qqb
 dFj
 dCd
 xDD
-moS
+dEM
 dHG
 dIk
 dIR
@@ -123809,7 +123809,7 @@ amA
 amA
 amA
 amA
-xMs
+lAy
 amA
 amA
 afp
@@ -123831,8 +123831,8 @@ aij
 qZW
 aBk
 qzH
-rlN
-tIh
+oBx
+rac
 aGH
 alj
 ucs
@@ -123851,14 +123851,14 @@ aBk
 aBk
 aBk
 aBk
-gbl
+eYK
 dTs
 dTs
-xws
+tRc
 oTm
-vUQ
-vUQ
-jhw
+hRM
+hRM
+nwg
 oTm
 oTm
 aHz
@@ -123869,7 +123869,7 @@ xsQ
 opG
 aGw
 aGw
-vxh
+cKJ
 aGw
 aGw
 qCr
@@ -123886,7 +123886,7 @@ aLC
 jVv
 aMf
 aMf
-srP
+aVl
 aGH
 uee
 aGH
@@ -123913,14 +123913,14 @@ dnP
 dnP
 cNp
 aPc
-qqV
+tBo
 aPc
 aPc
 wfg
 wfg
 bER
 aPc
-tMA
+pQh
 aTM
 aVs
 aXi
@@ -123941,9 +123941,9 @@ bXB
 bTV
 aie
 bWL
-pUg
+uIx
 bYe
-iDm
+pMO
 bnA
 bWK
 bZN
@@ -123952,7 +123952,7 @@ bYw
 bWK
 bZN
 bZN
-hpN
+vMI
 bjV
 bjV
 bjV
@@ -123968,13 +123968,13 @@ dbG
 dqs
 dri
 dbK
-qmC
+qLo
 dUt
 dcw
 dgb
 dFk
 dFk
-pqi
+fug
 ums
 dgb
 dgb
@@ -123990,7 +123990,7 @@ cto
 dXm
 cto
 crW
-mPg
+kIK
 cko
 aKm
 dim
@@ -124002,9 +124002,9 @@ dBz
 dYS
 dYS
 hJW
-vzY
+uTY
 dYS
-fir
+sKb
 reY
 tLj
 tLj
@@ -124048,7 +124048,7 @@ amz
 ant
 amz
 jIG
-kQa
+jGU
 bfT
 ats
 auD
@@ -124059,7 +124059,7 @@ nNg
 auT
 auT
 ath
-hvY
+rFX
 afl
 aik
 aeE
@@ -124070,14 +124070,14 @@ ltx
 aGH
 alj
 aJY
-yfb
+jDx
 aJY
-oGC
+sfT
 wQM
 aBk
 qzH
 aBk
-gcn
+ume
 aBk
 aBk
 aFb
@@ -124086,15 +124086,15 @@ qzH
 imz
 aBk
 aBk
-jtt
+scW
 aEV
-vUQ
+hRM
 qzH
 aBk
 aHz
 oTm
 oTm
-fxV
+xYK
 aBk
 imz
 aBk
@@ -124103,16 +124103,16 @@ aIE
 aGE
 aGE
 flu
-pbV
+bPQ
 aGE
 aGE
 aGE
-rRF
+gSF
 aHA
 aBk
 aKF
 aGH
-jri
+jcb
 aLm
 aLt
 aGH
@@ -124131,7 +124131,7 @@ kMb
 kMb
 kMb
 dMq
-eZO
+jkg
 bAZ
 atC
 avT
@@ -124152,7 +124152,7 @@ skj
 epG
 jze
 qWC
-qqV
+tBo
 aXq
 aOI
 aTM
@@ -124178,10 +124178,10 @@ bWL
 bXI
 bYg
 bYK
-eZO
+jkg
 bWL
 bTX
-pUg
+uIx
 bYK
 bWL
 bTX
@@ -124189,10 +124189,10 @@ bTW
 bYK
 bjV
 bjV
-qAG
+keR
 bjV
 bjV
-qAG
+keR
 bjV
 bGr
 sTc
@@ -124200,7 +124200,7 @@ bjV
 daO
 dbH
 dqt
-wwY
+fVl
 dUe
 dcw
 dUt
@@ -124212,7 +124212,7 @@ lqb
 nJj
 sZV
 dgY
-hwN
+bfv
 dcw
 cZu
 aKm
@@ -124234,14 +124234,14 @@ dXN
 dAH
 dBy
 uXH
-gDq
+tkY
 dYm
 dYm
 dYP
-gDq
+tkY
 dCd
 dYm
-gDq
+tkY
 dIk
 dIK
 uHv
@@ -124312,7 +124312,7 @@ imz
 aBk
 oTm
 oTm
-jhw
+nwg
 oTm
 aFc
 aBk
@@ -124328,7 +124328,7 @@ qzH
 aBk
 aHz
 aHG
-vUQ
+hRM
 aBk
 aBk
 aFb
@@ -124371,7 +124371,7 @@ dMf
 kMb
 bUN
 bpr
-eZO
+jkg
 chZ
 civ
 caH
@@ -124396,7 +124396,7 @@ aXh
 aYb
 aXh
 bcO
-iVc
+aBS
 beQ
 vBp
 bgo
@@ -124405,7 +124405,7 @@ bjw
 bkC
 bkO
 bgl
-mxx
+sfW
 bTW
 bWE
 bXx
@@ -124417,7 +124417,7 @@ bWL
 bTW
 bTX
 uBL
-ngy
+nSZ
 bTW
 bTW
 bYK
@@ -124436,7 +124436,7 @@ dxM
 dqt
 dri
 dUe
-vBU
+oGT
 dUt
 dqt
 cWp
@@ -124451,13 +124451,13 @@ dcw
 dbK
 fwp
 cko
-mPg
+kIK
 cCH
-oSG
+kBw
 cto
 dXm
 cto
-qSg
+nUE
 cmN
 cok
 cvw
@@ -124465,7 +124465,7 @@ dwH
 dwI
 dwI
 dXN
-nac
+oBM
 dBy
 dCf
 dBy
@@ -124504,7 +124504,7 @@ abi
 amB
 amz
 amz
-xWh
+sOS
 anM
 anP
 anP
@@ -124532,8 +124532,8 @@ afl
 dTs
 bgH
 dTs
-qhy
-twd
+oiH
+oqV
 ltx
 aGH
 aGH
@@ -124542,10 +124542,10 @@ aGH
 wQM
 wQM
 wQM
-vUQ
-mno
-feO
-twd
+hRM
+vMn
+xTk
+oqV
 oTm
 oTm
 imz
@@ -124553,7 +124553,7 @@ aBk
 imz
 aBk
 aBk
-iIN
+wra
 oTm
 aBk
 oTm
@@ -124562,14 +124562,14 @@ aBk
 iBV
 aBk
 aBk
-vUQ
+hRM
 imz
 aIk
 aIp
-iIN
-fbr
-jhw
-vUQ
+wra
+kbl
+nwg
+hRM
 oTm
 oTm
 oTm
@@ -124588,7 +124588,7 @@ aLF
 aBk
 aBk
 aMg
-srP
+aVl
 aMf
 cPD
 aGH
@@ -124608,7 +124608,7 @@ bAZ
 bnA
 aSH
 bvz
-rjY
+rcb
 lFE
 aOy
 dLx
@@ -124621,11 +124621,11 @@ mzU
 kPA
 hRC
 mNN
-qqV
+tBo
 oPz
 aTM
 aVW
-hjR
+ncN
 aXh
 bhq
 aTM
@@ -124653,21 +124653,21 @@ bTW
 bYK
 bWL
 bTW
-pUg
+uIx
 bYK
-qAG
+keR
 bjV
 bjV
 bjV
 bjV
 bjV
-qAG
+keR
 bKI
 bjV
 bjV
 daO
 dpF
-pzE
+hzS
 dri
 dUe
 dcw
@@ -124676,12 +124676,12 @@ dqt
 dEv
 dHo
 dHo
-pqi
+fug
 ums
 dBc
 dBf
 cYK
-qmC
+qLo
 cZu
 aKm
 cko
@@ -124696,7 +124696,7 @@ dbQ
 duD
 del
 dwJ
-fFU
+ffr
 dwJ
 daX
 dAD
@@ -124754,7 +124754,7 @@ xWI
 anP
 anP
 auQ
-nzq
+kFe
 aww
 aww
 xVA
@@ -124766,20 +124766,20 @@ afl
 dTs
 dTs
 dTs
-qhy
-lzF
-tIh
+oiH
+clp
+rac
 aBk
 iBV
 aBk
 aBk
-vUQ
+hRM
 aCG
 agK
 agK
 oLT
 mTi
-nJy
+clu
 agK
 agK
 agC
@@ -124797,12 +124797,12 @@ aBk
 qzH
 aBk
 dzO
-feO
-twd
-vMZ
+xTk
+oqV
+oFq
 dzO
-feO
-twd
+xTk
+oqV
 aBk
 oTm
 oTm
@@ -124845,13 +124845,13 @@ bvz
 caH
 aOz
 dNs
-jwL
+grD
 wfg
 hRC
 wfg
 aOy
 lUk
-pzh
+keP
 vVU
 lFE
 hRC
@@ -124879,7 +124879,7 @@ bTX
 bWL
 bXJ
 bYg
-iDm
+pMO
 bnA
 bWL
 bZO
@@ -124892,13 +124892,13 @@ bYK
 bjV
 bnA
 bnA
-eZO
+jkg
 wqI
 bnA
 bnA
 bnA
 bnA
-qAG
+keR
 daO
 dpG
 dqt
@@ -124918,12 +124918,12 @@ dBb
 dcw
 cZu
 aKm
-mjg
+gyl
 cUc
 cCH
 dpH
 cET
-lPp
+imY
 cto
 crW
 cUc
@@ -124995,7 +124995,7 @@ nNg
 axc
 aJe
 cTE
-pxl
+eRN
 afl
 dTs
 dTs
@@ -125003,7 +125003,7 @@ dTs
 dTs
 dTs
 riN
-twd
+oqV
 aBk
 aBk
 igY
@@ -125011,30 +125011,30 @@ dzO
 dTs
 dTs
 dTs
-qhy
-qhy
+oiH
+oiH
 oJC
-qhy
-qhy
-qhy
+oiH
+oiH
+oiH
 agC
-qrw
+qAW
 igY
 aBk
 aBk
 aGr
 aBk
-vUQ
+hRM
 aEX
 mTi
 agC
 aBk
 pmt
-qhy
+oiH
 dTs
 dTs
-feO
-qhy
+xTk
+oiH
 dTs
 dTs
 xLp
@@ -125075,14 +125075,14 @@ bUN
 bpr
 bnA
 aSH
-tUZ
+dFY
 caH
 aOz
 ndI
 wok
 wTo
 wok
-jwL
+grD
 aOy
 myt
 phx
@@ -125109,20 +125109,20 @@ bli
 biW
 bFF
 bTW
-kTd
+eWh
 bXx
 bTX
 bYh
 bYK
 bnA
-ngy
+nSZ
 bTW
 bTX
-kTd
+eWh
 bTW
 bTX
 bTW
-iDm
+pMO
 bjV
 bnA
 dak
@@ -125146,21 +125146,21 @@ kMT
 kMT
 klS
 dgY
-igV
+oKB
 dgb
-igV
+oKB
 xVf
 cZu
 aKm
 cko
-mPg
+kIK
 cCH
 dpI
 dXf
 dXo
 cmb
 cXx
-mPg
+kIK
 hjo
 xLK
 xLK
@@ -125224,7 +125224,7 @@ atv
 auF
 avi
 aww
-nLS
+tnP
 nNg
 axc
 aJe
@@ -125237,38 +125237,38 @@ dTs
 dTs
 dTs
 xGe
-qhy
-uqF
-vUQ
+oiH
+peX
+hRM
 dzO
-qhy
+oiH
 dTs
 dTs
 dTs
 dTs
 dTs
 dTs
-qhy
+oiH
 dTs
-qhy
-qhy
+oiH
+oiH
 oit
 aBk
 aGp
 aGr
 aBk
 aCG
-feO
+xTk
 dTs
 dTs
 mTi
 agK
 mTi
-qhy
+oiH
 dTs
 dTs
 dTs
-qhy
+oiH
 dTs
 dTs
 mTi
@@ -125314,7 +125314,7 @@ caH
 aOz
 aJX
 wfg
-jwL
+grD
 hRC
 xMy
 aOy
@@ -125322,7 +125322,7 @@ eNw
 phx
 xTh
 fxU
-iSV
+wZH
 aPc
 bfF
 aUc
@@ -125333,7 +125333,7 @@ aPL
 aUU
 baL
 bcO
-uWH
+vEm
 bad
 aVn
 big
@@ -125341,7 +125341,7 @@ bkD
 mzH
 bli
 biW
-mxx
+sfW
 bTX
 bWF
 bXx
@@ -125352,7 +125352,7 @@ bZN
 bZF
 bTW
 bTX
-kTd
+eWh
 bTX
 bTZ
 bTW
@@ -125362,7 +125362,7 @@ bZN
 bZN
 bZN
 bZN
-fJM
+dDS
 nsf
 bFF
 bnA
@@ -125375,10 +125375,10 @@ dbK
 dbK
 dkY
 dcw
-qmC
+qLo
 dcw
 dcw
-qmC
+qLo
 dkY
 dcw
 dvg
@@ -125437,7 +125437,7 @@ dTs
 dTs
 dTs
 apW
-soj
+aEk
 amz
 amz
 aFF
@@ -125473,7 +125473,7 @@ dTs
 xGe
 dTs
 mTi
-gIL
+bNW
 dTs
 dTs
 dTs
@@ -125485,20 +125485,20 @@ dTs
 dTs
 dTs
 dTs
-qhy
-lzF
+oiH
+clp
 oTm
 oTm
 aBk
 jNK
-ksz
+qYk
 dTs
 dTs
 dTs
 dTs
-nJy
-xLF
-qhy
+clu
+jAI
+oiH
 dTs
 dTs
 dTs
@@ -125554,7 +125554,7 @@ aPc
 aOy
 eNw
 hgV
-mIa
+lsw
 aPc
 kOS
 nnA
@@ -125579,7 +125579,7 @@ bGs
 bTZ
 bWF
 rMO
-tfo
+iqu
 bYi
 rDe
 bZC
@@ -125694,7 +125694,7 @@ avh
 auT
 aww
 xVA
-roD
+gKl
 aJe
 cTE
 aOk
@@ -125721,11 +125721,11 @@ dTs
 dTs
 dTs
 dTs
-giq
-giq
-sfE
-mHl
-klF
+cDQ
+cDQ
+lyH
+ojV
+yak
 dTs
 dTs
 dTs
@@ -125769,14 +125769,14 @@ kMb
 bnh
 kMb
 dMq
-eZO
+jkg
 wqI
 bnA
 bnA
-eZO
+jkg
 bnA
 bnA
-gpr
+ofz
 oHf
 bnA
 lFE
@@ -125802,10 +125802,10 @@ aUU
 baN
 nmi
 paV
-iVc
+aBS
 bcO
 bih
-pTo
+otg
 jcO
 bih
 bih
@@ -125821,24 +125821,24 @@ bTW
 bTX
 bZD
 bTW
-kTd
+eWh
 etY
 bTX
 bTZ
 etY
 bTW
-pUg
+uIx
 bZD
 bTW
 bYh
 yfq
-mxx
+sfW
 bnA
 bnA
 bnA
 dbL
 dbN
-dth
+hCC
 dbN
 pMQ
 dft
@@ -125846,11 +125846,11 @@ dbN
 dbN
 mTY
 dbN
-wjN
+cSt
 dbK
 dhc
 dhd
-qmC
+qLo
 dcw
 dbK
 dbK
@@ -125860,7 +125860,7 @@ cCH
 dpL
 cto
 crW
-hbw
+lWn
 cpZ
 csi
 sAs
@@ -125924,7 +125924,7 @@ vWS
 asL
 anP
 auF
-nzq
+kFe
 aww
 aww
 xVA
@@ -125939,12 +125939,12 @@ xGe
 xGe
 xGe
 kzq
-ylW
+qvp
 eyB
-gMI
-ylW
-ylW
-ylW
+nIa
+qvp
+qvp
+qvp
 dTs
 dTs
 dTs
@@ -125955,15 +125955,15 @@ dTs
 dTs
 dTs
 dTs
-giq
+cDQ
 aFz
 aFz
 aFz
-jND
+cpP
 dTs
 dTs
 dTs
-ylW
+qvp
 ccK
 ccK
 dTs
@@ -125978,7 +125978,7 @@ aen
 jEN
 aGH
 aGH
-xAf
+vmk
 aHZ
 aEh
 aKj
@@ -126045,20 +126045,20 @@ bli
 biW
 aSH
 bul
-rPq
+kCj
 bXF
 bXK
 bXK
-eFC
+fDr
 bXK
 bXK
-iHL
+puQ
 bXK
 bXK
 bXK
 bXK
 bXK
-eFC
+fDr
 bXK
 bZP
 bXK
@@ -126068,14 +126068,14 @@ bYd
 bYK
 aSH
 bul
-jkG
+itq
 bWH
 dbM
 dbN
 ggd
 dbN
-loy
-wjN
+hHy
+cSt
 dbN
 fYS
 fYS
@@ -126086,7 +126086,7 @@ dbK
 dbK
 dcw
 dcw
-qmC
+qLo
 dcw
 dbK
 cUc
@@ -126142,7 +126142,7 @@ alR
 amz
 amz
 ant
-iRY
+rro
 anP
 anT
 aod
@@ -126171,14 +126171,14 @@ ihV
 dTs
 xGe
 dTs
-qTV
-qTV
+sGW
+sGW
 enk
 aFz
 aFz
-jND
-ylW
-ylW
+cpP
+qvp
+qvp
 dTs
 dTs
 dTs
@@ -126189,17 +126189,17 @@ dTs
 dTs
 dTs
 tab
-rIa
-giq
+qhT
+cDQ
 aFz
 aFz
-giq
+cDQ
 dTs
 dTs
-ylW
-ylW
-nDe
-nDe
+qvp
+qvp
+jxd
+jxd
 dTs
 dTs
 dTs
@@ -126219,7 +126219,7 @@ azT
 aKM
 aGH
 aBk
-jeW
+hUr
 dTs
 dTs
 mTi
@@ -126257,14 +126257,14 @@ mMZ
 mMZ
 lFE
 vFr
-qqV
+tBo
 tdF
 wfg
-qqV
+tBo
 aUz
 aWL
 eVV
-nKP
+moT
 bhb
 aVC
 bda
@@ -126277,7 +126277,7 @@ bjZ
 mLF
 bli
 biW
-gpr
+ofz
 jUV
 jUV
 jfE
@@ -126317,14 +126317,14 @@ xjb
 dbN
 dbK
 dhc
-wUC
+urH
 xVf
 dkY
 dlA
-qED
+tbi
 dbK
 cUc
-lCQ
+phT
 dpH
 cET
 crW
@@ -126404,16 +126404,16 @@ cWq
 bRg
 dTs
 kzq
-rIa
-giq
-vrz
+qhT
+cDQ
+mVN
 aFz
 aFz
 vte
 azV
-klF
-ylW
-ylW
+yak
+qvp
+qvp
 dTs
 dTs
 dTs
@@ -126422,15 +126422,15 @@ dTs
 dTs
 dTs
 dTs
-ylW
-fAr
-giq
+qvp
+vtN
+cDQ
 vte
 aFz
-giq
-klF
+cDQ
+yak
 lFH
-tBl
+mws
 ccK
 ccK
 ccK
@@ -126457,7 +126457,7 @@ mTi
 dTs
 dTs
 mTi
-gbS
+iky
 dTs
 dTs
 dTs
@@ -126496,7 +126496,7 @@ mqT
 uiQ
 evf
 aUN
-jet
+vsF
 fHw
 fKy
 aUN
@@ -126507,7 +126507,7 @@ paV
 bgb
 aUU
 biC
-aaI
+fqU
 bka
 blf
 bgl
@@ -126517,7 +126517,7 @@ ktp
 buh
 buh
 buh
-ayD
+qDN
 buh
 buh
 aie
@@ -126527,7 +126527,7 @@ bnA
 bnA
 bnA
 bnA
-eZO
+jkg
 bnA
 pld
 bWL
@@ -126540,10 +126540,10 @@ bnA
 bnA
 dbL
 dcx
-dth
+hCC
 hMn
 kUA
-iyd
+kFQ
 dbN
 dhf
 dhf
@@ -126607,7 +126607,7 @@ rvL
 akK
 alF
 alP
-uFt
+swT
 amz
 ant
 apj
@@ -126638,15 +126638,15 @@ afl
 dTs
 dTs
 kzq
-fAr
-giq
+vtN
+cDQ
 vte
 aFz
 aFz
 aFz
 aFz
-klF
-ylW
+yak
+qvp
 dTs
 dTs
 dTs
@@ -126658,12 +126658,12 @@ dTs
 ccK
 ccK
 ccK
-xvu
+sGX
 aFz
 aFz
-giq
-jND
-qTV
+cDQ
+cpP
+sGW
 nID
 nID
 tXQ
@@ -126684,7 +126684,7 @@ aSM
 azT
 aKA
 aKA
-iDR
+irw
 aGH
 aEX
 mTi
@@ -126713,11 +126713,11 @@ mnX
 mnX
 yhu
 aSH
-utA
+tbT
 aCo
 aOA
 nlP
-jPm
+oag
 eGB
 eGB
 tFr
@@ -126735,9 +126735,9 @@ bgM
 bhn
 aXa
 aVn
-sOL
+oRk
 bda
-iVc
+aBS
 bgc
 aUU
 biW
@@ -126758,20 +126758,20 @@ bnA
 dTs
 dTs
 dTs
-qAG
+keR
 bjV
 tGK
 bjV
-eZO
+jkg
 bFF
 fYs
 bXI
 bYd
-iDm
+pMO
 bFF
 bnA
-qAG
-qAG
+keR
+keR
 dbL
 dbN
 ddp
@@ -126796,7 +126796,7 @@ cCH
 dpI
 cto
 crW
-hbw
+lWn
 dTs
 dTs
 sAs
@@ -126864,7 +126864,7 @@ avh
 auT
 auT
 tJf
-mCI
+lWr
 auT
 hYc
 aaw
@@ -126872,14 +126872,14 @@ atL
 dTs
 dTs
 kzq
-fAr
+vtN
 aFz
 aFz
 aFz
 pmW
-giq
+cDQ
 aFz
-klF
+yak
 dTs
 dTs
 dTs
@@ -126892,7 +126892,7 @@ dTs
 wNO
 wNO
 aAW
-fAr
+vtN
 aFz
 aFz
 aFz
@@ -126914,14 +126914,14 @@ hdd
 jEN
 jEN
 aGH
-mKy
+jWF
 aKa
 aKi
-wan
-hML
+qhw
+eaD
 aGH
 aEX
-gbS
+iky
 mTi
 mTi
 mTi
@@ -126958,7 +126958,7 @@ sRZ
 tFr
 kdO
 tEO
-nFd
+wDU
 mGG
 fSw
 pMD
@@ -126984,7 +126984,7 @@ bvz
 bnA
 bKI
 bjV
-qAG
+keR
 bkP
 bkm
 dTs
@@ -126997,7 +126997,7 @@ dTs
 iXM
 bjV
 bnA
-mxx
+sfW
 fYs
 bTW
 bYe
@@ -127013,7 +127013,7 @@ dap
 dap
 dfv
 dbN
-wjN
+cSt
 dbN
 dbN
 rlU
@@ -127100,7 +127100,7 @@ lCm
 nCw
 axa
 aJe
-tIT
+vDQ
 aPP
 dTs
 dTs
@@ -127113,7 +127113,7 @@ mgg
 aFz
 aFz
 vte
-klF
+yak
 dTs
 dTs
 dTs
@@ -127126,7 +127126,7 @@ cxn
 aBg
 aBg
 aAW
-fAr
+vtN
 vte
 aFz
 vte
@@ -127135,8 +127135,8 @@ aFz
 aFz
 aFz
 aFz
-lYK
-ylW
+iVE
+qvp
 dTs
 dTs
 dTs
@@ -127184,16 +127184,16 @@ mQb
 otC
 yhu
 aOy
-jQI
+gHx
 lFE
-hSy
+rkf
 gdO
 dSH
 uFF
 gdO
 inl
 hCw
-fEO
+dbV
 fSw
 jqa
 eDb
@@ -127214,8 +127214,8 @@ bCI
 bnA
 bnA
 aSH
-tUZ
-eZO
+dFY
+jkg
 bjV
 iXM
 bkP
@@ -127236,7 +127236,7 @@ bWL
 bTW
 bYe
 bYK
-mxx
+sfW
 bnA
 dap
 daP
@@ -127250,7 +127250,7 @@ dge
 dhg
 dhg
 dhj
-oRf
+vFM
 nMO
 oOj
 eNG
@@ -127332,23 +127332,23 @@ avO
 awN
 awT
 nNg
-oPp
+srn
 aJd
 bgH
 bgH
 dTs
 dTs
 bgH
-lly
-dDs
+awm
+wKV
 aFz
-giq
-giq
+cDQ
+cDQ
 aFz
 aKH
 aFz
-jND
-ylW
+cpP
+qvp
 dTs
 dTs
 dTs
@@ -127360,7 +127360,7 @@ aJQ
 aAX
 xdJ
 rOw
-gta
+gvm
 beM
 aFz
 mgg
@@ -127370,7 +127370,7 @@ aFz
 aFz
 bfh
 ccK
-ylW
+qvp
 dTs
 dTs
 dTs
@@ -127416,7 +127416,7 @@ aoi
 bnA
 aSH
 bvz
-fsE
+iNN
 aOy
 plK
 lFE
@@ -127435,11 +127435,11 @@ aOy
 bnA
 aPr
 bCI
-eZO
+jkg
 bnA
-eZO
+jkg
 btR
-wZU
+jrI
 aHP
 aHP
 bnA
@@ -127467,7 +127467,7 @@ dTs
 bnA
 bFF
 bWL
-rfE
+mro
 bYd
 bYK
 bFF
@@ -127476,12 +127476,12 @@ dap
 daQ
 dbP
 heR
-mly
+axd
 dej
 dap
 eeL
 dgf
-lpx
+qgO
 dhh
 diN
 dbN
@@ -127489,12 +127489,12 @@ wjC
 dhe
 dbN
 dkL
-eJp
+few
 fzp
 dmP
 dgo
 cUc
-lCQ
+phT
 dpI
 cto
 crW
@@ -127543,7 +127543,7 @@ rvL
 akK
 alH
 akk
-soj
+aEk
 amz
 amz
 apj
@@ -127573,28 +127573,28 @@ aWz
 bgH
 bgH
 bgH
-lly
+awm
 aFU
 aFz
-giq
-giq
+cDQ
+cDQ
 aFz
 aFz
 vte
 aGb
-jND
-ylW
+cpP
+qvp
 dTs
 dTs
-giq
-klF
+cDQ
+yak
 dTs
 aJc
 pmn
 ikj
 hPq
 aAW
-ylW
+qvp
 aFU
 aFz
 njb
@@ -127604,7 +127604,7 @@ aFz
 aFz
 aGI
 lMc
-ylW
+qvp
 dTs
 dTs
 dTs
@@ -127614,13 +127614,13 @@ aen
 hdd
 jEN
 xyH
-mct
+duf
 aLe
 mfi
 aLD
 aKK
 aLe
-mct
+duf
 dTs
 dTs
 dTs
@@ -127675,13 +127675,13 @@ bnA
 btR
 bux
 aHP
-ykj
-eZO
+kSN
+jkg
 bnA
-eZO
+jkg
 bnA
 bnA
-gpr
+ofz
 bvz
 bnA
 bjV
@@ -127718,7 +127718,7 @@ dgf
 dhh
 dhh
 diN
-wjN
+cSt
 dkh
 dkM
 dkM
@@ -127731,7 +127731,7 @@ cUc
 cCH
 dpH
 cET
-qSg
+nUE
 ctm
 dTs
 dTs
@@ -127805,31 +127805,31 @@ aJd
 qZW
 bRg
 aXY
-vnn
+djp
 bgH
-lly
+awm
 dUz
 aFz
 vGq
 aFz
 aFS
 aFz
-giq
-giq
+cDQ
+cDQ
 azW
-jND
-qTV
-urz
-giq
-klF
+cpP
+sGW
+lXG
+cDQ
+yak
 ccK
 lMc
 wMm
 xFD
 phV
 aBi
-ylW
-fAr
+qvp
+vtN
 aFz
 aFz
 vte
@@ -127838,7 +127838,7 @@ vte
 aFz
 aGI
 ccK
-ylW
+qvp
 dTs
 dTs
 dTs
@@ -127864,7 +127864,7 @@ dTs
 dTs
 dTs
 mTi
-iPV
+qic
 dTs
 xGe
 dTs
@@ -127890,16 +127890,16 @@ yhu
 yhu
 yhu
 yhu
-fsE
+iNN
 yhu
 uJh
-fsE
+iNN
 rHN
 aCo
 bnA
 ajW
 bnA
-eZO
+jkg
 bnA
 bnA
 bnA
@@ -127942,20 +127942,20 @@ bFF
 bnA
 dap
 daQ
-toU
+gsU
 dbP
 fCw
 dej
 dap
 dbN
-idp
+sOF
 fbp
 dhh
 diN
 dbN
 rBv
 dbN
-wjN
+cSt
 dlB
 dlR
 dmf
@@ -128023,7 +128023,7 @@ apj
 anP
 aqv
 vWS
-jxr
+dnC
 anP
 aqv
 vWS
@@ -128048,22 +128048,22 @@ aFz
 vte
 aGO
 aFz
-giq
-giq
+cDQ
+cDQ
 aFz
 aFz
 aFz
 aFz
 aFz
-hXL
+iGf
 ccK
 aAW
 aAP
 aAP
 kpx
 aBi
-ylW
-fAr
+qvp
+vtN
 aFz
 mgg
 aFz
@@ -128072,8 +128072,8 @@ aFz
 bfh
 cnD
 ccK
-ylW
-ylW
+qvp
+qvp
 dTs
 dTs
 hdd
@@ -128111,18 +128111,18 @@ kMb
 dMq
 bnA
 bnA
-eZO
+jkg
 bnA
 bnA
-eZO
+jkg
 bnA
 aSH
 bvz
-eZO
+jkg
 bnA
 bnA
 bnA
-eZO
+jkg
 bXB
 bul
 aiP
@@ -128130,20 +128130,20 @@ aiP
 aiP
 vFV
 vFV
-jkG
+itq
 bul
 bul
 bul
 bul
-jkG
+itq
 aiP
-pQJ
-pQJ
+jON
+jON
 vFV
 puK
 vFV
 bul
-jkG
+itq
 bul
 bul
 bul
@@ -128151,7 +128151,7 @@ bul
 bul
 eDC
 bvz
-eZO
+jkg
 brj
 dTs
 dTs
@@ -128167,11 +128167,11 @@ dTs
 dTs
 dTs
 dTs
-mxx
+sfW
 bWL
 bXJ
 bYd
-iDm
+pMO
 bFF
 bnA
 dap
@@ -128185,15 +128185,15 @@ bNg
 dgf
 dhh
 dhh
-lbg
+evh
 djA
 dki
 dbN
 dbL
 dbL
-eJp
+few
 dmf
-eJp
+few
 dgo
 cUc
 cCH
@@ -128288,22 +128288,22 @@ aFz
 aGO
 vte
 aFz
-giq
-giq
+cDQ
+cDQ
 aGI
 aAW
 ccK
 ccK
 aBi
 aAW
-ylW
-fAr
+qvp
+vtN
 aFz
 vte
 aFz
 aFz
 mux
-klF
+yak
 dTs
 dTs
 dTs
@@ -128317,9 +128317,9 @@ dTs
 dTs
 dTs
 dTs
-gbS
+iky
 mTi
-gbS
+iky
 dTs
 dTs
 dTs
@@ -128351,7 +128351,7 @@ bul
 bul
 bul
 jUV
-qOG
+uqy
 bul
 bul
 bul
@@ -128361,11 +128361,11 @@ eDC
 vFV
 ajA
 ajA
-pyy
+iPY
 ajA
 shu
 ajA
-pyy
+iPY
 ajA
 ajA
 buh
@@ -128381,7 +128381,7 @@ buh
 buh
 ktp
 jUV
-wFj
+xcg
 ktp
 buh
 aie
@@ -128403,11 +128403,11 @@ dTs
 dTs
 bFF
 bWL
-kTd
+eWh
 bYe
 bYK
 bFF
-eZO
+jkg
 dap
 daQ
 dbP
@@ -128434,7 +128434,7 @@ cCH
 dpH
 cET
 crW
-jNx
+oyn
 dTs
 dTs
 aUY
@@ -128482,9 +128482,9 @@ alP
 ham
 ekV
 sSi
-xvC
+faU
 sSi
-xvC
+faU
 lSX
 tzM
 aFF
@@ -128494,7 +128494,7 @@ sgw
 apI
 anP
 aqx
-gau
+ybh
 apI
 anP
 aJd
@@ -128509,10 +128509,10 @@ pnG
 aeE
 bgH
 bgH
-lly
+awm
 oMP
-giq
-giq
+cDQ
+cDQ
 aFz
 azV
 vte
@@ -128522,24 +128522,24 @@ aFz
 aGJ
 njb
 aFz
-giq
-giq
+cDQ
+cDQ
 aGI
 lMc
 ccK
 lMc
 ccK
-nDe
+jxd
 lMc
 aFU
 aFz
 aFz
 aFz
-giq
-giq
-klF
-ylW
-ylW
+cDQ
+cDQ
+yak
+qvp
+qvp
 dTs
 dTs
 dTs
@@ -128577,23 +128577,23 @@ kMb
 kMb
 kMb
 dMq
-eZO
+jkg
 atc
 buh
 buh
 buh
-ayD
-ayD
+qDN
+qDN
 buh
 buh
 buh
 buh
 buh
-ayD
+qDN
 buh
 jUV
 bvz
-eZO
+jkg
 bnA
 bnA
 bnA
@@ -128608,7 +128608,7 @@ bnA
 bnA
 bnA
 bnA
-eZO
+jkg
 bnA
 bnA
 bnA
@@ -128618,7 +128618,7 @@ aSH
 bvz
 bnA
 bnA
-eZO
+jkg
 bnA
 dTs
 dTs
@@ -128644,7 +128644,7 @@ bFF
 bnA
 dap
 daQ
-vsw
+rsc
 dcz
 ddu
 dek
@@ -128656,7 +128656,7 @@ cnU
 diR
 eeU
 dkk
-mjg
+gyl
 dbL
 dlF
 dlT
@@ -128724,7 +128724,7 @@ anv
 anM
 anP
 aqD
-iLG
+sJn
 aqW
 anP
 aqD
@@ -128744,36 +128744,36 @@ gDW
 bgH
 bgH
 xGe
-ylW
-rIa
-giq
+qvp
+qhT
+cDQ
 aFz
 aFz
 aFz
 aFz
-giq
-giq
+cDQ
+cDQ
 aFz
 aFz
 vte
 azV
-mHl
+ojV
 guK
 ccK
 ccK
 ccK
 ccK
-nDe
+jxd
 ccK
 aGR
 vte
 aFz
 vte
 aGF
-giq
-klF
-ylW
-ylW
+cDQ
+yak
+qvp
+qvp
 dTs
 dTs
 dTs
@@ -128849,7 +128849,7 @@ bAZ
 bAZ
 bnA
 aSH
-tUZ
+dFY
 bnA
 bjV
 bkP
@@ -128873,7 +128873,7 @@ dTs
 bWL
 vzF
 bYd
-iDm
+pMO
 bFF
 bnA
 dap
@@ -128885,7 +128885,7 @@ dap
 dap
 cUc
 cCH
-oSG
+kBw
 cto
 crW
 cko
@@ -128979,34 +128979,34 @@ bgH
 bgH
 xGe
 dTs
-fAr
+vtN
 vte
 aFz
 aFz
 lRa
 aFz
-giq
-giq
+cDQ
+cDQ
 aFz
 aFz
 aFz
 aFz
-mHl
+ojV
 lcY
 aGg
 ccK
 lMc
-ylW
-ylW
-urz
+qvp
+qvp
+lXG
 aFz
 aFz
 aFz
 aFz
 vte
 vte
-klF
-ylW
+yak
+qvp
 dTs
 dTs
 dTs
@@ -129048,7 +129048,7 @@ adQ
 gvY
 ael
 aeJ
-eZO
+jkg
 bAZ
 bAZ
 bpr
@@ -129059,7 +129059,7 @@ bpr
 bAZ
 bAZ
 bnA
-gpr
+ofz
 bvz
 bnA
 bpr
@@ -129108,7 +129108,7 @@ bWL
 bTW
 nSf
 bYK
-mxx
+sfW
 bnA
 aKm
 aKm
@@ -129122,15 +129122,15 @@ cCH
 cto
 cto
 crY
-fkY
+kBI
 dkl
 cYs
 aKm
 aKm
-vfa
+mdW
 csb
 aKm
-sYj
+rgI
 cUc
 cCH
 dpH
@@ -129212,8 +129212,8 @@ aje
 aje
 aRv
 xGe
-ylW
-fAr
+qvp
+vtN
 azE
 mgg
 aFz
@@ -129223,23 +129223,23 @@ aFz
 mgg
 aFz
 vte
-giq
-giq
-giq
-giq
+cDQ
+cDQ
+cDQ
+cDQ
 aFz
 hHn
 nID
-urz
-giq
-giq
+lXG
+cDQ
+cDQ
 aFz
 aFz
 mgg
 aFz
 aFz
 aFz
-klF
+yak
 dTs
 dTs
 dTs
@@ -129256,7 +129256,7 @@ sCp
 sCp
 sCp
 sCp
-qph
+lYd
 dTs
 dTs
 gGC
@@ -129305,7 +129305,7 @@ aZi
 aZi
 aZi
 bpr
-eZO
+jkg
 bpr
 aZi
 aZi
@@ -129315,10 +129315,10 @@ aZi
 aZi
 aZi
 bpr
-eZO
+jkg
 aSH
 bvz
-eZO
+jkg
 bkP
 dTs
 dTs
@@ -129339,27 +129339,27 @@ dTs
 dTs
 dTs
 bWL
-pUg
+uIx
 bYe
 bYK
 bFF
 aPd
 cko
-mjg
+gyl
 cko
 pxT
-mjg
+gyl
 cko
 cko
-mPg
+kIK
 cCH
 cto
-oSG
+kBw
 cto
 cto
 dkm
 cUc
-sYj
+rgI
 aKm
 aKm
 aKm
@@ -129369,7 +129369,7 @@ cUc
 cCH
 dpI
 cto
-qSg
+nUE
 cvw
 aKm
 dTs
@@ -129447,7 +129447,7 @@ bAw
 bAw
 qTQ
 ccK
-qFg
+tEk
 aFz
 aFz
 aFz
@@ -129457,24 +129457,24 @@ iVH
 aFz
 aFz
 aFz
-giq
-giq
+cDQ
+cDQ
 vGq
-giq
+cDQ
 aFz
 aFz
 aFz
 vte
-mHl
+ojV
 aFz
 vte
 aFz
 aFz
 aFz
-giq
-giq
-klF
-ylW
+cDQ
+cDQ
+yak
+qvp
 dTs
 dTs
 dTs
@@ -129586,7 +129586,7 @@ cvn
 cvn
 cvn
 cvx
-lCQ
+phT
 cto
 cto
 cto
@@ -129594,13 +129594,13 @@ cto
 dkm
 cmU
 cvn
-iPd
+xgV
 cvn
 cvn
-iPd
+xgV
 cvn
 cvx
-lCQ
+phT
 dpI
 cto
 crW
@@ -129656,7 +129656,7 @@ arq
 asv
 aus
 wWZ
-wNl
+vVk
 aas
 dTs
 dTs
@@ -129681,7 +129681,7 @@ qew
 lLB
 qTQ
 ccK
-qFg
+tEk
 aFz
 aFz
 vte
@@ -129692,20 +129692,20 @@ aFz
 aFz
 vte
 aFz
-giq
-giq
-giq
+cDQ
+cDQ
+cDQ
 nLd
-mHl
-giq
-giq
-giq
-giq
-giq
-giq
-giq
-giq
-giq
+ojV
+cDQ
+cDQ
+cDQ
+cDQ
+cDQ
+cDQ
+cDQ
+cDQ
+cDQ
 dTs
 dTs
 dTs
@@ -129719,7 +129719,7 @@ dTs
 dTs
 dTs
 mTb
-voW
+oLX
 mjy
 sCp
 qmI
@@ -129761,9 +129761,9 @@ kMb
 bUN
 bDy
 bnA
-gpr
+ofz
 bvz
-eZO
+jkg
 bAZ
 aZi
 aZi
@@ -129784,7 +129784,7 @@ aZi
 aZi
 bAZ
 bnA
-eZO
+jkg
 bnA
 bnA
 dTs
@@ -129807,7 +129807,7 @@ dTs
 dTs
 dTs
 bWL
-pUg
+uIx
 bYe
 caP
 bZN
@@ -129823,7 +129823,7 @@ daT
 coZ
 cto
 cto
-oSG
+kBw
 cto
 dkn
 daT
@@ -129835,10 +129835,10 @@ daT
 daT
 daT
 coZ
-eIJ
+qqY
 cET
 crW
-bWI
+xvf
 aKm
 nkB
 aUX
@@ -129915,19 +129915,19 @@ bAw
 bAw
 qTQ
 lMc
-qFg
+tEk
 vte
 njb
 aFz
 vte
 aFz
-giq
-edk
-rIa
+cDQ
+sal
+qhT
 aFz
 aFz
 aAw
-mHl
+ojV
 aFz
 aFz
 aFz
@@ -129953,7 +129953,7 @@ dTs
 dTs
 vYZ
 sCp
-qSo
+kOg
 sCp
 sCp
 sCp
@@ -130046,15 +130046,15 @@ deM
 bYM
 caf
 bYM
-sPY
+tPh
 cSa
-sPY
+tPh
 cma
 cSa
 cma
-sPY
+tPh
 cSa
-sPY
+tPh
 cma
 cSa
 cma
@@ -130065,7 +130065,7 @@ cma
 cSa
 cma
 cma
-jPn
+khd
 cma
 cSa
 cma
@@ -130123,7 +130123,7 @@ app
 arq
 ata
 avl
-rfs
+xun
 axA
 aas
 dTs
@@ -130149,19 +130149,19 @@ bAw
 bAw
 gff
 dTs
-ylW
-rIa
+qvp
+qhT
 aFz
 aFz
 aFz
 vte
-edk
+sal
 dTs
 dTs
 xTz
 beM
 aGv
-mHl
+ojV
 bfh
 oMP
 aFz
@@ -130184,20 +130184,20 @@ dTs
 dTs
 dTs
 xmH
-ndW
-vcE
+wlb
+wjt
 sCp
 sCp
 gGC
 gGC
 mTb
 sGQ
-rPc
+qar
 sCp
 dRK
 gGC
 gGC
-poo
+igS
 sCp
 sCp
 sCp
@@ -130229,7 +130229,7 @@ qdS
 bCp
 bDy
 bnA
-niZ
+sfk
 aie
 bnA
 bpr
@@ -130241,7 +130241,7 @@ aZi
 aZi
 aZi
 bpr
-eZO
+jkg
 bpr
 aZi
 aZi
@@ -130284,7 +130284,7 @@ cto
 cnU
 cto
 cto
-wvB
+kEy
 cto
 cto
 cnU
@@ -130308,7 +130308,7 @@ cto
 crW
 coc
 aKm
-jNx
+oyn
 vUI
 tbc
 gvo
@@ -130351,7 +130351,7 @@ dTs
 dTs
 dTs
 aas
-nOn
+rft
 app
 aiM
 arq
@@ -130384,8 +130384,8 @@ bAw
 omh
 dTs
 dTs
-fAr
-giq
+vtN
+cDQ
 aFz
 vte
 aFz
@@ -130394,11 +130394,11 @@ dTs
 dTs
 dTs
 dTs
-mUq
-mUq
-ylW
-ylW
-mUq
+yfI
+yfI
+qvp
+qvp
+yfI
 dTs
 dTs
 dTs
@@ -130416,7 +130416,7 @@ dTs
 dTs
 dTs
 dTs
-vcE
+wjt
 qmI
 xmH
 sCp
@@ -130434,7 +130434,7 @@ qmI
 sCp
 max
 mTb
-qph
+lYd
 mTb
 xHP
 sCp
@@ -130465,7 +130465,7 @@ bAZ
 bYN
 wqI
 bnA
-eZO
+jkg
 bpr
 aZi
 aZi
@@ -130486,7 +130486,7 @@ aZi
 aZi
 bpr
 aHW
-jzJ
+uLH
 dTs
 dTs
 dTs
@@ -130511,11 +130511,11 @@ dTs
 bXF
 bXK
 bXK
-eFC
+fDr
 bXK
 bXK
 cmb
-fdD
+hMU
 cmb
 cmb
 cmb
@@ -130524,7 +130524,7 @@ cmb
 cmb
 cmb
 cmb
-fdD
+hMU
 cmb
 cmb
 cmb
@@ -130536,7 +130536,7 @@ cmb
 cmb
 cmb
 cmb
-kjU
+fuC
 cpR
 cET
 crW
@@ -130619,19 +130619,19 @@ xGe
 dTs
 dTs
 dTs
-mUq
-rIa
-mHl
-kFL
-ylW
+yfI
+qhT
+ojV
+nGj
+qvp
 dTs
 dTs
 dTs
 dTs
 dTs
-ylW
-ylW
-ylW
+qvp
+qvp
+qvp
 dTs
 dTs
 dTs
@@ -130672,9 +130672,9 @@ sCp
 mTb
 nWL
 sCp
-qSo
+kOg
 sCp
-pKP
+wEN
 dLt
 dKA
 mEu
@@ -130750,11 +130750,11 @@ bTV
 bTV
 cvn
 cvn
-iPd
+xgV
 jOo
 cvn
 cvn
-iPd
+xgV
 cvn
 cvn
 cvn
@@ -130765,7 +130765,7 @@ cvn
 cvn
 cvn
 cvn
-iPd
+xgV
 cvn
 cvn
 cvn
@@ -130774,7 +130774,7 @@ cCH
 cto
 cto
 crW
-bWI
+xvf
 aKm
 ctm
 vUI
@@ -130854,10 +130854,10 @@ dTs
 dTs
 dTs
 dTs
-ylW
+qvp
 xTz
 ccK
-ylW
+qvp
 dTs
 dTs
 dTs
@@ -130907,8 +130907,8 @@ sCp
 xBb
 sCp
 nWL
-jEA
-pKP
+cSY
+wEN
 mQZ
 ptU
 mEu
@@ -130925,7 +130925,7 @@ bkP
 dTs
 bkm
 blt
-qAG
+keR
 bjV
 bjV
 bjV
@@ -130945,15 +130945,15 @@ bjV
 bkP
 lrR
 bkm
-rcs
+jsr
 dTs
 dTs
 dTs
 bqp
 blt
-qAG
+keR
 bjV
-xFs
+qPx
 dTs
 dTs
 dTs
@@ -130987,11 +130987,11 @@ cko
 cko
 cko
 cko
-mjg
+gyl
 cko
 cko
 cko
-mjg
+gyl
 cko
 aeC
 cko
@@ -131003,7 +131003,7 @@ cko
 cko
 cko
 cko
-mjg
+gyl
 cCH
 abt
 cto
@@ -131142,7 +131142,7 @@ sCp
 xHP
 sGQ
 sCp
-pKP
+wEN
 mQZ
 ptU
 mEu
@@ -131153,7 +131153,7 @@ kMb
 vsQ
 dLQ
 mQZ
-rdV
+jxH
 bnA
 dTs
 dTs
@@ -131162,7 +131162,7 @@ bqp
 mXh
 bjV
 bkP
-rcs
+jsr
 bqp
 dTs
 dTs
@@ -131175,7 +131175,7 @@ dTs
 dTs
 dTs
 bqp
-rcs
+jsr
 bqp
 dTs
 dTs
@@ -131217,12 +131217,12 @@ dTs
 dTs
 dTs
 cmH
-fSM
+snq
 cmH
 cmH
 cmH
 cmH
-fSM
+snq
 cmH
 cmH
 cmH
@@ -131242,7 +131242,7 @@ cCH
 cpR
 cET
 crW
-bWI
+xvf
 fCL
 lPn
 sAs
@@ -131392,9 +131392,9 @@ dTs
 dTs
 dTs
 dTs
-jzJ
+uLH
 bqp
-rcs
+jsr
 bqp
 dTs
 dTs
@@ -131598,8 +131598,8 @@ sCp
 sCp
 hTr
 sCp
-qph
-poo
+lYd
+igS
 axw
 gGC
 dTs
@@ -131794,7 +131794,7 @@ bAw
 bAw
 lqs
 kvS
-jds
+lJU
 dTs
 dTs
 dTs
@@ -131941,7 +131941,7 @@ dTs
 dTs
 dTs
 cCH
-hKf
+tPd
 cET
 crY
 daT
@@ -132011,7 +132011,7 @@ bAw
 bAw
 bGp
 ppH
-oiX
+fjI
 bAw
 bAw
 bAw
@@ -132179,7 +132179,7 @@ cto
 cto
 cto
 cnT
-oSG
+kBw
 cto
 mES
 dXU
@@ -132304,7 +132304,7 @@ sCp
 sCp
 sCp
 sCp
-kzl
+qNE
 dTs
 dTs
 dTs
@@ -132408,7 +132408,7 @@ dTs
 dTs
 dTs
 dTs
-lCQ
+phT
 abt
 cto
 cto
@@ -132537,8 +132537,8 @@ sCp
 sCp
 qmI
 sCp
-vcE
-vcE
+wjt
+wjt
 gGC
 dTs
 dTs
@@ -132645,9 +132645,9 @@ dTs
 cVC
 cmb
 cmb
-fdD
+hMU
 cmb
-fdD
+hMU
 cmb
 dBh
 aVd
@@ -132943,7 +132943,7 @@ dTs
 dTs
 dTs
 dTs
-hfr
+kfa
 bAw
 bAw
 kvS
@@ -132994,7 +132994,7 @@ dTs
 dTs
 dTs
 xmH
-ndW
+wlb
 dTs
 dTs
 axw
@@ -133228,17 +133228,17 @@ dTs
 dTs
 sCp
 sCp
-oZd
+qEW
 mTb
 sCp
-oZd
+qEW
 gGC
 dTs
 dTs
 dTs
 gGC
 pNG
-vcE
+wjt
 pNG
 gGC
 gGC
@@ -133460,11 +133460,11 @@ xGe
 xGe
 xGe
 wLU
-mbK
+sJM
 onL
-mbK
+sJM
 fwv
-bZB
+cCX
 nFh
 wLU
 xGe

--- a/_maps/map_files/desertdam/desertdam.dmm
+++ b/_maps/map_files/desertdam/desertdam.dmm
@@ -121,6 +121,10 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
+"aaI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/water_treatment_two/lobby)
 "aaJ" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -215,9 +219,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
 "abg" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairleftrailup"
-	},
+/obj/structure/stairs/seamless/platform,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached2"
 	},
@@ -474,6 +476,7 @@
 /area/desert_dam/exterior/valley/valley_labs)
 "acp" = (
 /obj/structure/flora/bush,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
 /area/desert_dam/exterior/valley/valley_labs)
 "acq" = (
@@ -765,6 +768,7 @@
 /area/desert_dam/exterior/valley/valley_crashsite)
 "adM" = (
 /obj/structure/platform_decoration,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt{
 	dir = 8
 	},
@@ -1165,6 +1169,12 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/dam_interior/south_tunnel)
+"afD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "afE" = (
 /obj/structure/platform_decoration{
 	dir = 4
@@ -1309,7 +1319,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_labs)
+"agA" = (
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 1;
+	name = "\improper Containment Lock"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "agB" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 8
 	},
@@ -1416,6 +1437,7 @@
 /obj/structure/desertdam/decals/road/stop{
 	icon_state = "stop_decal5"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
 "agY" = (
@@ -1695,6 +1717,7 @@
 	},
 /area/desert_dam/exterior/valley/valley_mining)
 "aif" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached17"
 	},
@@ -1735,6 +1758,7 @@
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "aio" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached19"
 	},
@@ -1813,6 +1837,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
 	icon_state = "cement3"
 	},
@@ -1971,6 +1996,7 @@
 /area/desert_dam/exterior/valley/valley_labs)
 "ajh" = (
 /obj/structure/flora/bush,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aji" = (
@@ -2087,6 +2113,7 @@
 /obj/structure/flora/desert/cactus/multiple{
 	icon_state = "cacti_8"
 	},
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "ajD" = (
@@ -2173,6 +2200,7 @@
 "ajQ" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/technology_scanner,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 9;
 	icon_state = "darkpurple2"
@@ -2210,6 +2238,7 @@
 /area/desert_dam/interior/lab_northeast/east_lab_biology)
 "ajZ" = (
 /obj/machinery/chem_master,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "darkpurple2"
@@ -2230,6 +2259,7 @@
 /obj/structure/flora/desert/cactus/multiple{
 	icon_state = "cacti_11"
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "akc" = (
@@ -2246,6 +2276,7 @@
 	icon_state = "stop_decal5"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_wilderness)
 "ake" = (
@@ -2480,7 +2511,7 @@
 /obj/structure/platform{
 	dir = 8
 	},
-/turf/closed/mineral,
+/turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "akW" = (
 /turf/open/ground/jungle{
@@ -2545,6 +2576,7 @@
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_excavation)
 "alf" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "darkpurple2"
@@ -2568,7 +2600,7 @@
 /obj/structure/platform{
 	dir = 1
 	},
-/turf/closed/mineral,
+/turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "all" = (
 /obj/machinery/light{
@@ -2598,11 +2630,9 @@
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
 "alr" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairuprailleft"
-	},
+/obj/structure/stairs/seamless/platform/alt,
 /turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
+	icon_state = "cement_sunbleached2"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
 "als" = (
@@ -2624,6 +2654,12 @@
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_biology)
+"alv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "aly" = (
 /obj/structure/closet/crate,
 /obj/item/storage/fancy/vials,
@@ -2686,6 +2722,7 @@
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_excavation)
 "alG" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "darkpurple2"
 	},
@@ -2737,6 +2774,7 @@
 "alN" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/vials,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkpurplecorners2"
@@ -2753,11 +2791,11 @@
 /turf/open/floor/plating,
 /area/desert_dam/interior/lab_northeast/east_lab_excavation)
 "alQ" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairuprailright"
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
+	icon_state = "cement_sunbleached9"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
 "alR" = (
@@ -2835,7 +2873,12 @@
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_biology)
 "amd" = (
-/obj/structure/platform,
+/obj/structure/stairs/cornerdark/seamless{
+	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
 "ame" = (
@@ -2854,18 +2897,8 @@
 /obj/structure/platform,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_labs)
-"amj" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "amk" = (
-/obj/structure/platform_decoration,
-/obj/structure/stairs{
+/obj/structure/stairs/seamless{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -2886,6 +2919,7 @@
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
 "amn" = (
 /obj/machinery/door/poddoor/mainship/open{
+	dir = 1;
 	name = "\improper Containment Lock"
 	},
 /turf/open/floor/plating,
@@ -2906,6 +2940,7 @@
 /area/desert_dam/interior/lab_northeast/east_lab_biology)
 "amq" = (
 /obj/machinery/door/poddoor/mainship/open{
+	dir = 1;
 	name = "\improper Containment Lock"
 	},
 /turf/open/floor/plating{
@@ -3106,6 +3141,7 @@
 	start_charge = 0
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "darkpurple2"
@@ -3138,6 +3174,7 @@
 /obj/structure/platform{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt{
 	dir = 8
 	},
@@ -3300,6 +3337,7 @@
 /obj/structure/flora/desert{
 	icon_state = "lightgrass_12"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_northwest)
 "anG" = (
@@ -3423,6 +3461,7 @@
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "anZ" = (
 /obj/machinery/light,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "darkpurple2"
 	},
@@ -3500,17 +3539,12 @@
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "aor" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/landmark/weed_node,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/turf/open/floor/plating{
+	dir = 5;
+	icon_state = "warnplate"
 	},
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
+/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "aou" = (
 /obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3587,6 +3621,7 @@
 /area/desert_dam/interior/dam_interior/west_tunnel)
 "aoI" = (
 /obj/machinery/door/poddoor/mainship/open{
+	dir = 1;
 	name = "\improper Containment Lock"
 	},
 /turf/open/floor/prison{
@@ -3605,6 +3640,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2"
 	},
@@ -4142,8 +4178,8 @@
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_security_armory)
 "aqw" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairleftraildown"
+/obj/structure/stairs/seamless/platform{
+	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached14"
@@ -4256,6 +4292,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "whitepurple"
@@ -4442,6 +4479,7 @@
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
 "arp" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkbrown2"
@@ -4601,6 +4639,7 @@
 	},
 /area/shuttle/tri_trans1/alpha)
 "arO" = (
+/obj/effect/landmark/weed_node,
 /turf/open/shuttle/escapepod{
 	icon_state = "floor12"
 	},
@@ -4739,6 +4778,7 @@
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/shuttle/dropship{
 	icon_state = "rasputin8"
 	},
@@ -4761,6 +4801,13 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/valley/valley_labs)
+"asu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
 "asv" = (
 /obj/machinery/door/airlock/mainship/security/glass{
 	dir = 1;
@@ -4889,6 +4936,7 @@
 	icon_state = "lightgrass_6"
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt{
 	dir = 1
 	},
@@ -4961,6 +5009,7 @@
 /obj/structure/flora/desert/cactus/multiple{
 	icon_state = "cacti_11"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 1
 	},
@@ -4980,11 +5029,15 @@
 	},
 /area/desert_dam/interior/caves/east_caves)
 "ate" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightrailup"
+/obj/structure/stairs/seamless/platform{
+	dir = 1
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
 "atf" = (
@@ -5040,6 +5093,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "floor_plate"
@@ -5183,6 +5237,7 @@
 	},
 /area/desert_dam/building/substation/northeast)
 "atI" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
 	icon_state = "cement9"
 	},
@@ -5381,6 +5436,7 @@
 	},
 /area/desert_dam/interior/dam_interior/west_tunnel)
 "aup" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkpurplecorners2"
@@ -5394,6 +5450,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "darkpurplecorners2"
@@ -5405,14 +5462,6 @@
 "auu" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/west_tunnel)
-"auv" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairuprailleft"
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
-	},
-/area/desert_dam/exterior/valley/valley_medical)
 "auw" = (
 /obj/machinery/power/apc{
 	start_charge = 0
@@ -5586,14 +5635,6 @@
 	icon_state = "whiteblue"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_lobby)
-"auX" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairuprailright"
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached1"
-	},
-/area/desert_dam/exterior/valley/valley_medical)
 "auZ" = (
 /obj/structure/rack,
 /turf/open/floor/prison,
@@ -5633,6 +5674,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	dir = 4;
 	icon_state = "whiteyellowfull"
@@ -5922,6 +5964,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/valley/valley_wilderness)
 "awg" = (
@@ -5934,11 +5977,11 @@
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/east_caves)
 "awn" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightraildown"
+/obj/structure/stairs/seamless/platform{
+	dir = 8
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
 "awo" = (
@@ -6016,10 +6059,12 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "awC" = (
-/turf/open/floor/plating/ground/dirt{
-	dir = 8
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkpurple2"
 	},
-/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "awE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6078,6 +6123,7 @@
 /turf/closed/wall/r_wall/prison,
 /area/desert_dam/building/security/detective)
 "awN" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	dir = 4;
 	icon_state = "whiteblue"
@@ -6232,6 +6278,7 @@
 /obj/structure/desertdam/decals/loose_sand_overlay{
 	dir = 6
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/desert_dam/interior/lab_northeast/east_lab_maintenence)
 "axt" = (
@@ -6558,6 +6605,12 @@
 	icon_state = "blue"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_RND)
+"ayD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "ayE" = (
 /obj/structure/closet/secure_closet/RD,
 /turf/open/floor/prison{
@@ -6792,6 +6845,12 @@
 	icon_state = "whitepurple"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+"azr" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "azs" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/dam_interior/western_dam_cave)
@@ -6902,7 +6961,7 @@
 /obj/structure/platform{
 	dir = 4
 	},
-/turf/closed/mineral,
+/turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "azM" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
@@ -6928,13 +6987,16 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/desert_dam/interior/dam_interior/west_tunnel)
 "azT" = (
-/turf/closed/mineral,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "azU" = (
 /obj/structure/platform{
 	dir = 8
 	},
-/turf/closed/mineral,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 8
+	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "azV" = (
 /obj/structure/flora/bush,
@@ -6985,7 +7047,7 @@
 /obj/structure/platform{
 	dir = 4
 	},
-/turf/closed/mineral,
+/turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aAo" = (
 /obj/structure/disposalpipe/segment{
@@ -7006,6 +7068,7 @@
 /obj/structure/flora/desert/cactus{
 	icon_state = "cactus_7"
 	},
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "tile"
 	},
@@ -7201,13 +7264,6 @@
 	icon_state = "asteroidfloor"
 	},
 /area/desert_dam/interior/dam_interior/south_tunnel)
-"aBq" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairleftrailup"
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "aBr" = (
 /obj/structure/desertdam/decals/road/stop{
 	dir = 1;
@@ -7248,12 +7304,6 @@
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_wilderness)
-"aBF" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairleftraildown"
-	},
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
 "aBG" = (
 /obj/machinery/light{
 	dir = 8
@@ -7427,6 +7477,7 @@
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "aCv" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "aCx" = (
@@ -7439,6 +7490,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/desert_dam/exterior/valley/tradeship)
 "aCB" = (
@@ -7488,6 +7540,7 @@
 	start_charge = 0
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "aCI" = (
@@ -7546,6 +7599,7 @@
 /obj/structure/barricade/wooden{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -7870,7 +7924,7 @@
 /obj/structure/platform{
 	dir = 8
 	},
-/turf/closed/mineral,
+/turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aEa" = (
 /turf/closed/wall,
@@ -7882,7 +7936,7 @@
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "aEf" = (
 /obj/structure/platform,
-/turf/closed/mineral,
+/turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aEg" = (
 /obj/machinery/door/airlock/mainship/maint{
@@ -7907,6 +7961,7 @@
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal9"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
 "aEj" = (
@@ -7918,7 +7973,7 @@
 /obj/structure/platform{
 	dir = 4
 	},
-/turf/closed/mineral,
+/turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aEn" = (
 /obj/effect/decal/warning_stripes{
@@ -7961,19 +8016,17 @@
 	},
 /area/desert_dam/building/medical/medsecure)
 "aEv" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairuprailleft"
-	},
+/obj/structure/stairs/seamless/platform/alt,
 /turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
+	icon_state = "cement_sunbleached2"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aEw" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairuprailright"
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
+	icon_state = "cement_sunbleached9"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aEx" = (
@@ -7984,6 +8037,7 @@
 /area/desert_dam/interior/dam_interior/south_tunnel)
 "aEy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
 	icon_state = "cement4"
 	},
@@ -8171,6 +8225,7 @@
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_2"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 4
 	},
@@ -8193,6 +8248,7 @@
 /obj/structure/flora/desert/cactus/multiple{
 	icon_state = "cacti_10"
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aFO" = (
@@ -8212,6 +8268,7 @@
 /area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "aFS" = (
 /obj/structure/flora/desert/grass,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/central_caves)
 "aFT" = (
@@ -8240,6 +8297,7 @@
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_7"
 	},
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/central_caves)
 "aGc" = (
@@ -8269,6 +8327,7 @@
 	},
 /area/desert_dam/building/dorms/restroom)
 "aGo" = (
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached15"
 	},
@@ -8333,6 +8392,7 @@
 /obj/structure/flora/desert/cactus{
 	icon_state = "cactus_4"
 	},
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/central_caves)
 "aGH" = (
@@ -8553,20 +8613,6 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
-"aHK" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairdownrailleft"
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
-"aHM" = (
-/obj/structure/stairs/railstairs,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
 "aHN" = (
 /obj/structure/flora/desert/grass/heavy{
 	icon_state = "heavygrass_3"
@@ -8688,6 +8734,7 @@
 /obj/structure/flora/desert/grass/heavy{
 	icon_state = "heavygrass_4"
 	},
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aIq" = (
@@ -8714,19 +8761,21 @@
 	},
 /area/desert_dam/exterior/river/riverside_central_north)
 "aIB" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightrailup"
+/obj/structure/stairs/seamless/platform{
+	dir = 1
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "cement_sunbleached9"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aID" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairleftrailup"
-	},
+/obj/structure/stairs/seamless/platform,
 /turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "cement_sunbleached9"
+	icon_state = "cement_sunbleached2"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aIE" = (
@@ -8790,20 +8839,12 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_telecoms)
-"aIR" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightraildown"
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "cement_sunbleached15"
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
 "aIW" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairleftraildown"
+/obj/structure/stairs/seamless/platform{
+	dir = 4
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "cement_sunbleached15"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aJc" = (
@@ -8905,6 +8946,7 @@
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aJX" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/east_engineering)
 "aJY" = (
@@ -8915,7 +8957,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/ground/mars/random/cave{
-	dir = 4
+	dir = 8
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aKc" = (
@@ -8942,15 +8984,16 @@
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aKh" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave{
-	dir = 10
+	dir = 5
 	},
-/area/desert_dam/exterior/valley/valley_crashsite)
+/area/desert_dam/exterior/valley/valley_labs)
 "aKi" = (
 /obj/structure/platform_decoration,
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/cave{
-	dir = 5
+	dir = 8
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aKj" = (
@@ -8976,12 +9019,6 @@
 "aKm" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_civilian)
-"aKn" = (
-/obj/structure/stairs,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
-	},
-/area/desert_dam/exterior/valley/valley_telecoms)
 "aKp" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 2;
@@ -9016,6 +9053,7 @@
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aKz" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 4
 	},
@@ -9029,6 +9067,7 @@
 /obj/structure/flora/desert/cactus{
 	icon_state = "cactus_8"
 	},
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aKD" = (
@@ -9064,6 +9103,7 @@
 /area/desert_dam/interior/caves/central_caves)
 "aKJ" = (
 /obj/structure/platform_decoration,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached1"
 	},
@@ -9109,17 +9149,15 @@
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aKR" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairuprailleft"
-	},
+/obj/structure/stairs/seamless/platform/alt,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aKS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/stairs/railstairs{
-	icon_state = "stairuprailright"
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached1"
@@ -9278,12 +9316,14 @@
 	dir = 9
 	},
 /obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating{
 	dir = 1;
 	icon_state = "asteroidfloor"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aLr" = (
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating{
 	dir = 9;
 	icon_state = "warnplate"
@@ -9326,21 +9366,6 @@
 	icon_state = "cement_sunbleached9"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
-"aLw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/stairs/railstairs{
-	icon_state = "stairdownrailleft"
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
-"aLx" = (
-/obj/structure/stairs/railstairs,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached1"
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
 "aLy" = (
 /obj/machinery/landinglight/ds2/delaytwo,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -9468,6 +9493,7 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aLV" = (
@@ -9988,6 +10014,7 @@
 "aNZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached2"
 	},
@@ -10153,6 +10180,13 @@
 	icon_state = "rasputin15"
 	},
 /area/shuttle/tri_trans2/alpha)
+"aOZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitepurple"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "aPa" = (
 /obj/structure/bed/chair/dropship/passenger,
 /obj/structure/cable,
@@ -10166,6 +10200,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/shuttle/dropship{
 	icon_state = "floor8"
 	},
@@ -10198,13 +10233,23 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/river/riverside_central_north)
+"aPj" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
 "aPk" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/exterior/valley/valley_wilderness)
 "aPn" = (
 /obj/structure/platform,
 /turf/open/floor/plating/ground/mars/random/cave{
-	dir = 5
+	dir = 8
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aPp" = (
@@ -10531,9 +10576,7 @@
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
 "aRi" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairleftrailup"
-	},
+/obj/structure/stairs/seamless/platform,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached2"
 	},
@@ -10543,6 +10586,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "tile"
 	},
@@ -10662,8 +10706,8 @@
 	},
 /area/shuttle/tri_trans2/alpha)
 "aRH" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairleftraildown"
+/obj/structure/stairs/seamless/platform{
+	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached14"
@@ -10679,6 +10723,7 @@
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
 "aRP" = (
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating{
 	dir = 5;
 	icon_state = "warnplate"
@@ -10986,6 +11031,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/warehouse/loading)
+"aTw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "aTx" = (
 /obj/structure/largecrate,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -11018,6 +11069,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "white"
 	},
@@ -11040,6 +11092,7 @@
 	dir = 8
 	},
 /obj/structure/platform,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
 "aTK" = (
@@ -11585,6 +11638,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "blue"
@@ -11634,6 +11688,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/administration/office)
 "aWx" = (
@@ -11710,6 +11765,7 @@
 /area/desert_dam/building/security/evidence)
 "aWL" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -11721,6 +11777,7 @@
 /area/desert_dam/building/administration/control_room)
 "aWN" = (
 /obj/structure/toilet,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "sterile_white"
 	},
@@ -11739,6 +11796,7 @@
 /turf/open/floor/wood,
 /area/desert_dam/building/security/office)
 "aWR" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	dir = 8;
 	icon_state = "carpet5-1"
@@ -12007,9 +12065,7 @@
 	},
 /area/desert_dam/building/administration/hallway)
 "aXT" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairleftrailup"
-	},
+/obj/structure/stairs/seamless/platform,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "tile"
 	},
@@ -12054,6 +12110,7 @@
 "aYb" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -12066,6 +12123,13 @@
 /obj/structure/rack,
 /turf/open/floor/prison,
 /area/desert_dam/building/water_treatment_two/hallway)
+"aYh" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal3"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/north_valley_dam)
 "aYj" = (
 /turf/open/floor/prison{
 	dir = 4;
@@ -12181,8 +12245,8 @@
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_labs)
 "aYy" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairleftraildown"
+/obj/structure/stairs/seamless/platform{
+	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "tile"
@@ -12377,6 +12441,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_wilderness)
 "aZm" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
 	icon_state = "cement14"
 	},
@@ -12477,6 +12542,7 @@
 /turf/closed/wall/r_wall,
 /area/desert_dam/building/administration/archives)
 "aZH" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached16"
 	},
@@ -12527,9 +12593,8 @@
 /area/desert_dam/building/administration/hallway)
 "aZQ" = (
 /obj/structure/flora/pottedplant,
-/obj/structure/closet/walllocker/hydrant{
-	pixel_y = 32
-	},
+/obj/structure/closet/walllocker/hydrant,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 9;
 	icon_state = "blue"
@@ -12552,6 +12617,7 @@
 	},
 /area/desert_dam/building/administration/lobby)
 "aZU" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "bluecorner"
@@ -12600,6 +12666,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "dark2"
 	},
@@ -12863,6 +12930,7 @@
 /turf/open/floor/prison,
 /area/desert_dam/building/water_treatment_two/hallway)
 "baQ" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "blue"
@@ -12929,6 +12997,7 @@
 	},
 /area/desert_dam/building/administration/lobby)
 "bbe" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "bluecorner"
 	},
@@ -13129,15 +13198,11 @@
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
 "bbZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/stairs/seamless/platform{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
-	},
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightrailup"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached4"
@@ -13172,11 +13237,10 @@
 	},
 /area/desert_dam/building/administration/meetingrooom)
 "bcs" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightraildown"
+/obj/structure/stairs/seamless/platform{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached12"
 	},
@@ -13399,6 +13463,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/computer/nuke_disk_generator/blue,
 /turf/open/floor/wood,
 /area/desert_dam/building/administration/meetingrooom)
 "bdp" = (
@@ -13622,6 +13687,7 @@
 	dir = 8;
 	on = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/carpet{
 	dir = 5;
 	icon_state = "carpetside"
@@ -13633,6 +13699,14 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_northwest)
+"bem" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/hydroponics/hydroponics_storage)
 "ben" = (
 /obj/machinery/landinglight/ds1/delaytwo{
 	dir = 1
@@ -13737,6 +13811,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/administration/overseer_office)
 "beJ" = (
@@ -13816,6 +13891,7 @@
 /obj/structure/flora/desert/grass/heavy{
 	icon_state = "heavygrass_6"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_northwest)
 "beW" = (
@@ -13857,6 +13933,7 @@
 	dir = 1;
 	on = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/carpet{
 	dir = 10;
 	icon_state = "carpetside"
@@ -13974,17 +14051,19 @@
 /turf/open/floor/wood,
 /area/desert_dam/building/administration/overseer_office)
 "bfB" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairdownrailleft"
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
+	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
 "bfC" = (
-/obj/structure/stairs/railstairs,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached1"
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
 "bfF" = (
@@ -14130,6 +14209,13 @@
 /obj/structure/curtain/open/shower,
 /turf/open/floor/plating,
 /area/desert_dam/building/water_treatment_one/breakroom)
+"bge" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkred2"
+	},
+/area/desert_dam/building/security/prison)
 "bgf" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -14312,6 +14398,7 @@
 	start_charge = 0
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/water_treatment_two/control_room)
 "bgW" = (
@@ -14544,11 +14631,11 @@
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
 "bic" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightrailup"
+/obj/structure/stairs/seamless/platform{
+	dir = 1
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/bar_valley_dam)
 "bie" = (
@@ -14626,13 +14713,17 @@
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
 "biu" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightraildown"
+/obj/structure/stairs/seamless/platform{
+	dir = 8
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"biv" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "biw" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -14677,6 +14768,7 @@
 /area/desert_dam/interior/dam_interior/hanger)
 "biI" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -14766,6 +14858,7 @@
 	},
 /area/desert_dam/building/water_treatment_two/control_room)
 "biY" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "red"
@@ -14889,15 +14982,17 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/north_valley_dam)
 "bjs" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairdownrailleft"
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
 "bjt" = (
-/obj/structure/stairs/railstairs,
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 4
+	},
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached15"
 	},
@@ -15186,6 +15281,11 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_wilderness)
+"bkF" = (
+/obj/structure/bed/chair,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/security/execution_chamber)
 "bkG" = (
 /obj/item/ammo_magazine/revolver/cmb,
 /obj/structure/table/woodentable,
@@ -15268,6 +15368,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2"
 	},
@@ -15310,6 +15411,7 @@
 /area/desert_dam/exterior/valley/valley_crashsite)
 "blf" = (
 /obj/machinery/light,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/water_treatment_two/lobby)
 "blg" = (
@@ -15518,6 +15620,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/north_tunnel_entrance)
 "bmd" = (
@@ -15690,6 +15793,7 @@
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
 "bmG" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/tech_storage)
 "bmI" = (
@@ -15952,6 +16056,7 @@
 "bnQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "bluecorner"
@@ -16180,6 +16285,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2"
 	},
@@ -16747,6 +16853,7 @@
 /area/desert_dam/interior/dam_interior/smes_main)
 "bqZ" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -16983,6 +17090,7 @@
 "brT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -17171,8 +17279,7 @@
 "bsy" = (
 /obj/structure/table,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+	dir = 4
 	},
 /obj/item/stack/sheet/metal,
 /turf/open/floor/prison{
@@ -17592,6 +17699,19 @@
 	icon_state = "grimy"
 	},
 /area/desert_dam/building/bar/bar)
+"bup" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "yellow"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
+"bus" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "but" = (
 /obj/structure/window/framed/wood/reinforced,
 /turf/open/floor/plating,
@@ -17835,11 +17955,11 @@
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
 "bvr" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairuprailright"
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 1
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement1"
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached9"
 	},
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bvy" = (
@@ -17895,6 +18015,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 9;
 	icon_state = "darkred2"
@@ -18094,6 +18215,7 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "bwu" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "warning"
@@ -18124,6 +18246,7 @@
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "bwz" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "bwA" = (
@@ -18163,6 +18286,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "dark"
 	},
@@ -18344,6 +18468,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2"
 	},
@@ -18372,11 +18497,9 @@
 	},
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bxs" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairuprailleft"
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement3"
+/obj/structure/stairs/seamless/platform/alt,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached2"
 	},
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bxt" = (
@@ -18436,6 +18559,7 @@
 /obj/structure/table,
 /obj/item/flashlight/flare,
 /obj/item/radio,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "darkyellow2"
@@ -18443,6 +18567,7 @@
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "bxL" = (
 /obj/structure/bed/stool,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "bxM" = (
@@ -18536,6 +18661,7 @@
 	layer = 2.7
 	},
 /obj/structure/platform,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "tile"
 	},
@@ -18726,6 +18852,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_northwest)
 "byY" = (
@@ -19198,6 +19325,7 @@
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
 "bAG" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/control_room)
 "bAH" = (
@@ -19255,6 +19383,13 @@
 	icon_state = "catwalk-255"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
+"bAX" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal12"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "bAZ" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/desert_dam/exterior/valley/valley_mining)
@@ -19362,11 +19497,10 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "bBs" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairleftrailup"
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement4"
+/obj/structure/cable,
+/obj/structure/stairs/seamless/platform,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "bBv" = (
@@ -19471,7 +19605,7 @@
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bBS" = (
 /obj/structure/bed/chair,
-/obj/structure/window/framed/colony/reinforced,
+/obj/structure/window/reinforced,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/courtroom)
 "bBU" = (
@@ -19501,14 +19635,6 @@
 	icon_state = "bluecorner"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
-"bCh" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightraildown"
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "bCi" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -19522,11 +19648,12 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "bCk" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairleftraildown"
+/obj/structure/cable,
+/obj/structure/stairs/seamless/platform{
+	dir = 4
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement12"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "bCm" = (
@@ -19689,10 +19816,12 @@
 	},
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "bCW" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightrailup"
+/obj/structure/stairs/seamless/platform{
+	dir = 1
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "bCX" = (
 /obj/structure/platform_decoration{
@@ -19714,10 +19843,11 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bDa" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairleftrailup"
+/obj/structure/cable,
+/obj/structure/stairs/seamless/platform,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bDb" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
@@ -19987,17 +20117,19 @@
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "bEg" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairdownrailleft"
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 8
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement3"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "bEh" = (
-/obj/structure/stairs/railstairs,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement1"
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "bEi" = (
@@ -20033,10 +20165,12 @@
 	},
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "bEq" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightraildown"
+/obj/structure/stairs/seamless/platform{
+	dir = 8
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "bEr" = (
 /obj/structure/platform,
@@ -20050,10 +20184,13 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bEv" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairleftraildown"
+/obj/structure/cable,
+/obj/structure/stairs/seamless/platform{
+	dir = 4
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bEw" = (
 /turf/open/floor/plating/ground/desertdam/asphalt,
@@ -20181,6 +20318,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -20294,11 +20432,17 @@
 /area/desert_dam/building/hydroponics/hydroponics_loading)
 "bFd" = (
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "whitepurplecorner"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
+"bFe" = (
+/obj/effect/landmark/excavation_site_spawner,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_medical)
 "bFf" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
@@ -20379,6 +20523,7 @@
 "bFr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkredcorners2"
@@ -20445,6 +20590,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkyellowcorners2"
@@ -20597,6 +20743,7 @@
 	},
 /area/desert_dam/exterior/valley/valley_mining)
 "bGh" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "darkyellowcorners2"
@@ -20615,6 +20762,11 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/atmos_storage)
+"bGm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "bGn" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
 	icon_state = "cement12"
@@ -21075,14 +21227,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
-"bHR" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightrailup"
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement4"
-	},
-/area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "bHS" = (
 /obj/structure/desertdam/decals/road/stop{
 	dir = 8;
@@ -21262,6 +21406,7 @@
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "bIz" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "green"
 	},
@@ -21409,11 +21554,11 @@
 	},
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "bJi" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairdownrailleft"
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 8
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement3"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "bJj" = (
@@ -21471,6 +21616,15 @@
 	icon_state = "white"
 	},
 /area/desert_dam/interior/dam_interior/lobby)
+"bJs" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/carpet{
+	icon_state = "carpetside"
+	},
+/area/desert_dam/building/administration/meetingrooom)
 "bJt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21517,6 +21671,7 @@
 	},
 /area/desert_dam/interior/dam_interior/south_tunnel)
 "bJH" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "darkredcorners2"
@@ -21709,8 +21864,15 @@
 	icon_state = "cement4"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
+"bKu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "bKv" = (
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkyellow2"
@@ -22033,11 +22195,16 @@
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
 "bLE" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 6;
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
+"bLG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "bLK" = (
 /obj/structure/cable,
 /obj/structure/bed/chair/office/light{
@@ -22173,6 +22340,7 @@
 "bMj" = (
 /obj/structure/table/reinforced,
 /obj/item/radio,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -22430,6 +22598,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 5;
 	icon_state = "darkred2"
@@ -22612,6 +22781,7 @@
 /area/desert_dam/building/security/courtroom)
 "bNP" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/warden)
 "bNQ" = (
@@ -22760,6 +22930,10 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
+"bOy" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/security/marshals_office)
 "bOz" = (
 /obj/structure/stairs{
 	dir = 4
@@ -22887,17 +23061,17 @@
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bOZ" = (
-/obj/structure/stairs/railstairs,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement1"
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "bPa" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairuprailleft"
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement3"
+/obj/structure/stairs/seamless/platform/alt,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached2"
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bPb" = (
@@ -22977,6 +23151,12 @@
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/prison)
+"bPB" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitepurplecorner"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "bPC" = (
 /obj/structure/table,
 /obj/machinery/computer/security{
@@ -23119,11 +23299,11 @@
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bQa" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairuprailright"
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 1
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement1"
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached9"
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bQb" = (
@@ -23163,6 +23343,7 @@
 	start_charge = 0
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 5;
 	icon_state = "darkyellow2"
@@ -23174,6 +23355,14 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
+"bQh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/medical/break_room)
 "bQj" = (
 /obj/machinery/light{
 	dir = 4
@@ -23205,9 +23394,11 @@
 /area/desert_dam/building/warehouse/loading)
 "bQu" = (
 /obj/machinery/light,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/prison)
 "bQv" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "darkredcorners2"
@@ -23246,6 +23437,7 @@
 /area/desert_dam/building/security/armory)
 "bQA" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 9;
 	icon_state = "darkred2"
@@ -23336,6 +23528,7 @@
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_2"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
 	},
@@ -23453,6 +23646,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
 "bRr" = (
@@ -23468,6 +23662,10 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/river/riverside_central_north)
+"bRu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "bRv" = (
 /turf/open/floor{
 	dir = 5;
@@ -23476,6 +23674,7 @@
 /area/desert_dam/exterior/valley/valley_telecoms)
 "bRx" = (
 /obj/machinery/light,
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "dark2"
 	},
@@ -23539,6 +23738,7 @@
 /obj/structure/flora/desert/cactus{
 	icon_state = "cactus_8"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_telecoms)
 "bRH" = (
@@ -23771,6 +23971,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "darkredcorners2"
@@ -23995,6 +24196,7 @@
 	layer = 2.5
 	},
 /obj/effect/spawner/random/technology_scanner,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "darkyellow2"
 	},
@@ -24180,6 +24382,7 @@
 /area/desert_dam/interior/dam_interior/western_dam_cave)
 "bUj" = (
 /obj/structure/bed/chair/office/dark,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "sterile_white"
 	},
@@ -24560,6 +24763,7 @@
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/south_valley_dam)
 "bVF" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached17"
 	},
@@ -24639,23 +24843,21 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
 	icon_state = "cement4"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
 "bVS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/stairs/seamless/platform{
+	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightrailup"
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement4"
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/interior/dam_interior/west_tunnel)
 "bVT" = (
@@ -24711,18 +24913,13 @@
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bVX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/structure/stairs/seamless/platform,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/obj/structure/stairs/railstairs{
-	icon_state = "stairleftrailup"
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement4"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bVY" = (
@@ -24806,6 +25003,13 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"bWl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/north_tunnel)
 "bWm" = (
 /obj/structure/platform{
 	dir = 8
@@ -24893,6 +25097,12 @@
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
+"bWI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "bWJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -24954,11 +25164,11 @@
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "bWT" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightraildown"
+/obj/structure/stairs/seamless/platform{
+	dir = 8
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement12"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/interior/dam_interior/west_tunnel)
 "bWU" = (
@@ -24979,12 +25189,13 @@
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bWX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/stairs/railstairs{
-	icon_state = "stairleftraildown"
+/obj/structure/cable,
+/obj/structure/stairs/seamless/platform{
+	dir = 4
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement12"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bWY" = (
@@ -25002,6 +25213,7 @@
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_4"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/south_valley_dam)
 "bXd" = (
@@ -25655,6 +25867,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -25808,6 +26021,15 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/north_wing_hallway)
+"bZB" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/decal/sandytile,
+/obj/effect/decal/sandytile,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
+/area/desert_dam/interior/caves/temple)
 "bZC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
@@ -26030,6 +26252,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/execution_chamber)
 "cap" = (
@@ -26156,6 +26379,7 @@
 /area/desert_dam/building/security/prison)
 "caW" = (
 /obj/effect/decal/cleanable/generic,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/bar/backroom)
 "caX" = (
@@ -26210,6 +26434,7 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
 	icon_state = "cement4"
 	},
@@ -26287,6 +26512,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
+"cbp" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached2"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "cbq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -26333,6 +26565,7 @@
 	on = 1
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "sterile_white"
 	},
@@ -26400,6 +26633,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached1"
 	},
@@ -26508,6 +26742,7 @@
 "ccc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "grimy"
 	},
@@ -26586,12 +26821,14 @@
 	},
 /area/desert_dam/exterior/river/riverside_central_north)
 "ccs" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/building/security/prison)
 "cct" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "darkyellowcorners2"
 	},
@@ -26839,16 +27076,14 @@
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_medical)
 "cdy" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairuprailleft"
-	},
+/obj/structure/stairs/seamless/platform/alt,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached2"
 	},
 /area/desert_dam/exterior/valley/valley_medical)
 "cdz" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairuprailright"
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached9"
@@ -26930,17 +27165,19 @@
 	},
 /area/desert_dam/building/security/prison)
 "cdO" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairdownrailleft"
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 8
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement3"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/interior/dam_interior/west_tunnel)
 "cdP" = (
-/obj/structure/stairs/railstairs,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement1"
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/interior/dam_interior/west_tunnel)
 "cdQ" = (
@@ -27088,14 +27325,6 @@
 	dir = 8
 	},
 /area/desert_dam/building/medical/chemistry)
-"cex" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairleftrailup"
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached4"
-	},
-/area/desert_dam/exterior/valley/valley_telecoms)
 "cez" = (
 /obj/structure/platform,
 /turf/open/ground/coast/corner{
@@ -27196,6 +27425,10 @@
 	icon_state = "cement_sunbleached17"
 	},
 /area/desert_dam/exterior/valley/valley_medical)
+"cfd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "cfe" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock{
 	dir = 4
@@ -27235,14 +27468,6 @@
 	icon_state = "dark"
 	},
 /area/desert_dam/interior/dam_interior/office)
-"cfp" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairleftraildown"
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
-	},
-/area/desert_dam/exterior/valley/valley_telecoms)
 "cfr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
@@ -27499,6 +27724,13 @@
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+"cgX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "cgY" = (
 /turf/open/floor/plating{
 	dir = 10;
@@ -27506,6 +27738,7 @@
 	},
 /area/desert_dam/building/substation/west)
 "cgZ" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating{
 	icon_state = "warnplate"
 	},
@@ -27599,6 +27832,7 @@
 /area/desert_dam/exterior/valley/valley_telecoms)
 "chw" = (
 /obj/structure/platform_decoration,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_telecoms)
 "chz" = (
@@ -27644,6 +27878,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/desert_dam/building/substation/west)
 "chS" = (
@@ -27779,6 +28014,7 @@
 /obj/structure/desertdam/decals/loose_sand_overlay{
 	dir = 6
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/south_tunnel)
 "cit" = (
@@ -27816,6 +28052,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/substation/west)
 "ciE" = (
@@ -28084,6 +28321,12 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/substation/west)
+"cjJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/lobby)
 "cjK" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -28465,6 +28708,7 @@
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "ckW" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	dir = 8;
 	icon_state = "whiteyellow"
@@ -28523,6 +28767,7 @@
 	},
 /area/desert_dam/exterior/river/riverside_south)
 "clj" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/desert_dam/building/warehouse/breakroom)
 "clk" = (
@@ -28714,17 +28959,17 @@
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "clV" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/structure/stairs/railstairs{
-	icon_state = "stairdownrailleft"
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 8
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement3"
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "clY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
 	icon_state = "cement1"
 	},
@@ -28970,6 +29215,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "sterile_white"
@@ -29091,6 +29337,12 @@
 	icon_state = "whitepurple"
 	},
 /area/desert_dam/building/medical/chemistry)
+"cnI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_west_entrance)
 "cnJ" = (
 /obj/machinery/smartfridge/chemistry,
 /turf/closed/wall,
@@ -29115,6 +29367,7 @@
 /obj/structure/toilet{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "sterile_white"
@@ -29213,6 +29466,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -29334,6 +29588,7 @@
 	},
 /area/desert_dam/building/medical/chemistry)
 "coP" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "whitepurplecorner"
 	},
@@ -29380,6 +29635,7 @@
 /area/desert_dam/building/medical/break_room)
 "coV" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -29403,6 +29659,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_civilian)
+"cpa" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/security/prison)
 "cpc" = (
 /obj/structure/largecrate,
 /turf/open/floor/prison{
@@ -29464,6 +29726,7 @@
 /area/desert_dam/building/warehouse/breakroom)
 "cpq" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	dir = 8;
 	icon_state = "carpet14-10"
@@ -29479,6 +29742,7 @@
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_3"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/north_valley_dam)
 "cpv" = (
@@ -29733,6 +29997,7 @@
 "cqu" = (
 /obj/effect/landmark/start/job/survivor,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -29961,6 +30226,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "whitegreen"
@@ -30006,6 +30272,7 @@
 /area/desert_dam/building/medical/lobby)
 "crI" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "darkyellowcorners2"
 	},
@@ -30218,10 +30485,6 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/building/telecommunication)
-"csu" = (
-/obj/structure/stairs,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
-/area/desert_dam/exterior/valley/valley_telecoms)
 "csw" = (
 /obj/machinery/computer/telecomms/monitor{
 	req_one_access = null
@@ -30311,6 +30574,7 @@
 	},
 /area/desert_dam/building/medical/west_wing_hallway)
 "csQ" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "whitegreencorner"
 	},
@@ -30406,6 +30670,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
 	icon_state = "cement14"
 	},
@@ -30483,12 +30748,14 @@
 "ctt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
 	icon_state = "cement14"
 	},
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "ctu" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
 	icon_state = "cement15"
 	},
@@ -30527,6 +30794,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greencorner"
@@ -30677,6 +30945,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
 	icon_state = "cement4"
 	},
@@ -30805,6 +31074,7 @@
 /turf/open/ground/coast/corner,
 /area/desert_dam/exterior/river/riverside_south)
 "cuV" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "whitegreencorner"
@@ -30853,6 +31123,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean2"
@@ -30891,6 +31162,7 @@
 /area/desert_dam/building/medical/east_wing_hallway)
 "cvh" = (
 /obj/structure/closet/secure_closet/medical_doctor,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/medical/CMO)
 "cvi" = (
@@ -30914,6 +31186,15 @@
 /obj/machinery/computer/med_data,
 /turf/open/floor/wood,
 /area/desert_dam/building/medical/CMO)
+"cvm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/dorms/hallway_westwing)
 "cvn" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached13"
@@ -30940,6 +31221,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/bar/bar)
 "cvt" = (
@@ -30981,14 +31263,6 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/building/telecommunication)
-"cvD" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairdownrailleft"
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
-	},
-/area/desert_dam/exterior/valley/valley_telecoms)
 "cvE" = (
 /obj/structure/table,
 /obj/item/encryptionkey,
@@ -31442,6 +31716,10 @@
 	icon_state = "delivery"
 	},
 /area/desert_dam/interior/dam_interior/south_tunnel)
+"cxf" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/lab_northeast/east_lab_RND)
 "cxg" = (
 /obj/item/weapon/gun/shotgun/double,
 /turf/open/floor/cult,
@@ -31622,6 +31900,7 @@
 /obj/structure/platform{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 4
 	},
@@ -31720,6 +31999,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "sterile_white"
@@ -31768,6 +32048,7 @@
 	},
 /area/desert_dam/building/medical/surgery_room_two)
 "cym" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/red/whitered{
 	dir = 1
 	},
@@ -31829,6 +32110,7 @@
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_11"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/bar_valley_dam)
 "cyP" = (
@@ -31894,6 +32176,7 @@
 	},
 /area/desert_dam/building/medical/surgery_room_one)
 "cyZ" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "sterile_white"
@@ -31943,10 +32226,17 @@
 	icon_state = "asteroidfloor"
 	},
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
+"czm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "czo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -32385,8 +32675,8 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "cAQ" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightrailup"
+/obj/structure/stairs/seamless/platform{
+	dir = 1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached4"
@@ -32438,6 +32728,7 @@
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "cBb" = (
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached17"
 	},
@@ -32459,6 +32750,7 @@
 	},
 /obj/machinery/light,
 /obj/structure/flora/pottedplant,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "whitegreencorner"
@@ -32477,6 +32769,7 @@
 /obj/effect/decal/medical_decals/triage/edge{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "whitegreen"
@@ -32492,6 +32785,7 @@
 /obj/effect/decal/medical_decals{
 	icon_state = "triagedecalbottom"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "whitegreencorner"
@@ -32522,6 +32816,7 @@
 /obj/effect/decal/medical_decals{
 	icon_state = "triagedecalbottom"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "whitegreen"
@@ -32550,6 +32845,7 @@
 /area/desert_dam/building/medical/surgery_room_one)
 "cBo" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "darkyellow2"
@@ -32671,6 +32967,7 @@
 /obj/structure/desertdam/decals/loose_sand_overlay{
 	dir = 10
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
 	icon_state = "cement4"
 	},
@@ -32941,13 +33238,19 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_civilian)
+"cCK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 6
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "cCL" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_cargo)
 "cCO" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightraildown"
+/obj/structure/stairs/seamless/platform{
+	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached12"
@@ -33048,6 +33351,7 @@
 /area/desert_dam/building/medical/emergency_room)
 "cDk" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/CE_office)
 "cDl" = (
@@ -33349,6 +33653,7 @@
 /obj/effect/decal/medical_decals{
 	icon_state = "cryomid"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 9;
 	icon_state = "whitegreen"
@@ -33375,6 +33680,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 5;
 	icon_state = "whitegreen"
@@ -33432,6 +33738,7 @@
 	},
 /area/desert_dam/building/medical/treatment_room)
 "cEE" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "whitegreencorner"
@@ -33462,10 +33769,9 @@
 /area/desert_dam/building/medical/east_wing_hallway)
 "cEI" = (
 /obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = -16;
 	start_charge = 0
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "whitegreen"
@@ -33485,6 +33791,7 @@
 /area/desert_dam/building/medical/east_wing_hallway)
 "cEN" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "whitegreen"
@@ -33526,6 +33833,7 @@
 /obj/structure/flora/desert/cactus/multiple{
 	icon_state = "cacti_9"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_civilian)
 "cEX" = (
@@ -34165,6 +34473,7 @@
 	},
 /area/desert_dam/building/medical/emergency_room)
 "cGX" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "whitegreen"
@@ -34264,6 +34573,7 @@
 /obj/structure/flora/desert/grass/heavy{
 	icon_state = "heavygrass_3"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/valley/valley_cargo)
 "cHn" = (
@@ -34324,6 +34634,7 @@
 /obj/effect/decal/medical_decals{
 	icon_state = "docdecal4"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "white"
 	},
@@ -34467,6 +34778,7 @@
 /obj/structure/flora/desert/grass/heavy{
 	icon_state = "heavygrass_5"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_telecoms)
 "cIe" = (
@@ -35061,6 +35373,7 @@
 /obj/structure/bed,
 /obj/effect/landmark/corpsespawner/prisoner,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/execution_chamber)
 "cKl" = (
@@ -35519,17 +35832,19 @@
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
 "cMN" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairdownrailleft"
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 8
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/valley/valley_medical)
 "cMO" = (
-/obj/structure/stairs/railstairs,
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 4
+	},
 /turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
+	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/valley/valley_medical)
 "cMP" = (
@@ -36033,6 +36348,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	dir = 8;
 	icon_state = "carpet6-2"
@@ -36227,6 +36543,7 @@
 /area/desert_dam/building/church)
 "cPj" = (
 /obj/machinery/light,
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "cult"
 	},
@@ -36551,6 +36868,7 @@
 "cQj" = (
 /obj/structure/toilet,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "sterile_white"
 	},
@@ -36604,6 +36922,12 @@
 "cQx" = (
 /turf/closed/wall/wood,
 /area/desert_dam/building/bar/bar_restroom)
+"cQy" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "cQz" = (
 /obj/machinery/door/airlock/mainship/generic{
 	name = "\improper Toilet Unit"
@@ -36771,6 +37095,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
+"cRe" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "cRg" = (
 /turf/open/floor/prison{
 	dir = 8;
@@ -36790,6 +37120,7 @@
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_workshop)
 "cRk" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkyellow2"
@@ -37085,6 +37416,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "freezerfloor"
 	},
@@ -37163,12 +37495,9 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_cargo)
 "cTd" = (
-/obj/effect/landmark/xeno_resin_wall,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached4"
-	},
-/area/desert_dam/exterior/valley/valley_crashsite)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "cTh" = (
 /obj/structure/flora/desert/grass/heavy{
 	icon_state = "heavygrass_10"
@@ -37619,6 +37948,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -37667,6 +37997,12 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
 /area/desert_dam/building/hydroponics/hydroponics_breakroom)
+"cVW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitepurplecorner"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "cVX" = (
 /obj/structure/platform{
 	dir = 1
@@ -37807,6 +38143,13 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/valley_mining)
+"cWQ" = (
+/obj/machinery/landinglight/ds2/delaythree,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "cWW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -37863,22 +38206,6 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_cargo)
-"cXn" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairuprailleft"
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/valley/valley_hydro)
-"cXo" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairuprailright"
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/valley/valley_hydro)
 "cXt" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -37927,6 +38254,7 @@
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "cXI" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "darkbrowncorners2"
@@ -37945,6 +38273,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "darkbrowncorners2"
 	},
@@ -38284,6 +38613,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "cZQ" = (
@@ -38311,6 +38641,12 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_northwing)
+"dab" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/exterior/valley/valley_medical_south)
 "dak" = (
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached20"
@@ -38418,6 +38754,15 @@
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/cafeteria/cold_room)
+"daS" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/engine_west_wing)
 "daT" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal1"
@@ -38598,6 +38943,7 @@
 "dbB" = (
 /obj/structure/table/reinforced,
 /obj/item/tool/kitchen/knife/butcher,
+/obj/structure/closet/walllocker/hydrant/extinguisher,
 /turf/open/floor/prison{
 	icon_state = "sterile_white"
 	},
@@ -38712,10 +39058,28 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
+"dbR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "cell_stripe"
+	},
+/area/desert_dam/building/warehouse/warehouse)
+"dbS" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "dbT" = (
 /obj/item/stool,
 /turf/open/floor/plating,
 /area/desert_dam/building/warehouse/loading)
+"dbV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "dbY" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
@@ -38787,6 +39151,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "yellowcorner"
@@ -38986,6 +39351,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "sterile_white"
 	},
@@ -39316,6 +39682,7 @@
 /turf/open/floor/prison,
 /area/desert_dam/building/hydroponics/hydroponics)
 "dey" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "vault"
@@ -39332,6 +39699,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "sterile_white"
 	},
@@ -39392,6 +39760,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_mining)
 "deP" = (
@@ -39473,6 +39842,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/warehouse/warehouse)
 "dfa" = (
@@ -40050,11 +40420,19 @@
 /area/desert_dam/building/medical/emergency_room)
 "dif" = (
 /obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating{
 	dir = 1;
 	icon_state = "asteroidfloor"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"dig" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "dil" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -40093,6 +40471,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "yellow"
 	},
@@ -40110,6 +40489,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "yellowcorner"
 	},
@@ -40247,6 +40627,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/cafeteria/loading)
 "djC" = (
@@ -40268,6 +40649,7 @@
 /area/desert_dam/building/hydroponics/hydroponics_storage)
 "djW" = (
 /obj/machinery/light,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/hydroponics/hydroponics_storage)
 "djY" = (
@@ -40299,16 +40681,14 @@
 	},
 /area/desert_dam/building/hydroponics/hydroponics_loading)
 "dkb" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairuprailleft"
-	},
+/obj/structure/stairs/seamless/platform/alt,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached2"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
 "dkc" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairuprailright"
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached9"
@@ -40413,6 +40793,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_civilian)
 "dko" = (
@@ -40511,6 +40892,13 @@
 	icon_state = "cement_sunbleached2"
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
+"dlr" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal2"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/south_valley_dam)
 "dlu" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -40586,11 +40974,12 @@
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
 "dlP" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/stairs/railstairs,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement{
-	icon_state = "cement1"
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "dlQ" = (
@@ -40617,6 +41006,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "sterile_white"
 	},
@@ -40848,6 +41238,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/water_treatment_one/hallway)
 "dpx" = (
@@ -40973,6 +41364,14 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+"dqc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/warehouse/loading)
 "dqd" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
@@ -41031,6 +41430,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "sterile_white"
 	},
@@ -41055,9 +41455,7 @@
 /area/desert_dam/building/water_treatment_one/hallway)
 "dqR" = (
 /obj/structure/flora/pottedplant,
-/obj/structure/closet/walllocker/hydrant{
-	pixel_y = 32
-	},
+/obj/structure/closet/walllocker/hydrant,
 /turf/open/floor/prison,
 /area/desert_dam/building/water_treatment_one/lobby)
 "dqS" = (
@@ -41278,6 +41676,7 @@
 /obj/structure/platform_decoration{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt{
 	dir = 8
 	},
@@ -41298,6 +41697,17 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
+"dth" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/cafeteria/loading)
 "dto" = (
 /obj/structure/table,
 /turf/open/floor/prison,
@@ -41590,6 +42000,7 @@
 /obj/structure/desertdam/decals/loose_sand_overlay{
 	dir = 9
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "tile"
 	},
@@ -41697,6 +42108,14 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/dorms/restroom)
+"dwt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "dww" = (
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 6
@@ -41853,6 +42272,7 @@
 "dxM" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/cheesewedge,
+/obj/structure/closet/walllocker/hydrant/extinguisher,
 /turf/open/floor/prison{
 	icon_state = "sterile_white"
 	},
@@ -41864,6 +42284,13 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
+"dxQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/dorms/hallway_westwing)
 "dxR" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/donut,
@@ -42129,6 +42556,12 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_northwing)
+"dzt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "dzx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -42247,6 +42680,12 @@
 	icon_state = "white"
 	},
 /area/desert_dam/building/water_treatment_one/breakroom)
+"dAy" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "dAA" = (
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/filtration_a)
@@ -42293,6 +42732,7 @@
 /area/desert_dam/building/dorms/hallway_northwing)
 "dAJ" = (
 /obj/machinery/light,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "green"
 	},
@@ -42461,6 +42901,14 @@
 	icon_state = "blue"
 	},
 /area/desert_dam/building/dorms/pool)
+"dBF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/administration/hallway)
 "dBJ" = (
 /obj/machinery/computer/pod/old{
 	name = "Personal Computer"
@@ -42506,6 +42954,7 @@
 	dir = 6
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/disposals)
 "dBT" = (
@@ -42545,6 +42994,7 @@
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_westwing)
 "dCc" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "green"
@@ -42679,6 +43129,7 @@
 	},
 /area/desert_dam/building/water_treatment_one/breakroom)
 "dCK" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	dir = 6;
 	icon_state = "whiteyellow"
@@ -42767,6 +43218,10 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/emergency_room)
+"dDs" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/interior/caves/central_caves)
 "dDv" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/welding,
@@ -42851,6 +43306,7 @@
 /obj/structure/toilet{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "freezerfloor"
 	},
@@ -42911,6 +43367,7 @@
 /obj/item/reagent_containers/food/snacks/chips,
 /obj/item/reagent_containers/food/snacks/donut,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "kitchen"
@@ -43111,6 +43568,12 @@
 	icon_state = "kitchen"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
+"dGr" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
+	},
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "dGv" = (
 /obj/structure/platform,
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
@@ -43216,6 +43679,7 @@
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/candy,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "kitchen"
@@ -43347,6 +43811,11 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/warehouse/breakroom)
+"dIb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/engine_west_wing)
 "dIj" = (
 /turf/open/floor/plating{
 	dir = 1;
@@ -43421,11 +43890,11 @@
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
 "dIC" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightrailup"
+/obj/structure/stairs/seamless/platform{
+	dir = 1
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "cement_sunbleached9"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
 "dID" = (
@@ -43554,11 +44023,11 @@
 	},
 /area/desert_dam/building/dorms/pool)
 "dJd" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightraildown"
+/obj/structure/stairs/seamless/platform{
+	dir = 8
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "cement_sunbleached15"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
 "dJe" = (
@@ -43602,6 +44071,11 @@
 	icon_state = "blue"
 	},
 /area/desert_dam/building/dorms/pool)
+"dJp" = (
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "dJA" = (
 /obj/structure/platform{
 	dir = 8
@@ -43660,6 +44134,7 @@
 /obj/effect/decal/cleanable/blood{
 	icon_state = "gib6"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2"
 	},
@@ -43709,6 +44184,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/administration/meetingrooom)
 "dKb" = (
@@ -43741,6 +44217,7 @@
 /obj/effect/decal/cleanable/blood{
 	layer = 3
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/administration/overseer_office)
 "dKf" = (
@@ -43943,6 +44420,7 @@
 /area/desert_dam/exterior/river/riverside_east)
 "dLn" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "freezerfloor"
 	},
@@ -44120,6 +44598,7 @@
 /area/desert_dam/building/water_treatment_one/lobby)
 "dNk" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "whiteyellowcorner"
 	},
@@ -44195,7 +44674,9 @@
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
 "dNT" = (
-/turf/closed/wall/mineral/sandstone,
+/turf/closed/wall/r_wall/chigusa{
+	name = "reinforced metal wall"
+	},
 /area/desert_dam/exterior/rock)
 "dNU" = (
 /obj/structure/disposalpipe/segment,
@@ -44223,6 +44704,7 @@
 /area/desert_dam/building/medical/west_wing_hallway)
 "dNX" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/water_treatment_one/control_room)
 "dNY" = (
@@ -44274,6 +44756,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/medical/break_room)
 "dOj" = (
@@ -44393,6 +44876,7 @@
 	icon_state = "gib6"
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "sterile_white"
@@ -44432,6 +44916,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/medical/break_room)
 "dOG" = (
@@ -44520,6 +45005,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/medical/break_room)
 "dOW" = (
@@ -44532,6 +45018,7 @@
 "dOX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/medical/break_room)
 "dOY" = (
@@ -44552,6 +45039,7 @@
 /area/desert_dam/building/medical/chemistry)
 "dPb" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean2"
@@ -44716,6 +45204,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "whitegreen"
@@ -44909,6 +45398,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "whitegreen"
@@ -44992,6 +45482,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "whitegreen"
@@ -45057,6 +45548,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "whitegreen"
@@ -45130,6 +45622,7 @@
 /area/desert_dam/building/medical/surgery_room_one)
 "dQJ" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 9;
 	icon_state = "whitegreen"
@@ -45205,6 +45698,18 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/emergency_room)
+"dQW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "dQX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
@@ -45455,6 +45960,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "whitegreen"
@@ -45579,6 +46085,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "whitegreenfull"
@@ -45799,6 +46306,7 @@
 /area/desert_dam/building/medical/virology_wing)
 "dSD" = (
 /obj/item/trash/semki,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "whitegreen"
@@ -45842,6 +46350,7 @@
 "dSS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "whitegreen"
@@ -45882,6 +46391,7 @@
 /area/desert_dam/building/medical/virology_isolation)
 "dSY" = (
 /obj/item/clothing/glasses/meson,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "whitegreen"
@@ -46036,6 +46546,7 @@
 	dir = 1
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "freezerfloor"
 	},
@@ -46438,6 +46949,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached18"
 	},
@@ -46637,6 +47149,10 @@
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/prison,
 /area/desert_dam/building/water_treatment_one/control_room)
+"dVQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/north_valley_dam)
 "dVS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46757,6 +47273,7 @@
 	dir = 1;
 	on = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/cafeteria/loading)
 "dWm" = (
@@ -46938,6 +47455,7 @@
 /area/desert_dam/building/cafeteria/cafeteria)
 "dWT" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached18"
 	},
@@ -47253,6 +47771,11 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/dorms/restroom)
+"dYA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "dYC" = (
 /obj/structure/table,
 /obj/item/radio,
@@ -47292,6 +47815,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "green"
@@ -47383,6 +47907,13 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/dorms/pool)
+"dZH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached10"
+	},
+/area/desert_dam/exterior/valley/valley_medical_south)
 "dZL" = (
 /turf/open/ground/river{
 	name = "pool"
@@ -47613,6 +48144,7 @@
 /area/desert_dam/building/dorms/pool)
 "ebj" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "green"
 	},
@@ -47685,6 +48217,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/water_treatment_one/control_room)
 "ebx" = (
@@ -47765,6 +48298,7 @@
 /area/desert_dam/building/water_treatment_one/breakroom)
 "ebM" = (
 /obj/machinery/light,
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "freezerfloor"
 	},
@@ -47926,6 +48460,7 @@
 	dir = 8;
 	on = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -47934,6 +48469,7 @@
 "ecw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -47995,6 +48531,12 @@
 	icon_state = "cell_stripe"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
+"edk" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
+	},
+/area/desert_dam/interior/caves/central_caves)
 "edo" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -48014,6 +48556,14 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/administration/hallway)
+"edH" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_one/hallway)
 "edJ" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "\improper Water Treatment Foyer"
@@ -48113,6 +48663,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_one/hallway)
+"edW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "eed" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 2;
@@ -48124,6 +48680,13 @@
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/water_treatment_one/breakroom)
+"een" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_cargo)
 "eeo" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -48357,6 +48920,19 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"egT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
+"eha" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal2"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "ehg" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal3"
@@ -48376,6 +48952,15 @@
 	dir = 10
 	},
 /area/desert_dam/exterior/valley/valley_medical)
+"ehW" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "eiI" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison{
@@ -48383,6 +48968,11 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_storage)
+"eiK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "eiP" = (
 /obj/effect/ai_node,
 /turf/open/ground/jungle{
@@ -48416,6 +49006,11 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
+"ejV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/area/desert_dam/exterior/valley/valley_telecoms)
 "ekf" = (
 /obj/structure/lattice{
 	layer = 2.9
@@ -48443,6 +49038,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/interior/caves/temple)
+"ekF" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal3"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "ekH" = (
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached9"
@@ -48475,6 +49077,13 @@
 	icon_state = "bluecorner"
 	},
 /area/desert_dam/building/administration/hallway)
+"elx" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal1"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "elz" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -48483,6 +49092,25 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/administration/hallway)
+"elD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "freezerfloor"
+	},
+/area/desert_dam/building/water_treatment_one/breakroom)
+"elG" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/lab_northwest/west_lab_xenoflora)
+"elW" = (
+/obj/structure/flora/tree/joshua,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_cargo)
 "emv" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -48506,14 +49134,43 @@
 /area/desert_dam/building/medical/east_wing_hallway)
 "emZ" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/valley/valley_cargo)
+"eni" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkredcorners2"
+	},
+/area/desert_dam/building/security/deathrow)
 "enk" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 6
 	},
 /area/desert_dam/interior/caves/central_caves)
+"enE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/building/substation/northeast)
+"eoa" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal7"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/south_valley_dam)
+"eou" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
+"epq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "dark2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_west_entrance)
 "epG" = (
 /obj/structure/table,
 /turf/open/floor/prison{
@@ -48529,11 +49186,34 @@
 	dir = 5
 	},
 /area/desert_dam/interior/east_engineering)
+"epQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "eqo" = (
-/obj/effect/landmark/xeno_resin_wall,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_crashsite)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkpurple2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
+"eqG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
+"erw" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt{
+	dir = 1
+	},
+/area/desert_dam/exterior/river/riverside_central_north)
 "erz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48638,6 +49318,10 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/east_caves)
+"eva" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/north_valley_dam)
 "evd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -48649,6 +49333,7 @@
 "evf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "whitegreenfull"
@@ -48674,6 +49359,11 @@
 /obj/vehicle/train/cargo/trolley,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"ewA" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/substation/northeast)
 "ewD" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/valley/valley_cargo)
@@ -48693,6 +49383,13 @@
 	icon_state = "cement_sunbleached18"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"exv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_one/garage)
 "exD" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -48724,6 +49421,7 @@
 /area/desert_dam/building/medical/break_room)
 "eyB" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 4
 	},
@@ -48750,6 +49448,13 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/desert_dam/building/bar/bar)
+"ezy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/bar/backroom)
 "ezI" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal1"
@@ -48814,6 +49519,13 @@
 	icon_state = "cement_sunbleached11"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
+"eDH" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached13"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
 "eDL" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_8"
@@ -48840,6 +49552,12 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_medical_south)
+"eEl" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "eEp" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -48851,6 +49569,17 @@
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"eFm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
+"eFC" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal2"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_mining)
 "eFM" = (
 /obj/structure/platform{
 	dir = 1
@@ -48867,6 +49596,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2"
 	},
@@ -48922,6 +49652,19 @@
 	dir = 4
 	},
 /area/desert_dam/interior/caves/east_caves)
+"eIJ" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "eIL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -48936,6 +49679,12 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_south)
+"eJp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/cafeteria/loading)
 "eJM" = (
 /obj/machinery/landinglight/ds2,
 /obj/effect/ai_node,
@@ -48943,6 +49692,13 @@
 	icon_state = "cement_sunbleached2"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"eJS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/building/medical/garage)
 "eKa" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -48976,6 +49732,7 @@
 /area/desert_dam/exterior/valley/valley_hydro)
 "eLo" = (
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	dir = 8;
 	icon_state = "whiteyellow"
@@ -49073,10 +49830,23 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached13"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
+"ePp" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"ePr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "ePQ" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -49122,6 +49892,10 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"eTw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/medical/break_room)
 "eUi" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -49149,6 +49923,20 @@
 /obj/effect/ai_node,
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/valley/valley_labs)
+"eUJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "eUR" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 2;
@@ -49174,11 +49962,21 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_two/equipment)
+"eWm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "eWG" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached4"
 	},
+/area/desert_dam/exterior/valley/valley_telecoms)
+"eWZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_telecoms)
 "eXb" = (
 /obj/effect/decal/warning_stripes{
@@ -49244,10 +50042,35 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
+"eZO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
+"eZX" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/landing/landing_pad_three_external)
+"faP" = (
+/obj/structure/flora/desert/cactus/multiple{
+	icon_state = "cacti_10"
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "fbp" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/cafeteria/loading)
+"fbr" = (
+/obj/structure/flora/desert/grass,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "fbt" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -49261,6 +50084,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"fbO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 6;
+	icon_state = "darkpurple2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "fcj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -49288,6 +50118,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/bcircuit,
 /area/desert_dam/interior/dam_interior/tech_storage)
+"fcX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 1
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "fdf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/mono,
@@ -49298,11 +50134,24 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"fdD" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal2"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "fdL" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner2{
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_east)
+"feq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/dorms/restroom)
 "fev" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -49312,6 +50161,12 @@
 	icon_state = "white"
 	},
 /area/desert_dam/building/water_treatment_one/breakroom)
+"feO" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "feS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -49328,6 +50183,16 @@
 	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"feX" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/hydroponics/hydroponics_breakroom)
 "ffh" = (
 /obj/machinery/door/airlock/mainship/security/glass{
 	dir = 1;
@@ -49339,6 +50204,10 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/security/office)
+"ffq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "ffA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -49354,6 +50223,10 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/building/substation/northeast)
+"ffF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "fgb" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -49376,7 +50249,11 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/ground/mars/random/cave,
+/obj/effect/decal/sandytile,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
 /area/desert_dam/interior/caves/temple)
 "fgN" = (
 /obj/structure/table/mainship,
@@ -49406,12 +50283,25 @@
 	icon_state = "whiteblue"
 	},
 /area/desert_dam/building/medical/medsecure)
+"fhI" = (
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "fif" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal1"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"fir" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/dorms/restroom)
 "fiw" = (
 /obj/structure/flora/rock/pile/alt2,
 /obj/docking_port/stationary/crashmode,
@@ -49436,6 +50326,19 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"fkj" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/desert_dam/interior/dam_interior/lobby)
+"fkp" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
+	},
+/area/desert_dam/building/security/evidence)
 "fkJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
@@ -49443,6 +50346,13 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/building/medical/virology_isolation)
+"fkY" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal1"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "flu" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -49454,6 +50364,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/tech_storage)
+"fmn" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal1"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/interior/dam_interior/south_tunnel)
 "fmt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -49464,12 +50381,24 @@
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/water_treatment_two/equipment)
+"fmC" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "fnb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached11"
 	},
 /area/desert_dam/exterior/valley/valley_medical)
+"fnp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
 "fof" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -49506,6 +50435,13 @@
 	icon_state = "cement_sunbleached9"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"fpw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating{
+	dir = 9;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "fpJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49529,6 +50465,10 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/security/staffroom)
+"fqn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "fqI" = (
 /obj/structure/table,
 /turf/open/floor{
@@ -49564,14 +50504,27 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
+"fsE" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "fsW" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+"fsX" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "fsZ" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison,
@@ -49585,6 +50538,15 @@
 	icon_state = "cement_sunbleached18"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"fte" = (
+/obj/machinery/landinglight/ds2{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "ftp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -49660,6 +50622,10 @@
 	dir = 9
 	},
 /area/desert_dam/interior/caves/temple)
+"fwI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/interior/lab_northeast/east_lab_maintenence)
 "fwJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -49701,6 +50667,13 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
+"fxV" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_3"
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "fxY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -49710,6 +50683,13 @@
 	icon_state = "whitegreencorner"
 	},
 /area/desert_dam/building/medical/west_wing_hallway)
+"fyo" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/lab_northwest/west_lab_xenoflora)
 "fyq" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
@@ -49732,6 +50712,7 @@
 /area/desert_dam/interior/lab_northeast/east_lab_RND)
 "fzp" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "sterile_white"
 	},
@@ -49758,6 +50739,17 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/tradeship)
+"fAr" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/interior/caves/central_caves)
+"fAx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "fBX" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison{
@@ -49771,6 +50763,7 @@
 	dir = 5
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "freezerfloor"
 	},
@@ -49847,12 +50840,34 @@
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"fDo" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_labs)
+"fDw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement13"
+	},
+/area/desert_dam/interior/dam_interior/south_tunnel)
 "fDL" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal2"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
+"fDS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/building/cafeteria/backroom)
+"fDV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/cult,
+/area/desert_dam/building/bar/bar)
 "fEf" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -49864,6 +50879,11 @@
 	dir = 6
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"fEO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/bright_clean,
+/area/desert_dam/interior/east_engineering)
 "fEQ" = (
 /obj/structure/desertdam/decals/road/stop{
 	dir = 4;
@@ -49881,6 +50901,12 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/surgery_room_one)
+"fFU" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/dorms/hallway_northwing)
 "fFY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -49938,6 +50964,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_two/equipment)
+"fHH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 4
+	},
+/area/desert_dam/interior/dam_interior/western_dam_cave)
 "fHT" = (
 /obj/structure/flora/rock/alt2{
 	name = "rock"
@@ -49977,6 +51009,13 @@
 	icon_state = "cement_sunbleached13"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"fJM" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal1"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_mining)
 "fKd" = (
 /obj/structure/cable,
 /turf/closed/wall{
@@ -50006,6 +51045,10 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/security/northern_hallway)
+"fKq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/bar/backroom)
 "fKt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/desertdam/decals/road/edge{
@@ -50063,6 +51106,12 @@
 "fMJ" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/north_tunnel_entrance)
+"fOT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached11"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "fOW" = (
 /obj/structure/cable,
 /turf/open/floor/prison,
@@ -50100,6 +51149,13 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
+"fPr" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkbrown2"
+	},
+/area/desert_dam/building/warehouse/loading)
 "fPt" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -50115,6 +51171,10 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics)
+"fPF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "fQD" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison,
@@ -50138,8 +51198,23 @@
 	dir = 6
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"fQY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/valley_labs)
+"fRs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "fRy" = (
-/obj/structure/stairs/railstairs,
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 4
+	},
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached15"
 	},
@@ -50157,6 +51232,13 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"fRR" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull"
+	},
+/area/desert_dam/building/water_treatment_one/floodgate_control)
 "fRX" = (
 /obj/effect/landmark/weed_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -50196,10 +51278,15 @@
 /area/desert_dam/exterior/valley/valley_mining)
 "fSH" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"fSM" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "fSP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50212,6 +51299,12 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
+"fSV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/warehouse/breakroom)
 "fTa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/shower{
@@ -50251,6 +51344,13 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"fUB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
 "fUE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -50280,6 +51380,18 @@
 	icon_state = "dark"
 	},
 /area/desert_dam/building/church)
+"fVX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
+"fVZ" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_cargo)
 "fWm" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -50383,6 +51495,10 @@
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
 /area/desert_dam/building/administration/hallway)
+"gaj" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/hydroponics/hydroponics_storage)
 "gak" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison{
@@ -50398,14 +51514,32 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics)
+"gau" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_security_armory)
 "gaw" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/lab_northeast/east_lab_RND)
+"gbl" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "gbQ" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"gbS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "gbX" = (
 /obj/machinery/light,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -50429,6 +51563,11 @@
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/cafeteria/backroom)
+"gcn" = (
+/obj/structure/flora/tree/joshua,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "gcG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/stationary/crashmode,
@@ -50457,6 +51596,15 @@
 	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"get" = (
+/obj/structure/table,
+/obj/item/storage/box/lightstick,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "gez" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -50464,6 +51612,10 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
+"geT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/administration/overseer_office)
 "geZ" = (
 /obj/structure/platform_decoration{
 	dir = 4
@@ -50494,6 +51646,12 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/cafeteria/loading)
+"ggq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "ggy" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal3"
@@ -50511,6 +51669,17 @@
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_excavation)
+"ggW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/north_tunnel)
+"ghD" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal2"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/river/riverside_east)
 "ghH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -50536,6 +51705,10 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_security_armory)
+"giq" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/interior/caves/central_caves)
 "giL" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/prison,
@@ -50615,6 +51788,14 @@
 	icon_state = "whiteblue"
 	},
 /area/desert_dam/building/medical/medsecure)
+"gli" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
 "glx" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -50627,6 +51808,19 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"gmE" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"gmL" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_west_entrance)
 "gmZ" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	dir = 2;
@@ -50652,6 +51846,7 @@
 	dir = 8;
 	on = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "freezerfloor"
 	},
@@ -50666,14 +51861,34 @@
 "goO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "yellowcorner"
 	},
 /area/desert_dam/building/hydroponics/hydroponics)
+"goQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/desert_dam/exterior/valley/valley_cargo)
 "goZ" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/valley/valley_hydro)
+"gpr" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
+"gpu" = (
+/obj/machinery/light,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "red"
+	},
+/area/desert_dam/building/security/northern_hallway)
 "gpP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -50688,6 +51903,12 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_cargo)
+"gqS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
 "grm" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -50705,6 +51926,15 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
+"grC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/lobby)
 "grJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -50731,6 +51961,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"gta" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/interior/caves/central_caves)
+"gtF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitepurple"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "guw" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/effect/landmark/lv624/fog_blocker,
@@ -50742,9 +51983,20 @@
 	dir = 5
 	},
 /area/desert_dam/interior/caves/central_caves)
+"guO" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/medical/break_room)
 "gvo" = (
 /turf/open/floor/plating,
 /area/desert_dam/exterior/landing/landing_pad_two)
+"gvt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/south_valley_dam)
 "gvG" = (
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 5
@@ -50756,6 +52008,14 @@
 	dir = 5
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
+"gvT" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/warehouse/warehouse)
 "gvY" = (
 /obj/structure/platform{
 	dir = 8
@@ -50782,6 +52042,14 @@
 	icon_state = "vault"
 	},
 /area/desert_dam/building/security/prison)
+"gwO" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal1"
+	},
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_labs)
 "gwU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -50791,6 +52059,15 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
+"gwX" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/administration/hallway)
 "gxl" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -50803,6 +52080,15 @@
 	icon_state = "cement4"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
+"gyo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/hydroponics/hydroponics_storage)
+"gyI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/building/medical/garage)
 "gzn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -50813,6 +52099,16 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/warehouse/loading)
+"gzs" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "cell_stripe"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
 "gzC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/lv624/fog_blocker,
@@ -50843,10 +52139,31 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"gBf" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/lobby)
+"gBx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/medical/morgue)
 "gCg" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /turf/open/floor/prison,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
+"gCm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "gCL" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison,
@@ -50856,7 +52173,11 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/ground/mars/random/cave,
+/obj/effect/decal/sandytile,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
 /area/desert_dam/interior/caves/temple)
 "gDi" = (
 /obj/structure/cable,
@@ -50865,6 +52186,22 @@
 	icon_state = "whiteyellowcorner"
 	},
 /area/desert_dam/interior/dam_interior/break_room)
+"gDq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/dorms/restroom)
+"gDs" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/building/administration/meetingrooom)
+"gDG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/exterior/valley/south_valley_dam)
 "gDW" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -50892,6 +52229,13 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_medical_south)
+"gFa" = (
+/obj/structure/table/reinforced,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkpurple2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "gFm" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -50909,6 +52253,20 @@
 	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"gFA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
+"gFB" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
 "gFE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -50950,7 +52308,9 @@
 	},
 /area/desert_dam/building/water_treatment_one/garage)
 "gGC" = (
-/turf/closed/wall/mineral/sandstone,
+/turf/closed/wall/r_wall/chigusa{
+	name = "reinforced metal wall"
+	},
 /area/desert_dam/interior/caves/temple)
 "gGO" = (
 /obj/structure/cable,
@@ -50986,6 +52346,12 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"gIL" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "gIR" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/desertdam/asphalt,
@@ -51019,8 +52385,15 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/deathrow)
+"gJH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement1"
+	},
+/area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "gJM" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -51036,6 +52409,12 @@
 	icon_state = "shallow_water_clean"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
+"gKz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 10
+	},
+/area/desert_dam/interior/dam_interior/western_dam_cave)
 "gKT" = (
 /obj/structure/bed/chair,
 /obj/structure/cable,
@@ -51047,6 +52426,7 @@
 "gLb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2"
 	},
@@ -51065,6 +52445,21 @@
 	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"gMI" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/desert_dam/interior/caves/central_caves)
+"gMR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/administration/hallway)
 "gNq" = (
 /obj/structure/table,
 /obj/item/tool/pen,
@@ -51104,6 +52499,12 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/medical/surgery_observation)
+"gOn" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "gOB" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
@@ -51120,6 +52521,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
+"gPJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
 "gQm" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -51128,6 +52536,13 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
+"gRj" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "gRl" = (
 /obj/structure/window/framed/colony,
 /obj/structure/cable,
@@ -51142,10 +52557,22 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/north_valley_dam)
+"gSr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "gSJ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_northwest)
+"gSR" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "cell_stripe"
+	},
+/area/desert_dam/building/warehouse/warehouse)
 "gSZ" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -51155,6 +52582,10 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"gTa" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/valley_cargo)
 "gTc" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner2{
 	dir = 1
@@ -51179,10 +52610,23 @@
 /area/desert_dam/building/security/staffroom)
 "gTP" = (
 /obj/docking_port/stationary/crashmode,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "floor_plate"
 	},
 /area/desert_dam/building/security/evidence)
+"gTX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 5
+	},
+/area/desert_dam/interior/dam_interior/western_dam_cave)
+"gUt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached13"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "gUv" = (
 /obj/machinery/floodlight/landing,
 /obj/machinery/landinglight/ds2/delayone{
@@ -51205,6 +52649,13 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/west_tunnel)
+"gUJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
 "gVx" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -51213,6 +52664,7 @@
 /area/desert_dam/exterior/valley/valley_hydro)
 "gVB" = (
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "darkyellow2"
@@ -51239,9 +52691,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"gWL" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "gWR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -51287,6 +52744,7 @@
 	dir = 8;
 	on = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/execution_chamber)
 "gYc" = (
@@ -51305,6 +52763,7 @@
 "gYE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -51322,6 +52781,14 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/east_caves)
+"gZs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/interior/dam_interior/workshop)
 "gZL" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -51330,6 +52797,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "whitepurplecorner"
@@ -51357,9 +52825,21 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_loading)
+"haZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "hbr" = (
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/riverside_central_south)
+"hbw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "hbx" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -51378,12 +52858,27 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/desert_dam/building/bar/backroom)
+"hcs" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/warehouse/loading)
 "hdd" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt{
 	dir = 8
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"hdr" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement1"
+	},
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "hdR" = (
 /obj/structure/cable,
 /turf/open/floor{
@@ -51405,8 +52900,27 @@
 /area/desert_dam/building/cafeteria/cold_room)
 "hfa" = (
 /obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/interior/caves/central_caves)
+"hfk" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
+"hfr" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave/rock{
+	dir = 4
+	},
+/area/desert_dam/interior/caves/east_caves)
+"hfH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_workshop)
 "hga" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -51434,6 +52948,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/lab_northeast/east_lab_excavation)
+"hgR" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/substation/west)
 "hgV" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -51454,9 +52972,16 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
+"hhe" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal10"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "hhj" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairdownrailleft"
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached14"
@@ -51475,6 +53000,10 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics)
+"hin" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "his" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	id = "northpath1"
@@ -51485,6 +53014,18 @@
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"hiF" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E"
+	},
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 2;
+	id = "dam_stormlock_north2";
+	name = "\improper Storm Lock"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/interior/dam_interior/south_tunnel)
 "hiH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -51511,12 +53052,36 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
+"hjR" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_two/control_room)
 "hjS" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/valley_medical_south)
+"hjX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/administration/hallway)
 "hjZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -51542,6 +53107,13 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
+"hkq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/interior/dam_interior/workshop)
 "hkv" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -51553,6 +53125,10 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/courtroom)
+"hlh" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/west_tunnel)
 "hlj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor{
@@ -51602,12 +53178,22 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/cafeteria/loading)
+"hnz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "hnJ" = (
 /obj/structure/platform_decoration{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/ground/mars/random/cave,
+/obj/effect/decal/sandytile,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
 /area/desert_dam/interior/caves/temple)
 "hnK" = (
 /obj/structure/cable,
@@ -51617,7 +53203,11 @@
 "hoc" = (
 /obj/structure/platform_decoration,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/ground/mars/random/cave,
+/obj/effect/decal/sandytile,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
 /area/desert_dam/interior/caves/temple)
 "hpe" = (
 /obj/effect/landmark/weed_node,
@@ -51636,8 +53226,20 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/ground/mars/random/cave,
+/obj/effect/decal/sandytile,
+/obj/effect/decal/sandytile,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
 /area/desert_dam/interior/caves/temple)
+"hpN" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal12"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_mining)
 "hpP" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -51646,6 +53248,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
 "hpY" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 6
 	},
@@ -51667,6 +53270,7 @@
 /area/desert_dam/exterior/valley/south_valley_dam)
 "hrk" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached1"
 	},
@@ -51687,6 +53291,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"hrO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "hsb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51745,6 +53355,14 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"hte" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "kitchen"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "htG" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -51754,6 +53372,17 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"htY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/hangar_storage)
 "huq" = (
 /obj/machinery/landinglight/ds1{
 	dir = 4
@@ -51767,6 +53396,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/warehouse/warehouse)
+"huF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/medical/lobby)
 "huZ" = (
 /obj/structure/cable,
 /turf/closed/wall,
@@ -51791,6 +53427,12 @@
 /obj/structure/bed/chair/office/light,
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"hvY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached10"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "hwc" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached4"
@@ -51824,6 +53466,13 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
+"hwN" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "kitchen"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "hwS" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 1
@@ -51850,6 +53499,7 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -51881,6 +53531,13 @@
 	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"hyl" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "hyv" = (
 /obj/structure/cable,
 /turf/closed/wall{
@@ -51900,6 +53557,12 @@
 "hyG" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge,
 /area/desert_dam/exterior/river/riverside_central_south)
+"hzz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 9
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "hzL" = (
 /obj/effect/ai_node,
 /turf/open/ground/coast{
@@ -51914,7 +53577,12 @@
 	pixel_x = 1;
 	pixel_y = 31
 	},
-/turf/open/floor/plating/ground/mars/random/cave,
+/obj/effect/decal/sandytile,
+/obj/effect/decal/sandytile,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
 /area/desert_dam/interior/caves/temple)
 "hAB" = (
 /obj/effect/decal/warning_stripes{
@@ -51931,6 +53599,13 @@
 	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"hAQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating{
+	dir = 6;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "hBr" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached3"
@@ -51940,6 +53615,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/desert_dam/building/substation/northeast)
+"hBL" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement1"
+	},
+/area/desert_dam/interior/dam_interior/workshop)
 "hBR" = (
 /turf/open/floor{
 	dir = 5;
@@ -51979,6 +53660,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"hCT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "hDc" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner,
 /area/desert_dam/exterior/river/riverside_south)
@@ -52060,10 +53748,15 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
+"hFZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "hGl" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
@@ -52073,6 +53766,12 @@
 	icon_state = "floor_plate"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
+"hGv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/desert_dam/building/dorms/hallway_westwing)
 "hGD" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -52125,6 +53824,12 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"hIS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "hIT" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
@@ -52175,6 +53880,13 @@
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/security/southern_hallway)
+"hKf" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "hKV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -52204,6 +53916,12 @@
 	icon_state = "warning"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+"hLY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached2"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "hMc" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached13"
@@ -52224,6 +53942,14 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
+"hML" = (
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/flora/rock/pile/alt3,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "hNn" = (
 /obj/structure/rack,
 /obj/item/storage/surgical_tray,
@@ -52236,6 +53962,12 @@
 	icon_state = "whiteblue"
 	},
 /area/desert_dam/building/medical/medsecure)
+"hNs" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
 "hNJ" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
 /obj/machinery/door/poddoor/shutters/mainship{
@@ -52244,13 +53976,17 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"hNK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/dorms/hallway_northwing)
 "hOc" = (
-/obj/structure/cable,
-/obj/structure/stairs/railstairs{
-	icon_state = "stairdownrailleft"
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached3"
+	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
 "hOe" = (
@@ -52281,12 +54017,6 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_breakroom)
-"hOB" = (
-/obj/structure/stairs/railstairs,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached1"
-	},
-/area/desert_dam/exterior/valley/valley_telecoms)
 "hOK" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached18"
@@ -52367,6 +54097,7 @@
 "hRs" = (
 /obj/structure/cable,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -52389,6 +54120,21 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"hSv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "floor_plate"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
+"hSy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/freezer,
+/area/desert_dam/interior/east_engineering)
 "hSB" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/structure/cable,
@@ -52537,10 +54283,17 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/administration/hallway)
+"hXL" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/interior/caves/central_caves)
 "hXS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2"
 	},
@@ -52550,12 +54303,37 @@
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"hXY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_hydro)
 "hYc" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached9"
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
+"hYe" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/north_tunnel)
+"hYK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "hYO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -52572,6 +54350,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
+"hYS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "greencorner"
+	},
+/area/desert_dam/building/telecommunication)
 "hZm" = (
 /obj/machinery/landinglight/ds2/delaythree{
 	dir = 1
@@ -52604,6 +54388,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
+"hZZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/interior/dam_interior/south_tunnel)
 "iaW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/stationary/crashmode,
@@ -52616,6 +54406,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_storage)
+"iby" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "ibE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -52653,6 +54450,13 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"icl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkredcorners2"
+	},
+/area/desert_dam/building/security/southern_hallway)
 "ico" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -52664,6 +54468,11 @@
 	icon_state = "kitchen"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
+"icq" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/south_tunnel)
 "icK" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_6"
@@ -52683,6 +54492,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"idm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/engine_room)
+"idp" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/building/cafeteria/loading)
 "idI" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -52690,6 +54510,12 @@
 	icon_state = "blue"
 	},
 /area/desert_dam/building/administration/hallway)
+"idM" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "idP" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
@@ -52717,11 +54543,25 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/disposals)
+"ift" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkbrown2"
+	},
+/area/desert_dam/building/warehouse/loading)
 "igw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
+"igC" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal5"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "igP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -52729,10 +54569,27 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/atmos_storage)
+"igV" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "kitchen"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "igY" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"iha" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal2"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "ihe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -52750,6 +54607,10 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_one/hallway)
+"ihJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_northwest)
 "ihU" = (
 /turf/open/floor/plating/catwalk,
 /area/desert_dam/exterior/river/riverside_central_north)
@@ -52834,12 +54695,25 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"ilf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet13-5"
+	},
+/area/desert_dam/building/church)
 "ilz" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal1"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"ims" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "imz" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -52861,6 +54735,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics)
+"imS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/medical/west_wing_hallway)
 "ini" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -52877,6 +54758,10 @@
 	dir = 1
 	},
 /area/desert_dam/interior/east_engineering)
+"inm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/security/warden)
 "inQ" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal8"
@@ -52904,6 +54789,10 @@
 	icon_state = "cement_sunbleached13"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"ipF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/valley_medical)
 "ipY" = (
 /obj/machinery/door/poddoor/shutters/mainship/open{
 	dir = 2;
@@ -52959,11 +54848,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"ivM" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/primary_tool_storage)
 "iwh" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 4
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"iwn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/interior/dam_interior/south_tunnel)
 "iwv" = (
 /obj/machinery/landinglight/ds2/delaythree{
 	dir = 8
@@ -52989,12 +54892,47 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_south)
+"ixF" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/desert_dam/building/security/northern_hallway)
 "ixM" = (
 /obj/structure/flora/rock/alt2{
 	name = "rock"
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_cargo)
+"ixT" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"ixU" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"ixW" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
+"iyd" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/cafeteria/loading)
 "iyj" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/mainship/orange{
@@ -53033,6 +54971,13 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/virology_wing)
+"iAH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "greencorner"
+	},
+/area/desert_dam/building/telecommunication)
 "iBL" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 4
@@ -53050,6 +54995,26 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"iCl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/desert_dam/building/medical/chemistry)
+"iDm" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal3"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_mining)
 "iDr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/stationary/crashmode,
@@ -53074,13 +55039,49 @@
 "iDQ" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"iDR" = (
+/obj/structure/platform,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"iEi" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/security/southern_hallway)
+"iEs" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
 "iEI" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
 	},
 /area/desert_dam/interior/dam_interior/western_dam_cave)
+"iEO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "iFE" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached1"
 	},
@@ -53090,10 +55091,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
 	icon_state = "cement4"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
+"iFX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "iGb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -53125,6 +55133,10 @@
 	dir = 9
 	},
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"iGD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/south_tunnel)
 "iGK" = (
 /obj/structure/flora/desert/grass,
 /obj/structure/cable,
@@ -53160,14 +55172,43 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/dorms/pool)
+"iHs" = (
+/obj/structure/table,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "dark2"
+	},
+/area/desert_dam/building/administration/archives)
 "iHt" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall/unmeltable,
 /area/desert_dam/interior/east_engineering)
+"iHL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal2"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_mining)
+"iHP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/building/substation/northeast)
 "iIq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor/prison,
 /area/desert_dam/building/medical/virology_isolation)
+"iIN" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_9"
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "iJq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -53203,6 +55244,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/staffroom)
+"iLp" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "iLB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -53212,6 +55258,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/security/lobby)
+"iLG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkred2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_security_armory)
 "iLP" = (
 /obj/structure/flora/rock/pile/alt2,
 /obj/effect/ai_node,
@@ -53227,6 +55280,14 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
+"iMn" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "iMq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -53234,6 +55295,12 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_northwing)
+"iMt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "iML" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -53248,15 +55315,41 @@
 	icon_state = "cement3"
 	},
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
+"iMQ" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal4"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_cargo)
 "iNd" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"iNE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/medical/morgue)
+"iNH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/hangar_storage)
 "iNT" = (
-/obj/structure/closet/walllocker/hydrant/extinguisher,
-/turf/closed/wall/r_wall,
-/area/desert_dam/building/cafeteria/cafeteria)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating{
+	dir = 4;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "iNZ" = (
 /turf/open/floor/prison{
 	dir = 10;
@@ -53269,6 +55362,10 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"iOl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "iOv" = (
 /obj/structure/platform{
 	dir = 4
@@ -53285,17 +55382,42 @@
 	icon_state = "dark"
 	},
 /area/desert_dam/building/church)
+"iPd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached13"
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
+"iPs" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowcorner"
+	},
+/area/desert_dam/interior/dam_interior/break_room)
 "iPK" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"iPV" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "iQk" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
+"iQI" = (
+/obj/structure/flora/desert/cactus/multiple{
+	icon_state = "cacti_12"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_labs)
 "iRn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -53327,6 +55449,17 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
+"iRY" = (
+/obj/machinery/light,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitepurple"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
+"iSk" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "iSu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -53346,6 +55479,15 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/security/northern_hallway)
+"iSV" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull"
+	},
+/area/desert_dam/interior/east_engineering)
 "iTK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/stationary/crashmode,
@@ -53353,6 +55495,17 @@
 	icon_state = "cement3"
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
+"iTR" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached13"
+	},
+/area/desert_dam/exterior/valley/valley_cargo)
+"iTX" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/hydroponics/hydroponics_loading)
 "iUL" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -53366,6 +55519,14 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"iVc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_two/hallway)
 "iVA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53463,6 +55624,12 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_mining)
+"iYa" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/river/riverside_south)
 "iYn" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -53478,6 +55645,13 @@
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/interior/dam_interior/disposals)
+"iYC" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_9"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_civilian)
 "iYI" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached18"
@@ -53492,6 +55666,12 @@
 "iZC" = (
 /turf/open/floor/asteroidfloor,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"jac" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "jam" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave{
@@ -53522,6 +55702,7 @@
 /area/desert_dam/exterior/valley/bar_valley_dam)
 "jbV" = (
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "jco" = (
@@ -53543,6 +55724,15 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
+"jcz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "jcL" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall,
@@ -53569,6 +55759,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_two/hallway)
+"jds" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 9
+	},
+/area/desert_dam/interior/caves/east_caves)
 "jdv" = (
 /turf/open/floor/plating/catwalk,
 /area/desert_dam/exterior/river/riverside_east)
@@ -53598,6 +55794,33 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_south)
+"jet" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_two/equipment)
+"jeW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"jeX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
+"jfs" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "jfz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
@@ -53618,6 +55841,13 @@
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
+"jfQ" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal4"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/north_valley_dam)
 "jgr" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal5"
@@ -53636,6 +55866,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -53657,6 +55888,11 @@
 	icon_state = "whiteblue"
 	},
 /area/desert_dam/building/medical/medsecure)
+"jhw" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "jhJ" = (
 /obj/structure/table,
 /obj/effect/landmark/dropship_console_spawn_lz2,
@@ -53690,14 +55926,34 @@
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"jjx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "jjJ" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/desert_dam/building/medical/east_wing_hallway)
+"jjS" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "jjV" = (
-/obj/machinery/miner/damaged/platinum,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/desert_dam/interior/caves/temple)
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/lab_northeast/east_lab_excavation)
 "jkk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53711,6 +55967,12 @@
 	icon_state = "cement4"
 	},
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
+"jkG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "jlg" = (
 /obj/structure/cable,
 /obj/structure/prop/mainship/brokengen,
@@ -53734,6 +55996,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "jmd" = (
@@ -53770,6 +56033,19 @@
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_RND)
+"jny" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/desert_dam/building/lab_northwest/west_lab_xenoflora)
+"jnD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "blue"
+	},
+/area/desert_dam/building/administration/control_room)
 "jnF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -53813,9 +56089,7 @@
 /obj/structure/platform_decoration{
 	dir = 8
 	},
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 8
-	},
+/turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "jpH" = (
 /obj/structure/bed/alien,
@@ -53834,19 +56108,45 @@
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/east_engineering)
+"jqe" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
+"jqm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/exterior/valley/valley_cargo)
+"jqs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/warehouse/warehouse)
+"jqv" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_medical)
 "jqH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "jqO" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightrailup"
+/obj/structure/stairs/seamless/platform{
+	dir = 1
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "jqQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -53858,6 +56158,22 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/warehouse/warehouse)
+"jri" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "asteroidplating"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"jrk" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/building/hydroponics/hydroponics_loading)
 "jrV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
@@ -53880,6 +56196,12 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
+"jsC" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "jsN" = (
 /obj/structure/platform{
 	dir = 1
@@ -53910,6 +56232,12 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_biology)
+"jtt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "jun" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -53950,6 +56278,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_wilderness)
+"jvM" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/hangar_storage)
 "jvZ" = (
 /obj/structure/platform{
 	dir = 1
@@ -53965,6 +56300,21 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/staffroom)
+"jwL" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull"
+	},
+/area/desert_dam/interior/east_engineering)
+"jwO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/emergency_room)
 "jwY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -53973,8 +56323,15 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
+"jxr" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkred2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_security_armory)
 "jxv" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "blue"
@@ -53988,10 +56345,49 @@
 	icon_state = "white"
 	},
 /area/desert_dam/interior/dam_interior/break_room)
+"jyf" = (
+/obj/structure/bed,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/desert_dam/building/dorms/hallway_northwing)
+"jyh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
 "jyo" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/indestructible,
 /area/desert_dam/exterior/rock)
+"jyu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitepurplecorner"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+"jyA" = (
+/obj/machinery/light,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "blue"
+	},
+/area/desert_dam/building/administration/hallway)
 "jze" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/prison{
@@ -54005,12 +56401,25 @@
 	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"jzw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
+"jzJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_mining)
 "jzR" = (
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/courtroom)
 "jAl" = (
@@ -54040,6 +56449,12 @@
 	dir = 6
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
+"jBl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitegreencorner"
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
 "jBp" = (
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 9
@@ -54064,6 +56479,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/desert_dam/building/water_treatment_one/floodgate_control)
+"jDB" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/medical/break_room)
 "jDV" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -54071,6 +56490,12 @@
 	icon_state = "cell_stripe"
 	},
 /area/desert_dam/building/warehouse/loading)
+"jEA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 5
+	},
+/area/desert_dam/interior/caves/temple)
 "jED" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -54099,6 +56524,10 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_hydro)
+"jFg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/valley/valley_telecoms)
 "jFG" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall,
@@ -54134,6 +56563,12 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/security/holding)
+"jGD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "freezerfloor"
+	},
+/area/desert_dam/building/security/prison)
 "jHu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -54171,6 +56606,13 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/office)
+"jIm" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal9"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical_south)
 "jIo" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -54206,6 +56648,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/desert_dam/building/hydroponics/hydroponics_storage)
+"jIJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/desert_dam/exterior/valley/valley_labs)
 "jJa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -54220,10 +56666,22 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"jJP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/desert_dam/building/substation/northeast)
 "jKe" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_wilderness)
+"jKo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/water_treatment_one/garage)
 "jKr" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 8
@@ -54242,6 +56700,7 @@
 /area/desert_dam/building/hydroponics/hydroponics_storage)
 "jKB" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "jLd" = (
@@ -54308,6 +56767,11 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"jMQ" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/interior/caves/central_caves)
 "jMT" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -54343,6 +56807,25 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_northwest)
+"jNx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
+"jNz" = (
+/obj/structure/table/reinforced,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
+"jND" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/interior/caves/central_caves)
 "jNF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -54357,6 +56840,14 @@
 /obj/structure/flora/rock/pile/alt,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"jNT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/security/southern_hallway)
 "jOe" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached12"
@@ -54368,6 +56859,12 @@
 	icon_state = "cement_sunbleached13"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
+"jOu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "jOP" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -54393,6 +56890,20 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"jPm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/desert_dam/interior/east_engineering)
+"jPn" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "jPV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
@@ -54422,12 +56933,36 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
+"jQG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_one/control_room)
+"jQI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/desert_dam/interior/east_engineering)
 "jRv" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor{
 	icon_state = "wood"
 	},
 /area/desert_dam/building/dorms/hallway_westwing)
+"jRx" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal4"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/south_valley_dam)
+"jRB" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "jSk" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison{
@@ -54449,6 +56984,7 @@
 	icon_state = "heavygrass_4"
 	},
 /obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "jSS" = (
@@ -54482,6 +57018,14 @@
 	icon_state = "cement2"
 	},
 /area/desert_dam/interior/dam_interior/west_tunnel)
+"jUv" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/engine_west_wing)
 "jUV" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached11"
@@ -54551,10 +57095,27 @@
 "jYe" = (
 /turf/closed/wall/r_wall,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"jYg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+"jYh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "jYx" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_11"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_mining)
 "jYN" = (
@@ -54590,6 +57151,20 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
+"kaB" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "cult"
+	},
+/area/desert_dam/building/church)
+"kbf" = (
+/obj/structure/flora/desert/grass/heavy{
+	icon_state = "heavygrass_4"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_medical)
 "kbA" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal3"
@@ -54597,6 +57172,16 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"kbB" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkred2"
+	},
+/area/desert_dam/building/security/southern_hallway)
 "kbX" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached13"
@@ -54609,6 +57194,12 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/substation/southwest)
+"kch" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/interior/dam_interior/north_tunnel)
 "kcm" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -54642,6 +57233,7 @@
 	dir = 5
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	dir = 4;
 	icon_state = "whiteyellowcorner"
@@ -54660,6 +57252,7 @@
 /area/desert_dam/exterior/valley/valley_medical_south)
 "kdM" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/deathrow)
 "kdO" = (
@@ -54684,6 +57277,12 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
+"kdW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement3"
+	},
+/area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "kea" = (
 /obj/structure/cable,
 /turf/open/floor/prison,
@@ -54734,6 +57333,20 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_telecoms)
+"kfz" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
+"kfD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
 "kfQ" = (
 /obj/structure/cable,
 /turf/open/floor{
@@ -54773,10 +57386,33 @@
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"kiP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "kjf" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall/r_wall,
 /area/desert_dam/building/dorms/pool)
+"kjJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/warehouse/loading)
+"kjU" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal8"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "kkm" = (
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 10
@@ -54789,6 +57425,12 @@
 "kln" = (
 /turf/open/ground/river/desertdam/clean/shallow,
 /area/desert_dam/exterior/river/riverside_central_south)
+"klF" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/interior/caves/central_caves)
 "klS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -54798,6 +57440,13 @@
 	icon_state = "kitchen"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
+"kmc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "cell_stripe"
+	},
+/area/desert_dam/building/warehouse/loading)
 "kmo" = (
 /obj/structure/platform{
 	dir = 1
@@ -54824,8 +57473,13 @@
 	icon_state = "greencorner"
 	},
 /area/desert_dam/building/telecommunication)
+"koi" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "koZ" = (
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -54850,6 +57504,30 @@
 /obj/item/stack/sheet/wood,
 /turf/open/floor/wood,
 /area/desert_dam/interior/caves/central_caves)
+"kpG" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/treatment_room)
+"kpQ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/west_wing_hallway)
+"kqk" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "kqw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54869,6 +57547,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "whitegreen"
 	},
@@ -54884,6 +57563,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -54894,6 +57574,19 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
+"krh" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/building/security/prison)
+"krp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "cult"
+	},
+/area/desert_dam/building/church)
 "kry" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -54905,6 +57598,12 @@
 /obj/machinery/faxmachine,
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"ksz" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "ksF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -54942,6 +57641,30 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
+"ktV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_two/control_room)
+"kul" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached13"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
+"kuD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/dorms/hallway_northwing)
 "kuR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -54978,6 +57701,7 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -55025,6 +57749,13 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_medical)
+"kwX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "kxg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55078,6 +57809,18 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_civilian)
+"kyu" = (
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 2;
+	id = "dam_shutter_hangar";
+	name = "\improper Hangar Lock"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
 "kzc" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
@@ -55085,6 +57828,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"kzl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/darkish,
+/area/desert_dam/interior/caves/temple)
 "kzp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/ai_node,
@@ -55095,6 +57842,7 @@
 /area/desert_dam/building/medical/surgery_room_one)
 "kzq" = (
 /obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/interior/caves/central_caves)
 "kzs" = (
@@ -55184,6 +57932,13 @@
 	dir = 10
 	},
 /area/desert_dam/interior/caves/temple)
+"kAO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/interior/dam_interior/north_tunnel)
 "kBb" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -55206,6 +57961,22 @@
 	dir = 9
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"kCr" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/lab_northeast/east_lab_workshop)
+"kCu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/north_valley_dam)
+"kCz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/medical/primary_storage)
 "kDu" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -55233,6 +58004,11 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/virology_wing)
+"kEx" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "kEX" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -55245,6 +58021,10 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
+"kFe" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/medical/CMO)
 "kFk" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt{
@@ -55258,6 +58038,13 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"kFL" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
+	},
+/area/desert_dam/interior/caves/central_caves)
 "kFV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -55287,6 +58074,7 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/warehouse/warehouse)
 "kHJ" = (
@@ -55338,12 +58126,27 @@
 /obj/effect/ai_node,
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river_mouth/southern)
+"kJL" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/north_valley_dam)
 "kJP" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal2"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"kKQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "kKT" = (
 /obj/machinery/light{
 	dir = 1
@@ -55383,6 +58186,12 @@
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/security/southern_hallway)
+"kMn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 1
+	},
+/area/desert_dam/interior/dam_interior/western_dam_cave)
 "kMv" = (
 /obj/structure/cable,
 /obj/effect/decal/warning_stripes/thin{
@@ -55421,6 +58230,20 @@
 	icon_state = "kitchen"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
+"kND" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkred2"
+	},
+/area/desert_dam/building/security/southern_hallway)
 "kOL" = (
 /obj/structure/flora/rock/alt3{
 	name = "rock"
@@ -55471,6 +58294,17 @@
 	name = "reinforced metal wall"
 	},
 /area/desert_dam/interior/dam_interior/west_tunnel)
+"kPX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/landing/landing_pad_three_external)
+"kQa" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "kQt" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal3"
@@ -55590,6 +58424,11 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
+"kTd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_mining)
 "kTi" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 6
@@ -55616,6 +58455,19 @@
 	icon_state = "cement1"
 	},
 /area/desert_dam/interior/dam_interior/north_tunnel)
+"kUO" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal4"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
+"kUX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_medical_south)
 "kUY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55644,6 +58496,17 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/building/water_treatment_one/floodgate_control)
+"kVu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/virology_wing)
 "kVw" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal9"
@@ -55677,6 +58540,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkred2"
@@ -55697,6 +58561,21 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
+"kWM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_one/hallway)
 "kXl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -55725,6 +58604,21 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/hangar_storage)
+"kXM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/medical/treatment_room)
+"kXO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/administration/hallway)
 "kXU" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner{
 	dir = 4
@@ -55739,6 +58633,10 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_south)
+"kYc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/security/execution_chamber)
 "kYL" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -55752,6 +58650,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_cargo)
+"kZj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/warehouse/breakroom)
 "kZm" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -55773,6 +58681,18 @@
 /obj/effect/ai_node,
 /turf/open/floor/carpet,
 /area/desert_dam/building/warehouse/breakroom)
+"kZN" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/exterior/valley/bar_valley_dam)
+"lag" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "laO" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -55787,6 +58707,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
+"lbg" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/building/cafeteria/loading)
 "lbk" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
@@ -55797,6 +58724,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/medical/break_room)
 "lbU" = (
@@ -55829,6 +58757,12 @@
 /obj/structure/flora/rock/pile,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_northwest)
+"lcC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 6
+	},
+/area/desert_dam/interior/dam_interior/western_dam_cave)
 "lcY" = (
 /obj/structure/flora/rock/alt2{
 	name = "rock"
@@ -55850,11 +58784,9 @@
 	},
 /area/desert_dam/interior/dam_interior/workshop)
 "ldY" = (
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/medical/east_wing_hallway)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/lab_northeast/east_lab_excavation)
 "lea" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge{
 	dir = 1
@@ -55865,6 +58797,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/desert_dam/exterior/valley/tradeship)
 "leP" = (
@@ -55902,6 +58835,12 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
+"lgt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "lgD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
@@ -55977,6 +58916,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"ljj" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "ljW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -55986,6 +58931,11 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_two/lobby)
+"lly" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/interior/caves/central_caves)
 "llO" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
@@ -56026,6 +58976,13 @@
 "lmV" = (
 /turf/closed/wall/r_wall,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"lnw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 5;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/lobby)
 "lnD" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
@@ -56043,6 +59000,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "whitegreenfull"
@@ -56063,6 +59021,13 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/surgery_room_two)
+"loy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/cafeteria/loading)
 "lpe" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -56073,6 +59038,14 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/lobby)
+"lpf" = (
+/obj/structure/table,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "kitchen"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "lpj" = (
 /obj/effect/turf_underlay/tiles/dark2,
 /turf/closed/shuttle{
@@ -56083,6 +59056,30 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/desert_dam/building/substation/southwest)
+"lpq" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
+"lpx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/building/cafeteria/loading)
+"lpA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "lpD" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_2"
@@ -56157,6 +59154,13 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"lqN" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_labs)
 "lqX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -56174,12 +59178,42 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_civilian)
+"lrF" = (
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"lrM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "lrR" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 8
 	},
 /area/desert_dam/exterior/valley/valley_mining)
+"lrV" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "lrY" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_8"
@@ -56223,6 +59257,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
+"lum" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "luo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
@@ -56239,6 +59280,12 @@
 	icon_state = "cement12"
 	},
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
+"luQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/desert_dam/building/church)
 "luT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -56357,6 +59404,14 @@
 	icon_state = "cement1"
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
+"lzF" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"lzM" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_medical)
 "lzZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -56399,6 +59454,7 @@
 "lBJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -56414,12 +59470,24 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
+"lCe" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "lCm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor{
 	icon_state = "white"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_lobby)
+"lCp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/desert_dam/building/security/southern_hallway)
 "lCs" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 9
@@ -56429,6 +59497,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_telecoms)
+"lCQ" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal4"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "lCX" = (
 /obj/effect/ai_node,
 /turf/open/ground/coast/corner{
@@ -56448,6 +59523,10 @@
 	dir = 8
 	},
 /area/desert_dam/interior/caves/east_caves)
+"lDE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "lDT" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_3"
@@ -56481,23 +59560,53 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"lFs" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "lFE" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/desert_dam/interior/east_engineering)
 "lFH" = (
 /obj/structure/flora/rock/pile/alt,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/interior/caves/central_caves)
+"lFR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/warehouse/warehouse)
 "lGp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_storage)
+"lGq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"lGv" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_labs)
 "lGy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -56543,6 +59652,12 @@
 /obj/machinery/microwave,
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"lIV" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "lIY" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -56555,6 +59670,10 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/treatment_room)
+"lJC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_northwest)
 "lJD" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -56588,6 +59707,10 @@
 "lKL" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+"lKX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "lLB" = (
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 5
@@ -56639,26 +59762,48 @@
 	dir = 5
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
+"lPp" = (
+/obj/structure/desertdam/decals/road/stop{
+	icon_state = "stop_decal5"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "lPy" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
-"lQM" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightraildown"
-	},
-/obj/effect/ai_node,
+"lPH" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "tile"
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
+"lQM" = (
+/obj/structure/stairs/seamless/platform{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
 "lRa" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/central_caves)
+"lRq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowcorner"
+	},
+/area/desert_dam/building/water_treatment_one/breakroom)
 "lRH" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
 	},
@@ -56673,10 +59818,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
-"lSp" = (
-/obj/structure/window/framed/mainship/requisitions,
-/turf/open/floor/mainship/mono,
-/area/desert_dam/exterior/valley/tradeship)
 "lSu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
@@ -56687,6 +59828,19 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_security_armory)
+"lSE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_medical)
+"lSN" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkbrown2"
+	},
+/area/desert_dam/building/warehouse/loading)
 "lSX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -56705,11 +59859,28 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
+"lTf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/control_room)
+"lTm" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"lTo" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "lTI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
 	on = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -56720,6 +59891,13 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"lUc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull"
+	},
+/area/desert_dam/building/medical/virology_wing)
 "lUk" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/prison{
@@ -56765,6 +59943,13 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"lWc" = (
+/obj/structure/flora/desert/grass/heavy{
+	icon_state = "heavygrass_3"
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "lWj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
@@ -56781,6 +59966,17 @@
 	icon_state = "white"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_lobby)
+"lXX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
 "lYm" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal8"
@@ -56793,6 +59989,12 @@
 	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
+"lYs" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "lYv" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_4"
@@ -56808,6 +60010,12 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_south)
+"lYK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/interior/caves/central_caves)
 "lYW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -56819,6 +60027,17 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
+"lZb" = (
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 4;
+	id = "dam_checkpoint_north";
+	name = "\improper Checkpoint Lock"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_west_entrance)
 "lZG" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 1
@@ -56839,6 +60058,12 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"lZW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement15"
+	},
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "mae" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -56851,6 +60076,12 @@
 	dir = 4
 	},
 /area/desert_dam/interior/caves/temple)
+"maC" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/interior/caves/central_caves)
 "maI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -56866,12 +60097,47 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/water_treatment_one/garage)
+"mbK" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/tile/darkish,
+/area/desert_dam/interior/caves/temple)
+"mct" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"mdJ" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "mdP" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal9"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"mdQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/virology_wing)
+"mev" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement3"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "meI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -56900,6 +60166,7 @@
 "mfG" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "dark"
 	},
@@ -56940,6 +60207,12 @@
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/interior/caves/central_caves)
+"mhP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "mhU" = (
 /obj/structure/rack,
 /turf/open/floor/prison{
@@ -56962,6 +60235,12 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/surgery_room_two)
+"mjg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "mjl" = (
 /obj/effect/ai_node,
 /turf/open/ground/coast{
@@ -56974,6 +60253,28 @@
 	dir = 9
 	},
 /area/desert_dam/interior/caves/temple)
+"mkm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
+"mkx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/primary_tool_storage)
 "mkJ" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_4"
@@ -56985,7 +60286,11 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/ground/mars/random/cave,
+/obj/effect/decal/sandytile,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
 /area/desert_dam/interior/caves/temple)
 "mld" = (
 /obj/machinery/landinglight/ds2/delayone{
@@ -57000,6 +60305,22 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"mly" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "freezerfloor"
+	},
+/area/desert_dam/building/cafeteria/cold_room)
+"mlF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "mlS" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal3"
@@ -57007,6 +60328,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"mmp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull"
+	},
+/area/desert_dam/building/medical/treatment_room)
 "mmz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -57045,6 +60373,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
+"mno" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "mnA" = (
 /obj/machinery/floodlight,
 /obj/machinery/camera/autoname/mainship,
@@ -57087,10 +60421,29 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_medical_south)
+"moS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/dorms/restroom)
 "mpj" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall,
 /area/desert_dam/building/dorms/pool)
+"mpV" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "kitchen"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "mqn" = (
 /obj/machinery/power/smes/buildable{
 	capacity = 1e+006;
@@ -57104,6 +60457,12 @@
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"mqQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached15"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "mqT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/decal/cleanable/dirt,
@@ -57116,6 +60475,12 @@
 "mrg" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner2,
 /area/desert_dam/exterior/river_mouth/southern)
+"mrl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "grimy"
+	},
+/area/desert_dam/building/bar/bar)
 "mrx" = (
 /obj/structure/flora/tree/joshua,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -57136,6 +60501,12 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/hanger)
+"mrY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement1"
+	},
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "msC" = (
 /obj/machinery/door/airlock/mainship/engineering{
 	dir = 2;
@@ -57177,6 +60548,12 @@
 	},
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"mtt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached15"
+	},
+/area/desert_dam/exterior/valley/valley_cargo)
 "mtC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -57200,6 +60577,13 @@
 	icon_state = "cell_stripe"
 	},
 /area/desert_dam/building/warehouse/warehouse)
+"mvk" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal7"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_labs)
 "mvl" = (
 /obj/structure/flora/rock/alt3{
 	name = "rock"
@@ -57225,6 +60609,12 @@
 /obj/structure/bed/chair/office/light,
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"mwr" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "freezerfloor"
+	},
+/area/desert_dam/interior/dam_interior/break_room)
 "mwS" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	id = "port_authority2"
@@ -57232,6 +60622,17 @@
 /obj/structure/window/framed/chigusa,
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"mxi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkbrown2"
+	},
+/area/desert_dam/interior/dam_interior/disposals)
 "mxn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -57240,6 +60641,12 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_northwing)
+"mxx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "myi" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
@@ -57280,6 +60687,12 @@
 	icon_state = "cement_sunbleached13"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
+"myZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "mzj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -57313,9 +60726,22 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_two/lobby)
+"mzI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached13"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
+"mzT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "mzU" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "whitegreenfull"
@@ -57344,12 +60770,21 @@
 	icon_state = "delivery"
 	},
 /area/desert_dam/interior/dam_interior/north_tunnel)
+"mBk" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "mBs" = (
 /obj/structure/cable,
 /turf/open/floor{
 	icon_state = "white"
 	},
 /area/desert_dam/building/medical/garage)
+"mBu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_cargo)
 "mBA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -57360,12 +60795,29 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_storage)
+"mCm" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "mCu" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal7"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
+"mCF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/hanger)
+"mCI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_lobby)
 "mDz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -57373,10 +60825,12 @@
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
 "mDA" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightraildown"
+/obj/structure/stairs/seamless/platform{
+	dir = 8
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "mDL" = (
 /obj/structure/cable,
@@ -57502,6 +60956,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/courtroom)
+"mGA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "mGG" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean,
@@ -57522,6 +60982,22 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"mHl" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/interior/caves/central_caves)
+"mIa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull"
+	},
+/area/desert_dam/interior/east_engineering)
 "mIs" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
@@ -57560,6 +61036,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
+"mJZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "mKm" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 4
@@ -57579,6 +61061,17 @@
 "mKs" = (
 /turf/closed/mineral,
 /area/desert_dam/exterior/valley/valley_telecoms)
+"mKy" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "mKO" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/effect/ai_node,
@@ -57624,6 +61117,13 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"mMn" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_3"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_medical_south)
 "mMy" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -57661,6 +61161,12 @@
 "mNk" = (
 /turf/closed/wall/r_wall,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"mNm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt{
+	dir = 8
+	},
+/area/desert_dam/exterior/river/riverside_east)
 "mNA" = (
 /obj/machinery/landinglight/ds1/delaythree{
 	dir = 4
@@ -57673,11 +61179,24 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
+"mNT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_medical_south)
+"mOb" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
 "mOk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -57687,12 +61206,47 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
+"mPa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "kitchen"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
+"mPg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
+"mPo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/workshop)
 "mPt" = (
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/detective)
+"mPE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
+"mPU" = (
+/obj/machinery/light,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/medical/break_room)
 "mQb" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -57720,6 +61274,13 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
+"mQO" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "mQQ" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_11"
@@ -57744,6 +61305,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"mRQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached13"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
 "mSb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -57754,6 +61321,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_one/hallway)
+"mSc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/medical/surgery_room_two)
 "mSg" = (
 /obj/structure/bed/chair/dropship/passenger,
 /obj/machinery/light{
@@ -57774,6 +61348,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2"
 	},
@@ -57782,8 +61357,11 @@
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/desert_dam/interior/dam_interior/western_dam_cave)
 "mTb" = (
-/turf/open/floor/plating/ground/mars/random/cave{
-	dir = 8
+/obj/effect/decal/sandytile,
+/obj/effect/decal/sandytile,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
 	},
 /area/desert_dam/interior/caves/temple)
 "mTf" = (
@@ -57826,6 +61404,13 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/north_wing_hallway)
+"mTJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/desert_dam/building/dorms/hallway_northwing)
 "mTL" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/dirttosand,
@@ -57846,6 +61431,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"mUq" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/desert_dam/interior/caves/central_caves)
 "mUw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -57853,6 +61444,12 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/treatment_room)
+"mUE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "red"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_west_entrance)
 "mVe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -57878,6 +61475,16 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_northwest)
+"mWg" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "blue"
+	},
+/area/desert_dam/building/administration/hallway)
 "mWC" = (
 /obj/structure/platform{
 	dir = 1
@@ -57899,6 +61506,26 @@
 	dir = 10
 	},
 /area/desert_dam/exterior/valley/valley_mining)
+"mXK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "blue"
+	},
+/area/desert_dam/building/administration/hallway)
+"mYn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitepurple"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+"mYq" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/desert_dam/building/medical/garage)
 "mYS" = (
 /obj/structure/table,
 /turf/open/floor/prison,
@@ -57915,6 +61542,18 @@
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"mZk" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement15"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
+"nac" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "green"
+	},
+/area/desert_dam/building/dorms/hallway_northwing)
 "nah" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -57939,6 +61578,14 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"naT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "floor_marked"
+	},
+/area/desert_dam/building/hydroponics/hydroponics_storage)
 "ncd" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
@@ -57962,10 +61609,10 @@
 /turf/open/floor/prison,
 /area/desert_dam/interior/east_engineering)
 "ndP" = (
-/obj/structure/stairs{
+/obj/structure/stairs/seamless{
 	dir = 8
 	},
-/turf/closed/mineral,
+/turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/interior/caves/temple)
 "ndT" = (
 /obj/structure/cable,
@@ -57980,6 +61627,10 @@
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"ndW" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/tile/darkish,
+/area/desert_dam/interior/caves/temple)
 "neg" = (
 /obj/effect/ai_node,
 /turf/open/floor{
@@ -58039,6 +61690,38 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"ngy" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal4"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_mining)
+"ngA" = (
+/obj/machinery/landinglight/ds2/delaytwo{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
+"ngH" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
+"nhj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "nil" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached13"
@@ -58056,6 +61739,12 @@
 	icon_state = "cement_sunbleached13"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
+"niZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached9"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "njb" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -58089,6 +61778,16 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"nkf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "nkB" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -58158,6 +61857,10 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"nmZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/dorms/hallway_westwing)
 "nnb" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/desert_dam/interior/dam_interior/hanger)
@@ -58166,6 +61869,12 @@
 	dir = 1
 	},
 /area/desert_dam/interior/dam_interior/western_dam_cave)
+"nny" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
 "nnA" = (
 /obj/structure/table,
 /obj/effect/spawner/random/toolbox,
@@ -58189,6 +61898,19 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_wilderness)
+"nol" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal11"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
+"noo" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "noC" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/catwalk,
@@ -58232,6 +61954,13 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"npV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "floor_plate"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "nqc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -58247,6 +61976,10 @@
 	icon_state = "cement_sunbleached10"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"nqK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_cargo)
 "nrb" = (
 /obj/structure/table,
 /obj/machinery/faxmachine,
@@ -58269,6 +62002,12 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/administration/control_room)
+"nrI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement3"
+	},
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "nrN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -58301,6 +62040,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_mining)
+"nsh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "yellow"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
+"nsP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
 "ntb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -58358,6 +62111,13 @@
 	icon_state = "cement4"
 	},
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
+"nuM" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "nvj" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_4"
@@ -58399,6 +62159,12 @@
 	icon_state = "cement_sunbleached13"
 	},
 /area/desert_dam/exterior/valley/valley_medical_south)
+"nxh" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
+	},
+/area/desert_dam/exterior/valley/valley_medical_south)
 "nxq" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -58430,6 +62196,14 @@
 	icon_state = "rasputin3"
 	},
 /area/shuttle/tri_trans1/alpha)
+"nyM" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "floor_plate"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
 "nza" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -58447,6 +62221,16 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"nzq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_lobby)
 "nzH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -58489,8 +62273,16 @@
 /obj/structure/sign/safety/hazard,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"nAI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 6;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/treatment_room)
 "nAZ" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "nBh" = (
@@ -58553,6 +62345,7 @@
 "nCr" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "whitegreen"
@@ -58565,6 +62358,10 @@
 	icon_state = "white"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_lobby)
+"nDe" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/interior/caves/central_caves)
 "nDh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -58583,6 +62380,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -58606,6 +62404,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/substation/central)
+"nDW" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal3"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "nEo" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
@@ -58613,6 +62418,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/west_tunnel)
+"nEV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement3"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
+"nFd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/bright_clean,
+/area/desert_dam/interior/east_engineering)
 "nFh" = (
 /obj/structure/showcase/yaut,
 /obj/effect/landmark/lv624/fog_blocker,
@@ -58650,6 +62465,36 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_south)
+"nHc" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
+"nHe" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/interior/lab_northeast/east_lab_maintenence)
+"nHr" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/lab_northeast/east_lab_RND)
+"nHw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
 "nHz" = (
 /obj/machinery/door/airlock/mainship/engineering,
 /obj/structure/cable,
@@ -58671,8 +62516,15 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/north_wing_hallway)
+"nHU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "nIf" = (
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached1"
 	},
@@ -58717,6 +62569,10 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_labs)
+"nJy" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "nKf" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
@@ -58739,8 +62595,26 @@
 	icon_state = "vault"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"nKP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_two/equipment)
+"nKS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
 "nLd" = (
 /obj/structure/flora/rock/pile/alt,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/central_caves)
 "nLt" = (
@@ -58756,12 +62630,25 @@
 	},
 /turf/open/floor/wood,
 /area/desert_dam/building/medical/break_room)
+"nLS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whiteyellow"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_lobby)
 "nMx" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached18"
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"nMz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "nMM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -58785,6 +62672,14 @@
 	icon_state = "floor_marked"
 	},
 /area/desert_dam/building/cafeteria/loading)
+"nMT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "nMW" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -58821,6 +62716,24 @@
 	icon_state = "wood"
 	},
 /area/desert_dam/building/dorms/hallway_westwing)
+"nNN" = (
+/obj/effect/landmark/excavation_site_spawner,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"nOn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_entrance)
+"nOo" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
 "nOE" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison{
@@ -58828,6 +62741,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
+"nPz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/desert_dam/building/water_treatment_one/breakroom)
 "nPH" = (
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 4
@@ -58848,6 +62767,12 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
+"nQv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
 "nQx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -58860,6 +62785,12 @@
 /obj/item/instrument/guitar,
 /turf/open/floor/mainship/mono,
 /area/desert_dam/exterior/valley/tradeship)
+"nQQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "nRC" = (
 /obj/machinery/light{
 	dir = 1
@@ -58910,6 +62841,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_mining)
+"nSm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/desert_dam/building/administration/hallway)
 "nSy" = (
 /obj/structure/flora/rock/alt2{
 	name = "rock"
@@ -58949,6 +62887,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "whitegreen"
 	},
@@ -58960,9 +62899,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"nTx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "cell_stripe"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
 "nTF" = (
-/obj/structure/stairs,
 /obj/effect/landmark/lv624/fog_blocker,
+/obj/structure/stairs/seamless,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/interior/caves/temple)
 "nTI" = (
@@ -58974,6 +62920,10 @@
 	dir = 9
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"nUJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/south_valley_dam)
 "nUW" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 4
@@ -58993,11 +62943,27 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"nVD" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_wilderness)
+"nVV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/substation/northeast)
 "nWL" = (
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 4
 	},
 /area/desert_dam/interior/caves/temple)
+"nWN" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/treatment_room)
 "nWR" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -59012,6 +62978,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"nXl" = (
+/obj/machinery/landinglight/ds2/delaytwo,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "nXt" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -59066,6 +63039,18 @@
 	dir = 5
 	},
 /area/desert_dam/exterior/valley/tradeship)
+"nZr" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached15"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
+"oab" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "oap" = (
 /obj/structure/window/reinforced/toughened{
 	dir = 4
@@ -59105,6 +63090,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/medical/virology_isolation)
+"ocC" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_2"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_medical_south)
 "odn" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached14"
@@ -59139,6 +63131,19 @@
 /obj/structure/window/framed/chigusa,
 /turf/closed/wall/r_wall/chigusa,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"oeE" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"oeU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkbrown2"
+	},
+/area/desert_dam/building/warehouse/loading)
 "oeV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -59154,6 +63159,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/valley/valley_telecoms)
+"ogq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/interior/dam_interior/south_tunnel)
+"ogG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "ogI" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	id = "northpath1"
@@ -59163,12 +63176,26 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"ohO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkbrown2"
+	},
+/area/desert_dam/building/warehouse/loading)
 "oit" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"oiX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 5
+	},
+/area/desert_dam/interior/caves/east_caves)
 "ojD" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -59248,10 +63275,27 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
+"onF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitepurplecorner"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "onL" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/interior/caves/temple)
+"ool" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/warehouse/breakroom)
 "oow" = (
 /obj/machinery/landinglight/ds2/delaytwo{
 	dir = 8
@@ -59271,6 +63315,7 @@
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
 "ooD" = (
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/warden)
 "ooW" = (
@@ -59278,6 +63323,12 @@
 	icon_state = "cement_sunbleached13"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
+"opc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/administration/control_room)
 "opG" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/valley/valley_crashsite)
@@ -59286,6 +63337,7 @@
 	icon_state = "road_edge_decal2"
 	},
 /obj/structure/desertdam/decals/loose_sand_overlay,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
 "oqC" = (
@@ -59362,6 +63414,16 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"ouf" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
 "ouG" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -59403,6 +63465,14 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/north_wing_hallway)
+"oxA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "oxL" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -59431,6 +63501,13 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/valley/tradeship)
+"oyL" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal7"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "oze" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -59493,6 +63570,13 @@
 	icon_state = "greencorner"
 	},
 /area/desert_dam/building/telecommunication)
+"oCm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/medical/break_room)
 "oCv" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison{
@@ -59500,6 +63584,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_one/equipment)
+"oCD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement1"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
 "oCQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -59517,6 +63608,7 @@
 "oDe" = (
 /obj/machinery/door/airlock/mainship/command/canterbury{
 	dir = 1;
+	locked = 1;
 	name = "\improper Command Cockpit"
 	},
 /turf/open/floor/plating/plating_catwalk,
@@ -59544,6 +63636,10 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/administration/hallway)
+"oEI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/water_treatment_one/hallway)
 "oEU" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -59554,6 +63650,10 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_biology)
+"oEW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "oFf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -59578,6 +63678,18 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
+"oGC" = (
+/obj/structure/platform,
+/obj/structure/flora/rock/pile/alt3,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"oGE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
 "oGQ" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -59641,7 +63753,17 @@
 /obj/structure/flora/rock/alt{
 	name = "rock"
 	},
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"oJZ" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/flora/rock/pile/alt3,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 8
+	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "oKn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -59664,10 +63786,31 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"oKQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement13"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
+"oLc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "oLz" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"oLE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_labs)
+"oLR" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "oLT" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -59712,11 +63855,17 @@
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_mining)
 "oNS" = (
-/obj/structure/stairs/railstairs,
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 4
+	},
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"oNT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/area/desert_dam/exterior/valley/north_valley_dam)
 "oNX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -59746,10 +63895,23 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/dam_interior/south_tunnel)
+"oOy" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/warehouse/breakroom)
 "oOD" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"oOG" = (
+/obj/structure/bed/chair,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/security/courtroom)
 "oOO" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -59771,6 +63933,13 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"oPp" = (
+/obj/structure/flora/pottedplant,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "whiteblue"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_lobby)
 "oPz" = (
 /obj/machinery/power/monitor{
 	name = "Core Power Monitoring"
@@ -59801,6 +63970,18 @@
 	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"oQK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
+"oRf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/cafeteria/loading)
 "oRg" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_3"
@@ -59830,6 +64011,10 @@
 	},
 /turf/open/ground/river/desertdam/clean/shallow,
 /area/desert_dam/exterior/river/riverside_central_south)
+"oSG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "oSY" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/effect/ai_node,
@@ -59854,6 +64039,12 @@
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"oTj" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "oTm" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -59920,6 +64111,13 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"oWj" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "oWr" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -59943,6 +64141,12 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"oXG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/virology_isolation)
 "oXK" = (
 /obj/effect/landmark/weed_node,
 /obj/structure/cable,
@@ -59967,11 +64171,24 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/administration/hallway)
+"oYj" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "floor_plate"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
 "oYW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/desert_dam/building/warehouse/breakroom)
+"oZd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 6
+	},
+/area/desert_dam/interior/caves/temple)
 "oZg" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -60016,6 +64233,12 @@
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"paI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "paV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -60024,6 +64247,10 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_two/hallway)
+"paZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/north_valley_dam)
 "pba" = (
 /obj/structure/flora/tree/joshua,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -60045,6 +64272,20 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/central_tunnel)
+"pbV" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"pcp" = (
+/obj/structure/desertdam/decals/road/stop{
+	dir = 1;
+	icon_state = "stop_decal5"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "pcA" = (
 /obj/structure/flora/rock/pile/alt,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -60072,6 +64313,19 @@
 "pcJ" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner{
 	dir = 8
+	},
+/area/desert_dam/exterior/river/riverside_east)
+"pdj" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached11"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
+"pdp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
 	},
 /area/desert_dam/exterior/river/riverside_east)
 "pdV" = (
@@ -60105,6 +64359,13 @@
 	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"peU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "greencorner"
+	},
+/area/desert_dam/building/telecommunication)
 "peV" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 2;
@@ -60144,6 +64405,13 @@
 	dir = 5
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
+"pgv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/warehouse/breakroom)
 "pgN" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 5
@@ -60217,6 +64485,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/bcircuit,
 /area/desert_dam/interior/dam_interior/smes_main)
+"pjm" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
+"pjq" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "pjv" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -60232,6 +64512,7 @@
 /area/desert_dam/interior/lab_northeast/east_lab_west_entrance)
 "pjM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "whitegreen"
@@ -60243,6 +64524,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -60264,6 +64546,11 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"pkL" = (
+/obj/structure/flora/desert/grass,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "pkY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -60281,6 +64568,12 @@
 	icon_state = "cement_sunbleached18"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
+"ple" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "plo" = (
 /obj/structure/flora/desert/grass,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -60343,6 +64636,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_wilderness)
+"pnH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "pnK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60361,6 +64660,13 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"poo" = (
+/obj/effect/decal/sandytile,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
+/area/desert_dam/interior/caves/temple)
 "poP" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 5
@@ -60401,6 +64707,23 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/virology_isolation)
+"pqa" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
+"pqi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "kitchen"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "pqj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -60506,6 +64829,11 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"ptK" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "ptU" = (
 /turf/open/ground/coast,
 /area/desert_dam/exterior/river/riverside_east)
@@ -60536,6 +64864,13 @@
 	icon_state = "cement_sunbleached11"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
+"pva" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/north_wing_hallway)
 "pvs" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/south_valley_dam)
@@ -60570,6 +64905,10 @@
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/security/southern_hallway)
+"pwF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/water_treatment_one/garage)
 "pwL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60606,12 +64945,23 @@
 	dir = 9
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
+"pxl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "pxm" = (
 /obj/machinery/computer/area_atmos/area,
 /turf/open/floor/prison/blue{
 	dir = 4
 	},
 /area/desert_dam/interior/east_engineering)
+"pxr" = (
+/obj/structure/platform,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "pxw" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -60641,6 +64991,22 @@
 "pys" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_medical_south)
+"pyy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
+"pzh" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull"
+	},
+/area/desert_dam/interior/east_engineering)
 "pzq" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -60655,6 +65021,13 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"pzE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "pAf" = (
 /obj/structure/sink{
 	dir = 1;
@@ -60677,6 +65050,14 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/virology_wing)
+"pAA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/administration/hallway)
 "pAK" = (
 /turf/open/floor/marking/asteroidwarning,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
@@ -60706,6 +65087,7 @@
 "pDp" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/east_engineering)
 "pDt" = (
@@ -60770,6 +65152,12 @@
 	dir = 5
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
+"pEA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "pEK" = (
 /obj/machinery/door/poddoor/mainship/open{
 	dir = 8;
@@ -60801,6 +65189,10 @@
 	icon_state = "cement_sunbleached9"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"pEZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/desert_dam/interior/dam_interior/western_dam_cave)
 "pFb" = (
 /obj/structure/platform{
 	dir = 1
@@ -60809,6 +65201,12 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_south)
+"pFh" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "whitepurple"
+	},
+/area/desert_dam/building/medical/chemistry)
 "pFj" = (
 /obj/structure/table,
 /obj/item/storage/fancy/vials,
@@ -60863,6 +65261,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_northwing)
+"pHV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "pHY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -60961,6 +65365,11 @@
 /obj/machinery/power/smes/preset,
 /turf/open/floor/mainship/mono,
 /area/desert_dam/exterior/valley/tradeship)
+"pKP" = (
+/obj/structure/stairs/seamless,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/desert_dam/interior/caves/temple)
 "pLj" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
@@ -60972,6 +65381,10 @@
 	dir = 5
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"pLv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/water_treatment_one/hallway)
 "pLT" = (
 /obj/structure/platform{
 	dir = 8
@@ -60997,8 +65410,21 @@
 "pMD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/east_engineering)
+"pML" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/desert_dam/building/security/prison)
 "pMQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
@@ -61012,6 +65438,12 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"pNd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/building/substation/southwest)
 "pNG" = (
 /obj/structure/xenoautopsy/tank/broken,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -61024,6 +65456,27 @@
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
+"pPs" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
+"pQJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
+"pQK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/hangar_storage)
 "pQS" = (
 /obj/structure/platform,
 /turf/open/ground/river/desertdam/clean/shallow_edge{
@@ -61050,6 +65503,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
+"pRz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/bcircuit,
+/area/desert_dam/interior/dam_interior/tech_storage)
 "pRU" = (
 /obj/structure/platform{
 	dir = 4
@@ -61059,6 +65516,13 @@
 	icon_state = "cement_sunbleached13"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"pSd" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_11"
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "pSj" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -61079,11 +65543,23 @@
 	icon_state = "wood"
 	},
 /area/desert_dam/building/water_treatment_one/hallway)
+"pTo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_two/lobby)
 "pTU" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"pUg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_mining)
 "pUl" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_2"
@@ -61096,6 +65572,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_northwing)
 "pUF" = (
@@ -61134,8 +65611,15 @@
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "pVo" = (
 /obj/structure/flora/rock/pile/alt2,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"pVC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "pVF" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -61176,8 +65660,8 @@
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
 "pWn" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairdownrailleft"
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached14"
@@ -61226,6 +65710,12 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_biology)
+"pYW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
 "pZm" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -61244,9 +65734,17 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_security_armory)
+"pZM" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal1"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_labs)
 "qab" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/west_tunnel)
 "qap" = (
@@ -61263,10 +65761,23 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+"qau" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/primary_tool_storage)
 "qaA" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/valley/valley_telecoms)
+"qaY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
 "qba" = (
 /obj/machinery/door/airlock/mainship/engineering{
 	dir = 2;
@@ -61323,6 +65834,15 @@
 /obj/structure/cable,
 /turf/closed/wall/r_wall/chigusa,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"qcC" = (
+/obj/structure/table,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/water_treatment_one/garage)
+"qdJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_cargo)
 "qdS" = (
 /turf/open/floor/plating/ground/desertdam/grate{
 	icon_state = "catwalk-255"
@@ -61359,6 +65879,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/interior/caves/east_caves)
+"qex" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/water_treatment_one/lobby)
 "qey" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -61382,6 +65906,10 @@
 	icon_state = "kitchen"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
+"qfp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/interior/dam_interior/western_dam_cave)
 "qfF" = (
 /obj/structure/table,
 /obj/item/assembly/infra,
@@ -61405,12 +65933,51 @@
 /obj/structure/flora/bush,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_hydro)
+"qgf" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
+"qgs" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/building/water_treatment_one/garage)
+"qgA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/security/northern_hallway)
 "qho" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_8"
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_medical_south)
+"qhy" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"qic" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal10"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/south_valley_dam)
+"qie" = (
+/obj/machinery/light,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "qix" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
@@ -61434,6 +66001,27 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/desert_dam/building/medical/break_room)
+"qiT" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"qjq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/substation/southwest)
+"qjM" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/west_wing_hallway)
 "qjT" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/donkpocket,
@@ -61447,6 +66035,12 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating,
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
+"qkl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/interior/dam_interior/south_tunnel)
 "qkJ" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
@@ -61454,6 +66048,16 @@
 /obj/item/stack/sheet/wood,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"qkP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement1"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
+"qkW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "qkY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -61462,12 +66066,24 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/north_wing_hallway)
+"qlg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "qlr" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"qlP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "qmg" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -61478,6 +66094,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
+"qmC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "qmG" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/ai_node,
@@ -61499,6 +66121,21 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
+"qmS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowcorner"
+	},
+/area/desert_dam/interior/dam_interior/break_room)
+"qmT" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal8"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/south_valley_dam)
 "qnk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -61511,6 +66148,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/west_tunnel)
 "qnU" = (
@@ -61539,6 +66177,15 @@
 	icon_state = "cement_sunbleached11"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
+"qph" = (
+/obj/effect/decal/sandytile,
+/obj/effect/decal/sandytile,
+/obj/effect/decal/sandytile,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
+/area/desert_dam/interior/caves/temple)
 "qpt" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 9
@@ -61568,6 +66215,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"qqL" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "qqR" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
@@ -61581,6 +66234,14 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
+"qqV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull"
+	},
+/area/desert_dam/interior/east_engineering)
 "qre" = (
 /obj/structure/largecrate/supply/explosives/mortar_flare,
 /obj/effect/decal/cleanable/dirt,
@@ -61593,6 +66254,13 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+"qrw" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_11"
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "qrD" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -61639,6 +66307,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/west_tunnel)
+"quM" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/warehouse/warehouse)
 "qvf" = (
 /obj/structure/platform{
 	dir = 8
@@ -61659,6 +66336,20 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/medical/virology_wing)
+"qwf" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/workshop)
+"qwm" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/north_wing_hallway)
 "qwp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -61707,6 +66398,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/valley/valley_hydro)
+"qyz" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal2"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_labs)
 "qyD" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/prison,
@@ -61755,6 +66453,10 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"qAG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_mining)
 "qAI" = (
 /turf/closed/mineral,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
@@ -61783,6 +66485,10 @@
 	icon_state = "floor_plate"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
+"qBV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/valley_mining)
 "qCr" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -61818,12 +66524,34 @@
 	icon_state = "cement_sunbleached18"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"qDi" = (
+/obj/effect/landmark/excavation_site_spawner,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_hydro)
+"qDp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/interior/dam_interior/north_tunnel)
 "qDM" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"qED" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "qEJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -61842,8 +66570,17 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"qFb" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/warehouse/loading)
 "qFd" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "wood"
 	},
@@ -61856,6 +66593,10 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/disposals)
+"qFg" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/interior/caves/central_caves)
 "qFh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -61926,6 +66667,13 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"qJb" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/building/substation/southwest)
 "qJc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61942,6 +66690,14 @@
 "qJq" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"qJt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/medical/lobby)
 "qJA" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/interior/dam_interior/western_dam_cave)
@@ -61957,6 +66713,13 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_biology)
+"qKy" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal3"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_labs)
 "qKA" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 1
@@ -61968,10 +66731,23 @@
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/valley_medical_south)
+"qLm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/treatment_room)
+"qLs" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "qLD" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating/ground/mars/random/cave,
+/turf/open/floor/tile/darkish,
 /area/desert_dam/interior/caves/temple)
 "qLT" = (
 /obj/structure/showcase{
@@ -61997,7 +66773,7 @@
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
 "qMp" = (
-/obj/structure/window/framed/mainship/requisitions,
+/obj/structure/window/framed/mainship,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/tradeship)
 "qMZ" = (
@@ -62009,6 +66785,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_cargo)
+"qNx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement3"
+	},
+/area/desert_dam/interior/dam_interior/northwestern_tunnel)
+"qNC" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/warehouse/warehouse)
 "qOn" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -62021,22 +66813,47 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/emergency_room)
+"qOG" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached11"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "qPe" = (
 /obj/machinery/floodlight/landing,
 /turf/open/floor{
 	icon_state = "asteroidplating"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"qPj" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal9"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/south_valley_dam)
+"qPA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "qPC" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"qQd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/area/desert_dam/exterior/valley/valley_telecoms)
 "qQe" = (
 /obj/structure/cable,
 /obj/effect/decal/warning_stripes/thin,
@@ -62050,6 +66867,10 @@
 	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"qQl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "qQG" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -62079,6 +66900,26 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_security_armory)
+"qSa" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal1"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
+"qSg" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal3"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
+"qSo" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 10
+	},
+/area/desert_dam/interior/caves/temple)
 "qSs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -62088,6 +66929,12 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/west_wing_hallway)
+"qSv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "yellow"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
 "qSO" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge{
 	dir = 4
@@ -62128,21 +66975,45 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/cavetodirt,
 /area/desert_dam/interior/caves/east_caves)
+"qTV" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/desert_dam/interior/caves/central_caves)
 "qTY" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached6"
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
+"qUc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "qUd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
 	icon_state = "cement14"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
+"qUC" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_6"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "qUE" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_cargo)
+"qUF" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "qUI" = (
 /obj/structure/platform{
 	dir = 1
@@ -62301,6 +67172,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/detective)
+"rcs" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "rcY" = (
 /obj/structure/cable,
 /turf/open/floor/prison,
@@ -62311,6 +67188,20 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/river/riverside_south)
+"rdV" = (
+/obj/structure/platform,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt{
+	dir = 8
+	},
+/area/desert_dam/exterior/river/riverside_east)
+"rea" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
+/area/desert_dam/building/security/prison)
 "reY" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -62326,6 +67217,18 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/interior/caves/temple)
+"rfs" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/lab_northeast/east_lab_east_entrance)
+"rfE" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_mining)
 "rfQ" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating,
@@ -62352,12 +67255,27 @@
 	dir = 10
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
+"rgK" = (
+/obj/structure/desertdam/decals/loose_sand_overlay,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
+"rhc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_cargo)
 "rhr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/security/staffroom)
+"ric" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/building/cafeteria/backroom)
 "riy" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge{
 	dir = 4
@@ -62365,6 +67283,7 @@
 /area/desert_dam/exterior/river_mouth/southern)
 "riN" = (
 /obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 8
 	},
@@ -62406,6 +67325,23 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/warehouse/breakroom)
+"rjY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
+"rkl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/interior/dam_interior/western_dam_cave)
+"rkm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/desert_dam/building/security/prison)
 "rko" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -62450,11 +67386,24 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/valley/tradeship)
+"rlN" = (
+/obj/structure/flora/desert/cactus{
+	icon_state = "cactus_4"
+	},
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "rlU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/desert_dam/building/cafeteria/loading)
+"rlV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement3"
+	},
+/area/desert_dam/interior/dam_interior/south_tunnel)
 "rmj" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -62491,6 +67440,27 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/virology_wing)
+"roA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/primary_tool_storage)
+"roD" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "whiteblue"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_lobby)
 "roU" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/south_tunnel)
@@ -62512,6 +67482,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -62543,6 +67514,13 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/interior/caves/east_caves)
+"rrY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/workshop)
 "rsn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -62562,6 +67540,11 @@
 /obj/effect/ai_node,
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/riverside_central_south)
+"rtL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/east_engineering)
 "rtX" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal3"
@@ -62573,6 +67556,14 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/west_tunnel)
+"rvB" = (
+/obj/structure/flora/desert/cactus{
+	icon_state = "cactus_8"
+	},
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "rvL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -62596,6 +67587,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/catwalk,
 /area/desert_dam/exterior/river/riverside_south)
+"rwW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached9"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "rxm" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -62605,6 +67602,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/workshop)
+"rxO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/desert_dam/building/security/prison)
 "rxU" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock{
@@ -62665,6 +67670,11 @@
 	icon_state = "cement1"
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
+"rzl" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "rzB" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_9"
@@ -62686,6 +67696,10 @@
 	icon_state = "white"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_lobby)
+"rAC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/valley/valley_cargo)
 "rAM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -62701,6 +67715,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
+"rAT" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal6"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_labs)
+"rAW" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/interior/dam_interior/west_tunnel)
 "rAX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -62743,7 +67771,11 @@
 "rCp" = (
 /obj/structure/platform,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/ground/mars/random/cave,
+/obj/effect/decal/sandytile,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
 /area/desert_dam/interior/caves/temple)
 "rCt" = (
 /obj/machinery/door/airlock/mainship/generic{
@@ -62768,12 +67800,36 @@
 	icon_state = "cement4"
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
+"rDd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached11"
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "rDe" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_mining)
+"rDw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached2"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
+"rEa" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkred2"
+	},
+/area/desert_dam/building/security/southern_hallway)
+"rEb" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "rEm" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -62820,6 +67876,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -62853,6 +67910,7 @@
 "rHl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "whitegreen"
@@ -62865,6 +67923,13 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"rHB" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/hydroponics/hydroponics_breakroom)
 "rHN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -62887,6 +67952,19 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"rIa" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/interior/caves/central_caves)
+"rIv" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal4"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "rJp" = (
 /obj/machinery/door/airlock/mainship/engineering,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
@@ -62925,6 +68003,13 @@
 "rLs" = (
 /turf/open/ground/river/desertdam/clean/shallow,
 /area/desert_dam/exterior/river_mouth/southern)
+"rLu" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_4"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "rLz" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/interior/dam_interior/west_tunnel)
@@ -62976,6 +68061,13 @@
 "rOw" = (
 /turf/open/floor/wood/broken,
 /area/desert_dam/interior/caves/central_caves)
+"rOJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/building/substation/northeast)
 "rOW" = (
 /obj/structure/cable,
 /turf/closed/mineral,
@@ -62991,6 +68083,10 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
+"rPc" = (
+/obj/machinery/miner/damaged/platinum,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/desert_dam/interior/caves/temple)
 "rPm" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
@@ -63002,6 +68098,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
+"rPq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "rPE" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
@@ -63009,6 +68111,14 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"rPY" = (
+/obj/structure/closet/secure_closet/scientist,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkpurple2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "rQo" = (
 /obj/machinery/door/poddoor/shutters/mainship/open{
 	id = null;
@@ -63023,7 +68133,12 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/ground/mars/random/cave,
+/obj/effect/decal/sandytile,
+/obj/effect/decal/sandytile,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
 /area/desert_dam/interior/caves/temple)
 "rQU" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -63045,6 +68160,25 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/southern_hallway)
+"rRc" = (
+/obj/structure/desertdam/decals/loose_sand_overlay{
+	dir = 9
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
+"rRF" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached11"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"rRT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/bar/bar)
 "rSc" = (
 /obj/structure/platform{
 	dir = 1
@@ -63066,6 +68200,14 @@
 	icon_state = "cement3"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
+"rSO" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/desert_dam/building/substation/northeast)
 "rSV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
@@ -63079,12 +68221,31 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"rTi" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
+"rTD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/desert_dam/building/church)
 "rTI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/desert_dam/building/administration/office)
+"rTJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "rTW" = (
 /obj/structure/window/reinforced/toughened{
 	dir = 8
@@ -63112,6 +68273,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
+"rVG" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "rVH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63131,6 +68299,18 @@
 "rWp" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner,
 /area/desert_dam/exterior/river_mouth/southern)
+"rWy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/administration/hallway)
 "rWV" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison{
@@ -63179,15 +68359,32 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/staffroom)
+"rYj" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/administration/office)
 "rYr" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 5
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"rYL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement1"
+	},
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "rYO" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/mainship/mono,
 /area/desert_dam/exterior/valley/tradeship)
+"rYS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
 "rYT" = (
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison{
@@ -63200,6 +68397,17 @@
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"rZo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/security/southern_hallway)
 "rZP" = (
 /obj/structure/largecrate/random,
 /obj/effect/ai_node,
@@ -63208,6 +68416,13 @@
 	icon_state = "floor_marked"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_loading)
+"rZT" = (
+/obj/structure/toilet,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/warehouse/breakroom)
 "rZU" = (
 /obj/structure/desertdam/decals/road/stop{
 	icon_state = "stop_decal5"
@@ -63226,6 +68441,7 @@
 "saT" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "white"
 	},
@@ -63272,6 +68488,13 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"sen" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreencorner"
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
 "seD" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 6
@@ -63297,6 +68520,11 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/treatment_room)
+"sfE" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/interior/caves/central_caves)
 "sfP" = (
 /obj/structure/toilet{
 	dir = 1
@@ -63342,6 +68570,15 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_security_armory)
+"sgG" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "freezerfloor"
+	},
+/area/desert_dam/building/hydroponics/hydroponics_breakroom)
 "sgQ" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal3"
@@ -63361,6 +68598,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "kitchen"
@@ -63387,6 +68625,7 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -63419,6 +68658,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"siS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical_south)
 "ska" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -63454,6 +68697,13 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/lobby)
+"slb" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "slB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -63472,11 +68722,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"slU" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal4"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_labs)
 "slX" = (
 /obj/structure/bed/alien{
 	color = "#aba9a9"
 	},
-/turf/open/floor/plating/ground/mars/random/cave,
+/obj/effect/decal/sandytile,
+/obj/effect/decal/sandytile,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
 /area/desert_dam/interior/caves/temple)
 "smc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -63528,6 +68790,7 @@
 /area/desert_dam/exterior/valley/valley_hydro)
 "snO" = (
 /obj/effect/landmark/excavation_site_spawner,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 9
 	},
@@ -63557,6 +68820,16 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
+"soj" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "soE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -63566,12 +68839,19 @@
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/water_treatment_two/equipment)
-"soS" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightrailup"
+"soL" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_2"
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "tile"
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/bar_valley_dam)
+"soS" = (
+/obj/structure/stairs/seamless/platform{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
 "soU" = (
@@ -63587,6 +68867,13 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"spM" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_5"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "sqe" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -63630,6 +68917,19 @@
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"srP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"srZ" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "freezerfloor"
+	},
+/area/desert_dam/building/security/prison)
 "ssn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63655,6 +68955,22 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_one/garage)
+"sti" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/lab_northwest/west_lab_xenoflora)
+"stE" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "stQ" = (
 /obj/effect/decal/medical_decals{
 	icon_state = "docstriping"
@@ -63711,6 +69027,12 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"svN" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/grate{
+	icon_state = "catwalk-255"
+	},
+/area/desert_dam/exterior/river/riverside_central_north)
 "svV" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -63727,6 +69049,19 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_workshop)
+"swM" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_2"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/landing/landing_pad_three_external)
+"swQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkpurple2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_RND)
 "swV" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -63767,6 +69102,12 @@
 	icon_state = "asteroidfloor"
 	},
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
+"syc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "syi" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -63784,6 +69125,13 @@
 	dir = 5
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"syL" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating{
+	dir = 10;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "syM" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
@@ -63809,6 +69157,14 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"sAb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkred2"
+	},
+/area/desert_dam/building/security/southern_hallway)
 "sAm" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt{
@@ -63832,6 +69188,37 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_cargo)
+"sAH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
+"sAW" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/building/hydroponics/hydroponics_loading)
+"sBv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached9"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
+"sBK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_hydro)
+"sBX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "darkpurple2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "sCa" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
@@ -63869,6 +69256,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/desert_dam/building/bar/bar)
+"sFc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/building/substation/northeast)
 "sFe" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -63876,6 +69269,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"sFw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkpurple2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
+"sFG" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
 "sFH" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -63907,6 +69315,10 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"sGI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/medical/virology_isolation)
 "sGQ" = (
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 10
@@ -63917,6 +69329,25 @@
 	dir = 10
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"sHr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/tech_storage)
+"sHG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/bcircuit,
+/area/desert_dam/interior/dam_interior/engine_room)
+"sHI" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitepurple"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "sHL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -63926,10 +69357,40 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/lobby)
+"sIf" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/exterior/valley/valley_cargo)
+"sIA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached11"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
+"sIB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "kitchen"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "sIE" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/east_caves)
+"sIL" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "yellow"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
 "sIY" = (
 /obj/effect/landmark/weed_node,
 /obj/structure/cable,
@@ -63956,8 +69417,15 @@
 	dir = 9
 	},
 /area/desert_dam/interior/dam_interior/western_dam_cave)
+"sKy" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating{
+	icon_state = "warnplate"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "sKJ" = (
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
 	icon_state = "cement12"
 	},
@@ -63974,6 +69442,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"sLQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "sMu" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
@@ -63989,8 +69463,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"sMP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"sMR" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "sNj" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "sterile_white"
@@ -64003,6 +69495,10 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/building/substation/northeast)
+"sOL" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/water_treatment_two/hallway)
 "sOR" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -64015,8 +69511,15 @@
 /area/desert_dam/exterior/river/riverside_east)
 "sPL" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/north_tunnel_entrance)
+"sPY" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "sQb" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -64033,6 +69536,25 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"sQv" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"sRa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull"
+	},
+/area/desert_dam/building/medical/emergency_room)
+"sRr" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/south_valley_dam)
 "sRu" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -64068,6 +69590,20 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
+"sSA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/lobby)
+"sSL" = (
+/obj/structure/flora/desert/grass/heavy{
+	icon_state = "heavygrass_3"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_cargo)
 "sTc" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_6"
@@ -64089,6 +69625,12 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
+"sTE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/grate{
+	icon_state = "catwalk-255"
+	},
+/area/desert_dam/exterior/river/riverside_central_south)
 "sUA" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
@@ -64118,14 +69660,22 @@
 	icon_state = "lightgrass_2"
 	},
 /obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "sWS" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/cafeteria/loading)
+"sWV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkred2"
+	},
+/area/desert_dam/building/security/deathrow)
 "sXh" = (
 /obj/effect/landmark/start/job/xenomorph,
 /obj/effect/landmark/start/job/xenomorph,
@@ -64157,6 +69707,10 @@
 "sYf" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/valley/valley_medical_south)
+"sYj" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_civilian)
 "sYo" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
@@ -64186,6 +69740,14 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"sZx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "sZM" = (
 /obj/structure/flora/rock{
 	name = "rock"
@@ -64197,6 +69759,7 @@
 	dir = 1;
 	on = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "kitchen"
@@ -64204,8 +69767,13 @@
 /area/desert_dam/building/cafeteria/cafeteria)
 "tab" = (
 /obj/structure/flora/rock/pile/alt2,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/interior/caves/central_caves)
+"tad" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/desert_dam/exterior/valley/valley_hydro)
 "tai" = (
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -64218,6 +69786,13 @@
 	},
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"taq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/bar/bar_restroom)
 "tat" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/desertdam/decals/road/edge{
@@ -64227,6 +69802,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"tau" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "grimy"
+	},
+/area/desert_dam/building/bar/bar)
 "taC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -64248,6 +69830,16 @@
 	icon_state = "cement3"
 	},
 /area/desert_dam/interior/dam_interior/south_tunnel)
+"taQ" = (
+/obj/structure/morgue{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/medical/morgue)
 "tbc" = (
 /obj/machinery/landinglight/ds2/delaytwo,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -64265,6 +69857,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2"
 	},
@@ -64326,17 +69919,43 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
+"teg" = (
+/obj/structure/table,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
+/area/desert_dam/building/security/prison)
 "teq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
+"teC" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/bar/bar_restroom)
 "teR" = (
-/obj/structure/bed/chair/comfy/beige,
+/obj/structure/bed/chair/comfy/beige{
+	dir = 4
+	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/interior/caves/temple)
+"tfo" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_mining)
 "tfs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -64348,6 +69967,7 @@
 "thd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -64363,6 +69983,12 @@
 /obj/item/stack/sheet/wood,
 /turf/open/floor/plating/catwalk,
 /area/desert_dam/exterior/river/riverside_south)
+"thF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "tib" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal8"
@@ -64376,6 +70002,13 @@
 	icon_state = "dark"
 	},
 /area/desert_dam/building/church)
+"tio" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_workshop)
 "tiR" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -64406,6 +70039,7 @@
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_3"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_hydro)
 "tkm" = (
@@ -64419,6 +70053,19 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/warehouse/loading)
+"tkX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkredfull2"
+	},
+/area/desert_dam/building/security/deathrow)
+"tlh" = (
+/obj/structure/desertdam/decals/road/stop{
+	icon_state = "stop_decal5"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "tlu" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -64469,6 +70116,16 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
+"tnx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/landing/landing_pad_three)
+"tnz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
 "tnH" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -64496,6 +70153,10 @@
 	icon_state = "whiteblue"
 	},
 /area/desert_dam/building/medical/medsecure)
+"toM" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/interior/dam_interior/south_tunnel_entrance)
 "toP" = (
 /obj/structure/flora/desert/grass/heavy{
 	icon_state = "heavygrass_3"
@@ -64503,6 +70164,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/central_caves)
+"toU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "freezerfloor"
+	},
+/area/desert_dam/building/cafeteria/cold_room)
 "tpf" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 2;
@@ -64534,6 +70202,19 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/exterior/valley/valley_cargo)
+"tqt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_west_wing)
+"tqu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating{
+	icon_state = "warnplate"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "tqQ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -64543,8 +70224,21 @@
 "trr" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/desert_dam/building/cafeteria/backroom)
+"trA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "trV" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -64578,6 +70272,7 @@
 "tsz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkbrown2"
@@ -64643,12 +70338,30 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+"tuk" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "tuO" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 5
 	},
 /area/desert_dam/interior/dam_interior/western_dam_cave)
+"tvb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkbrown2"
+	},
+/area/desert_dam/interior/dam_interior/disposals)
 "tvf" = (
 /obj/structure/platform{
 	dir = 1
@@ -64658,10 +70371,25 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"tvD" = (
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "tvM" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 4
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"twd" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "twm" = (
@@ -64693,11 +70421,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
+"twX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/shuttle/dropship{
+	icon_state = "rasputin3"
+	},
+/area/shuttle/tri_trans2/alpha)
 "txc" = (
 /obj/structure/platform_decoration{
 	dir = 4
@@ -64714,6 +70449,18 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"txl" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"txx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "txF" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -64775,6 +70522,13 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
+"tAN" = (
+/obj/structure/desertdam/decals/road/stop{
+	icon_state = "stop_decal5"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "tBa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -64785,6 +70539,11 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/building/medical/emergency_room)
+"tBl" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/interior/caves/central_caves)
 "tBs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -64828,6 +70587,16 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/lobby)
+"tCI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement1"
+	},
+/area/desert_dam/interior/dam_interior/south_tunnel)
+"tDG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/security/prison)
 "tDH" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -64837,6 +70606,7 @@
 "tEz" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "tED" = (
@@ -64859,6 +70629,7 @@
 /area/desert_dam/exterior/valley/valley_crashsite)
 "tFr" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/interior/east_engineering)
 "tFS" = (
@@ -64907,6 +70678,11 @@
 	icon_state = "cement_sunbleached9"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"tIh" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "tIq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -64923,6 +70699,12 @@
 	icon_state = "cement14"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"tIT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "tIU" = (
 /obj/structure/table/mainship,
 /obj/effect/spawner/random/toolbox,
@@ -64962,6 +70744,13 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_civilian)
+"tKh" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "tKB" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -64977,6 +70766,13 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/security/staffroom)
+"tKO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/desert_dam/building/dorms/hallway_westwing)
 "tLj" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -65001,6 +70797,12 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_east)
+"tLL" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached2"
+	},
+/area/desert_dam/exterior/valley/valley_medical_south)
 "tLN" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -65011,6 +70813,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/hanger)
+"tMA" = (
+/obj/machinery/pipedispenser,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/east_engineering)
 "tMX" = (
 /obj/machinery/door/poddoor/mainship/open{
 	dir = 4;
@@ -65056,6 +70863,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -65063,7 +70871,7 @@
 /area/desert_dam/interior/dam_interior/lobby)
 "tPZ" = (
 /obj/structure/closet/walllocker/medical_wall,
-/turf/closed/wall/mainship/outer/canterbury,
+/turf/closed/wall/mainship,
 /area/desert_dam/exterior/valley/tradeship)
 "tQm" = (
 /obj/machinery/landinglight/ds2{
@@ -65078,6 +70886,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"tQz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/interior/dam_interior/north_tunnel)
 "tRn" = (
 /obj/structure/flora/desert/cactus{
 	icon_state = "cactus_4"
@@ -65089,9 +70901,14 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/landing/landing_pad_one)
+"tRN" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/hydroponics/hydroponics_loading)
 "tRQ" = (
 /obj/structure/desertdam/decals/loose_sand_overlay,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "tile"
 	},
@@ -65162,11 +70979,26 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/alt,
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
+"tUx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreencorner"
+	},
+/area/desert_dam/building/medical/west_wing_hallway)
 "tUF" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
 	},
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"tUN" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
 "tUS" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -65177,6 +71009,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
+"tUZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "tVs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -65213,6 +71051,12 @@
 	icon_state = "kitchen"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
+"tXG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "tXJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65224,6 +71068,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "tXQ" = (
@@ -65275,6 +71120,20 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_south)
+"uac" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_telecoms)
+"uaw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "blue"
+	},
+/area/desert_dam/building/administration/hallway)
 "uax" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -65316,6 +71175,16 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
+"ubd" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "floor_plate"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
 "ubh" = (
 /obj/machinery/light{
 	dir = 8
@@ -65327,6 +71196,20 @@
 /obj/item/tool/hand_labeler,
 /turf/open/floor/prison,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"ubq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/central_tunnel)
+"ubK" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "ubV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/mineral,
@@ -65401,6 +71284,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/courtroom)
+"ufK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "ufL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -65410,6 +71299,7 @@
 /area/desert_dam/building/hydroponics/hydroponics_loading)
 "ufP" = (
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 5
 	},
@@ -65424,6 +71314,18 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/valley/tradeship)
+"ugs" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"uht" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "uhI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -65514,6 +71416,23 @@
 	icon_state = "kitchen"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
+"umD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "floor_plate"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
+"umZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/lobby)
 "unt" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/mainship/mono,
@@ -65550,6 +71469,12 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"upU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "uqe" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -65568,12 +71493,25 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"uqF" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "uqK" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"urb" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "urw" = (
 /obj/structure/desertdam/decals/loose_sand_overlay{
 	dir = 9
@@ -65582,6 +71520,12 @@
 	icon_state = "cement_sunbleached2"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"urz" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
+	},
+/area/desert_dam/interior/caves/central_caves)
 "urD" = (
 /obj/machinery/door/airlock/mainship/security/glass{
 	name = "\improper Security Armoury"
@@ -65615,12 +71559,17 @@
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/valley/valley_cargo)
+"utd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_medical_south)
 "ute" = (
 /obj/structure/desertdam/decals/road/stop{
 	icon_state = "stop_decal5"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
 "uts" = (
@@ -65635,11 +71584,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
+"utA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached11"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "utB" = (
 /obj/structure/flora/desert/cactus/multiple{
 	icon_state = "cacti_10"
 	},
 /obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "utE" = (
@@ -65692,6 +71650,13 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/interior/lab_northeast/east_lab_RND)
+"uwd" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/desert_dam/building/lab_northwest/west_lab_xenoflora)
 "uwC" = (
 /obj/machinery/computer/nuke_disk_generator/green,
 /obj/machinery/light,
@@ -65747,6 +71712,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/interior/east_engineering)
+"uzr" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "uzw" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/prison{
@@ -65782,6 +71754,7 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2"
 	},
@@ -65821,12 +71794,28 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
+"uBY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt{
+	dir = 1
+	},
+/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "uCF" = (
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/dam_interior/south_tunnel)
+"uDw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/valley_telecoms)
+"uDD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "uEy" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/phoron{
@@ -65837,6 +71826,23 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"uFc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
+"uFt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitepurplecorner"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "uFF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/atmos_personal,
@@ -65860,10 +71866,19 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/administration/hallway)
+"uGG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkred2"
+	},
+/area/desert_dam/building/security/southern_hallway)
 "uGL" = (
 /obj/item/stack/sheet/mineral/sandstone,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -65918,9 +71933,19 @@
 	},
 /area/desert_dam/exterior/valley/valley_mining)
 "uJj" = (
-/obj/machinery/computer/nuke_disk_generator/blue,
-/turf/open/floor/wood,
-/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
+"uJC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "uJK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -65954,6 +71979,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_one/garage)
+"uKt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkbrown2"
+	},
+/area/desert_dam/building/warehouse/warehouse)
 "uKw" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/chigusa,
@@ -65975,6 +72007,23 @@
 	icon_state = "delivery"
 	},
 /area/desert_dam/interior/dam_interior/south_tunnel)
+"uLz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
+"uLI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_medical)
+"uME" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/desert_dam/exterior/valley/valley_medical_south)
 "uMG" = (
 /obj/structure/platform{
 	dir = 1
@@ -66002,6 +72051,7 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/southern_hallway)
 "uNF" = (
@@ -66023,6 +72073,20 @@
 	},
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner,
 /area/desert_dam/exterior/river/riverside_east)
+"uPw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/primary_tool_storage)
+"uPA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "uPF" = (
 /obj/effect/ai_node,
 /turf/open/floor{
@@ -66030,6 +72094,12 @@
 	icon_state = "vault"
 	},
 /area/desert_dam/building/substation/northeast)
+"uPI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "uPS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -66061,8 +72131,17 @@
 	dir = 8;
 	on = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/bar/bar)
+"uRq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "uRx" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/prison{
@@ -66092,6 +72171,20 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/security/northern_hallway)
+"uSb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/interior/dam_interior/central_tunnel)
+"uTe" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/interior/dam_interior/engine_room)
 "uTo" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -66099,6 +72192,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
+"uUz" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/interior/caves/central_caves)
 "uVK" = (
 /obj/item/tool/pickaxe,
 /obj/effect/decal/remains/human,
@@ -66130,6 +72229,15 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+"uWo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_one/hallway)
 "uWx" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -66138,6 +72246,18 @@
 	icon_state = "greencorner"
 	},
 /area/desert_dam/building/telecommunication)
+"uWH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_two/hallway)
 "uWO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -66152,6 +72272,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
+"uXd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt{
+	dir = 1
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
 "uXk" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -66227,6 +72353,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"uYI" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "uZm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -66257,6 +72388,25 @@
 	icon_state = "bluecorner"
 	},
 /area/desert_dam/building/administration/hallway)
+"uZK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
+"vac" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "vaA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -66266,6 +72416,12 @@
 	},
 /turf/open/floor/wood,
 /area/desert_dam/building/bar/bar)
+"vaB" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkred2"
+	},
+/area/desert_dam/building/security/warden)
 "vaN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -66300,6 +72456,12 @@
 	icon_state = "cement_sunbleached11"
 	},
 /area/desert_dam/exterior/valley/valley_medical)
+"vbS" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "vco" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -66317,11 +72479,20 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/west_tunnel)
+"vcE" = (
+/turf/open/floor/tile/darkish,
+/area/desert_dam/interior/caves/temple)
 "vcQ" = (
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"vde" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
+	},
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "vdZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -66357,6 +72528,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
+"vey" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "vez" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -66374,6 +72551,18 @@
 	icon_state = "cement_sunbleached20"
 	},
 /area/desert_dam/exterior/valley/valley_mining)
+"vfa" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_4"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_civilian)
+"vfe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/warehouse/warehouse)
 "vfS" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -66381,6 +72570,20 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
+"vgd" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
+"vge" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "vgi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -66408,6 +72611,14 @@
 	icon_state = "grimy"
 	},
 /area/desert_dam/building/bar/bar)
+"vgA" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/desert_dam/exterior/valley/tradeship)
 "vgF" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/desert_dam/interior/caves/east_caves)
@@ -66420,6 +72631,10 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
+"vhb" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_hydro)
 "vhf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -66451,6 +72666,12 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/detective)
+"viU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
 "viV" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -66472,6 +72693,13 @@
 /obj/effect/spawner/random/tool,
 /turf/open/floor/prison,
 /area/desert_dam/interior/east_engineering)
+"vjC" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached2"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "vjX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -66487,6 +72715,13 @@
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/lobby)
+"vki" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/lobby)
 "vks" = (
@@ -66518,6 +72753,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/armory)
+"vlH" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal3"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "vmm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -66542,6 +72784,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"vnn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
+"vnr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/administration/control_room)
+"vnx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "vnT" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
@@ -66570,6 +72832,22 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
+"voW" = (
+/obj/effect/ai_node,
+/obj/effect/decal/sandytile,
+/obj/effect/decal/sandytile,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
+/area/desert_dam/interior/caves/temple)
+"vpa" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
 "vpv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -66613,11 +72891,27 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/central_caves)
+"vrz" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/interior/caves/central_caves)
 "vrY" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 9
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"vse" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/desert_dam/interior/dam_interior/western_dam_cave)
+"vsw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "freezerfloor"
+	},
+/area/desert_dam/building/cafeteria/cold_room)
 "vsQ" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge,
 /area/desert_dam/exterior/river/riverside_east)
@@ -66643,6 +72937,7 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/bar/bar)
 "vuF" = (
@@ -66651,6 +72946,13 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical_south)
+"vwc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitepurplecorner"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "vwr" = (
 /obj/machinery/landinglight/ds1/delaythree{
 	dir = 1
@@ -66668,6 +72970,7 @@
 	dir = 10
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor{
 	icon_state = "dark2"
 	},
@@ -66698,6 +73001,13 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/west_tunnel)
+"vxh" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "vxt" = (
 /obj/effect/landmark/start/job/survivor,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -66708,6 +73018,13 @@
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/water_treatment_one/breakroom)
+"vxN" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "vxT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -66723,6 +73040,13 @@
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"vyp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating{
+	dir = 4;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "vyt" = (
 /obj/structure/flora/rock/pile/alt,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -66766,6 +73090,23 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_mining)
+"vzU" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
+"vzY" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/building/dorms/restroom)
 "vAi" = (
 /obj/machinery/door/airlock/mainship/security/glass{
 	name = "\improper Security Office"
@@ -66783,6 +73124,32 @@
 	dir = 6
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"vAC" = (
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_telecoms)
+"vAG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/west_wing_hallway)
+"vAK" = (
+/obj/machinery/iv_drip,
+/obj/machinery/door_control{
+	id = "medstorage3";
+	name = "Medical Secure Shutters"
+	},
+/turf/open/floor{
+	icon_state = "whiteblue"
+	},
+/area/desert_dam/building/medical/medsecure)
 "vBp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -66802,6 +73169,13 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
+"vBU" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "vCe" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -66835,6 +73209,18 @@
 	icon_state = "cement_sunbleached2"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"vDy" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached6"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
+"vDD" = (
+/obj/structure/platform_decoration{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/desert_dam/exterior/valley/valley_labs)
 "vDE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -66913,6 +73299,10 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/caves/central_caves)
+"vGM" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "vGO" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -66938,6 +73328,24 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
+"vHu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
+"vHX" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_hydro)
 "vIa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -66961,9 +73369,11 @@
 /area/desert_dam/exterior/valley/valley_hydro)
 "vJB" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/medical/virology_isolation)
 "vJW" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached6"
 	},
@@ -66976,6 +73386,13 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
+"vJZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/virology_isolation)
 "vKb" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -67053,6 +73470,14 @@
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"vMn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "vMp" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
@@ -67079,6 +73504,17 @@
 "vMQ" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/interior/dam_interior/western_dam_cave)
+"vMZ" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_2"
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"vNC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/building/warehouse/loading)
 "vNT" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal3"
@@ -67091,21 +73527,31 @@
 	dir = 1;
 	on = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/emergency_room)
+"vOs" = (
+/obj/structure/table/woodentable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/carpet,
+/area/desert_dam/building/administration/meetingrooom)
 "vOx" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached2"
 	},
 /area/desert_dam/exterior/valley/valley_medical)
+"vOC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "green"
+	},
+/area/desert_dam/building/dorms/hallway_westwing)
 "vOI" = (
 /obj/structure/cable,
-/obj/structure/stairs/railstairs{
-	icon_state = "stairleftrailup"
-	},
+/obj/structure/stairs/seamless/platform,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached4"
 	},
@@ -67180,6 +73626,12 @@
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"vRP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_labs)
 "vRR" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -67192,6 +73644,14 @@
 	icon_state = "cement_sunbleached19"
 	},
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"vSZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/medical/west_wing_hallway)
 "vTk" = (
 /obj/structure/bed/chair,
 /obj/effect/ai_node,
@@ -67212,12 +73672,46 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
+"vUk" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal5"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
+"vUm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement3"
+	},
+/area/desert_dam/interior/dam_interior/north_tunnel)
+"vUz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/primary_tool_storage)
 "vUI" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_civilian)
+"vUQ" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"vVm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/medical/lobby)
 "vVn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -67246,6 +73740,10 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/interior/east_engineering)
+"vWl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "vWw" = (
 /obj/machinery/landinglight/ds2{
 	dir = 8
@@ -67254,6 +73752,10 @@
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"vWx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/administration/meetingrooom)
 "vWI" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -67302,12 +73804,30 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/north_tunnel)
+"vYa" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_one/equipment)
 "vYm" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"vYD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/interior/dam_interior/central_tunnel)
+"vYE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached15"
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "vYZ" = (
 /obj/structure/rack,
 /obj/item/tool/pickaxe/drill,
@@ -67334,17 +73854,38 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/lobby)
+"vZM" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "vZV" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 6
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"waa" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
 "wai" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached16"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"wan" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "wav" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_9"
@@ -67376,10 +73917,20 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"waW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/bar/bar)
 "wba" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/catwalk,
 /area/desert_dam/exterior/river/riverside_east)
+"wbl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/building/water_treatment_one/garage)
 "wbv" = (
 /turf/open/floor/plating/ground/desertdam/asphalt{
 	icon_state = "cement_sunbleached2"
@@ -67401,6 +73952,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"wcA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "wcO" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall,
@@ -67453,6 +74008,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"wgk" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "wgp" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "\improper Research Hallway"
@@ -67483,6 +74044,10 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/bar/bar_restroom)
+"whn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_labs)
 "whC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -67490,19 +74055,47 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/engine_room)
+"whD" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/north_valley_dam)
 "whJ" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 10
 	},
 /area/desert_dam/interior/caves/temple)
+"wib" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/engine_west_wing)
+"wie" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/building/hydroponics/hydroponics_loading)
 "win" = (
-/obj/structure/cable,
-/obj/structure/stairs/railstairs,
+/obj/structure/stairs/seamless/platform/alt{
+	dir = 4
+	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
+"wiB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/hydroponics/hydroponics)
 "wiX" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
@@ -67510,6 +74103,21 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"wjc" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"wjn" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "kitchen"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "wjr" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 1
@@ -67534,6 +74142,18 @@
 	icon_state = "floor_marked"
 	},
 /area/desert_dam/building/cafeteria/loading)
+"wjN" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/cafeteria/loading)
+"wjV" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached13"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "wkt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -67548,6 +74168,16 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_one/hallway)
+"wkv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/interior/dam_interior/northwestern_tunnel)
+"wkI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "wkM" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -67591,6 +74221,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
+"wnJ" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "wnV" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
@@ -67635,6 +74272,7 @@
 /area/desert_dam/exterior/valley/valley_hydro)
 "wqF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "sterile_white"
@@ -67692,10 +74330,18 @@
 "wsw" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"wsS" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/desert_dam/exterior/valley/valley_labs)
 "wtl" = (
-/obj/structure/stairs,
-/obj/structure/cable,
-/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/obj/structure/stairs/seamless,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached15"
+	},
 /area/desert_dam/exterior/valley/valley_telecoms)
 "wtr" = (
 /obj/structure/cable,
@@ -67729,10 +74375,29 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/security/northern_hallway)
+"wut" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "wuz" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_medical_south)
+"wuG" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "kitchen"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "wuJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -67741,6 +74406,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_storage)
+"wvB" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "wvK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -67748,9 +74420,42 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/interior/east_engineering)
+"wvM" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
+"wvY" = (
+/obj/structure/stairs/cornerdark/seamless,
+/obj/structure/platform_decoration,
+/turf/open/floor/plating,
+/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "wwd" = (
 /turf/closed/wall/r_wall,
 /area/desert_dam/interior/dam_interior/hanger)
+"wwQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/medical/chemistry)
+"wwY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
 "wxc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -67805,6 +74510,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -67819,6 +74525,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/south_tunnel)
+"wzn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "dark2"
+	},
+/area/desert_dam/building/administration/archives)
 "wzq" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -67831,6 +74543,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -67843,6 +74556,30 @@
 "wAC" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"wAE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
+"wBa" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
+"wBc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "wBs" = (
 /obj/effect/landmark/nuke_spawn,
 /turf/open/floor/prison{
@@ -67885,6 +74622,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"wCR" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "freezerfloor"
+	},
+/area/desert_dam/building/hydroponics/hydroponics_breakroom)
 "wCZ" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	id = "port_authority1"
@@ -67928,6 +74672,12 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_westwing)
+"wFj" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached11"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "wFv" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/tile/red/whitered{
@@ -67936,6 +74686,7 @@
 /area/desert_dam/building/medical/office1)
 "wFH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	icon_state = "sterile_white"
 	},
@@ -67975,6 +74726,12 @@
 	icon_state = "whiteyellow"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_lobby)
+"wIN" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/desert_dam/building/security/observation)
 "wJs" = (
 /obj/structure/closet/crate/medical,
 /obj/effect/decal/cleanable/dirt,
@@ -68035,7 +74792,9 @@
 /area/desert_dam/interior/dam_interior/break_room)
 "wLU" = (
 /obj/effect/landmark/lv624/fog_blocker,
-/turf/closed/wall/mineral/sandstone,
+/turf/closed/wall/r_wall/chigusa{
+	name = "reinforced metal wall"
+	},
 /area/desert_dam/interior/caves/temple)
 "wMm" = (
 /obj/effect/landmark/corpsespawner/chef{
@@ -68046,6 +74805,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/desert_dam/interior/caves/central_caves)
+"wMn" = (
+/obj/structure/flora/desert/cactus{
+	icon_state = "cactus_7"
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "wMo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor{
@@ -68063,8 +74829,14 @@
 	},
 /area/desert_dam/exterior/river/riverside_east)
 "wMF" = (
-/turf/closed/wall/mainship/outer/canterbury,
+/turf/closed/wall/mainship,
 /area/desert_dam/exterior/valley/tradeship)
+"wNl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "red"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_entrance)
 "wNs" = (
 /turf/closed/shuttle{
 	icon_state = "swallc4"
@@ -68192,6 +74964,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
+"wRx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "darkbrown2"
+	},
+/area/desert_dam/building/warehouse/loading)
 "wRR" = (
 /obj/structure/flora/desert/grass,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -68221,6 +75000,19 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_mining)
+"wSi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached13"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
+"wSm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "wSt" = (
 /obj/structure/cryofeed/right{
 	name = "\improper coolant feed"
@@ -68232,6 +75024,7 @@
 "wSE" = (
 /obj/structure/cable,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/marshals_office)
 "wSH" = (
@@ -68330,6 +75123,28 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_northwing)
+"wUq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
+	},
+/area/desert_dam/exterior/valley/valley_medical)
+"wUC" = (
+/obj/machinery/door/airlock/mainship/generic{
+	dir = 2;
+	name = "\improper Toilet Unit"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "sterile_white"
+	},
+/area/desert_dam/building/cafeteria/cafeteria)
+"wVo" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_hydro)
 "wVs" = (
 /obj/effect/ai_node,
 /turf/open/floor{
@@ -68343,6 +75158,14 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/west_tunnel)
+"wVK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/desert_dam/interior/dam_interior/central_tunnel)
 "wWi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68358,6 +75181,13 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_south)
+"wWx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/desert_dam/building/water_treatment_one/breakroom)
 "wWZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -68365,6 +75195,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/lab_northeast/east_lab_east_entrance)
+"wYq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement,
+/area/desert_dam/interior/dam_interior/north_tunnel_entrance)
 "wYS" = (
 /obj/structure/flora/tree/joshua,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -68379,6 +75213,13 @@
 	dir = 5
 	},
 /area/desert_dam/exterior/valley/valley_labs)
+"wZU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "xab" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/prison,
@@ -68395,11 +75236,16 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/security/northern_hallway)
+"xar" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "xaB" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -68428,6 +75274,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"xbk" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt{
+	dir = 1
+	},
+/area/desert_dam/exterior/river/riverside_central_north)
 "xbr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -68437,10 +75289,22 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/west_wing_hallway)
+"xbQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "xcX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor/wood,
 /area/desert_dam/building/administration/office)
+"xdg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
+	},
+/area/desert_dam/exterior/valley/valley_cargo)
 "xdh" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal1"
@@ -68476,6 +75340,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_security_armory)
+"xeo" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/security/courtroom)
 "xet" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68486,6 +75357,7 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -68602,12 +75474,36 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"xif" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/hanger)
+"xin" = (
+/obj/machinery/landinglight/ds2/delaytwo{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/landing/landing_pad_three_external)
 "xix" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
+"xiz" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "xiB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -68616,6 +75512,11 @@
 	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
+"xiV" = (
+/obj/structure/flora/rock/pile/alt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "xjb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -68624,6 +75525,15 @@
 	icon_state = "floor_marked"
 	},
 /area/desert_dam/building/cafeteria/loading)
+"xjz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/building/water_treatment_one/hallway)
 "xjC" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison,
@@ -68633,6 +75543,13 @@
 /obj/structure/cable,
 /turf/open/floor/bcircuit,
 /area/desert_dam/interior/dam_interior/smes_main)
+"xjS" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal1"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
 "xjY" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
@@ -68640,6 +75557,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
+"xke" = (
+/obj/structure/flora/desert/grass/heavy{
+	icon_state = "heavygrass_5"
+	},
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
+"xkJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt{
+	dir = 10
+	},
+/area/desert_dam/interior/dam_interior/western_dam_cave)
 "xkN" = (
 /obj/machinery/microwave,
 /obj/structure/table/mainship,
@@ -68653,6 +75583,7 @@
 	on = 1
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "sterile_white"
@@ -68701,12 +75632,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/interior/caves/temple)
+"xmN" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/bar_valley_dam)
 "xmX" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"xnf" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/valley_wilderness)
 "xnv" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement{
@@ -68775,6 +75718,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -68814,6 +75758,11 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
+"xsd" = (
+/obj/structure/flora/desert/grass,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_medical)
 "xsQ" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -68875,12 +75824,25 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_one/lobby)
+"xvu" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/desert_dam/interior/caves/central_caves)
 "xvz" = (
 /obj/structure/flora/desert/grass{
 	icon_state = "lightgrass_2"
 	},
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"xvC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "xvJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -68890,6 +75852,16 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
+"xvK" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
 "xvS" = (
 /obj/machinery/landinglight/ds1/delaytwo,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -68909,6 +75881,12 @@
 	icon_state = "whiteyellowcorner"
 	},
 /area/desert_dam/interior/dam_interior/break_room)
+"xws" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "xwG" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -68982,11 +75960,28 @@
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/warehouse/warehouse)
+"xAf" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "xAB" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/desert_dam/building/administration/control_room)
+"xAW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement{
+	icon_state = "cement1"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
 "xBb" = (
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 6
@@ -69018,12 +76013,11 @@
 	},
 /area/desert_dam/building/security/prison)
 "xCf" = (
-/obj/structure/stairs/railstairs{
-	icon_state = "stairrightraildown"
+/obj/structure/stairs/seamless/platform{
+	dir = 8
 	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/desertdam/asphalt{
-	icon_state = "cement_sunbleached15"
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "xCj" = (
@@ -69077,6 +76071,29 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+"xEQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/primary_tool_storage)
+"xEX" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal3"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_medical)
+"xEY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/desert_dam/building/dorms/hallway_westwing)
 "xFk" = (
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 6
@@ -69086,6 +76103,18 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/mainship/blue,
 /area/desert_dam/exterior/valley/tradeship)
+"xFn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
+"xFs" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/exterior/valley/valley_mining)
 "xFu" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -69098,6 +76127,18 @@
 	},
 /turf/open/floor/wood,
 /area/desert_dam/interior/caves/central_caves)
+"xFR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "xFV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall/r_wall,
@@ -69143,6 +76184,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/water_treatment_one/hallway)
+"xHE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreencorner"
+	},
+/area/desert_dam/building/medical/west_wing_hallway)
 "xHP" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -69208,6 +76256,7 @@
 	},
 /area/desert_dam/exterior/river/riverside_central_north)
 "xJQ" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/desert_dam/interior/caves/temple)
 "xKY" = (
@@ -69232,6 +76281,11 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/security/northern_hallway)
+"xLF" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "xLK" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
@@ -69248,6 +76302,15 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"xLU" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/west_wing_hallway)
 "xMd" = (
 /obj/structure/cable,
 /turf/open/floor/prison{
@@ -69267,6 +76330,14 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/river/riverside_central_north)
+"xMs" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "xMy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -69305,6 +76376,7 @@
 /area/desert_dam/exterior/valley/valley_hydro)
 "xMS" = (
 /obj/structure/bed/chair/office/light,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "whitegreenfull"
@@ -69348,6 +76420,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/riverside_east)
+"xOM" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "xPA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/desertdam/decals/road/edge{
@@ -69392,6 +76469,14 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/lab_northeast/east_lab_maintenence)
+"xRz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/engine_west_wing)
 "xRI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -69399,6 +76484,10 @@
 	},
 /turf/open/floor/wood,
 /area/desert_dam/building/medical/CMO)
+"xSK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/desert_dam/building/security/courtroom)
 "xTh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -69414,6 +76503,12 @@
 	dir = 8
 	},
 /area/desert_dam/interior/caves/central_caves)
+"xTN" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/valley_cargo)
 "xUM" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -69421,7 +76516,7 @@
 "xUU" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/body,
 /obj/effect/landmark/lv624/fog_blocker,
-/turf/open/floor/plating/ground/mars/random/cave,
+/turf/open/floor/tile/darkish,
 /area/desert_dam/interior/caves/temple)
 "xVf" = (
 /obj/effect/ai_node,
@@ -69450,15 +76545,29 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
+"xVH" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/desert_dam/building/medical/west_wing_hallway)
 "xVI" = (
 /obj/structure/cable,
-/obj/structure/stairs/railstairs{
-	icon_state = "stairleftraildown"
+/obj/structure/stairs/seamless/platform{
+	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
+"xWh" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	icon_state = "whitepurplecorner"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "xWm" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -69490,15 +76599,37 @@
 	icon_state = "cement12"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
+"xXb" = (
+/obj/structure/desertdam/decals/road/edge{
+	icon_state = "road_edge_decal3"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/south_valley_dam)
+"xXh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "xXq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+"xXL" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/desert_dam/building/medical/chemistry)
 "xXT" = (
 /obj/structure/flora/rock/alt3{
 	name = "rock"
@@ -69525,6 +76656,14 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/administration/lobby)
+"xYT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/desert_dam/building/church)
 "xZe" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal4"
@@ -69538,6 +76677,15 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_wilderness)
+"ybk" = (
+/obj/structure/desertdam/decals/loose_sand_overlay{
+	dir = 9
+	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "ybx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -69565,6 +76713,13 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
+"yck" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkbrowncorners2"
+	},
+/area/desert_dam/building/warehouse/warehouse)
 "ycr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -69587,6 +76742,17 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/building/medical/garage)
+"ydV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitepurplecorner"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
+"yeb" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "yei" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -69603,6 +76769,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_cargo)
+"yfb" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 6
+	},
+/area/desert_dam/exterior/valley/valley_crashsite)
 "yfq" = (
 /obj/structure/desertdam/decals/road/edge{
 	icon_state = "road_edge_decal3"
@@ -69647,6 +76819,14 @@
 	name = "reinforced metal wall"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
+"yhl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean"
+	},
+/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "yhu" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt{
@@ -69692,6 +76872,13 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/north_wing_hallway)
+"yiM" = (
+/obj/structure/flora/desert/grass{
+	icon_state = "lightgrass_3"
+	},
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_crashsite)
 "yiP" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached{
@@ -69729,8 +76916,22 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
+"ykj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_mining)
+"ykw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt{
+	icon_state = "cement_sunbleached19"
+	},
+/area/desert_dam/exterior/valley/valley_cargo)
 "ykK" = (
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "darkyellowcorners2"
@@ -69773,6 +76974,10 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"ylW" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/interior/caves/central_caves)
 "yma" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -71292,7 +78497,7 @@ dTs
 bUd
 aia
 bUe
-bUg
+xkJ
 bUg
 dTs
 dTs
@@ -71392,7 +78597,7 @@ jOV
 mFm
 ekk
 gbQ
-gbQ
+iOl
 cBS
 wAC
 wAC
@@ -71526,7 +78731,7 @@ dTs
 dTs
 bUg
 bUg
-bUg
+xkJ
 bUg
 bUg
 bPO
@@ -71628,7 +78833,7 @@ hQr
 dTs
 jPc
 cBS
-wAC
+hFZ
 wAC
 dTs
 dTs
@@ -71718,8 +78923,8 @@ dTs
 qJA
 qJA
 qJA
-qJA
-qJA
+pEZ
+pEZ
 qJA
 qJA
 qJA
@@ -71740,7 +78945,7 @@ dTs
 dTs
 qJA
 qJA
-qJA
+pEZ
 dTs
 dTs
 dTs
@@ -71752,9 +78957,9 @@ dTs
 dTs
 dTs
 bUg
+xkJ
 bUg
-bUg
-bUg
+xkJ
 bUg
 dTs
 dTs
@@ -71762,7 +78967,7 @@ bUg
 ahn
 bUg
 bUg
-bUg
+xkJ
 bUg
 bPO
 bPO
@@ -71778,7 +78983,7 @@ dTs
 dTs
 dTs
 ceA
-ceA
+eWZ
 ceA
 dTs
 dTs
@@ -71791,14 +78996,14 @@ dTs
 dTs
 ceA
 ceA
+eWZ
 ceA
-ceA
 dTs
 dTs
 dTs
 dTs
 dTs
-ceA
+eWZ
 ceA
 ceA
 dTs
@@ -71949,14 +79154,14 @@ dTs
 dTs
 dTs
 qJA
-nPH
-qJA
+fHH
+pEZ
 qJA
 nPH
 qJA
 nns
 qJA
-dww
+lcC
 qJA
 nns
 sKl
@@ -71988,7 +79193,7 @@ azs
 bUg
 bUg
 bUg
-bUg
+xkJ
 bUg
 bUg
 bUg
@@ -72020,7 +79225,7 @@ ceA
 ceA
 ceA
 ceA
-ceA
+eWZ
 ceA
 ceA
 ceA
@@ -72034,14 +79239,14 @@ ceA
 ceA
 ceA
 ceA
-ceA
+eWZ
 ceA
 ceA
 ceA
 cIe
 ceA
-ceA
-ceA
+eWZ
+eWZ
 ceG
 jZZ
 dTs
@@ -72076,7 +79281,7 @@ cjH
 czA
 dTs
 dTs
-czA
+nqK
 cwB
 cwB
 cwB
@@ -72095,7 +79300,7 @@ qjT
 hQr
 dTs
 jPc
-cBS
+afD
 dTs
 dTs
 dTs
@@ -72112,7 +79317,7 @@ dTs
 dTs
 wAC
 wAC
-wAC
+hFZ
 wAC
 wAC
 dTs
@@ -72180,7 +79385,7 @@ qJA
 ejB
 nPH
 nPH
-qJA
+pEZ
 ejB
 ldx
 qJA
@@ -72189,14 +79394,14 @@ qJA
 qJA
 ejB
 qJA
+pEZ
 qJA
 qJA
 qJA
-qJA
-qJA
+vse
 qJA
 nPH
-qJA
+pEZ
 qJA
 yiv
 qJA
@@ -72207,7 +79412,7 @@ dTs
 dTs
 dTs
 ejB
-hgy
+gTX
 qJA
 qJA
 qJA
@@ -72270,7 +79475,7 @@ beO
 beO
 aUu
 ceA
-ceA
+eWZ
 ceA
 ceA
 bRG
@@ -72314,7 +79519,7 @@ oOP
 doE
 doE
 doE
-doE
+qdJ
 qbx
 dTs
 dTs
@@ -72444,12 +79649,12 @@ qJA
 qJA
 ldx
 qJA
-qJA
+pEZ
 qJA
 ejB
 qJA
 qJA
-nns
+kMn
 bPO
 azs
 azs
@@ -72535,7 +79740,7 @@ kEX
 cjH
 cjH
 ctw
-cqd
+iAH
 cuA
 cuA
 knM
@@ -72581,7 +79786,7 @@ uPY
 uPY
 uPY
 uPY
-uPY
+oEW
 uPY
 rYr
 kRZ
@@ -72645,10 +79850,10 @@ aQU
 wTE
 xND
 nns
-qJA
+pEZ
 qJA
 nPH
-qJA
+pEZ
 qJA
 dTs
 dTs
@@ -72666,7 +79871,7 @@ dTs
 qJA
 dww
 qJA
-qJA
+pEZ
 qJA
 nns
 qJA
@@ -72676,16 +79881,16 @@ dTs
 qJA
 qJA
 qJA
-qJA
+pEZ
 qJA
 qJA
 hgy
 qJA
-qJA
+pEZ
 yiv
 qJA
 bPO
-azs
+qfp
 azs
 bRM
 aQK
@@ -72715,12 +79920,12 @@ ceA
 aRy
 aSL
 ceA
+eWZ
 ceA
 ceA
 ceA
 ceA
-ceA
-ceA
+eWZ
 ceA
 ceA
 cjO
@@ -72747,7 +79952,7 @@ cjO
 cjO
 tDH
 ceA
-ceA
+eWZ
 ceG
 dTs
 dTs
@@ -72760,7 +79965,7 @@ cgm
 cgn
 cgY
 cih
-cih
+hgR
 cgm
 ckv
 hOq
@@ -72772,7 +79977,7 @@ cmZ
 cqd
 cuB
 eEb
-cvF
+hYS
 cvF
 cxR
 dHa
@@ -72800,9 +80005,9 @@ gOB
 gbQ
 cRE
 uPY
-rYr
+upU
 kTi
-uPY
+oEW
 uPY
 wQK
 jPc
@@ -72811,7 +80016,7 @@ qbg
 pAK
 cBS
 uPY
-uPY
+oEW
 wQK
 uPY
 uPY
@@ -72908,13 +80113,13 @@ qJA
 qJA
 qJA
 qJA
-nns
+kMn
 qJA
 sKl
 dTs
 dTs
 qJA
-nns
+kMn
 qJA
 qJA
 qJA
@@ -72925,13 +80130,13 @@ bKc
 aTQ
 cxj
 iWa
-azs
+qfp
 dTs
 dTs
 azs
+qfp
 azs
-azs
-azs
+qfp
 azs
 azs
 bPO
@@ -72998,7 +80203,7 @@ cih
 cjI
 cqa
 oBW
-cqd
+iAH
 cqd
 cqd
 cqd
@@ -73012,7 +80217,7 @@ kkH
 cQm
 doE
 doE
-doE
+qdJ
 doE
 doE
 cQm
@@ -73027,11 +80232,11 @@ kRZ
 kTi
 uPY
 uPY
-uPY
+oEW
 iXh
 gbQ
 gbQ
-gbQ
+iOl
 cBS
 uPY
 uPY
@@ -73049,7 +80254,7 @@ uPY
 uPY
 cuL
 mUm
-mUm
+elx
 jML
 uPY
 uPY
@@ -73118,12 +80323,12 @@ dTs
 dTs
 dTs
 ejB
+pEZ
 qJA
 qJA
 qJA
 qJA
-qJA
-qJA
+pEZ
 qJA
 qJA
 qJA
@@ -73134,12 +80339,12 @@ dTs
 dTs
 dTs
 dTs
-qJA
+pEZ
 ejB
 qJA
 qqj
 qJA
-qJA
+pEZ
 yiv
 ejB
 qJA
@@ -73180,8 +80385,8 @@ ceA
 ceA
 axk
 ceA
-aRy
-aSL
+jjx
+oLc
 ceA
 ceA
 acs
@@ -73203,7 +80408,7 @@ bBS
 bgz
 bgz
 bgz
-bgz
+xSK
 aTZ
 aTZ
 aTZ
@@ -73211,13 +80416,13 @@ ceA
 ceA
 cjO
 bQN
-bSH
+txx
 bUR
 cjO
-cjO
+qlP
 cjO
 ceA
-ceG
+jqe
 dTs
 dTs
 dTs
@@ -73235,11 +80440,11 @@ uWx
 cni
 cni
 cni
+peU
 cni
-cni
-cni
+peU
 cqa
-cvF
+hYS
 cwy
 cjH
 cjH
@@ -73259,12 +80464,12 @@ njv
 aKY
 cGu
 cGu
-cGu
+rTJ
 cGu
 cGu
 gbQ
 gbQ
-gbQ
+iOl
 gbQ
 gbQ
 cGu
@@ -73276,11 +80481,11 @@ cGu
 gbQ
 gbQ
 gbQ
-gbQ
+iOl
 gbQ
 cGu
 cES
-cRE
+gCm
 dsE
 tmE
 tmE
@@ -73288,7 +80493,7 @@ sFU
 uPY
 qeM
 uPY
-fRI
+wgk
 wAC
 dTs
 dTs
@@ -73353,12 +80558,12 @@ dTs
 dTs
 qqj
 hgy
-qJA
-yiv
+pEZ
+gKz
 qJA
 mTa
 qJA
-yiv
+gKz
 qJA
 dTs
 dTs
@@ -73372,7 +80577,7 @@ dTs
 qJA
 qJA
 qJA
-qJA
+pEZ
 nPH
 mTa
 qJA
@@ -73399,7 +80604,7 @@ dTs
 dTs
 dTs
 vMQ
-vMQ
+rkl
 iEI
 dTs
 dTs
@@ -73431,10 +80636,10 @@ bou
 bsb
 aUe
 bgz
-bKf
+oOG
 bKf
 bBS
-bgz
+xSK
 bKf
 bLe
 bgz
@@ -73457,7 +80662,7 @@ dTs
 dTs
 dTs
 aIP
-chv
+vAC
 cgm
 cgm
 chb
@@ -73496,7 +80701,7 @@ cGG
 cGG
 cFI
 cFS
-cGG
+fte
 nVC
 cGG
 cFS
@@ -73506,7 +80711,7 @@ cGS
 cDV
 cEZ
 cFc
-cFI
+ngA
 cFS
 cGG
 cFc
@@ -73717,7 +80922,7 @@ dTs
 dTs
 dTs
 vul
-cOj
+elW
 cTD
 cYZ
 doE
@@ -73752,7 +80957,7 @@ cBS
 kzc
 tmE
 tmE
-sFU
+nDW
 uPY
 uPY
 uPY
@@ -73882,7 +81087,7 @@ ceA
 ceA
 aQc
 beO
-dzh
+qQd
 aSL
 ceA
 ceA
@@ -73902,7 +81107,7 @@ bgz
 bgz
 bzW
 mGv
-bgz
+xSK
 bgz
 ufq
 bgz
@@ -73927,16 +81132,16 @@ cjO
 cjO
 kzQ
 ceA
+eWZ
 ceA
 ceA
 ceA
-ceA
-ceA
+eWZ
 gez
 uOe
 cjO
 ceA
-ceA
+eWZ
 ceA
 ceA
 cjO
@@ -73961,7 +81166,7 @@ dTs
 cDM
 cDY
 cDY
-cDY
+tnx
 cDY
 cDY
 wMF
@@ -73982,7 +81187,7 @@ wMF
 wMF
 rfQ
 cML
-cBS
+afD
 dsE
 tmE
 tmE
@@ -74139,7 +81344,7 @@ bgz
 bgz
 bgz
 bKZ
-bgz
+xSK
 bMZ
 bNO
 aTZ
@@ -74147,18 +81352,18 @@ ceA
 vVF
 cjO
 cjO
-cjO
+qlP
 cjO
 oIk
+qlP
 cjO
-cjO
 ceA
 ceA
-ceA
+eWZ
 ceA
 tDH
 cjO
-cvD
+hOc
 cxv
 beO
 beO
@@ -74192,11 +81397,11 @@ cUA
 doE
 dTs
 dTs
-cDb
+nXl
 cDY
 wMF
-lSp
-lSp
+qMp
+qMp
 wMF
 wMF
 jpH
@@ -74224,7 +81429,7 @@ sFU
 uPY
 uPY
 uPY
-nTW
+epQ
 wAC
 dTs
 dTs
@@ -74285,7 +81490,7 @@ bhN
 bik
 bwX
 biZ
-bhT
+mCF
 bwX
 bhT
 bhT
@@ -74295,13 +81500,13 @@ bhT
 bwX
 bhT
 biZ
-bwX
+gPJ
 bhT
 bhT
 bwX
 biZ
 bsr
-bhT
+mCF
 afh
 dTs
 dTs
@@ -74325,7 +81530,7 @@ aLY
 aLY
 aLY
 bLW
-gxo
+gZs
 bVf
 bLW
 aLY
@@ -74348,7 +81553,7 @@ aSK
 cvr
 aPR
 aRy
-dzh
+qQd
 dzh
 aSL
 cjO
@@ -74368,7 +81573,7 @@ bsl
 aUe
 bgz
 bKf
-bKf
+oOG
 bBS
 bgz
 bKf
@@ -74392,7 +81597,7 @@ ceA
 ceA
 cjO
 tDH
-csu
+wtl
 dzh
 oeX
 dzh
@@ -74415,9 +81620,9 @@ cjO
 cxt
 qbx
 cwB
-oOP
+xdg
 doE
-doE
+qdJ
 cyB
 cTG
 cTG
@@ -74443,7 +81648,7 @@ pmo
 wMF
 fqM
 knw
-oMM
+vgA
 oMM
 kMv
 kMe
@@ -74456,7 +81661,7 @@ xWn
 tmE
 sFU
 uPY
-uPY
+oEW
 lpD
 fRI
 dTs
@@ -74521,11 +81726,11 @@ bjx
 bjx
 tFX
 bjx
-bjx
+pPs
 bjx
 bjx
 blw
-bjx
+pPs
 bjx
 tFX
 bjx
@@ -74547,16 +81752,16 @@ bCe
 bCP
 bzh
 bFG
-bzi
+pQK
 bzi
 bJb
 bKm
 byo
 bLW
+qwf
 bLW
 bLW
-bLW
-bLW
+qwf
 bLW
 bLW
 bMW
@@ -74584,7 +81789,7 @@ aPR
 aRy
 sCK
 dzh
-aSL
+oLc
 cjO
 ceA
 ceA
@@ -74613,20 +81818,20 @@ bgz
 aTZ
 ceA
 ceA
-ceA
+eWZ
 ceA
 cjO
-bUT
+fAx
 bUT
 bUT
 ceA
 ceA
 gpY
-cwl
+ufK
 ceA
 cjO
 cjO
-hOB
+win
 cgb
 dzh
 aSL
@@ -74641,11 +81846,11 @@ crm
 ciF
 ciF
 chv
-ceA
+eWZ
 aRy
 dzh
 beO
-cvD
+hOc
 aKq
 cUh
 cUh
@@ -74760,16 +81965,16 @@ biE
 bjk
 blx
 bhP
+hSv
 bhP
 bhP
 bhP
 bhP
-bhP
-bhP
+hSv
 bhP
 bhA
 bst
-bhT
+mCF
 agP
 buI
 bhu
@@ -74796,7 +82001,7 @@ hmF
 bMW
 bVf
 bLW
-bLW
+qwf
 bUX
 bLU
 dTs
@@ -74817,7 +82022,7 @@ cvr
 aXd
 aRy
 dzh
-dzh
+qQd
 ekS
 cjO
 ceA
@@ -74834,7 +82039,7 @@ bom
 oFf
 bsb
 aTZ
-bdQ
+xeo
 bKf
 bKf
 bBS
@@ -74879,7 +82084,7 @@ ceA
 aRy
 dzh
 dzh
-csu
+wtl
 ewD
 ewD
 cYZ
@@ -74983,10 +82188,10 @@ aQU
 wTE
 bhe
 bdD
+hSv
 bhP
 bhP
-bhP
-bhP
+hSv
 bhP
 bhP
 biE
@@ -75001,7 +82206,7 @@ bhP
 bhP
 asR
 bhP
-bhA
+ubd
 bst
 bhT
 bsr
@@ -75020,7 +82225,7 @@ bzi
 bJd
 bzi
 bMw
-bLW
+qwf
 bME
 bLW
 bNZ
@@ -75079,17 +82284,17 @@ bsp
 bKN
 bLd
 bLL
-bLd
+lCp
 bNE
 bRz
-bTm
+krh
 bVA
-bSz
+rxO
 bSz
 cak
 caR
 bNE
-cdG
+srZ
 bNE
 cdG
 bNE
@@ -75113,7 +82318,7 @@ cjO
 eWG
 dzh
 bqd
-hOB
+win
 cHv
 ewD
 cYZ
@@ -75161,7 +82366,7 @@ uPY
 uPY
 uPY
 uPY
-fRI
+wgk
 dTs
 dTs
 acu
@@ -75247,12 +82452,12 @@ jbV
 bTA
 bVj
 bzi
-bzi
+pQK
 bzi
 kXK
 bzi
 bzi
-bzi
+pQK
 bMw
 bLW
 mhU
@@ -75303,15 +82508,15 @@ ycr
 bsm
 aUS
 bld
-bwH
+wIN
 bwH
 bwH
 aUS
 emv
 nYe
-bIW
+rEa
 bsp
-bLd
+lCp
 bLd
 bLd
 bNE
@@ -75361,7 +82566,7 @@ cZb
 cZb
 csG
 cOj
-uPY
+oEW
 cDK
 cDY
 qMp
@@ -75485,18 +82690,18 @@ bzk
 bzk
 lBM
 bVo
-bzk
+jvM
 bzk
 bMw
 bLW
 bLW
 cvf
 cvf
-cvf
+rrY
 cvf
 cCh
 gxo
-bVf
+hkq
 bLW
 bLW
 bUY
@@ -75550,15 +82755,15 @@ bLM
 bLd
 bNE
 bRD
-bTn
+rkm
 bWM
 bSz
-bSz
+rxO
 bTn
-bTn
+rkm
 cdt
-cdN
-cdN
+jGD
+jGD
 cdN
 bNE
 dTs
@@ -75581,7 +82786,7 @@ dzh
 dzh
 dzh
 beO
-cvD
+hOc
 aKq
 ewD
 cYZ
@@ -75599,8 +82804,8 @@ uPY
 cDL
 cDY
 wMF
-lSp
-lSp
+qMp
+qMp
 wMF
 wMF
 xkN
@@ -75776,7 +82981,7 @@ bml
 bml
 aUS
 ttf
-qet
+jNT
 bIX
 bNE
 bNF
@@ -75797,7 +83002,7 @@ cdN
 bNE
 dTs
 cjO
-kzQ
+uac
 aRy
 aSL
 cfC
@@ -75815,7 +83020,7 @@ bqd
 dzh
 dzh
 dzh
-aKn
+wtl
 ewD
 ewD
 cYZ
@@ -75830,7 +83035,7 @@ cZb
 csG
 doE
 uPY
-cDM
+cWQ
 cDY
 cDY
 cDY
@@ -75854,11 +83059,11 @@ wMF
 wMF
 rfQ
 waU
-cBS
+afD
 dsE
 ozv
 tmE
-sFU
+nDW
 prz
 lpD
 wQK
@@ -75938,17 +83143,17 @@ bjz
 bhP
 bhP
 brD
-xVF
+gFB
 bhT
 buD
 bhz
 bhz
-cwr
+kyu
 bSg
 bSg
 bSg
 bVQ
-bVQ
+iNH
 bSg
 bSg
 omj
@@ -75959,7 +83164,7 @@ bzm
 clY
 wOt
 bLY
-bLY
+hBL
 bLY
 bLY
 xbg
@@ -75986,7 +83191,7 @@ kfo
 aWf
 aPR
 aRy
-sCK
+ejV
 sCK
 ekS
 cjO
@@ -76019,7 +83224,7 @@ bQu
 bNE
 bSb
 eXh
-bSz
+rxO
 bYT
 bYT
 iJA
@@ -76049,7 +83254,7 @@ ctE
 aTH
 bqd
 bqd
-hOB
+win
 cHv
 ewD
 cYZ
@@ -76062,7 +83267,7 @@ cZb
 cZb
 cZb
 csG
-doE
+qdJ
 tTv
 aLy
 cDY
@@ -76194,7 +83399,7 @@ bLW
 kFa
 bLW
 bLW
-bLW
+qwf
 bLW
 kFa
 gxo
@@ -76248,7 +83453,7 @@ qet
 bIW
 bNF
 bOD
-bOD
+tDG
 bOD
 bNE
 bSn
@@ -76256,18 +83461,18 @@ bTo
 bSz
 bYT
 bYT
-bTn
+rkm
 bYl
 bNE
 chd
-cdN
+jGD
 bcM
 bNE
 dTs
 cjO
 cjO
-cex
-cfp
+vOI
+xVI
 cjO
 qpI
 tAs
@@ -76306,7 +83511,7 @@ cFP
 cGa
 cGQ
 cFe
-cFP
+xin
 cGa
 cGQ
 cFe
@@ -76328,7 +83533,7 @@ snZ
 vPD
 sFU
 uPY
-uPY
+oEW
 prz
 nTW
 wAC
@@ -76388,7 +83593,7 @@ aQU
 xWm
 bdD
 bhP
-bhP
+hSv
 bhP
 bhP
 bhP
@@ -76402,7 +83607,7 @@ bhP
 bhP
 bhP
 bhP
-bhP
+hSv
 biG
 bhP
 bhA
@@ -76420,7 +83625,7 @@ bBj
 bBj
 bFK
 phP
-kFV
+htY
 bJf
 bKo
 bMw
@@ -76495,7 +83700,7 @@ cbI
 bNE
 ciK
 ciK
-cdN
+jGD
 bNE
 dTs
 dTs
@@ -76515,7 +83720,7 @@ ceA
 cjO
 kzQ
 aUh
-ceA
+eWZ
 ceA
 cjO
 kZd
@@ -76535,6 +83740,7 @@ uPY
 aLK
 cDX
 cDX
+uDD
 cDX
 cDX
 cDX
@@ -76543,17 +83749,16 @@ cDX
 cDX
 cDX
 cDX
-cDX
-cDX
+uDD
 cES
 cDX
 cDX
 cDX
 cDX
+uDD
 cDX
 cDX
-cDX
-cDX
+uDD
 cDX
 cES
 cRB
@@ -76563,7 +83768,7 @@ tmE
 sFU
 uPY
 uPY
-lpD
+swM
 fRI
 dTs
 dTs
@@ -76622,12 +83827,12 @@ aQU
 xWm
 bdD
 bhP
-bhP
+hSv
 hGl
 bhP
+hSv
 bhP
-bhP
-bhP
+hSv
 cAx
 bjk
 blx
@@ -76659,7 +83864,7 @@ bJf
 bKp
 byo
 bMa
-bLW
+qwf
 mOk
 bLW
 bOM
@@ -76690,8 +83895,8 @@ aXf
 aZN
 dzh
 hiH
-sCK
-aSL
+ejV
+oLc
 cjO
 aoj
 aUf
@@ -76793,7 +83998,7 @@ mUm
 mUm
 ueR
 tmE
-tmE
+ffF
 sFU
 lpD
 pMX
@@ -76862,11 +84067,11 @@ bim
 bim
 bim
 bim
-bim
+ouf
 bim
 bhS
 bim
-bim
+ouf
 bim
 bim
 bim
@@ -76950,24 +84155,24 @@ bGD
 bsT
 bNG
 bOG
-bOG
+cpa
 bOG
 bNG
 cal
 cal
 bXO
+rxO
 bSz
-bSz
-nrN
+pML
 cak
 bTm
-bTm
+krh
 bTm
 csh
 bNE
 dTs
 jZZ
-cxk
+uDw
 aRy
 aSL
 lCI
@@ -77125,7 +84330,7 @@ bBw
 luw
 bzt
 bzt
-bzq
+ehW
 bzt
 bzt
 bzt
@@ -77156,10 +84361,10 @@ aSK
 cvr
 aXd
 aRy
-dzh
+qQd
 sCK
 sCK
-aSL
+oLc
 cjO
 aoj
 aND
@@ -77216,13 +84421,13 @@ dTs
 dTs
 dTs
 cuy
-ceD
+jOu
 cjO
 cxq
 cxQ
+qdJ
 doE
-doE
-doE
+qdJ
 crv
 cTD
 cYZ
@@ -77327,7 +84532,7 @@ nOE
 bhz
 biI
 bhz
-bhz
+vpa
 bhz
 nOE
 bhz
@@ -77342,25 +84547,25 @@ bhz
 fKl
 bhz
 bhz
-oKo
+sFG
 bhz
 qJc
 bhz
-bhz
+vpa
 byq
 bzr
 bzr
-bTE
+qNx
 euJ
 bTE
-bzr
+kdW
 bzr
 oze
 jlY
 iMM
 bzr
 bTE
-bTE
+qNx
 euJ
 bTE
 bTE
@@ -77369,7 +84574,7 @@ cyU
 cyU
 kcL
 cEs
-cEt
+mPo
 cEs
 gJb
 kFa
@@ -77417,12 +84622,12 @@ rZY
 bGH
 bJH
 bNF
+bge
 bOJ
-bOJ
-bOJ
+bge
 bNF
 bSX
-bTn
+rkm
 bYl
 bZH
 cai
@@ -77454,7 +84659,7 @@ dTs
 cjO
 cxr
 cwz
-doE
+qdJ
 doE
 doE
 gNP
@@ -77498,7 +84703,7 @@ tTd
 tTd
 mHb
 uPY
-uPY
+oEW
 uPY
 dTs
 dTs
@@ -77565,10 +84770,10 @@ bhz
 bhz
 bhz
 bhz
+vpa
 bhz
 bhz
-bhz
-bhz
+vpa
 bhz
 bhz
 bhz
@@ -77582,7 +84787,7 @@ buD
 bhz
 bhz
 bhz
-bwU
+gJH
 bWY
 cXG
 oze
@@ -77597,11 +84802,11 @@ bWY
 mvg
 mvg
 bwU
-bwU
+gJH
 bLY
 bLY
 bLY
-bLY
+hBL
 bLY
 cGy
 cEs
@@ -77643,7 +84848,7 @@ pfC
 bsb
 aWK
 bqh
-wjv
+fkp
 bpN
 bDE
 aWK
@@ -77691,7 +84896,7 @@ oZk
 czv
 doE
 doE
-rKU
+fVZ
 cTD
 cYZ
 doE
@@ -77719,16 +84924,16 @@ cVH
 cWn
 cNo
 aMI
-daw
+eZX
 deU
 vcQ
-vcQ
+lPH
 aMT
 daw
 lmV
 uPY
 uPY
-uPY
+oEW
 uPY
 uPY
 uPY
@@ -77819,7 +85024,7 @@ bKM
 bSh
 bzt
 bBw
-bwT
+wkv
 xri
 bzt
 bzt
@@ -77833,7 +85038,7 @@ mDA
 bzt
 bzt
 bRj
-bLW
+qwf
 bLW
 bLW
 bLW
@@ -77860,7 +85065,7 @@ aPR
 aRy
 dzh
 dzh
-dzh
+qQd
 aSL
 cjO
 aoj
@@ -77882,7 +85087,7 @@ bBb
 bDE
 aWK
 ttf
-bGH
+rZo
 bIW
 bNF
 bPz
@@ -77890,7 +85095,7 @@ bPK
 bRx
 bNE
 bTh
-bUV
+rea
 bYm
 bNE
 bTh
@@ -77898,7 +85103,7 @@ leP
 bYm
 bNE
 bTh
-bUV
+rea
 bYm
 bNE
 dTs
@@ -77907,7 +85112,7 @@ daZ
 sVo
 mfa
 gNP
-doE
+qdJ
 qbx
 czA
 dTs
@@ -77923,7 +85128,7 @@ dTs
 dTs
 vul
 cxT
-doE
+qdJ
 doE
 cDc
 cTD
@@ -77949,7 +85154,7 @@ gHj
 huv
 cxu
 sAq
-hJT
+quM
 hJT
 cXD
 aMI
@@ -77958,7 +85163,7 @@ deV
 vcQ
 vcQ
 aMU
-bjE
+kPX
 utN
 uPY
 uPY
@@ -78030,7 +85235,7 @@ bjx
 bjx
 bjx
 bjx
-bjx
+pPs
 bjx
 bjx
 bjx
@@ -78091,7 +85296,7 @@ aUA
 aUM
 aWE
 aPR
-aFx
+pVC
 bqd
 bqd
 dzh
@@ -78129,7 +85334,7 @@ bTj
 bNE
 bTj
 leP
-bTj
+teg
 bNE
 bTj
 bUV
@@ -78143,7 +85348,7 @@ cYZ
 doE
 cNQ
 doE
-cxV
+jqm
 dTs
 dTs
 dTs
@@ -78190,12 +85395,12 @@ aMI
 bjE
 aMJ
 vcQ
-vcQ
+lPH
 aNe
 bjE
 utN
 uPY
-uPY
+oEW
 uPY
 uPY
 dTs
@@ -78267,7 +85472,7 @@ bhP
 bhP
 mKW
 mKW
-bhP
+hSv
 bhP
 bhP
 bhP
@@ -78281,7 +85486,7 @@ bhA
 xVF
 bhT
 buD
-bhz
+vpa
 bin
 bhu
 bzv
@@ -78312,11 +85517,11 @@ gwU
 bLW
 bXS
 djY
-duP
+tvb
 duP
 duP
 dLd
-dLd
+mxi
 dNm
 bXQ
 dTs
@@ -78377,7 +85582,7 @@ cYZ
 doE
 qUE
 doE
-qbx
+xTN
 czA
 dTs
 dTs
@@ -78418,7 +85623,7 @@ cLI
 cLO
 cUZ
 cVH
-cOB
+gvT
 aMw
 aMI
 dbc
@@ -78428,7 +85633,7 @@ vcQ
 aNm
 dbc
 utN
-uPY
+oEW
 uPY
 uPY
 dTs
@@ -78496,7 +85701,7 @@ ams
 bhP
 bhP
 azI
-bhP
+hSv
 bhP
 jTF
 bhP
@@ -78504,11 +85709,11 @@ bhP
 bhP
 bhP
 mKW
+hSv
 bhP
 bhP
 bhP
-bhP
-bhP
+hSv
 bhP
 bhP
 bhA
@@ -78520,7 +85725,7 @@ bxb
 bhu
 bzw
 bzt
-bwc
+rEb
 mvg
 bzr
 bEg
@@ -78584,10 +85789,10 @@ brY
 bFm
 aYd
 bDL
-bGH
+rZo
 bJK
 bLa
-bLa
+uGG
 bLa
 bsS
 bsp
@@ -78595,13 +85800,13 @@ bLO
 btX
 bNf
 bNL
-bLO
+icl
 lDp
 bNf
 bNL
 bLO
 btX
-bIW
+rEa
 bsp
 cQm
 cGI
@@ -78727,7 +85932,7 @@ xMI
 aiZ
 aoE
 cck
-bhP
+hSv
 mKW
 bhP
 mKW
@@ -78746,7 +85951,7 @@ bhP
 bhP
 bhP
 bhA
-xVF
+gFB
 bsu
 buD
 bhz
@@ -78884,7 +86089,7 @@ cLQ
 cLI
 cLI
 cLO
-cUZ
+dbR
 cVI
 cOB
 cXD
@@ -78942,7 +86147,7 @@ dTs
 dTs
 bDO
 iNZ
-wJZ
+pEA
 kBc
 apz
 aql
@@ -78968,7 +86173,7 @@ bhQ
 bhP
 bhP
 bhQ
-bhP
+hSv
 bhP
 bhQ
 bhP
@@ -78990,7 +86195,7 @@ bzy
 bzt
 bwc
 bwT
-bzt
+mhP
 bzt
 bxY
 bGV
@@ -79031,7 +86236,7 @@ aFx
 axk
 ceA
 aRy
-aSL
+oLc
 ceA
 ceA
 aVB
@@ -79054,10 +86259,10 @@ aYd
 bDL
 bGL
 bJM
-bLb
+kbB
 bLb
 bJM
-nNs
+iEi
 nNs
 nNs
 bNd
@@ -79090,7 +86295,7 @@ cZb
 csG
 doE
 doE
-doE
+qdJ
 doE
 cTD
 ewD
@@ -79120,12 +86325,12 @@ cLI
 cLO
 cUY
 cVI
-cOB
+gvT
 cXD
 cYC
 dbe
 ddL
-deW
+qNC
 aMQ
 aNo
 aNK
@@ -79157,7 +86362,7 @@ dTs
 dTs
 ars
 apa
-kBb
+xiz
 axZ
 dTs
 dTs
@@ -79191,21 +86396,21 @@ dTs
 dTs
 dTs
 axZ
-vAr
+cQy
 aiZ
 aoE
 cck
 bhT
 bhP
-mKW
+umD
+hSv
 bhP
-bhP
-bhP
-mKW
-mKW
 bhP
 mKW
+mKW
 bhP
+mKW
+hSv
 bhP
 bhP
 bhP
@@ -79222,8 +86427,8 @@ bwY
 bhu
 bzu
 bzt
-bHR
-bCh
+jqO
+mDA
 bCT
 bzu
 bxY
@@ -79253,7 +86458,7 @@ cti
 vmL
 wVJ
 vmL
-vmL
+oGE
 aJJ
 vmL
 ahp
@@ -79261,7 +86466,7 @@ vZj
 aSK
 cvr
 aPR
-aFx
+pVC
 axk
 ceA
 aRy
@@ -79309,7 +86514,7 @@ svo
 mWC
 daZ
 cxU
-cwz
+sIf
 doE
 doE
 doE
@@ -79416,7 +86621,7 @@ apz
 aqg
 aqg
 asa
-iNZ
+npV
 bDO
 dTs
 dTs
@@ -79429,7 +86634,7 @@ aiZ
 aiZ
 aoE
 cck
-bhR
+nTx
 bhP
 bhP
 nji
@@ -79443,15 +86648,15 @@ bhP
 mKW
 bhR
 bhP
-mKW
+umD
 bhR
 bhP
 bhP
-brD
+gzs
 bEO
 bIh
 bJt
-bLx
+xif
 bON
 bhu
 bsi
@@ -79509,7 +86714,7 @@ awM
 awM
 awM
 awM
-frj
+ixF
 bqA
 oFf
 bsb
@@ -79520,7 +86725,7 @@ bBd
 bFw
 aYd
 bDL
-aQH
+kND
 bIX
 bIX
 bJU
@@ -79542,10 +86747,10 @@ bBL
 bBL
 dTs
 doE
-cxV
+jqm
 czA
 cwz
-doE
+qdJ
 doE
 cTC
 cUl
@@ -79556,7 +86761,7 @@ dlM
 cZb
 cZb
 csG
-cMF
+sSL
 doE
 cJd
 cJd
@@ -79566,7 +86771,7 @@ cJd
 cJd
 doE
 qUE
-doE
+qdJ
 cTD
 cYZ
 dTs
@@ -79622,7 +86827,7 @@ dsl
 dsl
 dsl
 dsl
-aoE
+aTw
 axZ
 apa
 kBb
@@ -79644,7 +86849,7 @@ dTs
 dTs
 dTs
 iNZ
-wJZ
+pEA
 kBc
 apz
 aql
@@ -79710,7 +86915,7 @@ bRc
 bRX
 bRk
 bUr
-cLX
+oCD
 cLX
 kxg
 cOo
@@ -79746,7 +86951,7 @@ axF
 bpq
 diO
 wuq
-bsn
+gpu
 aYd
 bbo
 bzd
@@ -79763,7 +86968,7 @@ bNI
 bQC
 bSB
 bWA
-cdg
+vaB
 bJU
 bBO
 bYs
@@ -79780,7 +86985,7 @@ czA
 dTs
 dTs
 cwz
-doE
+qdJ
 cTC
 dlb
 cMJ
@@ -79795,7 +87000,7 @@ czv
 cJd
 cOd
 coi
-iOV
+xYT
 cPi
 cJd
 doE
@@ -79829,7 +87034,7 @@ dbi
 dbi
 deY
 dfA
-cXK
+vfe
 cXD
 bvA
 dTs
@@ -79893,20 +87098,20 @@ dTs
 dTs
 dTs
 vAr
-aiZ
+lJC
 axY
-aoE
+aTw
 fSe
 bhP
 bhP
 bhP
 bhP
-bhP
+hSv
 bhP
 bhP
 mKW
 bhP
-bhP
+hSv
 mKW
 bhP
 bhP
@@ -79943,19 +87148,19 @@ bPX
 tdf
 bRY
 bOR
-bTG
+pqa
 bTG
 bTG
 xeQ
 bZc
 bTG
-bYC
+ngH
 bTG
 ddP
-ddP
+gUJ
 dKz
 bTG
-ddP
+gUJ
 bTG
 bYC
 cio
@@ -79966,13 +87171,13 @@ aPR
 aFx
 aPu
 ceA
-aRy
+jjx
 aSL
 ceA
 ceA
 aVM
 aXZ
-aZM
+bOy
 bes
 bkG
 bmX
@@ -79995,7 +87200,7 @@ bJV
 bMs
 bNJ
 bNi
-bNi
+inm
 bWA
 cfN
 bJU
@@ -80028,7 +87233,7 @@ cru
 doE
 cJd
 coi
-cNZ
+rTD
 fVP
 coi
 cJd
@@ -80059,7 +87264,7 @@ cVH
 vDE
 cXK
 cYJ
-cYJ
+jqs
 cXK
 deZ
 cXK
@@ -80091,11 +87296,11 @@ aPD
 iqK
 aau
 aoE
-axZ
+ihJ
 apa
 kBb
 axZ
-axZ
+ihJ
 axZ
 nmW
 apu
@@ -80133,7 +87338,7 @@ fPt
 sqe
 eHU
 bhP
-bhP
+hSv
 bhP
 bhP
 bhP
@@ -80144,17 +87349,17 @@ mKW
 mKW
 bhP
 bhP
+hSv
 bhP
 bhP
-bhP
-bhP
+hSv
 bhP
 bhA
 bEO
 bDo
 bJt
 bLx
-bhz
+vpa
 cwr
 bpJ
 bAr
@@ -80185,12 +87390,12 @@ bWT
 bTG
 bTI
 bTG
-bTG
+pqa
 bTG
 bTI
 bTG
 bTG
-bTG
+pqa
 bTI
 cio
 cfl
@@ -80203,7 +87408,7 @@ ceA
 aRy
 aSL
 ceA
-ceA
+eWZ
 aVM
 aZM
 aZM
@@ -80239,7 +87444,7 @@ car
 bBL
 ccY
 hUM
-cKX
+sWV
 cPF
 bBL
 dTs
@@ -80258,7 +87463,7 @@ dlM
 cZb
 cZb
 csG
-doE
+qdJ
 cJd
 cJd
 cJd
@@ -80327,7 +87532,7 @@ aau
 aoE
 axZ
 apa
-kBb
+xiz
 brB
 axZ
 vAr
@@ -80335,11 +87540,11 @@ aiZ
 aiZ
 aiZ
 aiZ
-aiZ
+lJC
 brB
 apu
 apu
-apu
+vZM
 vAr
 aiZ
 aiZ
@@ -80354,7 +87559,7 @@ aqg
 asa
 aiZ
 aiZ
-aiZ
+lJC
 aiZ
 aiZ
 dTs
@@ -80441,24 +87646,24 @@ ceA
 aVM
 aZM
 aZM
-aZM
+bOy
 aZM
 jIo
 aVM
 bpe
 bou
-bou
+qgA
 bom
 bsQ
 btX
 bvH
 bBe
-bBe
+sAb
 bBe
 fwg
 bHg
 bKh
-bIW
+rEa
 bJV
 bNi
 bNi
@@ -80494,15 +87699,15 @@ cZb
 csG
 doE
 cJe
-coi
+luQ
 cOe
 iOV
 tif
 coi
-coi
+luQ
 cJe
 doE
-doE
+qdJ
 cTD
 cYZ
 dTs
@@ -80515,14 +87720,14 @@ boP
 lFb
 clj
 bvA
-cph
+yck
 cmS
 mvi
 cMd
 cLI
 cLI
 cLO
-cUY
+gSR
 cVI
 vDE
 cXM
@@ -80554,7 +87759,7 @@ dTs
 dTs
 dsl
 aOK
-nKt
+uJj
 aPF
 aRc
 dsl
@@ -80566,7 +87771,7 @@ gjl
 mZc
 mZc
 mZc
-mZc
+qgf
 mZc
 mZc
 byi
@@ -80590,7 +87795,7 @@ eKa
 ipB
 ipB
 uBs
-bgN
+hnz
 bgN
 bgN
 bgN
@@ -80665,7 +87870,7 @@ cwq
 bkj
 aSK
 aPR
-aFx
+pVC
 axk
 ceA
 aRy
@@ -80695,7 +87900,7 @@ bKK
 bIX
 bKO
 bNi
-bNi
+inm
 bQH
 bTw
 bWB
@@ -80798,7 +88003,7 @@ aSC
 aau
 aOc
 akz
-alp
+dAy
 kYL
 alp
 alp
@@ -80809,10 +88014,10 @@ avC
 ame
 afy
 jCY
-aoG
+hIS
 ame
 ame
-ame
+xbQ
 ame
 oZJ
 aoE
@@ -80826,7 +88031,7 @@ ame
 gGO
 kYL
 kYL
-kYL
+vac
 kYL
 gLB
 kYL
@@ -80902,7 +88107,7 @@ aPR
 aFx
 axk
 ceA
-aRy
+jjx
 ekS
 ceA
 axF
@@ -80969,7 +88174,7 @@ cPe
 cNU
 cPk
 cJd
-doE
+qdJ
 doE
 cTD
 cYZ
@@ -80998,8 +88203,8 @@ cYC
 dbe
 ddL
 deW
-cpf
-cXK
+uKt
+vfe
 cXD
 bvA
 dTs
@@ -81038,7 +88243,7 @@ aiZ
 acW
 aqy
 aja
-aiZ
+lJC
 aiZ
 aiZ
 vYm
@@ -81056,8 +88261,8 @@ aqg
 asa
 aoE
 ame
-aiZ
-aqy
+lJC
+hfk
 aja
 aiZ
 aqy
@@ -81089,7 +88294,7 @@ brG
 bsy
 btp
 uPS
-bvY
+oWj
 bxf
 bys
 bLz
@@ -81147,10 +88352,10 @@ bnC
 bnC
 cjO
 cjO
-cjO
+qlP
 ccm
-aUu
-cjO
+syc
+qlP
 aNH
 aTy
 boq
@@ -81173,10 +88378,10 @@ bGx
 bZu
 car
 bBL
-ccY
+eni
 hUM
 cKX
-cPF
+tkX
 bBL
 dTs
 dTs
@@ -81189,7 +88394,7 @@ dTs
 dTs
 dTs
 vul
-doE
+qdJ
 cUl
 cZb
 cZb
@@ -81207,7 +88412,7 @@ doE
 doE
 cTD
 cYZ
-doE
+qdJ
 dTs
 dTs
 boP
@@ -81258,7 +88463,7 @@ dsl
 luW
 njK
 rgj
-nKt
+uJj
 hBR
 hBR
 nKt
@@ -81289,15 +88494,15 @@ aqg
 aqg
 asa
 aoE
-ame
+xbQ
 aqy
 axZ
 axZ
-ars
+iFX
 dTs
 dTs
 axZ
-ars
+iFX
 ars
 dTs
 dTs
@@ -81318,10 +88523,10 @@ bni
 bnM
 boA
 bDi
-bDi
+bGm
 boA
 boA
-boA
+mBk
 uPS
 bMc
 bMc
@@ -81335,7 +88540,7 @@ gWW
 bWa
 bBD
 bAt
-bAt
+hYe
 bDK
 brQ
 bpJ
@@ -81373,7 +88578,7 @@ ceA
 aRy
 qTY
 beO
-beO
+rTi
 beO
 beO
 beO
@@ -81422,7 +88627,7 @@ dTs
 dTs
 dTs
 czA
-vul
+gTa
 doE
 cUl
 cvJ
@@ -81494,21 +88699,21 @@ hBR
 hBR
 hBR
 woX
-nKt
+uJj
 hBR
 aPF
 aRc
 aau
-axZ
+ihJ
 aja
 aVI
 azf
 jxv
 aYu
-aYu
+jnD
 aYu
 aZx
-aYu
+jnD
 aWk
 fJx
 bdE
@@ -81553,13 +88758,13 @@ bnN
 fUE
 bEo
 rSy
-rSy
+jac
 rSy
 rSy
 ngn
 gYc
 bMc
-bvY
+oWj
 bvY
 bJj
 kUJ
@@ -81611,7 +88816,7 @@ bqd
 bqd
 qTY
 qTY
-qTY
+vDy
 qTY
 qTY
 qTY
@@ -81639,7 +88844,7 @@ cyH
 cJr
 bNw
 bZJ
-bZJ
+kYc
 caZ
 bZJ
 qZq
@@ -81667,12 +88872,12 @@ cJd
 cNY
 cOn
 cOD
-cPf
+ilf
 cNv
 cPm
 cJd
 doE
-doE
+qdJ
 cTD
 cYZ
 doE
@@ -81681,7 +88886,7 @@ dTs
 boP
 boP
 boP
-bLS
+fSV
 uAO
 cna
 bvA
@@ -81693,7 +88898,7 @@ cLG
 cOF
 cLO
 cUY
-cVI
+lFR
 cOB
 cXD
 bvA
@@ -81751,7 +88956,7 @@ aWl
 baR
 aWM
 aiZ
-aoE
+aTw
 apz
 aqg
 ahk
@@ -81830,7 +89035,7 @@ bOX
 bOX
 bOX
 cdR
-cuo
+uPA
 cxc
 pbH
 aWE
@@ -81838,16 +89043,16 @@ aPR
 aFx
 axk
 ceA
-ceA
+eWZ
 bft
 rFg
 ceA
 cjO
-aTH
+rwW
 bqd
 bqd
 bqd
-bqd
+pnH
 bqd
 aTU
 cjO
@@ -81877,7 +89082,7 @@ tnH
 kea
 kea
 fof
-bZJ
+kYc
 bZw
 dTs
 dTs
@@ -81913,7 +89118,7 @@ doE
 doE
 dTs
 boP
-boQ
+rZT
 boR
 bNb
 lVK
@@ -82035,7 +89240,7 @@ blI
 sOR
 bAv
 bwe
-bBP
+qDp
 bHT
 bJh
 bDK
@@ -82056,7 +89261,7 @@ qsq
 cuo
 psu
 aUp
-aUp
+lKX
 dTs
 dTs
 dTs
@@ -82140,10 +89345,10 @@ cNv
 cOn
 cJe
 doE
-doE
+qdJ
 cTD
 cYZ
-doE
+qdJ
 doE
 dTs
 boP
@@ -82206,7 +89411,7 @@ dTs
 aVI
 aNu
 aWl
-bdE
+vnr
 aWl
 aYw
 afa
@@ -82225,10 +89430,10 @@ aql
 ara
 ahz
 aoE
-aiZ
+lJC
 aiZ
 brB
-axZ
+ihJ
 dTs
 dTs
 dTs
@@ -82285,11 +89490,11 @@ dTs
 dTs
 dTs
 bOX
-bOY
+ubq
 bVY
 cuq
-moj
-aUp
+wut
+lKX
 aUp
 dTs
 dTs
@@ -82303,13 +89508,13 @@ cxc
 bQb
 aSK
 aPR
-aFx
+pVC
 axk
 ceA
 ceA
 grm
 ceA
-ceA
+eWZ
 ceA
 bVK
 bqi
@@ -82358,7 +89563,7 @@ dTs
 dTs
 dTs
 czA
-vul
+gTa
 doE
 cUl
 cZb
@@ -82400,15 +89605,15 @@ fvC
 cYy
 cZv
 cZv
-cZv
+fPr
 cZv
 dfB
 dfI
 dfI
 dfI
+kjJ
 dfI
-dfI
-cVU
+ift
 cZB
 dTs
 dTs
@@ -82445,14 +89650,14 @@ dJL
 bdE
 afe
 bdE
-bdE
+vnr
 kRF
 aWl
 aYS
-aWl
+opc
 baR
 aWM
-aiZ
+lJC
 aoE
 apz
 jco
@@ -82532,7 +89737,7 @@ dTs
 dTs
 bOX
 cdR
-cuo
+uPA
 cxc
 cfP
 aWE
@@ -82553,7 +89758,7 @@ bZv
 brq
 bBf
 ceA
-ceA
+eWZ
 aNH
 jba
 aOC
@@ -82575,7 +89780,7 @@ cyH
 cJt
 bNw
 bZM
-bZM
+bkF
 cba
 bZJ
 gXX
@@ -82600,12 +89805,12 @@ cZb
 csG
 cJe
 coi
-cNZ
+rTD
 coi
 cOS
 cPg
 coi
-coi
+luQ
 coi
 cJe
 rxm
@@ -82615,7 +89820,7 @@ doE
 cOj
 doE
 qUE
-doE
+qdJ
 bpY
 bPE
 dHR
@@ -82638,7 +89843,7 @@ cZx
 cXa
 cXa
 cXa
-cXa
+oeU
 cZx
 cZx
 cZx
@@ -82718,7 +89923,7 @@ bhu
 blZ
 bmm
 bmF
-bCA
+sHr
 bDe
 bDj
 bEy
@@ -82726,7 +89931,7 @@ xeM
 uRx
 blZ
 btt
-uPS
+hYK
 bMc
 bxk
 brF
@@ -82753,7 +89958,7 @@ dTs
 dTs
 afd
 jBg
-bOY
+ubq
 bVp
 cuq
 moj
@@ -82784,7 +89989,7 @@ brr
 bFt
 ceA
 bZK
-brr
+jFg
 bFt
 wEo
 ceA
@@ -82845,15 +90050,15 @@ cJe
 doE
 cTD
 cYZ
+qdJ
 doE
-doE
-doE
+qdJ
 doE
 doE
 bpY
 bPE
 dHR
-brL
+pgv
 pIg
 cps
 bpY
@@ -82863,9 +90068,9 @@ cOi
 cOW
 cUz
 cVo
-cVN
+dqc
 xhA
-cVU
+ift
 cVN
 cIp
 dep
@@ -82931,7 +90136,7 @@ aiZ
 beD
 beU
 bfp
-brB
+tuk
 axZ
 dTs
 dTs
@@ -82954,7 +90159,7 @@ bmn
 xjC
 bCA
 bnU
-bnU
+pRz
 fcD
 xeM
 bEC
@@ -82970,9 +90175,9 @@ dTs
 blI
 blI
 bUq
-bzE
+kAO
 bBP
-bAt
+hYe
 bAt
 bDK
 brQ
@@ -82989,12 +90194,12 @@ aWy
 cNe
 cOP
 bVp
-cuq
+uSb
 psu
 bYE
 bZf
 bZV
-caC
+mwr
 kzM
 cbi
 caC
@@ -83007,14 +90212,14 @@ cvr
 aPR
 aFx
 axk
-ceD
+jOu
 cwl
 ceA
-ceA
+eWZ
 ceA
 aUh
 can
-brr
+jFg
 bFu
 ceA
 can
@@ -83083,7 +90288,7 @@ doE
 doE
 doE
 doE
-doE
+qdJ
 bpY
 bPJ
 ddg
@@ -83253,7 +90458,7 @@ bFt
 vVF
 can
 brr
-bFt
+sKy
 ceA
 fWm
 aNH
@@ -83281,7 +90486,7 @@ bZw
 bZw
 cdH
 bZJ
-bZJ
+kYc
 bZw
 dTs
 dTs
@@ -83295,7 +90500,7 @@ dTs
 czA
 vul
 doE
-doE
+qdJ
 cUl
 qNk
 dvo
@@ -83307,7 +90512,7 @@ cOb
 cOX
 cOb
 cOb
-cOb
+krp
 cJd
 cJd
 vul
@@ -83331,9 +90536,9 @@ cOi
 cOW
 adY
 cVi
-cVN
+dqc
 xhA
-cWj
+wRx
 cVN
 dca
 deq
@@ -83342,7 +90547,7 @@ dfp
 cVi
 cIq
 cjf
-bQt
+vNC
 cOi
 cOi
 cZB
@@ -83396,15 +90601,15 @@ aqg
 asa
 aoE
 ame
-aiZ
+lJC
 aiZ
 aiZ
 aqz
-aiZ
+lJC
 goG
 brB
 apu
-apu
+vZM
 dTs
 dTs
 dTs
@@ -83420,7 +90625,7 @@ dTs
 blZ
 bmp
 xjC
-bCA
+sHr
 bnU
 bnU
 fcD
@@ -83454,7 +90659,7 @@ bOY
 bOY
 bOY
 bOY
-cOP
+nhj
 cOL
 cbh
 cur
@@ -83483,7 +90688,7 @@ cwl
 ceA
 can
 bud
-bFt
+sKy
 ceA
 bZK
 brr
@@ -83538,7 +90743,7 @@ doE
 cJe
 cOb
 cOv
-sYa
+kaB
 cOb
 cOv
 cOb
@@ -83557,7 +90762,7 @@ brL
 qZM
 rJY
 prX
-rJY
+oOy
 lcd
 fRE
 cJc
@@ -83569,12 +90774,12 @@ tkt
 xhA
 cWj
 cVN
-cVN
+dqc
 cIq
 cIq
 cIq
 cIq
-cVN
+dqc
 dgp
 cOi
 cOi
@@ -83615,7 +90820,7 @@ aXL
 aYj
 edz
 bsE
-aZc
+nSm
 aZP
 aZS
 aZT
@@ -83637,7 +90842,7 @@ aiZ
 aiZ
 aiZ
 aiZ
-aiZ
+lJC
 aiZ
 axY
 dTs
@@ -83654,7 +90859,7 @@ dTs
 blZ
 bmq
 bCf
-bCA
+sHr
 bnV
 bnV
 bnV
@@ -83662,7 +90867,7 @@ sDf
 brM
 blZ
 btv
-bvY
+oWj
 mJW
 hYP
 hYP
@@ -83670,10 +90875,10 @@ hYP
 twW
 bUs
 bWa
-gWW
+vUm
 bWa
 bUm
-kXm
+ggW
 btD
 bJi
 vXJ
@@ -83684,14 +90889,14 @@ bML
 bOh
 bPa
 bWh
-bWh
+nrI
 bWh
 cGr
 cGr
 cGr
 iTK
 dam
-cur
+wVK
 psu
 bYE
 bYE
@@ -83707,7 +90912,7 @@ qqR
 qwp
 aEI
 aEx
-cvv
+hZZ
 dTs
 dTs
 dTs
@@ -83787,7 +90992,7 @@ cTG
 cTG
 cUB
 brL
-brL
+pgv
 rQU
 cnc
 con
@@ -83900,7 +91105,7 @@ bvY
 bvY
 bvY
 bMc
-bMc
+dwt
 bvY
 bMc
 cbT
@@ -83920,7 +91125,7 @@ bQa
 bXa
 cCT
 cCT
-cCT
+rYL
 cCT
 lzE
 cCT
@@ -84033,10 +91238,10 @@ cME
 cOi
 adY
 cVi
-cVN
+dqc
 jsl
 cYz
-cIq
+hcs
 cIq
 cIq
 cIq
@@ -84090,7 +91295,7 @@ buN
 buN
 buJ
 buJ
-bvh
+sBv
 aoG
 apz
 aqg
@@ -84137,11 +91342,11 @@ byu
 byu
 boB
 bLz
-bAt
+hYe
 bwe
-bmf
+kch
 bAt
-cfr
+bWl
 cfr
 bAt
 bDK
@@ -84159,7 +91364,7 @@ bQc
 bOY
 pqj
 cbh
-cuq
+uSb
 psu
 bTt
 bZh
@@ -84236,21 +91441,21 @@ cUl
 dVb
 crz
 csG
-doE
+qdJ
 doE
 cJd
 cOx
-cOb
+krp
 cOb
 cPj
 cJd
-cwB
+goQ
 oOP
 doE
 doE
+qdJ
 doE
-doE
-doE
+qdJ
 ixM
 cQm
 doE
@@ -84310,11 +91515,11 @@ dTs
 dTs
 aVm
 cQs
-aWq
+rYj
 rTI
 aWq
 aXL
-aYm
+mXK
 pwL
 pDA
 aYX
@@ -84404,7 +91609,7 @@ cbW
 ccE
 bTt
 mAZ
-bGn
+qkl
 qqR
 bJE
 aEH
@@ -84457,7 +91662,7 @@ eOD
 eOD
 eOD
 eOD
-eOD
+tad
 eOD
 eOD
 dTs
@@ -84479,8 +91684,8 @@ sYa
 cOb
 cJd
 doE
-doE
-doE
+qdJ
+qdJ
 doE
 doE
 doE
@@ -84491,8 +91696,8 @@ doE
 bpY
 cat
 dHR
-cne
-brL
+ool
+pgv
 cps
 bpY
 cIt
@@ -84502,7 +91707,7 @@ cOi
 adY
 cZB
 cVO
-fvC
+qFb
 cWj
 cWW
 cVN
@@ -84688,17 +91893,17 @@ dNS
 dNS
 eOD
 eOD
+tad
 eOD
 eOD
-eOD
-eOD
+tad
 eOD
 eOD
 dTs
 dTs
 dTs
 czA
-oOP
+xdg
 doE
 cUl
 cZb
@@ -84713,7 +91918,7 @@ cJd
 cJd
 cJd
 doE
-doE
+qdJ
 tCb
 doE
 doE
@@ -84724,7 +91929,7 @@ cQm
 doE
 boP
 caw
-dHR
+kZj
 cne
 cou
 cqh
@@ -84735,7 +91940,7 @@ cME
 cOi
 adY
 cZB
-cIq
+hcs
 fvC
 cWj
 cVN
@@ -84748,7 +91953,7 @@ cIq
 cVN
 cIq
 cIq
-cIq
+hcs
 cZB
 cZB
 cZB
@@ -84784,7 +91989,7 @@ djg
 aXL
 aYm
 pwL
-pDA
+pAA
 aZb
 aWY
 bff
@@ -84827,7 +92032,7 @@ dTs
 dTs
 dTs
 dTs
-oTs
+tQz
 bmf
 brP
 qyN
@@ -84865,7 +92070,7 @@ qIf
 bOY
 bTt
 bZk
-dEb
+qmS
 wLE
 dMC
 dMC
@@ -84953,7 +92158,7 @@ doE
 doE
 doE
 doE
-doE
+qdJ
 cQm
 boP
 boP
@@ -84972,14 +92177,14 @@ cVi
 cIq
 xhA
 cYA
-cZz
+ohO
 cZz
 deR
+ohO
 cZz
 cZz
 cZz
-cZz
-cZz
+ohO
 cZz
 cZv
 cZv
@@ -85096,7 +92301,7 @@ bRy
 bOY
 lhI
 fCZ
-bOY
+ubq
 bYE
 bZl
 dEb
@@ -85106,7 +92311,7 @@ bZX
 ccH
 bTt
 mAZ
-bGn
+qkl
 qqR
 bJE
 aEH
@@ -85115,7 +92320,7 @@ aFy
 aEI
 aEx
 cvv
-roU
+iGD
 dTs
 dTs
 dTs
@@ -85153,7 +92358,7 @@ dTs
 dTs
 eOD
 eOD
-eOD
+tad
 eOD
 eOD
 eOD
@@ -85218,13 +92423,13 @@ cVN
 cVN
 cVN
 cIq
+hcs
 cIq
-cIq
-cIq
+hcs
 xhA
 cIq
 cIq
-cVU
+ift
 cZB
 acu
 "}
@@ -85260,7 +92465,7 @@ dJP
 xYE
 bbj
 bbC
-aiZ
+lJC
 akz
 aNp
 aNp
@@ -85280,7 +92485,7 @@ aql
 ara
 asa
 aoE
-aqy
+hfk
 axZ
 dTs
 dTs
@@ -85328,7 +92533,7 @@ cDU
 cGA
 bRy
 cOP
-rCC
+eUJ
 fCZ
 bOY
 bYE
@@ -85336,7 +92541,7 @@ bZm
 dEb
 dKs
 dEb
-bZX
+iPs
 ccE
 bTt
 mAZ
@@ -85395,7 +92600,7 @@ eOD
 eOD
 eOD
 eOD
-eOD
+tad
 eOD
 dTs
 czA
@@ -85407,9 +92612,9 @@ cZb
 cZb
 csG
 doE
+qdJ
 doE
-doE
-cUl
+iMQ
 cZb
 cNw
 iaW
@@ -85482,7 +92687,7 @@ aVm
 duV
 aWw
 aWq
-aWq
+rYj
 aXL
 aYl
 aYH
@@ -85497,11 +92702,11 @@ bbC
 aiZ
 aiZ
 aiZ
+lJC
 aiZ
-aiZ
 ame
 ame
-ame
+xbQ
 ame
 ame
 ame
@@ -85515,7 +92720,7 @@ aqg
 asa
 aoE
 brB
-axZ
+ihJ
 axZ
 dTs
 dTs
@@ -85567,7 +92772,7 @@ fCZ
 bOY
 bYE
 bZn
-bZX
+iPs
 dEb
 dEb
 dEb
@@ -85632,7 +92837,7 @@ eOD
 eOD
 eOD
 uAo
-vul
+gTa
 doE
 doE
 rxm
@@ -85672,7 +92877,7 @@ cOi
 cUz
 jDV
 cVP
-cXa
+oeU
 cXa
 cZx
 dcb
@@ -85683,7 +92888,7 @@ cXa
 cXa
 cZx
 cZx
-cZx
+lSN
 cZx
 cZx
 cZx
@@ -85742,7 +92947,7 @@ bdg
 bdg
 bdf
 udu
-ajL
+bKu
 pUO
 cGD
 cGD
@@ -85808,7 +93013,7 @@ dNk
 kUz
 bYE
 yll
-bGn
+qkl
 qqR
 bJE
 aEI
@@ -85832,7 +93037,7 @@ cQx
 cQx
 cQN
 uax
-cQQ
+taq
 cQx
 dTs
 dTs
@@ -85887,7 +93092,7 @@ dvo
 dvo
 csG
 doE
-doE
+qdJ
 doE
 doE
 cQm
@@ -85908,7 +93113,7 @@ tzc
 cVU
 cVN
 cIq
-cIq
+hcs
 dcc
 cIq
 tng
@@ -85925,7 +93130,7 @@ cZB
 aOW
 iUL
 aOW
-aOW
+kmc
 cZB
 cZB
 acu
@@ -85952,7 +93157,7 @@ aVm
 aVm
 aVm
 aVm
-aXR
+mWg
 edz
 qVk
 hga
@@ -85968,7 +93173,7 @@ buM
 bcq
 bdf
 bdB
-bdC
+geT
 bdC
 beE
 bdC
@@ -86026,13 +93231,13 @@ bHc
 bQg
 bHa
 cFx
-bHa
+qau
 bOq
 bPx
 bOY
 rCC
 fCZ
-bOY
+ubq
 bYE
 bYE
 bTt
@@ -86102,7 +93307,7 @@ dTs
 dTs
 cHl
 doE
-doE
+qdJ
 doE
 cUl
 cZb
@@ -86110,15 +93315,15 @@ cZb
 cZb
 cZb
 cZb
+rhc
 cZb
-cZb
-cZb
+rhc
 cZb
 cZb
 cZb
 cKd
 cZb
-dvo
+mBu
 csG
 doE
 doE
@@ -86139,18 +93344,18 @@ cNj
 cOi
 cUz
 tzc
-cWj
+wRx
 cIq
 cIq
 cIq
 dcc
 cIq
-cIq
+hcs
 cVU
 dfL
 cIq
 dfL
-cIq
+hcs
 dfL
 cZB
 dTs
@@ -86191,13 +93396,13 @@ erz
 oYa
 giT
 pXd
-pXd
-oYa
+gMR
+dBF
 bbU
 giT
 buY
 wln
-bsE
+kXO
 bsE
 aZc
 bdg
@@ -86244,7 +93449,7 @@ dTs
 dTs
 bxq
 bxr
-bDb
+ggq
 cbl
 bFP
 bGX
@@ -86256,7 +93461,7 @@ bMe
 bMM
 bNn
 bOk
-bOk
+xEQ
 bHW
 bHa
 cFy
@@ -86269,7 +93474,7 @@ qFk
 uAh
 uAh
 bZp
-uAh
+vMn
 dfS
 dfS
 oCV
@@ -86282,12 +93487,12 @@ aEI
 aEI
 aEx
 cvv
-roU
+iGD
 roU
 cir
 adt
 adx
-aec
+fKq
 buA
 adt
 dTs
@@ -86299,7 +93504,7 @@ dTs
 cQx
 cQG
 cQQ
-uqe
+teC
 cQQ
 cQx
 dTs
@@ -86322,7 +93527,7 @@ dTs
 dTs
 eOD
 tjX
-eOD
+tad
 eOD
 eOD
 eOD
@@ -86357,7 +93562,7 @@ cTc
 csE
 xBc
 doE
-doE
+qdJ
 cQm
 cQm
 boP
@@ -86392,7 +93597,7 @@ cZB
 cbK
 aPa
 wzq
-aQs
+twX
 aRm
 cbK
 cZB
@@ -86432,7 +93637,7 @@ buX
 bbD
 hXF
 elz
-elz
+gwX
 elz
 bzJ
 bAE
@@ -86444,7 +93649,7 @@ bdC
 bfy
 bdg
 udu
-ajL
+bKu
 pUO
 cGD
 cGD
@@ -86452,9 +93657,9 @@ amt
 vzj
 aeA
 aeA
-aeA
+fDo
 poP
-aeq
+whn
 dTs
 dTs
 bkU
@@ -86465,7 +93670,7 @@ bms
 sPL
 bms
 boH
-fMJ
+wYq
 bmf
 brQ
 bsC
@@ -86480,22 +93685,22 @@ dTs
 bxr
 bDb
 cbl
-bxr
+lgt
 bPx
 bHW
 bJm
-bHa
-bHa
+qau
+qau
 bHa
 bMN
+qau
 bHa
-bHa
 ciT
 ciT
-ciT
+uPw
 cFA
 cGs
-cAq
+ivM
 cAq
 bTJ
 bWg
@@ -86504,7 +93709,7 @@ bWh
 cGr
 cGr
 cGr
-qIf
+lDE
 fCZ
 cGr
 bWh
@@ -86532,7 +93737,7 @@ adw
 adw
 cQx
 cQG
-cQQ
+taq
 uqe
 cQQ
 cQx
@@ -86576,14 +93781,14 @@ cUl
 cZb
 cZb
 csG
-cIh
+ykw
 cJo
 daU
 cJQ
 cJQ
 cJX
 cJQ
-daU
+rAC
 daU
 daU
 cKi
@@ -86657,7 +93862,7 @@ aXQ
 aYq
 aYo
 aYX
-aZw
+uaw
 aZw
 aZw
 aZw
@@ -86674,7 +93879,7 @@ bBi
 dKc
 beH
 bfa
-bdC
+geT
 hWz
 bdg
 udu
@@ -86734,7 +93939,7 @@ bPx
 bOY
 cun
 clU
-clU
+hdr
 dNl
 dNl
 dNl
@@ -86750,7 +93955,7 @@ cfQ
 cgB
 cgB
 qHO
-raL
+icq
 dTs
 dTs
 adt
@@ -86795,14 +94000,14 @@ eOD
 uRz
 eOD
 eOD
-xFk
+cCK
 ibU
 ibU
-ibU
+hXY
 ibU
 dTs
 dTs
-vul
+gTa
 doE
 doE
 doE
@@ -86814,7 +94019,7 @@ cTC
 cJo
 daU
 daU
-daU
+rAC
 cJX
 daU
 daU
@@ -86877,13 +94082,13 @@ ach
 ahH
 awK
 aGA
-aHl
+sti
 aIf
 aIf
 rmY
 rmY
 aIf
-aIf
+jny
 aLM
 aWY
 aWY
@@ -86898,7 +94103,7 @@ aZC
 aZC
 aZC
 idI
-xeH
+rWy
 bsE
 bsE
 bbX
@@ -86921,7 +94126,7 @@ vCE
 ajK
 aeA
 aeA
-aeA
+fDo
 poP
 mKm
 asq
@@ -86947,10 +94152,10 @@ dTs
 qqS
 bxr
 bDg
-qXy
+wkI
 cts
 bHa
-bHa
+qau
 xYo
 cqu
 ciT
@@ -86965,16 +94170,16 @@ ciT
 bTc
 bTP
 bHc
-bOY
+ubq
 bOY
 bQc
 bOY
 bOY
+ubq
 bOY
 bOY
 bOY
-bOY
-bOY
+ubq
 bOY
 bOY
 mAZ
@@ -86989,23 +94194,23 @@ oOu
 dTs
 adt
 adz
-pFK
+ezy
 bOB
 adt
 ced
-cij
+rRT
 cQR
 cpq
 cBX
 cPX
-cij
+rRT
 cij
 cij
 iqz
 cij
 adw
 lNu
-lNu
+wcA
 lNu
 dTs
 dTs
@@ -87052,7 +94257,7 @@ daU
 daU
 daU
 daU
-daU
+rAC
 daU
 cKi
 cTC
@@ -87113,7 +94318,7 @@ adV
 aGz
 aHm
 aIf
-rmY
+uwd
 aJr
 aJr
 rmY
@@ -87134,7 +94339,7 @@ aZC
 idI
 xeH
 bsE
-bsE
+kXO
 aZb
 bdf
 bdf
@@ -87189,7 +94394,7 @@ wPI
 bHa
 ciT
 ciT
-vjo
+roA
 bJm
 bOm
 bHc
@@ -87258,10 +94463,10 @@ dTs
 dTs
 eOD
 eOD
-xFk
+cCK
 ibU
 ibU
-ibU
+hXY
 ibU
 ibU
 ibU
@@ -87290,10 +94495,10 @@ cJZ
 daU
 cKi
 cTC
-doE
+qdJ
 cKr
 qUE
-doE
+qdJ
 cTC
 cUl
 yeU
@@ -87328,7 +94533,7 @@ cZB
 cbK
 aPp
 aQs
-aQs
+twX
 aRr
 cbK
 cZB
@@ -87351,7 +94556,7 @@ aIf
 aJr
 aJr
 aIf
-aIf
+jny
 aLN
 aWY
 aWY
@@ -87380,7 +94585,7 @@ ahh
 ahh
 ahh
 udu
-ajL
+bKu
 pUO
 akN
 uWT
@@ -87413,7 +94618,7 @@ bxq
 aTF
 aTF
 aTF
-bxr
+lgt
 bDg
 cbm
 bxr
@@ -87441,7 +94646,7 @@ dTs
 aUp
 raY
 afd
-afd
+vYD
 afd
 jBg
 bOY
@@ -87506,7 +94711,7 @@ dTs
 dTs
 czA
 cGi
-doE
+qdJ
 doE
 cUl
 cZb
@@ -87606,10 +94811,10 @@ bsJ
 bsE
 bsE
 bsE
-bsE
+kXO
 aYk
 aZA
-ahF
+hLY
 ajg
 bfB
 bfJ
@@ -87645,12 +94850,12 @@ bqP
 bxr
 byv
 bxr
-bxr
+lgt
 bxr
 bxr
 bDg
 cbm
-cbU
+fRs
 bPx
 fPp
 wPI
@@ -87662,7 +94867,7 @@ ckL
 bOo
 bHc
 bQg
-xYo
+mkx
 ciT
 bTe
 bLq
@@ -87678,7 +94883,7 @@ dTs
 dTs
 bOY
 bOY
-bOY
+ubq
 afC
 xnv
 cfj
@@ -87730,7 +94935,7 @@ dTs
 ibU
 ibU
 ibU
-ibU
+hXY
 dTs
 dTs
 dTs
@@ -87744,7 +94949,7 @@ doE
 doE
 cUl
 cvJ
-crz
+een
 csG
 cTC
 cJo
@@ -87814,7 +95019,7 @@ ach
 axn
 aGA
 aHn
-aIf
+jny
 aIM
 aJs
 aJs
@@ -87830,14 +95035,14 @@ aWY
 aZC
 aZY
 bav
-aZY
-aZY
+wzn
+wzn
 aZC
 eln
 byA
 btH
 qxs
-bsE
+kXO
 bAn
 dJZ
 dKb
@@ -87847,7 +95052,7 @@ adO
 aii
 bfC
 bfK
-aii
+nQQ
 mTR
 pUO
 edN
@@ -87888,7 +95093,7 @@ cbU
 bPx
 fPp
 wPI
-ciT
+uPw
 dDD
 bMj
 ghH
@@ -88078,7 +95283,7 @@ aZw
 aZw
 aZR
 ahh
-ahh
+vRP
 ahh
 bfL
 iVN
@@ -88112,12 +95317,12 @@ aUl
 bqU
 bvr
 bxt
-bxt
+mrY
 bSP
 bSP
 bSP
 bDc
-cbl
+jeX
 cbU
 bPx
 bIb
@@ -88147,7 +95352,7 @@ dTs
 dTs
 dTs
 qKe
-qKe
+iwn
 xnv
 cfj
 wzl
@@ -88286,25 +95491,25 @@ aIf
 aIN
 aJu
 aJu
-bWb
+elG
 aIf
 aIf
 aMa
-ahF
+hLY
 ajg
-ajK
+qqL
 dTs
 dTs
 aZC
 baa
 baw
 aZY
-qHt
+iHs
 aZC
 buZ
-pwL
+hjX
 bsE
-bbX
+jyA
 bcT
 bcT
 bcT
@@ -88321,9 +95526,9 @@ edN
 edN
 edN
 dzU
-ahF
+hLY
 ajg
-ooW
+kul
 ooW
 ooW
 ooW
@@ -88394,22 +95599,22 @@ dTs
 adw
 ahW
 foP
-cdq
+tau
 ceb
 ceO
 cil
 nza
-cvt
+fDV
 cKl
 wtS
-cij
+rRT
 cvt
 cRa
 cxi
 cij
 adw
 lyw
-lNu
+wcA
 eHi
 cTs
 lNu
@@ -88443,7 +95648,7 @@ dTs
 vul
 doE
 doE
-doE
+qdJ
 cUl
 cvJ
 crz
@@ -88463,7 +95668,7 @@ cTC
 doE
 cKr
 doE
-doE
+qdJ
 cTC
 dUO
 dVb
@@ -88522,7 +95727,7 @@ aJu
 aJu
 aLb
 aIf
-aIf
+jny
 aMb
 adO
 mFD
@@ -88538,7 +95743,7 @@ aZC
 buO
 pwL
 bsE
-aZc
+nSm
 bcU
 bdi
 bdG
@@ -88584,23 +95789,23 @@ aTF
 qqS
 aTF
 bxr
-bWc
+lpA
 cbm
 cbU
 bGX
 bIc
 dFb
-bHa
+qau
 ciT
 bHa
 vjo
-ciT
+uPw
 ciT
 cyT
 ciT
 ciT
 ciT
-bOm
+vUz
 bLq
 dTs
 dTs
@@ -88621,7 +95826,7 @@ cfj
 cfS
 cgz
 aEx
-qKe
+hZZ
 dTs
 dTs
 dTs
@@ -88631,12 +95836,12 @@ aYW
 ylg
 cRt
 eLH
-xbh
+waW
 ezr
 cil
 cFL
 iqz
-cij
+rRT
 cij
 cij
 cij
@@ -88648,7 +95853,7 @@ eHi
 dod
 lNu
 lNu
-lNu
+wcA
 mTj
 dTs
 dTs
@@ -88664,7 +95869,7 @@ dTs
 dTs
 dTs
 ibU
-ibU
+hXY
 ibU
 ibU
 ibU
@@ -88694,7 +95899,7 @@ daU
 cKf
 cKi
 cTC
-doE
+qdJ
 cKr
 tLl
 tLl
@@ -88750,7 +95955,7 @@ adN
 adE
 aGz
 aHr
-aIf
+jny
 aIN
 fqI
 abI
@@ -88820,7 +96025,7 @@ aTF
 bxr
 bWc
 cbm
-cbV
+sZx
 bPx
 bHW
 ckQ
@@ -88848,14 +96053,14 @@ dTs
 dTs
 dTs
 qKe
-qKe
+iwn
 qKe
 xnv
 cfj
 wzl
 bJE
 aEx
-qKe
+cvv
 dTs
 dTs
 dTs
@@ -88874,9 +96079,9 @@ cij
 cxi
 cQT
 cxi
-cij
+rRT
 but
-lNu
+wcA
 lNu
 eHi
 dod
@@ -88884,7 +96089,7 @@ lNu
 xLS
 lNu
 lNu
-rUK
+pkL
 lNu
 aFQ
 aHh
@@ -88909,12 +96114,12 @@ dTs
 dTs
 ibU
 oXw
-tLl
+vhb
 tLl
 tLl
 bYV
 aEq
-aEq
+sBK
 fdk
 hOK
 cJp
@@ -88943,7 +96148,7 @@ mbl
 dto
 dto
 dtp
-dtp
+pwF
 dxW
 dsJ
 dTs
@@ -88986,7 +96191,7 @@ aGA
 aHs
 aIf
 aIO
-aJw
+fyo
 aJw
 aIL
 aIf
@@ -89023,7 +96228,7 @@ edN
 edN
 gIR
 dzU
-vzj
+thF
 aeA
 akv
 dTs
@@ -89051,7 +96256,7 @@ dTs
 aGP
 soU
 aTF
-bxr
+lgt
 bWc
 qXy
 ctt
@@ -89059,7 +96264,7 @@ bHb
 bHa
 ckT
 ciT
-ciT
+uPw
 ciT
 ghH
 ckL
@@ -89089,7 +96294,7 @@ cfj
 rEo
 bJE
 aEx
-qKe
+cvv
 dTs
 dTs
 dTs
@@ -89114,7 +96319,7 @@ lNu
 lNu
 eHi
 dod
-xLS
+spM
 lNu
 lNu
 lNu
@@ -89136,7 +96341,7 @@ oXw
 tLl
 tLl
 jfA
-tLl
+vhb
 fCr
 ibU
 ibU
@@ -89151,21 +96356,21 @@ sLx
 wya
 fdk
 hqp
+iTR
+cRL
+cRL
+iTR
+cRL
+cRL
+iTR
 cRL
 cRL
 cRL
-cRL
-cRL
-cRL
-cRL
-cRL
-cRL
-cRL
-cUB
+mtt
 doE
 cKr
 tLl
-tLl
+vhb
 hOK
 bYV
 sLx
@@ -89227,7 +96432,7 @@ aIf
 aLN
 aGz
 adZ
-vCE
+qlg
 ajL
 anE
 aeA
@@ -89314,7 +96519,7 @@ aDn
 aEa
 cEn
 acw
-qKe
+iwn
 aBX
 cvv
 roU
@@ -89324,7 +96529,7 @@ cfS
 cgz
 aEx
 cBI
-qKe
+roU
 dTs
 dTs
 adw
@@ -89350,7 +96555,7 @@ cTr
 dod
 cTh
 lNu
-lNu
+wcA
 xeD
 lNu
 lNu
@@ -89364,9 +96569,9 @@ dTs
 dTs
 cqn
 aFQ
+vhb
 tLl
-tLl
-kpb
+qDi
 tLl
 tLl
 tLl
@@ -89408,7 +96613,7 @@ dVj
 wJQ
 dVA
 chD
-chD
+qgs
 chD
 dWf
 dtp
@@ -89457,12 +96662,12 @@ aIf
 aJr
 aJr
 aIf
-aIf
+jny
 aLN
 aGz
 aeA
 vCE
-ajL
+bKu
 aeA
 dTs
 aZC
@@ -89564,7 +96769,7 @@ dTs
 adw
 ahW
 bum
-bum
+mrl
 ceb
 ceN
 cij
@@ -89574,7 +96779,7 @@ cFL
 coq
 cQD
 cil
-cij
+rRT
 cij
 cij
 but
@@ -89608,10 +96813,10 @@ tLl
 tLl
 tLl
 tLl
+vhb
 tLl
 tLl
-tLl
-tLl
+vhb
 tLl
 tLl
 bYV
@@ -89646,7 +96851,7 @@ dtr
 ibV
 ciG
 dtp
-dto
+qcC
 dyb
 bgd
 nDN
@@ -89686,7 +96891,7 @@ aig
 aza
 aGz
 aHm
-aIf
+jny
 rmY
 aJr
 aJr
@@ -89702,7 +96907,7 @@ dTs
 dTs
 dTs
 aeq
-aeq
+whn
 aew
 pba
 ahh
@@ -89711,11 +96916,11 @@ ajK
 gjQ
 bcT
 bdn
-bdj
+vWx
 beg
+vOs
 bew
-bew
-bfe
+bJs
 bfq
 bcT
 bfL
@@ -89778,7 +96983,7 @@ aEa
 aCF
 wRU
 aCU
-aCU
+yhl
 aEb
 cEv
 aSW
@@ -89812,17 +97017,17 @@ cij
 cij
 adw
 adw
-mkJ
+rLu
 xLS
 eHi
 dod
 lDT
-iOa
+soL
 kWh
 lNu
 lNu
 lNu
-aFQ
+toM
 aHj
 cqn
 nxZ
@@ -89875,7 +97080,7 @@ glx
 dVj
 wJQ
 dVB
-dVE
+wbl
 dVE
 eCK
 dWg
@@ -89883,7 +97088,7 @@ dtp
 dto
 dyb
 bgk
-dAn
+elD
 dAn
 dyb
 dTs
@@ -89990,7 +97195,7 @@ cBa
 tJx
 bWc
 cbm
-cbU
+fRs
 bHd
 bIe
 cnv
@@ -90157,7 +97362,7 @@ aHt
 aIg
 aKZ
 aIf
-aIf
+jny
 aIM
 aIg
 aLO
@@ -90172,7 +97377,7 @@ dTs
 dTs
 aew
 aeA
-aeA
+fDo
 ahh
 vCE
 ajL
@@ -90194,7 +97399,7 @@ hZV
 ali
 dzU
 vzj
-poP
+fQY
 aeq
 dTs
 dTs
@@ -90218,15 +97423,15 @@ bpM
 bwf
 kQu
 snr
-bRR
+dIb
 bAz
 cBa
-tJx
+hyl
 bWc
 cbm
 bxr
 bHd
-bIf
+qQl
 bIf
 bKz
 bxq
@@ -90253,13 +97458,13 @@ aDC
 nBv
 suJ
 suJ
-oIP
+lFs
 cEv
 bgn
 cAN
 cAP
 bha
-cCG
+pHV
 ncm
 dTs
 dTs
@@ -90267,10 +97472,10 @@ dTs
 dTs
 wgv
 uzC
+cfd
 wgv
 wgv
-wgv
-wgv
+cfd
 pXe
 cTr
 oKn
@@ -90285,7 +97490,7 @@ lNu
 eHi
 dZF
 iGC
-wgv
+cfd
 pXe
 tyc
 vqt
@@ -90345,7 +97550,7 @@ aLX
 dsJ
 dtt
 dtp
-dWi
+jKo
 dWi
 dtp
 dxY
@@ -90398,7 +97603,7 @@ aGA
 aGA
 xzR
 vCE
-ajL
+bKu
 poP
 dTs
 dTs
@@ -90484,7 +97689,7 @@ igw
 aDs
 cZK
 aDD
-aDx
+dYA
 acw
 byr
 suJ
@@ -90511,10 +97716,10 @@ qbp
 lNu
 lNu
 lNu
-lNu
+wcA
 iOa
 lNu
-lNu
+wcA
 olG
 eHi
 dod
@@ -90622,16 +97827,16 @@ ahY
 aAB
 aQn
 aQn
-ahC
+vDD
 ahh
 ahF
 ajK
 ahh
-ahh
+vRP
 dTs
 dTs
 aeA
-vCE
+qlg
 ajL
 aeA
 dTs
@@ -90659,7 +97864,7 @@ ahh
 vzj
 pUO
 edN
-cGD
+oLE
 dzU
 vzj
 aeA
@@ -90692,7 +97897,7 @@ bzH
 tJx
 bWc
 cbm
-bxr
+lgt
 bHd
 bIf
 bIf
@@ -90728,13 +97933,13 @@ jgX
 cyD
 bha
 cCG
-ncm
+eFm
 dTs
 dTs
 dTs
 wgv
 wgv
-pXe
+sMR
 lNu
 lNu
 mTj
@@ -90854,12 +98059,12 @@ acF
 acF
 anB
 sff
+jIJ
 ahC
-ahC
-abR
+rRc
 ahh
 vCE
-ajL
+bKu
 ahh
 dTs
 dTs
@@ -90876,7 +98081,7 @@ baI
 aiu
 akB
 aeA
-aMO
+iEO
 ajL
 amg
 bcT
@@ -90886,10 +98091,10 @@ bcU
 bcT
 bcU
 bcU
-bcU
+gDs
 bcT
 bfN
-ahh
+vRP
 vzj
 pUO
 hZV
@@ -90918,10 +98123,10 @@ dTs
 dTs
 bpM
 bwi
-bpP
+wib
 bSc
 bEF
-tnn
+daS
 bpO
 byx
 bYG
@@ -90929,8 +98134,8 @@ cbm
 bFP
 bHd
 bIf
-bIf
-bIf
+qQl
+qQl
 bxq
 dTs
 dTs
@@ -90946,7 +98151,7 @@ aCt
 aCx
 aEa
 aCJ
-aCI
+ims
 aCI
 aCI
 aEa
@@ -90971,7 +98176,7 @@ wgv
 pXe
 xeD
 lNu
-lNu
+wcA
 lNu
 lNu
 ekH
@@ -91021,11 +98226,11 @@ hBr
 hBr
 hBr
 hBr
+ljj
 hBr
 hBr
 hBr
-hBr
-hBr
+ljj
 cYP
 pxw
 oAV
@@ -91038,23 +98243,23 @@ sYo
 rkC
 spa
 ovJ
-rkC
+vjC
 oAV
 oAV
 oAV
 oAV
 gFy
 dsJ
-dtp
+pwF
 dVL
 gGo
 dVL
-dtu
+exv
 ebD
 dyb
 dty
 dWH
-dAn
+elD
 dwl
 dyb
 dTs
@@ -91090,10 +98295,10 @@ ahF
 ajg
 abV
 abV
-abV
+eqG
 ajg
 ajc
-ajL
+bKu
 dTs
 dTs
 dTs
@@ -91128,12 +98333,12 @@ vzj
 pUO
 edN
 edN
-dzU
+qKy
 vzj
 hDT
 aeA
 aeA
-poP
+fQY
 dTs
 dTs
 dTs
@@ -91182,11 +98387,11 @@ aEa
 aCL
 aCI
 aCI
-aCJ
+hin
 aEb
 cEv
 aSW
-aSW
+uBY
 acw
 acw
 czk
@@ -91248,13 +98453,13 @@ aEq
 fdk
 cWy
 peQ
-aqf
+sIA
 cYQ
+eWm
 peQ
 peQ
 peQ
-peQ
-peQ
+eWm
 aqf
 aqf
 peQ
@@ -91263,9 +98468,9 @@ peQ
 aAC
 wFK
 gdW
+wVo
 gdW
-gdW
-gdW
+wVo
 gdW
 hOK
 bYV
@@ -91321,7 +98526,7 @@ dTs
 dTs
 ahh
 aLv
-aii
+nQQ
 aii
 aby
 aii
@@ -91333,10 +98538,10 @@ dTs
 dTs
 aew
 plo
-vCE
+qlg
 aji
 ajg
-ajg
+qPA
 ajg
 ajg
 ajg
@@ -91349,17 +98554,17 @@ ajc
 ajg
 ooW
 ooW
+kul
+ooW
+ooW
+kul
 ooW
 ooW
 ooW
-ooW
-ooW
-ooW
-ooW
-ooW
+kul
 ooW
 ajM
-pUO
+slU
 cGD
 cGD
 dzU
@@ -91386,15 +98591,15 @@ dTs
 dTs
 bpM
 bwk
-bEG
+xRz
 fZA
-bpP
+wib
 bSR
 bzH
-tJx
+hyl
 bDg
 cbm
-bxr
+lgt
 bHf
 bHf
 bHf
@@ -91562,7 +98767,7 @@ iVN
 uRH
 hVT
 ybA
-vzj
+thF
 xof
 dTs
 aeq
@@ -91575,11 +98780,11 @@ aii
 aii
 iFE
 aii
-aii
+nQQ
 aii
 aii
 alX
-aii
+nQQ
 ajL
 iVN
 uRH
@@ -91658,7 +98863,7 @@ dTs
 tUF
 ekH
 btm
-dod
+xmN
 tyc
 wyR
 kry
@@ -91676,7 +98881,7 @@ lNu
 lNu
 lNu
 lNu
-iOa
+soL
 rzE
 tyc
 lwC
@@ -91717,24 +98922,24 @@ oKG
 aEq
 fdk
 hOK
-cYT
+lrM
 tLl
 tLl
-tLl
+vHX
 tLl
 gdW
 cWy
 oQx
 gdW
-gdW
+wVo
 gdW
 dgK
 qQg
 gdW
 tLl
+vhb
 tLl
-tLl
-tLl
+vhb
 hOK
 bYV
 aEq
@@ -91749,7 +98954,7 @@ dqe
 dqe
 edO
 dus
-wkt
+kWM
 dVH
 dus
 dyb
@@ -91787,14 +98992,14 @@ dTs
 dTs
 dTs
 axq
-ahh
+vRP
 pUO
 edN
 cGD
 dzU
 pUO
 edN
-cGD
+oLE
 dzU
 vzj
 xof
@@ -91838,7 +99043,7 @@ cGD
 dzU
 blM
 kWb
-bkZ
+paZ
 dTs
 dTs
 dTs
@@ -91878,11 +99083,11 @@ dTs
 dTs
 dTs
 aEa
-uJj
+aCl
 aCJ
 aEa
 aCN
-aCJ
+hin
 aCL
 aDq
 aEa
@@ -91890,7 +99095,7 @@ dTs
 dTs
 dTs
 oGQ
-tUF
+kZN
 ekH
 dod
 tyc
@@ -91905,7 +99110,7 @@ dTs
 dTs
 wgv
 wgv
-pXe
+sMR
 lNu
 lDT
 qHF
@@ -91941,7 +99146,7 @@ cOH
 dkJ
 lql
 cRg
-cRg
+qJb
 cOH
 aRO
 bYV
@@ -91952,7 +99157,7 @@ aEq
 fdk
 hOK
 cYT
-tLl
+vhb
 tLl
 tLl
 daF
@@ -91980,21 +99185,21 @@ dpw
 dqf
 dqf
 dqf
-dqf
+pLv
 edO
 dus
 wkt
 dtx
-dus
+oEI
 eeq
 dyY
-dAq
+nPz
 bBN
 qmG
 dAq
 eeC
 neg
-dAn
+elD
 pAf
 dyb
 dTs
@@ -92023,7 +99228,7 @@ dTs
 ane
 aaF
 pUO
-cGD
+oLE
 edN
 dzU
 pUO
@@ -92031,7 +99236,7 @@ cGD
 edN
 dzU
 vzj
-xof
+rgK
 dTs
 dTs
 dTs
@@ -92070,7 +99275,7 @@ wnE
 biJ
 cGD
 dzU
-blM
+nOo
 bhi
 cMI
 bkZ
@@ -92088,7 +99293,7 @@ dTs
 bpM
 bRd
 daB
-kSI
+jUv
 fZA
 bEG
 bAD
@@ -92096,11 +99301,11 @@ cBa
 tJx
 bDg
 caF
-cts
+lZW
 bPv
 ckd
 ckX
-bJr
+fkj
 cnw
 bLr
 dTs
@@ -92132,7 +99337,7 @@ jmd
 eft
 sCf
 iYI
-mTj
+bus
 wgv
 dTs
 dTs
@@ -92143,7 +99348,7 @@ pij
 lNu
 kWh
 lNu
-lNu
+wcA
 lNu
 iGK
 tyc
@@ -92157,7 +99362,7 @@ tUF
 lNu
 lNu
 lNu
-lNu
+wcA
 iGC
 tUF
 pal
@@ -92197,18 +99402,18 @@ des
 daI
 dbr
 dgL
-hia
+kfz
 diG
 daF
 daF
 tLl
-tLl
+vhb
 hOK
 bYV
 sLx
 sms
 fdk
-hOK
+dzt
 dhs
 dpx
 dqg
@@ -92224,7 +99429,7 @@ edT
 dWw
 pWg
 fev
-dWE
+wWx
 ebO
 dyb
 dAn
@@ -92260,10 +99465,10 @@ pUO
 cGD
 cGD
 dzU
-pUO
+slU
 cGD
 cGD
-dzU
+qKy
 vzj
 xof
 wZM
@@ -92274,7 +99479,7 @@ dTs
 dTs
 dTs
 mKm
-mKm
+uJC
 xzR
 aeA
 qxv
@@ -92305,9 +99510,9 @@ biK
 uWT
 bjo
 blM
-bhi
+eva
 kWb
-bkZ
+paZ
 dTs
 dTs
 dTs
@@ -92324,13 +99529,13 @@ bVa
 daB
 joI
 fZA
-bpP
+wib
 bAD
 bzH
-tJx
+hyl
 cbj
 ctu
-bxr
+lgt
 bHf
 cQO
 clS
@@ -92359,7 +99564,7 @@ dTs
 dTs
 dTs
 dTs
-pXe
+sMR
 iYI
 tyc
 wyR
@@ -92367,12 +99572,12 @@ kry
 sCf
 iYI
 lNu
-qKA
+iMt
 dTs
 dTs
 dTs
 pXe
-lNu
+wcA
 lNu
 lNu
 xeD
@@ -92387,13 +99592,13 @@ sCf
 qKA
 lAR
 wgv
-pij
+dGr
 xeD
 lNu
 lNu
 lNu
 qKA
-pXe
+sMR
 lNu
 iGC
 dTs
@@ -92425,7 +99630,7 @@ tLl
 dbu
 dbn
 dbq
-daK
+tUN
 daK
 dTP
 dTP
@@ -92486,14 +99691,14 @@ acu
 acu
 dTs
 ads
-aqb
+aKh
 aqb
 ane
-ahh
+vRP
 pUO
 vqR
 vqR
-otn
+rAT
 mCu
 vqR
 vqR
@@ -92527,11 +99732,11 @@ aeA
 aeA
 aeA
 aeA
-aeA
+fDo
 qxv
+fDo
 aeA
-aeA
-aeA
+fDo
 ahF
 ajK
 pUO
@@ -92574,7 +99779,7 @@ bLr
 iwh
 iwh
 nue
-cNW
+nUJ
 pLm
 iwh
 iwh
@@ -92624,10 +99829,10 @@ pij
 lNu
 lNu
 lyw
-lNu
+wcA
 iGC
 wgv
-wgv
+cfd
 cvH
 dTs
 dTs
@@ -92640,7 +99845,7 @@ dTs
 dTs
 dMV
 cPJ
-cRi
+qjq
 cRi
 kbY
 cSu
@@ -92655,13 +99860,13 @@ fdk
 hOK
 cYT
 tLl
-tLl
+vhb
 dbu
 dbn
 dbq
 eew
 dTP
-dTP
+nKS
 dTP
 daK
 dUA
@@ -92685,12 +99890,12 @@ doH
 doH
 doH
 eby
-bnn
+uWo
 ecl
 dus
 eeq
 dzb
-dWE
+wWx
 dWE
 dWN
 rEH
@@ -92735,31 +99940,31 @@ otn
 uRH
 uRH
 uRH
-uRH
-uRH
-hVT
-uRH
-uRH
-uRH
-uRH
-uRH
-uRH
+pZM
 uRH
 hVT
 uRH
 uRH
 uRH
+uRH
+uRH
+uRH
+uRH
+gwO
+uRH
+uRH
+pZM
 uRH
 agT
-mCu
+mvk
 cGD
 cGD
 dzU
 agw
-aeA
+fDo
 sgi
 aiQ
-adj
+mzT
 adj
 adj
 adj
@@ -92767,7 +99972,7 @@ jMC
 aeA
 smY
 vCE
-ajL
+bKu
 vTR
 boc
 aox
@@ -92775,11 +99980,11 @@ bjo
 blM
 bhi
 bkw
-kWb
+viU
 bkZ
 dTs
 bkZ
-bkZ
+paZ
 bkZ
 dTs
 dTs
@@ -92810,10 +100015,10 @@ dCt
 dCt
 dCt
 dCt
-dCt
+egT
 cNW
 tWC
-cNW
+nUJ
 bUt
 bVs
 bWj
@@ -92825,7 +100030,7 @@ pLm
 dTs
 dTs
 wgv
-wgv
+cfd
 pXe
 lNu
 iYI
@@ -92852,10 +100057,10 @@ tyc
 eft
 jmd
 sCf
+wcA
 lNu
 lNu
-lNu
-lNu
+wcA
 cAW
 iGC
 cvH
@@ -92894,7 +100099,7 @@ dbu
 dbn
 dbq
 dTP
-dTP
+nKS
 dUg
 dDQ
 dbs
@@ -92962,11 +100167,11 @@ aaV
 cGD
 abq
 cGD
-cGD
+oLE
 edN
 cGD
 cGD
-cGD
+oLE
 acR
 cGD
 cGD
@@ -92999,7 +100204,7 @@ dTs
 dTs
 bkZ
 bgP
-bhi
+eva
 bhF
 bhZ
 bir
@@ -93015,12 +100220,12 @@ bkZ
 bkZ
 bmu
 bhk
-bhk
+xFn
 bhk
 cBa
 bqV
 brU
-bqV
+tqt
 bqV
 bqV
 btG
@@ -93035,12 +100240,12 @@ bEE
 oVo
 oVo
 tCF
-tCF
+grC
 tCF
 tCF
 bMm
 euG
-hpw
+rYS
 hpw
 hpw
 pTU
@@ -93054,7 +100259,7 @@ bWk
 cNW
 cNW
 cNW
-cNW
+nUJ
 cNW
 pLm
 iwh
@@ -93069,10 +100274,10 @@ kry
 sCf
 coE
 pal
-lNu
+wcA
 lNu
 mTj
-pij
+dGr
 lNu
 lNu
 pal
@@ -93087,10 +100292,10 @@ rFU
 jMT
 sCf
 lNu
+wcA
 lNu
 lNu
-lNu
-iGC
+vde
 wgv
 wgv
 dTs
@@ -93111,7 +100316,7 @@ cOH
 cQr
 cRi
 kbY
-cSv
+pNd
 cTi
 tLl
 bYV
@@ -93120,13 +100325,13 @@ wya
 oKG
 aEq
 fdk
-hOK
+dzt
 cYT
 tLl
-tLl
+vhb
 dbu
 dbn
-dbq
+sIL
 daK
 dTP
 deu
@@ -93138,7 +100343,7 @@ deu
 dbn
 dbu
 tLl
-tLl
+vhb
 hOK
 bYV
 aEq
@@ -93149,7 +100354,7 @@ cXh
 eaU
 dqi
 dqS
-dqV
+qex
 dqV
 edO
 dus
@@ -93158,7 +100363,7 @@ dVT
 dus
 dyb
 ebE
-dAq
+nPz
 dAq
 dBV
 dCJ
@@ -93206,25 +100411,25 @@ edN
 cGD
 tAt
 cGD
-cGD
+oLE
 tAt
 cGD
 cGD
-tAt
+lGv
 cGD
 cGD
 tAt
 cGD
-cGD
+oLE
 tAt
 cGD
 agV
 cGD
 cGD
-cGD
+oLE
 dzU
 aeA
-aeA
+fDo
 aiQ
 aeq
 dTs
@@ -93232,7 +100437,7 @@ dTs
 dTs
 dTs
 bkZ
-bhj
+dVQ
 bhi
 bhF
 bhZ
@@ -93240,14 +100445,14 @@ bir
 boc
 biP
 bjo
-blM
+nOo
 bhi
-bhi
+eva
 bhi
 kWb
 hsN
 bmu
-bhk
+xFn
 bmL
 bob
 boI
@@ -93267,7 +100472,7 @@ vZn
 bZi
 cbq
 bFT
-bFT
+umZ
 ckh
 ckh
 lpe
@@ -93356,13 +100561,13 @@ aEq
 fdk
 hOK
 cYT
-tLl
+vhb
 tLl
 daF
 dbn
 dcg
 dTP
-dTZ
+iEs
 deu
 dbn
 dbq
@@ -93384,15 +100589,15 @@ hOK
 dqW
 dqT
 dqV
-dqV
+qex
 edO
-dus
+oEI
 dVY
 ecn
 ecy
 dyb
 dze
-dzb
+lRq
 dAq
 dBW
 dCK
@@ -93432,7 +100637,7 @@ abv
 abz
 cGD
 cGD
-cGD
+oLE
 tBD
 fDL
 oqy
@@ -93445,7 +100650,7 @@ fDL
 fDL
 fDL
 fDL
-fDL
+qyz
 fDL
 fDL
 fDL
@@ -93472,13 +100677,13 @@ bhF
 bhZ
 bir
 boc
-biP
+kCu
 bjo
 blM
 bhi
 bhi
 bhi
-bhi
+eva
 bhi
 bhk
 bmL
@@ -93487,15 +100692,15 @@ aAo
 bju
 bpP
 bpP
+xRz
 bEG
-bEG
-bEG
+xRz
 que
 bEG
 jQw
 bpP
 bEG
-bEG
+xRz
 bpP
 bCw
 bDl
@@ -93509,7 +100714,7 @@ crI
 bPv
 dCt
 dCt
-mdP
+qPj
 fif
 fif
 tSK
@@ -93623,7 +100828,7 @@ edL
 eaw
 ebW
 eco
-dus
+oEI
 dyb
 dyb
 eeq
@@ -93674,9 +100879,9 @@ aiQ
 ade
 jMC
 aeA
-aYx
+iQI
 aeA
-aeA
+fDo
 ajg
 ajg
 ajg
@@ -93701,9 +100906,9 @@ dTs
 dTs
 dTs
 bhj
-bhi
+eva
 bhF
-bhZ
+nny
 bir
 biN
 bje
@@ -93824,7 +101029,7 @@ gdW
 dUL
 jOe
 cYT
-tLl
+vhb
 dbu
 daG
 dbp
@@ -93892,7 +101097,7 @@ dTs
 dTs
 dTs
 ane
-ads
+hzz
 aaN
 eRn
 fDL
@@ -93917,15 +101122,15 @@ dTs
 dTs
 aeA
 aeA
-aeA
+fDo
 agw
 hDT
 vzj
-pUO
+slU
 cGD
 cGD
 dzU
-aeA
+fDo
 akv
 dTs
 dTs
@@ -93944,12 +101149,12 @@ biP
 bjo
 bhF
 bit
+hNs
 bit
-bit
 azM
 azM
 azM
-azM
+oNT
 azM
 bod
 boJ
@@ -93979,7 +101184,7 @@ bHm
 dCt
 naH
 ozu
-ozu
+gvt
 bRr
 ozu
 ozu
@@ -94062,20 +101267,20 @@ tLl
 dbu
 daG
 dbq
-gcb
+uFc
 dTP
 dTP
 dTP
 dTP
-dUb
+wiB
 dUD
 dUG
 daK
-deu
+qSv
 dbn
 dbu
 tLl
-hOK
+dzt
 bYV
 aEq
 aEq
@@ -94084,14 +101289,14 @@ xqQ
 fdk
 hOK
 dqW
-dqV
+qex
 gnt
 dqV
 edO
 fMa
 bnn
 bHj
-tYL
+xjz
 edU
 rko
 rko
@@ -94191,7 +101396,7 @@ dwd
 bqY
 bqY
 bsG
-bEA
+gli
 sgr
 bwo
 bxz
@@ -94210,7 +101415,7 @@ dwW
 dwX
 bMn
 bHm
-dCt
+egT
 naH
 ozu
 ozu
@@ -94289,7 +101494,7 @@ tLl
 mAm
 tLl
 gdW
-mDz
+kwX
 jOe
 cYT
 tLl
@@ -94364,7 +101569,7 @@ dTs
 ahh
 ahh
 ahh
-ahh
+vRP
 ahh
 ahh
 soS
@@ -94411,12 +101616,12 @@ biN
 bje
 bjo
 bhG
+nQv
 bib
 bib
 bib
 bib
-bib
-bib
+nQv
 bib
 bib
 bod
@@ -94430,7 +101635,7 @@ kvx
 rHf
 fGR
 byD
-bZS
+aPj
 bZS
 bZS
 fsW
@@ -94442,7 +101647,7 @@ ckm
 cnr
 bKD
 bJz
-bMo
+tnz
 bRO
 dCt
 naH
@@ -94454,14 +101659,14 @@ ozu
 xsS
 mfK
 dCt
+egT
+dCt
+dCt
+egT
 dCt
 dCt
 dCt
-dCt
-dCt
-dCt
-dCt
-dCt
+egT
 bic
 biu
 jbx
@@ -94539,8 +101744,8 @@ dfT
 eDQ
 fMI
 dTP
-dUh
-daI
+jzw
+bup
 dbu
 gdW
 hOK
@@ -94557,12 +101762,12 @@ dsb
 dsA
 dqm
 dus
-vqv
+edH
 ecr
 dus
 dOg
 dzf
-wLA
+vYa
 dzg
 dzf
 dCL
@@ -94598,7 +101803,7 @@ dTs
 dTs
 adD
 adD
-aQn
+wsS
 aQn
 abY
 aci
@@ -94639,7 +101844,7 @@ dTs
 dTs
 bhj
 bhF
-bhZ
+nny
 bir
 boc
 biP
@@ -94684,7 +101889,7 @@ ozu
 ozu
 bRr
 ozu
-ozu
+gvt
 xsS
 mfK
 dCt
@@ -94763,7 +101968,7 @@ pnK
 dTK
 eeP
 daK
-hia
+kfz
 nqc
 eew
 ddR
@@ -94839,7 +102044,7 @@ acj
 acp
 acy
 ahC
-ahC
+jIJ
 dTs
 dTs
 dTs
@@ -94877,7 +102082,7 @@ bhZ
 bir
 biO
 bjf
-bjq
+kJL
 bjf
 bjf
 bjq
@@ -94896,7 +102101,7 @@ bFY
 bFY
 bFY
 oAX
-bEA
+gli
 fpg
 nTa
 bAG
@@ -94914,7 +102119,7 @@ cuW
 bRO
 dCt
 naH
-ozu
+gvt
 ozu
 bRr
 uml
@@ -94982,13 +102187,13 @@ dTs
 cPL
 dTA
 dTA
-kfQ
+wCR
 cSA
 cPL
 cTM
 cTO
 cUF
-cTO
+rHB
 cVV
 lwm
 eGM
@@ -95021,8 +102226,8 @@ fCB
 hOK
 dqW
 het
-dqV
-dqV
+qex
+qex
 dqm
 dus
 dWa
@@ -95093,7 +102298,7 @@ ahh
 ahh
 pUO
 aht
-uWT
+lqN
 dzU
 ahh
 dTs
@@ -95105,7 +102310,7 @@ dTs
 bhk
 bhk
 bhk
-bhk
+xFn
 bhF
 bhZ
 bir
@@ -95115,7 +102320,7 @@ bjr
 biP
 biP
 bjr
-biP
+kCu
 aox
 atM
 aox
@@ -95146,7 +102351,7 @@ bJz
 jmX
 cuW
 bRO
-dCt
+egT
 naH
 ozu
 ozu
@@ -95219,7 +102424,7 @@ cQw
 wDY
 cSB
 cTj
-cTN
+feX
 mvz
 cUG
 cTN
@@ -95232,7 +102437,7 @@ gdW
 dbu
 dTQ
 dbs
-nqc
+lXX
 daK
 ddT
 dex
@@ -95354,7 +102559,7 @@ biQ
 bmg
 aox
 biP
-bjo
+aYh
 blM
 btc
 bpV
@@ -95462,7 +102667,7 @@ cWy
 peQ
 ass
 jOe
-tLl
+vhb
 daF
 daH
 dbq
@@ -95471,14 +102676,14 @@ dTP
 daK
 daK
 daK
-daK
+tUN
 daK
 fMI
 daK
-deu
+qSv
 djt
 daF
-tLl
+vhb
 hOK
 bYV
 aEq
@@ -95498,7 +102703,7 @@ ect
 dqo
 dpB
 dzj
-wLA
+vYa
 dzg
 bgq
 dCL
@@ -95570,11 +102775,11 @@ dTs
 bXh
 aiW
 bXg
-bXg
+pYW
 akJ
 akS
 alr
-bhF
+wBa
 cEl
 lPy
 bit
@@ -95582,12 +102787,12 @@ bit
 bit
 bit
 bit
-bit
+hNs
 bit
 cdC
 aui
 bki
-bje
+whD
 vNT
 blM
 btc
@@ -95595,15 +102800,15 @@ bpW
 vFS
 bra
 lmq
-bra
+waa
 pGZ
 bOr
-bra
+waa
 btc
 bzN
 bTb
 bST
-bST
+lTf
 bSf
 cbP
 bGb
@@ -95621,9 +102826,9 @@ ozu
 bRr
 uml
 vgm
-xsS
+xXb
 mfK
-dCt
+egT
 dCt
 dCt
 dsk
@@ -95682,7 +102887,7 @@ dTs
 dTs
 dTs
 cPL
-cQA
+sgG
 cPL
 cQA
 cPL
@@ -95690,19 +102895,19 @@ cPL
 cTO
 cUs
 cTO
-cTO
+rHB
 cVV
 gdW
 gdW
-hqp
+czm
 jOe
 tLl
 dbu
 daG
-dbq
+sIL
 gcb
 dTP
-dTP
+nKS
 daK
 daK
 dUb
@@ -95813,7 +103018,7 @@ jvg
 bib
 ani
 bib
-bib
+nQv
 bib
 bib
 bib
@@ -95849,10 +103054,10 @@ bLE
 bHm
 bHm
 dCt
-ngo
+qic
 oAM
 oAM
-inQ
+qmT
 ozu
 ozu
 xsS
@@ -95923,14 +103128,14 @@ cPL
 cPL
 cTP
 iKk
-cTO
+rHB
 cVq
 cPL
 vuu
 gdW
 hqp
 jOe
-tLl
+vhb
 dbu
 daG
 dbt
@@ -95953,13 +103158,13 @@ aEq
 aEq
 fdk
 hOK
-tLl
+vhb
 dpB
 dNX
 dVw
 dNY
 dOa
-dVI
+jQG
 dVO
 dWe
 ecv
@@ -96053,7 +103258,7 @@ bhk
 bhk
 bhk
 blM
-bir
+jfQ
 biP
 biP
 bjo
@@ -96081,7 +103286,7 @@ bHm
 bRO
 bRO
 bHm
-dCt
+egT
 dCt
 blO
 nil
@@ -96290,27 +103495,27 @@ blM
 bir
 bki
 bje
-bjo
+aYh
 blM
 bhk
 bhi
 bTR
-bhi
+eva
 bhi
 btQ
 bvi
 whC
 bvi
-bHq
+uTe
 bvi
 bvi
-bvi
+idm
 bvi
 bwu
 bEQ
 bvi
 bHq
-bvi
+idm
 btQ
 cNW
 cNW
@@ -96389,12 +103594,12 @@ dTI
 dTI
 cPL
 cTl
-cTO
+rHB
 iKk
 cUH
 hOA
 cVV
-tLl
+vhb
 gdW
 hqp
 sbP
@@ -96404,10 +103609,10 @@ daF
 daG
 dcj
 dTP
-dUb
+wiB
 dUj
 daG
-dUv
+nsh
 dTZ
 aMs
 diK
@@ -96547,13 +103752,13 @@ bHr
 bvi
 btQ
 dCt
-dCt
+egT
 dCt
 dCt
 chz
 ciE
 cie
-qDb
+fnp
 aFo
 aFo
 aFo
@@ -96643,7 +103848,7 @@ deu
 dUp
 dUv
 dTP
-fMI
+jyh
 deu
 dbn
 dbu
@@ -96755,11 +103960,11 @@ aKO
 agm
 auH
 blM
+svN
 cyP
+svN
 cyP
-cyP
-cyP
-blM
+nOo
 bYf
 aea
 aea
@@ -96789,9 +103994,9 @@ hbr
 cif
 qDb
 aFo
-aFo
+sTE
 wrl
-aFo
+sTE
 mfK
 chA
 hbr
@@ -96820,7 +104025,7 @@ lYE
 dGA
 dGA
 dHA
-coF
+iYa
 dfc
 dgF
 jrV
@@ -96857,7 +104062,7 @@ dTs
 dTs
 cPL
 cTn
-cTO
+rHB
 kuR
 cTO
 cVs
@@ -96872,7 +104077,7 @@ dbu
 daG
 dbq
 dTP
-daK
+tUN
 dUh
 dUH
 dbr
@@ -96895,11 +104100,11 @@ kpb
 syO
 dhA
 ego
-tLl
+vhb
 tLl
 syO
 jKr
-dhA
+qLs
 tLl
 lwm
 hqp
@@ -97005,7 +104210,7 @@ slB
 bAK
 bAK
 bAK
-bAK
+sHG
 bwv
 aFo
 aAs
@@ -97059,7 +104264,7 @@ wiX
 ukB
 ukB
 sgQ
-tjV
+vxN
 tjV
 tjV
 tjV
@@ -97093,7 +104298,7 @@ cPL
 cTo
 cTO
 ecI
-cTO
+rHB
 cTO
 cVV
 tLl
@@ -97101,7 +104306,7 @@ tLl
 tJI
 jOe
 tLl
-tLl
+vhb
 dbu
 daG
 dbq
@@ -97126,7 +104331,7 @@ hOK
 tLl
 tLl
 syO
-ibU
+hXY
 ibU
 jKr
 jKr
@@ -97177,7 +104382,7 @@ dTs
 dTs
 aWZ
 aWZ
-mim
+xbk
 mim
 mim
 bXi
@@ -97223,7 +104428,7 @@ bXn
 bXn
 bXv
 blM
-cyP
+svN
 cyP
 cyP
 cyP
@@ -97257,7 +104462,7 @@ cld
 cig
 qDb
 aFo
-aFo
+sTE
 aFo
 aFo
 mfK
@@ -97331,7 +104536,7 @@ hOA
 cPL
 cPL
 tLl
-tLl
+vhb
 syi
 xmX
 tLl
@@ -97341,11 +104546,11 @@ daG
 dbq
 daK
 daK
+nKS
 dTP
 dTP
 dTP
-dTP
-fMI
+jyh
 deu
 dbn
 dbu
@@ -97413,7 +104618,7 @@ dTs
 mim
 mim
 mim
-mim
+xbk
 kFk
 bXi
 aZg
@@ -97430,12 +104635,12 @@ aZg
 aZg
 aZg
 bXz
-aPP
+tIT
 aXW
-aWa
+vge
 aWB
 aZk
-aPP
+tIT
 bZs
 bXn
 bXn
@@ -97464,7 +104669,7 @@ vNT
 blM
 bhk
 bhk
-bhk
+xFn
 bhk
 kvj
 btQ
@@ -97478,16 +104683,16 @@ hdR
 bwv
 bwv
 cgU
-bwv
+aAs
 bHv
 bIu
 btQ
 dCt
+egT
 dCt
 dCt
 dCt
-dCt
-dCt
+egT
 dCt
 qDb
 naH
@@ -97520,18 +104725,18 @@ dTs
 dTs
 tWE
 cdw
-cdw
+lzM
 cdw
 ciU
 cfw
-dPY
+qUc
 idg
 chr
 ciU
 cdw
 cdw
 cdw
-cdw
+lzM
 cdw
 ceo
 tjV
@@ -97591,7 +104796,7 @@ aEq
 aEq
 fdk
 hOK
-tLl
+vhb
 iNd
 dqp
 dqp
@@ -97602,7 +104807,7 @@ rJC
 rJC
 dqp
 dqp
-ibU
+hXY
 lwm
 qck
 jOe
@@ -97650,7 +104855,7 @@ fIK
 ard
 asy
 fIK
-fIK
+erw
 adu
 bWq
 aIG
@@ -97697,7 +104902,7 @@ bje
 bjo
 blM
 bhk
-bhk
+xFn
 bhk
 bhk
 bhk
@@ -97705,7 +104910,7 @@ kpf
 bvk
 jnF
 aAs
-bwv
+aAs
 bzP
 bwv
 hdR
@@ -97724,7 +104929,7 @@ dCt
 dCt
 dCt
 qDb
-naH
+jRx
 uml
 ddt
 xsS
@@ -97743,7 +104948,7 @@ dTs
 dTs
 dTs
 rwf
-jhp
+vAK
 jhp
 uBx
 evl
@@ -97752,7 +104957,7 @@ aDX
 rwf
 dTs
 cOk
-xqW
+wUq
 nXt
 coJ
 coI
@@ -97762,7 +104967,7 @@ dPY
 idg
 hwy
 ciU
-cdw
+lzM
 cdw
 cdw
 cdw
@@ -97797,12 +105002,12 @@ dTs
 ibU
 goZ
 tLl
-tLl
+vhb
 tLl
 tLl
 hqp
 jOe
-tLl
+vhb
 ego
 daF
 daF
@@ -97842,7 +105047,7 @@ qck
 jOe
 gdW
 ebP
-iNd
+nMz
 ibU
 dTs
 dTs
@@ -97885,7 +105090,7 @@ aRi
 aRH
 aPP
 aPP
-aPP
+tIT
 aPP
 aPP
 aPP
@@ -97927,14 +105132,14 @@ bXv
 blM
 bir
 biP
-biP
+kCu
 bjo
 blM
 bhk
 bhk
 bhk
 bhk
-bhk
+xFn
 btQ
 bvj
 ujO
@@ -97942,7 +105147,7 @@ bwv
 bwv
 bwv
 bwv
-bwv
+aAs
 bwv
 bwv
 cgU
@@ -97954,7 +105159,7 @@ dCt
 dCt
 dCt
 dCt
-dCt
+egT
 dCt
 dCt
 qDb
@@ -98028,7 +105233,7 @@ dTs
 dTs
 dTs
 dTs
-ibU
+hXY
 oXw
 tLl
 tLl
@@ -98113,23 +105318,23 @@ dTs
 dTs
 dTs
 dTs
-bRg
-aPP
+cTE
+tIT
 aOk
 aaS
 aXU
+mzI
+aXU
+aXU
+mzI
 aXU
 aXU
 aXU
-aXU
-aXU
-aXU
-aXU
-aXU
+mzI
 aXU
 agg
 aXU
-aXU
+mzI
 aXU
 aXU
 aif
@@ -98194,7 +105399,7 @@ cie
 qDb
 aFo
 aFo
-aFo
+sTE
 aFo
 mfK
 chA
@@ -98226,15 +105431,15 @@ nTI
 nTI
 ciU
 cfw
-ciu
+vWl
 ibE
 nTp
 ilz
 ilz
-ilz
+xjS
 cix
 ciU
-cdw
+lzM
 ceo
 tjV
 pFb
@@ -98284,7 +105489,7 @@ wuJ
 xqf
 dTY
 dTY
-dcY
+gaj
 cXz
 gdW
 hOK
@@ -98361,7 +105566,7 @@ dTs
 dTs
 dTs
 bRg
-aXv
+kKQ
 aPP
 aaB
 abZ
@@ -98369,12 +105574,12 @@ abZ
 abZ
 amM
 buj
-buj
+qkW
 aZk
 aXv
 bRg
 bRg
-bRg
+cTE
 aPP
 bZs
 bXn
@@ -98393,10 +105598,10 @@ bXn
 bXn
 bXv
 blM
+svN
 cyP
 cyP
-cyP
-cyP
+svN
 blM
 bZs
 bXn
@@ -98412,7 +105617,7 @@ bAK
 bAK
 tcK
 aFo
-bwv
+aAs
 iVQ
 chA
 cif
@@ -98528,7 +105733,7 @@ wya
 fdk
 hOK
 tLl
-iNd
+nMz
 dpC
 rJC
 rJC
@@ -98585,7 +105790,7 @@ aow
 apx
 arf
 arf
-asz
+lZb
 aow
 asB
 aow
@@ -98605,7 +105810,7 @@ aCp
 buj
 buj
 aZk
-aXv
+kKQ
 bdc
 euN
 oBK
@@ -98660,7 +105865,7 @@ cld
 cld
 cig
 qDb
-aFo
+sTE
 aFo
 aFo
 aFo
@@ -98697,10 +105902,10 @@ cfw
 iAf
 uYD
 chu
-idg
+mJZ
 idg
 dPY
-pUR
+xEX
 ciU
 cdw
 ceo
@@ -98735,9 +105940,9 @@ dTs
 vwF
 ioB
 dsU
-cXn
+dkb
 hqp
-aqf
+sIA
 rpQ
 xML
 aqf
@@ -98748,7 +105953,7 @@ eiI
 dTX
 dcn
 dcn
-dTX
+bem
 uur
 prI
 prI
@@ -98772,7 +105977,7 @@ rJC
 rJC
 rJC
 dqp
-ibU
+hXY
 lwm
 hqp
 jOe
@@ -98816,7 +106021,7 @@ dTs
 dTs
 dTs
 aow
-aqK
+gmL
 asx
 asx
 asA
@@ -98830,11 +106035,11 @@ dTs
 dTs
 dTs
 aXv
-aPP
+tIT
 aXW
 buj
 buj
-buj
+qkW
 aCp
 aWa
 aWB
@@ -98842,7 +106047,7 @@ aZk
 aXv
 bRg
 wjr
-bgH
+bLG
 dTs
 dTs
 dTs
@@ -98878,7 +106083,7 @@ bwv
 bwv
 bwv
 bwv
-bwv
+aAs
 bwv
 bwv
 cgU
@@ -98887,17 +106092,17 @@ bHv
 bIu
 btQ
 dCt
+egT
 dCt
 dCt
-dCt
-dCt
+egT
 dCt
 dCt
 qDb
 naH
 ozu
 ozu
-xsS
+xXb
 mfK
 chA
 hbr
@@ -98926,7 +106131,7 @@ tWE
 cdw
 cdw
 coJ
-ciU
+mGA
 cfw
 ciu
 idg
@@ -98969,24 +106174,24 @@ ioB
 ioB
 ioB
 dtX
-cXo
+dkc
 hqp
 rpQ
-rpQ
+pdj
 aqf
 jOe
 gdW
 cXz
+gyo
 dTY
 dTY
-dTY
-dUq
+naT
 dUq
 dTX
 lUO
 dUq
 dUq
-dcY
+gaj
 cXz
 gdW
 hOK
@@ -99012,7 +106217,7 @@ hqp
 jOe
 gdW
 viV
-iNd
+nMz
 dTs
 dTs
 dTs
@@ -99053,11 +106258,11 @@ aow
 aqK
 asx
 asx
-asA
+cnI
 asC
 atp
 aud
-avq
+mUE
 aow
 dTs
 dTs
@@ -99073,7 +106278,7 @@ aCQ
 buj
 buj
 aZk
-aXv
+kKQ
 aeE
 bgH
 bgH
@@ -99095,13 +106300,13 @@ bXn
 bXn
 bXv
 blM
-bir
+jfQ
 bki
 bje
 vNT
 blM
 bhk
-bhk
+xFn
 bhk
 bhk
 bhk
@@ -99109,7 +106314,7 @@ qba
 bvk
 sIY
 bwv
-bwv
+aAs
 aAs
 bwv
 bwv
@@ -99126,7 +106331,7 @@ dCt
 dCt
 dCt
 dCt
-dCt
+egT
 qDb
 naH
 uml
@@ -99163,12 +106368,12 @@ cdw
 ciU
 cfw
 dPY
-dPY
+qUc
 cht
 poi
 qEJ
 poi
-cix
+bAX
 aKv
 cdw
 ceo
@@ -99208,7 +106413,7 @@ cWy
 peQ
 peQ
 aqf
-jOe
+mlF
 gdW
 dck
 dcY
@@ -99229,7 +106434,7 @@ sLx
 wya
 fdk
 hOK
-tLl
+vhb
 tLl
 gdW
 dqp
@@ -99285,7 +106490,7 @@ dTs
 dTs
 aow
 aqM
-asx
+acT
 asx
 asA
 asB
@@ -99332,12 +106537,12 @@ blM
 bir
 biP
 biP
-bjo
+aYh
 blM
 bhk
 bhk
 bhk
-bhk
+xFn
 bhk
 btQ
 bvj
@@ -99345,9 +106550,9 @@ ujO
 bwv
 bwv
 bwv
+aAs
 bwv
-bwv
-bwv
+aAs
 bwv
 cgU
 bwv
@@ -99357,14 +106562,14 @@ btQ
 dCt
 dCt
 dCt
-dCt
+egT
 dCt
 dCt
 dCt
 qDb
 naH
 ozu
-ozu
+gvt
 xsS
 mfK
 chA
@@ -99393,7 +106598,7 @@ dTs
 dTs
 tWE
 cdw
-cdw
+lzM
 ciU
 cfw
 cge
@@ -99524,7 +106729,7 @@ pjI
 asA
 asG
 nfU
-aud
+epq
 avq
 aow
 dTs
@@ -99533,14 +106738,14 @@ dTs
 dTs
 aXv
 aPP
-aXW
+rIv
 buj
 buj
 buj
-aCp
+pcp
 ybg
 aWB
-aZk
+vlH
 bRg
 aXY
 dTs
@@ -99565,7 +106770,7 @@ fGT
 blM
 cyP
 cyP
-cyP
+svN
 cyP
 blM
 bYJ
@@ -99634,11 +106839,11 @@ dPY
 dPY
 rZU
 idg
-idg
+mJZ
 dPY
 chr
 aKv
-cdw
+lzM
 ceo
 tjV
 cgq
@@ -99673,10 +106878,10 @@ djx
 dtY
 gdW
 gdW
-gdW
+wVo
 gdW
 hqp
-jOe
+mlF
 gdW
 dck
 dck
@@ -99715,7 +106920,7 @@ xmX
 gdW
 ebP
 iNd
-ibU
+hXY
 dTs
 dTs
 dTs
@@ -99753,7 +106958,7 @@ dTs
 dTs
 aow
 aqK
-asx
+acT
 asx
 asA
 aow
@@ -99776,7 +106981,7 @@ buj
 buj
 aZk
 aip
-bRg
+cTE
 wjr
 dTs
 dTs
@@ -99816,7 +107021,7 @@ bAK
 bAK
 bwv
 aFo
-bwv
+aAs
 iVQ
 chA
 cif
@@ -99863,13 +107068,13 @@ gNO
 cOk
 wOZ
 ciU
-cfw
+kUO
 dPY
 dPY
 gNv
 icM
 cdc
-cdc
+eha
 ciy
 ciU
 nXt
@@ -99921,7 +107126,7 @@ thd
 dfj
 haK
 dfj
-dea
+tRN
 dda
 dkI
 cUj
@@ -99995,15 +107200,15 @@ aow
 auI
 aow
 aow
-awC
-awC
+awd
+awd
 dTs
 dTs
 aHO
-aPP
+tIT
 aaC
 aXC
-aXC
+iha
 aXC
 aCQ
 buj
@@ -100021,7 +107226,7 @@ dTs
 dTs
 dTs
 dTs
-bhk
+xFn
 bhk
 bhk
 bhk
@@ -100031,7 +107236,7 @@ bXi
 aZg
 bXz
 blM
-cyP
+svN
 cyP
 cyP
 cyP
@@ -100064,7 +107269,7 @@ clf
 hbr
 cif
 qDb
-aFo
+sTE
 aFo
 wrl
 aFo
@@ -100084,10 +107289,10 @@ cdv
 dTs
 dTs
 cOk
-caH
+rjY
 chZ
 civ
-caH
+rjY
 dTs
 dTs
 dTs
@@ -100143,7 +107348,7 @@ dnD
 drg
 cZc
 gdW
-hqp
+czm
 jOe
 gdW
 cZc
@@ -100176,7 +107381,7 @@ rJC
 rJC
 dqp
 dqp
-ibU
+hXY
 lwm
 hqp
 jOe
@@ -100230,8 +107435,8 @@ qrp
 azp
 awd
 awd
-awd
-lKL
+yeb
+fhI
 dTs
 dTs
 aPP
@@ -100241,10 +107446,10 @@ abZ
 abZ
 amM
 buj
-buj
+qkW
 aZk
 dTs
-bRg
+cTE
 dTs
 dTs
 dTs
@@ -100258,17 +107463,17 @@ dTs
 bgP
 biw
 bmL
-bit
+hNs
 bjs
 bjJ
-wkV
+uXd
 mim
 bXA
 blM
 bir
 biP
 biP
-bjo
+aYh
 blM
 bhl
 bhk
@@ -100329,7 +107534,7 @@ dTs
 dTs
 dTs
 dTs
-tWE
+ipF
 ciU
 dPR
 dPY
@@ -100383,7 +107588,7 @@ gdW
 cZc
 dde
 ddY
-wqY
+iTX
 wxc
 dea
 pbC
@@ -100452,7 +107657,7 @@ dTs
 dTs
 dTs
 dTs
-lKL
+jYg
 jnY
 ayK
 ayZ
@@ -100461,14 +107666,14 @@ xEl
 xEl
 xEl
 obs
-axr
+jyu
 axS
 axS
 axt
-lKL
+dJp
 lKL
 dTs
-aPP
+tIT
 aXW
 buj
 buj
@@ -100534,7 +107739,7 @@ oXx
 qDb
 naH
 ozu
-ozu
+gvt
 xsS
 mfK
 cuR
@@ -100550,10 +107755,10 @@ dLK
 caH
 cdw
 cej
-cdw
+lzM
 cdw
 caH
-chZ
+paI
 civ
 caH
 dTs
@@ -100566,12 +107771,12 @@ cer
 xqW
 ciU
 cfw
-idg
+mJZ
 idg
 ute
 dPY
 dPY
-idg
+mJZ
 pUR
 aaY
 cdw
@@ -100609,7 +107814,7 @@ ghQ
 lwj
 nlb
 cle
-gdW
+wVo
 gdW
 hqp
 jOe
@@ -100622,7 +107827,7 @@ rza
 dea
 dcN
 wRi
-dhZ
+wie
 dhZ
 eeV
 xqQ
@@ -100644,7 +107849,7 @@ rJC
 rJC
 rJC
 dpC
-ibU
+hXY
 lwm
 qck
 jOe
@@ -100699,21 +107904,21 @@ ayZ
 ayZ
 azk
 tPi
-lKL
+jYg
 dTs
 dTs
 aPP
 aXW
 buj
-buj
+qkW
 buj
 aCp
-buj
+qkW
 buj
 aZk
 dTs
 aeE
-bgH
+bLG
 aOg
 dTs
 dTs
@@ -100723,7 +107928,7 @@ dTs
 dTs
 dTs
 bkZ
-bhj
+dVQ
 bhi
 bhF
 bhZ
@@ -100733,10 +107938,10 @@ bie
 bie
 blg
 blM
-bir
+jfQ
 biP
 biP
-bjo
+aYh
 blM
 bhk
 cpu
@@ -100761,7 +107966,7 @@ btQ
 cNW
 dCt
 euG
-hpw
+rYS
 hpw
 hpw
 hpw
@@ -100782,20 +107987,20 @@ hbr
 hyG
 dLL
 caH
-cdw
+lzM
 cdw
 aDV
 aMD
 caH
 cib
-ceY
+mqQ
 caH
 cer
 aFG
 cer
 cer
 xqW
-cdw
+lzM
 cdw
 cdw
 coK
@@ -100808,7 +108013,7 @@ cdc
 cdc
 ciy
 cib
-cjT
+gUt
 cjT
 cjT
 cjT
@@ -100819,10 +108024,10 @@ cEg
 cEg
 lnT
 cEg
-cDf
+gyI
 cIz
 cCc
-caH
+rjY
 caH
 caH
 caH
@@ -100846,14 +108051,14 @@ dnD
 gdW
 gdW
 hqp
-jOe
+mlF
 gdW
 gdW
 dda
 ddZ
 jsv
 wxc
-dea
+tRN
 hAB
 dhZ
 wRi
@@ -100868,7 +108073,7 @@ xqQ
 fdk
 hOK
 iNd
-ibU
+hXY
 dpC
 rJC
 rJC
@@ -100885,7 +108090,7 @@ jOe
 gdW
 mMy
 fHZ
-fHZ
+edW
 ibU
 ibU
 dTs
@@ -100921,11 +108126,11 @@ dTs
 dTs
 dTs
 dTs
-lKL
+jYg
 ayK
 ayZ
 xEl
-ayZ
+ebT
 ayZ
 ayZ
 ayZ
@@ -100960,12 +108165,12 @@ bkZ
 pCf
 bhi
 bhF
-azM
+oNT
 bit
 bjM
 bjM
 bjM
-bjM
+mRQ
 bju
 bir
 biP
@@ -100983,7 +108188,7 @@ bwx
 bxK
 awA
 bzQ
-bAM
+get
 bAM
 bsd
 wyS
@@ -101000,7 +108205,7 @@ hqT
 hqT
 hqT
 shm
-naH
+jRx
 uml
 vgm
 xsS
@@ -101029,12 +108234,12 @@ ilz
 ilz
 ilz
 ilz
-ilz
+xjS
 ilz
 ilz
 ilz
 qVN
-dPY
+qUc
 ciu
 cht
 ilz
@@ -101049,7 +108254,7 @@ poi
 fKt
 cCd
 cDf
-cDf
+gyI
 cDf
 cDf
 cDf
@@ -101085,7 +108290,7 @@ gdW
 gdW
 dde
 dea
-dea
+tRN
 wyJ
 dea
 hAB
@@ -101122,10 +108327,10 @@ tLl
 eLU
 fCr
 ibU
+hXY
 ibU
 ibU
-ibU
-ibU
+hXY
 ibU
 dTs
 dTs
@@ -101163,10 +108368,10 @@ ayZ
 axQ
 azc
 azc
-ayO
+vwc
 ayZ
 ayZ
-azp
+mYn
 dTs
 dTs
 dTs
@@ -101237,7 +108442,7 @@ fif
 tSK
 ozu
 ozu
-xsS
+xXb
 mfK
 bVE
 dCt
@@ -101258,7 +108463,7 @@ ciu
 ciu
 ciu
 cda
-ciu
+vWl
 ciu
 cda
 ciu
@@ -101266,17 +108471,17 @@ ciu
 cda
 dPY
 dPY
-cda
+lpq
 dPY
 ciu
 dPY
 ibE
 cda
-ciu
+vWl
 dPY
 slN
 ciu
-idg
+mJZ
 lFc
 ibE
 dPY
@@ -101285,17 +108490,17 @@ cCd
 cDf
 cDf
 cDf
-cDf
+gyI
 cDf
 cHx
 cIB
 cEf
 cdw
 sqi
-civ
+ple
 cMN
 cid
-chU
+lSE
 cgr
 hzL
 dTs
@@ -101316,13 +108521,13 @@ gdW
 tJI
 aqf
 hBr
-jpa
+noo
 ddc
 dea
 dea
 ddY
 dea
-dcN
+jrk
 uYz
 rPp
 dhZ
@@ -101335,7 +108540,7 @@ sLx
 hjm
 fdk
 hOK
-fCr
+gFA
 ibU
 dqp
 rJC
@@ -101426,46 +108631,46 @@ dTs
 dTs
 dTs
 bkZ
-bhj
+dVQ
 bhF
-azM
+oNT
 bhZ
 bir
-biP
+kCu
 biP
 biP
 blN
-biP
+kCu
 biP
 biP
 bjo
 kBt
 bit
-blL
+qaY
 bre
 dvO
 pqt
 gYE
 pqt
 pqt
+xXh
 pqt
-pqt
-pqt
+xXh
 qYC
 pqt
-pqt
+xXh
 uWf
 aKl
 brf
-brf
+lGq
 brf
 bre
 euG
-hpw
+rYS
 nqm
 kVU
 naH
-ozu
+gvt
 ozu
 ozu
 bRr
@@ -101474,7 +108679,7 @@ ozu
 xsS
 mfK
 bVE
-dCt
+egT
 duy
 mEu
 bnh
@@ -101485,7 +108690,7 @@ vsQ
 dLQ
 ccP
 cdy
-cel
+wSm
 ceX
 cfw
 ciu
@@ -101521,7 +108726,7 @@ cDf
 cDf
 cDf
 cDf
-cHx
+eJS
 cDf
 cCc
 cdw
@@ -101650,7 +108855,7 @@ dTs
 dTs
 dTs
 bRg
-bRg
+cTE
 bRg
 bRg
 azz
@@ -101724,20 +108929,20 @@ ceY
 cfw
 ciu
 ciu
-chq
+vUk
+cdc
+cdc
+eha
 cdc
 cdc
 cdc
-cdc
-cdc
-cdc
-cdc
+eha
 cdc
 cdc
 ppI
 cdc
 cdc
-cdc
+eha
 cfA
 sML
 fEQ
@@ -101747,11 +108952,11 @@ ctO
 ntj
 ctO
 ctO
-hPB
+igC
 dTM
 aBV
 cDf
-cDf
+gyI
 cDf
 cDf
 cDf
@@ -101786,13 +108991,13 @@ dIw
 gdW
 gdW
 dde
-dea
+tRN
 dea
 dfk
-dea
+tRN
 vMp
 xjY
-dgT
+sAW
 dgT
 eeW
 aEq
@@ -101824,7 +109029,7 @@ gdW
 gdW
 gdW
 gdW
-gdW
+wVo
 gdW
 gdW
 gdW
@@ -101861,7 +109066,7 @@ apD
 arL
 arL
 lse
-atk
+hfH
 arL
 avy
 arJ
@@ -101886,7 +109091,7 @@ dTs
 oBK
 bRg
 bRg
-bRg
+cTE
 dTs
 dTs
 dTs
@@ -101897,7 +109102,7 @@ dTs
 bhj
 bhF
 azM
-bhZ
+nny
 bir
 biP
 biP
@@ -101907,7 +109112,7 @@ biQ
 biQ
 biQ
 bnt
-blM
+nOo
 gHU
 gHU
 diL
@@ -101934,7 +109139,7 @@ hwc
 kVU
 ngo
 oAM
-oAM
+dlr
 oAM
 inQ
 ozu
@@ -101955,7 +109160,7 @@ dLZ
 caH
 caH
 caH
-cfw
+kUO
 ciu
 ciu
 chr
@@ -101977,7 +109182,7 @@ ciu
 dPY
 dPY
 ciu
-dPY
+qUc
 ciu
 xOb
 idg
@@ -101989,14 +109194,14 @@ cEh
 cEh
 ydw
 cEh
-cDf
+gyI
 cDf
 cDf
 dnP
 hrk
 jXq
 caH
-caH
+rjY
 caH
 dTs
 dTs
@@ -102018,12 +109223,12 @@ cZc
 gdW
 gdW
 gdW
-gdW
+wVo
 dda
 deb
 dea
 dea
-dea
+tRN
 rAP
 dea
 dea
@@ -102047,7 +109252,7 @@ gdW
 gdW
 tLl
 tLl
-tLl
+vhb
 tLl
 lwm
 hqp
@@ -102092,7 +109297,7 @@ dTs
 dTs
 ajz
 apZ
-arL
+kCr
 arL
 wQc
 atQ
@@ -102119,7 +109324,7 @@ dTs
 dTs
 aYz
 bRg
-bRg
+cTE
 bRg
 dTs
 dTs
@@ -102138,7 +109343,7 @@ tKB
 ggy
 ati
 auo
-iif
+eDH
 iif
 iif
 lYn
@@ -102163,14 +109368,14 @@ bDx
 bDx
 bDx
 cNW
-dCt
+egT
 hwc
 kVU
 mdP
 fif
 fif
 fif
-tSK
+eoa
 ozu
 ozu
 xsS
@@ -102219,7 +109424,7 @@ chr
 pdV
 cCe
 mBs
-mBs
+mYq
 fCD
 cFT
 cGU
@@ -102273,7 +109478,7 @@ fdk
 hOK
 viV
 vuu
-tLl
+vhb
 tLl
 gdW
 wRX
@@ -102333,7 +109538,7 @@ auj
 arL
 avA
 arJ
-ayK
+lum
 ayZ
 ayZ
 azp
@@ -102352,7 +109557,7 @@ dTs
 dTs
 dTs
 bgH
-oBK
+lYs
 bRg
 bRg
 bRg
@@ -102387,7 +109592,7 @@ bwA
 bxL
 bsN
 brf
-bxQ
+sMP
 bBH
 brh
 aff
@@ -102425,11 +109630,11 @@ ceo
 cdw
 cfw
 ciu
-ciu
+vWl
 chr
 chZ
 vXl
-vXl
+fOT
 civ
 ciR
 bdh
@@ -102439,12 +109644,12 @@ clH
 cmt
 dPj
 ciR
-ciU
+mGA
 csH
 dPZ
+eha
 cdc
-cdc
-cdc
+eha
 cdc
 cdc
 dPZ
@@ -102461,10 +109666,10 @@ cGV
 cIC
 cCc
 cdw
+lzM
 cdw
 cdw
-cdw
-cdw
+lzM
 dTs
 dTs
 dTs
@@ -102485,7 +109690,7 @@ nlb
 cjS
 dtY
 gdW
-tLl
+vhb
 tLl
 dde
 dea
@@ -102513,7 +109718,7 @@ gdW
 hqp
 jOe
 gdW
-gdW
+wVo
 gdW
 gdW
 gdW
@@ -102524,12 +109729,12 @@ gdW
 gdW
 gdW
 gdW
+wVo
 gdW
 gdW
 gdW
 gdW
-gdW
-gdW
+wVo
 hqp
 jOe
 gdW
@@ -102563,7 +109768,7 @@ arB
 arL
 atj
 cRj
-atQ
+tio
 arL
 avy
 arJ
@@ -102596,7 +109801,7 @@ dTs
 dTs
 dTs
 dTs
-bmJ
+oYj
 vGm
 aCP
 ari
@@ -102627,15 +109832,15 @@ brh
 bDz
 igP
 bFa
-bFa
+ogG
 bIy
 bDx
 cNW
 dCt
-hwc
+oQK
 kVU
 naH
-ozu
+gvt
 ozu
 ozu
 bRr
@@ -102644,7 +109849,7 @@ ozu
 xsS
 mfK
 bVE
-dCt
+egT
 dCU
 dKA
 mEu
@@ -102654,7 +109859,7 @@ kMb
 vsQ
 dLP
 bPi
-caH
+rjY
 ceo
 cdw
 cfw
@@ -102669,7 +109874,7 @@ ciR
 bGP
 ckA
 dOS
-ckB
+wwQ
 cmu
 coM
 ciR
@@ -102682,9 +109887,9 @@ cjT
 cjT
 cjT
 dPS
+wSi
 dPS
-dPS
-ceY
+mqQ
 cCf
 cCg
 cCg
@@ -102723,12 +109928,12 @@ bLk
 tLl
 dda
 dea
+tRN
+dea
+tRN
 dea
 dea
-dea
-dea
-dea
-dea
+tRN
 dea
 dda
 gdW
@@ -102755,7 +109960,7 @@ hGN
 qck
 jOe
 gdW
-gdW
+wVo
 lwX
 dtE
 lwX
@@ -102794,7 +109999,7 @@ dTs
 dTs
 ajz
 arC
-arL
+kCr
 ckK
 cRj
 auj
@@ -102807,7 +110012,7 @@ ayZ
 azp
 avG
 wZp
-axL
+fPF
 axL
 ayx
 aCr
@@ -102823,7 +110028,7 @@ dTs
 bgH
 aYz
 bRg
-bRg
+cTE
 wjr
 dTs
 dTs
@@ -102833,7 +110038,7 @@ dTs
 biy
 bbV
 aCP
-bZc
+nsP
 bjO
 bkk
 bky
@@ -102855,12 +110060,12 @@ brh
 bxN
 tui
 brf
-bxQ
+sMP
 bBI
 brh
 bDA
 igP
-bFa
+ogG
 bFa
 bIy
 bDx
@@ -102874,7 +110079,7 @@ oAM
 oAM
 inQ
 ozu
-ozu
+gvt
 xsS
 mfK
 bVE
@@ -102895,13 +110100,13 @@ cfw
 cge
 pjv
 chr
-chZ
+paI
 vXl
 dnP
 ceY
 ciR
 bLu
-ckB
+wwQ
 dYp
 xgw
 ckB
@@ -102967,7 +110172,7 @@ dda
 dda
 gdW
 hqp
-jOe
+mlF
 bYV
 aEq
 aEq
@@ -102987,7 +110192,7 @@ peQ
 peQ
 qix
 qck
-oQx
+nZr
 gdW
 gdW
 lwX
@@ -103065,14 +110270,14 @@ dTs
 dTs
 dTs
 dTs
-vGm
+nyM
 aCP
 bZc
 bjO
 bkj
 bkj
 blj
-bmJ
+oYj
 biy
 dTs
 dTs
@@ -103087,10 +110292,10 @@ dTs
 dTs
 brh
 bcW
-bse
+cgX
 awB
 bxQ
-bBI
+dbV
 brh
 bDB
 ebg
@@ -103099,14 +110304,14 @@ bFa
 bIz
 bDx
 fyq
-dCt
+egT
 fpu
 hqT
 nil
 nil
 nil
 pTU
-naH
+jRx
 uml
 vgm
 xsS
@@ -103125,7 +110330,7 @@ bVz
 caH
 ceo
 cdw
-cfw
+kUO
 ciu
 ciu
 chr
@@ -103150,7 +110355,7 @@ cwH
 cwH
 cvN
 crC
-dPT
+qJt
 dPT
 cBd
 cCg
@@ -103190,15 +110395,15 @@ gdW
 tLl
 tLl
 tLl
+vhb
 tLl
 tLl
 tLl
 tLl
+vhb
 tLl
 tLl
-tLl
-tLl
-gdW
+wVo
 gdW
 hqp
 jOe
@@ -103213,7 +110418,7 @@ qck
 jOe
 gFK
 lwm
-lwm
+kqk
 lwm
 lwm
 lwm
@@ -103234,7 +110439,7 @@ dtE
 gdW
 hqp
 jOe
-gdW
+wVo
 iNd
 dTs
 dTs
@@ -103258,7 +110463,7 @@ afG
 afH
 afK
 alc
-afK
+hCT
 agI
 afG
 arE
@@ -103289,7 +110494,7 @@ dTs
 dTs
 aYz
 bRg
-bRg
+cTE
 bRg
 bRg
 dTs
@@ -103346,7 +110551,7 @@ ozu
 xsS
 mfK
 bVD
-dCt
+egT
 bXo
 ptU
 mEu
@@ -103356,7 +110561,7 @@ kMb
 kMb
 vsQ
 dLW
-caH
+rjY
 cen
 cdw
 cfw
@@ -103369,9 +110574,9 @@ ciR
 cjn
 cjU
 ckE
-clI
+xXL
 ntb
-cnG
+pFh
 coO
 cpA
 cjV
@@ -103382,7 +110587,7 @@ dPT
 dPT
 dQp
 crD
-crD
+vki
 crD
 dQC
 ctQ
@@ -103450,7 +110655,7 @@ gdW
 gdW
 gdW
 gdW
-gdW
+wVo
 dxe
 dxe
 xlx
@@ -103465,7 +110670,7 @@ dAA
 dGv
 bNu
 dtE
-gdW
+wVo
 hqp
 jOe
 gdW
@@ -103500,7 +110705,7 @@ bYD
 kIM
 cRj
 atk
-atk
+hfH
 atQ
 awG
 ayM
@@ -103525,7 +110730,7 @@ aOg
 bRg
 bRg
 bRg
-bRg
+cTE
 dTs
 dTs
 dTs
@@ -103535,12 +110740,12 @@ dTs
 dTs
 vGm
 aCP
-bZc
+nsP
 bjO
 bkk
 bky
 blj
-bmJ
+oYj
 biy
 dTs
 dTs
@@ -103561,7 +110766,7 @@ fpJ
 dTs
 brh
 mnA
-bFa
+ogG
 bFa
 wTP
 bIB
@@ -103597,7 +110802,7 @@ cfw
 cge
 cgL
 chr
-chZ
+paI
 civ
 ciS
 cjn
@@ -103612,9 +110817,9 @@ cqr
 dPG
 csJ
 ctR
+qJt
 dPT
-dPT
-dQp
+vVm
 dQs
 dQs
 dQy
@@ -103623,7 +110828,7 @@ dQJ
 cBe
 cCi
 cCi
-dRg
+jwO
 dRm
 uHN
 dSf
@@ -103691,7 +110896,7 @@ kVg
 dzm
 eyF
 dxe
-gdW
+wVo
 lwX
 bNu
 cmQ
@@ -103738,9 +110943,9 @@ aul
 avF
 arJ
 ayO
+ebT
 ayZ
-ayZ
-azp
+mYn
 avG
 dTs
 dTs
@@ -103755,7 +110960,7 @@ aCr
 dTs
 dTs
 aOg
-bRg
+cTE
 bRg
 qZW
 bRg
@@ -103843,7 +111048,7 @@ cnH
 coQ
 cpC
 cjV
-crD
+vki
 crD
 skA
 dQh
@@ -103914,7 +111119,7 @@ tLl
 gdW
 gdW
 gdW
-gdW
+wVo
 cFf
 ghQ
 dHg
@@ -103922,7 +111127,7 @@ gdW
 din
 hUT
 dWy
-dzm
+fRR
 dWK
 din
 gdW
@@ -103953,14 +111158,14 @@ acu
 afG
 afJ
 afQ
-afQ
+iNT
 afQ
 agM
 afG
 afJ
 afQ
 afQ
-afQ
+iNT
 agM
 afG
 arI
@@ -103992,7 +111197,7 @@ bRg
 bRg
 bRg
 bRg
-bRg
+cTE
 bRg
 bRg
 bRg
@@ -104042,7 +111247,7 @@ dTs
 dTs
 dTs
 qDb
-naH
+jRx
 ozu
 ozu
 xsS
@@ -104063,7 +111268,7 @@ ceo
 cdw
 cfw
 ciu
-ciu
+vWl
 chr
 chZ
 civ
@@ -104085,7 +111290,7 @@ lib
 cwI
 cxA
 wOy
-ctQ
+lnw
 vkf
 dQK
 cBf
@@ -104146,16 +111351,16 @@ hlu
 viV
 tLl
 gdW
-gdW
+wVo
 gdW
 gdW
 cFf
 ghQ
 dHg
-gdW
+wVo
 din
 fVJ
-dzm
+fRR
 iXE
 dWK
 din
@@ -104229,7 +111434,7 @@ bRg
 bRg
 bRg
 bRg
-bRg
+cTE
 wjr
 dTs
 dTs
@@ -104240,7 +111445,7 @@ auu
 aCR
 bjO
 bkk
-bky
+rAW
 blj
 ctg
 dTs
@@ -104279,7 +111484,7 @@ qDb
 naH
 ozu
 ozu
-xsS
+xXb
 mfK
 dCt
 dCt
@@ -104300,11 +111505,11 @@ cge
 cgL
 chr
 chZ
-civ
+ple
 ciS
 cjq
 cjq
-ckH
+iCl
 clI
 clI
 cnG
@@ -104312,9 +111517,9 @@ coO
 cpA
 cjV
 crF
-crF
+gBf
 dQd
-ctS
+cjJ
 cvP
 cwJ
 cwK
@@ -104442,7 +111647,7 @@ ayL
 ayZ
 ayZ
 ayZ
-ayZ
+ebT
 axr
 axS
 axS
@@ -104457,7 +111662,7 @@ avG
 dTs
 pxa
 pxa
-vit
+nVD
 pxa
 vit
 wDA
@@ -104467,16 +111672,16 @@ pnG
 wjr
 dTs
 dTs
-bgH
+bLG
 oBK
 wrs
 aPk
-bgr
+mPE
 aXW
 buj
 buj
 aZk
-aCP
+gqS
 auu
 biy
 biy
@@ -104491,7 +111696,7 @@ dTs
 aWz
 aOg
 bRg
-bRg
+cTE
 bRg
 xhv
 bRg
@@ -104530,7 +111735,7 @@ caH
 cen
 cdw
 cfw
-ciu
+vWl
 ciu
 chr
 chZ
@@ -104540,7 +111745,7 @@ cjr
 cjq
 ckH
 clI
-clI
+xXL
 dPa
 coR
 cpD
@@ -104551,11 +111756,11 @@ eud
 ctS
 cvQ
 cwK
-cwK
+huF
 cxZ
 crF
 sHL
-dQe
+sSA
 cBg
 cCg
 cDn
@@ -104613,13 +111818,13 @@ fdk
 lwm
 viV
 tLl
-gdW
+wVo
 gdW
 fhm
+wVo
 gdW
 gdW
-gdW
-gdW
+wVo
 fhm
 dxe
 xJG
@@ -104635,7 +111840,7 @@ dtE
 lwX
 lwX
 lwX
-gdW
+wVo
 dKB
 cGT
 cGT
@@ -104657,11 +111862,11 @@ aae
 bbY
 aju
 ahr
-ahr
-ahr
+aiz
+aiz
 ahr
 aju
-aju
+nMT
 ahr
 anO
 akO
@@ -104670,11 +111875,8 @@ akO
 aoP
 azv
 akO
-akO
+aiq
 avI
-ayZ
-ayZ
-ayZ
 ayZ
 ayZ
 ayZ
@@ -104685,11 +111887,14 @@ ayZ
 ebT
 ayZ
 ayZ
+ebT
+ayZ
+ayZ
 azx
-axr
+jyu
 avH
 bRg
-pxa
+ptK
 pnG
 bRg
 dTs
@@ -104700,7 +111905,7 @@ vit
 pxa
 fgl
 noc
-jKe
+rzl
 jKe
 mTL
 aAu
@@ -104709,10 +111914,10 @@ bgr
 aXW
 nrl
 buj
-aZk
+vlH
 aCP
 bUr
-auu
+hlh
 bZc
 avZ
 jLd
@@ -104729,7 +111934,7 @@ bRg
 qZW
 xhv
 bRg
-bRg
+cTE
 jFR
 aWz
 dTs
@@ -104744,13 +111949,13 @@ dTs
 iwh
 nue
 qDb
-naH
+jRx
 ozu
 ozu
 xsS
 mfK
 bVE
-dCt
+egT
 dEl
 tiZ
 eDR
@@ -104760,7 +111965,7 @@ kMb
 kMb
 vsQ
 dLX
-caH
+rjY
 ceo
 cdw
 cfw
@@ -104862,13 +112067,13 @@ din
 dxe
 dxe
 gdW
-gdW
+wVo
 gdW
 bVk
 bVk
 bVk
 gdW
-gdW
+wVo
 gdW
 cCb
 rWp
@@ -104887,7 +112092,7 @@ acu
 (151,1,1) = {"
 acu
 afi
-ahr
+aiz
 xQQ
 uxI
 fRX
@@ -104902,12 +112107,12 @@ azv
 bRT
 bZU
 aoW
-bZU
+ixW
 bZU
 bZU
 ayr
 ayr
-ayr
+lrV
 ayr
 ayr
 hGF
@@ -104929,7 +112134,7 @@ dTs
 dTs
 dTs
 dTs
-oBK
+lYs
 bRg
 bRg
 bRg
@@ -104950,20 +112155,20 @@ bTI
 bZc
 avZ
 aCP
-bZc
+nsP
 avZ
 avc
 awq
 aOg
+cTE
 bRg
 bRg
 bRg
-bRg
-bRg
+cTE
 bRg
 xhv
 bRg
-bRg
+cTE
 bRg
 bRg
 aBD
@@ -104996,29 +112201,29 @@ vsQ
 dLX
 caH
 ceo
-cdw
+lzM
 cfw
 cge
 cgL
 chr
-dNI
+fVX
 vXl
 ceX
 cjs
 dOj
 dOu
 dOl
-cmx
+xHE
 cnK
 cjX
 cmx
 cqt
-dOj
+tUx
 dQG
 mMG
 dQg
 cnK
-cjX
+imS
 cmx
 cqt
 dOj
@@ -105029,7 +112234,7 @@ cCj
 cDp
 dRg
 dRm
-uXZ
+sRa
 dSj
 dSv
 cCf
@@ -105181,11 +112386,11 @@ aZk
 atI
 avm
 bUr
-bUr
+xAW
 avm
 bUr
 bUr
-avm
+oKQ
 bUr
 bUr
 bzV
@@ -105193,7 +112398,7 @@ bzV
 bzV
 bzV
 bzV
-bzV
+qkP
 bzV
 aBJ
 bzV
@@ -105208,7 +112413,7 @@ aBG
 uXp
 aVY
 aBG
-aVY
+fDw
 bID
 aBY
 shm
@@ -105232,19 +112437,19 @@ caH
 ceo
 cdw
 cfw
-ciu
+vWl
 lZM
 chr
 chZ
 fnb
-civ
+ple
 cjt
-dOl
+vSZ
 dOv
 xbr
 dOG
 dOG
-dOG
+vAG
 dPk
 dPr
 dPH
@@ -105388,9 +112593,9 @@ avG
 ayP
 ayZ
 ayZ
-axQ
+cVW
 avH
-bij
+lag
 azu
 dTs
 dTs
@@ -105403,9 +112608,9 @@ bRg
 bRg
 bRg
 bRg
-wjr
+dfr
 bgH
-aYz
+koi
 bRg
 bgr
 aXW
@@ -105422,7 +112627,7 @@ abZ
 abZ
 abZ
 abZ
-abZ
+qSa
 abZ
 abZ
 abZ
@@ -105431,14 +112636,14 @@ abZ
 abZ
 aBK
 abZ
+qSa
 abZ
 abZ
-abZ
-abZ
+qSa
 bJD
 duq
 bJD
-bJD
+fmn
 bJD
 bJD
 bJD
@@ -105446,10 +112651,10 @@ bJD
 duq
 bJD
 fif
-tSK
+eoa
 ozu
 ozu
-xsS
+xXb
 mfK
 bVE
 dCt
@@ -105487,11 +112692,11 @@ nCr
 csP
 dNW
 csP
-csP
+xVH
 cyb
 dQA
 dNW
-dNW
+xLU
 cBj
 cCl
 cCl
@@ -105601,7 +112806,7 @@ ahr
 agQ
 kqZ
 amr
-aor
+aoP
 akO
 dCO
 akL
@@ -105620,7 +112825,7 @@ dTs
 dTs
 avG
 ayK
-ayZ
+ebT
 ayZ
 azp
 avG
@@ -105633,7 +112838,7 @@ dTs
 dTs
 dTs
 dTs
-bRg
+cTE
 bRg
 bRg
 bRg
@@ -105643,7 +112848,7 @@ aOg
 bRg
 bgr
 aXW
-buj
+qkW
 buj
 buj
 aBn
@@ -105671,13 +112876,13 @@ azZ
 buj
 bJE
 duw
-bJE
-bJE
-bIF
-bJE
+ogq
 bJE
 bIF
-duw
+bJE
+ogq
+bIF
+hiF
 bJE
 ssy
 ozu
@@ -105686,7 +112891,7 @@ ozu
 xsS
 mfK
 bVD
-dCt
+egT
 dAB
 mEu
 bnh
@@ -105709,10 +112914,10 @@ civ
 cjs
 cjZ
 ckN
+qjM
 ckN
 ckN
-ckN
-cjZ
+kpQ
 cpG
 cqw
 crK
@@ -105824,26 +113029,26 @@ acu
 acu
 afi
 ajy
+cTd
 afN
-afN
-afN
+cTd
 amd
 agH
 aNk
 fcj
-ahr
+aiz
 agQ
 kqZ
 amr
 aoP
-akO
+aiq
 dCO
 akL
 dTs
 dTs
 dTs
 dTs
-axT
+nHe
 aqC
 aqC
 aqC
@@ -105853,14 +113058,14 @@ dTs
 dTs
 dTs
 avG
-ayK
+lum
 ayZ
 ayZ
 azp
 avG
 bij
 azu
-bRg
+cTE
 wjr
 dTs
 dTs
@@ -105871,12 +113076,12 @@ bRg
 bRg
 bRg
 bRg
+cTE
 bRg
 bRg
-bRg
-bRg
+cTE
 bgr
-aXW
+rIv
 buj
 azN
 aCj
@@ -105884,18 +113089,18 @@ aBr
 aBx
 aCj
 aAa
+lIV
 aCj
+aAa
+lIV
 aCj
 aAa
 aCj
 aCj
-aAa
+mdJ
 aCj
 aCj
-aAa
-aCj
-aCj
-aAa
+mdJ
 aCj
 aAU
 aBQ
@@ -105916,7 +113121,7 @@ bJE
 svy
 ozu
 ozu
-ozu
+gvt
 xsS
 mfK
 bVE
@@ -105939,7 +113144,7 @@ cgN
 cht
 ilz
 cix
-ciU
+mGA
 cjv
 cka
 cka
@@ -106061,7 +113266,7 @@ ajy
 afN
 qjX
 afN
-amj
+amk
 amE
 aUj
 fcj
@@ -106080,7 +113285,7 @@ dTs
 axT
 aqC
 aqC
-aqC
+fwI
 aqC
 aqJ
 dTs
@@ -106092,7 +113297,7 @@ ayZ
 ayZ
 azp
 avG
-bij
+lag
 azu
 bRg
 gvR
@@ -106130,7 +113335,7 @@ aXC
 aXC
 aXC
 aXC
-aXC
+iha
 aXC
 aXC
 aXC
@@ -106148,7 +113353,7 @@ bIH
 ntP
 bIH
 oAM
-inQ
+qmT
 ozu
 byV
 xsS
@@ -106167,7 +113372,7 @@ dLZ
 caH
 ceo
 cdw
-cfw
+kUO
 ciu
 cgN
 chu
@@ -106198,9 +113403,9 @@ cBl
 cCm
 ctW
 cEy
-cEB
+qLm
 cGg
-trV
+kpG
 cHc
 cEG
 cJC
@@ -106303,7 +113508,7 @@ ahr
 agQ
 kqZ
 amr
-aoP
+trA
 akO
 dFM
 aCr
@@ -106330,7 +113535,7 @@ bij
 azu
 bRg
 bRg
-bRg
+cTE
 bRg
 azF
 aaB
@@ -106367,14 +113572,14 @@ byZ
 byZ
 byZ
 byZ
-byZ
+nEV
 byZ
 byZ
 byZ
 aZm
 bID
 cEX
-bJF
+rlV
 taH
 bJF
 bJF
@@ -106386,9 +113591,9 @@ naH
 uml
 vgm
 xsS
-mfK
+mkm
 bVE
-dCt
+egT
 uMG
 ptU
 mEu
@@ -106398,26 +113603,26 @@ kMb
 vsQ
 dLQ
 dLZ
-caH
+rjY
 ceo
 cdw
 cfw
 cge
 cgM
-chu
+tAN
 ciu
 chr
 ciU
 cjv
 jPV
-naz
+gBx
 naz
 vaN
 dPb
 cka
 cpI
 qTq
-dPI
+pva
 crM
 ctX
 cuZ
@@ -106427,7 +113632,7 @@ dQt
 cye
 uKJ
 kLA
-kLA
+kCz
 uKJ
 cCn
 ctW
@@ -106528,8 +113733,8 @@ afi
 ajy
 afN
 afN
-afN
-amd
+cTd
+wvY
 agH
 aNk
 qIk
@@ -106547,7 +113752,7 @@ avK
 awH
 awI
 aCr
-aqC
+fwI
 aqC
 avG
 axW
@@ -106586,32 +113791,32 @@ bij
 aBD
 bRg
 bRg
-bRg
+cTE
 bRg
 bRg
 pnG
-bRg
+vGM
 dTs
 dTs
 bRg
 bRg
-bRg
+cTE
 bRg
 aBD
 bRg
 bRg
-bRg
+cTE
 bRg
 bRg
 ahV
-aPk
+fqn
 roU
 aBp
 cFj
 cFj
 cFj
 cFj
-cFj
+tCI
 cFj
 aBp
 aCc
@@ -106641,7 +113846,7 @@ cgN
 chu
 ciu
 chr
-ciU
+mGA
 cjv
 dOn
 dOx
@@ -106669,7 +113874,7 @@ cEz
 cEB
 dRJ
 nBZ
-cHJ
+kXM
 cIF
 cHJ
 sgs
@@ -106768,7 +113973,7 @@ afG
 amR
 fcj
 ahr
-agQ
+bRu
 kqZ
 amr
 aoP
@@ -106776,7 +113981,7 @@ akO
 eNU
 aug
 aun
-ucW
+nHr
 auq
 ucW
 awJ
@@ -106824,7 +114029,7 @@ bRg
 bRg
 iLP
 aeE
-aam
+eEl
 dTs
 dTs
 dTs
@@ -106849,10 +114054,10 @@ aBH
 ceQ
 bID
 aCe
-kVU
+sAH
 naH
 ozu
-ozu
+gvt
 xsS
 mfK
 bVD
@@ -106869,7 +114074,7 @@ bii
 caH
 cen
 cdw
-cfw
+kUO
 ciu
 cgN
 chu
@@ -107011,7 +114216,7 @@ dCO
 aug
 aun
 auq
-auq
+cxf
 auq
 afo
 aCr
@@ -107032,7 +114237,7 @@ dTs
 bRg
 bRg
 bRg
-bRg
+cTE
 bRg
 bgr
 aXW
@@ -107055,24 +114260,24 @@ bRg
 bRg
 xXT
 bRg
+cTE
 bRg
-bRg
-wjr
-bgH
+dfr
+biv
 dTs
 dTs
 dTs
 dTs
 bgH
 bgH
-oBK
+lYs
 bRg
-bRg
+cTE
 qZW
 bRg
 bRg
 bRg
-bRg
+cTE
 qKe
 bID
 bID
@@ -107092,13 +114297,13 @@ bUF
 bVF
 dCt
 dCt
-aWH
+pdp
 aWH
 kMb
 kMb
 kMb
 aWH
-aWH
+pdp
 aWH
 caH
 ciu
@@ -107109,7 +114314,7 @@ cgM
 chu
 ciu
 chr
-ciU
+mGA
 cjv
 cke
 ckO
@@ -107140,7 +114345,7 @@ dSm
 cHc
 cEG
 cJF
-cKw
+mmp
 eBZ
 cLV
 cJA
@@ -107183,7 +114388,7 @@ cko
 cCH
 cto
 cto
-crW
+qSg
 rjq
 cko
 cko
@@ -107232,10 +114437,10 @@ agQ
 agQ
 agQ
 agQ
-agQ
+bRu
 agQ
 fcj
-ahr
+aiz
 agQ
 kqZ
 alD
@@ -107255,7 +114460,7 @@ avG
 ayd
 ayj
 ayj
-ayj
+uht
 avH
 ayK
 ayZ
@@ -107284,15 +114489,15 @@ byZ
 byZ
 byZ
 byZ
-aPk
-bRg
+fqn
+cTE
 bRg
 bRg
 bRg
 bRg
 aeE
-bgH
-bgH
+biv
+biv
 dTs
 dTs
 dTs
@@ -107302,9 +114507,9 @@ bgH
 aYz
 bRg
 bRg
+cTE
 bRg
-bRg
-aeE
+haZ
 aam
 dTs
 dTs
@@ -107339,7 +114544,7 @@ ilz
 ilz
 cfz
 ciu
-cgN
+wBc
 chu
 ciu
 chr
@@ -107351,7 +114556,7 @@ dOI
 tBR
 ckc
 cka
-yiG
+qwm
 dPt
 pif
 crR
@@ -107480,8 +114685,8 @@ auh
 auq
 auq
 avM
-auq
-axE
+cxf
+swQ
 aCr
 aqC
 aqC
@@ -107501,7 +114706,7 @@ bgH
 aam
 oBK
 bRg
-bRg
+cTE
 bgr
 aXW
 blT
@@ -107512,11 +114717,11 @@ aAh
 aPk
 aPk
 aPk
-aPk
+fqn
 bRg
 bRg
 bRg
-bRg
+cTE
 bij
 ftw
 bRg
@@ -107525,7 +114730,7 @@ mrC
 bRg
 aeE
 gDW
-bgH
+biv
 dTs
 dTs
 dTs
@@ -107533,10 +114738,10 @@ dTs
 dTs
 dTs
 gDW
-bgH
-oBK
+biv
+oab
 bRg
-bRg
+cTE
 bRg
 lIg
 dTs
@@ -107549,7 +114754,7 @@ dTs
 dTs
 dTs
 dTs
-pvs
+sRr
 qJq
 qDb
 naH
@@ -107558,7 +114763,7 @@ ozu
 ozu
 bUH
 ozu
-ozu
+gvt
 ssy
 bbF
 jdv
@@ -107568,7 +114773,7 @@ kMb
 jdv
 bbF
 biz
-ciu
+vWl
 ciu
 cda
 ciu
@@ -107579,10 +114784,10 @@ cdc
 ciy
 ciU
 cjv
+iNE
 ckc
 ckc
-ckc
-ckc
+iNE
 dPb
 cka
 yiG
@@ -107609,7 +114814,7 @@ cHc
 cIH
 cJG
 cKx
-cKx
+sGI
 cJG
 cMQ
 cNE
@@ -107648,7 +114853,7 @@ pys
 pys
 aKm
 cUc
-cCH
+lCQ
 cto
 cto
 crW
@@ -107676,11 +114881,11 @@ dTs
 cxm
 aKm
 aKm
+sYj
 aKm
 aKm
 aKm
-aKm
-cpZ
+cRe
 dTs
 dTs
 dTs
@@ -107717,7 +114922,7 @@ avN
 auq
 axE
 aCr
-aqC
+fwI
 aqC
 avG
 axW
@@ -107732,7 +114937,7 @@ azp
 avG
 dTs
 bgH
-bgH
+bLG
 aYz
 bRg
 bRg
@@ -107747,9 +114952,9 @@ ftw
 aPk
 bRg
 bRg
-bRg
-bRg
-bRg
+vGM
+vGM
+vGM
 bRg
 nly
 bgr
@@ -107758,7 +114963,7 @@ aFz
 aFz
 bfh
 ccK
-ccK
+ylW
 dTs
 dTs
 dTs
@@ -107768,14 +114973,14 @@ dTs
 dTs
 dTs
 dTs
-bgH
-oBK
-bRg
-bRg
-aXY
-ccK
-ccK
-ccK
+biv
+oab
+vGM
+dbS
+vbS
+ylW
+ylW
+ylW
 dTs
 dTs
 dTs
@@ -107787,7 +114992,7 @@ pvs
 svJ
 qDb
 naH
-ozu
+gvt
 ozu
 ozu
 bUI
@@ -107804,17 +115009,17 @@ bbF
 bjh
 ciu
 ciu
-cdb
+rVG
 lZM
 ciu
 jMw
 chr
-chY
+rDw
 cel
 ceY
 cjv
 ckg
-ckg
+taQ
 ckg
 ckg
 ckg
@@ -107848,7 +115053,7 @@ cNa
 cMR
 cNF
 cNF
-cOm
+oXG
 cMP
 dTs
 dTs
@@ -107878,7 +115083,7 @@ lpN
 pys
 wuz
 vyt
-pys
+utd
 pys
 aKm
 cUc
@@ -107890,7 +115095,7 @@ lJD
 ewX
 cEV
 aKm
-cPz
+vfa
 cJl
 aKm
 qeu
@@ -107948,7 +115153,7 @@ aug
 aur
 auq
 awe
-auq
+cxf
 axE
 aCr
 aqC
@@ -107969,30 +115174,30 @@ dTs
 bgH
 dTs
 bRg
-bRg
+cTE
 bgr
 aXW
-bkE
+jjS
 aWB
 aZk
 bij
-aPk
+fqn
 aPk
 bRg
-bRg
-aeE
-aam
+vGM
+stE
+eEl
 dTs
 dTs
 mgg
 bHD
 bqa
-aFz
+vte
 aFz
 aFz
 aGI
-ccK
-ccK
+tBl
+ylW
 dTs
 dTs
 dTs
@@ -108003,14 +115208,14 @@ dTs
 dTs
 dTs
 dTs
-bgH
-oBK
+biv
+oab
 bRg
-aFz
+vte
 aGI
-ccK
-ccK
-ccK
+lMc
+tBl
+ylW
 dTs
 dTs
 dTs
@@ -108019,7 +115224,7 @@ dTs
 dTs
 pvs
 qJq
-qDb
+fnp
 naH
 bSl
 bSl
@@ -108034,7 +115239,7 @@ jdv
 jdv
 jdv
 jdv
-bbT
+ghD
 bbT
 cdc
 cdc
@@ -108070,10 +115275,10 @@ cyk
 cyk
 cyk
 cEF
-cEB
+qLm
 dRM
 cHc
-cHc
+nWN
 cIH
 cJG
 vJB
@@ -108104,11 +115309,11 @@ dTs
 dTs
 qHn
 qHn
-kcP
+nxh
 pys
 icK
 qho
-pys
+utd
 eEh
 pys
 pys
@@ -108116,7 +115321,7 @@ pys
 mmU
 cko
 cUc
-cCH
+lCQ
 cpR
 cET
 crW
@@ -108138,16 +115343,16 @@ dTs
 dTs
 dTs
 dTs
-cwu
+gWL
 cwu
 cux
-aKm
+sYj
 aKm
 aKm
 aKm
 cEU
 cUK
-cpZ
+cRe
 dTs
 dTs
 dTs
@@ -108181,7 +115386,7 @@ api
 aug
 jnu
 auq
-auq
+cxf
 auq
 axE
 aCr
@@ -108191,7 +115396,7 @@ avG
 aye
 ayl
 ayv
-ayj
+uht
 avH
 ayO
 ayZ
@@ -108213,19 +115418,19 @@ bij
 bRg
 qZW
 bRg
-aeE
+stE
 dTs
 dTs
 dTs
 dTs
-beM
-bHD
-bqa
-aFz
-aFz
+rIa
+maC
+uUz
+mHl
+mHl
 snO
-ccK
-ccK
+ylW
+ylW
 dTs
 dTs
 dTs
@@ -108238,13 +115443,13 @@ dTs
 dTs
 dTs
 dTs
-aYz
+xar
 aFz
 aFz
 aGg
 ccK
 ccK
-ccK
+ylW
 dTs
 dTs
 dTs
@@ -108283,7 +115488,7 @@ ciV
 cjw
 cjw
 ckR
-cjx
+oCm
 cmB
 cnN
 cjy
@@ -108323,7 +115528,7 @@ iGe
 cRQ
 cPM
 cAe
-raC
+uME
 raC
 qHn
 qHn
@@ -108352,7 +115557,7 @@ cvn
 cvx
 cCH
 cto
-cto
+oSG
 crW
 lJD
 cko
@@ -108378,7 +115583,7 @@ aKm
 cJl
 cPz
 aKm
-aKm
+sYj
 aKm
 aKm
 ctm
@@ -108402,10 +115607,10 @@ afK
 afK
 agI
 afG
-afH
+fpw
 afK
 afK
-agI
+syL
 afG
 aqF
 anX
@@ -108443,7 +115648,7 @@ aXW
 blT
 buj
 aZk
-bij
+lag
 bRg
 bRg
 aeE
@@ -108452,7 +115657,7 @@ xGe
 xGe
 xGe
 xGe
-hfa
+jMQ
 nMW
 mhJ
 vrk
@@ -108472,7 +115677,7 @@ xGe
 xGe
 xGe
 xGe
-hfa
+jMQ
 vrk
 vrk
 vrk
@@ -108488,7 +115693,7 @@ dTs
 dTs
 egS
 qDb
-naH
+jRx
 ozu
 ozu
 ozu
@@ -108507,12 +115712,12 @@ ccO
 caH
 cen
 cdw
-cfw
+kUO
 ciu
 ciu
-chr
+ekF
 chZ
-civ
+ple
 ciV
 cjx
 xkY
@@ -108531,7 +115736,7 @@ cvW
 cwQ
 cxE
 cym
-czc
+mSc
 czc
 cAt
 miO
@@ -108560,7 +115765,7 @@ cAe
 pys
 pys
 xrh
-raC
+uME
 qHn
 qHn
 qHn
@@ -108570,7 +115775,7 @@ dTs
 dTs
 qHn
 kcP
-pys
+utd
 pys
 mQQ
 pys
@@ -108579,18 +115784,18 @@ hXE
 pys
 cAe
 tLA
-cWb
+jIm
 vuF
 vuF
 daT
 daT
-coZ
+oyL
 cto
 cto
 crW
 lJD
 cko
-aKm
+sYj
 aKm
 aKm
 aKm
@@ -108634,7 +115839,7 @@ afG
 afI
 akW
 akW
-agL
+tqu
 amn
 afI
 akW
@@ -108686,11 +115891,11 @@ dTs
 dTs
 dTs
 dTs
-ccJ
+lzF
 aHb
 uXk
 aBk
-aBk
+imz
 uGU
 mTi
 dTs
@@ -108705,17 +115910,17 @@ dTs
 dTs
 dTs
 dTs
-mTi
-aEV
+qhy
+wnJ
 aBk
 aBk
-aCG
-mTi
-mTi
+qiT
+qhy
+qhy
 dTs
 dTs
 dTs
-mTi
+fsX
 vCe
 dTs
 dTs
@@ -108727,7 +115932,7 @@ ozu
 byV
 ozu
 xsS
-hwc
+oQK
 hhj
 dEX
 mEu
@@ -108751,7 +115956,7 @@ ciV
 cjx
 hFL
 cjx
-cjx
+oCm
 cmB
 cnN
 cjy
@@ -108784,7 +115989,7 @@ cHL
 cMU
 cNH
 dAl
-cOm
+oXG
 cJG
 cJG
 cJG
@@ -108805,9 +116010,9 @@ gJP
 sYf
 pys
 pys
+utd
 pys
-pys
-pys
+utd
 pys
 pys
 lhu
@@ -108829,7 +116034,7 @@ aKm
 aKm
 aKm
 aKm
-aKm
+sYj
 cpZ
 cwu
 dTs
@@ -108841,13 +116046,13 @@ dTs
 cwu
 cux
 csa
-aKm
+sYj
 aKm
 aKm
 nkB
 aKm
 aKm
-aKm
+sYj
 kON
 dTs
 dTs
@@ -108876,10 +116081,10 @@ eiP
 agL
 afG
 aqH
-bAR
+vzU
 aoP
 akO
-api
+gtF
 aCr
 aCr
 aCr
@@ -108887,7 +116092,7 @@ aCr
 aCr
 aCr
 aCr
-aqC
+fwI
 aqC
 aqC
 axT
@@ -108905,10 +116110,10 @@ dTs
 dTs
 bRg
 bRg
-bRg
+cTE
 alW
 aXW
-blT
+nkf
 buj
 aZk
 bij
@@ -108920,13 +116125,13 @@ dTs
 dTs
 dTs
 dTs
-ccJ
-aHb
+lzF
+xsQ
 aHA
 aGq
 aBk
 aBk
-aEX
+jeW
 dTs
 dTs
 dTs
@@ -108938,23 +116143,23 @@ dTs
 dTs
 dTs
 dTs
-mTi
-aEV
+qhy
+xws
 aBk
 aBk
 aBk
-aEX
+ksz
 dTs
 dTs
 dTs
 dTs
 dTs
-mTi
-vCe
-mTi
+qhy
+qUF
+qhy
 dTs
 dTs
-fyq
+mOb
 qDb
 ngo
 oAM
@@ -108974,7 +116179,7 @@ bcY
 bPi
 caH
 ceo
-cdw
+lzM
 cfw
 cge
 cgL
@@ -108996,7 +116201,7 @@ crM
 ctY
 cvb
 gOd
-cwQ
+jaY
 cxE
 cyo
 czd
@@ -109009,7 +116214,7 @@ cEE
 dRq
 dRP
 cHg
-cHf
+nAI
 cHL
 cIK
 cIK
@@ -109030,7 +116235,7 @@ cFK
 pys
 pys
 pys
-pys
+utd
 pys
 pys
 pys
@@ -109039,7 +116244,7 @@ dco
 kcP
 pys
 pys
-hXE
+ocC
 pys
 pys
 rzB
@@ -109054,7 +116259,7 @@ cto
 cUP
 cto
 cto
-cto
+oSG
 crW
 lJD
 cko
@@ -109099,15 +116304,15 @@ acu
 (169,1,1) = {"
 acu
 afG
-afJ
+aor
 afQ
 all
 agM
 afG
 afJ
-afQ
+iNT
 all
-agM
+hAQ
 afG
 aqI
 bAR
@@ -109146,7 +116351,7 @@ blT
 buj
 aZk
 bij
-bRg
+cTE
 wjr
 bgH
 xGe
@@ -109154,48 +116359,48 @@ dTs
 dTs
 dTs
 dTs
-ccJ
+lzF
 aHb
 aHA
 aBk
-aBk
+imz
 niK
 uGU
-aJV
-mTi
+txl
+qhy
 dTs
 dTs
-aJV
-aJV
+txl
+txl
 dTs
 dTs
 dTs
 dTs
 dTs
-aEV
+xws
 aBk
 aBk
 imz
 aBk
-aEX
+ksz
 dTs
 dTs
 dTs
 dTs
-mTi
+fsX
 oLT
 vCe
-mTi
+fsX
 dTs
 dTs
 qJq
 hwc
 hpw
+rYS
 hpw
 hpw
 hpw
-hpw
-kVU
+sAH
 dCt
 dEl
 mEu
@@ -109211,13 +116416,13 @@ ceo
 cdw
 cfw
 ciu
-ciu
+vWl
 chr
 chZ
 civ
 ciV
 cjz
-dOq
+bQh
 ckS
 clQ
 cmC
@@ -109250,7 +116455,7 @@ cIK
 cLm
 cHL
 cMW
-cNH
+vJZ
 vmm
 oRT
 cPN
@@ -109259,16 +116464,16 @@ obW
 cRR
 cPM
 cAe
-pys
+utd
 pys
 pys
 pys
 moI
-mIH
+mMn
 pys
 wYS
-pys
-pys
+utd
+utd
 wTk
 pys
 pys
@@ -109276,15 +116481,15 @@ boY
 pys
 pys
 pys
-pys
+utd
 pys
 cAe
-pwf
+tLL
 tSa
 kHJ
 lNg
 lNg
-cmb
+fdD
 cVA
 cto
 cto
@@ -109292,26 +116497,26 @@ cto
 crW
 vBK
 cvw
-aKm
+sYj
 cqT
 aKm
+sYj
 aKm
 aKm
 aKm
 aKm
-aKm
-pfV
+alv
 cwu
 dTs
 dTs
 dTs
 ctn
 cux
+sYj
 aKm
 aKm
 aKm
-aKm
-csb
+iYC
 aKm
 fCL
 aKm
@@ -109372,7 +116577,7 @@ dTs
 dTs
 bRg
 aiS
-ajm
+hrO
 ajE
 ajm
 akc
@@ -109388,38 +116593,38 @@ dTs
 dTs
 dTs
 dTs
-ccJ
+lzF
 dsX
 srf
 aBk
 aBk
-aBk
-aBk
-imz
-uGU
-aJV
-aEV
-aBk
-aBk
-uGU
+oTm
+oTm
+jhw
+gbl
+txl
+xws
+oTm
+oTm
+gbl
 dTs
 dTs
 dTs
-aEV
-aBk
+xws
+jhw
 aBk
 igY
 aBk
 pmt
-mTi
+qhy
 dTs
 dTs
 dTs
 dTs
-mTi
+qhy
 mTi
 weZ
-mTi
+qhy
 dTs
 dTs
 qJq
@@ -109454,7 +116659,7 @@ cjA
 dOq
 cki
 clR
-cki
+eTw
 cnP
 coU
 dPm
@@ -109472,7 +116677,7 @@ cwS
 cwS
 cwS
 cwS
-cve
+xvK
 cEH
 dRs
 dRR
@@ -109529,7 +116734,7 @@ coc
 aKm
 aKm
 cmJ
-aKm
+sYj
 aKm
 aKm
 aKm
@@ -109538,7 +116743,7 @@ aKm
 pfV
 ctn
 cux
-aKm
+sYj
 aKm
 aKm
 aKm
@@ -109588,7 +116793,7 @@ dTs
 dTs
 dTs
 aqC
-aqC
+fwI
 aqC
 aqC
 axT
@@ -109610,7 +116815,7 @@ ajm
 ajm
 ajr
 akc
-blT
+nkf
 buj
 aZk
 bij
@@ -109622,38 +116827,38 @@ dTs
 dTs
 dTs
 dTs
-ccJ
+lzF
 dsX
 srf
-aBk
-aBk
-aBk
-aBk
-aBk
-aBk
+vUQ
+iLp
+oTm
+oTm
+oTm
+oTm
+oTm
+imz
+oTm
+oTm
+jhw
+oTm
+gbl
+xws
+oTm
 aBk
 imz
 aBk
 aBk
-aBk
-aBk
-uGU
-aEV
-aBk
-aBk
-aBk
-aBk
-aBk
-aEX
-mTi
+ksz
+qhy
 dTs
 dTs
 dTs
 dTs
-mTi
-mTi
+qhy
+gbS
 vCe
-mTi
+qhy
 dTs
 dTs
 dTs
@@ -109661,7 +116866,7 @@ pvs
 abk
 adi
 abU
-abU
+gDG
 abO
 abO
 abk
@@ -109682,7 +116887,7 @@ iAf
 pjv
 chr
 chZ
-civ
+ple
 ciW
 cjB
 eyb
@@ -109728,7 +116933,7 @@ diY
 cPM
 cAe
 pys
-pys
+utd
 pys
 yil
 cdM
@@ -109825,7 +117030,7 @@ xWA
 aqC
 aqC
 gZL
-axT
+nHe
 dTs
 dTs
 dTs
@@ -109839,14 +117044,14 @@ dTs
 dTs
 bRg
 bRg
-aaC
+hhe
 ajo
 ajF
 ajF
 aCQ
 blT
 buj
-aZk
+vlH
 bij
 bRg
 aXY
@@ -109856,39 +117061,39 @@ dTs
 dTs
 dTs
 dTs
-ccJ
-aHb
-aHA
+lzF
+dsX
+srf
 aBk
 aBk
 aGH
-aGH
-agN
+wQM
+ybk
 aAq
 aGH
 aGH
-aGH
-aGH
-aGH
-aGH
-aGH
-aGH
+lVW
+wQM
+wQM
+wQM
+wQM
+wQM
 aBk
 aBk
 aBk
 aBk
 aBk
-aEX
+slb
 dTs
 dTs
 dTs
 dTs
 dTs
-mTi
+qhy
 mTi
 vCe
-aEV
-aBk
+xws
+oTm
 dTs
 dTs
 dTs
@@ -109897,7 +117102,7 @@ adk
 agf
 abU
 abU
-abU
+gDG
 abo
 dEW
 kMb
@@ -109967,30 +117172,30 @@ pys
 pys
 pys
 pys
+utd
 pys
 pys
-pys
-pys
+utd
 wTk
 pys
-pys
+utd
 ist
 pys
 pys
 pys
-pys
+utd
 cAe
 pwf
 ojD
 tSa
 acD
 lAT
-lAT
+siS
 cto
 cUP
 cto
 cto
-abt
+jRB
 crW
 pmG
 xwG
@@ -110009,7 +117214,7 @@ vDG
 cok
 cok
 cok
-cok
+sLQ
 cok
 cok
 cok
@@ -110018,7 +117223,7 @@ cok
 iQk
 cvw
 cmJ
-ctm
+jNx
 dTs
 dTs
 dTs
@@ -110047,7 +117252,7 @@ dTs
 akL
 akL
 bAR
-aoP
+trA
 akO
 api
 akL
@@ -110084,20 +117289,20 @@ aZk
 bij
 bRg
 bRg
-aXY
+xnf
 xGe
 dTs
 dTs
 dTs
 dTs
 nAZ
-aHb
+dsX
 aHA
 aBk
-aBk
+imz
 aGH
 agN
-aGH
+wQM
 aGT
 aGT
 aGT
@@ -110106,23 +117311,23 @@ awv
 aGT
 aGT
 aGT
-aGH
+wQM
 aGH
 aBk
 oTm
 oTm
 aCG
-mTi
+qhy
 dTs
 dTs
 dTs
 dTs
-mTi
-mTi
+qhy
+qhy
 mTi
 tFc
 aBk
-aBk
+jhw
 dTs
 dTs
 dTs
@@ -110145,12 +117350,12 @@ bVz
 caH
 ceo
 cdw
-cfw
+kUO
 ciu
 ciu
 chr
 chZ
-civ
+ple
 ciW
 cjD
 fLB
@@ -110164,20 +117369,20 @@ bZx
 pBn
 csT
 cub
-cvg
+asu
 cwd
 cwV
 cxH
 cvg
 cze
+asu
 cvg
 cvg
-cvg
-cvg
+asu
 cvg
 cwd
 dRy
-dSc
+nHw
 cHj
 cHL
 cHL
@@ -110197,12 +117402,12 @@ cMP
 cAe
 pys
 pys
-pys
+utd
 pys
 rzB
 pys
 pys
-pys
+utd
 pys
 pys
 gJP
@@ -110216,7 +117421,7 @@ jsg
 cAe
 gEK
 hFC
-tSa
+kUX
 kHJ
 lNg
 lNg
@@ -110237,17 +117442,17 @@ cod
 cod
 cod
 cod
-cod
+uPI
 qoS
 xwG
-qoS
+rDd
 cod
 cod
 cod
 cod
 cod
 cod
-cod
+uPI
 mEf
 mEf
 coc
@@ -110308,7 +117513,7 @@ dTs
 bRg
 bRg
 aXW
-ajr
+gSr
 ajm
 ajr
 akc
@@ -110316,7 +117521,7 @@ blT
 ieU
 aZk
 bij
-bRg
+cTE
 bRg
 bRg
 myC
@@ -110324,46 +117529,46 @@ dTs
 dTs
 dTs
 dTs
-aEV
+xws
 gcW
 aGc
 mZj
 aGw
 aGw
 aGw
-aGw
+gmE
 gJM
 aGw
 aGw
-aGw
-aGw
+mZj
+qCr
 aGw
 aGw
 aHU
-aGH
-aGH
-aBk
+wQM
+oTj
+vUQ
 oTm
 oTm
-aEX
-mTi
+ixU
+qhy
 dTs
 dTs
 dTs
-mTi
-mTi
+qhy
+qhy
 hUz
-mTi
+qhy
 dzH
-aBk
-aBk
+imz
+oTm
 dTs
 dTs
 dTs
 abk
 adm
 abU
-abU
+gDG
 abO
 aVE
 abo
@@ -110381,7 +117586,7 @@ ceo
 cdw
 cfw
 cge
-cgL
+vgd
 chr
 chZ
 civ
@@ -110444,7 +117649,7 @@ dTs
 dTs
 xVE
 xVE
-ctp
+dab
 pys
 mmU
 abJ
@@ -110457,7 +117662,7 @@ vuF
 daT
 coZ
 cto
-cto
+oSG
 cto
 crY
 daT
@@ -110468,7 +117673,7 @@ cFH
 cmN
 coc
 aKm
-aKm
+sYj
 aKm
 aKm
 aKm
@@ -110484,7 +117689,7 @@ aKm
 aKm
 cmU
 mEf
-cvx
+vYE
 aKm
 ctm
 dTs
@@ -110509,7 +117714,7 @@ aah
 anV
 ajO
 ajO
-ajO
+aOZ
 ajO
 amG
 ajO
@@ -110523,9 +117728,9 @@ ajO
 ajO
 ajO
 ajO
-alD
+onF
 akO
-api
+gtF
 akL
 dTs
 dTs
@@ -110544,7 +117749,7 @@ bRg
 aXW
 ajm
 ajm
-ajr
+gSr
 akc
 blT
 buj
@@ -110558,39 +117763,39 @@ dTs
 dTs
 dTs
 dTs
-aBk
+oTm
 aFp
 uNF
 uNF
 aGE
 aGE
 yiP
-aGE
+pbV
 aGc
 vGO
 aGc
 aGc
+vGO
 aGc
+vGO
 aGc
-aGc
-aGc
+gmE
 aGw
-aGw
-aGw
+mZj
 aHU
 aBk
 uGU
-mTi
+qhy
 dTs
 dTs
 dTs
-aJV
+txl
 aJV
 aJV
 aEV
 ltx
 aBk
-aCG
+dzO
 dTs
 dTs
 dTs
@@ -110613,7 +117818,7 @@ bVz
 caH
 ceo
 cdw
-cfw
+kUO
 ciu
 ciu
 chr
@@ -110646,7 +117851,7 @@ czf
 dRj
 dRy
 dSc
-cGB
+kfD
 cHN
 cIN
 cJI
@@ -110663,7 +117868,7 @@ twm
 cLu
 cAe
 pys
-pys
+utd
 pys
 pys
 pys
@@ -110686,7 +117891,7 @@ hFC
 hFC
 tSa
 acD
-lAT
+siS
 lAT
 cto
 cUP
@@ -110694,11 +117899,11 @@ cto
 cto
 cto
 cto
-cnT
+gRj
 cto
 cto
 cto
-crW
+qSg
 cmN
 coc
 aKm
@@ -110740,13 +117945,13 @@ dTs
 dTs
 dTs
 akL
-amr
+myx
 aiq
 akO
 akO
 akO
 akO
-akO
+aiq
 akO
 azv
 acG
@@ -110754,7 +117959,7 @@ hFS
 aoJ
 aoJ
 aoJ
-aoJ
+iMn
 aoJ
 aoJ
 apT
@@ -110782,24 +117987,24 @@ aXC
 aCQ
 aaM
 aWB
-aZk
+vlH
 bij
 aPP
 aPP
 aPP
 xFu
 byY
-aBk
-aBk
-aBk
-aBk
+oTm
+oTm
+oTm
+oTm
 aBk
 dsX
 srf
 aBk
 aBk
 aGH
-aGH
+oTj
 fEf
 aGE
 saV
@@ -110808,29 +118013,29 @@ aGE
 aGE
 aGE
 wCa
-aGE
+pbV
 flu
 aGc
 aHA
-aBk
+imz
 aBk
 sym
-aJV
-aJV
-aEV
-aBk
+txl
+txl
+xws
+jhw
 aBk
 igY
 iBV
 ltx
-aCG
-mTi
+dzO
+fsX
 dTs
 dTs
 dTs
 abk
 afw
-abU
+gDG
 abU
 abO
 aVR
@@ -110854,12 +118059,12 @@ chr
 chZ
 civ
 ciW
-cjG
+jDB
 dOr
 dOD
 dOM
 dOY
-cjG
+jDB
 coU
 yiG
 bZx
@@ -110923,7 +118128,7 @@ acD
 lAT
 lAT
 cto
-cUP
+tlh
 cto
 cto
 cto
@@ -110932,10 +118137,10 @@ cnU
 cto
 cto
 cto
-crW
+qSg
 cmN
 coc
-aKm
+sYj
 duC
 oVs
 dwF
@@ -111020,11 +118225,11 @@ aZk
 bij
 byZ
 byZ
-byZ
+nEV
 sKT
 bAO
-aGw
-aGw
+gmE
+mZj
 aGw
 aGw
 aGw
@@ -111033,16 +118238,16 @@ aHA
 aBk
 aBk
 aGH
-aGH
-aGH
+wQM
+wQM
 aGW
 aHb
-aHA
+srf
 awv
 aGT
 aHJ
 aHV
-aGH
+oTj
 aGH
 aHb
 aHA
@@ -111050,14 +118255,14 @@ aBk
 aBk
 imz
 aBk
+iLp
 aBk
-aBk
-aBk
-aBk
+imz
+oTm
 aBk
 aBk
 ltx
-aEX
+ksz
 dTs
 dTs
 dTs
@@ -111082,7 +118287,7 @@ caH
 cdw
 cdw
 cfw
-cge
+pjm
 pjv
 chr
 chZ
@@ -111111,10 +118316,10 @@ nDQ
 cBx
 cBx
 dyW
-ldY
+itT
 cEM
 qMf
-dSn
+fUB
 cHO
 cIP
 cJK
@@ -111130,10 +118335,10 @@ cQB
 cQB
 cLu
 cAe
+utd
 pys
 pys
-pys
-pys
+utd
 fCf
 dTs
 dTs
@@ -111151,7 +118356,7 @@ cAe
 cAe
 vdZ
 xyC
-xyC
+dZH
 qKF
 kHJ
 lNg
@@ -111159,7 +118364,7 @@ lNg
 cmb
 cmb
 cmb
-cmb
+fdD
 cmb
 cmb
 cmb
@@ -111172,7 +118377,7 @@ coc
 aKm
 duC
 dvD
-iWM
+mTJ
 dxf
 kEe
 iMq
@@ -111184,7 +118389,7 @@ dFf
 eaA
 eaH
 dBo
-dGC
+tKO
 gYP
 pEL
 nNI
@@ -111212,14 +118417,14 @@ ahd
 alE
 azv
 akO
-aph
+bPB
 ajP
 ajP
 alE
 akO
 akO
 akO
-akO
+aiq
 aph
 pvy
 apv
@@ -111244,7 +118449,7 @@ bRg
 bRg
 pnG
 aXW
-ajm
+hrO
 ajU
 buj
 aCp
@@ -111257,42 +118462,42 @@ rzf
 bzV
 pLj
 bAP
+pbV
 aGE
-aGE
-aGE
+flu
 aGE
 wCa
 aGc
-aHA
+uXk
 aBk
-aBk
-aBk
-aGH
-aGH
-aGH
+oTm
+oTm
+wQM
+wQM
+wQM
 aHb
 aHA
+lVW
 aGH
 aGH
 aGH
-aGH
-aGH
-aBk
+wQM
+oTm
 aHb
 uXk
 aBk
 aBk
+imz
 aBk
-aBk
-aBk
+vUQ
 fHT
 aBk
 aBk
 aBk
-aKC
+rvB
 ltx
-aEX
-mTi
+ksz
+qhy
 dTs
 dTs
 dTs
@@ -111313,7 +118518,7 @@ dJT
 dTs
 dTs
 caH
-cdw
+lzM
 cdw
 cfw
 ciu
@@ -111326,7 +118531,7 @@ cjG
 dOr
 dCw
 dOO
-cmF
+guO
 cjG
 coU
 yiG
@@ -111383,7 +118588,7 @@ dTs
 qHn
 cAe
 dvj
-xyC
+dZH
 xyC
 xyC
 hFC
@@ -111410,7 +118615,7 @@ dwF
 duC
 dXC
 mxn
-dAD
+nac
 dBo
 dZR
 eaA
@@ -111452,7 +118657,7 @@ afP
 ahd
 ajP
 ajP
-ajP
+pvy
 ajP
 ajk
 akL
@@ -111462,7 +118667,7 @@ amr
 aoP
 azv
 api
-dqd
+eou
 dqd
 dTs
 dTs
@@ -111491,45 +118696,45 @@ aPP
 aPP
 xFu
 byY
-aBk
+vUQ
 aBk
 aCG
 oit
 aBk
 aHb
 aHA
-aCG
-agC
+dzO
+twd
 dTs
 dTs
-agC
+twd
 aKC
 xsQ
 aHA
 aBk
 aBk
-aBk
-aBk
-aBk
-aBk
+imz
+oTm
+oTm
+oTm
 aHb
 aHA
 aBk
 aBk
-aBk
-aBk
-aBk
-aBk
-aBk
+imz
 oTm
-eqo
+oTm
+oTm
+vUQ
+oTm
+oTm
 aBk
 ltx
-uGU
-mTi
-mTi
-ccJ
-aBk
+gbl
+qhy
+qhy
+kEx
+oTm
 dTs
 dTs
 dTs
@@ -111552,9 +118757,9 @@ cdw
 cfw
 ciu
 ciu
-chr
+ekF
 chZ
-civ
+ple
 ciW
 dOh
 dAW
@@ -111569,7 +118774,7 @@ dPN
 crM
 cue
 cvl
-cvi
+kFe
 cxb
 cug
 cug
@@ -111589,9 +118794,9 @@ cHO
 cKF
 cHO
 cHN
+mdQ
 cIP
-cIP
-dTh
+kVu
 cLp
 cPP
 cLu
@@ -111621,13 +118826,13 @@ xyC
 nmw
 nmw
 nmw
+mNT
 nmw
 nmw
-nmw
 cod
 cod
 cod
-cod
+uPI
 cod
 cod
 coc
@@ -111648,12 +118853,12 @@ dXZ
 dBo
 dZR
 eaA
-dFf
+hGv
 eaA
 eaH
 dBo
 dGC
-wEG
+xEY
 dHE
 dBr
 dBr
@@ -111725,49 +118930,49 @@ bRg
 aPP
 xGe
 dTs
-aBk
-aBk
-aEX
-ccJ
-aBk
+oTm
+oTm
+ksz
+lzF
+vUQ
+jsC
+azr
+dTs
+dTs
+dTs
+dTs
+lzF
+oTm
 aHb
-aHA
-dTs
-dTs
-dTs
-dTs
-ccJ
+uXk
 aBk
-aHb
-aHA
-aBk
-aBk
-agN
-aGH
-aGH
-aGH
-aHb
-iDy
-aGH
-aGH
-aGH
-aGH
+oTm
+ybk
+wQM
+wQM
+wQM
+jsC
+ixT
+wQM
+wQM
+wQM
+wQM
 aGW
-aBk
+oTm
 aBk
 oTm
 oTm
-aKD
+xke
 jSx
-aBk
+oTm
 ufP
-aJV
-aEV
-aBk
-aBk
+txl
+xws
+oTm
+oTm
 aGH
 wbv
-aHU
+nHU
 dTs
 dTs
 czT
@@ -111795,7 +119000,7 @@ dOh
 hwl
 dOh
 cjG
-cnQ
+mPU
 cjy
 cpM
 bZA
@@ -111870,7 +119075,7 @@ abt
 cto
 crW
 cmN
-coc
+bWI
 aKm
 duC
 oVs
@@ -111882,13 +119087,13 @@ dZf
 dBr
 dZS
 dFf
-dFf
+hGv
 eaz
 eaz
 dBr
 dGC
 wEG
-dHD
+vOC
 dBr
 dEr
 dFf
@@ -111910,15 +119115,15 @@ dTs
 dTs
 dTs
 afP
-alL
+rPY
 aiI
 aAi
-alI
+als
 ajY
 ann
+sFw
 alt
-alt
-akZ
+sBX
 afP
 dTs
 dTs
@@ -111945,15 +119150,15 @@ dTs
 dTs
 bRg
 bRg
-ajr
+gSr
 buj
 buj
 buj
 aaC
 abD
 aXC
-aBa
-bij
+nol
+lag
 bRg
 aeE
 dTs
@@ -111961,34 +119166,34 @@ xGe
 dTs
 dTs
 dTs
-aEX
+ksz
 dTs
-aBk
+imz
 aHb
-aHA
+uXk
 dTs
 dTs
 dTs
 dTs
 dTs
-aBk
-aHb
-aHA
-aBk
-agN
-aGH
-aGH
-aGH
-aGH
+oTm
+jsC
+azr
+vUQ
+ybk
+wQM
+wQM
+wQM
+wQM
 aIB
-aIR
+xCf
 xyH
-aGH
-aGH
-aGH
-aGH
-aGH
-aBk
+wQM
+wQM
+wQM
+wQM
+wQM
+imz
 aBk
 lYv
 eDL
@@ -112064,7 +119269,7 @@ cLp
 cPQ
 cQC
 bnA
-bjV
+qAG
 bjV
 cTp
 bjV
@@ -112108,13 +119313,13 @@ coc
 aKm
 duC
 dvD
-iWM
+mTJ
 dxf
 kEe
 pHI
 dXZ
 dFU
-dFf
+hGv
 dFf
 smh
 dFf
@@ -112161,7 +119366,7 @@ dTs
 dTs
 akL
 amr
-aoP
+trA
 azv
 api
 xzM
@@ -112183,7 +119388,7 @@ bgC
 bgC
 bgC
 bgC
-bgC
+mev
 bzR
 byZ
 byZ
@@ -112200,18 +119405,18 @@ dTs
 qzH
 aHb
 aHA
-aEX
+ksz
 dTs
 dTs
 dTs
 dTs
-aBk
+oTm
 aHb
 aHA
 aBk
-aGH
-aGH
-akV
+lVW
+wQM
+xAf
 azU
 azU
 geZ
@@ -112219,8 +119424,8 @@ fOY
 azU
 azU
 azU
-aDZ
-aGH
+lrF
+wQM
 wQM
 oTm
 aBk
@@ -112251,18 +119456,18 @@ dTs
 dTs
 caH
 wqK
-dPR
+ubK
 ciu
 ciu
 chr
 chZ
-dnP
+tXG
 cjT
 cjT
 cjT
 cjT
 cjT
-cjT
+gUt
 cjT
 vXl
 cjT
@@ -112281,7 +119486,7 @@ cpx
 wFv
 wFv
 cDy
-cEM
+uLz
 dRA
 dRZ
 iLT
@@ -112302,7 +119507,7 @@ bjV
 ppp
 bjV
 bjV
-brj
+xFs
 dTs
 dTs
 dTs
@@ -112327,17 +119532,17 @@ dcw
 deB
 dSq
 dcw
-dcw
-dlN
+qmC
+qie
 dbK
 aKm
 aKm
 cUc
 cCH
-cto
+oSG
 cto
 crW
-cmN
+hbw
 coc
 aKm
 duC
@@ -112351,7 +119556,7 @@ dBr
 dZT
 dFf
 dFf
-dFf
+hGv
 dFf
 dBr
 eaP
@@ -112398,7 +119603,7 @@ amr
 aoP
 azv
 api
-dqd
+eou
 dTs
 dTs
 dTs
@@ -112411,17 +119616,17 @@ dTs
 dTs
 dTs
 dTs
-bij
+lag
 awE
 bzV
 bzV
 bzV
 bzV
+qkP
 bzV
 bzV
 bzV
-bzV
-alW
+mZk
 dTs
 dTs
 dTs
@@ -112433,43 +119638,43 @@ dTs
 oLT
 agC
 aHb
-aHA
-aEX
+uXk
+ksz
 dTs
 dTs
 dTs
 dTs
-aBk
+oTm
 sMu
 aHA
 aBk
 aGH
-aGH
-alj
-aJY
-aKA
-aJY
-aJY
-aKz
+wQM
+aSM
+azT
+fmC
 aJY
 azT
-aEf
-aGH
+aKA
+myZ
+fmC
+aPn
+wQM
 wQM
 oTm
-aBk
-aBk
-aBk
-aBk
-aBk
-aBk
-adK
-aMf
-aMf
+vUQ
+vUQ
+oTm
+jhw
+vUQ
+iLp
+mQO
+pjq
+iSk
 bmB
 aMf
 ucZ
-aGc
+vGO
 aGE
 fRy
 cDP
@@ -112485,7 +119690,7 @@ dTs
 dTs
 caH
 ciU
-cfw
+kUO
 cge
 pjv
 chr
@@ -112493,14 +119698,14 @@ ciU
 cdw
 cdw
 cdw
-nXt
+jqv
 cdw
 cdw
 cdw
 cdw
-ciU
+mGA
 caH
-kwO
+vHu
 oWr
 cdw
 dTs
@@ -112518,7 +119723,7 @@ cDy
 cEJ
 kXq
 dSc
-cxH
+jBl
 cHO
 cIU
 cJM
@@ -112553,10 +119758,10 @@ dao
 dao
 dcw
 dqt
-dqt
+pzE
 cWp
 cWp
-cWp
+wjn
 dgY
 dgY
 cWp
@@ -112565,7 +119770,7 @@ cWp
 dcw
 cZu
 aKm
-aKm
+sYj
 cUc
 cCH
 cto
@@ -112584,7 +119789,7 @@ dAD
 dBo
 dZR
 eaA
-dFf
+hGv
 eaA
 eaA
 dBo
@@ -112668,38 +119873,38 @@ mTi
 aEV
 aHb
 aHA
-uGU
-mTi
+gbl
+qhy
 dTs
 dTs
-aEV
-aBk
+xws
+oTm
 aHb
-aHA
+uXk
 aBk
 aGH
-aGH
-alj
-aKy
-ucs
+wQM
+aSM
+aKA
+iRQ
 nDi
 aKy
 sDw
-aKy
-aKg
-aEf
+aKA
+aKA
+pxr
 aGH
 aGH
+vUQ
 aBk
+imz
+oTm
+oTm
 aBk
-aBk
-aBk
-aBk
-aBk
-aBk
-adK
-aMf
-aMg
+qzH
+mQO
+iSk
+eiK
 aTq
 aUO
 ucZ
@@ -112716,12 +119921,12 @@ vsQ
 dLP
 bxS
 mQZ
-dLZ
+rdV
 caH
 ciU
 cfw
 ciu
-ciu
+vWl
 chr
 ciU
 cdw
@@ -112736,7 +119941,7 @@ aMz
 caH
 kwO
 civ
-cdw
+lzM
 dTs
 dTs
 dTs
@@ -112759,7 +119964,7 @@ cHL
 cHL
 cLq
 rGX
-cMb
+lUc
 cMb
 cMb
 cOQ
@@ -112767,7 +119972,7 @@ cPT
 cQC
 bnA
 bjV
-bjV
+qAG
 bjV
 bjV
 dnN
@@ -112813,7 +120018,7 @@ oVs
 dwF
 duC
 dym
-xfT
+kuD
 dAD
 dBo
 dZR
@@ -112847,9 +120052,9 @@ ajV
 akY
 aln
 aln
-aiE
+fbO
 amH
-alI
+als
 wpx
 aln
 anL
@@ -112859,12 +120064,12 @@ afP
 aoM
 ape
 ape
-ape
+nuM
 apw
 afP
 amr
 aoP
-azv
+dig
 api
 akL
 dTs
@@ -112883,8 +120088,8 @@ bij
 axh
 bRg
 dTs
-tFc
-aBk
+oeE
+oTm
 aBk
 aeo
 aBk
@@ -112899,39 +120104,39 @@ dTs
 dTs
 dTs
 ccJ
-jNK
+xiV
 aHb
 aHA
 imz
-uGU
-aEV
-aBk
-aBk
-aBk
+gbl
+xws
+oTm
+oTm
+oTm
 aHb
 aHA
 aBk
-aGH
-aGH
-alj
-aKz
-aKh
+wQM
+wQM
+aSM
+myZ
+aKA
 aJE
 iRQ
-aKg
-tvM
-aKh
-aEf
+aKA
+iRQ
+aKA
+aPn
 aGH
 aGH
+iLp
+aBk
+qUC
 aBk
 aBk
-aIk
-aBk
-aBk
-aBk
-aBk
-adK
+iBV
+jhw
+mQO
 aMf
 aMo
 aMg
@@ -112957,7 +120162,7 @@ cfw
 ciu
 ciu
 chr
-ciU
+mGA
 cdw
 cdw
 cdw
@@ -113025,7 +120230,7 @@ mQC
 dAg
 dFh
 dHo
-dDK
+hte
 dDK
 dAk
 cYK
@@ -113043,7 +120248,7 @@ cmN
 coc
 aKm
 duC
-dvD
+jyf
 iWM
 dxf
 kEe
@@ -113052,12 +120257,12 @@ dAD
 dBo
 dZR
 eaA
-dFf
+hGv
 eaC
 eaC
 dBo
 dGC
-jJa
+cvm
 pEL
 nNI
 tsO
@@ -113091,7 +120296,7 @@ alI
 alI
 aoI
 aoN
-apg
+ffq
 nmc
 apg
 apy
@@ -113117,55 +120322,55 @@ bij
 axh
 dTs
 dTs
-vCe
-agC
+qUF
+twd
 aBk
 aGZ
 fHT
 aBk
-aEX
+ksz
 dTs
 dTs
 dTs
 dTs
 dTs
 dTs
-mTi
+qhy
 mTi
 aEV
 aBk
 aHb
-aGc
+vGO
+aGw
+gmE
 aGw
 aGw
-aGw
-aGw
-aGw
-aGw
+qCr
+qCr
 aGc
 aHA
 aBk
-aGH
-aGH
-alj
-azT
-aJY
+wQM
+wQM
+aSM
 aKA
 aKA
-aJY
 aKA
-aJE
-aEf
+aKA
+myZ
+aKA
+aKA
+aPn
 aGH
-aGH
-aBk
+lVW
 oTm
-eqo
-aBk
+oTm
+oTm
+oTm
 aHz
 aBk
-aBk
-adK
+oTm
+mQO
 aMf
 aMp
 aMf
@@ -113186,7 +120391,7 @@ dJT
 dLQ
 dLZ
 caH
-aKv
+ePr
 cfw
 cge
 cgL
@@ -113194,7 +120399,7 @@ chr
 dBN
 dnP
 civ
-coJ
+xsd
 coI
 aMz
 aMB
@@ -113203,7 +120408,7 @@ aNh
 aMz
 caH
 kwO
-civ
+ple
 dTs
 dTs
 dTs
@@ -113261,10 +120466,10 @@ dFk
 dAG
 dDK
 dDK
-dFk
+mpV
 dFk
 dgb
-dcw
+qmC
 dbK
 aKm
 aKm
@@ -113273,7 +120478,7 @@ cCH
 abt
 cto
 crW
-cmN
+hbw
 coc
 aKm
 duC
@@ -113281,7 +120486,7 @@ dvE
 dwF
 duC
 dym
-xfT
+kuD
 dAD
 dBo
 jRv
@@ -113312,7 +120517,7 @@ acu
 acu
 afP
 ajY
-aiI
+eqo
 als
 alZ
 alI
@@ -113320,9 +120525,9 @@ amI
 oEU
 pYK
 eKm
+als
 alI
-alI
-alI
+als
 aoI
 aoN
 apg
@@ -113346,66 +120551,66 @@ dTs
 dTs
 dTs
 bRg
-bRg
+cTE
 bij
 axh
 dTs
 dTs
-vCe
-ccJ
-aBk
-aBk
-imz
+qUF
+lzF
+oTm
+oTm
+iLp
 aFN
-uGU
+gbl
 dTs
 dTs
 dTs
 dTs
 dTs
 dTs
-mTi
-aEV
+qhy
+lTo
 aBk
 aBk
 aHb
 aGc
 aGE
-aGE
+pbV
 fHr
+flu
 aGE
 aGE
-aGE
-aGc
+vGO
 tai
 aBk
-aGH
-aGH
-alj
-azT
-azT
+lVW
+wQM
+aSM
+aJY
+myZ
 sDw
 iWY
-aJY
-lEv
-aJY
-aEf
+aKA
+sDw
+myZ
+aPn
 aGH
 aGH
-aBk
 oTm
 oTm
-aBk
-aBk
-aHz
-aHG
-adK
+oTm
+oTm
+vUQ
+yiM
+lWc
+mQO
 aMf
 aMq
 hJX
 aMg
 aTr
-baX
+vnx
 dEW
 kMb
 kMb
@@ -113422,18 +120627,18 @@ dLZ
 caH
 ciU
 cfw
-ciu
+vWl
 ciu
 cht
 ilz
 cix
 ciU
 cdw
-cdw
+lzM
 aMz
 sNT
 rcY
-rcY
+ewA
 aNI
 aNZ
 pen
@@ -113454,7 +120659,7 @@ cDA
 cEM
 uYs
 dSc
-cGB
+kfD
 cub
 cIX
 cJN
@@ -113468,12 +120673,12 @@ dTs
 dTs
 xPG
 bnA
-bjV
+qAG
 bjV
 jdB
 bjV
 bjV
-bjV
+qAG
 dnN
 bqp
 dTs
@@ -113489,7 +120694,7 @@ qCu
 dao
 deC
 dcw
-hYO
+jcz
 dDK
 dgY
 uVX
@@ -113501,7 +120706,7 @@ dDK
 dcw
 cZu
 aKm
-aKm
+sYj
 cUc
 cCH
 cpR
@@ -113561,7 +120766,7 @@ afP
 aoO
 apq
 apq
-apq
+vyp
 apS
 afP
 amx
@@ -113584,28 +120789,28 @@ bRg
 bij
 axh
 dTs
-mTi
-vCe
+qhy
+qUF
 ccJ
 aBk
+vUQ
 aBk
 aBk
 aBk
-aBk
-aEX
+ksz
 dTs
 dTs
 dTs
 dTs
 dTs
-ccJ
-aBk
-aBk
-eqo
+lzF
+vUQ
+vUQ
+oTm
 dsX
-aHA
+srf
 aGq
-aBk
+oTm
 sXh
 aBk
 aBk
@@ -113613,29 +120818,29 @@ oUr
 aHb
 tai
 aBk
-aGH
-aGH
-alj
-azT
-azT
+wQM
+wQM
+aSM
+aKA
+myZ
 aKA
 aKA
 doT
 aKA
 aKy
 aJN
+xyH
 aGH
-aGH
+vUQ
 aBk
 aBk
 aBk
-qzH
 aBk
+iBV
 aBk
-aBk
-adK
-aUO
-uqo
+mQO
+lTm
+oLR
 aMf
 aMf
 aTr
@@ -113653,14 +120858,14 @@ vsQ
 dJT
 dLQ
 ccP
-auv
+cdy
 civ
-cfw
+kUO
 ciu
 ciu
 chu
 ciu
-chr
+ekF
 ciU
 cdw
 cdw
@@ -113685,7 +120890,7 @@ cAI
 cBF
 cBG
 cDA
-cEJ
+sen
 cEM
 dSc
 cHj
@@ -113719,7 +120924,7 @@ dao
 dao
 tKc
 oMw
-dbw
+ric
 dao
 deD
 dcw
@@ -113727,7 +120932,7 @@ mmz
 cWp
 cWp
 dHl
-ico
+mPa
 tXg
 dHl
 dHl
@@ -113760,7 +120965,7 @@ jfz
 dDJ
 dGE
 wEG
-dCb
+nmZ
 dIl
 dJm
 dBC
@@ -113779,14 +120984,14 @@ acu
 (189,1,1) = {"
 acu
 afP
-ajY
+awC
 aiI
 rYT
 alI
 amo
+jNz
 amo
-amo
-amo
+jNz
 qKx
 alI
 ajY
@@ -113816,30 +121021,30 @@ dTs
 dTs
 dTs
 bij
-axh
+uZK
 dTs
-mTi
+qhy
 vCe
 njF
 gIF
-aBk
-igY
+oTm
+nNN
 aBk
 aCG
-mTi
+qhy
 dTs
 dTs
 dTs
 dTs
 dTs
-ccJ
+lzF
 aEY
 gJM
 qCr
 uNF
-aHA
-aBk
-aCG
+srf
+oTm
+dzO
 kge
 aBk
 aGV
@@ -113847,17 +121052,17 @@ aBk
 aHb
 aHA
 aBk
-aGH
-aGH
-alj
-azT
-azT
+wQM
+wQM
+aSM
+fmC
 aKA
-aKy
-azT
-aKg
-tvM
-aKM
+aKA
+fcX
+aKA
+aJY
+iRQ
+aPn
 aGH
 wQM
 oTm
@@ -113867,8 +121072,8 @@ aBk
 aBk
 imz
 aBk
-adK
-aMf
+urb
+srP
 aMg
 aMf
 bmB
@@ -113887,12 +121092,12 @@ vsQ
 dJT
 dLQ
 ccQ
-auX
+cdz
 civ
 cfw
 cge
 pjv
-chu
+tAN
 ciu
 chr
 ciU
@@ -113927,7 +121132,7 @@ cub
 cIV
 cIV
 cHL
-aeI
+qMZ
 prT
 pSF
 aeI
@@ -113938,7 +121143,7 @@ xGe
 dTs
 blt
 bjV
-bjV
+qAG
 bjV
 bjV
 bjV
@@ -113963,10 +121168,10 @@ dGa
 dHI
 ums
 ums
-dHo
+wuG
 dVo
 cYK
-dcw
+qmC
 cZu
 aKm
 cUL
@@ -113987,11 +121192,11 @@ maI
 hby
 dBp
 bAi
-hCl
+dxQ
 eal
 hCl
 dav
-hCl
+dxQ
 hCl
 ebc
 jQv
@@ -114027,7 +121232,7 @@ ahe
 aiE
 afP
 aoM
-ape
+nuM
 ape
 ape
 apw
@@ -114052,62 +121257,62 @@ dTs
 bij
 axh
 dTs
-mTi
+qhy
 vCe
 aEV
-aBk
-aFb
-aBk
-aBk
-uGU
-mTi
+oTm
+fbr
+oTm
+vUQ
+ugs
+qhy
 dTs
 dTs
 dTs
 dTs
 dTs
-aEV
+xws
 aHb
-aGc
-wCa
+vGO
+aGE
 aGE
 aGo
-aBk
-aEX
-mTi
-agC
+oTm
+ksz
+qhy
+twd
 aBk
 wCO
 aHb
 aGc
 mZj
-aGw
-aHK
+gmE
+pWn
 wCv
 mWI
 aKg
-aKz
 aJY
-azT
-azT
+aJY
+sQv
+aKA
 aKA
 aPn
-aGH
+lVW
 wQM
 oTm
-aEX
-mTi
-agC
-aBk
+ksz
+idM
+twd
+oTm
 igY
 aBk
-adK
+urb
 aMf
 aMf
 aMf
 aTq
 aTr
-aGc
+vGO
 aGH
 aGH
 aGH
@@ -114120,7 +121325,7 @@ kMb
 vsQ
 aUn
 bXy
-dLZ
+rdV
 caH
 ciU
 cfw
@@ -114129,18 +121334,18 @@ ciu
 chu
 ciu
 chr
-ciU
+mGA
 cdw
-coI
+kbf
 aMz
 aNb
-aNh
+nVV
 aNh
 aMz
 aMz
-cbD
+dQW
 civ
-caH
+rjY
 cdv
 dTs
 dTs
@@ -114185,17 +121390,17 @@ dTs
 dTs
 dao
 daN
-dbw
+ric
 gcf
 uyn
 dao
 deF
 dqt
-mmz
+uRq
 dxT
 dGD
 cYK
-ums
+pqi
 ico
 dSr
 dWA
@@ -114203,7 +121408,7 @@ dHo
 dWO
 dbK
 dbK
-cko
+mjg
 lJD
 dWV
 dXb
@@ -114283,57 +121488,57 @@ dTs
 dTs
 dTs
 dTs
-bij
-axh
+gOn
+kiP
 dTs
-mTi
-tFc
+qhy
+uYI
 akb
-aBk
-aFT
+oTm
+pSd
 aGr
 aBk
 imz
-uGU
-mTi
+gbl
+qhy
 dTs
 dTs
 dTs
-mTi
-aBk
+qhy
+oTm
 aHb
 aHA
 aBk
-aBk
-aCG
+oTm
+dzO
 dTs
 dTs
-mTi
-mTi
+qhy
+qhy
 aBk
 aBk
 fEf
 aGE
 aGE
-aGE
-aHM
+pbV
+fRy
 aIj
-aKy
+fcX
 npN
 sDw
+iWY
 aKA
-azT
-azT
-azT
-aEf
+myZ
+aKA
+iDR
 aGH
 aGH
-aCG
-mTi
+dzO
+qhy
 dTs
 dTs
-agC
-aBk
+twd
+imz
 aBk
 adK
 ble
@@ -114390,7 +121595,7 @@ cAG
 cEM
 cEM
 dSc
-cGB
+kfD
 cub
 cIX
 cJN
@@ -114398,7 +121603,7 @@ cHL
 aeI
 aeI
 aeI
-aeI
+qMZ
 cLu
 dTs
 dTs
@@ -114420,7 +121625,7 @@ dTs
 dao
 daN
 dbx
-gcf
+fDS
 dof
 dao
 deG
@@ -114434,7 +121639,7 @@ ums
 dFk
 dFk
 dFk
-dqt
+pzE
 dcw
 cZu
 cko
@@ -114487,26 +121692,26 @@ alt
 alt
 alt
 alt
-alt
+sFw
 akZ
 qKx
 als
 alI
 alI
-aoI
+agA
 aoN
 apg
 apg
-apg
+ffq
 apy
 afP
 amx
 alV
 bfT
-bfT
+kQa
 msC
 vPy
-vPy
+rSO
 atV
 avU
 aIw
@@ -114520,7 +121725,7 @@ dTs
 bij
 prG
 aBk
-uGU
+ugs
 dzH
 aBk
 aBk
@@ -114529,50 +121734,50 @@ aGp
 aBk
 qzH
 aBk
-uGU
+gbl
 dTs
 dTs
-mTi
-aEV
-aBk
+qhy
+xws
+oTm
 aHb
 aHA
 aBk
-aBk
+oTm
 dTs
 dTs
 dTs
 dTs
-mTi
-agC
-aBk
-aBk
-aBk
-aBk
-aGH
-aGH
-alj
-azT
+qhy
+twd
+oTm
+vUQ
+vUQ
+iLp
+wQM
+wQM
+aSM
 aJY
 aKA
+aKA
 lih
-azT
-azT
-azT
+aKA
+aKA
+aKA
 aEf
 aGH
 aGH
-aEX
-mTi
+ksz
+fsX
 dTs
 dTs
-mTi
+qhy
 agC
 aBk
 adK
 bln
 uqo
-aUO
+wjc
 aMf
 aHb
 aGc
@@ -114590,7 +121795,7 @@ dLQ
 mQZ
 dLZ
 caH
-ciU
+mGA
 cfw
 cge
 cgL
@@ -114609,7 +121814,7 @@ aNC
 cbD
 civ
 caH
-nTI
+bFe
 cdv
 cOk
 cOk
@@ -114641,11 +121846,11 @@ dTs
 dTs
 dTs
 bqp
-bqp
+jzJ
 blt
 bjV
 bjV
-bjV
+qAG
 dnN
 dTs
 dTs
@@ -114660,12 +121865,12 @@ dao
 dbK
 dyT
 ftp
-dgY
+hwN
 dDK
 dDK
 ico
 ico
-dgY
+hwN
 dJV
 dJi
 dDK
@@ -114675,7 +121880,7 @@ cmM
 oRs
 dWW
 cto
-cto
+oSG
 cUP
 cto
 crW
@@ -114685,7 +121890,7 @@ dXX
 duC
 dxj
 dXy
-xfT
+kuD
 dXY
 dBr
 dBr
@@ -114753,50 +121958,50 @@ dTs
 bRg
 bij
 axh
-aBk
-aBk
+oTm
+oTm
 ltx
-aBk
+imz
 aBk
 imz
 aBk
 aBk
 aBk
 aBk
-aBk
-dTs
-dTs
-ccJ
-aBk
 oTm
-cTd
+dTs
+dTs
+lzF
+oTm
+oTm
+dsX
 aHA
 aBk
-aBk
+oTm
 dTs
 dTs
 dTs
 dTs
-mTi
-ccJ
+qhy
+lzF
+oTm
 aBk
 aBk
 aBk
-aBk
-aGH
-aGH
-azK
-aAm
-aAm
+wQM
+wvM
+mKy
+oJZ
+wan
 jpm
 htb
-aAm
-aAm
-aAm
-aEl
+wan
+wan
+wan
+tvD
+mCm
 aGH
-aGH
-aEX
+ksz
 dTs
 dTs
 dTs
@@ -114810,9 +122015,9 @@ aMf
 aMf
 aHb
 baX
-aGH
+lVW
 xpe
-aGH
+lVW
 duy
 mEu
 kMb
@@ -114821,7 +122026,7 @@ kMb
 kMb
 vsQ
 dLQ
-mQZ
+mNm
 dLZ
 caH
 ciU
@@ -114829,16 +122034,16 @@ cfw
 ciu
 lZM
 chu
-ciu
+vWl
 chr
 ciU
 cdw
 aNr
 aMz
-auc
+rOJ
 auc
 atm
-auc
+rOJ
 aNC
 cbD
 civ
@@ -114846,7 +122051,7 @@ caH
 cdw
 cdw
 cdv
-cOk
+uLI
 cOk
 dTs
 dTs
@@ -114880,7 +122085,7 @@ bqp
 blt
 bjV
 bjV
-bjV
+qAG
 brj
 dTs
 dTs
@@ -114891,7 +122096,7 @@ dby
 sTg
 dqu
 dvf
-mmz
+uRq
 ddi
 ftp
 dCe
@@ -114906,14 +122111,14 @@ lqr
 hav
 hav
 gFE
-oRs
+wAE
 cCH
 bQD
 cET
 cUP
 cto
 crW
-vBK
+nHc
 dXr
 rLV
 dXx
@@ -114969,14 +122174,14 @@ afP
 afP
 afP
 amx
-alV
+jYh
 hpe
 anv
 aIw
 asW
+jJP
 atV
-atV
-avU
+sFc
 aIw
 dTs
 dTs
@@ -114984,29 +122189,29 @@ dTs
 dTs
 dTs
 aYz
-bRg
+cTE
 bij
 aiJ
 ajh
-aBk
+oTm
 ltx
 agN
 aGH
 aGH
 aGH
 aGH
+lVW
 aGH
-aGH
-aBk
-uGU
-aJV
-aEV
-aBk
 oTm
-cTd
-aHA
+gbl
+txl
+xws
+oTm
+oTm
+dsX
+iDy
 aBk
-aCG
+dzO
 dTs
 dTs
 dTs
@@ -115017,19 +122222,19 @@ aBk
 oUr
 igY
 aBk
-aGH
-aGH
-aGH
-aGH
-aGH
+wQM
+wQM
+wQM
+wQM
+wQM
 aID
 aIW
-aGH
-aGH
-aGH
-aGH
-aGH
-aGH
+wvM
+wQM
+wQM
+wQM
+oTj
+oTj
 dTs
 dTs
 dTs
@@ -115045,7 +122250,7 @@ aST
 aGU
 bhw
 aGH
-ltx
+xpe
 aGH
 dAB
 euC
@@ -115060,12 +122265,12 @@ dLZ
 caH
 ciU
 cfw
+vWl
 ciu
-ciu
-chq
+vUk
 cdc
 ciy
-ciU
+mGA
 cdw
 cdw
 aMz
@@ -115075,12 +122280,12 @@ aNB
 auA
 aMz
 cbD
-civ
+ple
 caH
 cdw
 owP
 cdw
-cdw
+lzM
 cdv
 cOk
 dTs
@@ -115111,7 +122316,7 @@ dTs
 dTs
 dTs
 bqp
-hVA
+qBV
 bjV
 bjV
 bjV
@@ -115119,7 +122324,7 @@ dnN
 dTs
 dTs
 bqp
-fSD
+vey
 daO
 dbz
 cOG
@@ -115152,7 +122357,7 @@ dXs
 cvx
 dXy
 dXA
-dXy
+hNK
 xfT
 dAD
 dBt
@@ -115194,7 +122399,7 @@ bfj
 bmy
 alI
 ajY
-aob
+gFa
 afP
 dTs
 dTs
@@ -115221,26 +122426,26 @@ aOg
 bRg
 bij
 axh
-aBk
-aBk
+oTm
+oTm
 utB
 aGH
 akV
-azU
+aKj
 aAF
-azU
+aKj
 aDZ
 aGH
+vUQ
+imz
 aBk
-aBk
-aBk
-aBk
-aBk
-aBk
+oTm
+oTm
+oTm
 aHb
 aHA
 iBV
-aEX
+ksz
 dTs
 dTs
 dTs
@@ -115250,18 +122455,18 @@ ccJ
 aBk
 aBk
 aBk
-aBk
-aBk
+imz
+oTm
 aGW
-aGH
-aGH
-aGH
-aHb
-aHA
-aGH
-aGH
-aGH
-aGH
+wQM
+wvM
+wQM
+jsC
+azr
+wQM
+wQM
+wvM
+wQM
 aGH
 aBk
 dTs
@@ -115270,8 +122475,8 @@ dTs
 dTs
 dTs
 ccJ
-aBk
-aGH
+imz
+oTj
 aGH
 aGH
 aGH
@@ -115292,16 +122497,16 @@ caH
 abg
 aqw
 caH
-ciU
+mGA
 cfw
 ciu
 ciu
 chr
-chY
+rDw
 cjT
 ceY
 cdw
-cdw
+lzM
 aMz
 aMz
 aMz
@@ -115316,7 +122521,7 @@ cdw
 cdw
 coI
 cdw
-cdv
+lCe
 cer
 cer
 cer
@@ -115349,7 +122554,7 @@ bqp
 blt
 tRn
 kIu
-bjV
+qAG
 dnN
 dTs
 hVA
@@ -115370,7 +122575,7 @@ ums
 dbK
 dbK
 dbK
-dgY
+hwN
 dcw
 cZu
 cko
@@ -115380,7 +122585,7 @@ dWZ
 dWZ
 cUP
 cto
-crW
+qSg
 cUc
 dXt
 dXw
@@ -115393,7 +122598,7 @@ dBu
 dBy
 dwm
 bJX
-dDL
+feq
 dFi
 dFW
 dFW
@@ -115425,7 +122630,7 @@ dTs
 afP
 ajY
 aiI
-ajp
+xFR
 alI
 ajY
 aob
@@ -115442,7 +122647,7 @@ bfT
 apj
 aIw
 asY
-aub
+iHP
 aub
 avV
 aIw
@@ -115455,9 +122660,9 @@ bRg
 xXT
 bij
 axh
-aBk
+oTm
 ajC
-ltx
+xOM
 aGH
 alj
 azT
@@ -115465,48 +122670,48 @@ nrg
 aJY
 aEf
 aGH
+vUQ
 aBk
 aBk
-aBk
-aHR
-aBk
-aBk
-aHb
+wMn
+oTm
+oTm
+dsX
 aHA
 aCG
-mTi
+qhy
 dTs
 dTs
 dTs
 dTs
 dTs
-ccJ
+kEx
 aBk
 imz
 aBk
-aBk
-aBk
-aBk
-aBk
+oTm
+oTm
+oTm
+oTm
 aBk
 aBk
 aHb
 aHA
 aBk
 aBk
+iLp
 aBk
 aBk
 aBk
-aBk
-aEX
+ksz
 dTs
 dTs
 dTs
 dTs
-mTi
-agK
-agK
-agK
+nJy
+jfs
+tKh
+feO
 rlk
 dTs
 dTs
@@ -115528,31 +122733,31 @@ civ
 caH
 ciU
 csH
-cdc
+eha
 cdc
 ciy
 ciU
 caH
-caH
+rjY
 caH
 xCj
 caH
 caH
-caH
+rjY
 caH
 caH
 caH
 cbD
 civ
 xCj
+rjY
 caH
 caH
 caH
 caH
 caH
 caH
-caH
-xCj
+iby
 caH
 bnA
 emI
@@ -115588,17 +122793,17 @@ bjV
 dnN
 fSD
 bjV
-iNT
+daO
 dbB
-dqs
+oxA
 dri
 dxN
-dcw
+qmC
 dUt
-dDK
+hte
 dgY
 dgY
-dgY
+hwN
 ums
 ums
 dDK
@@ -115612,7 +122817,7 @@ dHm
 dWW
 dXe
 dXg
-dXm
+lPp
 cto
 crW
 cUc
@@ -115622,7 +122827,7 @@ dim
 dxl
 dXy
 sdm
-dAD
+nac
 dBv
 dBy
 dDa
@@ -115670,7 +122875,7 @@ dTs
 dTs
 dTs
 apW
-amx
+uzr
 alV
 bfT
 apj
@@ -115689,51 +122894,51 @@ bRg
 bRg
 bij
 axh
-aBk
-aBk
-ltx
+oTm
+oTm
+xOM
 aGH
 alj
-aJY
+sQv
 aBw
 azT
 aEf
 aGH
-aGH
+wQM
 aBk
 imz
-aBk
+oTm
 aGq
-aBk
+oTm
 aHb
 aHA
 aEX
-mTi
+qhy
 dTs
 dTs
 dTs
 dTs
 dTs
-ccJ
-aBk
-qzH
-aBk
-aFb
-aFb
+lzF
+oTm
+ePp
+vUQ
+fbr
+fbr
 aHR
 aBk
 aBk
-aBk
-aHb
+imz
+xsQ
 iDy
 aBk
 aBk
-aBk
+vUQ
 aBk
 iBV
 aBk
-uGU
-mTi
+gbl
+fsX
 dTs
 nzm
 mTi
@@ -115748,7 +122953,7 @@ dTs
 dTs
 dTs
 xGe
-aGH
+lVW
 bXo
 ptU
 mEu
@@ -115770,11 +122975,11 @@ cjT
 cjT
 aNj
 aNj
+gUt
 cjT
 cjT
 cjT
-cjT
-cjT
+gUt
 cjT
 cbF
 cbG
@@ -115782,7 +122987,7 @@ cbH
 cbH
 cbH
 cbH
-cbH
+wjV
 cbH
 cbH
 cbH
@@ -115802,7 +123007,7 @@ bWD
 bWJ
 bWJ
 bXM
-bnA
+eZO
 dTs
 dTs
 dTs
@@ -115834,12 +123039,12 @@ dDK
 dDK
 dIm
 eGt
-nJj
+sIB
 vIa
 dDK
+hte
 dDK
-dDK
-dqt
+pzE
 dqt
 dvm
 dHm
@@ -115910,7 +123115,7 @@ bfT
 anD
 aIw
 aIw
-auA
+enE
 auA
 auA
 aIw
@@ -115923,8 +123128,8 @@ cYu
 bgC
 awg
 axU
-aBk
-aBk
+oTm
+oTm
 ltx
 aGH
 alj
@@ -115933,47 +123138,47 @@ aJY
 aJY
 bpI
 aEv
+gmE
 aGw
 aGw
 aGw
-aGw
-aGw
-aGw
+mZj
+gmE
 aGc
-aHA
+uXk
 uGU
-mTi
-mTi
+fsX
+qhy
 dTs
 dTs
 dTs
-mTi
-ccJ
-aBk
+qhy
+lzF
+oTm
 aBk
 aHC
 aBk
+vUQ
 aBk
+oTm
 aBk
-aBk
-aBk
-aBk
+oTm
 aHb
 srf
 oTm
 aGZ
-aBk
+oTm
 kOL
 aBk
 aBk
 aBk
-uGU
-mTi
+gbl
+qhy
 mTi
 ccJ
 aBk
 uGU
-aJV
+qCR
 mTi
 dTs
 dTs
@@ -116025,14 +123230,14 @@ bnA
 mzj
 bnA
 bnA
-bnA
+eZO
 wqI
 yhu
+eZO
 bnA
 bnA
 bnA
-bnA
-bFF
+mxx
 kVw
 bZN
 wRY
@@ -116055,7 +123260,7 @@ jYx
 bjV
 bjV
 dzE
-bjV
+qAG
 daO
 dbD
 dqs
@@ -116064,7 +123269,7 @@ dbK
 dcw
 dUt
 dcw
-cWp
+wjn
 cWp
 cWp
 ums
@@ -116076,14 +123281,14 @@ dcw
 dcw
 cZu
 cko
-cUc
+mPg
 cCH
 dWZ
 dWZ
 cUP
 cto
 crW
-cUc
+mPg
 cko
 aKm
 dim
@@ -116095,7 +123300,7 @@ dBx
 dBy
 dDa
 hCb
-dDL
+feq
 dBy
 dBy
 dBy
@@ -116138,9 +123343,9 @@ apW
 apW
 apW
 alO
-amy
+ydV
 alV
-bfT
+kQa
 aiH
 anG
 aJd
@@ -116157,37 +123362,37 @@ awf
 bzV
 bzV
 alW
-aBk
-aBk
+oTm
+jhw
 dZl
-aGH
+lVW
 alj
 aKz
 hLq
 nDi
 aEj
 aEw
-aGE
+pbV
 wCa
 aGE
 aGE
 aGE
-aGE
+pbV
 aGE
 feU
-aFN
+faP
 uGU
-mTi
-mTi
+qhy
+qhy
 dTs
 dTs
-mTi
-aEV
+qhy
+wnJ
 aBk
 aGr
 aBk
-aBk
-aBk
+imz
+vUQ
 aHS
 imz
 aBk
@@ -116196,12 +123401,12 @@ aHb
 srf
 oTm
 aBk
+oTm
+oTm
 aBk
 aBk
 aBk
-aBk
-aBk
-aBk
+vUQ
 uGU
 aKE
 aKQ
@@ -116245,7 +123450,7 @@ dCZ
 gYv
 giL
 ndI
-dBk
+rtL
 dBk
 kdQ
 aTG
@@ -116281,7 +123486,7 @@ dTs
 dTs
 bjV
 dTs
-bqp
+jzJ
 fSD
 bjV
 bjV
@@ -116292,7 +123497,7 @@ bjV
 bjV
 daO
 dbE
-dqs
+oxA
 drY
 dUe
 dcw
@@ -116315,7 +123520,7 @@ cCH
 dXe
 dXg
 cUP
-cto
+oSG
 crW
 cUc
 cko
@@ -116359,13 +123564,13 @@ dTs
 dTs
 dTs
 apW
-amx
+uzr
 amz
-alV
+jYh
 ant
 amz
 aiH
-aiO
+sHI
 akj
 akj
 akj
@@ -116392,57 +123597,57 @@ bRg
 bRg
 qzH
 aBk
-aBk
+vUQ
 ltx
 aGH
 alj
 aKA
 lEv
-aJY
+sQv
 aEf
-aGH
-aGH
+wQM
+wQM
 aBk
 aBk
 aBk
 oTm
 oTm
+imz
 aBk
+imz
 aBk
-aBk
-aBk
-uGU
-mTi
+ufP
+qhy
 dTs
 dTs
-ccJ
-aBk
+lzF
+oTm
 aBk
 aBk
 aBk
 gIF
-aBk
+oTm
 aFT
 aBk
-aBk
-aBk
+oTm
+oTm
 aHb
 aHA
 aBk
 aBk
-aBk
-aBk
-aBk
 oTm
 oTm
-aBk
+vUQ
+oTm
+oTm
+oTm
 imz
 aKF
 aGH
+lVW
 aGH
 aGH
-aGH
-aGH
+lVW
 aLC
 aLI
 aBk
@@ -116460,36 +123665,36 @@ kMb
 dMq
 xCj
 caH
+rjY
 caH
 caH
 caH
 caH
-caH
-vOx
+cbp
 cel
 cel
-cel
+wSm
 cel
 fnb
-vXl
+fOT
 ceX
 aQd
 aPc
 wfg
 wfg
-aPc
+jwL
 wfg
 jze
 aPc
 aOH
 aTM
 aVr
-aXh
+ktV
 bgW
 bho
 aTM
 aYg
-bad
+sOL
 bdb
 bfS
 bgl
@@ -116499,7 +123704,7 @@ paa
 bgl
 bgl
 bnA
-bnA
+eZO
 bFF
 bWL
 bTW
@@ -116539,15 +123744,15 @@ ums
 tXg
 dHi
 dxT
-cYK
+lpf
 dcw
 cZu
 aKm
 cko
-cUc
+mPg
 cCH
 dWZ
-cto
+oSG
 cUP
 cto
 crW
@@ -116567,7 +123772,7 @@ qqb
 dFj
 dCd
 xDD
-dYP
+moS
 dHG
 dIk
 dIR
@@ -116604,7 +123809,7 @@ amA
 amA
 amA
 amA
-amA
+xMs
 amA
 amA
 afp
@@ -116626,45 +123831,45 @@ aij
 qZW
 aBk
 qzH
-aeo
-ltx
+rlN
+tIh
 aGH
 alj
 ucs
 aKA
 azT
 aEf
-aGH
-aBk
+wQM
 aBk
 aBk
 aBk
 oTm
 oTm
+oTm
 aBk
 aBk
 aBk
 aBk
 aBk
-uGU
+gbl
 dTs
 dTs
-aEV
-aBk
-aBk
-aBk
-aBk
-aBk
-aBk
+xws
+oTm
+vUQ
+vUQ
+jhw
+oTm
+oTm
 aHz
 igY
-aBk
-aBk
-aHb
+oTm
+oTm
+xsQ
 opG
 aGw
 aGw
-aGw
+vxh
 aGw
 aGw
 qCr
@@ -116681,7 +123886,7 @@ aLC
 jVv
 aMf
 aMf
-aMf
+srP
 aGH
 uee
 aGH
@@ -116708,14 +123913,14 @@ dnP
 dnP
 cNp
 aPc
-wfg
+qqV
 aPc
 aPc
 wfg
 wfg
 bER
 aPc
-aOH
+tMA
 aTM
 aVs
 aXi
@@ -116736,9 +123941,9 @@ bXB
 bTV
 aie
 bWL
-bTW
+pUg
 bYe
-bYK
+iDm
 bnA
 bWK
 bZN
@@ -116747,7 +123952,7 @@ bYw
 bWK
 bZN
 bZN
-bYw
+hpN
 bjV
 bjV
 bjV
@@ -116763,13 +123968,13 @@ dbG
 dqs
 dri
 dbK
-dcw
+qmC
 dUt
 dcw
 dgb
 dFk
 dFk
-ums
+pqi
 ums
 dgb
 dgb
@@ -116785,7 +123990,7 @@ cto
 dXm
 cto
 crW
-cUc
+mPg
 cko
 aKm
 dim
@@ -116797,9 +124002,9 @@ dBz
 dYS
 dYS
 hJW
-tLj
+vzY
 dYS
-dYS
+fir
 reY
 tLj
 tLj
@@ -116832,18 +124037,18 @@ amz
 bzs
 amz
 amz
-amz
+ant
 amz
 amz
 bzs
 amz
-amz
+ant
 amz
 amz
 ant
 amz
 jIG
-bfT
+kQa
 bfT
 ats
 auD
@@ -116854,25 +124059,25 @@ nNg
 auT
 auT
 ath
-aJg
+hvY
 afl
 aik
 aeE
 agK
 agC
-aBk
+oTm
 ltx
 aGH
 alj
-azT
-aKg
-azT
-aEf
-aGH
+aJY
+yfb
+aJY
+oGC
+wQM
 aBk
 qzH
 aBk
-aGZ
+gcn
 aBk
 aBk
 aFb
@@ -116881,33 +124086,33 @@ qzH
 imz
 aBk
 aBk
-uGU
+jtt
 aEV
-aBk
+vUQ
 qzH
 aBk
 aHz
+oTm
+oTm
+fxV
 aBk
-aBk
-aHz
-aBk
-aBk
+imz
 aBk
 aFc
 aIE
 aGE
 aGE
 flu
+pbV
 aGE
 aGE
 aGE
-aGE
-aGc
+rRF
 aHA
 aBk
 aKF
 aGH
-aLg
+jri
 aLm
 aLt
 aGH
@@ -116918,7 +124123,7 @@ aGH
 aGH
 aMi
 uee
-aGH
+lVW
 bXo
 ptU
 mEu
@@ -116926,7 +124131,7 @@ kMb
 kMb
 kMb
 dMq
-bnA
+eZO
 bAZ
 atC
 avT
@@ -116947,7 +124152,7 @@ skj
 epG
 jze
 qWC
-wfg
+qqV
 aXq
 aOI
 aTM
@@ -116973,10 +124178,10 @@ bWL
 bXI
 bYg
 bYK
-bnA
+eZO
 bWL
 bTX
-bTW
+pUg
 bYK
 bWL
 bTX
@@ -116984,10 +124189,10 @@ bTW
 bYK
 bjV
 bjV
+qAG
 bjV
 bjV
-bjV
-bjV
+qAG
 bjV
 bGr
 sTc
@@ -116995,7 +124200,7 @@ bjV
 daO
 dbH
 dqt
-dri
+wwY
 dUe
 dcw
 dUt
@@ -117007,7 +124212,7 @@ lqb
 nJj
 sZV
 dgY
-dgY
+hwN
 dcw
 cZu
 aKm
@@ -117029,14 +124234,14 @@ dXN
 dAH
 dBy
 uXH
-dYm
+gDq
 dYm
 dYm
 dYP
-dYm
+gDq
 dCd
 dYm
-dYm
+gDq
 dIk
 dIK
 uHv
@@ -117062,7 +124267,7 @@ dTs
 dTs
 apW
 amx
-amz
+ant
 amz
 amz
 amz
@@ -117089,12 +124294,12 @@ axa
 aJe
 aPP
 aOk
-afl
+cWq
 bRg
 dfr
 dTs
 pVo
-aBk
+oTm
 ltx
 aGH
 azK
@@ -117102,13 +124307,13 @@ aAm
 aAm
 aAm
 aEl
-aGH
+wQM
 imz
 aBk
-aBk
-aBk
-aBk
-aBk
+oTm
+oTm
+jhw
+oTm
 aFc
 aBk
 aBk
@@ -117123,7 +124328,7 @@ qzH
 aBk
 aHz
 aHG
-aBk
+vUQ
 aBk
 aBk
 aFb
@@ -117131,20 +124336,20 @@ aIu
 aBk
 aBk
 aBk
-aBk
-aBk
-aBk
+oTm
+oTm
+oTm
 aBk
 aGq
-aHb
-aHA
+dsX
+srf
 aBk
 aKF
 aGH
 aLi
 aLn
 aLu
-aGH
+lVW
 aLC
 aBk
 aLR
@@ -117166,7 +124371,7 @@ dMf
 kMb
 bUN
 bpr
-bnA
+eZO
 chZ
 civ
 caH
@@ -117191,7 +124396,7 @@ aXh
 aYb
 aXh
 bcO
-bcO
+iVc
 beQ
 vBp
 bgo
@@ -117200,7 +124405,7 @@ bjw
 bkC
 bkO
 bgl
-bFF
+mxx
 bTW
 bWE
 bXx
@@ -117212,7 +124417,7 @@ bWL
 bTW
 bTX
 uBL
-bWL
+ngy
 bTW
 bTW
 bYK
@@ -117226,12 +124431,12 @@ bjV
 bjV
 bjV
 bjV
-iNT
+daO
 dxM
 dqt
 dri
 dUe
-dvg
+vBU
 dUt
 dqt
 cWp
@@ -117246,13 +124451,13 @@ dcw
 dbK
 fwp
 cko
-cUc
+mPg
 cCH
-cto
+oSG
 cto
 dXm
 cto
-crW
+qSg
 cmN
 cok
 cvw
@@ -117260,7 +124465,7 @@ dwH
 dwI
 dwI
 dXN
-dAD
+nac
 dBy
 dCf
 dBy
@@ -117299,7 +124504,7 @@ abi
 amB
 amz
 amz
-anv
+xWh
 anM
 anP
 anP
@@ -117327,54 +124532,54 @@ afl
 dTs
 bgH
 dTs
-mTi
-agC
+qhy
+twd
 ltx
 aGH
 aGH
 aGH
 aGH
-aGH
-aGH
-aGH
+wQM
+wQM
+wQM
+vUQ
+mno
+feO
+twd
+oTm
+oTm
+imz
 aBk
-aCG
-agK
-agC
-aBk
-aBk
-aBk
-aBk
-aBk
-aBk
-aBk
-aGp
+imz
 aBk
 aBk
-eqo
-eqo
+iIN
+oTm
+aBk
+oTm
+oTm
 aBk
 iBV
 aBk
 aBk
-aBk
-aBk
+vUQ
+imz
 aIk
 aIp
-aGp
-aFb
-aBk
-aBk
+iIN
+fbr
+jhw
+vUQ
 oTm
 oTm
-aBk
-aBk
-aBk
-aHb
-aHA
+oTm
+oTm
+oTm
+dsX
+srf
 jNK
 aKF
-aGH
+lVW
 aLj
 aLo
 aGH
@@ -117383,7 +124588,7 @@ aLF
 aBk
 aBk
 aMg
-aMf
+srP
 aMf
 cPD
 aGH
@@ -117403,7 +124608,7 @@ bAZ
 bnA
 aSH
 bvz
-caH
+rjY
 lFE
 aOy
 dLx
@@ -117416,11 +124621,11 @@ mzU
 kPA
 hRC
 mNN
-wfg
+qqV
 oPz
 aTM
 aVW
-aXi
+hjR
 aXh
 bhq
 aTM
@@ -117448,21 +124653,21 @@ bTW
 bYK
 bWL
 bTW
-bTW
+pUg
 bYK
+qAG
 bjV
 bjV
 bjV
 bjV
 bjV
-bjV
-bjV
+qAG
 bKI
 bjV
 bjV
 daO
 dpF
-dqt
+pzE
 dri
 dUe
 dcw
@@ -117471,12 +124676,12 @@ dqt
 dEv
 dHo
 dHo
-ums
+pqi
 ums
 dBc
 dBf
 cYK
-dcw
+qmC
 cZu
 aKm
 cko
@@ -117491,7 +124696,7 @@ dbQ
 duD
 del
 dwJ
-dwJ
+fFU
 dwJ
 daX
 dAD
@@ -117549,7 +124754,7 @@ xWI
 anP
 anP
 auQ
-avi
+nzq
 aww
 aww
 xVA
@@ -117561,29 +124766,29 @@ afl
 dTs
 dTs
 dTs
-oLT
-ccJ
-ltx
+qhy
+lzF
+tIh
 aBk
 iBV
 aBk
 aBk
-aBk
+vUQ
 aCG
 agK
 agK
 oLT
 mTi
-mTi
+nJy
 agK
 agK
 agC
 aBk
+oTm
 aBk
 aBk
-qzH
-aBk
-aBk
+oTm
+oTm
 aBk
 oTm
 dzO
@@ -117591,13 +124796,13 @@ agC
 aBk
 qzH
 aBk
-aCG
-agK
-agC
-aHC
-aCG
-agK
-agC
+dzO
+feO
+twd
+vMZ
+dzO
+feO
+twd
 aBk
 oTm
 oTm
@@ -117611,7 +124816,7 @@ aKG
 aKR
 aLg
 uBd
-aLw
+pWn
 aLA
 aLG
 gJM
@@ -117640,13 +124845,13 @@ bvz
 caH
 aOz
 dNs
-aPc
+jwL
 wfg
 hRC
 wfg
 aOy
 lUk
-gQm
+pzh
 vVU
 lFE
 hRC
@@ -117674,7 +124879,7 @@ bTX
 bWL
 bXJ
 bYg
-bYK
+iDm
 bnA
 bWL
 bZO
@@ -117687,13 +124892,13 @@ bYK
 bjV
 bnA
 bnA
-bnA
+eZO
 wqI
 bnA
 bnA
 bnA
 bnA
-bjV
+qAG
 daO
 dpG
 dqt
@@ -117713,12 +124918,12 @@ dBb
 dcw
 cZu
 aKm
-cko
+mjg
 cUc
 cCH
 dpH
 cET
-dXm
+lPp
 cto
 crW
 cUc
@@ -117765,7 +124970,7 @@ dTs
 dTs
 apW
 amx
-amz
+ant
 amz
 apj
 anP
@@ -117790,7 +124995,7 @@ nNg
 axc
 aJe
 cTE
-aOk
+pxl
 afl
 dTs
 dTs
@@ -117798,38 +125003,38 @@ dTs
 dTs
 dTs
 riN
-agC
+twd
 aBk
 aBk
 igY
-aCG
+dzO
 dTs
 dTs
 dTs
-mTi
-mTi
+qhy
+qhy
 oJC
-mTi
-mTi
-mTi
+qhy
+qhy
+qhy
 agC
-aFT
+qrw
 igY
 aBk
 aBk
 aGr
 aBk
-aBk
+vUQ
 aEX
 mTi
 agC
 aBk
-aCG
-mTi
+pmt
+qhy
 dTs
 dTs
-agK
-mTi
+feO
+qhy
 dTs
 dTs
 xLp
@@ -117845,7 +125050,7 @@ aKJ
 aKS
 aLk
 aLp
-aLx
+fRy
 aLB
 flu
 aLJ
@@ -117854,7 +125059,7 @@ aMf
 aGH
 aGH
 xpe
-aGH
+lVW
 sPA
 kMb
 kMb
@@ -117870,14 +125075,14 @@ bUN
 bpr
 bnA
 aSH
-bvz
+tUZ
 caH
 aOz
 ndI
 wok
 wTo
 wok
-aPc
+jwL
 aOy
 myt
 phx
@@ -117904,20 +125109,20 @@ bli
 biW
 bFF
 bTW
-bTX
+kTd
 bXx
 bTX
 bYh
 bYK
 bnA
-bWL
+ngy
 bTW
 bTX
-bTX
+kTd
 bTW
 bTX
 bTW
-bYK
+iDm
 bjV
 bnA
 dak
@@ -117941,21 +125146,21 @@ kMT
 kMT
 klS
 dgY
+igV
 dgb
-dgb
-dgb
+igV
 xVf
 cZu
 aKm
 cko
-cUc
+mPg
 cCH
 dpI
 dXf
 dXo
 cmb
 cXx
-cUc
+mPg
 hjo
 xLK
 xLK
@@ -118019,7 +125224,7 @@ atv
 auF
 avi
 aww
-wIc
+nLS
 nNg
 axc
 aJe
@@ -118032,38 +125237,38 @@ dTs
 dTs
 dTs
 xGe
-mTi
-agC
-aBk
-aCG
-mTi
+qhy
+uqF
+vUQ
+dzO
+qhy
 dTs
 dTs
 dTs
 dTs
 dTs
 dTs
-mTi
+qhy
 dTs
-mTi
-mTi
+qhy
+qhy
 oit
 aBk
 aGp
 aGr
 aBk
 aCG
-agK
+feO
 dTs
 dTs
 mTi
 agK
 mTi
-mTi
+qhy
 dTs
 dTs
 dTs
-mTi
+qhy
 dTs
 dTs
 mTi
@@ -118077,13 +125282,13 @@ aHA
 aBk
 aKF
 aGH
-aGH
+lVW
 aGH
 aGH
 aLC
 aBk
 aBk
-aBk
+imz
 aLI
 aMf
 aMf
@@ -118109,7 +125314,7 @@ caH
 aOz
 aJX
 wfg
-aPc
+jwL
 hRC
 xMy
 aOy
@@ -118117,7 +125322,7 @@ eNw
 phx
 xTh
 fxU
-kOS
+iSV
 aPc
 bfF
 aUc
@@ -118128,7 +125333,7 @@ aPL
 aUU
 baL
 bcO
-nmi
+uWH
 bad
 aVn
 big
@@ -118136,7 +125341,7 @@ bkD
 mzH
 bli
 biW
-bFF
+mxx
 bTX
 bWF
 bXx
@@ -118147,7 +125352,7 @@ bZN
 bZF
 bTW
 bTX
-bTX
+kTd
 bTX
 bTZ
 bTW
@@ -118157,7 +125362,7 @@ bZN
 bZN
 bZN
 bZN
-bZN
+fJM
 nsf
 bFF
 bnA
@@ -118170,10 +125375,10 @@ dbK
 dbK
 dkY
 dcw
+qmC
 dcw
 dcw
-dcw
-dcw
+qmC
 dkY
 dcw
 dvg
@@ -118232,10 +125437,10 @@ dTs
 dTs
 dTs
 apW
-alT
+soj
 amz
 amz
-apj
+aFF
 anP
 anS
 aod
@@ -118251,7 +125456,7 @@ pZy
 nMM
 xWI
 auF
-avh
+pvZ
 awy
 aww
 xVA
@@ -118268,7 +125473,7 @@ dTs
 xGe
 dTs
 mTi
-agK
+gIL
 dTs
 dTs
 dTs
@@ -118280,20 +125485,20 @@ dTs
 dTs
 dTs
 dTs
-mTi
-ccJ
-aBk
-aBk
+qhy
+lzF
+oTm
+oTm
 aBk
 jNK
-aEX
+ksz
 dTs
 dTs
 dTs
 dTs
-mTi
-mTi
-mTi
+nJy
+xLF
+qhy
 dTs
 dTs
 dTs
@@ -118315,7 +125520,7 @@ aLe
 aLe
 aLe
 aLD
-aBk
+imz
 aBk
 aBk
 aBk
@@ -118349,7 +125554,7 @@ aPc
 aOy
 eNw
 hgV
-xTh
+mIa
 aPc
 kOS
 nnA
@@ -118374,7 +125579,7 @@ bGs
 bTZ
 bWF
 rMO
-bXI
+tfo
 bYi
 rDe
 bZC
@@ -118489,9 +125694,9 @@ avh
 auT
 aww
 xVA
-axc
+roD
 aJe
-bRg
+cTE
 aOk
 afl
 bRg
@@ -118516,16 +125721,16 @@ dTs
 dTs
 dTs
 dTs
-aFz
-aFz
-vte
-aFz
-aGI
+giq
+giq
+sfE
+mHl
+klF
 dTs
 dTs
 dTs
 dTs
-ccK
+lMc
 ccK
 dTs
 dTs
@@ -118543,7 +125748,7 @@ aGH
 aIB
 xCf
 aGH
-aGH
+lVW
 aGH
 aBk
 dTs
@@ -118564,14 +125769,14 @@ kMb
 bnh
 kMb
 dMq
-bnA
+eZO
 wqI
 bnA
 bnA
+eZO
 bnA
 bnA
-bnA
-aSH
+gpr
 oHf
 bnA
 lFE
@@ -118597,10 +125802,10 @@ aUU
 baN
 nmi
 paV
-bcO
+iVc
 bcO
 bih
-bih
+pTo
 jcO
 bih
 bih
@@ -118616,24 +125821,24 @@ bTW
 bTX
 bZD
 bTW
-bTX
+kTd
 etY
 bTX
 bTZ
 etY
 bTW
-bTW
+pUg
 bZD
 bTW
 bYh
 yfq
-bFF
+mxx
 bnA
 bnA
 bnA
 dbL
 dbN
-ggd
+dth
 dbN
 pMQ
 dft
@@ -118641,11 +125846,11 @@ dbN
 dbN
 mTY
 dbN
-dbN
+wjN
 dbK
 dhc
 dhd
-dcw
+qmC
 dcw
 dbK
 dbK
@@ -118655,7 +125860,7 @@ cCH
 dpL
 cto
 crW
-cmN
+hbw
 cpZ
 csi
 sAs
@@ -118701,7 +125906,7 @@ alz
 alC
 alP
 amy
-amz
+ant
 amz
 apj
 anP
@@ -118719,7 +125924,7 @@ vWS
 asL
 anP
 auF
-avi
+nzq
 aww
 aww
 xVA
@@ -118734,12 +125939,12 @@ xGe
 xGe
 xGe
 kzq
-ccK
+ylW
 eyB
-nID
-ccK
-ccK
-ccK
+gMI
+ylW
+ylW
+ylW
 dTs
 dTs
 dTs
@@ -118750,15 +125955,15 @@ dTs
 dTs
 dTs
 dTs
+giq
 aFz
 aFz
 aFz
-aFz
-aGg
+jND
 dTs
 dTs
 dTs
-ccK
+ylW
 ccK
 ccK
 dTs
@@ -118773,7 +125978,7 @@ aen
 jEN
 aGH
 aGH
-akV
+xAf
 aHZ
 aEh
 aKj
@@ -118840,20 +126045,20 @@ bli
 biW
 aSH
 bul
-bWH
+rPq
 bXF
 bXK
 bXK
+eFC
+bXK
+bXK
+iHL
 bXK
 bXK
 bXK
-bZP
 bXK
 bXK
-bXK
-bXK
-bXK
-bXK
+eFC
 bXK
 bZP
 bXK
@@ -118863,14 +126068,14 @@ bYd
 bYK
 aSH
 bul
-bul
+jkG
 bWH
 dbM
 dbN
 ggd
 dbN
-iwS
-dbN
+loy
+wjN
 dbN
 fYS
 fYS
@@ -118881,7 +126086,7 @@ dbK
 dbK
 dcw
 dcw
-dcw
+qmC
 dcw
 dbK
 cUc
@@ -118929,15 +126134,15 @@ acu
 dTs
 akk
 akm
-awb
+jjV
 awb
 akK
-akK
+ldY
 alR
 amz
 amz
 ant
-anD
+iRY
 anP
 anT
 aod
@@ -118966,14 +126171,14 @@ ihV
 dTs
 xGe
 dTs
-nID
-nID
+qTV
+qTV
 enk
 aFz
 aFz
-aGg
-ccK
-ccK
+jND
+ylW
+ylW
 dTs
 dTs
 dTs
@@ -118984,17 +126189,17 @@ dTs
 dTs
 dTs
 tab
-beM
+rIa
+giq
 aFz
 aFz
-aFz
-aFz
+giq
 dTs
 dTs
-ccK
-ccK
-ccK
-ccK
+ylW
+ylW
+nDe
+nDe
 dTs
 dTs
 dTs
@@ -119006,15 +126211,15 @@ aIv
 aen
 jEN
 jEN
-aGH
-alj
+lVW
+aSM
 iRQ
 aKA
 azT
 aKM
 aGH
 aBk
-aEX
+jeW
 dTs
 dTs
 mTi
@@ -119024,7 +126229,7 @@ dTs
 dTs
 dTs
 xGe
-aGH
+lVW
 dEW
 kMb
 kMb
@@ -119052,14 +126257,14 @@ mMZ
 mMZ
 lFE
 vFr
-wfg
+qqV
 tdF
 wfg
-wfg
+qqV
 aUz
 aWL
 eVV
-bhb
+nKP
 bhb
 aVC
 bda
@@ -119072,7 +126277,7 @@ bjZ
 mLF
 bli
 biW
-aSH
+gpr
 jUV
 jUV
 jfE
@@ -119112,14 +126317,14 @@ xjb
 dbN
 dbK
 dhc
-dhd
+wUC
 xVf
 dkY
 dlA
-dlA
+qED
 dbK
 cUc
-cCH
+lCQ
 dpH
 cET
 crW
@@ -119195,20 +126400,20 @@ axe
 aJe
 aPP
 aOk
-afl
+cWq
 bRg
 dTs
 kzq
-beM
+rIa
+giq
+vrz
+aFz
 aFz
 vte
-aFz
-aFz
-aFz
 azV
-aGI
-ccK
-ccK
+klF
+ylW
+ylW
 dTs
 dTs
 dTs
@@ -119217,15 +126422,15 @@ dTs
 dTs
 dTs
 dTs
-ccK
-aFU
+ylW
+fAr
+giq
+vte
 aFz
-aFz
-aFz
-aFz
-aGI
+giq
+klF
 lFH
-lMc
+tBl
 ccK
 ccK
 ccK
@@ -119241,9 +126446,9 @@ aen
 jEN
 jEN
 aGH
-alj
-nDi
-aKg
+aSM
+sDw
+aKA
 tvM
 aKN
 lVW
@@ -119252,7 +126457,7 @@ mTi
 dTs
 dTs
 mTi
-mTi
+gbS
 dTs
 dTs
 dTs
@@ -119291,7 +126496,7 @@ mqT
 uiQ
 evf
 aUN
-aUN
+jet
 fHw
 fKy
 aUN
@@ -119302,7 +126507,7 @@ paV
 bgb
 aUU
 biC
-bka
+aaI
 bka
 blf
 bgl
@@ -119312,7 +126517,7 @@ ktp
 buh
 buh
 buh
-buh
+ayD
 buh
 buh
 aie
@@ -119322,7 +126527,7 @@ bnA
 bnA
 bnA
 bnA
-bnA
+eZO
 bnA
 pld
 bWL
@@ -119335,10 +126540,10 @@ bnA
 bnA
 dbL
 dcx
-ggd
+dth
 hMn
 kUA
-hMn
+iyd
 dbN
 dhf
 dhf
@@ -119402,9 +126607,9 @@ rvL
 akK
 alF
 alP
-amB
+uFt
 amz
-amz
+ant
 apj
 anP
 anU
@@ -119433,15 +126638,15 @@ afl
 dTs
 dTs
 kzq
-aFU
+fAr
+giq
+vte
 aFz
 aFz
 aFz
 aFz
-aFz
-aFz
-aGI
-ccK
+klF
+ylW
 dTs
 dTs
 dTs
@@ -119453,12 +126658,12 @@ dTs
 ccK
 ccK
 ccK
-beM
+xvu
 aFz
 aFz
-aFz
-aGg
-nID
+giq
+jND
+qTV
 nID
 nID
 tXQ
@@ -119473,13 +126678,13 @@ aIv
 adS
 afA
 jEN
-jEN
+hdd
 aGH
-alj
+aSM
 azT
-aKh
 aKA
-aEf
+aKA
+iDR
 aGH
 aEX
 mTi
@@ -119508,11 +126713,11 @@ mnX
 mnX
 yhu
 aSH
-puK
+utA
 aCo
 aOA
 nlP
-uyW
+jPm
 eGB
 eGB
 tFr
@@ -119530,9 +126735,9 @@ bgM
 bhn
 aXa
 aVn
-bad
+sOL
 bda
-bcO
+iVc
 bgc
 aUU
 biW
@@ -119553,20 +126758,20 @@ bnA
 dTs
 dTs
 dTs
-bjV
+qAG
 bjV
 tGK
 bjV
-bnA
+eZO
 bFF
 fYs
 bXI
 bYd
-bYK
+iDm
 bFF
 bnA
-bjV
-bjV
+qAG
+qAG
 dbL
 dbN
 ddp
@@ -119591,7 +126796,7 @@ cCH
 dpI
 cto
 crW
-cmN
+hbw
 dTs
 dTs
 sAs
@@ -119659,7 +126864,7 @@ avh
 auT
 auT
 tJf
-auT
+mCI
 auT
 hYc
 aaw
@@ -119667,14 +126872,14 @@ atL
 dTs
 dTs
 kzq
-aFU
+fAr
 aFz
 aFz
 aFz
 pmW
+giq
 aFz
-aFz
-aGI
+klF
 dTs
 dTs
 dTs
@@ -119687,7 +126892,7 @@ dTs
 wNO
 wNO
 aAW
-aFU
+fAr
 aFz
 aFz
 aFz
@@ -119696,7 +126901,7 @@ aFz
 aFz
 lRa
 aGg
-ccK
+cnD
 dTs
 dTs
 dTs
@@ -119709,14 +126914,14 @@ hdd
 jEN
 jEN
 aGH
-azK
+mKy
 aKa
 aKi
-aAm
-aEl
+wan
+hML
 aGH
 aEX
-mTi
+gbS
 mTi
 mTi
 mTi
@@ -119753,7 +126958,7 @@ sRZ
 tFr
 kdO
 tEO
-fSw
+nFd
 mGG
 fSw
 pMD
@@ -119779,7 +126984,7 @@ bvz
 bnA
 bKI
 bjV
-bjV
+qAG
 bkP
 bkm
 dTs
@@ -119792,7 +126997,7 @@ dTs
 iXM
 bjV
 bnA
-bFF
+mxx
 fYs
 bTW
 bYe
@@ -119808,7 +127013,7 @@ dap
 dap
 dfv
 dbN
-dbN
+wjN
 dbN
 dbN
 rlU
@@ -119865,13 +127070,13 @@ acu
 dTs
 akk
 akE
-akK
+ldY
 rvL
 akK
 alH
 alP
 amx
-amz
+ant
 amz
 apj
 xWI
@@ -119895,7 +127100,7 @@ lCm
 nCw
 axa
 aJe
-aPP
+tIT
 aPP
 dTs
 dTs
@@ -119908,7 +127113,7 @@ mgg
 aFz
 aFz
 vte
-aGI
+klF
 dTs
 dTs
 dTs
@@ -119921,17 +127126,17 @@ cxn
 aBg
 aBg
 aAW
-aFU
+fAr
+vte
+aFz
 vte
 aFz
 aFz
 aFz
 aFz
 aFz
-aFz
-aFz
-aGI
-ccK
+lYK
+ylW
 dTs
 dTs
 dTs
@@ -119942,12 +127147,12 @@ aen
 jEN
 jEN
 aGH
-aGH
+lVW
 aGH
 aSM
 aTz
 aGH
-aGH
+lVW
 aGH
 aEX
 mTi
@@ -119979,16 +127184,16 @@ mQb
 otC
 yhu
 aOy
-eGB
+jQI
 lFE
-dSH
+hSy
 gdO
 dSH
 uFF
 gdO
 inl
 hCw
-hCw
+fEO
 fSw
 jqa
 eDb
@@ -120009,8 +127214,8 @@ bCI
 bnA
 bnA
 aSH
-bvz
-bnA
+tUZ
+eZO
 bjV
 iXM
 bkP
@@ -120031,7 +127236,7 @@ bWL
 bTW
 bYe
 bYK
-bFF
+mxx
 bnA
 dap
 daP
@@ -120045,7 +127250,7 @@ dge
 dhg
 dhg
 dhj
-rlU
+oRf
 nMO
 oOj
 eNG
@@ -120107,7 +127312,7 @@ alP
 amx
 amz
 amz
-apj
+aFF
 xWI
 aoA
 bZY
@@ -120127,23 +127332,23 @@ avO
 awN
 awT
 nNg
-axb
+oPp
 aJd
 bgH
 bgH
 dTs
 dTs
 bgH
-kzq
-aFU
+lly
+dDs
 aFz
-aFz
-aFz
+giq
+giq
 aFz
 aKH
 aFz
-aGg
-ccK
+jND
+ylW
 dTs
 dTs
 dTs
@@ -120155,7 +127360,7 @@ aJQ
 aAX
 xdJ
 rOw
-cnD
+gta
 beM
 aFz
 mgg
@@ -120165,7 +127370,7 @@ aFz
 aFz
 bfh
 ccK
-ccK
+ylW
 dTs
 dTs
 dTs
@@ -120178,8 +127383,8 @@ aGH
 agN
 aGH
 aGH
-aBq
-aBF
+aID
+aIW
 aGH
 aGH
 aGH
@@ -120211,7 +127416,7 @@ aoi
 bnA
 aSH
 bvz
-yhu
+fsE
 aOy
 plK
 lFE
@@ -120230,11 +127435,11 @@ aOy
 bnA
 aPr
 bCI
+eZO
 bnA
-bnA
-bnA
+eZO
 btR
-bux
+wZU
 aHP
 aHP
 bnA
@@ -120262,7 +127467,7 @@ dTs
 bnA
 bFF
 bWL
-bXJ
+rfE
 bYd
 bYK
 bFF
@@ -120271,12 +127476,12 @@ dap
 daQ
 dbP
 heR
-fCw
+mly
 dej
 dap
 eeL
 dgf
-dhh
+lpx
 dhh
 diN
 dbN
@@ -120284,12 +127489,12 @@ wjC
 dhe
 dbN
 dkL
-dlR
+eJp
 fzp
 dmP
 dgo
 cUc
-cCH
+lCQ
 dpI
 cto
 crW
@@ -120338,8 +127543,8 @@ rvL
 akK
 alH
 akk
-alT
-ant
+soj
+amz
 amz
 apj
 anP
@@ -120368,28 +127573,28 @@ aWz
 bgH
 bgH
 bgH
-kzq
+lly
 aFU
 aFz
+giq
+giq
 aFz
 aFz
-aFz
-aFz
-aFz
+vte
 aGb
-aGg
-ccK
+jND
+ylW
 dTs
 dTs
-aFz
-aGI
+giq
+klF
 dTs
 aJc
 pmn
 ikj
 hPq
 aAW
-ccK
+ylW
 aFU
 aFz
 njb
@@ -120399,23 +127604,23 @@ aFz
 aFz
 aGI
 lMc
-ccK
+ylW
 dTs
 dTs
 dTs
 aon
 aIv
 aen
-jEN
+hdd
 jEN
 xyH
-aLe
+mct
 aLe
 mfi
 aLD
 aKK
 aLe
-aLe
+mct
 dTs
 dTs
 dTs
@@ -120470,13 +127675,13 @@ bnA
 btR
 bux
 aHP
-aHP
+ykj
+eZO
+bnA
+eZO
 bnA
 bnA
-bnA
-bnA
-bnA
-aSH
+gpr
 bvz
 bnA
 bjV
@@ -120513,7 +127718,7 @@ dgf
 dhh
 dhh
 diN
-dbN
+wjN
 dkh
 dkM
 dkM
@@ -120526,7 +127731,7 @@ cUc
 cCH
 dpH
 cET
-crW
+qSg
 ctm
 dTs
 dTs
@@ -120574,7 +127779,7 @@ alJ
 alP
 amy
 amz
-amz
+ant
 anD
 anP
 anQ
@@ -120600,40 +127805,40 @@ aJd
 qZW
 bRg
 aXY
-aWz
+vnn
 bgH
-kzq
+lly
 dUz
 aFz
 vGq
 aFz
 aFS
 aFz
-aFz
-aFz
+giq
+giq
 azW
-aGg
-nID
-aGR
-aFz
-aGI
+jND
+qTV
+urz
+giq
+klF
 ccK
-ccK
+lMc
 wMm
 xFD
 phV
 aBi
-ccK
-aFU
+ylW
+fAr
 aFz
 aFz
 vte
 aFz
-aFz
+vte
 aFz
 aGI
 ccK
-ccK
+ylW
 dTs
 dTs
 dTs
@@ -120659,7 +127864,7 @@ dTs
 dTs
 dTs
 mTi
-oLT
+iPV
 dTs
 xGe
 dTs
@@ -120685,16 +127890,16 @@ yhu
 yhu
 yhu
 yhu
-yhu
+fsE
 yhu
 uJh
-yhu
+fsE
 rHN
 aCo
 bnA
 ajW
 bnA
-bnA
+eZO
 bnA
 bnA
 bnA
@@ -120737,20 +127942,20 @@ bFF
 bnA
 dap
 daQ
-heR
+toU
 dbP
 fCw
 dej
 dap
 dbN
-dgf
+idp
 fbp
 dhh
 diN
 dbN
 rBv
 dbN
-dbN
+wjN
 dlB
 dlR
 dmf
@@ -120803,7 +128008,7 @@ dTs
 akk
 akn
 hgM
-akK
+ldY
 akK
 alR
 amz
@@ -120818,7 +128023,7 @@ apj
 anP
 aqv
 vWS
-apI
+jxr
 anP
 aqv
 vWS
@@ -120840,25 +128045,25 @@ hfa
 aFz
 aFz
 aFz
-aFz
+vte
 aGO
 aFz
+giq
+giq
 aFz
 aFz
 aFz
 aFz
 aFz
-aFz
-aFz
-aGg
+hXL
 ccK
 aAW
 aAP
 aAP
 kpx
 aBi
-ccK
-aFU
+ylW
+fAr
 aFz
 mgg
 aFz
@@ -120867,11 +128072,11 @@ aFz
 bfh
 cnD
 ccK
-ccK
-ccK
+ylW
+ylW
 dTs
 dTs
-jEN
+hdd
 jEN
 jEN
 dTs
@@ -120906,18 +128111,18 @@ kMb
 dMq
 bnA
 bnA
+eZO
 bnA
 bnA
-bnA
-bnA
+eZO
 bnA
 aSH
 bvz
+eZO
 bnA
 bnA
 bnA
-bnA
-bnA
+eZO
 bXB
 bul
 aiP
@@ -120925,20 +128130,20 @@ aiP
 aiP
 vFV
 vFV
+jkG
 bul
 bul
 bul
 bul
-bul
-bul
+jkG
 aiP
-aiP
-aiP
+pQJ
+pQJ
 vFV
 puK
 vFV
 bul
-bul
+jkG
 bul
 bul
 bul
@@ -120946,7 +128151,7 @@ bul
 bul
 eDC
 bvz
-bnA
+eZO
 brj
 dTs
 dTs
@@ -120962,11 +128167,11 @@ dTs
 dTs
 dTs
 dTs
-bFF
+mxx
 bWL
 bXJ
 bYd
-bYK
+iDm
 bFF
 bnA
 dap
@@ -120980,15 +128185,15 @@ bNg
 dgf
 dhh
 dhh
-diN
+lbg
 djA
 dki
 dbN
 dbL
 dbL
-dlR
+eJp
 dmf
-dlR
+eJp
 dgo
 cUc
 cCH
@@ -121083,22 +128288,22 @@ aFz
 aGO
 vte
 aFz
-aFz
-aFz
+giq
+giq
 aGI
 aAW
 ccK
 ccK
 aBi
 aAW
-ccK
-aFU
+ylW
+fAr
 aFz
-aFz
+vte
 aFz
 aFz
 mux
-aGI
+klF
 dTs
 dTs
 dTs
@@ -121112,9 +128317,9 @@ dTs
 dTs
 dTs
 dTs
+gbS
 mTi
-mTi
-mTi
+gbS
 dTs
 dTs
 dTs
@@ -121146,7 +128351,7 @@ bul
 bul
 bul
 jUV
-eDC
+qOG
 bul
 bul
 bul
@@ -121156,11 +128361,11 @@ eDC
 vFV
 ajA
 ajA
-ajA
+pyy
 ajA
 shu
 ajA
-ajA
+pyy
 ajA
 ajA
 buh
@@ -121176,7 +128381,7 @@ buh
 buh
 ktp
 jUV
-jUV
+wFj
 ktp
 buh
 aie
@@ -121198,11 +128403,11 @@ dTs
 dTs
 bFF
 bWL
-bTX
+kTd
 bYe
 bYK
 bFF
-bnA
+eZO
 dap
 daQ
 dbP
@@ -121229,7 +128434,7 @@ cCH
 dpH
 cET
 crW
-ctm
+jNx
 dTs
 dTs
 aUY
@@ -121277,9 +128482,9 @@ alP
 ham
 ekV
 sSi
+xvC
 sSi
-sSi
-sSi
+xvC
 lSX
 tzM
 aFF
@@ -121289,7 +128494,7 @@ sgw
 apI
 anP
 aqx
-sgw
+gau
 apI
 anP
 aJd
@@ -121304,37 +128509,37 @@ pnG
 aeE
 bgH
 bgH
-kzq
+lly
 oMP
-aFz
-aFz
+giq
+giq
 aFz
 azV
-aFz
+vte
 azW
-aFz
+vte
 aFz
 aGJ
 njb
 aFz
-aFz
-aFz
+giq
+giq
 aGI
+lMc
 ccK
+lMc
 ccK
-ccK
-ccK
-ccK
-ccK
+nDe
+lMc
 aFU
 aFz
 aFz
 aFz
-aFz
-aFz
-aGI
-ccK
-ccK
+giq
+giq
+klF
+ylW
+ylW
 dTs
 dTs
 dTs
@@ -121372,23 +128577,23 @@ kMb
 kMb
 kMb
 dMq
-bnA
+eZO
 atc
 buh
 buh
 buh
+ayD
+ayD
 buh
 buh
 buh
 buh
 buh
-buh
-buh
-buh
+ayD
 buh
 jUV
 bvz
-bnA
+eZO
 bnA
 bnA
 bnA
@@ -121403,7 +128608,7 @@ bnA
 bnA
 bnA
 bnA
-bnA
+eZO
 bnA
 bnA
 bnA
@@ -121413,7 +128618,7 @@ aSH
 bvz
 bnA
 bnA
-bnA
+eZO
 bnA
 dTs
 dTs
@@ -121439,7 +128644,7 @@ bFF
 bnA
 dap
 daQ
-dbP
+vsw
 dcz
 ddu
 dek
@@ -121451,7 +128656,7 @@ cnU
 diR
 eeU
 dkk
-cko
+mjg
 dbL
 dlF
 dlT
@@ -121519,7 +128724,7 @@ anv
 anM
 anP
 aqD
-aqd
+iLG
 aqW
 anP
 aqD
@@ -121539,36 +128744,36 @@ gDW
 bgH
 bgH
 xGe
-ccK
-beM
+ylW
+rIa
+giq
 aFz
 aFz
 aFz
 aFz
+giq
+giq
 aFz
 aFz
-aFz
-aFz
-aFz
-aFz
+vte
 azV
-aFz
+mHl
 guK
 ccK
 ccK
 ccK
 ccK
-ccK
+nDe
 ccK
 aGR
 vte
 aFz
-aFz
+vte
 aGF
-aFz
-aGI
-ccK
-ccK
+giq
+klF
+ylW
+ylW
 dTs
 dTs
 dTs
@@ -121644,7 +128849,7 @@ bAZ
 bAZ
 bnA
 aSH
-bvz
+tUZ
 bnA
 bjV
 bkP
@@ -121668,7 +128873,7 @@ dTs
 bWL
 vzF
 bYd
-bYK
+iDm
 bFF
 bnA
 dap
@@ -121680,7 +128885,7 @@ dap
 dap
 cUc
 cCH
-cto
+oSG
 cto
 crW
 cko
@@ -121743,7 +128948,7 @@ dTs
 dTs
 apW
 amx
-amz
+ant
 amz
 apj
 aas
@@ -121774,34 +128979,34 @@ bgH
 bgH
 xGe
 dTs
-aFU
+fAr
 vte
 aFz
 aFz
 lRa
 aFz
+giq
+giq
 aFz
 aFz
 aFz
 aFz
-aFz
-aFz
-aFz
+mHl
 lcY
 aGg
 ccK
-ccK
-ccK
-ccK
-aGR
-aFz
+lMc
+ylW
+ylW
+urz
 aFz
 aFz
 aFz
 aFz
 vte
-aGI
-ccK
+vte
+klF
+ylW
 dTs
 dTs
 dTs
@@ -121812,9 +129017,9 @@ dTs
 dTs
 dTs
 gGC
-sCp
+mTb
 nWL
-sCp
+xHP
 sCp
 mTb
 gGC
@@ -121843,7 +129048,7 @@ adQ
 gvY
 ael
 aeJ
-bnA
+eZO
 bAZ
 bAZ
 bpr
@@ -121854,7 +129059,7 @@ bpr
 bAZ
 bAZ
 bnA
-aSH
+gpr
 bvz
 bnA
 bpr
@@ -121903,7 +129108,7 @@ bWL
 bTW
 nSf
 bYK
-bFF
+mxx
 bnA
 aKm
 aKm
@@ -121917,15 +129122,15 @@ cCH
 cto
 cto
 crY
-daT
+fkY
 dkl
 cYs
 aKm
 aKm
-cPz
+vfa
 csb
 aKm
-aKm
+sYj
 cUc
 cCH
 dpH
@@ -122007,8 +129212,8 @@ aje
 aje
 aRv
 xGe
-ccK
-aFU
+ylW
+fAr
 azE
 mgg
 aFz
@@ -122017,24 +129222,24 @@ aFz
 aFz
 mgg
 aFz
-aFz
-aFz
-aFz
-aFz
-aFz
+vte
+giq
+giq
+giq
+giq
 aFz
 hHn
 nID
-aGR
-aFz
-aFz
+urz
+giq
+giq
 aFz
 aFz
 mgg
 aFz
 aFz
 aFz
-aGI
+klF
 dTs
 dTs
 dTs
@@ -122051,7 +129256,7 @@ sCp
 sCp
 sCp
 sCp
-sCp
+qph
 dTs
 dTs
 gGC
@@ -122100,7 +129305,7 @@ aZi
 aZi
 aZi
 bpr
-bnA
+eZO
 bpr
 aZi
 aZi
@@ -122110,10 +129315,10 @@ aZi
 aZi
 aZi
 bpr
-bnA
+eZO
 aSH
 bvz
-bnA
+eZO
 bkP
 dTs
 dTs
@@ -122134,27 +129339,27 @@ dTs
 dTs
 dTs
 bWL
-bTW
+pUg
 bYe
 bYK
 bFF
 aPd
 cko
-cko
+mjg
 cko
 pxT
+mjg
 cko
 cko
-cko
-cUc
+mPg
 cCH
 cto
-cto
+oSG
 cto
 cto
 dkm
 cUc
-aKm
+sYj
 aKm
 aKm
 aKm
@@ -122164,7 +129369,7 @@ cUc
 cCH
 dpI
 cto
-crW
+qSg
 cvw
 aKm
 dTs
@@ -122212,7 +129417,7 @@ dTs
 aas
 any
 app
-app
+aiM
 arq
 aas
 atK
@@ -122242,7 +129447,7 @@ bAw
 bAw
 qTQ
 ccK
-aFU
+qFg
 aFz
 aFz
 aFz
@@ -122252,24 +129457,24 @@ iVH
 aFz
 aFz
 aFz
-aFz
-aFz
+giq
+giq
 vGq
+giq
 aFz
 aFz
 aFz
+vte
+mHl
 aFz
 vte
 aFz
 aFz
 aFz
-aFz
-aFz
-aFz
-aFz
-aFz
-aGI
-ccK
+giq
+giq
+klF
+ylW
 dTs
 dTs
 dTs
@@ -122280,20 +129485,20 @@ dTs
 dTs
 dTs
 gGC
-sCp
+mTb
 sCp
 nWL
 xHP
 gvG
-sCp
+mTb
 dTs
 gGC
 sCp
 sCp
 sCp
-sCp
+xHP
 gvG
-sCp
+xHP
 gGC
 dTs
 dTs
@@ -122381,7 +129586,7 @@ cvn
 cvn
 cvn
 cvx
-cCH
+lCQ
 cto
 cto
 cto
@@ -122389,13 +129594,13 @@ cto
 dkm
 cmU
 cvn
+iPd
 cvn
 cvn
-cvn
-cvn
+iPd
 cvn
 cvx
-cCH
+lCQ
 dpI
 cto
 crW
@@ -122446,12 +129651,12 @@ dTs
 aas
 any
 kRV
-app
+aiM
 arq
 asv
 aus
 wWZ
-axA
+wNl
 aas
 dTs
 dTs
@@ -122472,35 +129677,35 @@ dTs
 dTs
 bAw
 uew
-bAw
+qew
 lLB
 qTQ
 ccK
-aFU
+qFg
 aFz
 aFz
-aFz
+vte
 aFz
 mgg
 aFz
 aFz
 aFz
+vte
 aFz
-aFz
-aFz
-aFz
-aFz
+giq
+giq
+giq
 nLd
-aFz
-aFz
-aFz
-aFz
-aFz
-aFz
-aFz
-aFz
-aFz
-aFz
+mHl
+giq
+giq
+giq
+giq
+giq
+giq
+giq
+giq
+giq
 dTs
 dTs
 dTs
@@ -122513,18 +129718,18 @@ dTs
 dTs
 dTs
 dTs
-sCp
-qmI
+mTb
+voW
 mjy
 sCp
 qmI
 sCp
+mTb
+mTb
+xHP
 sCp
 sCp
-sCp
-sCp
-sCp
-sCp
+xHP
 nWL
 sCp
 dTs
@@ -122556,9 +129761,9 @@ kMb
 bUN
 bDy
 bnA
-aSH
+gpr
 bvz
-bnA
+eZO
 bAZ
 aZi
 aZi
@@ -122579,7 +129784,7 @@ aZi
 aZi
 bAZ
 bnA
-bnA
+eZO
 bnA
 bnA
 dTs
@@ -122602,7 +129807,7 @@ dTs
 dTs
 dTs
 bWL
-bTW
+pUg
 bYe
 caP
 bZN
@@ -122618,7 +129823,7 @@ daT
 coZ
 cto
 cto
-cto
+oSG
 cto
 dkn
 daT
@@ -122630,10 +129835,10 @@ daT
 daT
 daT
 coZ
-dpH
+eIJ
 cET
 crW
-coc
+bWI
 aKm
 nkB
 aUX
@@ -122709,20 +129914,20 @@ wtZ
 bAw
 bAw
 qTQ
-ccK
-aFU
-aFz
+lMc
+qFg
+vte
 njb
 aFz
+vte
 aFz
-aFz
-aFz
-bfh
-beM
+giq
+edk
+rIa
 aFz
 aFz
 aAw
-aFz
+mHl
 aFz
 aFz
 aFz
@@ -122748,7 +129953,7 @@ dTs
 dTs
 vYZ
 sCp
-sGQ
+qSo
 sCp
 sCp
 sCp
@@ -122841,15 +130046,15 @@ deM
 bYM
 caf
 bYM
+sPY
+cSa
+sPY
 cma
 cSa
 cma
-cma
+sPY
 cSa
-cma
-cma
-cSa
-cma
+sPY
 cma
 cSa
 cma
@@ -122860,7 +130065,7 @@ cma
 cSa
 cma
 cma
-cSa
+jPn
 cma
 cSa
 cma
@@ -122918,7 +130123,7 @@ app
 arq
 ata
 avl
-aus
+rfs
 axA
 aas
 dTs
@@ -122944,21 +130149,21 @@ bAw
 bAw
 gff
 dTs
-ccK
-beM
+ylW
+rIa
 aFz
 aFz
 aFz
-aFz
-bfh
+vte
+edk
 dTs
 dTs
 xTz
 beM
 aGv
-aFz
+mHl
 bfh
-beM
+oMP
 aFz
 dTs
 dTs
@@ -122979,20 +130184,20 @@ dTs
 dTs
 dTs
 xmH
-xmH
-sCp
+ndW
+vcE
 sCp
 sCp
 gGC
 gGC
-sCp
+mTb
 sGQ
-sCp
+rPc
 sCp
 dRK
 gGC
 gGC
-xBb
+poo
 sCp
 sCp
 sCp
@@ -123024,7 +130229,7 @@ qdS
 bCp
 bDy
 bnA
-atc
+niZ
 aie
 bnA
 bpr
@@ -123036,7 +130241,7 @@ aZi
 aZi
 aZi
 bpr
-bnA
+eZO
 bpr
 aZi
 aZi
@@ -123079,7 +130284,7 @@ cto
 cnU
 cto
 cto
-cnU
+wvB
 cto
 cto
 cnU
@@ -123103,7 +130308,7 @@ cto
 crW
 coc
 aKm
-ctm
+jNx
 vUI
 tbc
 gvo
@@ -123146,9 +130351,9 @@ dTs
 dTs
 dTs
 aas
-any
+nOn
 app
-app
+aiM
 arq
 asw
 avo
@@ -123179,8 +130384,8 @@ bAw
 omh
 dTs
 dTs
-aFU
-aFz
+fAr
+giq
 aFz
 vte
 aFz
@@ -123189,11 +130394,11 @@ dTs
 dTs
 dTs
 dTs
-xTz
-xTz
-ccK
-ccK
-xTz
+mUq
+mUq
+ylW
+ylW
+mUq
 dTs
 dTs
 dTs
@@ -123211,7 +130416,7 @@ dTs
 dTs
 dTs
 dTs
-sCp
+vcE
 qmI
 xmH
 sCp
@@ -123228,10 +130433,10 @@ sCp
 qmI
 sCp
 max
-sCp
-gvG
-sCp
-sCp
+mTb
+qph
+mTb
+xHP
 sCp
 max
 nWL
@@ -123260,7 +130465,7 @@ bAZ
 bYN
 wqI
 bnA
-bnA
+eZO
 bpr
 aZi
 aZi
@@ -123281,7 +130486,7 @@ aZi
 aZi
 bpr
 aHW
-bqp
+jzJ
 dTs
 dTs
 dTs
@@ -123306,9 +130511,20 @@ dTs
 bXF
 bXK
 bXK
+eFC
 bXK
 bXK
-bXK
+cmb
+fdD
+cmb
+cmb
+cmb
+cmb
+cmb
+cmb
+cmb
+cmb
+fdD
 cmb
 cmb
 cmb
@@ -123320,18 +130536,7 @@ cmb
 cmb
 cmb
 cmb
-cmb
-cmb
-cmb
-cmb
-cmb
-cmb
-cmb
-cmb
-cmb
-cmb
-cmb
-cVA
+kjU
 cpR
 cET
 crW
@@ -123414,19 +130619,19 @@ xGe
 dTs
 dTs
 dTs
-xTz
-beM
-aFz
-bfh
-ccK
+mUq
+rIa
+mHl
+kFL
+ylW
 dTs
 dTs
 dTs
 dTs
 dTs
-ccK
-ccK
-ccK
+ylW
+ylW
+ylW
 dTs
 dTs
 dTs
@@ -123446,7 +130651,7 @@ dTs
 dTs
 tFS
 qmI
-sCp
+xHP
 dTs
 gGC
 sCp
@@ -123459,17 +130664,17 @@ gCS
 rQQ
 gvG
 qmI
-sCp
-sCp
+mTb
+xHP
 sCp
 teR
 sCp
-sCp
+mTb
 nWL
 sCp
-sGQ
+qSo
 sCp
-nTF
+pKP
 dLt
 dKA
 mEu
@@ -123545,22 +130750,22 @@ bTV
 bTV
 cvn
 cvn
+iPd
+jOo
+cvn
+cvn
+iPd
+cvn
+cvn
+cvn
+cvn
 cvn
 jOo
 cvn
 cvn
 cvn
 cvn
-cvn
-cvn
-cvn
-cvn
-jOo
-cvn
-cvn
-cvn
-cvn
-cvn
+iPd
 cvn
 cvn
 cvn
@@ -123569,7 +130774,7 @@ cCH
 cto
 cto
 crW
-coc
+bWI
 aKm
 ctm
 vUI
@@ -123613,7 +130818,7 @@ dTs
 dTs
 xGe
 aaq
-bcH
+aiN
 anA
 apJ
 aqp
@@ -123640,7 +130845,7 @@ dTs
 dTs
 dTs
 bAw
-bAw
+qew
 bAw
 qew
 bGp
@@ -123649,10 +130854,10 @@ dTs
 dTs
 dTs
 dTs
-ccK
+ylW
 xTz
 ccK
-ccK
+ylW
 dTs
 dTs
 dTs
@@ -123683,7 +130888,7 @@ sCp
 dTs
 dTs
 gGC
-sCp
+mTb
 sCp
 sCp
 jBp
@@ -123692,7 +130897,7 @@ rCp
 mth
 fgo
 sCp
-sCp
+mTb
 gGC
 gGC
 sCp
@@ -123702,8 +130907,8 @@ sCp
 xBb
 sCp
 nWL
-gvG
-nTF
+jEA
+pKP
 mQZ
 ptU
 mEu
@@ -123720,7 +130925,7 @@ bkP
 dTs
 bkm
 blt
-bjV
+qAG
 bjV
 bjV
 bjV
@@ -123740,15 +130945,15 @@ bjV
 bkP
 lrR
 bkm
-bkm
+rcs
 dTs
 dTs
 dTs
 bqp
 blt
+qAG
 bjV
-bjV
-brj
+xFs
 dTs
 dTs
 dTs
@@ -123782,11 +130987,11 @@ cko
 cko
 cko
 cko
+mjg
 cko
 cko
 cko
-cko
-cko
+mjg
 cko
 aeC
 cko
@@ -123798,7 +131003,7 @@ cko
 cko
 cko
 cko
-cko
+mjg
 cCH
 abt
 cto
@@ -123868,7 +131073,7 @@ dTs
 dTs
 dTs
 bAw
-bAw
+qew
 dTs
 dTs
 dTs
@@ -123917,7 +131122,7 @@ dTs
 dTs
 gGC
 hAv
-sCp
+mTb
 sCp
 sGQ
 sCp
@@ -123934,10 +131139,10 @@ gGC
 gGC
 gGC
 sCp
-sCp
+xHP
 sGQ
 sCp
-nTF
+pKP
 mQZ
 ptU
 mEu
@@ -123948,7 +131153,7 @@ kMb
 vsQ
 dLQ
 mQZ
-dLZ
+rdV
 bnA
 dTs
 dTs
@@ -123957,7 +131162,7 @@ bqp
 mXh
 bjV
 bkP
-bkm
+rcs
 bqp
 dTs
 dTs
@@ -123970,7 +131175,7 @@ dTs
 dTs
 dTs
 bqp
-bkm
+rcs
 bqp
 dTs
 dTs
@@ -124012,12 +131217,12 @@ dTs
 dTs
 dTs
 cmH
+fSM
 cmH
 cmH
 cmH
 cmH
-cmH
-cmH
+fSM
 cmH
 cmH
 cmH
@@ -124037,7 +131242,7 @@ cCH
 cpR
 cET
 crW
-coc
+bWI
 fCL
 lPn
 sAs
@@ -124088,7 +131293,7 @@ aiN
 bcH
 bQV
 aRx
-axC
+ciN
 dTs
 dTs
 dTs
@@ -124100,7 +131305,7 @@ dTs
 dTs
 dTs
 bAw
-bAw
+qew
 bAw
 bAw
 bAw
@@ -124119,9 +131324,9 @@ dTs
 dTs
 dTs
 bAw
+qew
 bAw
 bAw
-bAw
 dTs
 dTs
 dTs
@@ -124145,7 +131350,7 @@ dTs
 dTs
 dTs
 dTs
-sCp
+xHP
 dTs
 dTs
 dTs
@@ -124187,9 +131392,9 @@ dTs
 dTs
 dTs
 dTs
+jzJ
 bqp
-bqp
-bkm
+rcs
 bqp
 dTs
 dTs
@@ -124315,7 +131520,7 @@ dTs
 dTs
 xGe
 dTs
-bcH
+aiN
 bcH
 apL
 bcH
@@ -124328,7 +131533,7 @@ bAw
 bGp
 bAw
 bAw
-bAw
+qew
 dTs
 dTs
 dTs
@@ -124338,7 +131543,7 @@ bAw
 qew
 bAw
 bAw
-bAw
+qew
 kvS
 bAw
 qew
@@ -124386,15 +131591,15 @@ dTs
 sGQ
 uso
 ays
-sCp
+mTb
 gGC
 gGC
 sCp
 sCp
 hTr
 sCp
-sCp
-sCp
+qph
+poo
 axw
 gGC
 dTs
@@ -124559,7 +131764,7 @@ aRx
 ciN
 bAw
 bGp
-bAw
+qew
 bAw
 eIH
 bAw
@@ -124589,7 +131794,7 @@ bAw
 bAw
 lqs
 kvS
-kvS
+jds
 dTs
 dTs
 dTs
@@ -124620,14 +131825,14 @@ dTs
 gGC
 ekg
 sCp
-sCp
+mTb
 slX
 gGC
 sCp
 sCp
 sGQ
 sCp
-sCp
+mTb
 sCp
 sCp
 gGC
@@ -124736,7 +131941,7 @@ dTs
 dTs
 dTs
 cCH
-cpR
+hKf
 cET
 crY
 daT
@@ -124801,12 +132006,12 @@ bAw
 bAw
 bAw
 bAw
-bAw
+qew
 bAw
 bAw
 bGp
 ppH
-lLB
+oiX
 bAw
 bAw
 bAw
@@ -124820,7 +132025,7 @@ dTs
 dTs
 dTs
 bAw
-bAw
+qew
 bAw
 bAw
 bAw
@@ -124857,13 +132062,13 @@ sCp
 sGQ
 sCp
 sCp
-sCp
+mTb
 xBb
 sCp
 sCp
 xJQ
 sCp
-sCp
+xHP
 sCp
 dTs
 dTs
@@ -124974,7 +132179,7 @@ cto
 cto
 cto
 cnT
-cto
+oSG
 cto
 mES
 dXU
@@ -125033,7 +132238,7 @@ kvS
 bAw
 kvS
 bAw
-bAw
+qew
 kvS
 bAw
 bAw
@@ -125088,18 +132293,18 @@ dTs
 gGC
 gGC
 qmI
-sCp
+xHP
 sCp
 qmI
 mTb
-sCp
+mTb
 sGQ
 sCp
 sCp
 sCp
-jjV
 sCp
 sCp
+kzl
 dTs
 dTs
 dTs
@@ -125203,7 +132408,7 @@ dTs
 dTs
 dTs
 dTs
-cCH
+lCQ
 abt
 cto
 cto
@@ -125290,7 +132495,7 @@ qew
 bAw
 bAw
 bAw
-bAw
+qew
 dTs
 dTs
 dTs
@@ -125317,7 +132522,7 @@ dTs
 dTs
 dTs
 qmI
-sCp
+xHP
 gGC
 axw
 ekp
@@ -125326,14 +132531,14 @@ sCp
 dTs
 dTs
 qmI
-sCp
+xHP
 sCp
 sCp
 sCp
 qmI
 sCp
-sGQ
-gvG
+vcE
+vcE
 gGC
 dTs
 dTs
@@ -125440,9 +132645,9 @@ dTs
 cVC
 cmb
 cmb
+fdD
 cmb
-cmb
-cmb
+fdD
 cmb
 dBh
 aVd
@@ -125490,12 +132695,12 @@ bcH
 bcH
 bcH
 bMD
+cAT
+aRx
+cAT
 aRx
 aRx
-aRx
-aRx
-aRx
-aRx
+cAT
 aRT
 bGp
 bAw
@@ -125738,17 +132943,17 @@ dTs
 dTs
 dTs
 dTs
-eIH
+hfr
 bAw
 bAw
 kvS
 bAw
+qew
 bAw
 bAw
+qew
 bAw
-bAw
-bAw
-bAw
+qew
 bGp
 bAw
 bAw
@@ -125789,7 +132994,7 @@ dTs
 dTs
 dTs
 xmH
-xmH
+ndW
 dTs
 dTs
 axw
@@ -125987,7 +133192,7 @@ ppH
 xIF
 qew
 bAw
-bAw
+qew
 bAw
 bAw
 qew
@@ -126023,17 +133228,17 @@ dTs
 dTs
 sCp
 sCp
-xBb
+oZd
+mTb
 sCp
-sCp
-xBb
+oZd
 gGC
 dTs
 dTs
 dTs
 gGC
 pNG
-jBp
+vcE
 pNG
 gGC
 gGC
@@ -126255,11 +133460,11 @@ xGe
 xGe
 xGe
 wLU
+mbK
+onL
+mbK
 fwv
-onL
-onL
-fwv
-onL
+bZB
 nFh
 wLU
 xGe
@@ -126443,7 +133648,7 @@ dTs
 dTs
 dTs
 bAw
-bAw
+qew
 bAw
 qew
 bAw
@@ -126454,10 +133659,10 @@ bAw
 dTs
 bAw
 bAw
+qew
 bAw
 bAw
-bAw
-bAw
+qew
 bAw
 dTs
 dTs
@@ -126493,7 +133698,7 @@ qLT
 dTs
 gGC
 gGC
-sCp
+mTb
 gGC
 dTs
 dTs


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Preweeds Chigusa, makes some minor balance changes and consistency changes which I'll list here
-To compensate for lack of deep caves, NE xeno territory now comes pre-fortified.
-Replaces stairs with a newer version I made for LV.
-Makes some cosmetic adjustments to NE temple area.
-Moves blue disk generator farther east after complaints from xeno mains about how close together the disks were.
-Makes the SW merchant ship not completely invulnerable.
-Fixes some improperly mounted fire extinguisher cabinets.
-Fixes some improperly rotated shutters.
-Preweeds 90% of Chigusa, with greater density in the eastern side.

## Why It's Good For The Game

Fixes good, people have been bugging me to preweed for a while now and currently we have the pop where Chigusa is relevant enough that it needs adjusted.

## Changelog
:cl:
balance: Chigusa NE caverns now start mazed.
balance: Chigusa is now almost entirely preweeded.
balance: Moved Chigusa blue disk generator to the dam are after complaints of disks being too close.
balance: The docked freighter in Chigusa is now vulnerable to acid and bullets.
fix: Changed a few improperly rotated shutters in Chigusa.
fix: Fixed a couple Chigusa fire cabinets that were hanging out in midair.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
