### PR TITLE
Simultaneous deployable reload fix

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -141,6 +141,7 @@
 #define TRAIT_GUN_IS_AIMING "aiming"
 #define TRAIT_GUN_BURST_FIRING "burst_firing"
 #define TRAIT_GUN_SILENCED "silenced"
+#define TRAIT_GUN_RELOADING "reloading"
 
 // item traits
 #define TRAIT_T_RAY_VISIBLE "t-ray-visible" // Visible on t-ray scanners if the atom/var/level == 1

--- a/code/modules/projectiles/mounted.dm
+++ b/code/modules/projectiles/mounted.dm
@@ -87,11 +87,12 @@
 	gun.reload(ammo_magazine, user)
 	update_icon_state()
 
+	REMOVE_TRAIT(src, TRAIT_GUN_RELOADING, GUN_TRAIT)
+
 	if(!CHECK_BITFIELD(gun.reciever_flags, AMMO_RECIEVER_REQUIRES_UNIQUE_ACTION))
 		return
 	gun.do_unique_action(gun, user)
 
-	REMOVE_TRAIT(src, TRAIT_GUN_RELOADING, GUN_TRAIT)
 
 
 ///This is called when a user tries to operate the gun

--- a/code/modules/projectiles/mounted.dm
+++ b/code/modules/projectiles/mounted.dm
@@ -69,6 +69,16 @@
 
 ///Reloads the internal_item
 /obj/machinery/deployable/mounted/proc/reload(mob/user, ammo_magazine)
+	if(HAS_TRAIT(src, TRAIT_GUN_RELOADING))
+		to_chat(user, span_warning("The weapon is already being reloaded!"))
+		return
+
+	if(user.do_actions)
+		to_chat(user, span_warning("You are busy doing something else!"))
+		return
+
+	ADD_TRAIT(src, TRAIT_GUN_RELOADING, GUN_TRAIT)
+
 	var/obj/item/weapon/gun/gun = internal_item
 	if(length(gun.chamber_items))
 		gun.unload(user)
@@ -80,6 +90,8 @@
 	if(!CHECK_BITFIELD(gun.reciever_flags, AMMO_RECIEVER_REQUIRES_UNIQUE_ACTION))
 		return
 	gun.do_unique_action(gun, user)
+
+	REMOVE_TRAIT(src, TRAIT_GUN_RELOADING, GUN_TRAIT)
 
 
 ///This is called when a user tries to operate the gun


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There is a bug, where you and your metafriend can simultaneously reload a deployed weapon, which allows it to have more ammo inside. Allows funny TAT things.

![image](https://user-images.githubusercontent.com/42085626/164019424-a5748f4b-f592-4d01-9aa9-4b81eaf2cce5.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed deployables being able to take several reloads at once
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
