### PR TITLE
Give Hivemind Transfer Plasma

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
@@ -46,6 +46,12 @@
 /datum/action/xeno_action/activable/psychic_cure/hivemind/should_show()
 	return !(owner.status_flags & INCORPOREAL)
 
+/datum/action/xeno_action/activable/transfer_plasma/hivemind
+	plasma_transfer_amount = PLASMA_TRANSFER_AMOUNT * 3
+
+/datum/action/xeno_action/activable/transfer_plasma/hivemind/should_show()
+	return !(owner.status_flags & INCORPOREAL)
+
 /datum/action/xeno_action/toggle_pheromones/hivemind/should_show()
 	return !(owner.status_flags & INCORPOREAL)
-	
+

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
@@ -47,7 +47,7 @@
 	return !(owner.status_flags & INCORPOREAL)
 
 /datum/action/xeno_action/activable/transfer_plasma/hivemind
-	plasma_transfer_amount = PLASMA_TRANSFER_AMOUNT * 3
+	plasma_transfer_amount = PLASMA_TRANSFER_AMOUNT * 2
 
 /datum/action/xeno_action/activable/transfer_plasma/hivemind/should_show()
 	return !(owner.status_flags & INCORPOREAL)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
@@ -42,6 +42,7 @@
 		/datum/action/xeno_action/activable/command_minions,
 		/datum/action/xeno_action/activable/plant_weeds/ranged,
 		/datum/action/xeno_action/activable/psychic_cure/hivemind,
+		/datum/action/xeno_action/activable/transfer_plasma/drone,
 		/datum/action/xeno_action/toggle_pheromones/hivemind,
 		/datum/action/xeno_action/activable/secrete_resin/ranged/slow,
 	)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
@@ -42,7 +42,7 @@
 		/datum/action/xeno_action/activable/command_minions,
 		/datum/action/xeno_action/activable/plant_weeds/ranged,
 		/datum/action/xeno_action/activable/psychic_cure/hivemind,
-		/datum/action/xeno_action/activable/transfer_plasma/drone,
+		/datum/action/xeno_action/activable/transfer_plasma/hivemind,
 		/datum/action/xeno_action/toggle_pheromones/hivemind,
 		/datum/action/xeno_action/activable/secrete_resin/ranged/slow,
 	)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The hivemind is one of the premiere support roles in the hive. It provides healing, building, and weeding against all odds from marines' superior firepower. It's the drone that keeps on supporting.

Weirdly, even though it can heal, it cannot give plasma to other xenomorphs. This can be an alternative to #9911 , but it depends on the maintainers. I'm giving it the drone plasma transfer since ~~hivelord has a lot more compared to drone, I'm giving hivemind a stronger plasma transfer, between drone and hivelord, just to make it more viable for a drone caste player to go hivemind, and it makes sense that~~ hivemind is drone that saw the weakness of fresh and embrace the resin.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Give Hivemind Transfer Plasma
balance: Provide Hivemind plasma transfer so it can support xenos; it is the same as drone

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
