### PR TITLE
Make mounted gun integrity consistent

### DIFF
--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -61,7 +61,7 @@
 	undeploy_time = 3 SECONDS
 	deployed_item = /obj/machinery/deployable/mounted
 
-	max_integrity = 125
+	max_integrity = 200
 	soft_armor = list("melee" = 0, "bullet" = 50, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 0, "acid" = 0)
 
 ///Unmovable ship mounted version.
@@ -143,7 +143,7 @@
 	undeploy_time = 3 SECONDS
 	deployed_item = /obj/machinery/deployable/mounted
 
-	max_integrity = 150
+	max_integrity = 200
 	soft_armor = list("melee" = 0, "bullet" = 50, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 0, "acid" = 0)
 
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changed MG and TL102 integrity to 200 in line with T27.

Currently the T27 has 200 integrity, while the MG has 150, and the TL102 has 125. Also normal guns have 250, if you put them on a BAS.

It doesn't make sense to me that the guns that are bigger and heavier have less hp then the guns that can actually be fired when not deployed, as currently thy can be destroyed literally in a couple of seconds worth of acid spit, as they have zero acid (and melee) armour.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
consistent integrity, heavy gun doesn't get deleted in 4 shots.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: MG and TL-102 have 200 integrity like the T27
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
