### PR TITLE
Permit Jaegar module medical storage hold cryobag and roller bed

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/storage.dm
+++ b/code/modules/clothing/modular_armor/attachments/storage.dm
@@ -225,6 +225,8 @@
 		/obj/item/reagent_containers/hypospray/advanced,
 		/obj/item/reagent_containers/hypospray,
 		/obj/item/stack/medical,
+		/obj/item/bodybag,
+		/obj/item/roller,
 		/obj/item/tweezers,
 	)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Promote different setup for corpsmen. I was surprised that the Jaegar medical storage can't hold these two despite limited storage, and corpsmen should be able to do so. It's not a major balance issue since cryobag is limited, and I won't be surprised if corpsmen will start to run 5 cryobags in Jaegar medical storage, but that's their choice. Sooner or later, such corpsmen will realized they don't need to do this.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Permit Jaegar module medical storage hold cryobag and roller bed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
