### PR TITLE
Reveal ghosts to surviving mobs at round end (excluding EORD and Valhalla)

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -901,6 +901,8 @@
 		return FALSE
 	if(buckled && buckle_flags & BUCKLE_PREVENTS_PULL)
 		return FALSE
+	if(status_flags & INCORPOREAL) //Incorporeal things can't be grabbed.
+		return FALSE
 	return TRUE
 
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -20,6 +20,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	hud_type = /datum/hud/ghost
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	dextrous = TRUE
+	status_flags = GODMODE | INCORPOREAL
 
 	initial_language_holder = /datum/language_holder/universal
 	var/atom/movable/following = null

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -815,7 +815,8 @@
 /mob/proc/update_sight()
 	SEND_SIGNAL(src, COMSIG_MOB_UPDATE_SIGHT)
 	sync_lighting_plane_alpha()
-
+	if(SSticker.current_state == GAME_STATE_FINISHED && !is_centcom_level(z)) //Reveal ghosts to remaining survivors
+		see_invisible = SEE_INVISIBLE_OBSERVER
 
 /mob/proc/sync_lighting_plane_alpha()
 	if(!hud_used)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A *spiritual* port of https://github.com/tgstation/tgstation/pull/51572/ 👻

## Why It's Good For The Game

We can already hear them. Why not see them?

## Changelog
:cl:
qol: Ghosts can now be heard as well as seen after the round ends unless you are alive in EORD or Valhalla.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
