### PR TITLE
Makes the shipside NanoTrasenMed and MarineMed have unlimited splints

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -836,7 +836,7 @@
 			/obj/item/stack/medical/heal_pack/ointment = -1,
 			/obj/item/stack/medical/heal_pack/advanced/bruise_pack = 32,
 			/obj/item/stack/medical/heal_pack/advanced/burn_pack = 32,
-			/obj/item/stack/medical/splint = 16,
+			/obj/item/stack/medical/splint = -1,
 		),
 		"Misc" = list(
 			/obj/item/healthanalyzer = 12,

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -241,7 +241,7 @@
 			/obj/item/stack/medical/heal_pack/advanced/burn_pack = 15,
 			/obj/item/stack/medical/heal_pack/ointment = -1,
 			/obj/item/stack/medical/heal_pack/gauze = -1,
-			/obj/item/stack/medical/splint = 15,
+			/obj/item/stack/medical/splint = -1,
 		),
 		"Misc" = list(
 			/obj/item/healthanalyzer = 15,
@@ -297,7 +297,7 @@
 			/obj/item/stack/medical/heal_pack/advanced/burn_pack = 15,
 			/obj/item/stack/medical/heal_pack/ointment = -1,
 			/obj/item/stack/medical/heal_pack/gauze = -1,
-			/obj/item/stack/medical/splint = 15,
+			/obj/item/stack/medical/splint = -1,
 		),
 		"Misc" = list(
 			/obj/item/healthanalyzer = 15,


### PR DESCRIPTION
## About The Pull Request
Self-explanatory title.

## Why It's Good For The Game
They're just splints.

## Changelog
:cl:
balance: The NanoTrasenMed Plus and MarineMed now have unlimited splints.
/:cl: