### PR TITLE
Splints work as tourniquets

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -260,7 +260,20 @@
 			return
 
 		if(affecting.limb_status & LIMB_DESTROYED)
-			to_chat(user, span_warning("[user == M ? "You don't" : "[M] doesn't"] have \a [limb]!"))
+			if(affecting.limb_status & LIMB_AMPUTATED)
+				to_chat(user, span_warning("[user == M ? "Your" : "[M]'s"] missing [limb] is already sealed up!"))
+				return
+			to_chat(user, span_notice("You start to apply a makeshift tourniquet to the missing [limb]'s stump..."))
+			if(!do_mob(user, M, SKILL_TASK_TOUGH * (user == M ? 2 : 1), BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
+				return
+			to_chat(user, span_notice("You cut off the bloodflow to the severed [limb]."))
+			affecting.add_limb_flags(LIMB_AMPUTATED) //Below this is so treating a severed arm or hand also catches the other
+			if(affecting.parent && affecting.parent.limb_status & LIMB_DESTROYED)
+				affecting.parent.add_limb_flags(LIMB_AMPUTATED) //It's only one stump, after all
+			for(var/datum/limb/child AS in affecting.children)
+				if(child.limb_status & LIMB_DESTROYED)
+					child.add_limb_flags(LIMB_AMPUTATED)
+			use(1)
 			return
 
 		if(affecting.limb_status & LIMB_SPLINTED)

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -18,9 +18,9 @@
 		//Blood regeneration if there is some space
 		if(blood_volume < BLOOD_VOLUME_NORMAL)
 			blood_volume += 0.1 // regenerate blood VERY slowly
-		
+
 		heart_multi = initial(heart_multi)
-		
+
 		// Damaged heart virtually reduces the blood volume, as the blood isn't
 		// being pumped properly anymore.
 		if(species && species.has_organ["heart"])
@@ -35,7 +35,7 @@
 					blood_volume = max(blood_volume - 1.3, 0)
 				else if(heart.is_bruised())
 					heart_multi *= 0.7
-					blood_volume = max(blood_volume - 0.5, 0)	
+					blood_volume = max(blood_volume - 0.5, 0)
 				else
 					heart_multi *= 0.9
 					blood_volume = max(blood_volume - 0.1, 0) //nulls regeneration
@@ -87,7 +87,7 @@
 		for(var/l in limbs)
 			var/datum/limb/temp = l
 			if(temp.limb_status & LIMB_DESTROYED && !(temp.limb_status & LIMB_AMPUTATED))
-				blood_max += 5 //Yer missing a fucking limb.
+				blood_max += 2.5 //Yer missing a fucking limb.
 				continue
 			if(!(temp.limb_status & LIMB_BLEEDING) || temp.limb_status & LIMB_ROBOT)
 				continue

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -764,7 +764,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(body_part == CHEST)
 		return FALSE
 
-	set_limb_flags(LIMB_DESTROYED)
+	if(amputation)
+		set_limb_flags(LIMB_DESTROYED | LIMB_AMPUTATED)
+	else
+		set_limb_flags(LIMB_DESTROYED)
 
 	for(var/i in implants)
 		var/obj/item/embedded_thing = i


### PR DESCRIPTION
## About The Pull Request
As title. Slap a splint on a missing limb to stop bleeding and pain. Won't expire on their own.
Also reduced the bleeding from missing limbs so that an arm and its hand being gone only bleed as much as a hand alone did before.
Alternative to #9986 
Also fixes a minor bug where if you amputated a limb it wouldn't properly count as amputated.

## Why It's Good For The Game
Field treatment option along with qc, slow to apply and still leaves you missing a limb but prevents the other penalties.
Also, funny as it was for someone to hit 0 blood in 100 seconds, that's a little excessive.

## Changelog
:cl:
add: Use splints on missing limbs to apply a tourniquet, stopping the bleeding and pain
balance: Missing limbs bleed half as much
/:cl: