### PR TITLE
change Tramadol reagent bottle from 20u to 60u

### DIFF
--- a/code/game/objects/items/reagent_containers/glass/bottle.dm
+++ b/code/game/objects/items/reagent_containers/glass/bottle.dm
@@ -173,7 +173,7 @@
 	desc = "A small bottle. Contains Tramadol - Used as a basic painkiller."
 	icon_state = "bottle1"
 	volume = 20
-	list_reagents = list(/datum/reagent/medicine/tramadol = 20)
+	list_reagents = list(/datum/reagent/medicine/tramadol = 60)
 
 /obj/item/reagent_containers/glass/bottle/oxycodone
 	name = "\improper Oxycodone bottle"

--- a/code/game/objects/items/reagent_containers/glass/bottle.dm
+++ b/code/game/objects/items/reagent_containers/glass/bottle.dm
@@ -172,7 +172,7 @@
 	name = "\improper Tramadol bottle"
 	desc = "A small bottle. Contains Tramadol - Used as a basic painkiller."
 	icon_state = "bottle1"
-	volume = 20
+	volume = 60
 	list_reagents = list(/datum/reagent/medicine/tramadol = 60)
 
 /obj/item/reagent_containers/glass/bottle/oxycodone


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The basic med reagent bottles, bica, kelo, and tri, have 60u whereby the tramadol reagent bottle has 20u. Heck, even meralyne and dermaline have 60u. It's time to fix that.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: change Tramadol reagent bottle from 20u to 60u
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
