### PR TITLE
Reduces cost of King from 1800 to 1200 points

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -217,7 +217,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	desc = "Places a Psychic Echo chamber that tallhosts can detect, then after a summon time selects a random sister to take over the mind of the gravity manipulating King."
 	icon = "king"
 	flags_gamemode = ABILITY_DISTRESS
-	psypoint_cost = 1800
+	psypoint_cost = 1200
 
 /datum/hive_upgrade/xenos/king/can_buy(mob/living/carbon/xenomorph/buyer, silent = TRUE)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Self-explanatory title.

## Why It's Good For The Game
I hardly ever see the King used in game, and when I have, it's frequently after the xenos hijack the dropship and are probably well on their way to winning. Also, for a single xeno, it's incredibly expensive--for the same amount you have to pay for the King (1800 points), a single xeno, you could get three different Primordial upgrades, which would affect most 10-30 members of the hive.
I received multiple suggestions to reduce the cost further to between 800-1000 points, but I imagine there was a reason King's cost was raised all the way to 1800 points. I would like to see if this reduction gets approved before going further.

## Changelog
:cl:
balance: The King now costs 1200 points instead of 1800 points to spawn.
/:cl: