### PR TITLE
Fixes Tyr module so it doesn't "stick" on sprites

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -81,7 +81,6 @@
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "mod_armor"
 	item_state = "mod_armor_a"
-	attachment_layer = COLLAR_LAYER
 	soft_armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = 15, "bio" = 15, "rad" = 15, "fire" = 15, "acid" = 15)
 	slowdown = 0.3
 	slot = ATTACHMENT_SLOT_MODULE


### PR DESCRIPTION
## About The Pull Request
The Tyr had an `attachment_layer` var that made it stay on a marine's sprite once equipped, even after taking it off. No other armor module seems to have this var, and in my testing, it didn't seem like the lack of it made a difference.

## Changelog
:cl:
fix: Fixed the Tyr attachment remaining on sprites even after being taken off.
/:cl: