### PR TITLE
Fix night vision scope offset

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -237,6 +237,8 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	var/mob/dead/observer/ghost = new(src)
 	var/turf/T = get_turf(src)
 
+	animate(client, pixel_x = 0, pixel_y = 0)
+
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
 		ghost.icon = H.stand_icon
@@ -276,7 +278,6 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 /mob/living/ghostize(can_reenter_corpse = TRUE, aghosting = FALSE)
 	if(aghosting)
 		set_afk_status(MOB_AGHOSTED)
-	reset_perspective()
 	. = ..()
 	if(!. || can_reenter_corpse)
 		return

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -278,6 +278,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 /mob/living/ghostize(can_reenter_corpse = TRUE, aghosting = FALSE)
 	if(aghosting)
 		set_afk_status(MOB_AGHOSTED)
+	reset_perspective()
 	. = ..()
 	if(!. || can_reenter_corpse)
 		return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -634,7 +634,8 @@ below 100 is not dizzy
 		return
 
 	update_sight()
-	animate(client, pixel_x = 0, pixel_y = 0)
+	if (stat == DEAD)
+		animate(client, pixel_x = 0, pixel_y = 0)
 	if(client.eye && client.eye != src)
 		var/atom/AT = client.eye
 		AT.get_remote_view_fullscreens(src)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -634,6 +634,8 @@ below 100 is not dizzy
 		return
 
 	update_sight()
+	if (stat == DEAD)
+		animate(client, pixel_x = 0, pixel_y = 0)
 	if(client.eye && client.eye != src)
 		var/atom/AT = client.eye
 		AT.get_remote_view_fullscreens(src)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -634,8 +634,6 @@ below 100 is not dizzy
 		return
 
 	update_sight()
-	if (stat == DEAD)
-		animate(client, pixel_x = 0, pixel_y = 0)
 	if(client.eye && client.eye != src)
 		var/atom/AT = client.eye
 		AT.get_remote_view_fullscreens(src)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes night vision scopes actually offset their vision when you scope in.
#9894 changed reset_perspective which uh, is called more than just when you die. Added a check to see if the mob is kill, before resetting their vision.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nightvision scopes actually working is good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Night vision scopes work properly when activated.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
