### PR TITLE
Updates LV medbay variant 2.

### DIFF
--- a/_maps/modularmaps/lv624/medbaytwo.dmm
+++ b/_maps/modularmaps/lv624/medbaytwo.dmm
@@ -153,7 +153,7 @@
 	},
 /area/lv624/lazarus/medbay)
 "nD" = (
-/obj/machinery/vending/MarineMed,
+/obj/machinery/vending/medical,
 /turf/open/floor/tile/blue/whiteblue,
 /area/lv624/lazarus/medbay)
 "oK" = (
@@ -310,7 +310,7 @@
 /turf/open/floor/tile/blue/whiteblue,
 /area/lv624/lazarus/medbay)
 "zi" = (
-/obj/machinery/vending/MarineMed,
+/obj/machinery/vending/medical,
 /turf/open/floor/tile/blue/whitebluefull,
 /area/lv624/lazarus/medbay)
 "zj" = (


### PR DESCRIPTION
## About The Pull Request

It swaps out the 2 Marine meds in this variant for Nanotransen+ units.

## Why It's Good For The Game

I don't think the shared shipside pill vendor being groundside was intentional, so this update swaps them out with the usual NT+ vendor....And well, there's not much else I can say about that

## Changelog
:cl:
fix: Swapped out the Marine Meds on a certain LV variant for the usual NT+.
/:cl: