### PR TITLE
Removes external wounds

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -188,6 +188,12 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define LIMB_REPAIRED (1<<8) //we just repaired the bone, stops the gelling after setting
 #define LIMB_STABILIZED (1<<9) //certain suits will support a broken limb while worn such as the b18
 
+//limb_wound_status
+#define LIMB_WOUND_BANDAGED (1<<0)
+#define LIMB_WOUND_SALVED (1<<1)
+#define LIMB_WOUND_DISINFECTED (1<<2)
+#define LIMB_WOUND_CLAMPED (1<<3)
+
 /////////////////MOVE DEFINES//////////////////////
 #define MOVE_INTENT_WALK 0
 #define MOVE_INTENT_RUN 1

--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -214,10 +214,8 @@ REAGENT SCANNER
 			var/datum/limb/e = X
 			var/limb = e.display_name
 			var/can_amputate = ""
-			for(var/datum/wound/W in e.wounds)
-				if(W.internal)
-					internal_bleed_detected = TRUE
-					break
+			if(e.wounds.len)
+				internal_bleed_detected = TRUE
 			if(e.body_part != CHEST && e.body_part != GROIN && e.body_part != HEAD)
 				can_amputate = "or amputation"
 				if((e.limb_status & LIMB_BROKEN) && !(e.limb_status & LIMB_SPLINTED) && !(e.limb_status & LIMB_STABILIZED))

--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -214,8 +214,9 @@ REAGENT SCANNER
 			var/datum/limb/e = X
 			var/limb = e.display_name
 			var/can_amputate = ""
-			if(e.wounds.len)
+			for(var/datum/wound/internal_bleeding/IB in e.wounds)
 				internal_bleed_detected = TRUE
+				break
 			if(e.body_part != CHEST && e.body_part != GROIN && e.body_part != HEAD)
 				can_amputate = "or amputation"
 				if((e.limb_status & LIMB_BROKEN) && !(e.limb_status & LIMB_SPLINTED) && !(e.limb_status & LIMB_STABILIZED))

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -114,15 +114,8 @@
 	if(!success)
 		to_chat(user, span_warning("The wounds on [patient]'s [target_limb.display_name] have already been treated."))
 		return
-	for (var/datum/wound/W AS in target_limb.wounds)
-		if (W.internal)
-			continue
-		if (W.damage_type == CUT)
-			user.visible_message(span_notice("[user] bandages [W.desc] on [patient]'s [target_limb.display_name]."),
-			span_notice("You bandage \a [W.desc] on [patient]'s [target_limb.display_name].") )
-		else if (istype(W,/datum/wound/bruise))
-			user.visible_message(span_notice("[user] places bruise patch over [W.desc] on [patient]'s [target_limb.display_name]."),
-			span_notice("You place a bruise patch over \a [W.desc] on [patient]'s [target_limb.display_name].") )
+	user.visible_message(span_notice("[user] bandages [patient]'s [target_limb.display_name]."),
+		span_notice("You bandage [patient]'s [target_limb.display_name].") )
 
 /obj/item/stack/medical/heal_pack/ointment
 	name = "ointment"
@@ -203,18 +196,8 @@
 	if(!success)
 		to_chat(user, span_warning("The wounds on [patient]'s [target_limb.display_name] have already been treated."))
 		return
-	for(var/datum/wound/W AS in target_limb.wounds)
-		if(W.internal)
-			continue
-		if(W.current_stage <= W.max_bleeding_stage)
-			user.visible_message(span_notice("[user] cleans [W.desc] on [patient]'s [target_limb.display_name] and seals its edges with bioglue."),
-			span_notice("You clean and seal [W.desc] on [patient]'s [target_limb.display_name]."))
-		else if (istype(W,/datum/wound/bruise))
-			user.visible_message(span_notice("[user] places a medicine patch over [W.desc] on [patient]'s [target_limb.display_name]."),
-			span_notice("You place medicine patch over [W.desc] on [patient]'s [target_limb.display_name]."))
-		else
-			user.visible_message(span_notice("[user] smears some bioglue over [W.desc] on [patient]'s [target_limb.display_name]."),
-			span_notice("You smear some bioglue over [W.desc] on [patient]'s [target_limb.display_name]."))
+	user.visible_message(span_notice("[user] cleans [patient]'s [target_limb.display_name] and seals its wounds with bioglue."),
+		span_notice("You clean and seal all the wounds on [patient]'s [target_limb.display_name]."))
 
 /obj/item/stack/medical/heal_pack/advanced/burn_pack
 	name = "advanced burn kit"

--- a/code/game/objects/machinery.dm
+++ b/code/game/objects/machinery.dm
@@ -347,10 +347,8 @@
 
 		dat += "<tr>"
 
-		for(var/datum/wound/W in e.wounds)
-			if(W.internal)
-				internal_bleeding = "Internal bleeding<br>"
-				break
+		if(e.wounds.len)
+			internal_bleeding = "Internal bleeding<br>"
 		if(istype(e, /datum/limb/chest) && occ["lung_ruptured"])
 			lung_ruptured = "Lung ruptured:<br>"
 		if(e.limb_status & LIMB_SPLINTED)

--- a/code/game/objects/machinery.dm
+++ b/code/game/objects/machinery.dm
@@ -347,8 +347,9 @@
 
 		dat += "<tr>"
 
-		if(e.wounds.len)
+		for(var/datum/wound/internal_bleeding/IB in e.wounds)
 			internal_bleeding = "Internal bleeding<br>"
+			break
 		if(istype(e, /datum/limb/chest) && occ["lung_ruptured"])
 			lung_ruptured = "Lung ruptured:<br>"
 		if(e.limb_status & LIMB_SPLINTED)

--- a/code/game/objects/machinery/autodoc.dm
+++ b/code/game/objects/machinery/autodoc.dm
@@ -443,7 +443,7 @@
 							if(!surgery)
 								break
 							sleep(FIXVEIN_MAX_DURATION*surgery_mod)
-							S.limb_ref.wounds -= W
+							qdel(W)
 						if(!surgery)
 							break
 						close_incision(occupant, S.limb_ref)

--- a/code/game/objects/machinery/autodoc.dm
+++ b/code/game/objects/machinery/autodoc.dm
@@ -216,10 +216,8 @@
 	var/surgery_list = list()
 	for(var/datum/limb/L in M.limbs)
 		if(L)
-			for(var/datum/wound/W in L.wounds)
-				if(W.internal)
-					surgery_list += create_autodoc_surgery(L,LIMB_SURGERY,ADSURGERY_INTERNAL)
-					break
+			if(L.wounds.len)
+				surgery_list += create_autodoc_surgery(L,LIMB_SURGERY,ADSURGERY_INTERNAL)
 
 			var/organdamagesurgery = 0
 			for(var/datum/internal_organ/I in L.internal_organs)
@@ -444,9 +442,8 @@
 						for(var/datum/wound/W in S.limb_ref.wounds)
 							if(!surgery)
 								break
-							if(W.internal)
-								sleep(FIXVEIN_MAX_DURATION*surgery_mod)
-								S.limb_ref.wounds -= W
+							sleep(FIXVEIN_MAX_DURATION*surgery_mod)
+							S.limb_ref.wounds -= W
 						if(!surgery)
 							break
 						close_incision(occupant, S.limb_ref)
@@ -1224,13 +1221,9 @@
 		if(href_list["internal"])
 			for(var/i in connected.occupant.limbs)
 				var/datum/limb/L = i
-				for(var/x in L.wounds)
-					var/datum/wound/W = x
-					if(!W.internal)
-						continue
+				if(L.wounds.len)
 					N.fields["autodoc_manual"] += create_autodoc_surgery(L,LIMB_SURGERY,ADSURGERY_INTERNAL)
 					needed++
-					break
 			if(!needed)
 				N.fields["autodoc_manual"] += create_autodoc_surgery(null,LIMB_SURGERY,ADSURGERY_INTERNAL,1)
 

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -18,9 +18,9 @@
 		//Blood regeneration if there is some space
 		if(blood_volume < BLOOD_VOLUME_NORMAL)
 			blood_volume += 0.1 // regenerate blood VERY slowly
-		
+
 		heart_multi = initial(heart_multi)
-		
+
 		// Damaged heart virtually reduces the blood volume, as the blood isn't
 		// being pumped properly anymore.
 		if(species && species.has_organ["heart"])
@@ -35,7 +35,7 @@
 					blood_volume = max(blood_volume - 1.3, 0)
 				else if(heart.is_bruised())
 					heart_multi *= 0.7
-					blood_volume = max(blood_volume - 0.5, 0)	
+					blood_volume = max(blood_volume - 0.5, 0)
 				else
 					heart_multi *= 0.9
 					blood_volume = max(blood_volume - 0.1, 0) //nulls regeneration
@@ -91,10 +91,7 @@
 				continue
 			if(!(temp.limb_status & LIMB_BLEEDING) || temp.limb_status & LIMB_ROBOT)
 				continue
-			for(var/w in temp.wounds)
-				var/datum/wound/W = w
-				if(W.bleeding())
-					blood_max += (W.damage / 60)
+			blood_max += temp.brute_dam / 60
 			if (temp.surgery_open_stage)
 				blood_max += 0.6  //Yer stomach is cut open
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -199,6 +199,8 @@
 				msg += "[span_warning("[t_He] [t_has] a splint on [t_his] [o.display_name]!")]\n"
 			if(o.limb_status & LIMB_STABILIZED)
 				msg += "[span_warning("[t_He] [t_has] a suit brace stabilizing [t_his] [o.display_name]!")]\n"
+			if(o.limb_status & LIMB_NECROTIZED)
+				msg += "[span_warning("An infection has rotted [t_his] [o.display_name] into uselessness!")]\n"
 
 	if(holo_card_color)
 		msg += "[t_He] has a [holo_card_color] holo card on [t_his] chest.\n"
@@ -245,91 +247,86 @@
 	if(on_fire)
 		msg += "[span_warning("[t_He] [t_is] on fire!")]\n"
 
-	var/list/wound_flavor_text = list()
+	var/list/wound_flavor_text = list() //List mapping each limb's display_name to its wound description
 	var/list/is_destroyed = list()
 	var/list/is_bleeding = list()
-	for(var/datum/limb/temp in limbs)
-		if(temp)
-			if(temp.limb_status & LIMB_DESTROYED)
-				is_destroyed["[temp.display_name]"] = 1
-				wound_flavor_text["[temp.display_name]"] = "[span_warning("<b>[t_He] is missing [t_his] [temp.display_name].</b>")]\n"
-				continue
-			if(temp.limb_status & LIMB_ROBOT)
-				if(!(temp.brute_dam + temp.burn_dam))
-					if(!(species.species_flags & IS_SYNTHETIC))
-						wound_flavor_text["[temp.display_name]"] = "[span_warning("[t_He] has a robot [temp.display_name]!")]\n"
-						continue
-				else
-					wound_flavor_text["[temp.display_name]"] = "<span class='warning'>[t_He] has a robot [temp.display_name]. It has"
-				if(temp.brute_dam) switch(temp.brute_dam)
-					if(0 to 20)
-						wound_flavor_text["[temp.display_name]"] += " some dents"
-					if(21 to INFINITY)
-						wound_flavor_text["[temp.display_name]"] += pick(" a lot of dents"," severe denting")
-				if(temp.brute_dam && temp.burn_dam)
-					wound_flavor_text["[temp.display_name]"] += " and"
-				if(temp.burn_dam) switch(temp.burn_dam)
-					if(0 to 20)
-						wound_flavor_text["[temp.display_name]"] += " some burns"
-					if(21 to INFINITY)
-						wound_flavor_text["[temp.display_name]"] += pick(" a lot of burns"," severe melting")
-				if(wound_flavor_text["[temp.display_name]"])
-					wound_flavor_text["[temp.display_name]"] += "!</span>\n"
-			else if(temp.wounds.len > 0)
-				var/list/wound_descriptors = list()
-				for(var/datum/wound/W in temp.wounds)
-					if(W.internal && !temp.surgery_open_stage) continue // can't see internal wounds
-					var/this_wound_desc = W.desc
-					if(W.damage_type == BURN && W.salved) this_wound_desc = "salved [this_wound_desc]"
-					if(W.bleeding()) this_wound_desc = "bleeding [this_wound_desc]"
-					else if(W.bandaged) this_wound_desc = "bandaged [this_wound_desc]"
-					if(W.germ_level > 190) this_wound_desc = "badly infected [this_wound_desc]"
-					else if(W.germ_level > 100) this_wound_desc = "lightly infected [this_wound_desc]"
-					if(this_wound_desc in wound_descriptors)
-						wound_descriptors[this_wound_desc] += W.amount
-						continue
-					wound_descriptors[this_wound_desc] = W.amount
-				if(wound_descriptors.len)
-					var/list/flavor_text = list()
-					var/list/no_exclude = list("gaping wound", "big gaping wound", "massive wound", "large bruise",\
-					"huge bruise", "massive bruise", "severe burn", "large burn", "deep burn", "carbonised area")
-					for(var/wound in wound_descriptors)
-						switch(wound_descriptors[wound])
-							if(1)
-								if(!flavor_text.len)
-									flavor_text += "<span class='warning'>[t_He] has[prob(10) && !(wound in no_exclude)  ? " what might be" : ""] a [wound]"
-								else
-									flavor_text += "[prob(10) && !(wound in no_exclude) ? " what might be" : ""] a [wound]"
-							if(2)
-								if(!flavor_text.len)
-									flavor_text += "<span class='warning'>[t_He] has[prob(10) && !(wound in no_exclude) ? " what might be" : ""] a pair of [wound]s"
-								else
-									flavor_text += "[prob(10) && !(wound in no_exclude) ? " what might be" : ""] a pair of [wound]s"
-							if(3 to 5)
-								if(!flavor_text.len)
-									flavor_text += "<span class='warning'>[t_He] has several [wound]s"
-								else
-									flavor_text += " several [wound]s"
-							if(6 to INFINITY)
-								if(!flavor_text.len)
-									flavor_text += "<span class='warning'>[t_He] has a bunch of [wound]s"
-								else
-									flavor_text += " a ton of [wound]\s"
-					var/flavor_text_string = ""
-					for(var/text = 1, text <= flavor_text.len, text++)
-						if(text == flavor_text.len && flavor_text.len > 1)
-							flavor_text_string += ", and"
-						else if(flavor_text.len > 1 && text > 1)
-							flavor_text_string += ","
-						flavor_text_string += flavor_text[text]
-					flavor_text_string += " on [t_his] [temp.display_name].</span><br>"
-					wound_flavor_text["[temp.display_name]"] = flavor_text_string
-				else
-					wound_flavor_text["[temp.display_name]"] = ""
-				if(temp.limb_status & LIMB_BLEEDING)
-					is_bleeding["[temp.display_name]"] = 1
+	for(var/datum/limb/temp AS in limbs)
+		if(temp.limb_status & LIMB_DESTROYED)
+			is_destroyed["[temp.display_name]"] = 1
+			wound_flavor_text["[temp.display_name]"] = "[span_warning("<b>[t_He] is missing [t_his] [temp.display_name].</b>")]\n"
+			continue
+		if(temp.limb_status & LIMB_ROBOT)
+			if(!(temp.brute_dam + temp.burn_dam))
+				if(!(species.species_flags & IS_SYNTHETIC))
+					wound_flavor_text["[temp.display_name]"] = "[span_warning("[t_He] has a robot [temp.display_name]!")]\n"
+					continue
 			else
-				wound_flavor_text["[temp.display_name]"] = ""
+				wound_flavor_text["[temp.display_name]"] = "<span class='warning'>[t_He] has a robot [temp.display_name]. It has"
+			if(temp.brute_dam) switch(temp.brute_dam)
+				if(0 to 20)
+					wound_flavor_text["[temp.display_name]"] += " some dents"
+				if(21 to INFINITY)
+					wound_flavor_text["[temp.display_name]"] += pick(" a lot of dents"," severe denting")
+			if(temp.brute_dam && temp.burn_dam)
+				wound_flavor_text["[temp.display_name]"] += " and"
+			if(temp.burn_dam) switch(temp.burn_dam)
+				if(0 to 20)
+					wound_flavor_text["[temp.display_name]"] += " some burns"
+				if(21 to INFINITY)
+					wound_flavor_text["[temp.display_name]"] += pick(" a lot of burns"," severe melting")
+			if(wound_flavor_text["[temp.display_name]"])
+				wound_flavor_text["[temp.display_name]"] += "!</span>\n"
+		else
+			var/healthy = TRUE
+			var/brute_desc = ""
+			switch(temp.brute_dam)
+				if(0.01 to 5)
+					brute_desc = "minor scrapes"
+				if(5 to 20)
+					brute_desc = "some cuts"
+				if(20 to 50)
+					brute_desc = "major lacerations"
+				if(50 to INFINITY)
+					brute_desc = "gaping wounds"
+			if(brute_desc)
+				healthy = FALSE
+				brute_desc = (temp.limb_wound_status & LIMB_WOUND_BANDAGED ? "bandaged " : "") + brute_desc
+
+			var/burn_desc = ""
+			switch(temp.burn_dam)
+				if(0.01 to 5)
+					brute_desc = "minor burns"
+				if(5 to 20)
+					brute_desc = "some blisters"
+				if(20 to 50)
+					brute_desc = "major burns"
+				if(50 to INFINITY)
+					brute_desc = "charring"
+			if(burn_desc)
+				healthy = FALSE
+				burn_desc = (temp.limb_wound_status & LIMB_WOUND_SALVED ? "salved " : "") + burn_desc
+
+			var/germ_desc = ""
+			switch(temp.germ_level)
+				if(INFECTION_LEVEL_ONE to INFECTION_LEVEL_TWO - 1)
+					germ_desc = "mildly infected "
+				if(INFECTION_LEVEL_TWO to INFINITY)
+					germ_desc = "heavily infected "
+			if(germ_desc)
+				healthy = FALSE
+
+			var/overall_desc = ""
+			if(healthy)
+				overall_desc = "[t_He] has a healthy [temp.display_name]."
+			else
+				overall_desc = "[t_He] has a [germ_desc][temp.display_name]"
+				if(brute_desc || burn_desc)
+					overall_desc += " with [brute_desc]"
+					if(brute_desc && burn_desc)
+						overall_desc += " and "
+					overall_desc += burn_desc
+				overall_desc += "."
+			wound_flavor_text["[temp.display_name]"] = span_warning(overall_desc + "\n")
 
 	//Handles the text strings being added to the actual description.
 	//If they have something that covers the limb, and it is not missing, put flavortext.  If it is covered but bleeding, add other flavortext.

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -119,11 +119,6 @@
 		if(organic_only && bodypart.limb_status & LIMB_ROBOT)
 			continue
 		var/external_dam = bodypart.brute_dam
-		for(var/j in bodypart.wounds)
-			var/datum/wound/wound = j
-			if(!wound.internal)
-				continue
-			external_dam -= wound.damage
 		. += external_dam
 
 

--- a/code/modules/mob/living/carbon/human/life/handle_organs.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_organs.dm
@@ -43,7 +43,7 @@
 				I.take_damage(rand(3,5))
 
 			//Moving makes open wounds get infected much faster
-			if(prob((E.brute_dam - (E.limb_wound_status & LIMB_WOUND_BANDAGED ? 50 : 0)) * 2))
+			if(prob((E.brute_dam - (E.limb_wound_status & LIMB_WOUND_BANDAGED ? 50 : 0)) * 4))
 				E.germ_level++
 
 		if(E.name in list("l_leg", "l_foot", "r_leg", "r_foot") && !lying_angle)

--- a/code/modules/mob/living/carbon/human/life/handle_organs.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_organs.dm
@@ -43,11 +43,8 @@
 				I.take_damage(rand(3,5))
 
 			//Moving makes open wounds get infected much faster
-			for(var/j in E.wounds)
-				var/datum/wound/W = j
-				if(!W.infection_check())
-					continue
-				W.germ_level += 1
+			if(prob((E.brute_dam - (E.limb_wound_status & LIMB_WOUND_BANDAGED ? 50 : 0)) * 2))
+				E.germ_level++
 
 		if(E.name in list("l_leg", "l_foot", "r_leg", "r_foot") && !lying_angle)
 			if(!E.is_usable() || E.is_malfunctioning() || ( E.is_broken() && !(E.limb_status & LIMB_SPLINTED) && !(E.limb_status & LIMB_STABILIZED) ) )

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -206,8 +206,7 @@
 				O.take_damage(O.min_bruised_damage, TRUE)
 
 		var/datum/limb/chest = H.get_limb("chest")
-		var/datum/wound/internal_bleeding/I = new (15) //Apply internal bleeding to chest
-		chest.wounds += I
+		new /datum/wound/internal_bleeding(15, chest) //Apply internal bleeding to chest
 		chest.fracture()
 
 

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -247,7 +247,7 @@
 /mob/living/carbon/human/proc/heal_limbs(health_to_heal)
 	var/proportion_to_heal = (health_to_heal < (species.total_health - health)) ? (health_to_heal / (species.total_health - health)) : 1
 	for(var/datum/limb/limb AS in limbs)
-		limb.heal_limb_damage(limb.brute_dam * proportion_to_heal, limb.burn_dam * proportion_to_heal, limb.brute_dam * proportion_to_heal, TRUE)
+		limb.heal_limb_damage(limb.brute_dam * proportion_to_heal, limb.burn_dam * proportion_to_heal, robo_repair = TRUE)
 	updatehealth()
 
 /mob/living/proc/on_revive()

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -299,7 +299,7 @@
 	brute_dam = 0
 	burn_dam = 0
 	germ_level = 0
-	wounds.Cut()
+	QDEL_LIST(wounds)
 	number_wounds = 0
 	limb_wound_status = NONE
 
@@ -683,8 +683,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 		var/datum/limb/appendage = c
 		appendage.droplimb(amputation, delete_limb)
 
-	//Replace all wounds on that arm with one wound on parent organ.
-	wounds.Cut()
+	//Clear out any internal and external wounds, damage the parent limb
+	QDEL_LIST(wounds)
 	if(parent && !amputation)
 		parent.createwound(CUT, max_damage * 0.25)
 	brute_dam = 0

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -880,7 +880,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 /datum/limb/proc/has_infected_wound()
 	return FALSE
 
-///Returns the first non-internal wound at non-zero damage if any exist
+///True if the limb has any damage on it
 /datum/limb/proc/has_external_wound()
 	return brute_dam || burn_dam
 

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -259,7 +259,7 @@
 	return result
 
 
-/datum/limb/proc/heal_limb_damage(brute, burn, internal = FALSE, robo_repair = FALSE, updating_health = FALSE)
+/datum/limb/proc/heal_limb_damage(brute, burn, robo_repair = FALSE, updating_health = FALSE)
 	if(limb_status & LIMB_ROBOT && !robo_repair)
 		return
 

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -343,7 +343,7 @@
 		brute_dam += damage
 		limb_wound_status &= !(LIMB_WOUND_BANDAGED | LIMB_WOUND_DISINFECTED)
 
-//For testing purposes
+///For testing convenience. Adds one internal_bleeding wound to the limb.
 /datum/limb/proc/add_internal_bleeding()
 	new /datum/wound/internal_bleeding(15, src)
 

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -187,8 +187,7 @@
 	//Possibly trigger an internal wound, too.
 	var/local_damage = brute_dam + burn_dam + brute
 	if(brute > 15 && local_damage > 30 && prob(brute*0.5) && !(limb_status & LIMB_ROBOT) && !(SSticker.mode?.flags_round_type & MODE_NO_PERMANENT_WOUNDS))
-		var/datum/wound/internal_bleeding/I = new (min(brute - 15, 15), src)
-		wounds += I
+		new /datum/wound/internal_bleeding(min(brute - 15, 15), src)
 		owner.custom_pain("You feel something rip in your [display_name]!", 1)
 
 	//If they have it splinted and no splint health, the splint won't hold.
@@ -344,7 +343,9 @@
 		brute_dam += damage
 		limb_wound_status &= !(LIMB_WOUND_BANDAGED | LIMB_WOUND_DISINFECTED)
 
-
+//For testing purposes
+/datum/limb/proc/add_internal_bleeding()
+	new /datum/wound/internal_bleeding(15, src)
 
 /****************************************************
 			PROCESSING & UPDATING
@@ -365,6 +366,8 @@
 	else
 		last_dam = brute_dam + burn_dam
 	if(germ_level)
+		return 1
+	if(wounds.len)
 		return 1
 	return 0
 
@@ -518,12 +521,11 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(burn_dam && limb_wound_status & LIMB_WOUND_SALVED && prob(75))
 		burn_dam = max(0, burn_dam - 0.5)
 
-
 	if(owner.bodytemperature >= 170 && !HAS_TRAIT(owner, TRAIT_STASIS))
 		for(var/datum/wound/W in wounds)
 			W.process()
 
-	// sync the organ's damage with its wounds
+	// sync the organ's bleeding-ness and icon
 	update_damages()
 	if (update_icon())
 		owner.UpdateDamageIcon(1)

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -523,7 +523,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			var/inaprovaline = owner.reagents.get_reagent_amount(/datum/reagent/medicine/inaprovaline)
 			var/old_qc = owner.reagents.get_reagent_amount(/datum/reagent/medicine/quickclotplus)
 			if(!(W.can_autoheal() || (bicardose && inaprovaline) || owner.reagents.get_reagent_amount(/datum/reagent/medicine/quickclot)))	//bicaridine and inaprovaline stop internal wounds from growing bigger with time, unless it is so small that it is already healing
-				W.open_wound(0.1 * wound_update_accuracy)
+				createwound(CUT, 0.1)
 			if(bicardose >= 30)	//overdose of bicaridine begins healing IB
 				W.damage = max(0, W.damage - 0.2)
 			if(old_qc >= 5)	//overdose of QC+ heals IB extremely fast.

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -420,10 +420,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 		return
 
 	if(brute_dam >= 20)
-		if(prob((brute_dam - (limb_wound_status & LIMB_WOUND_BANDAGED ? 50 : 0)) * 2))
+		if(prob((brute_dam - (limb_wound_status & LIMB_WOUND_BANDAGED ? 50 : 0)) * 4))
 			germ_level++
 	if(burn_dam >= 20)
-		if(prob(burn_dam - (limb_wound_status & LIMB_WOUND_SALVED ? 50 : 0)))
+		if(prob(burn_dam - (limb_wound_status & LIMB_WOUND_SALVED ? 50 : 0) * 2))
 			germ_level++
 
 
@@ -518,7 +518,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 	for(var/datum/wound/W in wounds)
 		// Internal wounds get worse over time. Low temperatures (cryo) stop them.
-		if(W.internal && owner.bodytemperature >= 170 && !HAS_TRAIT(owner, TRAIT_STASIS))
+		if(owner.bodytemperature >= 170 && !HAS_TRAIT(owner, TRAIT_STASIS))
 			var/bicardose = owner.reagents.get_reagent_amount(/datum/reagent/medicine/bicaridine)
 			var/inaprovaline = owner.reagents.get_reagent_amount(/datum/reagent/medicine/inaprovaline)
 			var/old_qc = owner.reagents.get_reagent_amount(/datum/reagent/medicine/quickclotplus)

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -22,12 +22,11 @@
 /datum/wound/New(initial_damage, datum/limb/plimb)
 	parent_limb = plimb
 	damage = initial_damage
+	parent_limb.wounds += src
 	return ..()
 
 //Called by the parent limb every life tick by default
 /datum/wound/process()
-	if(can_autoheal())
-		damage -= 0.1
 	if(damage <= 0)
 		qdel(src)
 
@@ -71,9 +70,10 @@
 
 	if(!(can_autoheal() || (bicardose && inaprovaline) || quickclot))	//bicaridine and inaprovaline stop internal wounds from harming the parent limb over time, unless it is so small that it is already healing
 		parent_limb.createwound(CUT, 0.1)
+		damage += 0.1
 
 	if(!quickclot) //Quickclot stops bleeding, magic!
-		parent_limb.owner.blood_volume = max(0, parent_limb.owner.blood_volume - damage/30)
+		parent_limb.owner.blood_volume = max(0, parent_limb.owner.blood_volume - damage/40)
 		if(prob(1))
 			parent_limb.owner.custom_pain("You feel a stabbing pain in your [parent_limb.display_name]!", 1)
 

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -20,8 +20,6 @@
 
 	///stages such as "cut", "deep cut", etc.
 	var/list/stages
-	///internal wounds can only be fixed through surgery
-	var/internal = FALSE
 	// maximum stage at which bleeding should still happen, counted from the right rather than the left of the list
 	// 1 means all stages except the last should bleed
 	var/max_bleeding_stage = 1
@@ -74,9 +72,6 @@
  */
 /datum/wound/proc/heal_wound_damage(heal_amount, heals_internal = FALSE)
 	// If the wound is internal, and we don't heal internal wounds just pass through.
-	if(internal && !heals_internal)
-		// heal nothing
-		return heal_amount
 
 	// either, the entire wound, or the heal_amount
 	var/healed_damage = min(damage, heal_amount)
@@ -221,7 +216,6 @@ datum/wound/cut/massive
 
 /** INTERNAL BLEEDING **/
 /datum/wound/internal_bleeding
-	internal = 1
 	stages = list("severed artery" = 30, "cut artery" = 20, "damaged artery" = 10, "bruised artery" = 5)
 	autoheal_cutoff = 5
 	max_bleeding_stage = 0	//all stages bleed. It's called internal bleeding after all.

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -20,9 +20,6 @@
 
 	///stages such as "cut", "deep cut", etc.
 	var/list/stages
-	// maximum stage at which bleeding should still happen, counted from the right rather than the left of the list
-	// 1 means all stages except the last should bleed
-	var/max_bleeding_stage = 1
 	///one of CUT, BRUISE, BURN
 	var/damage_type = CUT
 	// whether this wound needs a bandage/salve to heal at all
@@ -42,8 +39,6 @@
 		damage_list += stages[V]
 
 	damage = initial_damage
-
-	max_bleeding_stage = desc_list.len - max_bleeding_stage
 
 	// initialize with the appropriate stage
 	current_stage = stages.len
@@ -116,115 +111,12 @@
 
 /** WOUND DEFINITIONS **/
 
-//Note that the MINIMUM damage before a wound can be applied should correspond to
-//the damage amount for the stage with the same name as the wound.
-//e.g. /datum/wound/cut/deep should only be applied for 15 damage and up,
-//because in it's stages list, "deep cut" = 15.
+//Mostly dead. Kill entirely or leave to generate a suitable internal?.
 /proc/get_wound_type(type = CUT, damage)
-	switch(type)
-		if(CUT)
-			switch(damage)
-				if(70 to INFINITY)
-					return /datum/wound/cut/massive
-				if(60 to 70)
-					return /datum/wound/cut/gaping_big
-				if(50 to 60)
-					return /datum/wound/cut/gaping
-				if(25 to 50)
-					return /datum/wound/cut/flesh
-				if(15 to 25)
-					return /datum/wound/cut/deep
-				if(0 to 15)
-					return /datum/wound/cut/small
-		if(BRUISE)
-			return /datum/wound/bruise
-		if(BURN)
-			switch(damage)
-				if(50 to INFINITY)
-					return /datum/wound/burn/carbonised
-				if(40 to 50)
-					return /datum/wound/burn/deep
-				if(30 to 40)
-					return /datum/wound/burn/severe
-				if(15 to 30)
-					return /datum/wound/burn/large
-				if(0 to 15)
-					return /datum/wound/burn/moderate
 	return null //no wound
 
-/** CUTS **/
-// link wound descriptions to amounts of damage
-
-/datum/wound/cut/small
-	max_bleeding_stage = 2
-	stages = list("ugly ripped cut" = 20, "ripped cut" = 10, "cut" = 5, "healing cut" = 2, "small scab" = 0)
-	damage_type = CUT
-
-/datum/wound/cut/deep
-	max_bleeding_stage = 3
-	stages = list("ugly deep ripped cut" = 25, "deep ripped cut" = 20, "deep cut" = 15, "clotted cut" = 8, "scab" = 2, "fresh skin" = 0)
-	damage_type = CUT
-
-/datum/wound/cut/flesh
-	max_bleeding_stage = 4
-	stages = list("ugly ripped flesh wound" = 35, "ugly flesh wound" = 30, "flesh wound" = 25, "blood soaked clot" = 15, "large scab" = 5, "fresh skin" = 0)
-	damage_type = CUT
-
-/datum/wound/cut/gaping
-	max_bleeding_stage = 2
-	stages = list("gaping wound" = 50, "large blood soaked clot" = 25, "large clot" = 15, "small angry scar" = 5, "small straight scar" = 0)
-	damage_type = CUT
-
-/datum/wound/cut/gaping_big
-	max_bleeding_stage = 2
-	stages = list("big gaping wound" = 60, "healing gaping wound" = 40, "large angry scar" = 10, "large straight scar" = 0)
-	damage_type = CUT
-
-datum/wound/cut/massive
-	max_bleeding_stage = 2
-	stages = list("massive wound" = 70, "massive healing wound" = 50, "massive angry scar" = 10,  "massive jagged scar" = 0)
-	damage_type = CUT
-
-/** BRUISES **/
-/datum/wound/bruise
-	stages = list("monumental bruise" = 80, "huge bruise" = 50, "large bruise" = 30,\
-				"moderate bruise" = 20, "small bruise" = 10, "tiny bruise" = 5)
-	max_bleeding_stage = 3
-	autoheal_cutoff = 30
-	damage_type = BRUISE
-
-/** BURNS **/
-/datum/wound/burn/moderate
-	stages = list("ripped burn" = 10, "moderate burn" = 5, "healing moderate burn" = 2, "fresh skin" = 0)
-	damage_type = BURN
-
-/datum/wound/burn/large
-	stages = list("ripped large burn" = 20, "large burn" = 15, "healing large burn" = 5, "fresh skin" = 0)
-	damage_type = BURN
-
-/datum/wound/burn/severe
-	stages = list("ripped severe burn" = 35, "severe burn" = 30, "healing severe burn" = 10, "burn scar" = 0)
-	damage_type = BURN
-
-/datum/wound/burn/deep
-	stages = list("ripped deep burn" = 45, "deep burn" = 40, "healing deep burn" = 15,  "large burn scar" = 0)
-	damage_type = BURN
-
-/datum/wound/burn/carbonised
-	stages = list("carbonised area" = 50, "healing carbonised area" = 20, "massive burn scar" = 0)
-	damage_type = BURN
 
 /** INTERNAL BLEEDING **/
 /datum/wound/internal_bleeding
 	stages = list("severed artery" = 30, "cut artery" = 20, "damaged artery" = 10, "bruised artery" = 5)
 	autoheal_cutoff = 5
-	max_bleeding_stage = 0	//all stages bleed. It's called internal bleeding after all.
-
-/** EXTERNAL ORGAN LOSS **/
-/datum/wound/lost_limb
-	damage_type = CUT
-	stages = list("ripped stump" = 65, "bloody stump" = 50, "clotted stump" = 25, "scarred stump" = 0)
-	max_bleeding_stage = 3
-
-/datum/wound/lost_limb/small
-	stages = list("ripped stump" = 40, "bloody stump" = 30, "clotted stump" = 15, "scarred stump" = 0)

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -5,51 +5,29 @@
 /datum/wound
 	///The limb this wound is on
 	var/datum/limb/parent_limb
-	///number representing the current stage
-	var/current_stage = 0
 
 	///description of the wound
 	var/desc = "wound"
 
 	///amount of damage this wound has
 	var/damage = 0
-	// amount of damage the current wound type requires(less means we need to apply the next healing stage)
-	var/min_damage = 0
 
 	/*  These are defined by the wound type and should not be changed */
 
-	///stages such as "cut", "deep cut", etc.
-	var/list/stages
 	///one of CUT, BRUISE, BURN
 	var/damage_type = CUT
-	// whether this wound needs a bandage/salve to heal at all
 	// the maximum amount of damage that this wound can have and still autoheal
 	var/autoheal_cutoff = 15
 
-	// helper lists
-	var/tmp/list/desc_list = list()
-	var/tmp/list/damage_list = list()
-
 /datum/wound/New(initial_damage, datum/limb/plimb)
 	parent_limb = plimb
-	//reading from a list("stage" = damage) is pretty difficult, so build two separate
-	//lists from them instead
-	for(var/V in stages)
-		desc_list += V
-		damage_list += stages[V]
-
 	damage = initial_damage
+	return ..()
 
