### PR TITLE
Fix TE power cell drain bug

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -363,6 +363,7 @@
 	fire_delay = initial(choice.fire_delay)
 	burst_amount = initial(choice.burst_amount)
 	fire_sound = initial(choice.fire_sound)
+	rounds_per_shot = initial(choice.rounds_per_shot)
 	SEND_SIGNAL(src, COMSIG_GUN_BURST_SHOTS_TO_FIRE_MODIFIED, burst_amount)
 	SEND_SIGNAL(src, COMSIG_GUN_AUTOFIREDELAY_MODIFIED, fire_delay)
 	SEND_SIGNAL(src, COMSIG_GUN_FIRE_MODE_TOGGLE, initial(choice.fire_mode), user.client)
@@ -370,11 +371,8 @@
 	base_gun_icon = initial(choice.icon_state)
 	update_icon()
 	to_chat(user, initial(choice.message_to_user))
-	var/old_drain_amount = rounds_per_shot
-	rounds_per_shot = initial(choice.rounds_per_shot)
-	if(length(chamber_items))
-		adjust_current_rounds(chamber_items[current_chamber_position], old_drain_amount - rounds_per_shot)
 	user?.hud_used.update_ammo_hud(user, src)
+
 	if(!in_chamber || !length(chamber_items))
 		return
 	QDEL_NULL(in_chamber)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If you change from one firemode with a lower charge/shot to a firemode with a higher charge/shot, you lose some charge = to the difference between the two. If you switch back you regain this charge, but it means you will only get 19 overcharge shots on a laser rifle etc if you change firemode with a cell in, and stay in that firemode.

This was added to fix some other funky energy gun bugs which no longer exist, so is now safe to remove.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Losing one shot because you changed firemode with a loaded gun is sad times.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Changing firemode with a loaded energy weapon no longer tweaks the cell charge
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
