### PR TITLE
Makes preplaced cables unacidable

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -18,6 +18,7 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 	icon_state = "l2-1-2-4-8-node"
 	color = "yellow"
 	layer = WIRE_LAYER //Above hidden pipes, GAS_PIPE_HIDDEN_LAYER
+	resistance_flags = UNACIDABLE //This is pre-placed in maps, cable/placed is player-made and the acidable one.
 	anchored = TRUE
 	obj_flags = CAN_BE_HIT
 	plane = FLOOR_PLANE
@@ -398,7 +399,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list(new/datum/stack_recipe("cable restrain
 	singular_name = "cable piece"
 	usesound = 'sound/items/deconstruct.ogg'
 	var/cable_color = "yellow"
-	var/obj/structure/cable/target_type = /obj/structure/cable
+	var/obj/structure/cable/target_type = /obj/structure/cable/placed
 	var/target_layer = CABLE_LAYER_2
 
 /obj/item/stack/cable_coil/Initialize(mapload, new_amount = null)
@@ -448,7 +449,7 @@ GLOBAL_LIST(cable_radial_layer_list)
 			name = "cable coil"
 			icon_state = "coil"
 			color = "yellow"
-			target_type = /obj/structure/cable
+			target_type = /obj/structure/cable/placed
 			target_layer = CABLE_LAYER_2
 		if("Layer 3")
 			name = "cable coil"
@@ -470,6 +471,9 @@ GLOBAL_LIST(cable_radial_layer_list)
 			target_layer = CABLE_LAYER_2
 	update_icon()
 
+//Player-placed cable. Not acid resistant like mapped cables!
+/obj/structure/cable/placed
+	resistance_flags = null
 
 ///////////////////////////////////
 // General procedures


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives pre-placed cables (as in, the ones mapped in) the unacidable flag.
I'm going to make tadpole not destroy them too later

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I've been thinking about making this change for a few months now, and I get that this is kind of a big xeno nerf, and a REALLY REALLY big buff to getting groundside engineering. I'm not _entirely_ sure whether it is good for the game myself, but here's a few reasons I think it is:

### Makes engineering power actually useful
Engineering is almost never worth fighting over as marine or xeno. The only reason you go after it is for the pretty small amount of points xenos get from it. Engineering _power_ just isn't useful 9/10 because xenos melted a couple cables and now the entire powergrid doesn't work until you track down the single wire hidden under a floorboard in the middle of a xeno maze and fix it. This:

### Provides more objectives to fight over
You've got 3-4 objectives right now: Miners, disks (not distress), silos. Maybe medbay depending on the map. Engineering already provides some extra depth, when it, er, actually fucking works. It's also really fucking cool to shout "COVERING SARGE!!!!" while your group's engineer frantically repairs the colony generator

### Removes noobtrap
If you're new to the game you're not gonna notice there was supposed to be wires hidden under the opaque generators. This is literally not a problem for anyone who has played too much TGMC, but it's kind of shitty for new engineers.

### Gives engineers more of a job
More shit to do for engineers is good. The issue with generators is that, depending on if xenos are _competent_ or not,
those engineers can be vapourised into uselessness. Because fuck you, that's why

### Very minorly reduces prep time for xenos
This is basically not worth writing down but it's one less thing to remember for xenos. I find it a chore to have to walk all over to the other side of some maps just to melt a few cables and leave.

### Makes powernet mapping issues more detectable
Pretty minor, you literally can't tell if xenos have melted the powernet or if someone forgot an extra cable (very easy mistake to make). Consistency means it's easy as fuck to spot

**However:**

### Might make power too strong
Nothing really drains power at the minute. Like, literally nothing. Most of the APCs groundside have absolutely 0 power consumption. The only thing that could drain power is razorwire and maybe vendors with the regular shitty 500W batteries. 
This'd lead to marines putting the engine on for a couple minutes, then fucking off. The entire station now has infinite power for the rest of the game.
We could just give power values to lights, airlocks and general machinery to fix this, then beef up shipside power so it doesn't drain away. I don't know if that'd cause lag or whatever though. And this is still an issue either way, this just makes it a more consistent issue

### Some engineering areas are really close to main paths
Example: LV624 engineering
This is more of a map balance issue than anything and there's a million ways we could fix it. Hopefully if it becomes unbalanced, someone will actually remedy it.


If this fucks anything else up, let me know.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Pre-placed cables can no longer be acided
balance: Placed cables can still be acided however
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