-	// initialize with the appropriate stage
-	current_stage = stages.len
-
-	while(current_stage > 1 && damage_list[current_stage-1] <= initial_damage)
-		current_stage--
-
-	min_damage = damage_list[current_stage]
-	desc = desc_list[current_stage]
-
+//Called by the parent limb every life tick by default
 /datum/wound/process()
+	if(can_autoheal())
+		damage -= 0.1
 	if(damage <= 0)
 		qdel(src)
 
@@ -66,7 +44,6 @@
 /**
  *heal the given amount of damage, and if the given amount of damage was more
  *than what needed to be healed, return how much heal was left
- *set @heals_internal to also heal internal organ damage
  */
 /datum/wound/proc/heal_wound_damage(heal_amount)
 	// either, the entire wound, or the heal_amount
@@ -74,44 +51,26 @@
 	heal_amount -= healed_damage // If the heal was large, we may have only removed the small exisitng damage
 	damage -= healed_damage // Heal the wound
 
-	// Update the stages
-	while(damage < damage_list[current_stage] && current_stage < desc_list.len)
-		current_stage++
-	desc = desc_list[current_stage]
-	min_damage = damage_list[current_stage]
-
 	// return amount of healing still leftover, can be used for other wounds
 	return heal_amount
 
-///Reopens the wound again
+///Reopens the wound again. Remove applied treatment, if there is any, and add new damage
 /datum/wound/proc/open_wound(initial_damage)
 	damage += initial_damage
 
-	var/damage_per_wound = damage
-	while(current_stage > 1 && damage_list[current_stage - 1] <= damage_per_wound)
-		current_stage--
-
-	desc = desc_list[current_stage]
-	min_damage = damage_list[current_stage]
-
 /** INTERNAL BLEEDING **/
 /datum/wound/internal_bleeding
-	stages = list("severed artery" = 30, "cut artery" = 20, "damaged artery" = 10, "bruised artery" = 5)
+	desc = "damaged artery"
 	autoheal_cutoff = 5
 
 /datum/wound/internal_bleeding/process()
 
 	var/bicardose = parent_limb.owner.reagents.get_reagent_amount(/datum/reagent/medicine/bicaridine)
 	var/inaprovaline = parent_limb.owner.reagents.get_reagent_amount(/datum/reagent/medicine/inaprovaline)
-	var/old_qc = parent_limb.owner.reagents.get_reagent_amount(/datum/reagent/medicine/quickclotplus)
 	var/quickclot = parent_limb.owner.reagents.get_reagent_amount(/datum/reagent/medicine/quickclot)
 
-	if(!(can_autoheal() || (bicardose && inaprovaline) || quickclot))	//bicaridine and inaprovaline stop internal wounds from growing bigger with time, unless it is so small that it is already healing
+	if(!(can_autoheal() || (bicardose && inaprovaline) || quickclot))	//bicaridine and inaprovaline stop internal wounds from harming the parent limb over time, unless it is so small that it is already healing
 		parent_limb.createwound(CUT, 0.1)
-	if(bicardose >= 30)	//overdose of bicaridine begins healing IB
-		damage -= 0.2
-	if(old_qc >= 5)	//overdose of QC+ heals IB extremely fast.
-		damage -= 5
 
 	if(!quickclot) //Quickclot stops bleeding, magic!
 		parent_limb.owner.blood_volume = max(0, parent_limb.owner.blood_volume - damage/30)

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -25,7 +25,7 @@
 	parent_limb.wounds += src
 	return ..()
 
-//Called by the parent limb every life tick by default
+///Called by the parent limb every life tick by default
 /datum/wound/process()
 	if(damage <= 0)
 		qdel(src)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -761,11 +761,10 @@
 	var/mob/living/carbon/human/H = L
 	for(var/datum/limb/X in H.limbs)
 		for(var/datum/wound/W in X.wounds)
-			if(W.internal)
-				W.damage = max(0, W.damage - (effect_str))
-				X.update_damages()
-				if (X.update_icon())
-					X.owner.UpdateDamageIcon(1)
+			W.damage = max(0, W.damage - (effect_str))
+			X.update_damages()
+			if (X.update_icon())
+				X.owner.UpdateDamageIcon(1)
 	return ..()
 
 
@@ -797,11 +796,10 @@
 	var/mob/living/carbon/human/H = L
 	for(var/datum/limb/X in H.limbs)
 		for(var/datum/wound/W in X.wounds)
-			if(W.internal)
-				W.damage = max(0, W.damage - (2.5*effect_str))
-				X.update_damages()
-				if (X.update_icon())
-					X.owner.UpdateDamageIcon(1)
+			W.damage = max(0, W.damage - (2.5*effect_str))
+			X.update_damages()
+			if (X.update_icon())
+				X.owner.UpdateDamageIcon(1)
 	L.reagents.add_reagent(/datum/reagent/toxin,5)
 	L.reagent_shock_modifier -= PAIN_REDUCTION_VERY_HEAVY
 	L.adjustStaminaLoss(15*effect_str)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -760,11 +760,8 @@
 		return ..()
 	var/mob/living/carbon/human/H = L
 	for(var/datum/limb/X in H.limbs)
-		for(var/datum/wound/W in X.wounds)
+		for(var/datum/wound/internal_bleeding/W in X.wounds)
 			W.damage = max(0, W.damage - (effect_str))
-			X.update_damages()
-			if (X.update_icon())
-				X.owner.UpdateDamageIcon(1)
 	return ..()
 
 
@@ -795,11 +792,8 @@
 /datum/reagent/medicine/quickclotplus/on_mob_life(mob/living/L, metabolism)
 	var/mob/living/carbon/human/H = L
 	for(var/datum/limb/X in H.limbs)
-		for(var/datum/wound/W in X.wounds)
+		for(var/datum/wound/internal_bleeding/W in X.wounds)
 			W.damage = max(0, W.damage - (2.5*effect_str))
-			X.update_damages()
-			if (X.update_icon())
-				X.owner.UpdateDamageIcon(1)
 	L.reagents.add_reagent(/datum/reagent/toxin,5)
 	L.reagent_shock_modifier -= PAIN_REDUCTION_VERY_HEAVY
 	L.adjustStaminaLoss(15*effect_str)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -715,6 +715,12 @@
 
 /datum/reagent/medicine/bicaridine/overdose_process(mob/living/L, metabolism)
 	L.apply_damage(effect_str, BURN)
+	if(!ishuman(L))
+		return
+	var/mob/living/carbon/human/H = L
+	for(var/datum/limb/X in H.limbs)
+		for(var/datum/wound/internal_bleeding/W in X.wounds)
+			W.damage = max(0, W.damage - (0.2*effect_str))
 
 /datum/reagent/medicine/bicaridine/overdose_crit_process(mob/living/L, metabolism)
 	L.apply_damages(effect_str, 3*effect_str, 2*effect_str)
@@ -803,6 +809,12 @@
 /datum/reagent/medicine/quickclotplus/overdose_process(mob/living/L, metabolism)
 	L.apply_damage(1.5*effect_str, TOX)
 	L.blood_volume -= 4
+	if(!ishuman(L))
+		return
+	var/mob/living/carbon/human/H = L
+	for(var/datum/limb/X in H.limbs)
+		for(var/datum/wound/internal_bleeding/W in X.wounds)
+			W.damage = max(0, W.damage - (5*effect_str))
 
 /datum/reagent/medicine/quickclotplus/overdose_crit_process(mob/living/L, metabolism)
 	L.blood_volume -= 20

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -119,8 +119,7 @@
 	span_notice("You put \the [tool] inside [target]'s [get_cavity(affected)] cavity."))
 	if(tool.w_class > get_max_wclass(affected)/2 && prob(50))
 		to_chat(user, span_warning("You tear some blood vessels trying to fit such a big object in this cavity."))
-		var/datum/wound/internal_bleeding/I = new (10)
-		affected.wounds += I
+		new /datum/wound/internal_bleeding(10, affected)
 		affected.owner.custom_pain("You feel something rip in your [affected.display_name]!", 1)
 	user.transferItemToLoc(tool, target)
 	affected.hidden = tool

--- a/code/modules/surgery/internal_bleeding.dm
+++ b/code/modules/surgery/internal_bleeding.dm
@@ -17,9 +17,8 @@
 
 /datum/surgery_step/fix_vein/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected, checks_only)
 	if(affected.surgery_open_stage >= 2)
-		for(var/datum/wound/W in affected.wounds)
-			if(W.internal)
-				return 1
+		if(affected.wounds.len)
+			return 1
 
 /datum/surgery_step/fix_vein/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] starts patching the damaged vein in [target]'s [affected.display_name] with \the [tool].") , \
@@ -31,10 +30,9 @@
 	user.visible_message(span_notice("[user] has patched the damaged vein in [target]'s [affected.display_name] with \the [tool]."), \
 		span_notice("You have patched the damaged vein in [target]'s [affected.display_name] with \the [tool]."))
 
-	for(var/datum/wound/W in affected.wounds)
-		if(W.internal)
-			affected.wounds -= W
-			affected.update_damages()
+	for(var/datum/wound/W AS in affected.wounds)
+		affected.wounds -= W
+		affected.update_damages()
 	if(ishuman(user) && prob(40))
 		user:bloody_hands(target, 0)
 

--- a/code/modules/surgery/internal_bleeding.dm
+++ b/code/modules/surgery/internal_bleeding.dm
@@ -17,7 +17,7 @@
 
 /datum/surgery_step/fix_vein/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected, checks_only)
 	if(affected.surgery_open_stage >= 2)
-		if(affected.wounds.len)
+		for(var/datum/wound/internal_bleeding/W in affected.wounds)
 			return TRUE
 
 /datum/surgery_step/fix_vein/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)

--- a/code/modules/surgery/internal_bleeding.dm
+++ b/code/modules/surgery/internal_bleeding.dm
@@ -30,8 +30,7 @@
 	user.visible_message(span_notice("[user] has patched the damaged vein in [target]'s [affected.display_name] with \the [tool]."), \
 		span_notice("You have patched the damaged vein in [target]'s [affected.display_name] with \the [tool]."))
 
-	for(var/datum/wound/internal_bleeding/W in affected.wounds)
-		qdel(W)
+	QDEL_LIST(affected.wounds)
 	if(ishuman(user) && prob(40))
 		user:bloody_hands(target, 0)
 

--- a/code/modules/surgery/internal_bleeding.dm
+++ b/code/modules/surgery/internal_bleeding.dm
@@ -30,7 +30,7 @@
 	user.visible_message(span_notice("[user] has patched the damaged vein in [target]'s [affected.display_name] with \the [tool]."), \
 		span_notice("You have patched the damaged vein in [target]'s [affected.display_name] with \the [tool]."))
 
-	for(var/datum/wound/W AS in affected.wounds)
+	for(var/datum/wound/internal_bleeding/W in affected.wounds)
 		qdel(W)
 	if(ishuman(user) && prob(40))
 		user:bloody_hands(target, 0)

--- a/code/modules/surgery/internal_bleeding.dm
+++ b/code/modules/surgery/internal_bleeding.dm
@@ -18,7 +18,7 @@
 /datum/surgery_step/fix_vein/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected, checks_only)
 	if(affected.surgery_open_stage >= 2)
 		if(affected.wounds.len)
-			return 1
+			return TRUE
 
 /datum/surgery_step/fix_vein/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] starts patching the damaged vein in [target]'s [affected.display_name] with \the [tool].") , \
@@ -31,8 +31,7 @@
 		span_notice("You have patched the damaged vein in [target]'s [affected.display_name] with \the [tool]."))
 
 	for(var/datum/wound/W AS in affected.wounds)
-		affected.wounds -= W
-		affected.update_damages()
+		qdel(W)
 	if(ishuman(user) && prob(40))
 		user:bloody_hands(target, 0)
 


### PR DESCRIPTION
## About The Pull Request
Wounds exist as a whole thing on top of limbs, tracking their individual damage and description and treatedness. The only gain from this is that if you examine someone you get to see what their wounds look like. This pr kills wounds as a datum with the exception of internal bleeding, which is refactored to process itself instead of being handled by the limb. Everything should work the same, with the sole exception of internal bleeding not contributing directly to the limb's brute loss.

## Why It's Good For The Game
Removes a level of abstraction which generally isn't thought about ingame and only really offers flavor (individual wound descs) as a benefit.

## Changelog
:cl:
refactor: Limbs have damage themselves instead of separating it into wounds
refactor: Internal bleeding doesn't count directly as damage on a limb.
/:cl:
