### PR TITLE
(Tactical) Binoculars can no longer be used while operating deployables

### DIFF
--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -15,7 +15,7 @@
 
 
 /obj/item/binoculars/attack_self(mob/user)
-	if(user.interactee)
+	if(user.interactee && istype(user.interactee, /obj/machinery/deployable))
 		to_chat(user, span_warning("You can't use this right now!"))
 		return
 	zoom(user)

--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -15,6 +15,9 @@
 
 
 /obj/item/binoculars/attack_self(mob/user)
+	if(user.interactee)
+		to_chat(user, span_warning("You can't use this right now!"))
+		return
 	zoom(user)
 
 #define MODE_CAS 0


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Use of these provided a problematic amount of cheese, especially for certain deployables with major damage potential (TAT).
Thanks to people using this enough for me to notice what was going on, it's time to prevent full-nightvision-sniperscope-sadar from existing for much longer.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Binocular - TAT cheese is a very cheesey move which invalidates all weaknesses of the TAT and makes it far more lethal than its intended capability. This removes an unintended deployable-binocular interaction.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Tactical Binoculars can no longer be used to cheese vision of deployable weaponry.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
