### PR TITLE
Change Minerva's Req, CAS armament area, and add Briefing Area

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -79,7 +79,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
 "av" = (
-/obj/structure/closet/firecloset/full,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "aw" = (
@@ -89,16 +89,11 @@
 	},
 /area/mainship/living/port_garden)
 "ax" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/obj/machinery/light,
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "ay" = (
 /turf/open/floor/tile/damaged/five,
@@ -149,7 +144,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/purple{
 	dir = 4
 	},
@@ -171,7 +165,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/ai_node,
 /obj/machinery/light,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
@@ -194,7 +187,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar/droppod)
 "aL" = (
@@ -224,7 +216,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar/droppod)
 "aO" = (
@@ -346,7 +337,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/effect/ai_node,
 /obj/structure/sign/poster,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
@@ -430,7 +420,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
 "bm" = (
@@ -891,7 +880,6 @@
 /area/mainship/hallways/hangar)
 "cK" = (
 /obj/structure/cable,
-/obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
@@ -956,9 +944,7 @@
 	pixel_x = -7;
 	pixel_y = 5
 	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 1
-	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "cX" = (
 /turf/open/floor/mainship/black/corner{
@@ -1431,6 +1417,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/closet/firecloset/full,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "eC" = (
@@ -1452,6 +1439,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment,
 /mob/living/simple_animal/cat/martin,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "eG" = (
@@ -1572,6 +1560,7 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "fc" = (
@@ -1712,7 +1701,6 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "fA" = (
@@ -1762,7 +1750,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "fH" = (
@@ -1772,20 +1759,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/effect/ai_node,
 /obj/structure/cable,
 /obj/structure/sign/poster,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar)
-"fI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "fK" = (
@@ -2091,7 +2066,6 @@
 /area/mainship/hull/starboard_hull)
 "gE" = (
 /obj/structure/cable,
-/obj/effect/ai_node,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -2270,6 +2244,7 @@
 	pixel_x = -4;
 	pixel_y = 6
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
@@ -2439,21 +2414,31 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "hR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar/droppod)
 "hS" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "hT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/ai_node,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "hU" = (
 /obj/item/frame/table,
 /obj/item/frame/table,
@@ -2567,12 +2552,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar)
 "in" = (
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
@@ -2718,11 +2700,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "iH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "iJ" = (
 /obj/structure/cable,
@@ -2733,7 +2723,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "iK" = (
@@ -3005,7 +2994,6 @@
 	dir = 1
 	},
 /obj/effect/decal/warning_stripes/box/small,
-/obj/effect/ai_node,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
@@ -3091,7 +3079,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/ai_node,
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/briefing)
@@ -3499,6 +3486,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/red{
 	dir = 1
 	},
@@ -3772,9 +3760,8 @@
 /area/mainship/shipboard/firing_range)
 "mF" = (
 /obj/effect/ai_node,
-/obj/structure/cable,
-/turf/open/floor/mainship/cargo,
-/area/mainship/shipboard/firing_range)
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "mG" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -3800,7 +3787,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
 "mJ" = (
@@ -4480,18 +4466,8 @@
 /area/mainship/living/briefing)
 "oM" = (
 /obj/effect/ai_node,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "oR" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -4932,6 +4908,7 @@
 /obj/machinery/gear{
 	id = "supply_elevator_gear"
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "qz" = (
@@ -5133,6 +5110,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/living/cryo_cells)
+"rv" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 4
+	},
+/area/mainship/medical/chemistry)
 "rw" = (
 /obj/effect/landmark/start/job/squadleader,
 /obj/effect/landmark/start/job/squadleader,
@@ -5336,7 +5319,6 @@
 /turf/open/floor/mainship/sterile/plain,
 /area/mainship/medical/lower_medical)
 "sf" = (
-/obj/effect/ai_node,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -5910,7 +5892,6 @@
 "ua" = (
 /obj/structure/cable,
 /obj/structure/cable,
-/obj/structure/closet/firecloset/full,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "uc" = (
@@ -5956,13 +5937,19 @@
 	},
 /area/mainship/hallways/starboard_hallway)
 "un" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/ai_node,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "uq" = (
 /obj/machinery/light{
 	dir = 8
@@ -6072,7 +6059,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/structure/disposalpipe/junction,
-/obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
@@ -6230,7 +6216,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "uZ" = (
@@ -6441,6 +6426,7 @@
 /area/mainship/medical/lounge)
 "vG" = (
 /obj/effect/decal/cleanable/blood/oil,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/plain,
 /area/mainship/medical/lower_medical)
 "vH" = (
@@ -7316,7 +7302,6 @@
 	dir = 10
 	},
 /obj/machinery/camera/autoname/mainship,
-/obj/effect/ai_node,
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
@@ -7655,6 +7640,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
 "zl" = (
@@ -9616,6 +9602,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "Fc" = (
@@ -10062,13 +10049,11 @@
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "Gn" = (
-/obj/effect/ai_node,
 /turf/open/floor/mainship/red{
 	dir = 8
 	},
 /area/mainship/living/briefing)
 "Go" = (
-/obj/effect/ai_node,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -10108,7 +10093,6 @@
 /obj/item/ammo_casing/bullet{
 	pixel_x = -2
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "Gu" = (
@@ -10877,7 +10861,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/ai_node,
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
@@ -11079,7 +11062,6 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/red{
 	dir = 8
 	},
@@ -11094,7 +11076,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
@@ -11104,7 +11085,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "JB" = (
@@ -11141,7 +11121,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/junction,
-/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "JG" = (
@@ -11316,6 +11295,10 @@
 	icon_state = "carpetside"
 	},
 /area/mainship/living/bridgebunks)
+"Kd" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/command/cic)
 "Ke" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/closed/wall/mainship,
@@ -11327,6 +11310,7 @@
 /obj/machinery/gear{
 	id = "supply_elevator_gear"
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "Kg" = (
@@ -11362,6 +11346,7 @@
 /obj/machinery/door/airlock/mainship/maint{
 	name = "\improper Core Hatch"
 	},
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/medical/chemistry)
 "Kl" = (
@@ -11372,9 +11357,12 @@
 	},
 /area/mainship/medical/chemistry)
 "Km" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/turf/open/floor/mainship/orange/full,
+/area/mainship/hallways/starboard_hallway)
 "Ko" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	name = "Oxygen Supply Console";
@@ -11638,6 +11626,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/purple/side{
 	dir = 8
 	},
@@ -11716,6 +11705,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "Lp" = (
@@ -12031,15 +12021,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "Mq" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/purple/full,
 /area/mainship/hallways/starboard_hallway)
 "Mr" = (
 /obj/structure/cable,
@@ -12126,6 +12118,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/grunt_rnr)
 "MA" = (
@@ -13712,7 +13705,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "Rz" = (
@@ -14705,6 +14697,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"Uz" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/command/self_destruct)
 "UA" = (
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/mainship/tcomms,
@@ -14910,7 +14906,6 @@
 	on = 1
 	},
 /obj/machinery/light,
-/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "Vd" = (
@@ -14934,7 +14929,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "Vg" = (
-/obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
@@ -14942,6 +14936,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "Vh" = (
@@ -15046,6 +15041,20 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
+"VB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "VC" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -15131,7 +15140,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
 "VQ" = (
@@ -15589,19 +15597,13 @@
 /turf/open/floor/plating,
 /area/mainship/command/self_destruct)
 "Xw" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar)
+/area/mainship/hallways/starboard_hallway)
 "Xx" = (
 /obj/machinery/atmospherics/components/unary/tank/carbon_dioxide{
 	name = "Chemical Tank"
@@ -15666,7 +15668,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/purple{
 	dir = 4
 	},
@@ -16190,16 +16191,9 @@
 /turf/closed/wall/mainship,
 /area/mainship/command/self_destruct)
 "Zw" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/living/briefing)
+/area/mainship/hull/port_hull)
 "Zx" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
@@ -16216,6 +16210,13 @@
 /obj/structure/largecrate/supply/supplies/mre,
 /turf/open/floor/mainship/cargo,
 /area/mainship/command/self_destruct)
+"ZA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/engineering/port_atmos)
 "ZB" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/command/self_destruct)
@@ -16239,7 +16240,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/port_atmos)
 "ZF" = (
@@ -16262,7 +16262,6 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/port_atmos)
 "ZJ" = (
-/obj/effect/ai_node,
 /turf/open/floor/mainship/black{
 	dir = 4
 	},
@@ -16284,7 +16283,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
@@ -21177,11 +21175,11 @@ VS
 VS
 VS
 VS
-aW
+hT
 bv
 NA
 NA
-VC
+av
 bE
 bE
 bE
@@ -21211,15 +21209,15 @@ BR
 BR
 BR
 ty
+Zw
+Ek
+eS
 Ek
 Ek
 eS
 Ek
 Ek
-eS
-Ek
-Ek
-Ek
+Zw
 eS
 Ek
 fx
@@ -21469,8 +21467,8 @@ ez
 AR
 mR
 dS
-VC
-ax
+eC
+CH
 aX
 OS
 bO
@@ -21692,7 +21690,7 @@ qJ
 qJ
 sE
 qM
-uX
+un
 vK
 wB
 xG
@@ -21904,7 +21902,7 @@ GU
 HQ
 Iu
 Jq
-Km
+Jt
 Tv
 Jq
 Mg
@@ -22082,13 +22080,13 @@ oE
 kt
 qM
 rY
-rY
+oM
 rY
 uZ
 vN
 wF
 xK
-vN
+zF
 zF
 AK
 BX
@@ -22307,7 +22305,7 @@ jk
 Qx
 RL
 Tk
-UZ
+Kd
 Wg
 Xv
 Xv
@@ -22351,9 +22349,9 @@ bk
 Ta
 dP
 Pm
-dz
+ax
 ua
-aW
+hT
 OS
 bT
 Ss
@@ -22492,7 +22490,7 @@ Hd
 HQ
 IA
 Jv
-Jv
+rv
 Jv
 Jv
 Mm
@@ -22748,20 +22746,20 @@ VD
 bg
 Bb
 bX
-fI
+Ry
 gn
 bw
 bw
 bw
 bw
+BK
 bw
 bw
 bw
-Al
 vo
 Or
-js
 je
+js
 js
 Fl
 js
@@ -22786,11 +22784,11 @@ Fl
 RK
 Go
 js
-js
-js
-js
-js
 je
+js
+js
+js
+js
 js
 Og
 js
@@ -22846,7 +22844,7 @@ VD
 ID
 Zm
 Jw
-cF
+il
 gV
 dw
 ey
@@ -22895,7 +22893,7 @@ ey
 ey
 ey
 gE
-PC
+Bi
 PC
 Bi
 PC
@@ -22998,8 +22996,8 @@ VC
 VC
 VC
 Zx
-Sr
 ye
+Sr
 ye
 JC
 YH
@@ -23977,8 +23975,8 @@ VC
 VC
 VC
 VC
-Zx
-Sr
+Uz
+ye
 ye
 ye
 JC
@@ -24070,13 +24068,13 @@ eA
 eA
 eA
 eA
-Xw
+iy
+Bi
 PC
 PC
 Bi
-PC
 ye
-Sr
+ye
 Zx
 wK
 tn
@@ -24126,17 +24124,17 @@ bw
 bw
 bw
 bw
-bw
-bw
-bw
 BK
+bw
+bw
+bw
 bw
 bw
 pK
 Bw
 bw
 bw
-BK
+bw
 bw
 bw
 Ow
@@ -24146,7 +24144,7 @@ bw
 bw
 Vg
 bw
-bw
+BK
 bw
 bw
 Ry
@@ -24157,7 +24155,7 @@ BK
 bw
 Wp
 Wp
-BK
+bw
 bw
 bw
 bw
@@ -24218,7 +24216,7 @@ Hr
 bj
 QM
 bO
-aW
+hT
 VC
 dz
 dY
@@ -24339,7 +24337,7 @@ gY
 WS
 WS
 WS
-Mq
+WS
 xS
 xS
 zQ
@@ -24541,7 +24539,7 @@ xS
 zQ
 zQ
 Ot
-Zw
+BG
 NB
 Lp
 bm
@@ -24553,7 +24551,7 @@ pp
 KB
 Lp
 Ot
-il
+zU
 Jo
 NI
 Ox
@@ -24606,7 +24604,7 @@ Am
 Am
 Am
 Am
-SP
+hR
 fu
 Vo
 cj
@@ -24618,8 +24616,8 @@ ea
 ea
 ea
 gt
+mF
 gY
-hR
 gY
 gY
 jA
@@ -24731,10 +24729,10 @@ Fp
 qy
 yA
 yA
-iH
+yA
 xS
 xS
-zQ
+Km
 zQ
 Ot
 Cj
@@ -24955,7 +24953,7 @@ QL
 TA
 Vr
 Wx
-XC
+ZA
 Yy
 ZE
 XC
@@ -25014,7 +25012,7 @@ jC
 jx
 iL
 gY
-oM
+sT
 vV
 qu
 vi
@@ -25096,11 +25094,11 @@ TY
 TY
 TY
 TY
-SP
+hR
 bo
 by
 by
-Io
+iH
 Jo
 SA
 eb
@@ -25221,7 +25219,7 @@ vi
 sV
 vg
 Ld
-iH
+yA
 yA
 yA
 yA
@@ -25322,7 +25320,7 @@ yA
 yA
 Px
 Px
-zR
+Mq
 zR
 Ot
 Cm
@@ -25337,7 +25335,7 @@ aG
 KG
 Ci
 Ot
-zU
+VB
 Jo
 NH
 OH
@@ -25403,7 +25401,7 @@ fl
 fO
 gw
 iG
-hT
+iN
 iN
 mA
 vf
@@ -25413,7 +25411,7 @@ ug
 SA
 SA
 Gq
-hR
+gY
 WS
 WS
 WS
@@ -25488,7 +25486,7 @@ Am
 Am
 Am
 Am
-SP
+hR
 fu
 Vo
 cj
@@ -25521,7 +25519,7 @@ Px
 zR
 zR
 Ot
-Zw
+BG
 NB
 Cn
 kp
@@ -25613,7 +25611,7 @@ gY
 PV
 MI
 yI
-Mq
+WS
 Px
 Px
 zR
@@ -25631,7 +25629,7 @@ JA
 KJ
 Cg
 cj
-il
+zU
 MX
 NH
 OK
@@ -25745,7 +25743,7 @@ ZM
 Wz
 QI
 Ha
-oK
+RH
 XH
 XE
 XE
@@ -25843,7 +25841,7 @@ ZO
 Wz
 Ln
 Ha
-RH
+oK
 XH
 XE
 hr
@@ -25907,14 +25905,14 @@ Bj
 Bp
 Bj
 Bj
-un
+Bj
 wT
 Bj
-zV
+Xw
 zV
 bR
 iJ
-Bj
+Bp
 Bj
 Bj
 Bp
@@ -26290,7 +26288,7 @@ eJ
 ei
 lw
 lz
-mF
+nB
 nB
 mE
 pX
@@ -27983,7 +27981,7 @@ IK
 IK
 IK
 IK
-MA
+IK
 MA
 NO
 Pn

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -2237,10 +2237,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "hc" = (
+/obj/structure/table/mainship,
+/obj/machinery/cell_charger,
+/obj/effect/spawner/random/powercell,
+/obj/effect/spawner/random/powercell,
 /obj/machinery/alarm{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "hd" = (
 /obj/machinery/vending/tool,
@@ -2460,6 +2464,11 @@
 	id = "reqaccess";
 	name = "Requisitions Access"
 	},
+/obj/item/stack/sheet/cardboard,
+/obj/item/stack/sheet/glass/reinforced{
+	amount = 30
+	},
+/obj/item/stack/sheet/wood/large_stack,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "hV" = (
@@ -2488,10 +2497,8 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hull/starboard_hull)
 "hZ" = (
-/obj/vehicle/ridden/motorbike{
-	dir = 4
-	},
-/turf/open/floor/mainship/cargo,
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ia" = (
 /obj/machinery/cryopod/right,
@@ -2730,15 +2737,15 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "iK" = (
-/obj/structure/closet/crate/ammo,
+/obj/structure/closet/crate/weapon,
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "iL" = (
-/obj/machinery/cic_maptable,
+/obj/structure/supply_drop,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "iM" = (
-/obj/machinery/vending/armor_supply,
+/obj/machinery/vending/cargo_supply,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "iN" = (
@@ -2897,7 +2904,7 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "jx" = (
-/obj/machinery/holopad,
+/obj/machinery/cic_maptable,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "jy" = (
@@ -2942,15 +2949,14 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
 "jC" = (
-/obj/structure/table/mainship,
-/obj/machinery/cell_charger,
-/obj/effect/spawner/random/powercell,
-/obj/effect/spawner/random/powercell,
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/holopad,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "jD" = (
-/obj/machinery/vending/cargo_supply,
-/turf/open/floor/mainship/mono,
+/obj/vehicle/ridden/motorbike{
+	dir = 4
+	},
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "jF" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -3241,7 +3247,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cryo_cells)
 "kC" = (
-/obj/machinery/vending/uniform_supply,
+/obj/machinery/vending/weapon,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "kE" = (
@@ -3403,20 +3409,16 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "lo" = (
-/obj/structure/table/mainship,
-/obj/item/stack/sheet/wood/large_stack,
-/obj/item/stack/sheet/glass/reinforced{
-	amount = 30
-	},
-/obj/item/stack/sheet/cardboard,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"lp" = (
-/obj/structure/closet/crate/weapon,
+/obj/structure/closet/crate/ammo,
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
-"lq" = (
+"lp" = (
 /obj/machinery/computer/camera_advanced/overwatch/req,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
+"lq" = (
+/obj/machinery/computer/supplydrop_console,
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "lr" = (
@@ -3723,7 +3725,7 @@
 /turf/closed/wall/mainship,
 /area/mainship/shipboard/starboard_missiles)
 "mr" = (
-/obj/structure/supply_drop,
+/obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ms" = (
@@ -3734,20 +3736,11 @@
 /obj/structure/table/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
-"mu" = (
-/obj/machinery/computer/supplydrop_console,
-/obj/structure/table/mainship,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "my" = (
 /obj/machinery/computer/supplycomp,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"mz" = (
-/obj/machinery/vending/weapon,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "mA" = (
@@ -24729,8 +24722,8 @@ ea
 gt
 gY
 gY
-jC
-lo
+gY
+gY
 sT
 SA
 jF
@@ -24826,9 +24819,9 @@ ea
 ea
 gt
 gY
-gY
+lo
 iK
-lp
+gY
 sT
 yB
 qu
@@ -24926,7 +24919,7 @@ gt
 gY
 hZ
 iM
-jD
+gY
 sT
 vV
 Ip
@@ -25021,10 +25014,10 @@ ea
 ea
 ea
 gt
-gY
+jC
 jx
 iL
-mr
+gY
 oM
 vV
 qu
@@ -25119,10 +25112,10 @@ ea
 ea
 ea
 gt
-gY
-gY
+jD
+lp
 lq
-mu
+gY
 sT
 vV
 Ip
@@ -25218,9 +25211,9 @@ fk
 fB
 gt
 gY
-gY
+mr
 kC
-mz
+gY
 sT
 yB
 qu

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -78,6 +78,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
+"au" = (
+/obj/structure/sign/poster,
+/turf/open/floor/wood,
+/area/mainship/living/pilotbunks)
 "av" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
@@ -3412,6 +3416,18 @@
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
+"ls" = (
+/obj/effect/decal/warning_stripes/thin,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/sign/poster,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/starboard_hull)
 "lu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -7162,6 +7178,12 @@
 	},
 /turf/open/floor/mainship/red/full,
 /area/mainship/hallways/starboard_hallway)
+"xU" = (
+/obj/structure/sign/poster{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/engineering/port_atmos)
 "xW" = (
 /obj/structure/flora/pottedplant/twentyone{
 	icon_state = "plant-12"
@@ -13302,6 +13324,12 @@
 	},
 /turf/open/floor/mainship/ai,
 /area/mainship/command/airoom)
+"Qj" = (
+/obj/structure/sign/poster{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/mainship/living/pilotbunks)
 "Qk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -16299,6 +16327,7 @@
 /area/mainship/living/port_garden)
 "ZS" = (
 /obj/structure/closet/radiation,
+/obj/structure/sign/poster,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
 "ZT" = (
@@ -25242,7 +25271,7 @@ Sb
 TC
 Oy
 Wz
-XG
+xU
 XG
 ZJ
 EU
@@ -26273,13 +26302,13 @@ cs
 dn
 Hn
 ei
-eJ
+au
 wM
 fW
 oa
 he
 wM
-eJ
+Qj
 ei
 lw
 lz
@@ -26293,7 +26322,7 @@ nP
 tc
 AC
 sr
-nP
+tc
 tc
 yJ
 Pl
@@ -26489,7 +26518,7 @@ sr
 ut
 qm
 sr
-nP
+tc
 tc
 yG
 zZ
@@ -26770,7 +26799,7 @@ gH
 WD
 hW
 hW
-jI
+ls
 lO
 lE
 mK

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -5545,8 +5545,8 @@
 /area/mainship/squads/req)
 "sO" = (
 /obj/structure/table/mainship,
-/obj/item/lightreplacer,
 /obj/item/stack/cable_coil/twentyfive,
+/obj/item/lightreplacer,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "sP" = (
@@ -24442,7 +24442,7 @@ jH
 Ir
 Bk
 gY
-gY
+sO
 nz
 oI
 SA
@@ -25616,7 +25616,7 @@ hc
 hU
 iO
 gY
-sO
+gY
 lv
 my
 qw

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -227,6 +227,7 @@
 /turf/open/floor/plating,
 /area/mainship/hull/starboard_hull)
 "aP" = (
+/obj/effect/ai_node,
 /turf/open/floor/mainship/black{
 	dir = 5
 	},
@@ -26001,7 +26002,7 @@ YB
 XE
 XE
 Hr
-ID
+bh
 gB
 aP
 cN

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -24634,7 +24634,7 @@ gY
 jA
 SA
 zS
-zS
+ug
 SA
 SA
 qV
@@ -25418,7 +25418,7 @@ mA
 vf
 SA
 zS
-zS
+ug
 SA
 SA
 Gq

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -1529,7 +1529,6 @@
 "eU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/autodoc,
-/obj/structure/sign/evac,
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "eV" = (

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -2727,6 +2727,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "iK" = (
@@ -11119,6 +11120,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "JB" = (
@@ -11126,7 +11128,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/ai_node,
 /turf/open/floor/mainship/blue{
 	dir = 4
 	},
@@ -11156,6 +11157,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/junction,
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "JG" = (

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -3397,6 +3397,9 @@
 /obj/machinery/door/airlock/multi_tile/mainship/marine/requisitions{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "lo" = (
@@ -6532,6 +6535,9 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/marine/requisitions{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/multi_tile{
 	dir = 1
 	},
 /turf/open/floor/mainship/mono,
@@ -12667,7 +12673,6 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
 	},
-/obj/vehicle/ridden/motorbike,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Om" = (

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -3674,9 +3674,7 @@
 /area/mainship/medical/medical_science)
 "mk" = (
 /obj/effect/ai_node,
-/turf/open/floor/mainship/orange{
-	dir = 8
-	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "ml" = (
 /obj/structure/bed/stool{
@@ -4472,6 +4470,7 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
 "oS" = (
@@ -5961,9 +5960,19 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
 "us" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/general)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/port_hallway)
 "ut" = (
 /obj/machinery/door/airlock/mainship/marine/general/smart,
 /turf/open/floor/mainship/mono,
@@ -8368,14 +8377,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"Bl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "Bm" = (
 /obj/machinery/power/apc/mainship{
 	dir = 8
@@ -11588,12 +11589,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
-"KY" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/red{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "KZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -21215,14 +21210,14 @@ eS
 Ek
 Ek
 eS
-Ek
-Ek
 Zw
+Ek
+Ek
 eS
 Ek
 fx
 hz
-iw
+us
 jk
 Wg
 Rw
@@ -21623,7 +21618,7 @@ UO
 UU
 Xp
 Ym
-Zq
+UU
 xo
 Zq
 UU
@@ -26295,14 +26290,14 @@ pX
 mE
 sr
 nP
-us
+tc
 AC
 sr
 nP
 tc
 yJ
 Pl
-KY
+Pl
 Pe
 Dt
 FN
@@ -26393,7 +26388,7 @@ pZ
 mE
 sr
 sZ
-tc
+mk
 sZ
 sr
 wU
@@ -26792,7 +26787,7 @@ st
 st
 yM
 Af
-Bl
+Cr
 Cr
 DA
 Ex
@@ -27079,7 +27074,7 @@ mE
 mE
 sr
 te
-tc
+mk
 te
 sr
 wU
@@ -27177,14 +27172,14 @@ mE
 mE
 sr
 EQ
-us
+tc
 tc
 sr
 wV
 tc
 yJ
 dI
-mk
+dI
 dI
 DD
 sn

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -8692,10 +8692,6 @@
 	dir = 4
 	},
 /area/mainship/medical/lower_medical)
-"Ce" = (
-/obj/structure/sign/safety/medical,
-/turf/closed/wall/mainship/white,
-/area/mainship/medical/lower_medical)
 "Cf" = (
 /turf/open/floor/plating{
 	icon_state = "warnplatecorner"
@@ -22596,7 +22592,7 @@ kt
 kt
 zO
 AS
-Ce
+kt
 kt
 kt
 Fg

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -7856,10 +7856,6 @@
 	},
 /turf/open/floor/mainship/purple/full,
 /area/mainship/hallways/starboard_hallway)
-"zS" = (
-/obj/structure/window/framed/mainship/requisitions,
-/turf/open/space/basic,
-/area/mainship/squads/req)
 "zU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -24628,7 +24624,7 @@ gY
 gY
 jA
 SA
-zS
+ug
 ug
 SA
 SA
@@ -25412,7 +25408,7 @@ iN
 mA
 vf
 SA
-zS
+ug
 ug
 SA
 SA

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -1,15 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/thick{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thick{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/tile/damaged/panel,
 /area/mainship/hallways/hangar)
 "ab" = (
 /obj/structure/droppod,
@@ -31,14 +22,18 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar/droppod)
 "af" = (
-/obj/effect/decal/warning_stripes/thick/corner,
-/obj/effect/decal/warning_stripes/thick/corner{
-	dir = 1
+/obj/structure/rack,
+/obj/item/tool/screwdriver,
+/obj/item/tool/crowbar/red,
+/obj/effect/decal/warning_stripes/thick{
+	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "ag" = (
-/obj/effect/decal/warning_stripes/thick/corner,
+/obj/effect/decal/warning_stripes/thick/corner{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "ah" = (
@@ -49,43 +44,34 @@
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar/droppod)
-"ai" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
-/area/mainship/hallways/hangar)
 "aj" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "an" = (
-/obj/structure/rack,
-/obj/item/tool/wrench,
-/obj/item/tool/extinguisher/mini,
-/obj/effect/decal/warning_stripes/thick{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thick{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/warning_stripes/thick/corner,
+/obj/item/ammo_casing/bullet{
+	pixel_x = -7;
+	pixel_y = 5
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "ao" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/thick/corner,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "ap" = (
 /obj/machinery/light,
 /turf/open/floor/mainship_hull,
 /area/mainship/powered)
 "aq" = (
-/turf/open/floor/tile/damaged/panel,
+/obj/structure/rack,
+/obj/item/tool/wrench,
+/obj/item/tool/extinguisher/mini,
+/obj/effect/decal/warning_stripes/thick{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "at" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
@@ -118,14 +104,13 @@
 /turf/open/floor/tile/damaged/five,
 /area/mainship/hallways/hangar)
 "az" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/effect/decal/cleanable/blood/oil{
+	name = "grease";
+	pixel_x = -7
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
 	},
-/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "aA" = (
 /obj/structure/cable,
@@ -154,6 +139,12 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"aF" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "aG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -257,9 +248,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
 "aR" = (
-/obj/effect/decal/cleanable/blood/oil{
-	name = "grease";
-	pixel_x = -10
+/obj/item/ammo_casing/bullet{
+	pixel_x = -6;
+	pixel_y = 6
 	},
 /turf/open/floor/mainship/blue{
 	dir = 8
@@ -425,6 +416,9 @@
 /obj/effect/decal/warning_stripes/thick{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "bl" = (
@@ -441,7 +435,7 @@
 /area/mainship/hallways/hangar/droppod)
 "bm" = (
 /turf/open/floor/mainship/red{
-	dir = 4
+	dir = 5
 	},
 /area/mainship/living/briefing)
 "bn" = (
@@ -639,6 +633,15 @@
 	dir = 1
 	},
 /area/mainship/hallways/hangar)
+"bR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "bT" = (
 /obj/machinery/dropship_part_fabricator,
 /turf/open/floor/mainship/cargo,
@@ -762,11 +765,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/port_garden)
 "ct" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/decal/cleanable/blood/oil{
+	name = "grease";
+	pixel_x = -2;
+	pixel_y = -6
 	},
-/obj/structure/closet/firecloset,
-/obj/item/clothing/mask/gas,
+/obj/structure/dropship_equipment/weapon/minirocket_pod,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "cu" = (
@@ -844,12 +848,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "cG" = (
-/obj/item/ammo_casing/bullet{
-	pixel_x = -4;
-	pixel_y = -5
-	},
+/obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/blue{
-	dir = 4
+	dir = 5
 	},
 /area/mainship/living/briefing)
 "cH" = (
@@ -951,11 +952,14 @@
 	},
 /area/mainship/command/corporateliaison)
 "cW" = (
-/obj/machinery/light{
+/obj/item/ammo_casing/bullet{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/turf/open/floor/mainship/cargo/arrow{
 	dir = 1
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/squads/req)
+/area/mainship/hallways/hangar)
 "cX" = (
 /turf/open/floor/mainship/black/corner{
 	dir = 4
@@ -1085,6 +1089,9 @@
 /obj/effect/decal/warning_stripes/thick/corner{
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "dw" = (
@@ -1097,9 +1104,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "dx" = (
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "dz" = (
 /obj/machinery/light{
@@ -1163,13 +1169,8 @@
 	},
 /area/mainship/squads/general)
 "dJ" = (
-/obj/item/ammo_casing/bullet{
-	pixel_x = 5;
-	pixel_y = -10
-	},
-/obj/item/ammo_casing/bullet{
-	pixel_x = -7;
-	pixel_y = 5
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
@@ -1182,15 +1183,6 @@
 /obj/structure/bed/chair/sofa/left,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
-"dM" = (
-/obj/effect/decal/cleanable/blood/oil{
-	name = "grease";
-	pixel_x = -7
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
-/area/mainship/hallways/hangar)
 "dO" = (
 /obj/docking_port/stationary/marine_dropship/minidropship,
 /turf/open/floor/plating,
@@ -1228,13 +1220,6 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "dS" = (
-/obj/effect/decal/cleanable/blood/oil{
-	name = "grease";
-	pixel_x = -10
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"dT" = (
 /obj/structure/dropship_equipment/weapon/heavygun,
 /obj/effect/decal/cleanable/blood/oil{
 	name = "grease";
@@ -1262,19 +1247,24 @@
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"dT" = (
+/obj/effect/decal/cleanable/blood/oil{
+	name = "grease";
+	pixel_x = -2;
+	pixel_y = -6
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "dU" = (
 /turf/open/floor/mainship/black/corner{
 	dir = 8
 	},
 /area/mainship/hallways/starboard_hallway)
 "dV" = (
-/obj/structure/dropship_equipment/weapon/rocket_pod,
-/obj/effect/decal/cleanable/blood/oil{
-	name = "grease";
-	pixel_x = -2;
-	pixel_y = -6
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
 	},
-/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "dX" = (
 /obj/structure/dropship_equipment/weapon/minirocket_pod,
@@ -1287,12 +1277,8 @@
 	},
 /area/mainship/hallways/hangar)
 "dZ" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "supply_elevator_railing"
-	},
 /turf/open/floor/mainship/cargo/arrow{
-	dir = 1
+	dir = 4
 	},
 /area/mainship/squads/req)
 "ea" = (
@@ -1313,6 +1299,7 @@
 /obj/item/paper,
 /obj/item/tool/pen,
 /obj/structure/paper_bin,
+/obj/item/tool/stamp/qm,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ef" = (
@@ -1441,6 +1428,9 @@
 	pixel_x = -9;
 	pixel_y = 4
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "eC" = (
@@ -1539,6 +1529,7 @@
 "eU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/autodoc,
+/obj/structure/sign/evac,
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "eV" = (
@@ -1576,10 +1567,6 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
-"fa" = (
-/obj/machinery/vending/cargo_supply,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "fb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1831,9 +1818,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "fP" = (
-/obj/effect/decal/cleanable/blood/oil{
-	name = "grease";
-	pixel_x = -7
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 1;
+	on = 1
+	},
+/obj/item/ammo_casing/bullet{
+	pixel_x = 10;
+	pixel_y = 4
 	},
 /turf/open/floor/mainship/orange{
 	dir = 8
@@ -1861,9 +1852,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "fT" = (
-/obj/effect/decal/cleanable/blood/oil{
-	name = "grease";
-	pixel_x = 8
+/obj/item/ammo_casing/bullet{
+	pixel_x = -3;
+	pixel_y = 7
 	},
 /turf/open/floor/mainship/red{
 	dir = 4
@@ -2234,10 +2225,8 @@
 	},
 /area/mainship/hallways/hangar)
 "gX" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
+/obj/vehicle/ridden/powerloader,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "gY" = (
 /turf/open/floor/mainship/mono,
@@ -2275,8 +2264,8 @@
 "hg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/item/ammo_casing/bullet{
-	pixel_x = 4;
-	pixel_y = 8
+	pixel_x = -4;
+	pixel_y = 6
 	},
 /turf/open/floor/mainship/orange{
 	dir = 8
@@ -2337,6 +2326,14 @@
 "ht" = (
 /turf/open/floor/plating,
 /area/mainship/living/evacuation)
+"hu" = (
+/obj/effect/decal/cleanable/blood/oil{
+	name = "grease";
+	pixel_x = -2;
+	pixel_y = -6
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "hv" = (
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/mono,
@@ -2377,17 +2374,6 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/port_hallway)
-"hE" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
 "hF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
@@ -2450,7 +2436,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "hR" = (
-/obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
@@ -2462,15 +2447,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "hU" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
+/obj/item/frame/table,
+/obj/item/frame/table,
+/obj/item/frame/table,
+/obj/structure/rack,
+/obj/machinery/door_control{
+	dir = 8;
+	id = "reqaccess";
+	name = "Requisitions Access"
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "hV" = (
 /obj/structure/table/gamblingtable,
@@ -2498,15 +2489,11 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hull/starboard_hull)
 "hZ" = (
-/obj/effect/decal/cleanable/blood/oil{
-	name = "grease";
-	pixel_x = -5;
-	pixel_y = -6
+/obj/vehicle/ridden/motorbike{
+	dir = 4
 	},
-/turf/open/floor/mainship/purple{
-	dir = 8
-	},
-/area/mainship/living/briefing)
+/turf/open/floor/mainship/cargo,
+/area/mainship/squads/req)
 "ia" = (
 /obj/machinery/cryopod/right,
 /obj/machinery/light{
@@ -2566,6 +2553,20 @@
 	dir = 5
 	},
 /area/space)
+"il" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "in" = (
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
@@ -2714,50 +2715,31 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "iH" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
+/obj/effect/ai_node,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/starboard_hallway)
+"iJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/mainship/cargo/arrow,
-/area/mainship/squads/req)
-"iI" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/briefing)
-"iK" = (
-/obj/item/frame/table,
-/obj/item/frame/table,
-/obj/item/frame/table,
-/obj/structure/rack,
-/obj/machinery/door_control{
-	dir = 8;
-	id = "reqaccess";
-	name = "Requisitions Access"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
+"iK" = (
+/obj/structure/closet/crate/ammo,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "iL" = (
-/obj/structure/rack,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/adv,
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/cic_maptable,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "iM" = (
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/tool/extinguisher,
-/obj/item/tool/extinguisher/mini,
-/obj/structure/rack,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/lightreplacer,
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "iN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -2767,10 +2749,18 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "iO" = (
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/tool/extinguisher,
+/obj/item/tool/extinguisher/mini,
+/obj/structure/rack,
+/obj/item/flashlight,
+/obj/item/flashlight,
+/obj/item/lightreplacer,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "iP" = (
 /obj/structure/table,
@@ -2813,6 +2803,15 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
+"jd" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/mainship/living/briefing)
 "je" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -2898,7 +2897,7 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "jx" = (
-/obj/structure/closet/crate,
+/obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "jy" = (
@@ -2911,10 +2910,25 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "jA" = (
+/obj/effect/ai_node,
 /obj/structure/cable,
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -2928,27 +2942,28 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
 "jC" = (
+/obj/structure/table/mainship,
+/obj/machinery/cell_charger,
+/obj/effect/spawner/random/powercell,
+/obj/effect/spawner/random/powercell,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/squads/req)
+"jD" = (
+/obj/machinery/vending/cargo_supply,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
+"jF" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
 /obj/machinery/door_control/mainship/req{
 	id = "qm_warehouse";
 	name = "Requisition Warehouse Shutters"
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/squads/req)
-"jD" = (
-/obj/vehicle/ridden/motorbike{
-	dir = 4
-	},
-/turf/open/floor/mainship/cargo,
-/area/mainship/squads/req)
-"jF" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "jG" = (
 /obj/effect/decal/warning_stripes/thin,
@@ -2979,10 +2994,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
 "jK" = (
-/obj/effect/decal/cleanable/blood/oil{
-	name = "grease";
-	pixel_x = 8
+/obj/effect/decal/warning_stripes/engineer,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
 	},
+/obj/effect/decal/warning_stripes/box/small,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
@@ -3004,6 +3021,11 @@
 "jM" = (
 /turf/open/floor/mainship/black{
 	dir = 8
+	},
+/area/mainship/hallways/starboard_hallway)
+"jO" = (
+/turf/open/floor/mainship/terragov/north{
+	dir = 6
 	},
 /area/mainship/hallways/starboard_hallway)
 "jP" = (
@@ -3055,6 +3077,18 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
+"jT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/obj/docking_port/stationary/marine_dropship/crash_target,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/living/briefing)
 "jV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3147,7 +3181,7 @@
 /area/mainship/hallways/port_hallway)
 "kp" = (
 /turf/open/floor/mainship/blue{
-	dir = 8
+	dir = 9
 	},
 /area/mainship/living/briefing)
 "kq" = (
@@ -3171,12 +3205,6 @@
 /obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"kv" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "kx" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 2
@@ -3213,14 +3241,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cryo_cells)
 "kC" = (
-/obj/item/ammo_casing/bullet{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/mainship/blue{
-	dir = 4
-	},
-/area/mainship/living/briefing)
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "kE" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/shipboard/starboard_missiles)
@@ -3371,57 +3394,32 @@
 	},
 /area/mainship/medical/lower_medical)
 "lm" = (
-/obj/machinery/door/airlock/mainship/marine/requisitions,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/door/airlock/multi_tile/mainship/marine/requisitions{
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "lo" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/structure/table/mainship,
+/obj/item/stack/sheet/wood/large_stack,
+/obj/item/stack/sheet/glass/reinforced{
+	amount = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/item/stack/sheet/cardboard,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "lp" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/obj/structure/closet/crate/weapon,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "lq" = (
-/obj/machinery/autolathe,
+/obj/machinery/computer/camera_advanced/overwatch/req,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "lr" = (
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
-"ls" = (
-/obj/machinery/vending/weapon,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"lt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "lu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -3435,9 +3433,16 @@
 /turf/open/floor/mainship/black,
 /area/mainship/engineering/port_atmos)
 "lv" = (
-/obj/structure/table/mainship,
-/obj/item/lightreplacer,
-/obj/item/stack/cable_coil/twentyfive,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "lw" = (
@@ -3715,8 +3720,8 @@
 /turf/closed/wall/mainship,
 /area/mainship/shipboard/starboard_missiles)
 "mr" = (
-/obj/vehicle/ridden/powerloader,
-/turf/open/floor/mainship/cargo,
+/obj/structure/supply_drop,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ms" = (
 /obj/machinery/computer/camera_advanced/overwatch/bravo{
@@ -3727,87 +3732,32 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "mu" = (
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
-/area/mainship/squads/req)
-"mv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"mw" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/effect/ai_node,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/light{
-	light_color = "#da2f1b"
-	},
+/obj/machinery/computer/supplydrop_console,
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "my" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/computer/supplycomp,
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "mz" = (
-/obj/machinery/door/airlock/mainship/marine/requisitions,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/vending/weapon,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "mA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/squads/req)
 "mB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/obj/structure/disposalpipe/segment/corner,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "mC" = (
@@ -3942,10 +3892,6 @@
 	},
 /turf/open/floor/mainship_hull,
 /area/space)
-"mW" = (
-/obj/machinery/roomba,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/briefing)
 "mY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -4077,11 +4023,10 @@
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
 "nz" = (
-/obj/structure/table/mainship,
-/obj/machinery/cell_charger,
-/obj/effect/spawner/random/powercell,
-/obj/effect/spawner/random/powercell,
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "nB" = (
 /obj/structure/cable,
@@ -4145,9 +4090,9 @@
 /turf/open/floor/mainship/red,
 /area/mainship/shipboard/firing_range)
 "nJ" = (
-/obj/structure/dropship_equipment/weapon/rocket_pod,
+/obj/structure/disposalpipe/segment/corner,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/area/mainship/squads/req)
 "nK" = (
 /obj/effect/landmark/start/job/squadcorpsman,
 /turf/open/floor/mainship/cargo/arrow{
@@ -4239,6 +4184,7 @@
 /area/mainship/shipboard/starboard_missiles)
 "nX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/purple{
 	dir = 4
 	},
@@ -4311,14 +4257,6 @@
 	dir = 8
 	},
 /area/mainship/medical/medical_science)
-"oi" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
-	},
-/obj/machinery/computer/ordercomp,
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
 "oj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -4400,10 +4338,6 @@
 	},
 /area/mainship/medical/medical_science)
 "ou" = (
-/obj/item/ammo_casing/bullet{
-	pixel_x = -6;
-	pixel_y = 6
-	},
 /turf/open/floor/mainship/blue{
 	dir = 8
 	},
@@ -4529,12 +4463,8 @@
 /turf/open/floor/mainship/sterile/plain,
 /area/mainship/medical/lower_medical)
 "oI" = (
-/obj/structure/table/mainship,
-/obj/item/stack/sheet/wood/large_stack,
-/obj/item/stack/sheet/glass/reinforced{
-	amount = 30
-	},
-/obj/item/stack/sheet/cardboard,
+/obj/machinery/autolathe,
+/obj/structure/sign/poster,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "oK" = (
@@ -4549,14 +4479,21 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/port_atmos)
 "oL" = (
-/obj/machinery/vending/MarineMed,
+/obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "oM" = (
+/obj/effect/ai_node,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "oR" = (
@@ -4684,6 +4621,10 @@
 "ps" = (
 /turf/closed/wall/mainship/research/containment/wall/purple,
 /area/mainship/medical/medical_science)
+"pt" = (
+/obj/machinery/vending/weapon,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "pu" = (
 /obj/structure/table/mainship,
 /obj/structure/paper_bin,
@@ -4795,23 +4736,17 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
-"pJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/computer/camera_advanced/overwatch/req,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "pK" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/squads/req)
+/area/mainship/hallways/hangar)
 "pM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4826,14 +4761,15 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "pN" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 6
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "pO" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -4845,11 +4781,8 @@
 /turf/open/floor/plating,
 /area/mainship/command/self_destruct)
 "pT" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/floor,
+/obj/docking_port/stationary/supply,
+/turf/open/floor/mainship/empty,
 /area/mainship/squads/req)
 "pV" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
@@ -4971,17 +4904,11 @@
 /turf/open/floor/mainship_hull,
 /area/space)
 "qu" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/door/poddoor/railing{
+	dir = 2;
+	id = "supply_elevator_railing"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/light{
-	light_color = "#da2f1b"
-	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "qv" = (
 /obj/structure/cable,
@@ -4991,8 +4918,9 @@
 	},
 /area/mainship/living/bridgebunks)
 "qw" = (
-/obj/machinery/power/apc/mainship,
-/turf/closed/wall/mainship,
+/obj/structure/table/mainship,
+/obj/machinery/door_control/old/req,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "qx" = (
 /obj/structure/closet/firecloset,
@@ -5002,11 +4930,13 @@
 	},
 /area/mainship/living/evacuation)
 "qy" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "qm_warehouse";
-	name = "\improper Warehouse Shutters"
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
 	},
-/turf/open/floor/mainship/mono,
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "qz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
@@ -5116,13 +5046,6 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
-"qT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/cic_maptable,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "qU" = (
 /obj/machinery/alarm{
 	dir = 8
@@ -5132,10 +5055,8 @@
 	},
 /area/mainship/engineering/port_atmos)
 "qV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
+/obj/vehicle/ridden/motorbike,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "qY" = (
 /obj/machinery/light/small{
@@ -5144,8 +5065,14 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
 "rg" = (
-/obj/vehicle/ridden/motorbike,
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "rk" = (
 /obj/structure/table/mainship,
@@ -5204,12 +5131,6 @@
 /obj/effect/landmark/start/job/squadsmartgunner,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cryo_cells)
-"rt" = (
-/obj/structure/sign/poster{
-	dir = 8
-	},
-/turf/closed/wall/mainship,
-/area/mainship/squads/req)
 "ru" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -5401,6 +5322,10 @@
 	dir = 4
 	},
 /area/mainship/medical/lower_medical)
+"sb" = (
+/obj/machinery/vending/MarineMed,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "sc" = (
 /obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile/purple/side{
@@ -5457,6 +5382,11 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
+"sk" = (
+/turf/open/floor/mainship/terragov/north{
+	dir = 10
+	},
+/area/mainship/hallways/starboard_hallway)
 "sl" = (
 /obj/machinery/door/poddoor/mainship/ammo,
 /turf/open/floor/mainship/mono,
@@ -5575,70 +5505,70 @@
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"sK" = (
+/obj/machinery/vending/tool,
+/turf/open/floor/mainship/purple{
+	dir = 9
+	},
+/area/mainship/living/briefing)
 "sL" = (
+/obj/machinery/door_control/mainship/req{
+	dir = 1;
+	id = "qm_warehouse";
+	name = "Requisition Warehouse Shutters"
+	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"sM" = (
-/obj/machinery/door/airlock/mainship/marine/requisitions,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"sN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+"sM" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/structure/disposalpipe/junction,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "sO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/effect/ai_node,
-/obj/structure/cable,
+/obj/structure/table/mainship,
+/obj/item/lightreplacer,
+/obj/item/stack/cable_coil/twentyfive,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "sP" = (
 /obj/machinery/door/poddoor/railing{
+	dir = 1;
 	id = "supply_elevator_railing"
 	},
-/obj/machinery/floodlight/landing{
-	name = "ASRS Light"
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
+/turf/open/floor/mainship/cargo/arrow,
 /area/mainship/squads/req)
 "sQ" = (
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
 "sT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/closet/crate/ammo,
-/turf/open/floor/mainship/cargo,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "sU" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -5659,8 +5589,11 @@
 	},
 /area/mainship/hallways/hangar)
 "sV" = (
-/obj/docking_port/stationary/supply,
-/turf/open/floor/mainship/empty,
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "sX" = (
 /obj/machinery/marine_selector/clothes/smartgun,
@@ -5774,11 +5707,27 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/port_hallway)
 "ts" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/secure/req{
+	dir = 1
 	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/door/window{
+	dir = 2
+	},
+/obj/item/tool/hand_labeler,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"tt" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/mainship/red{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "tu" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/gas,
@@ -5807,10 +5756,6 @@
 "ty" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/lounge)
-"tz" = (
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/squads/req)
 "tA" = (
 /obj/structure/table/mainship,
 /obj/machinery/chem_dispenser/soda,
@@ -5852,15 +5797,12 @@
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lounge)
 "tI" = (
-/obj/effect/decal/warning_stripes/engineer,
-/obj/effect/decal/warning_stripes/box/small{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/box/small,
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
-/area/mainship/living/briefing)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "tJ" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/job/squadcorpsman,
@@ -5975,18 +5917,33 @@
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"uc" = (
+/turf/open/floor/mainship/terragov{
+	dir = 1
+	},
+/area/mainship/hallways/starboard_hallway)
 "ue" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/mainship,
-/area/mainship/squads/req)
-"uf" = (
-/obj/structure/window/framed/mainship/requisitions,
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id = "qm_warehouse";
-	name = "\improper Warehouse Shutters"
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
 /turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
+"uf" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "ug" = (
 /obj/structure/window/framed/mainship/requisitions,
@@ -6348,18 +6305,22 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "vf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/ai_node,
+/obj/machinery/light,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/junction,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "vg" = (
-/obj/machinery/door/poddoor/railing{
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
+/obj/structure/bed/chair/comfy/black,
+/turf/open/floor/mainship/silver/full,
+/area/mainship/hallways/starboard_hallway)
 "vi" = (
 /turf/open/floor/mainship/empty,
 /area/mainship/squads/req)
@@ -6560,58 +6521,66 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "vS" = (
-/obj/machinery/camera/autoname/mainship{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/bed/chair/office/dark,
-/obj/machinery/door_control{
-	dir = 4;
-	id = "reqaccess2";
-	name = "Requisitions Access"
-	},
-/obj/effect/landmark/start/job/shiptech,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"vT" = (
-/obj/structure/table/mainship,
-/obj/machinery/door_control/old/req,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"vU" = (
-/obj/structure/table/mainship,
-/obj/item/whistle,
-/obj/machinery/light,
-/obj/item/tool/stamp/qm,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"vV" = (
-/obj/machinery/computer/supplydrop_console,
-/obj/structure/table/mainship,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"vW" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 5
-	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
-"vY" = (
 /obj/structure/cable,
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/multi_tile/mainship/marine/requisitions{
 	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"wb" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
+"vT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
+/area/mainship/hallways/starboard_hallway)
+"vU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment/corner,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
+"vV" = (
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id = "qm_warehouse";
+	name = "\improper Warehouse Shutters"
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"vY" = (
+/obj/structure/window/framed/mainship/requisitions,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
+"wb" = (
+/obj/machinery/holopad,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/starboard_hallway)
 "wd" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/purple/side{
@@ -6839,38 +6808,26 @@
 /obj/structure/ship_ammo/heavygun,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
-"wJ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/secure/req{
-	dir = 1
-	},
-/obj/machinery/door/window{
-	dir = 2
-	},
-/obj/item/tool/hand_labeler,
-/obj/machinery/door/poddoor/shutters/mainship/req/ro{
-	dir = 2
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "wK" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
-"wL" = (
-/obj/structure/window/framed/mainship/requisitions,
-/obj/machinery/door/poddoor/shutters/mainship/req/ro{
-	dir = 2
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "wM" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/pilotbunks)
 "wQ" = (
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "supply_elevator_railing"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
 /area/mainship/squads/req)
 "wT" = (
 /obj/structure/cable,
@@ -6943,6 +6900,11 @@
 	dir = 1
 	},
 /area/mainship/living/evacuation)
+"xb" = (
+/obj/structure/table/reinforced,
+/obj/item/facepaint/green,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "xc" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
@@ -7200,23 +7162,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
-"xR" = (
-/obj/machinery/line_nexter{
-	dir = 2
-	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "xS" = (
-/obj/structure/barricade/metal,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"xT" = (
-/obj/structure/supply_drop,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor/mainship/red/full,
+/area/mainship/hallways/starboard_hallway)
 "xW" = (
 /obj/structure/flora/pottedplant/twentyone{
 	icon_state = "plant-12"
@@ -7377,8 +7328,9 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lounge)
 "yr" = (
-/obj/item/ammo_casing/bullet{
-	pixel_x = -3
+/obj/effect/decal/cleanable/blood/oil{
+	name = "grease";
+	pixel_x = -10
 	},
 /turf/open/floor/mainship/blue{
 	dir = 8
@@ -7445,36 +7397,23 @@
 	},
 /area/mainship/medical/lower_medical)
 "yA" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/computer/ordercomp,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/starboard_hallway)
 "yB" = (
-/obj/structure/closet/crate/weapon,
-/turf/open/floor/mainship/cargo,
+/obj/structure/window/framed/mainship/requisitions,
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id = "qm_warehouse";
+	name = "\improper Warehouse Shutters"
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "yD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/ammo_casing/bullet{
-	pixel_x = -6;
-	pixel_y = 4
-	},
 /turf/open/floor/mainship/purple{
-	dir = 4
+	dir = 5
 	},
 /area/mainship/living/briefing)
-"yE" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/effect/ai_node,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
 "yF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -7497,12 +7436,11 @@
 /turf/open/floor/carpet,
 /area/mainship/living/bridgebunks)
 "yI" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 8;
-	id = "supply_elevator_railing"
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "yJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -7835,11 +7773,12 @@
 	},
 /area/mainship/medical/lower_medical)
 "zD" = (
-/obj/item/ammo_casing/bullet{
-	pixel_x = 5;
-	pixel_y = -8
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/red{
+	dir = 1
+	},
 /area/mainship/living/briefing)
 "zE" = (
 /obj/machinery/body_scanconsole,
@@ -7872,9 +7811,6 @@
 	},
 /area/mainship/medical/lower_medical)
 "zI" = (
-/obj/item/ammo_casing/bullet{
-	pixel_x = -7
-	},
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
@@ -7910,31 +7846,20 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "zQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+/obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/orange/full,
 /area/mainship/hallways/starboard_hallway)
 "zR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/purple/full,
 /area/mainship/hallways/starboard_hallway)
 "zS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
+/obj/structure/window/framed/mainship/requisitions,
+/turf/open/space/basic,
 /area/mainship/squads/req)
 "zU" = (
 /obj/structure/cable,
@@ -7950,15 +7875,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "zV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/ai_node,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "zW" = (
@@ -8216,15 +8136,13 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_one)
 "AH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/obj/machinery/door_control/mainship/req{
-	dir = 8;
-	id = "qm_warehouse";
-	name = "Requisition Warehouse Shutters"
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
 	},
-/turf/open/floor/mainship/mono,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "AI" = (
 /obj/machinery/door/poddoor/mainship/umbilical/south{
@@ -8357,11 +8275,18 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "AZ" = (
-/obj/structure/flora/pottedplant/twentyone{
-	icon_state = "plant-09"
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
 	},
-/turf/open/floor/mainship/black,
-/area/mainship/hallways/starboard_hallway)
+/obj/structure/bed/chair/office/dark,
+/obj/machinery/door_control{
+	dir = 4;
+	id = "reqaccess2";
+	name = "Requisitions Access"
+	},
+/obj/effect/landmark/start/job/shiptech,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "Ba" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8384,12 +8309,20 @@
 /turf/open/floor/plating,
 /area/mainship/hull/starboard_hull)
 "Bc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/black,
-/area/mainship/hallways/starboard_hallway)
+/obj/structure/rack,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/adv,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/squads/req)
 "Bd" = (
+/obj/machinery/vending/shared_vending/marine_engi,
+/obj/machinery/alarm,
 /turf/open/floor/mainship/orange{
-	dir = 4
+	dir = 5
 	},
 /area/mainship/living/briefing)
 "Be" = (
@@ -8400,9 +8333,16 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/self_destruct)
 "Bf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/black,
-/area/mainship/hallways/starboard_hallway)
+/obj/machinery/door/poddoor/railing{
+	id = "supply_elevator_railing"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/mainship/squads/req)
 "Bg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8435,13 +8375,16 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "Bk" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Bl" = (
@@ -8464,14 +8407,13 @@
 /turf/open/floor/freezer,
 /area/mainship/living/cafeteria_starboard)
 "Bp" = (
-/obj/item/ammo_casing/bullet{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/turf/open/floor/mainship/red{
-	dir = 4
-	},
-/area/mainship/living/briefing)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "Bq" = (
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/food/snacks/creamcheesebreadslice,
@@ -8499,13 +8441,10 @@
 /area/mainship/hull/port_hull)
 "Bw" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "By" = (
@@ -8558,10 +8497,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "BG" = (
-/obj/machinery/light{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/briefing)
 "BH" = (
 /obj/structure/cable,
@@ -8766,8 +8709,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "Cj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/mono,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/briefing)
 "Ck" = (
 /obj/structure/disposalpipe/segment{
@@ -8782,8 +8731,15 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "Cm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/briefing)
 "Cn" = (
 /obj/structure/flora/pottedplant/twentyone,
@@ -8992,25 +8948,6 @@
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
-"CZ" = (
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/red{
-	dir = 9
-	},
-/area/mainship/living/briefing)
-"Da" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mainship/red{
-	dir = 1
-	},
-/area/mainship/living/briefing)
-"Db" = (
-/turf/open/floor/mainship/red{
-	dir = 5
-	},
-/area/mainship/living/briefing)
 "Dd" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -9020,60 +8957,27 @@
 /area/mainship/hallways/hangar)
 "De" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/orange{
-	dir = 9
-	},
-/area/mainship/living/briefing)
-"Dg" = (
-/obj/machinery/vending/shared_vending/marine_engi,
-/obj/machinery/alarm,
-/turf/open/floor/mainship/orange{
-	dir = 5
-	},
+/turf/open/floor/mainship/black,
 /area/mainship/living/briefing)
 "Dh" = (
 /turf/open/floor/mainship/black{
 	dir = 4
 	},
 /area/mainship/command/self_destruct)
-"Di" = (
-/obj/machinery/vending/tool,
-/turf/open/floor/mainship/purple{
-	dir = 9
-	},
-/area/mainship/living/briefing)
 "Dk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/purple{
-	dir = 5
-	},
-/area/mainship/living/briefing)
-"Dl" = (
-/turf/open/floor/mainship/blue{
-	dir = 9
-	},
-/area/mainship/living/briefing)
-"Dm" = (
-/turf/open/floor/mainship/blue{
-	dir = 1
-	},
+/turf/open/floor/mainship/black,
 /area/mainship/living/briefing)
 "Dn" = (
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/blue{
-	dir = 5
+/obj/structure/flora/pottedplant/twentyone{
+	icon_state = "plant-09"
 	},
+/turf/open/floor/mainship/black,
 /area/mainship/living/briefing)
 "Do" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
+/obj/structure/barricade/metal,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "Dp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -9125,6 +9029,18 @@
 /obj/structure/ship_ammo/minirocket,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"Dz" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/ammo_casing/bullet{
+	pixel_x = 9;
+	pixel_y = 5
+	},
+/turf/open/floor/mainship/purple{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "DA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -9176,13 +9092,13 @@
 	},
 /area/mainship/living/cryo_cells)
 "DF" = (
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
+/obj/machinery/line_nexter{
+	dir = 2
 	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 10
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "DG" = (
 /obj/structure/cable,
@@ -9404,6 +9320,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
+"Eo" = (
+/turf/open/floor/mainship/terragov/north{
+	dir = 4
+	},
+/area/mainship/hallways/starboard_hallway)
 "Ep" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/operating_room_two)
@@ -9425,24 +9346,18 @@
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "Et" = (
-/obj/structure/closet/bombcloset,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/structure/closet/firecloset,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/mainship/cargo,
+/area/mainship/squads/req)
 "Eu" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/red{
-	dir = 8
-	},
-/area/mainship/living/briefing)
+/obj/structure/closet/emcloset,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/mainship/cargo,
+/area/mainship/squads/req)
 "Ev" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/purple{
-	dir = 4
-	},
+/turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "Ew" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -9557,12 +9472,12 @@
 /turf/closed/wall/mainship,
 /area/mainship/living/bridgebunks)
 "EN" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id = "qm_warehouse";
-	name = "\improper Warehouse Shutters"
+/obj/machinery/door/poddoor/railing{
+	id = "supply_elevator_railing"
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
 /area/mainship/squads/req)
 "EO" = (
 /turf/closed/wall/mainship,
@@ -9800,11 +9715,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "Fm" = (
-/obj/machinery/holopad,
-/obj/item/ammo_casing/bullet{
-	pixel_x = -7;
-	pixel_y = 5
-	},
+/obj/machinery/vending/engivend,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "Fn" = (
@@ -9815,12 +9726,10 @@
 	},
 /area/mainship/squads/general)
 "Fp" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "qm_warehouse";
-	name = "\improper Warehouse Shutters"
+/obj/machinery/door/poddoor/railing{
+	id = "supply_elevator_railing"
 	},
-/obj/structure/window/framed/mainship/requisitions,
-/turf/closed/wall/mainship,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "Fq" = (
 /obj/effect/ai_node,
@@ -9850,14 +9759,6 @@
 	dir = 4
 	},
 /area/mainship/living/cafeteria_starboard)
-"Fu" = (
-/obj/effect/decal/cleanable/blood/oil{
-	name = "grease";
-	pixel_x = -2;
-	pixel_y = -6
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/briefing)
 "Fv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -9928,8 +9829,7 @@
 /area/mainship/hull/port_hull)
 "FG" = (
 /obj/item/ammo_casing/bullet{
-	pixel_x = 4;
-	pixel_y = -9
+	pixel_x = -3
 	},
 /turf/open/floor/mainship/blue{
 	dir = 8
@@ -9945,9 +9845,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
 "FI" = (
-/obj/item/ammo_casing/bullet{
-	pixel_x = -7
-	},
+/obj/structure/table/reinforced,
+/obj/item/tool/hand_labeler,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "FJ" = (
@@ -10062,9 +9961,14 @@
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "FY" = (
-/obj/structure/dropship_equipment/weapon/minirocket_pod,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/mainship/squads/req)
 "FZ" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -10128,10 +10032,6 @@
 /obj/structure/window/framed/mainship/white,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
-"Gg" = (
-/obj/item/ammo_casing/bullet,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/briefing)
 "Gh" = (
 /obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 2
@@ -10171,8 +10071,7 @@
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "Gn" = (
-/obj/structure/rack,
-/obj/item/storage/box/sentry,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/red{
 	dir = 8
 	},
@@ -10187,24 +10086,38 @@
 /area/mainship/hallways/hangar)
 "Gp" = (
 /obj/structure/table/reinforced,
-/obj/item/facepaint/green,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "Gq" = (
-/obj/machinery/vending/uniform_supply,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/ROsign{
+	dir = 1
+	},
+/obj/machinery/computer/ordercomp,
 /turf/open/floor/mainship/mono,
-/area/mainship/living/briefing)
+/area/mainship/squads/req)
 "Gr" = (
-/obj/structure/table/reinforced,
+/obj/item/ammo_casing/bullet{
+	pixel_x = 5;
+	pixel_y = -10
+	},
+/obj/item/ammo_casing/bullet{
+	pixel_x = -7;
+	pixel_y = 5
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "Gs" = (
-/obj/machinery/vending/armor_supply,
+/obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "Gt" = (
-/obj/structure/table/reinforced,
-/obj/item/tool/hand_labeler,
+/obj/item/ammo_casing/bullet{
+	pixel_x = -2
+	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "Gu" = (
@@ -10345,13 +10258,7 @@
 /area/mainship/living/numbertwobunks)
 "GP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/item/ammo_casing/bullet{
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/turf/open/floor/mainship/orange{
-	dir = 8
-	},
+/turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "GQ" = (
 /obj/structure/disposalpipe/trunk{
@@ -10441,7 +10348,8 @@
 	},
 /area/mainship/medical/lower_medical)
 "He" = (
-/obj/machinery/computer/camera_advanced/remote_fob,
+/obj/structure/rack,
+/obj/item/storage/box/sentry,
 /turf/open/floor/mainship/red{
 	dir = 8
 	},
@@ -10459,23 +10367,20 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "Hh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 1;
-	on = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/item/ammo_casing/bullet{
-	pixel_x = 10;
-	pixel_y = 4
+	pixel_x = 4;
+	pixel_y = 8
 	},
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
 /area/mainship/living/briefing)
 "Hi" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/decal/cleanable/blood/oil{
+	name = "grease";
+	pixel_x = 8
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
@@ -10491,17 +10396,19 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/port_atmos)
 "Hk" = (
+/obj/effect/decal/cleanable/blood/oil{
+	name = "grease";
+	pixel_x = -7
+	},
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
 /area/mainship/living/briefing)
 "Hm" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/ammo_casing/bullet{
-	pixel_x = 9;
-	pixel_y = 5
+/obj/effect/decal/cleanable/blood/oil{
+	name = "grease";
+	pixel_x = -5;
+	pixel_y = -6
 	},
 /turf/open/floor/mainship/purple{
 	dir = 8
@@ -10511,10 +10418,7 @@
 /turf/closed/wall/mainship,
 /area/mainship/living/port_garden)
 "Ho" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/purple{
 	dir = 4
 	},
@@ -10557,11 +10461,10 @@
 	},
 /area/mainship/squads/general)
 "Hw" = (
-/obj/machinery/light{
-	dir = 8
+/turf/open/floor/mainship/terragov/north{
+	dir = 9
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/squads/req)
+/area/mainship/hallways/starboard_hallway)
 "Hx" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -10689,15 +10592,13 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "HU" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 1
-	},
+/obj/machinery/computer/camera_advanced/remote_fob,
 /turf/open/floor/mainship/red{
 	dir = 8
 	},
 /area/mainship/living/briefing)
 "HV" = (
-/obj/machinery/vending/weapon,
+/obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "HW" = (
@@ -10840,19 +10741,13 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "Ip" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/door/poddoor/railing{
+	dir = 2;
+	id = "supply_elevator_railing"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 1
 	},
-/obj/machinery/door_control/mainship/req{
-	dir = 1;
-	id = "qm_warehouse";
-	name = "Requisition Warehouse Shutters"
-	},
-/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Iq" = (
 /obj/structure/table/mainship,
@@ -11106,10 +11001,6 @@
 /obj/effect/landmark/start/job/staffofficer,
 /turf/open/floor/carpet,
 /area/mainship/living/bridgebunks)
-"Jk" = (
-/obj/machinery/vending/engivend,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/briefing)
 "Jl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /obj/structure/disposalpipe/segment,
@@ -11438,12 +11329,13 @@
 /turf/closed/wall/mainship,
 /area/mainship/living/commandbunks)
 "Kf" = (
-/obj/machinery/door_control/mainship/req{
-	dir = 4;
-	id = "qm_warehouse";
-	name = "Requisition Warehouse Shutters"
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
 	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "Kg" = (
 /obj/machinery/door/poddoor/shutters/mainship/cic/armory{
@@ -11602,7 +11494,6 @@
 	},
 /area/mainship/living/briefing)
 "KI" = (
-/obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/mainship/blue{
 	dir = 10
 	},
@@ -11737,11 +11628,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "Ld" = (
-/obj/item/ammo_casing/bullet{
-	pixel_x = -2
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/briefing)
+/obj/structure/table/mainship,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/starboard_hallway)
 "Le" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -11955,15 +11844,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
-"LH" = (
-/obj/item/ammo_casing/bullet{
-	pixel_x = 5;
-	pixel_y = 6
-	},
-/turf/open/floor/mainship/orange{
-	dir = 1
-	},
-/area/mainship/living/briefing)
 "LK" = (
 /obj/machinery/bodyscanner{
 	dir = 8
@@ -12059,6 +11939,10 @@
 /turf/open/floor/wood,
 /area/mainship/living/bridgebunks)
 "Mb" = (
+/obj/effect/decal/cleanable/blood/oil{
+	name = "grease";
+	pixel_x = 8
+	},
 /turf/open/floor/mainship/purple{
 	dir = 4
 	},
@@ -12071,9 +11955,10 @@
 	},
 /area/mainship/medical/chemistry)
 "Me" = (
-/obj/structure/closet/toolcloset,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/structure/table/mainship,
+/obj/item/megaphone,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/starboard_hallway)
 "Mf" = (
 /obj/machinery/light,
 /obj/structure/table/mainship,
@@ -12161,18 +12046,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "Mq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "Mr" = (
 /obj/structure/cable,
@@ -12331,12 +12206,10 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/shipboard/weapon_room)
 "MP" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 8;
-	id = "reqaccess2"
+/turf/open/floor/mainship/terragov/north{
+	dir = 1
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/area/mainship/hallways/starboard_hallway)
 "MQ" = (
 /obj/machinery/alarm,
 /turf/open/floor/mainship/floor,
@@ -12466,8 +12339,9 @@
 /turf/closed/wall/mainship/outer,
 /area/mainship/hull/port_hull)
 "Np" = (
+/obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/red{
-	dir = 8
+	dir = 9
 	},
 /area/mainship/living/briefing)
 "Nq" = (
@@ -12475,10 +12349,12 @@
 /area/mainship/shipboard/weapon_room)
 "Nr" = (
 /obj/item/ammo_casing/bullet{
-	pixel_x = 6;
-	pixel_y = -7
+	pixel_x = 5;
+	pixel_y = 6
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
 /area/mainship/living/briefing)
 "Ns" = (
 /turf/open/floor/mainship/floor,
@@ -12537,13 +12413,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "NB" = (
-/obj/item/ammo_casing/bullet{
-	pixel_x = -7;
-	pixel_y = 5
-	},
-/turf/open/floor/mainship/purple{
-	dir = 1
-	},
+/turf/open/floor/mainship/black,
 /area/mainship/living/briefing)
 "NC" = (
 /obj/structure/closet/firecloset,
@@ -12772,11 +12642,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Of" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/blue{
-	dir = 4
+/turf/open/floor/mainship/terragov/north{
+	dir = 5
 	},
-/area/mainship/living/briefing)
+/area/mainship/hallways/starboard_hallway)
 "Og" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction,
@@ -12798,6 +12667,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
 	},
+/obj/vehicle/ridden/motorbike,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Om" = (
@@ -13210,14 +13080,11 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/port_hallway)
 "Px" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
+/obj/structure/bed/chair{
+	dir = 1
 	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
+/turf/open/floor/mainship/blue/full,
+/area/mainship/hallways/starboard_hallway)
 "Py" = (
 /obj/structure/dropship_equipment/operatingtable,
 /turf/open/floor/mainship/cargo,
@@ -13364,17 +13231,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "PV" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 8;
-	id = "supply_elevator_railing"
-	},
-/obj/machinery/floodlight/landing{
-	name = "ASRS Light"
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
-/area/mainship/squads/req)
+/obj/machinery/light,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "PW" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -13627,7 +13486,7 @@
 "QJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/orange{
-	dir = 8
+	dir = 9
 	},
 /area/mainship/living/briefing)
 "QK" = (
@@ -13793,12 +13652,10 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/weapon_room)
 "Rm" = (
-/obj/structure/rack,
-/obj/item/tool/screwdriver,
-/obj/item/tool/crowbar/red,
 /obj/effect/decal/warning_stripes/thick{
-	dir = 8
+	dir = 4
 	},
+/obj/structure/closet/toolcloset,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Rn" = (
@@ -13856,6 +13713,17 @@
 	dir = 8
 	},
 /area/mainship/command/cic)
+"Ry" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "Rz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -14030,10 +13898,6 @@
 	},
 /area/mainship/living/port_garden)
 "Sg" = (
-/obj/item/ammo_casing/bullet{
-	pixel_x = -3;
-	pixel_y = 7
-	},
 /turf/open/floor/mainship/red{
 	dir = 4
 	},
@@ -14139,6 +14003,9 @@
 /obj/structure/prop/mainship/sensor_computer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
+"Sy" = (
+/turf/open/floor/mainship/terragov/north,
+/area/mainship/hallways/starboard_hallway)
 "Sz" = (
 /obj/structure/prop/mainship/sensor_computer2,
 /turf/open/floor/mainship/mono,
@@ -14481,6 +14348,15 @@
 	dir = 1
 	},
 /area/mainship/hallways/hangar)
+"Tt" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
+/area/mainship/living/briefing)
 "Tv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -14726,12 +14602,10 @@
 	},
 /area/mainship/shipboard/weapon_room)
 "Uh" = (
-/obj/structure/rack,
-/obj/item/tool/wrench,
-/obj/item/tool/extinguisher/mini,
 /obj/effect/decal/warning_stripes/thick{
-	dir = 4
+	dir = 8
 	},
+/obj/structure/closet/bombcloset,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Ui" = (
@@ -14797,6 +14671,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
+"Us" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/turf/open/floor/mainship/purple{
+	dir = 1
+	},
+/area/mainship/living/briefing)
 "Ut" = (
 /obj/machinery/light{
 	dir = 8
@@ -14820,8 +14703,14 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "Uy" = (
+/obj/structure/rack,
+/obj/item/tool/wrench,
+/obj/item/tool/extinguisher/mini,
 /obj/effect/decal/warning_stripes/thick{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -15116,9 +15005,9 @@
 /turf/closed/wall/mainship,
 /area/mainship/hallways/hangar/droppod)
 "Vp" = (
-/obj/item/ammo_casing/bullet{
-	pixel_x = -7;
-	pixel_y = 5
+/obj/effect/decal/cleanable/blood/oil{
+	name = "grease";
+	pixel_x = 8
 	},
 /turf/open/floor/mainship/red{
 	dir = 4
@@ -15752,12 +15641,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/port_atmos)
 "XD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/turf/open/floor/mainship/terragov/north{
+	dir = 8
+	},
+/area/mainship/hallways/starboard_hallway)
 "XE" = (
 /turf/open/floor/mainship_hull,
 /area/space)
@@ -15785,10 +15672,10 @@
 /turf/open/floor/engine,
 /area/mainship/engineering/port_atmos)
 "XL" = (
-/obj/effect/decal/cleanable/blood/oil{
-	name = "grease";
-	pixel_x = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/purple{
 	dir = 4
 	},
@@ -16123,6 +16010,14 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engine_core)
+"YM" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/blue{
+	dir = 1
+	},
+/area/mainship/living/briefing)
 "YN" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -16303,6 +16198,17 @@
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct,
 /turf/closed/wall/mainship,
 /area/mainship/command/self_destruct)
+"Zw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/living/briefing)
 "Zx" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
@@ -16383,6 +16289,15 @@
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"ZN" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/living/briefing)
 "ZO" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/mainship/mono,
@@ -21365,7 +21280,7 @@ XE
 VS
 Uy
 du
-dx
+dQ
 dQ
 eB
 av
@@ -21559,9 +21474,9 @@ ZK
 YB
 XE
 VS
-an
-af
-VC
+ez
+AR
+mR
 dS
 VC
 ax
@@ -21657,11 +21572,11 @@ ZK
 YB
 XE
 VS
-ez
-AR
-mR
-dT
-eC
+af
+an
+az
+dP
+cW
 aW
 aZ
 VC
@@ -21757,9 +21672,9 @@ XE
 VS
 Rm
 ag
-dM
-ai
-Wt
+dV
+dV
+dx
 aA
 aZ
 VC
@@ -21853,11 +21768,11 @@ ZK
 YB
 XE
 VS
-Me
-VC
-VC
-VC
-VC
+ay
+AR
+mR
+aj
+eC
 aW
 ba
 NA
@@ -21951,11 +21866,11 @@ ZK
 YB
 XE
 VS
-Et
-VC
-VC
+ay
+AR
+mR
 aj
-VC
+eC
 aC
 bb
 bw
@@ -22050,14 +21965,14 @@ YB
 XE
 VS
 Uh
-du
-dx
 ao
-Wu
+dP
+dP
+dT
 aD
 aZ
 VC
-FY
+VC
 VC
 aW
 VC
@@ -22148,14 +22063,14 @@ YB
 XE
 VS
 aq
-AR
-mR
+ag
 dV
-eC
+dV
+VC
 aW
 aZ
 VC
-nJ
+VC
 VC
 aW
 VC
@@ -22246,10 +22161,10 @@ YB
 XE
 VS
 aa
-af
-VC
-VC
-VC
+AR
+mR
+ct
+eC
 aI
 OS
 OS
@@ -24226,28 +24141,28 @@ bw
 BK
 bw
 bw
-bw
+pK
 Bw
 bw
 bw
-bw
+BK
 bw
 bw
 Ow
-Bw
+Al
 bw
 bw
 bw
 Vg
 bw
 bw
-Bw
+bw
+bw
+Ry
 bw
 bw
 bw
 BK
-bw
-bw
 bw
 Wp
 Wp
@@ -24324,28 +24239,28 @@ gW
 iF
 VC
 VC
-dz
-az
+pN
 VC
-dz
-ct
-pI
 VC
 dz
-sL
 VC
 VC
-iF
 VC
-iF
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+VC
 VC
 aW
+VC
 Wv
-dz
 VC
 VC
-VC
-dz
 VC
 VC
 VC
@@ -24422,31 +24337,31 @@ SA
 SA
 ug
 ug
-SA
+rg
 lm
 SA
 SA
 SA
-MP
-MP
 SA
-sM
-ue
-SA
-SA
-SA
-SA
-cj
-Io
-AZ
+gZ
+gY
+WS
+WS
+WS
+Mq
+xS
+xS
+zQ
+zQ
+Ot
+BG
+Dn
 Cg
-CZ
-Eu
 Np
 Gn
 He
 HU
-Np
+tt
 Jx
 Ky
 Cg
@@ -24519,32 +24434,32 @@ gq
 gX
 hP
 jH
-jx
+Ir
 Bk
-lo
-mr
+gY
+gY
 nz
 oI
+SA
+Et
 gY
-gY
-kv
-sN
-fQ
-kv
-vS
-wJ
-xR
+PV
+MI
+yI
+WS
+xS
+xS
+zQ
+zQ
 Ot
-Io
-Jo
+BG
+NB
 Cg
-Da
-Ci
 zD
-Gp
-Gt
-Gr
 Ci
+xb
+FI
+Gp
 UJ
 KA
 Cg
@@ -24614,32 +24529,32 @@ ea
 ea
 ea
 gt
-gY
+dZ
 hQ
 CW
-jx
+gY
 jz
-lo
-mu
 gY
 gY
 gY
+Bc
+SA
+Eu
 gY
-gY
-sN
-gY
-gY
-vT
-wL
+PV
+MI
+yI
+WS
 xS
+xS
+zQ
+zQ
 Ot
-Io
-Jo
+Zw
+NB
 Lp
-Db
-Bp
 bm
-bm
+jd
 Sg
 fT
 Vp
@@ -24647,7 +24562,7 @@ pp
 KB
 Lp
 Ot
-zU
+il
 Jo
 NI
 Ox
@@ -24714,33 +24629,33 @@ ea
 gt
 gY
 hR
-hS
-hS
+gY
+gY
 jA
-lp
-mv
+SA
 zS
-XD
-pK
+zS
+SA
+SA
 qV
-AH
-sO
 gY
-gY
-vU
-wL
+WS
+WS
+WS
+WS
 xS
+xS
+zQ
+zQ
 Ot
-hE
-Jo
+BG
+NB
 Ci
-Fu
+hu
 Ci
-Ci
-Gq
 Gs
 HV
-Ci
+pt
 Jy
 Ci
 Ci
@@ -24812,25 +24727,25 @@ ea
 gt
 gY
 gY
-gY
-gY
-jz
-gY
+jC
+lo
+sT
+SA
 jF
-SA
-SA
-SA
-SA
+Fp
+Bf
+Fp
+EN
 Fp
 qy
-Fp
-rt
-ug
-wL
-gY
-Ot
+yA
+yA
+iH
+xS
+xS
 zQ
-Bc
+zQ
+Ot
 Cj
 De
 GP
@@ -24911,32 +24826,32 @@ gt
 gY
 gY
 iK
-gY
+lp
 sT
 yB
-jF
-SA
-rg
-wQ
-wQ
-Kf
-wQ
-wQ
-ts
-wQ
-SA
-SA
+qu
+vi
+vi
+vi
+vi
+vi
+sV
+vg
+Ld
 yA
-Io
-Jo
+yA
+yA
+yA
+yA
+Ot
 BG
-LH
-Ci
+NB
+aF
 Nr
-Gr
-Gt
-Gp
 Ci
+Gp
+FI
+xb
 Jy
 gG
 Ci
@@ -25007,33 +24922,33 @@ ea
 ea
 gt
 gY
-gY
+hZ
 iM
 jD
-lt
-fa
-jF
-SA
-wQ
-pN
-vg
-vg
+sT
+vV
+Ip
+vi
+vi
+vi
+vi
+vi
 sP
 vg
-vg
-vW
+Ld
+yA
 Hw
-gY
+XD
+sk
+yA
 Ot
-Io
-Jo
+BG
+NB
 Cg
-Dg
-tI
 Bd
 jK
 Hi
-Bd
+ZN
 zI
 Jz
 KD
@@ -25105,34 +25020,34 @@ ea
 ea
 gt
 gY
-gY
+jx
 iL
-gY
+mr
 oM
-ls
+vV
 qu
-SA
-cW
+vi
+vi
 pT
 vi
 vi
-vi
-vi
-vi
+sV
+vg
+Me
 wb
-wQ
-gY
+MP
+uc
+Sy
+yA
 Ot
-Io
-Jo
+jT
+NB
 Cl
-Jk
-Ci
 Fm
 oL
+sb
 Cg
-oL
-Ci
+sb
 Jy
 Ci
 Cl
@@ -25205,31 +25120,31 @@ gt
 gY
 gY
 lq
-gY
-pJ
+mu
+sT
 vV
 Ip
-uf
-jC
-pT
 vi
 vi
 vi
 vi
 vi
-wb
-wQ
-gY
+sP
+vg
+Ld
+yA
+Of
+Eo
+jO
+yA
 Ot
-Io
-Jo
+BG
+NB
 Cg
-Di
+sK
 SN
-SN
-hZ
 Hm
-SN
+Dz
 SN
 OT
 KE
@@ -25302,32 +25217,32 @@ fB
 gt
 gY
 gY
-gY
-gY
-qT
-xT
-jF
-EN
-wQ
-dZ
+kC
+mz
+sT
+yB
+qu
+vi
+vi
+vi
 vi
 vi
 sV
-vi
-vi
+vg
+Ld
 iH
-wQ
-gY
+yA
+yA
+yA
+yA
 Ot
-Io
-Jo
-iI
+BG
 NB
 dJ
-Ci
+Us
 Gr
 Gp
-Gt
+xb
 FI
 Ba
 rV
@@ -25402,23 +25317,23 @@ gZ
 gY
 gY
 gY
-jz
-gY
-jF
+sL
+SA
+AH
 uf
 wQ
-pT
-vi
-vi
-vi
-vi
-vi
-oi
-wQ
-gY
-Ot
+uf
+FY
+uf
+Kf
+yA
+yA
+yA
+Px
+Px
 zR
-Bf
+zR
+Ot
 Cm
 Dk
 Ev
@@ -25431,7 +25346,7 @@ aG
 KG
 Ci
 Ot
-Mq
+zU
 Jo
 NH
 OH
@@ -25499,32 +25414,32 @@ gw
 iG
 hT
 iN
-iN
+mA
 vf
-hT
-mw
 SA
-wQ
-pT
-vi
-vi
-vi
-vi
-vi
-wb
-wQ
-gY
-Ot
-Io
-Jo
-Ci
-mW
-Ci
-Ci
+zS
+zS
+SA
+SA
 Gq
+hR
+WS
+WS
+WS
+WS
+Px
+Px
+zR
+zR
+Ot
+BG
+NB
+Ci
+Ci
+Ci
 Gs
 HV
-Ci
+pt
 Jy
 Ci
 Ci
@@ -25597,27 +25512,27 @@ ug
 hS
 gY
 gY
+nJ
+sM
+ue
 gY
-gY
-gY
-my
-SA
+AZ
 ts
 DF
-yI
-yI
-PV
-yI
-yI
-Px
-wQ
 gY
+gY
+PV
+MI
+yI
+WS
+Px
+Px
+zR
+zR
 Ot
-Io
-Jo
+Zw
+NB
 Cn
-Dl
-kp
 kp
 ou
 aR
@@ -25696,36 +25611,36 @@ hc
 hU
 iO
 gY
-fQ
+sO
 lv
 my
 qw
-tz
-wQ
-wQ
-wQ
-wQ
-wQ
-wQ
-wQ
-wQ
+vY
+Do
 gY
+gY
+PV
+MI
+yI
+Mq
+Px
+Px
+zR
+zR
 Ot
-Io
-Jo
+BG
+NB
 Cg
-Dm
-Ld
-Ci
+YM
 Gt
+FI
+xb
 Gp
-Gr
-Gg
 JA
 KJ
 Cg
 cj
-zU
+il
 MX
 NH
 OK
@@ -25794,31 +25709,31 @@ SA
 SA
 SA
 ug
+gY
+vS
+SA
 ug
-SA
-mz
-SA
 vY
+Do
 gY
 gY
-gY
-gY
-gY
-gY
-gY
-gY
-gY
+WS
+WS
+WS
+WS
+Px
+Px
+zR
+zR
 Ot
-Io
-AZ
-Cg
+BG
 Dn
-Of
+Cg
 cG
 cu
 cu
-kC
 cu
+Tt
 JB
 KL
 Cg
@@ -25890,11 +25805,11 @@ jM
 jM
 eg
 jM
-dC
 jM
 jM
-eg
-mA
+jM
+vT
+jM
 jM
 uk
 pV
@@ -25906,11 +25821,11 @@ jM
 jM
 jM
 jM
+jM
+jM
 rL
 Io
 dU
-eg
-jM
 jM
 jM
 jM
@@ -25990,28 +25905,28 @@ En
 En
 En
 En
-En
-En
+tI
+vU
 mB
 Bj
+Bp
 Bj
 Bj
 Bj
+Bp
 Bj
-Bj
-un
 Bj
 un
 wT
 Bj
-yE
 zV
+zV
+bR
+iJ
 Bj
 Bj
-Do
 Bj
-Bj
-Bj
+Bp
 Bj
 Bj
 Bj


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

One picture is worth a thousand words.

![image](https://user-images.githubusercontent.com/6610922/162842532-712bfd7e-5993-46dc-aeea-da009b20c93c.png)

Two pictures are worth twice the thousand words

![image](https://user-images.githubusercontent.com/6610922/162843092-2fe43837-3cd8-400a-8f21-1699582fa3ff.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Minerva is known for its symmetry. I didn't follow that philosophy when I changed its req, so here we go.

To deal with the empty space from the symmetry adjustment, I had to add a briefing area. You're welcome, RPers.

Also, CAS armament area is more pretty.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Minerva's req has been change to make req conveyor belt symmetrical in respect to req
add: briefing area in Minerva
add: Minerva's CAS armament area is now prettier
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
