### PR TITLE
Xenomorphs can now slash cargo containers

### DIFF
--- a/code/game/objects/structures/cargo_container.dm
+++ b/code/game/objects/structures/cargo_container.dm
@@ -7,6 +7,7 @@
 	bound_height = 64
 	density = TRUE
 	max_integrity = 200
+	resistance_flags = XENO_DAMAGEABLE
 	opacity = TRUE
 	anchored = TRUE
 	throwpass = FALSE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. One line add, lets go.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Marines can melee cargo containers to their heart's content with their bayonet weapons, but xenomorphs must use acid to destroy cargo containers.

As a player, I know that if marines can melee an object to death, xenomorphs should do the same. If marines must shoot the living crap out of it to destroy (say a reinforced wall), then xenomorphs must acid.

Stay tune for more objects for xenomorphs to slash to come.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Xenomorphs can now slash cargo containers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
