### PR TITLE
Drastically reduces blood loss from missing limbs

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -87,7 +87,7 @@
 		for(var/l in limbs)
 			var/datum/limb/temp = l
 			if(temp.limb_status & LIMB_DESTROYED && !(temp.limb_status & LIMB_AMPUTATED))
-				blood_max += 5 //Yer missing a fucking limb.
+				blood_max += 0.8 //Yer missing a fucking limb.
 				continue
 			if(!(temp.limb_status & LIMB_BLEEDING) || temp.limb_status & LIMB_ROBOT)
 				continue


### PR DESCRIPTION
## About The Pull Request
Per title. Missing limb blood loss has been reduced from 5 > 0.8.

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/59634950/162610195-b4af23c7-d85a-4b71-b8fd-c797947cbaba.png)
This happened in a minute or so. This is very much _**not**_ okay.

## Changelog
:cl: Lewdcifer
balance: Drastically reduced blood loss from missing limbs.
/:cl: