### PR TITLE
PoS, Minerva, and Icarus have 2x1 maint doors

### DIFF
--- a/_maps/map_files/Icarus_Military_Port/icarus_military_port.dmm
+++ b/_maps/map_files/Icarus_Military_Port/icarus_military_port.dmm
@@ -1217,9 +1217,6 @@
 /area/icarus/interior/biodome)
 "btn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 1
-	},
 /obj/structure/cable,
 /turf/open/floor/plating/mainship,
 /area/icarus/interior/hangartwo)
@@ -2332,9 +2329,7 @@
 /area/icarus/interior/cargo)
 "cRv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 1
-	},
+/obj/machinery/door/airlock/multi_tile/mainship/maint,
 /turf/open/floor/plating/mainship,
 /area/icarus/interior/swcaveslz)
 "cRZ" = (
@@ -2760,11 +2755,11 @@
 /turf/open/shuttle/dropship/floor,
 /area/icarus/interior/lzone)
 "dCm" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 8
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
 	},
-/turf/open/floor/mainship/mono,
-/area/icarus/interior/hangartwo)
+/turf/open/floor/plating/mainship,
+/area/icarus/interior/scrapyardone)
 "dCy" = (
 /obj/docking_port/mobile/crashmode/bigbury,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -3193,8 +3188,8 @@
 /turf/open/floor/plating/mainship,
 /area/icarus/interior/scrapyardone)
 "ebE" = (
-/obj/machinery/door/airlock/mainship/maint,
-/turf/open/floor/plating/mainship,
+/obj/machinery/door/airlock/multi_tile/mainship/maint,
+/turf/open/floor/mainship/mono,
 /area/icarus/interior/scrapyardone)
 "ecj" = (
 /obj/effect/particle_effect/smoke/phosphorus{
@@ -3337,12 +3332,9 @@
 /turf/open/floor/plating/mainship,
 /area/icarus/interior/swcaveslz)
 "eni" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plating,
-/area/icarus/interior/research)
+/obj/machinery/door/airlock/multi_tile/mainship/maint,
+/turf/open/floor/mainship/mono,
+/area/icarus/interior/shipbayone)
 "eod" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -4178,11 +4170,13 @@
 	},
 /area/icarus/interior/hangartwo)
 "fiK" = (
-/obj/machinery/door/airlock/mainship/maint,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/icarus/interior/scrapyardone)
 "fiM" = (
@@ -4447,9 +4441,6 @@
 /turf/open/floor/plating/mainship,
 /area/icarus/interior/dorms)
 "fwL" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 1
-	},
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/icarus/interior/scrapyardone)
@@ -6226,6 +6217,12 @@
 	},
 /turf/open/floor/mainship,
 /area/icarus/interior/hangarone)
+"hTZ" = (
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/icarus/interior/hangartwo)
 "hUx" = (
 /obj/machinery/door/airlock/centcom,
 /obj/structure/cable,
@@ -7084,6 +7081,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icarus/interior/library)
+"iTq" = (
+/obj/machinery/door/airlock/multi_tile/mainship/maint,
+/turf/open/floor/plating/mainship,
+/area/icarus/interior/hangartwo)
 "iTU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
@@ -8357,6 +8358,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/icarus/interior/library)
+"kAG" = (
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
+	},
+/turf/open/floor/plating/mainship,
+/area/icarus/interior/hangartwo)
 "kAJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -8658,9 +8665,11 @@
 	},
 /area/icarus/exterior/secaves)
 "kSK" = (
-/obj/machinery/light,
-/turf/open/floor/plating/mainship,
-/area/icarus/interior/swcaveslz)
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/icarus/interior/library)
 "kTL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -8995,6 +9004,10 @@
 	},
 /turf/open/floor/plating,
 /area/icarus/interior/shipbayconnector)
+"loe" = (
+/obj/machinery/light,
+/turf/open/floor/plating/plating_catwalk,
+/area/icarus/interior/swcaveslz)
 "loj" = (
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -9234,10 +9247,10 @@
 /turf/open/floor/plating,
 /area/icarus/interior/shipbayconnector)
 "lEv" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
 	dir = 1
 	},
-/turf/open/floor/plating/mainship,
+/turf/open/floor/mainship/mono,
 /area/icarus/interior/medbay)
 "lEJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -9533,6 +9546,10 @@
 /obj/structure/cargo_container/gorg,
 /turf/open/floor/plating/mainship,
 /area/icarus/interior/shipbaytwo)
+"maA" = (
+/obj/machinery/door/airlock/multi_tile/mainship/maint,
+/turf/open/floor/mainship/mono,
+/area/icarus/interior/swcaveslz)
 "maB" = (
 /obj/machinery/door/poddoor/mainship{
 	dir = 1;
@@ -9759,11 +9776,9 @@
 /turf/open/floor/mainship/mono,
 /area/icarus/interior/hangartwo)
 "mlp" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/icarus/interior/library)
+/obj/machinery/door/airlock/multi_tile/mainship/maint,
+/turf/open/floor/plating/mainship,
+/area/icarus/interior/medbay)
 "mlL" = (
 /turf/open/floor/mainship/mono,
 /area/icarus/exterior/secaves)
@@ -10403,9 +10418,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/plating/mainship,
 /area/icarus/interior/hangartwo)
@@ -10593,11 +10605,10 @@
 	},
 /area/icarus/interior/research)
 "nAc" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/plating,
-/area/icarus/interior/research)
+/area/icarus/interior/library)
 "nAO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -11568,11 +11579,10 @@
 /turf/open/floor/mainship/mono,
 /area/icarus/interior/shipbayone)
 "oXm" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/multi_tile/mainship/maint,
 /turf/open/floor/mainship/mono,
-/area/icarus/interior/shipbayone)
+/area/icarus/interior/library)
 "oYo" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/intel_computer,
@@ -11701,11 +11711,11 @@
 /turf/open/floor/plating,
 /area/icarus/interior/lzone)
 "pdq" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
 	dir = 1
 	},
 /turf/open/floor/mainship/mono,
-/area/icarus/interior/swcaveslz)
+/area/icarus/interior/library)
 "pdQ" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -11734,9 +11744,7 @@
 /area/icarus/interior/disposals)
 "peG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 1
-	},
+/obj/machinery/door/airlock/multi_tile/mainship/maint,
 /turf/open/floor/plating,
 /area/icarus/interior/library)
 "peO" = (
@@ -12376,7 +12384,9 @@
 /turf/open/floor/mainship_hull,
 /area/icarus/interior/shipbaytwo)
 "pXS" = (
-/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/icarus/interior/monitoring)
 "pXT" = (
@@ -13272,9 +13282,9 @@
 /turf/open/floor/mainship,
 /area/icarus/interior/cargo)
 "rcb" = (
-/obj/machinery/door/airlock/mainship/maint,
-/turf/open/floor/mainship/mono,
-/area/icarus/interior/medbay)
+/obj/machinery/door/airlock/multi_tile/mainship/maint,
+/turf/open/floor/plating,
+/area/icarus/interior/research)
 "rcB" = (
 /obj/machinery/light,
 /turf/open/floor/plating,
@@ -14665,9 +14675,6 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/icarus/interior/research)
 "sNg" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
 /turf/open/floor/plating/mainship,
@@ -15169,6 +15176,10 @@
 /obj/structure/closet/crate/trashcart,
 /turf/open/floor/plating,
 /area/icarus/interior/medbay)
+"twm" = (
+/obj/machinery/door/airlock/multi_tile/mainship/maint,
+/turf/open/floor/mainship/mono,
+/area/icarus/interior/hangartwo)
 "tws" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -15710,9 +15721,12 @@
 	},
 /area/icarus/exterior/secaves)
 "ugO" = (
-/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/closet/crate/trashcart,
 /turf/open/floor/plating/mainship,
-/area/icarus/interior/research)
+/area/icarus/interior/library)
 "ugP" = (
 /turf/closed/wall/mainship,
 /area/icarus/interior/swcaveslz)
@@ -17221,9 +17235,6 @@
 	},
 /area/icarus/interior/shipbaytwo)
 "waW" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/ai_node,
 /obj/structure/cable,
@@ -18157,9 +18168,11 @@
 /turf/open/floor/mainship/mono,
 /area/icarus/interior/swcaveslz)
 "xjy" = (
-/obj/structure/closet/crate/trashcart,
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
+	},
 /turf/open/floor/plating/mainship,
-/area/icarus/interior/library)
+/area/icarus/interior/research)
 "xkL" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
@@ -32695,13 +32708,13 @@ twB
 twB
 twB
 twB
-ebE
+xsc
+dCm
 twB
 twB
 twB
 twB
-twB
-twB
+okr
 fiK
 twB
 fGD
@@ -33315,7 +33328,7 @@ xsc
 xsc
 xsc
 fja
-twB
+ebE
 xys
 xys
 xys
@@ -36412,7 +36425,7 @@ ibC
 xSu
 vIA
 xou
-xRK
+oXm
 cDZ
 xLS
 rnd
@@ -36616,8 +36629,8 @@ ibC
 xSu
 ibC
 eJZ
-xSu
-tDg
+ibC
+kSK
 eOJ
 tDg
 rMU
@@ -37248,8 +37261,8 @@ xSu
 xSu
 xSu
 xSu
-xSu
-sEO
+ibC
+pdq
 hyF
 kMF
 vnM
@@ -37434,7 +37447,7 @@ ibC
 nRM
 xSu
 tDg
-mlp
+qgl
 qgl
 rMU
 riY
@@ -37450,9 +37463,9 @@ pmS
 rMU
 xSu
 tPs
-pIb
+ugO
 rsf
-xjy
+slp
 slp
 hyF
 huQ
@@ -37638,8 +37651,8 @@ vPO
 xpo
 xSu
 xSu
-xSu
-sEO
+ibC
+pdq
 rMU
 riY
 pmS
@@ -38064,8 +38077,8 @@ xSu
 xSu
 xSu
 xSu
-xSu
-sEO
+ibC
+pdq
 hyF
 eyP
 cBE
@@ -38268,7 +38281,7 @@ vki
 xSu
 vki
 xSu
-kCy
+wWI
 wWI
 hyF
 ltb
@@ -39865,8 +39878,8 @@ xss
 xys
 wwJ
 xys
-xaG
-tDg
+eni
+kSK
 tDg
 tDg
 tDg
@@ -39875,7 +39888,7 @@ udL
 udL
 sFw
 tfG
-udL
+nAc
 peG
 vnm
 vbz
@@ -40069,7 +40082,7 @@ xaK
 xaK
 oct
 oFw
-oXm
+xys
 nSS
 tDg
 tDg
@@ -40080,7 +40093,7 @@ tDg
 xkL
 tDg
 qqV
-hyF
+tDg
 vol
 vQT
 xpJ
@@ -41753,7 +41766,7 @@ uZO
 uZO
 uZO
 vrO
-wAu
+loe
 ugP
 opX
 vlc
@@ -41957,8 +41970,8 @@ vZq
 gSp
 gSp
 gSp
-kSK
-ugP
+dtS
+maA
 opX
 vlc
 iSh
@@ -42162,7 +42175,7 @@ kQq
 gSp
 gSp
 dtS
-pdq
+vlc
 opX
 mcO
 awN
@@ -42359,7 +42372,7 @@ qpM
 qpM
 qpM
 qpM
-qpM
+wXg
 pXS
 qpM
 qpM
@@ -45022,7 +45035,7 @@ tws
 vlc
 vlc
 hWh
-ugP
+dtS
 dtS
 eWV
 ugP
@@ -52148,8 +52161,8 @@ qcL
 cHC
 wdH
 arb
-dCm
-arb
+qcL
+hTZ
 arb
 arb
 arb
@@ -52163,7 +52176,7 @@ arb
 arb
 arb
 nkG
-arb
+kAG
 arb
 arb
 vUf
@@ -52353,7 +52366,7 @@ kXy
 kXy
 arb
 hUD
-fWi
+hUD
 arb
 usL
 usL
@@ -52759,10 +52772,10 @@ aux
 hUD
 hUD
 hUD
-arb
+twm
 hUD
 jjx
-arb
+iTq
 hUD
 hUD
 hUD
@@ -52772,7 +52785,7 @@ izi
 hUD
 hUD
 jjx
-arb
+iTq
 eod
 jQD
 tdG
@@ -56189,8 +56202,8 @@ xTs
 xTs
 xTs
 rCq
-rcb
-meO
+sLw
+lEv
 meO
 meO
 meO
@@ -56425,8 +56438,8 @@ uoH
 uoH
 alk
 eZS
-eZS
-cAN
+aOL
+rcb
 aOL
 dPu
 nDH
@@ -56630,11 +56643,11 @@ cUW
 nDH
 nDH
 nDH
-eni
+nDH
 iYU
 aKB
-cAN
-ugO
+aOL
+aOL
 cAN
 whP
 vUf
@@ -56805,7 +56818,7 @@ rfj
 ryt
 rxx
 rdY
-meO
+mlp
 twk
 urs
 rdY
@@ -56833,12 +56846,12 @@ aOL
 jWi
 aOL
 aOL
-aOL
-cAN
+eZS
 cAN
 cAN
 cAN
 uSX
+xjy
 cAN
 whP
 vUf
@@ -57222,7 +57235,7 @@ rdY
 rdY
 rdY
 rdY
-meO
+mlp
 xEO
 xEO
 xEO
@@ -57236,7 +57249,7 @@ tha
 tha
 tha
 tha
-cAN
+rcb
 aOL
 aOL
 aOL
@@ -57426,7 +57439,7 @@ wYs
 rdY
 rdY
 rdY
-lEv
+xfr
 xEO
 xEO
 hsh
@@ -57440,7 +57453,7 @@ tha
 tha
 tha
 tha
-nAc
+aOL
 aOL
 aOL
 pOj

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -555,6 +555,15 @@
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct,
 /turf/closed/wall/mainship/outer,
 /area/mainship/command/self_destruct)
+"bI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/port_hull)
 "bJ" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/drinks/cans/aspen{
@@ -4563,6 +4572,9 @@
 /obj/structure/ship_ammo/heavygun,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"ph" = (
+/turf/open/floor/mainship/mono,
+/area/mainship/living/evacuation)
 "pj" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
@@ -6948,9 +6960,7 @@
 /turf/closed/wall/mainship,
 /area/mainship/living/cafeteria_starboard)
 "xi" = (
-/obj/machinery/door/airlock/mainship/generic/ert{
-	dir = 2
-	},
+/obj/machinery/door/airlock/multi_tile/mainship/generic/noglass,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
 "xk" = (
@@ -7243,13 +7253,7 @@
 	},
 /area/mainship/living/cafeteria_starboard)
 "yh" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/structure/cable,
@@ -7601,9 +7605,6 @@
 "zb" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
@@ -8479,9 +8480,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
 "BE" = (
-/obj/machinery/door/airlock/mainship/generic/ert{
-	name = "Shuttle Airlock"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -8489,6 +8487,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/door/airlock/multi_tile/mainship/generic/noglass{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
 "BF" = (
@@ -10545,8 +10546,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
 "HL" = (
-/obj/machinery/door/airlock/mainship/generic/ert{
-	name = "Shuttle Airlock"
+/obj/machinery/door/airlock/multi_tile/mainship/generic/noglass{
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
@@ -11755,8 +11756,8 @@
 /turf/closed/wall/mainship/outer,
 /area/mainship/hull/port_hull)
 "Lt" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 8
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/mainship/living/evacuation)
@@ -18486,8 +18487,8 @@ ht
 ht
 gN
 oc
+bI
 bD
-bs
 bD
 bD
 bD
@@ -18584,19 +18585,19 @@ ht
 ht
 gN
 yh
+Lt
 gN
 gP
 gP
 gN
 gN
 gN
-gN
 gP
 gP
 gP
 gP
 gN
-gN
+ht
 Lt
 LW
 MK
@@ -18683,7 +18684,7 @@ ht
 gN
 yi
 zb
-At
+FH
 At
 At
 At
@@ -18693,8 +18694,8 @@ At
 At
 At
 At
-At
 FH
+At
 Lv
 LW
 ML
@@ -19464,7 +19465,7 @@ tj
 uC
 vr
 hw
-gN
+ph
 yo
 zk
 Au
@@ -19565,13 +19566,13 @@ gN
 gN
 gN
 gN
-gN
+ph
 BE
 gN
 gN
 gN
 gN
-gN
+ph
 HL
 gN
 gN
@@ -19663,13 +19664,13 @@ tl
 kl
 kl
 kl
-kl
+vw
 BF
 kl
 kl
 tl
 kl
-kl
+vw
 vw
 kl
 tl

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -173,10 +173,12 @@
 	},
 /area/mainship/hallways/hangar)
 "aG" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 8
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/mainship/living/cryo_cells)
 "aH" = (
@@ -2424,6 +2426,9 @@
 /obj/structure/flora/pottedplant/twentyone,
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
+"ij" = (
+/turf/open/floor/plating,
+/area/mainship/living/cryo_cells)
 "il" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -2900,18 +2905,14 @@
 	},
 /area/mainship/shipboard/firing_range)
 "jR" = (
-/obj/machinery/door/airlock/mainship/engineering/storage{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/mainship,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/obj/machinery/door/airlock/multi_tile/mainship/maint/free_access{
+	dir = 1
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/engineering/engineering_workshop)
@@ -3217,6 +3218,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"kW" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "kX" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -4122,6 +4131,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
+"nT" = (
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/mainship/living/cryo_cells)
 "nU" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -4271,15 +4289,16 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "ow" = (
-/obj/machinery/door/airlock/mainship/maint,
 /obj/structure/cable,
-/obj/machinery/door/firedoor/mainship,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/area/mainship/living/pilotbunks)
 "ox" = (
 /obj/machinery/light,
 /turf/open/floor/mainship/floor,
@@ -5570,12 +5589,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "tc" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "td" = (
 /obj/structure/cable,
@@ -9435,10 +9452,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_umbilical)
 "Ej" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 8
-	},
-/obj/machinery/door/airlock/mainship/maint,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -9601,7 +9614,12 @@
 	},
 /area/mainship/medical/surgery_hallway)
 "EI" = (
-/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
 "EJ" = (
@@ -11938,6 +11956,10 @@
 	dir = 8
 	},
 /area/mainship/engineering/engine_core)
+"LM" = (
+/obj/machinery/door/airlock/multi_tile/mainship/maint,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "LN" = (
 /obj/machinery/cloning/vats,
 /turf/open/floor/mainship/sterile/corner{
@@ -12784,6 +12806,13 @@
 	},
 /turf/open/shuttle/escapepod/five,
 /area/mainship/command/self_destruct)
+"Oq" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "Or" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 2
@@ -14137,16 +14166,6 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "Sw" = (
-/obj/machinery/door/airlock/mainship/engineering/storage{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/mainship,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -39237,10 +39256,8 @@ bZ
 bZ
 Wy
 Mb
-Mb
-aL
-Mb
-Mb
+bZ
+Oq
 Mb
 Mb
 Mb
@@ -39251,7 +39268,9 @@ Mb
 Mb
 Mb
 Mb
-aL
+Mb
+bZ
+Oq
 Mb
 tp
 tp
@@ -41261,7 +41280,7 @@ Mb
 cu
 Mb
 Mb
-Mb
+bZ
 ow
 YT
 kx
@@ -53862,8 +53881,8 @@ rq
 rc
 ad
 eP
-tc
 IY
+kW
 IY
 IY
 IY
@@ -54118,7 +54137,8 @@ nd
 sK
 rc
 ad
-aL
+fL
+tc
 Mb
 Mb
 Mb
@@ -54130,9 +54150,8 @@ Mb
 Mb
 Mb
 Mb
-Mb
-Mb
-aL
+bZ
+Oq
 Mb
 sO
 Or
@@ -56189,23 +56208,23 @@ UQ
 UQ
 UQ
 Po
-Mb
+LM
 Zo
 SK
 WC
 SK
-SK
+ij
 aG
 SK
 WC
 SK
-SK
+ij
 aG
 SK
 WC
 SK
-SK
-aG
+ij
+nT
 SK
 WC
 Mb
@@ -56446,7 +56465,7 @@ wV
 wV
 wV
 PM
-dJ
+bZ
 eP
 IY
 IY


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Good door. Some maint halls are hell to push through since enterance is 1 tile, and 1 tile enterance is terrible. 2 tiles enterance is less terrible.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: add 2x1 maint doors in PoS, Minerva, and Icarus
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
