### PR TITLE
Add Minerva's starboard ERT shuttle landing zone

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -1524,10 +1524,6 @@
 /obj/machinery/autodoc,
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
-"eV" = (
-/obj/structure/sign/custodian,
-/turf/closed/wall/mainship,
-/area/mainship/hull/starboard_hull)
 "eW" = (
 /obj/structure/table/woodentable,
 /obj/machinery/computer/skills,
@@ -2357,6 +2353,14 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/port_hallway)
+"hE" = (
+/obj/effect/decal/siding{
+	dir = 5
+	},
+/turf/open/floor/mainship/terragov/north{
+	dir = 5
+	},
+/area/space)
 "hF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
@@ -2371,6 +2375,14 @@
 	dir = 1
 	},
 /area/mainship/hallways/port_hallway)
+"hH" = (
+/obj/effect/decal/siding{
+	dir = 6
+	},
+/turf/open/floor/mainship/terragov/north{
+	dir = 6
+	},
+/area/space)
 "hK" = (
 /obj/machinery/light{
 	dir = 1
@@ -2512,43 +2524,34 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "id" = (
-/turf/open/floor/mainship/blue{
-	dir = 8
-	},
-/area/mainship/living/cryo_cells)
-"ie" = (
+/obj/machinery/cryopod/right,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cryo_cells)
-"if" = (
-/obj/machinery/computer/cryopod{
-	dir = 1
-	},
-/turf/open/floor/mainship/blue{
-	dir = 4
-	},
-/area/mainship/living/cryo_cells)
-"ig" = (
-/obj/machinery/cryopod/right,
+"ie" = (
 /obj/machinery/light{
-	dir = 4
+	light_color = "#da2f1b"
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/cryo_cells)
+/turf/open/floor/mainship_hull,
+/area/mainship/powered)
 "ih" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 9
-	},
-/area/space)
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "ij" = (
-/turf/open/floor/mainship/terragov/north{
+/obj/machinery/light/small{
 	dir = 1
 	},
-/area/space)
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "ik" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 5
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
 	},
-/area/space)
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "il" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -2784,20 +2787,21 @@
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/living/cryo_cells)
 "iW" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 8
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
 	},
-/area/space)
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "iY" = (
-/turf/open/floor/mainship/terragov{
-	dir = 1
-	},
-/area/space)
+/obj/effect/decal/warning_stripes/thin,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "iZ" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 4
-	},
-/area/space)
+/obj/effect/landmark/start/job/squadmarine,
+/turf/open/floor/mainship/cargo/arrow,
+/area/mainship/living/cryo_cells)
 "jc" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
@@ -2827,6 +2831,11 @@
 	},
 /turf/closed/wall/mainship,
 /area/mainship/living/evacuation)
+"jh" = (
+/obj/structure/cable,
+/obj/structure/bed/chair/wood,
+/turf/open/floor/freezer,
+/area/mainship/living/cafeteria_starboard)
 "jj" = (
 /turf/open/floor/mainship/silver/corner,
 /area/mainship/hallways/port_hallway)
@@ -3108,18 +3117,22 @@
 	},
 /area/mainship/living/cryo_cells)
 "jX" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 10
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
 	},
-/area/space)
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "jY" = (
-/turf/open/floor/mainship/terragov/north,
-/area/space)
-"jZ" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 6
+/obj/effect/landmark/start/job/squadmarine,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
 	},
-/area/space)
+/area/mainship/living/cryo_cells)
+"jZ" = (
+/obj/effect/decal/warning_stripes/thin,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "ka" = (
 /obj/structure/prop/mainship/name_stencil,
 /turf/open/floor/mainship_hull,
@@ -3203,6 +3216,10 @@
 /obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"kv" = (
+/mob/living/simple_animal/corgi/ranger,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/cafeteria_starboard)
 "kx" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 2
@@ -3227,14 +3244,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cryo_cells)
 "kA" = (
-/turf/open/floor/mainship/blue{
-	dir = 4
-	},
-/area/mainship/living/cryo_cells)
-"kB" = (
 /obj/machinery/cryopod/right,
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cryo_cells)
@@ -3242,15 +3254,6 @@
 /obj/machinery/vending/weapon,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"kE" = (
-/turf/closed/wall/mainship/outer,
-/area/mainship/shipboard/starboard_missiles)
-"kH" = (
-/obj/machinery/door/poddoor/mainship/umbilical/south{
-	dir = 2
-	},
-/turf/closed/wall/mainship/outer,
-/area/mainship/shipboard/starboard_missiles)
 "kI" = (
 /turf/open/floor/mainship_hull/dir{
 	dir = 10
@@ -3605,15 +3608,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/self_destruct)
-"lR" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/shipboard/starboard_missiles)
-"lS" = (
-/turf/open/floor/mainship/mono,
-/area/mainship/shipboard/starboard_missiles)
 "lV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -3724,9 +3718,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"mq" = (
-/turf/closed/wall/mainship,
-/area/mainship/shipboard/starboard_missiles)
 "mr" = (
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/mono,
@@ -3739,6 +3730,10 @@
 /obj/structure/table/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"mv" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic/noglass,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "my" = (
 /obj/machinery/computer/supplycomp,
 /obj/machinery/light{
@@ -3853,7 +3848,9 @@
 "mO" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/job/squadcorpsman,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
 /area/mainship/living/cryo_cells)
 "mP" = (
 /obj/structure/cable,
@@ -4097,44 +4094,23 @@
 	},
 /area/mainship/living/cryo_cells)
 "nL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
-/obj/effect/landmark/start/job/squadcorpsman,
-/obj/effect/landmark/start/latejoin,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/cargo/arrow,
 /area/mainship/living/cryo_cells)
 "nM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/living/cryo_cells)
 "nN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/mainship/cargo/arrow,
-/area/mainship/living/cryo_cells)
-"nO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/cargo/arrow,
-/area/mainship/living/cryo_cells)
-"nP" = (
-/obj/structure/sign/poster{
-	dir = 1
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/general)
-"nQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
 	on = 1
@@ -4145,40 +4121,32 @@
 	dir = 8
 	},
 /area/mainship/living/cryo_cells)
-"nR" = (
+"nO" = (
 /obj/effect/landmark/start/job/squadengineer,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
 /area/mainship/living/cryo_cells)
-"nS" = (
-/obj/structure/prop/mainship/missile_tube,
-/obj/structure/window/reinforced/toughened{
+"nP" = (
+/obj/structure/sign/poster{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/shipboard/starboard_missiles)
-"nT" = (
-/obj/structure/prop/mainship/missile_tube,
-/obj/structure/prop/mainship/missile_tube,
-/obj/structure/window/reinforced/toughened{
-	dir = 8;
-	pixel_x = -4
-	},
-/obj/structure/window/reinforced/toughened{
-	dir = 1
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
+"nQ" = (
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/shipboard/starboard_missiles)
-"nU" = (
-/obj/structure/prop/mainship/missile_tube,
-/obj/structure/window/reinforced/toughened{
-	dir = 8;
-	pixel_x = -4
+/area/mainship/hull/starboard_hull)
+"nR" = (
+/obj/docking_port/stationary/ert/target{
+	id = "starboard_target";
+	name = "Starboard"
 	},
-/obj/structure/window/reinforced/toughened{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/shipboard/starboard_missiles)
+/turf/open/floor/plating/mainship,
+/area/mainship/hull/starboard_hull)
 "nX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/ai_node,
@@ -4522,24 +4490,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
 "oW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/cryo_cells)
-"oX" = (
-/obj/machinery/light{
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/turf/open/floor/mainship/red{
-	dir = 8
-	},
-/area/mainship/shipboard/starboard_missiles)
-"oY" = (
-/turf/open/floor/mainship/red{
-	dir = 4
-	},
-/area/mainship/shipboard/starboard_missiles)
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "oZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -4551,10 +4507,6 @@
 /obj/machinery/light,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/port_atmos)
-"pa" = (
-/obj/structure/window/framed/mainship/hull,
-/turf/open/floor/plating,
-/area/mainship/shipboard/starboard_missiles)
 "pb" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/mainship/sterile/corner,
@@ -4577,6 +4529,13 @@
 	dir = 4
 	},
 /area/mainship/medical/lower_medical)
+"pm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
+/area/mainship/living/cafeteria_starboard)
 "pn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -4844,28 +4803,6 @@
 /obj/item/healthanalyzer,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
-"qi" = (
-/turf/open/floor/mainship/red{
-	dir = 1
-	},
-/area/mainship/shipboard/starboard_missiles)
-"qj" = (
-/turf/open/floor/mainship/red/corner{
-	dir = 1
-	},
-/area/mainship/shipboard/starboard_missiles)
-"qk" = (
-/obj/structure/rack,
-/obj/item/tool/crowbar/red,
-/turf/open/floor/mainship/mono,
-/area/mainship/shipboard/starboard_missiles)
-"ql" = (
-/obj/structure/table/mainship,
-/obj/machinery/prop/mainship/computer,
-/turf/open/floor/mainship/red{
-	dir = 4
-	},
-/area/mainship/shipboard/starboard_missiles)
 "qm" = (
 /obj/structure/sign/prop1{
 	name = "Smartgunner Preparations"
@@ -5047,12 +4984,6 @@
 /obj/vehicle/ridden/motorbike,
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
-"qY" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/starboard_hull)
 "rg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -5063,6 +4994,14 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"rh" = (
+/obj/effect/decal/siding{
+	dir = 9
+	},
+/turf/open/floor/mainship/terragov/north{
+	dir = 9
+	},
+/area/space)
 "rk" = (
 /obj/structure/table/mainship,
 /obj/item/weapon/gun/rifle/standard_carbine,
@@ -5116,15 +5055,12 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
-"rs" = (
-/obj/effect/landmark/start/job/squadsmartgunner,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/cryo_cells)
 "ru" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/cargo/arrow,
+/obj/effect/landmark/start/job/squadleader,
+/obj/effect/landmark/start/latejoin,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
 /area/mainship/living/cryo_cells)
 "rv" = (
 /obj/effect/ai_node,
@@ -5133,10 +5069,12 @@
 	},
 /area/mainship/medical/chemistry)
 "rw" = (
-/obj/effect/landmark/start/job/squadleader,
-/obj/effect/landmark/start/job/squadleader,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/cryo_cells)
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "rx" = (
 /obj/docking_port/stationary/marine_dropship/hangar/one,
 /obj/docking_port/stationary/marine_dropship/crash_target,
@@ -5151,17 +5089,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"rz" = (
-/turf/open/floor/mainship/red,
-/area/mainship/shipboard/starboard_missiles)
-"rA" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/open/floor/mainship/red{
-	dir = 6
-	},
-/area/mainship/shipboard/starboard_missiles)
 "rC" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/gas,
@@ -5334,6 +5261,12 @@
 	},
 /turf/open/floor/mainship/sterile/plain,
 /area/mainship/medical/lower_medical)
+"se" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "sf" = (
 /obj/machinery/light{
 	dir = 4
@@ -5408,12 +5341,6 @@
 	dir = 4
 	},
 /area/mainship/squads/general)
-"su" = (
-/obj/effect/landmark/start/job/squadsmartgunner,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
-/area/mainship/living/cryo_cells)
 "sv" = (
 /obj/machinery/light,
 /turf/open/floor/mainship/floor,
@@ -5421,14 +5348,12 @@
 "sw" = (
 /obj/effect/landmark/start/job/squadsmartgunner,
 /obj/effect/landmark/start/latejoin,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
 /area/mainship/living/cryo_cells)
 "sx" = (
-/obj/effect/landmark/start/job/squadleader,
-/obj/effect/landmark/start/latejoin,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
+/turf/open/floor/mainship/mono,
 /area/mainship/living/cryo_cells)
 "sy" = (
 /obj/structure/table/woodentable,
@@ -5436,11 +5361,11 @@
 /turf/open/floor/wood,
 /area/mainship/medical/lounge)
 "sz" = (
-/obj/effect/landmark/start/job/squadleader,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
+/obj/machinery/door/airlock/multi_tile/mainship/generic/noglass{
+	dir = 1
 	},
-/area/mainship/living/cryo_cells)
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "sB" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -5589,6 +5514,10 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
+"sW" = (
+/obj/effect/decal/siding,
+/turf/open/floor/mainship/terragov/north,
+/area/space)
 "sX" = (
 /obj/machinery/marine_selector/clothes/smartgun,
 /turf/open/floor/mainship/floor,
@@ -5798,11 +5727,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "tJ" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/job/squadcorpsman,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
+/turf/open/floor/mainship/floor,
 /area/mainship/living/cryo_cells)
 "tL" = (
 /obj/machinery/vending/dinnerware,
@@ -5995,9 +5920,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/general)
 "uu" = (
-/obj/effect/landmark/start/job/squadmarine,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/cryo_cells)
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "uv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -6581,6 +6510,16 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"vX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/starboard_hull)
 "vY" = (
 /obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/door/poddoor/shutters/mainship/req/ro{
@@ -6603,12 +6542,15 @@
 /turf/open/floor/plating,
 /area/mainship/living/evacuation)
 "wf" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/mob/living/simple_animal/corgi/ranger,
 /turf/open/floor/mainship/mono,
-/area/mainship/living/cryo_cells)
+/area/mainship/hull/starboard_hull)
 "wh" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 2
@@ -6651,13 +6593,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
-"wo" = (
-/obj/effect/landmark/start/latejoin,
-/obj/structure/sign/prop4,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
-/area/mainship/living/cryo_cells)
 "wp" = (
 /obj/structure/bed/chair/sofa/corner{
 	dir = 8
@@ -6929,24 +6864,34 @@
 	},
 /area/mainship/living/cafeteria_starboard)
 "xe" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/computer/cryopod{
+	dir = 1
+	},
 /turf/open/floor/mainship/black{
 	dir = 1
 	},
 /area/mainship/living/cafeteria_starboard)
 "xf" = (
-/obj/machinery/camera/autoname/mainship{
+/obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/turf/open/floor/mainship/black{
-	dir = 5
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/mainship/living/cafeteria_starboard)
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "xg" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/cafeteria_starboard)
+"xh" = (
+/obj/effect/decal/siding{
+	dir = 8
+	},
+/turf/open/floor/mainship/terragov/north{
+	dir = 8
+	},
+/area/space)
 "xi" = (
 /obj/machinery/door/airlock/mainship/generic/ert{
 	dir = 2
@@ -7179,6 +7124,11 @@
 	},
 /turf/open/floor/mainship/red/full,
 /area/mainship/hallways/starboard_hallway)
+"xT" = (
+/turf/open/floor/mainship/terragov{
+	dir = 1
+	},
+/area/space)
 "xU" = (
 /obj/structure/sign/poster{
 	dir = 1
@@ -7208,25 +7158,28 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "ya" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mainship/black{
-	dir = 8
-	},
-/area/mainship/living/cafeteria_starboard)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/cryo_cells)
 "yb" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cafeteria_starboard)
 "yc" = (
-/turf/open/floor/mainship/black/corner,
-/area/mainship/living/cafeteria_starboard)
+/obj/effect/landmark/start/job/squadleader,
+/obj/effect/landmark/start/job/squadleader,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/mainship/living/cryo_cells)
 "yd" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/black,
-/area/mainship/living/cafeteria_starboard)
+/obj/effect/landmark/start/latejoin,
+/obj/structure/sign/prop4,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/mainship/living/cryo_cells)
 "ye" = (
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
@@ -7235,13 +7188,14 @@
 /turf/open/floor/mainship/black,
 /area/mainship/living/cafeteria_starboard)
 "yg" = (
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/black{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/area/mainship/living/cafeteria_starboard)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/starboard_hull)
 "yh" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 8
@@ -7516,26 +7470,19 @@
 /area/mainship/living/cafeteria_starboard)
 "yQ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/visible,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cafeteria_starboard)
 "yR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
+/turf/open/floor/mainship/black/corner,
 /area/mainship/living/cafeteria_starboard)
 "yS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -7554,12 +7501,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar/droppod)
 "yU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/freezer,
+/turf/open/floor/mainship/black,
 /area/mainship/living/cafeteria_starboard)
 "yV" = (
 /obj/machinery/door/airlock/mainship/secure{
@@ -7569,35 +7514,29 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
 "yW" = (
-/obj/structure/bed/chair/wood,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/freezer,
-/area/mainship/living/cafeteria_starboard)
-"yX" = (
-/obj/structure/bed/chair/wood,
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/freezer,
-/area/mainship/living/cafeteria_starboard)
-"yY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/floor/freezer,
+/turf/open/floor/mainship/black,
 /area/mainship/living/cafeteria_starboard)
+"yX" = (
+/obj/effect/landmark/start/latejoin,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/cryo_cells)
+"yY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/cryo_cells)
 "yZ" = (
 /turf/open/floor/freezer,
 /area/mainship/living/cafeteria_starboard)
 "za" = (
-/obj/structure/window/framed/mainship/requisitions,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/cafeteria_starboard)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/starboard_hull)
 "zb" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -7874,6 +7813,14 @@
 	},
 /turf/open/floor/mainship/purple/full,
 /area/mainship/hallways/starboard_hallway)
+"zT" = (
+/obj/effect/decal/siding{
+	dir = 10
+	},
+/turf/open/floor/mainship/terragov/north{
+	dir = 10
+	},
+/area/space)
 "zU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -7931,11 +7878,13 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
 "Aa" = (
-/obj/effect/landmark/start/job/squadengineer,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
 	},
-/area/mainship/living/cryo_cells)
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "Ab" = (
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
@@ -7978,8 +7927,8 @@
 /area/mainship/living/cafeteria_starboard)
 "Aj" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cafeteria_starboard)
 "Ak" = (
@@ -8019,8 +7968,7 @@
 	},
 /area/mainship/command/self_destruct)
 "Aq" = (
-/obj/structure/table/mainship,
-/obj/item/pizzabox,
+/obj/structure/bed/chair/wood,
 /turf/open/floor/freezer,
 /area/mainship/living/cafeteria_starboard)
 "Ar" = (
@@ -9086,12 +9034,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/general)
 "DE" = (
-/obj/effect/landmark/start/latejoin,
-/obj/structure/sign/prop4,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
 	},
-/area/mainship/living/cryo_cells)
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "DF" = (
 /obj/machinery/line_nexter{
 	dir = 2
@@ -9125,10 +9073,10 @@
 /area/mainship/living/cafeteria_starboard)
 "DK" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment/corner,
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cafeteria_starboard)
 "DL" = (
@@ -9271,11 +9219,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/port_garden)
 "Ef" = (
-/obj/effect/landmark/start/latejoin,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
 	},
-/area/mainship/living/cryo_cells)
+/obj/machinery/light/small,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "Eg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10403,6 +10353,11 @@
 	dir = 8
 	},
 /area/mainship/living/briefing)
+"Hl" = (
+/obj/structure/table/mainship,
+/obj/item/pizzabox,
+/turf/open/floor/freezer,
+/area/mainship/living/cafeteria_starboard)
 "Hm" = (
 /obj/effect/decal/cleanable/blood/oil{
 	name = "grease";
@@ -11868,10 +11823,11 @@
 	dir = 1
 	},
 /area/mainship/hallways/starboard_hallway)
-"LO" = (
-/obj/structure/janitorialcart,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/starboard_hull)
+"LP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/cafeteria_starboard)
 "LQ" = (
 /obj/structure/sign/vacuum,
 /turf/closed/wall/mainship,
@@ -12165,6 +12121,14 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
+"MF" = (
+/obj/effect/decal/siding{
+	dir = 1
+	},
+/turf/open/floor/mainship/terragov/north{
+	dir = 1
+	},
+/area/space)
 "MH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -12332,6 +12296,14 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
+"Nn" = (
+/obj/effect/decal/siding{
+	dir = 4
+	},
+/turf/open/floor/mainship/terragov/north{
+	dir = 4
+	},
+/area/space)
 "No" = (
 /obj/machinery/door/poddoor/mainship/umbilical/south{
 	dir = 8
@@ -13158,6 +13130,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/engineering_workshop)
+"PK" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/starboard_hull)
 "PL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -13309,11 +13289,10 @@
 /turf/open/floor/mainship/ai,
 /area/mainship/command/airoom)
 "Qh" = (
-/obj/effect/landmark/start/job/squadsmartgunner,
-/obj/effect/landmark/start/latejoin,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/cargo/arrow,
 /area/mainship/living/cryo_cells)
 "Qi" = (
 /obj/structure/cable,
@@ -14804,7 +14783,12 @@
 /area/mainship/command/cic)
 "UL" = (
 /obj/effect/landmark/start/job/squadcorpsman,
-/turf/open/floor/mainship/floor,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
 /area/mainship/living/cryo_cells)
 "UM" = (
 /obj/machinery/computer/camera_advanced/overwatch/bravo{
@@ -15199,7 +15183,10 @@
 /area/mainship/medical/lower_medical)
 "VV" = (
 /obj/effect/landmark/start/latejoin,
-/turf/open/floor/mainship/floor,
+/obj/structure/sign/prop4,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
 /area/mainship/living/cryo_cells)
 "VW" = (
 /obj/machinery/loadout_vendor,
@@ -15677,10 +15664,13 @@
 /turf/closed/wall/mainship/outer,
 /area/mainship/engineering/port_atmos)
 "XI" = (
-/obj/effect/landmark/start/job/squadleader,
-/obj/effect/landmark/start/latejoin,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/cryo_cells)
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "XJ" = (
 /turf/open/floor/engine,
 /area/mainship/engineering/port_atmos)
@@ -15761,15 +15751,6 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
-"XX" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/glass/bucket/janibucket,
-/obj/item/tool/wet_sign,
-/obj/item/tool/wet_sign,
-/obj/item/tool/wet_sign,
-/obj/item/storage/bag/trash,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/starboard_hull)
 "XZ" = (
 /turf/open/floor/mainship/red/corner{
 	dir = 1
@@ -16222,11 +16203,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
 "Zy" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/shipboard/starboard_missiles)
+/turf/open/floor/plating/mainship,
+/area/mainship/hull/starboard_hull)
 "Zz" = (
 /obj/machinery/light{
 	dir = 8
@@ -16273,11 +16251,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/port_atmos)
 "ZG" = (
-/obj/effect/landmark/start/job/squadmarine,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
-/area/mainship/living/cryo_cells)
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "ZI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -27493,14 +27469,14 @@ mN
 nK
 ib
 ia
-su
-su
+sw
+sw
 kz
 ia
 vn
 ho
 wX
-ya
+Yw
 yO
 Ai
 Tg
@@ -27583,15 +27559,15 @@ Hr
 ID
 ho
 ib
-uu
-uu
+jW
+jW
 ib
 ib
 mO
 UL
 ib
 ib
-rs
+sw
 sw
 ib
 ib
@@ -27600,7 +27576,7 @@ ho
 wZ
 yb
 yP
-yb
+kv
 yb
 yb
 DI
@@ -27681,22 +27657,22 @@ Hr
 tX
 ho
 ib
-jW
-jW
-ib
-ib
-tJ
+iZ
+iU
+sx
+sx
+mP
 nL
-ib
-ib
+ya
+ya
 Qh
 Qh
-ib
-ib
-wo
-ho
-wZ
-yb
+ya
+ya
+Qh
+yY
+pm
+LP
 yQ
 Aj
 Aj
@@ -27776,25 +27752,25 @@ YB
 XE
 XE
 aO
-ID
+bh
 hq
 id
+iZ
 iU
-iU
-id
-id
+tJ
+tJ
 mP
 nM
-id
-id
+tJ
+tJ
 iU
 iU
-id
-id
+tJ
+tJ
 iU
-id
+sx
 xd
-yc
+yb
 yR
 Ak
 Ak
@@ -27874,27 +27850,27 @@ YB
 XE
 XE
 aO
-bh
+ID
 hq
-ie
-iU
-iU
-ie
-ie
-mP
+ib
+jY
+jY
+ib
+ib
+nO
 nN
-oW
-oW
+ib
+ib
 ru
 ru
-oW
-oW
-ru
-wf
-xe
+ib
+ib
 yd
+ho
+xe
+yb
 yU
-An
+yZ
 An
 An
 DM
@@ -27971,29 +27947,29 @@ ZK
 Gi
 XE
 XE
-aO
-ID
-hq
-if
-iU
-iU
+Hr
+tX
+ho
 kA
+jY
+jY
+ib
 kA
-iU
 nO
+nO
+ib
 kA
+yc
+ru
+ib
 kA
-iU
-iU
-kA
-kA
-iU
-kA
+yX
+ho
 xd
-yf
+yb
 yW
 Aq
-Bo
+Hl
 Cv
 Bq
 Bo
@@ -28072,25 +28048,25 @@ ap
 Hr
 tX
 ho
-ib
-ZG
-ZG
-ib
-ib
-Aa
-nQ
-ib
-ib
-sx
-sx
-ib
-ib
-DE
 ho
-xd
-yf
-yX
-Ar
+hq
+hq
+ho
+ho
+hq
+hq
+ho
+ho
+hq
+hq
+ho
+ho
+ho
+ho
+xg
+xg
+xg
+jh
 Bq
 Ar
 DO
@@ -28168,27 +28144,27 @@ ZK
 YB
 XE
 Hr
-ID
-ho
-ib
-uu
-uu
-ib
-ib
-nR
-nR
-ib
-ib
-rw
-XI
-ib
-ib
-VV
-ho
-xd
-yf
-yY
-As
+gM
+Wh
+bA
+bA
+bA
+EC
+bA
+bA
+bA
+Wh
+bA
+bA
+bA
+Wh
+bA
+mT
+za
+PK
+vX
+xg
+yZ
 Br
 As
 As
@@ -28266,26 +28242,26 @@ ZK
 Gi
 XE
 Hr
-ID
-ho
-ig
+Hr
+Hr
+Hr
+Hr
 ZG
+sz
+Hr
+Hr
+Hr
+Hr
 ZG
-kB
-ig
-Aa
-Aa
-ib
-ig
 sz
-sz
-kB
-ig
-Ef
-ho
-xf
+Hr
+Hr
+Hr
+Hr
+QM
+QM
 yg
-yZ
+xg
 yZ
 Bu
 yZ
@@ -28363,28 +28339,28 @@ ZK
 ZK
 ZK
 YB
+XE
+XE
 Hr
-tX
-ho
-ho
-hq
-hq
-ho
-ho
-hq
-hq
-ho
-ho
-hq
-hq
-ho
-ho
-ho
-ho
+ih
+ik
+rw
+uu
+wf
+rw
+rw
+rw
+rw
+rw
+wf
+rw
+rw
+rw
+Aa
+mv
+yg
 xg
 xg
-za
-za
 xg
 Cw
 xg
@@ -28461,26 +28437,26 @@ ZK
 ZK
 ZK
 YB
+XE
+XE
 Hr
+ij
+jZ
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+DE
+se
 gM
-Wh
-bA
-bA
-bA
-Wh
-bA
-mT
-bA
-Wh
-bA
-bA
-bA
-Wh
-bA
-mT
-wh
-bA
-bA
 Wh
 bA
 bA
@@ -28559,24 +28535,24 @@ ZK
 ZK
 ZK
 Gi
+XE
+ie
 Hr
-Hr
-Hr
-Hr
-aO
-aO
-kE
-kE
-kE
-kE
-kE
-qi
-rz
-mq
-eV
-QM
-eM
-Hr
+ik
+nQ
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+DE
 Hr
 aO
 aO
@@ -28659,23 +28635,23 @@ ZK
 ZK
 YB
 XE
-XE
-RC
-XE
-XE
-kH
-lR
-lS
-nS
-oX
-qj
-rz
-mq
-LO
-XX
-WD
+aO
+iY
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+DE
 Hr
-RC
 XE
 XE
 XE
@@ -28757,23 +28733,23 @@ ZK
 ZK
 YB
 XE
-XE
-XE
-XE
-XE
-kH
-lS
-lS
-nT
-lS
-qk
-rz
+aO
+iY
+nR
 Zy
-WD
-qY
-WD
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+DE
 Hr
-XE
 XE
 XE
 XE
@@ -28787,9 +28763,9 @@ HI
 aO
 XE
 XE
-XE
-XE
-XE
+rh
+xh
+zT
 XE
 XE
 XE
@@ -28855,23 +28831,23 @@ ZK
 ZK
 YB
 XE
-XE
-XE
-XE
-XE
-kH
-lS
-lS
-nU
-oY
-ql
-rA
-kE
+aO
+iY
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+DE
 Hr
-Hr
-Hr
-Hr
-XE
 XE
 XE
 XE
@@ -28885,9 +28861,9 @@ HJ
 Hr
 XE
 XE
-XE
-XE
-XE
+MF
+xT
+sW
 XE
 XE
 XE
@@ -28952,24 +28928,24 @@ ZK
 ZK
 ZK
 YB
-XE
-XE
-XE
-XE
-XE
-kE
-kE
-kE
-kE
-pa
-pa
-pa
-kE
-XE
-XE
-XE
-XE
-XE
+ie
+Hr
+iW
+oW
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Ef
+Hr
 XE
 XE
 XE
@@ -28983,9 +28959,9 @@ Hr
 Hr
 XE
 XE
-XE
-XE
-XE
+hE
+Nn
+hH
 XE
 XE
 XE
@@ -29051,23 +29027,23 @@ ZK
 ZK
 Gi
 XE
-XE
-Zl
-Zl
-Zl
-XE
-XE
-XE
-RC
-XE
-XE
-XE
-RC
-XE
-XE
-XE
-XE
-XE
+Hr
+ij
+jZ
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+Zy
+DE
+Hr
 XE
 XE
 XE
@@ -29149,23 +29125,23 @@ ZK
 ZK
 ZK
 YB
-hr
+Hr
 ih
 iW
 jX
-YB
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
+jX
+xf
+jX
+jX
+jX
+jX
+jX
+xf
+jX
+jX
+jX
+XI
+Hr
 XE
 XE
 XE
@@ -29247,23 +29223,23 @@ ZK
 ZK
 ZK
 YB
-hr
-ij
-iY
-jY
-YB
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
+Hr
+Hr
+Hr
+Hr
+Hr
+Hr
+aO
+aO
+aO
+Hr
+Hr
+Hr
+Hr
+Hr
+Hr
+Hr
+Hr
 XE
 XE
 XE
@@ -29345,16 +29321,16 @@ ZK
 ZK
 ZK
 YB
-hr
-ik
-iZ
-jZ
-YB
 XE
 XE
 XE
 XE
 XE
+RC
+XE
+XE
+XE
+RC
 XE
 XE
 XE
@@ -29444,9 +29420,9 @@ ZK
 ZK
 YB
 XE
-Wm
-Wm
-Wm
+XE
+XE
+XE
 XE
 XE
 Zl

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -48,6 +48,10 @@
 /obj/structure/dropship_equipment/weapon/rocket_pod,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"ak" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic/noglass,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "an" = (
 /obj/effect/decal/warning_stripes/thick/corner,
 /obj/item/ammo_casing/bullet{
@@ -119,6 +123,14 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"aB" = (
+/obj/effect/decal/siding{
+	dir = 5
+	},
+/turf/open/floor/mainship/terragov/north{
+	dir = 5
+	},
+/area/space)
 "aC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -710,6 +722,12 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
+"ch" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "ci" = (
 /obj/machinery/camera/autoname/mainship,
 /obj/structure/closet/toolcloset,
@@ -993,6 +1011,9 @@
 /obj/machinery/faxmachine,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
+"dd" = (
+/turf/open/floor/mainship/mono,
+/area/mainship/living/evacuation)
 "de" = (
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/terragov/north{
@@ -1285,6 +1306,11 @@
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/plating,
 /area/mainship/squads/req)
+"ed" = (
+/obj/structure/cable,
+/obj/structure/bed/chair/wood,
+/turf/open/floor/freezer,
+/area/mainship/living/cafeteria_starboard)
 "ee" = (
 /obj/structure/table/mainship,
 /obj/item/paper,
@@ -1940,6 +1966,14 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/living/evacuation)
+"gj" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "gk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -2289,6 +2323,10 @@
 "ho" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/cryo_cells)
+"hp" = (
+/mob/living/simple_animal/corgi/ranger,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/cafeteria_starboard)
 "hq" = (
 /obj/structure/window/framed/mainship/requisitions,
 /turf/open/floor/plating,
@@ -2353,14 +2391,6 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/port_hallway)
-"hE" = (
-/obj/effect/decal/siding{
-	dir = 5
-	},
-/turf/open/floor/mainship/terragov/north{
-	dir = 5
-	},
-/area/space)
 "hF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
@@ -2375,14 +2405,6 @@
 	dir = 1
 	},
 /area/mainship/hallways/port_hallway)
-"hH" = (
-/obj/effect/decal/siding{
-	dir = 6
-	},
-/turf/open/floor/mainship/terragov/north{
-	dir = 6
-	},
-/area/space)
 "hK" = (
 /obj/machinery/light{
 	dir = 1
@@ -2563,6 +2585,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"im" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/evacuation)
 "in" = (
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
@@ -2831,11 +2862,6 @@
 	},
 /turf/closed/wall/mainship,
 /area/mainship/living/evacuation)
-"jh" = (
-/obj/structure/cable,
-/obj/structure/bed/chair/wood,
-/turf/open/floor/freezer,
-/area/mainship/living/cafeteria_starboard)
 "jj" = (
 /turf/open/floor/mainship/silver/corner,
 /area/mainship/hallways/port_hallway)
@@ -3164,6 +3190,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/evacuation)
+"kf" = (
+/obj/effect/decal/siding,
+/turf/open/floor/mainship/terragov/north,
+/area/space)
 "ki" = (
 /turf/open/floor/mainship/silver{
 	dir = 8
@@ -3216,10 +3246,6 @@
 /obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"kv" = (
-/mob/living/simple_animal/corgi/ranger,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/cafeteria_starboard)
 "kx" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 2
@@ -3730,10 +3756,6 @@
 /obj/structure/table/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
-"mv" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic/noglass,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/starboard_hull)
 "my" = (
 /obj/machinery/computer/supplycomp,
 /obj/machinery/light{
@@ -3885,6 +3907,14 @@
 	icon_state = "TGMC2"
 	},
 /turf/open/floor/mainship_hull,
+/area/space)
+"mX" = (
+/obj/effect/decal/siding{
+	dir = 1
+	},
+/turf/open/floor/mainship/terragov/north{
+	dir = 1
+	},
 /area/space)
 "mY" = (
 /obj/structure/cable,
@@ -4451,6 +4481,16 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
+"oQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/starboard_hull)
 "oR" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -4529,13 +4569,6 @@
 	dir = 4
 	},
 /area/mainship/medical/lower_medical)
-"pm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/black{
-	dir = 1
-	},
-/area/mainship/living/cafeteria_starboard)
 "pn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -4996,10 +5029,10 @@
 /area/mainship/squads/req)
 "rh" = (
 /obj/effect/decal/siding{
-	dir = 9
+	dir = 10
 	},
 /turf/open/floor/mainship/terragov/north{
-	dir = 9
+	dir = 10
 	},
 /area/space)
 "rk" = (
@@ -5261,12 +5294,6 @@
 	},
 /turf/open/floor/mainship/sterile/plain,
 /area/mainship/medical/lower_medical)
-"se" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/starboard_hull)
 "sf" = (
 /obj/machinery/light{
 	dir = 4
@@ -5318,11 +5345,21 @@
 /obj/machinery/door/poddoor/mainship/ammo,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"sm" = (
+/turf/open/floor/mainship/terragov{
+	dir = 1
+	},
+/area/space)
 "sn" = (
 /turf/open/floor/mainship/blue{
 	dir = 8
 	},
 /area/mainship/squads/general)
+"sq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/cafeteria_starboard)
 "sr" = (
 /turf/closed/wall/mainship,
 /area/mainship/squads/general)
@@ -5353,6 +5390,7 @@
 	},
 /area/mainship/living/cryo_cells)
 "sx" = (
+/obj/effect/landmark/start/job/squadmarine,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cryo_cells)
 "sy" = (
@@ -5515,9 +5553,10 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "sW" = (
-/obj/effect/decal/siding,
-/turf/open/floor/mainship/terragov/north,
-/area/space)
+/obj/structure/table/mainship,
+/obj/item/pizzabox,
+/turf/open/floor/freezer,
+/area/mainship/living/cafeteria_starboard)
 "sX" = (
 /obj/machinery/marine_selector/clothes/smartgun,
 /turf/open/floor/mainship/floor,
@@ -5727,6 +5766,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "tJ" = (
+/obj/effect/landmark/start/job/squadmarine,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cryo_cells)
 "tL" = (
@@ -5920,12 +5960,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/general)
 "uu" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
 "uv" = (
 /obj/structure/cable,
@@ -6257,6 +6299,14 @@
 /obj/structure/bed/chair/comfy/black,
 /turf/open/floor/mainship/silver/full,
 /area/mainship/hallways/starboard_hallway)
+"vh" = (
+/obj/effect/decal/siding{
+	dir = 9
+	},
+/turf/open/floor/mainship/terragov/north{
+	dir = 9
+	},
+/area/space)
 "vi" = (
 /turf/open/floor/mainship/empty,
 /area/mainship/squads/req)
@@ -6510,16 +6560,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"vX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/starboard_hull)
 "vY" = (
 /obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/door/poddoor/shutters/mainship/req/ro{
@@ -6545,10 +6585,8 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/starboard_hull)
 "wh" = (
@@ -6763,6 +6801,14 @@
 "wM" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/pilotbunks)
+"wN" = (
+/obj/effect/decal/siding{
+	dir = 4
+	},
+/turf/open/floor/mainship/terragov/north{
+	dir = 4
+	},
+/area/space)
 "wQ" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 8;
@@ -6873,10 +6919,10 @@
 /area/mainship/living/cafeteria_starboard)
 "xf" = (
 /obj/effect/decal/warning_stripes/thin{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/light/small{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -6885,17 +6931,14 @@
 /turf/closed/wall/mainship,
 /area/mainship/living/cafeteria_starboard)
 "xh" = (
-/obj/effect/decal/siding{
-	dir = 8
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
 	},
-/turf/open/floor/mainship/terragov/north{
-	dir = 8
-	},
-/area/space)
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "xi" = (
-/obj/machinery/door/airlock/mainship/generic/ert{
-	dir = 2
-	},
+/obj/machinery/door/airlock/multi_tile/mainship/generic/noglass,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
 "xk" = (
@@ -6982,6 +7025,14 @@
 	dir = 1
 	},
 /area/mainship/medical/lounge)
+"xz" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/light/small,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "xA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -7124,11 +7175,6 @@
 	},
 /turf/open/floor/mainship/red/full,
 /area/mainship/hallways/starboard_hallway)
-"xT" = (
-/turf/open/floor/mainship/terragov{
-	dir = 1
-	},
-/area/space)
 "xU" = (
 /obj/structure/sign/poster{
 	dir = 1
@@ -7158,27 +7204,28 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "ya" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/cryo_cells)
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/starboard_hull)
 "yb" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cafeteria_starboard)
 "yc" = (
-/obj/effect/landmark/start/job/squadleader,
-/obj/effect/landmark/start/job/squadleader,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/start/job/squadcorpsman,
+/turf/open/floor/mainship/floor,
 /area/mainship/living/cryo_cells)
 "yd" = (
-/obj/effect/landmark/start/latejoin,
-/obj/structure/sign/prop4,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
+/obj/effect/landmark/start/job/squadengineer,
+/turf/open/floor/mainship/floor,
 /area/mainship/living/cryo_cells)
 "ye" = (
 /obj/structure/cable,
@@ -7197,9 +7244,6 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
 "yh" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -7216,7 +7260,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/mainship,
 /obj/effect/ai_node,
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -7242,6 +7285,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
 "yl" = (
@@ -7287,7 +7331,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/obj/machinery/camera/autoname/mainship,
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
@@ -7520,29 +7563,27 @@
 /turf/open/floor/mainship/black,
 /area/mainship/living/cafeteria_starboard)
 "yX" = (
-/obj/effect/landmark/start/latejoin,
-/turf/open/floor/mainship/floor,
+/obj/effect/landmark/start/job/squadleader,
+/obj/effect/landmark/start/job/squadleader,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
 /area/mainship/living/cryo_cells)
 "yY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/mainship/living/cryo_cells)
 "yZ" = (
 /turf/open/floor/freezer,
 /area/mainship/living/cafeteria_starboard)
 "za" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/starboard_hull)
+/turf/open/floor/mainship/floor,
+/area/mainship/living/cryo_cells)
 "zb" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
@@ -7813,14 +7854,6 @@
 	},
 /turf/open/floor/mainship/purple/full,
 /area/mainship/hallways/starboard_hallway)
-"zT" = (
-/obj/effect/decal/siding{
-	dir = 10
-	},
-/turf/open/floor/mainship/terragov/north{
-	dir = 10
-	},
-/area/space)
 "zU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -7879,10 +7912,10 @@
 /area/mainship/squads/general)
 "Aa" = (
 /obj/effect/decal/warning_stripes/thin{
-	dir = 5
+	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/ai_node,
+/obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/starboard_hull)
 "Ab" = (
@@ -7995,6 +8028,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
+/obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
 "Av" = (
@@ -8427,18 +8461,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
 "BE" = (
-/obj/machinery/door/airlock/mainship/generic/ert{
-	name = "Shuttle Airlock"
+/obj/effect/landmark/start/latejoin,
+/obj/structure/sign/prop4,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/evacuation)
+/area/mainship/living/cryo_cells)
 "BF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8729,6 +8757,7 @@
 /area/mainship/squads/general)
 "Cu" = (
 /obj/machinery/holopad,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/black{
 	dir = 4
 	},
@@ -8742,6 +8771,7 @@
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 8
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cafeteria_starboard)
 "Cx" = (
@@ -8897,6 +8927,13 @@
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
+"Dc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
+/area/mainship/living/cafeteria_starboard)
 "Dd" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -9034,12 +9071,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/general)
 "DE" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/starboard_hull)
+/obj/effect/landmark/start/latejoin,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/cryo_cells)
 "DF" = (
 /obj/machinery/line_nexter{
 	dir = 2
@@ -9108,7 +9142,6 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/structure/cable,
-/obj/effect/ai_node,
 /turf/open/floor/freezer,
 /area/mainship/living/cafeteria_starboard)
 "DP" = (
@@ -9219,13 +9252,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/port_garden)
 "Ef" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/light/small,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
-/area/mainship/hull/starboard_hull)
+/area/mainship/living/cryo_cells)
 "Eg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9357,15 +9388,8 @@
 /turf/open/floor/freezer,
 /area/mainship/living/cafeteria_starboard)
 "EC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/starboard_hull)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/cryo_cells)
 "ED" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -9646,6 +9670,14 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"Fj" = (
+/obj/effect/decal/siding{
+	dir = 8
+	},
+/turf/open/floor/mainship/terragov/north{
+	dir = 8
+	},
+/area/space)
 "Fk" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -9984,6 +10016,14 @@
 /obj/structure/window/framed/mainship/white,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
+"Gg" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/starboard_hull)
 "Gh" = (
 /obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 2
@@ -10353,11 +10393,6 @@
 	dir = 8
 	},
 /area/mainship/living/briefing)
-"Hl" = (
-/obj/structure/table/mainship,
-/obj/item/pizzabox,
-/turf/open/floor/freezer,
-/area/mainship/living/cafeteria_starboard)
 "Hm" = (
 /obj/effect/decal/cleanable/blood/oil{
 	name = "grease";
@@ -10500,8 +10535,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
 "HL" = (
-/obj/machinery/door/airlock/mainship/generic/ert{
-	name = "Shuttle Airlock"
+/obj/machinery/door/airlock/multi_tile/mainship/generic/noglass{
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
@@ -11710,17 +11745,14 @@
 /turf/closed/wall/mainship/outer,
 /area/mainship/hull/port_hull)
 "Lt" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 8
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/mainship/living/evacuation)
 "Lv" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
-	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
 	},
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
@@ -11823,11 +11855,6 @@
 	dir = 1
 	},
 /area/mainship/hallways/starboard_hallway)
-"LP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/cafeteria_starboard)
 "LQ" = (
 /obj/structure/sign/vacuum,
 /turf/closed/wall/mainship,
@@ -12121,14 +12148,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
-"MF" = (
-/obj/effect/decal/siding{
-	dir = 1
-	},
-/turf/open/floor/mainship/terragov/north{
-	dir = 1
-	},
-/area/space)
 "MH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -12260,9 +12279,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "Ni" = (
-/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/hull/starboard_hull)
 "Nj" = (
 /obj/effect/landmark/start/job/captain,
 /obj/structure/bed/fancy,
@@ -12294,16 +12314,9 @@
 /obj/effect/decal/warning_stripes/thick{
 	icon_state = "N-corner"
 	},
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
-"Nn" = (
-/obj/effect/decal/siding{
-	dir = 4
-	},
-/turf/open/floor/mainship/terragov/north{
-	dir = 4
-	},
-/area/space)
 "No" = (
 /obj/machinery/door/poddoor/mainship/umbilical/south{
 	dir = 8
@@ -13130,14 +13143,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/engineering_workshop)
-"PK" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/starboard_hull)
 "PL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -15029,6 +15034,14 @@
 /obj/machinery/light,
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
+"Vu" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
+/area/mainship/living/cafeteria_starboard)
 "Vv" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/mainship/orange,
@@ -15537,6 +15550,14 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
+"Xk" = (
+/obj/effect/decal/siding{
+	dir = 6
+	},
+/turf/open/floor/mainship/terragov/north{
+	dir = 6
+	},
+/area/space)
 "Xl" = (
 /obj/structure/window/framed/mainship/requisitions,
 /turf/open/floor/plating,
@@ -15665,7 +15686,7 @@
 /area/mainship/engineering/port_atmos)
 "XI" = (
 /obj/effect/decal/warning_stripes/thin{
-	dir = 9
+	dir = 5
 	},
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -18560,7 +18581,7 @@ ht
 ht
 gN
 yh
-gN
+Lt
 gP
 gP
 gN
@@ -18572,7 +18593,7 @@ gP
 gP
 gP
 gN
-gN
+ht
 Lt
 LW
 MK
@@ -18661,7 +18682,7 @@ yi
 zb
 At
 At
-At
+FH
 At
 At
 FH
@@ -18669,8 +18690,8 @@ At
 At
 At
 At
-At
 FH
+At
 Lv
 LW
 ML
@@ -18769,7 +18790,7 @@ zf
 zf
 zf
 zf
-Lw
+im
 LW
 ML
 ML
@@ -19440,7 +19461,7 @@ tj
 uC
 vr
 hw
-gN
+dd
 yo
 zk
 Au
@@ -19542,12 +19563,12 @@ gN
 gN
 gN
 gN
-BE
+yj
+HL
 gN
 gN
 gN
-gN
-gN
+dd
 HL
 gN
 gN
@@ -19645,7 +19666,7 @@ kl
 kl
 tl
 kl
-kl
+vw
 vw
 kl
 tl
@@ -27554,9 +27575,9 @@ ZK
 YB
 XE
 XE
-XE
+ap
 Hr
-ID
+tX
 ho
 ib
 jW
@@ -27576,7 +27597,7 @@ ho
 wZ
 yb
 yP
-kv
+hp
 yb
 yb
 DI
@@ -27652,10 +27673,10 @@ ZK
 Gi
 XE
 XE
-ap
-Hr
-tX
-ho
+XE
+aO
+ID
+hq
 ib
 iZ
 iU
@@ -27663,16 +27684,16 @@ sx
 sx
 mP
 nL
-ya
-ya
+yc
+yc
 Qh
-Qh
-ya
-ya
 Qh
 yY
-pm
-LP
+yY
+Qh
+Ef
+Dc
+sq
 yQ
 Aj
 Aj
@@ -27761,14 +27782,14 @@ tJ
 tJ
 mP
 nM
-tJ
-tJ
+yd
+yd
 iU
 iU
-tJ
-tJ
+za
+za
 iU
-sx
+EC
 xd
 yb
 yR
@@ -27849,9 +27870,9 @@ ZK
 YB
 XE
 XE
-aO
+Hr
 ID
-hq
+ho
 ib
 jY
 jY
@@ -27865,7 +27886,7 @@ ru
 ru
 ib
 ib
-yd
+BE
 ho
 xe
 yb
@@ -27959,17 +27980,17 @@ nO
 nO
 ib
 kA
-yc
+yX
 ru
 ib
 kA
-yX
+DE
 ho
-xd
+Vu
 yb
 yW
 Aq
-Hl
+sW
 Cv
 Bq
 Bo
@@ -28046,19 +28067,19 @@ ZK
 YB
 ap
 Hr
-tX
+ID
 ho
 ho
-hq
-hq
 ho
 ho
-hq
-hq
 ho
 ho
-hq
-hq
+ho
+ho
+ho
+ho
+ho
+ho
 ho
 ho
 ho
@@ -28066,7 +28087,7 @@ ho
 xg
 xg
 xg
-jh
+ed
 Bq
 Ar
 DO
@@ -28149,7 +28170,7 @@ Wh
 bA
 bA
 bA
-EC
+uu
 bA
 bA
 bA
@@ -28160,9 +28181,9 @@ bA
 Wh
 bA
 mT
-za
-PK
-vX
+Ni
+Gg
+oQ
 xg
 yZ
 Br
@@ -28277,7 +28298,7 @@ KV
 IQ
 by
 MD
-Ni
+by
 NO
 Pp
 Qm
@@ -28345,19 +28366,19 @@ Hr
 ih
 ik
 rw
-uu
 wf
+xf
 rw
 rw
 rw
 rw
 rw
-wf
-rw
-rw
+xf
 rw
 Aa
-mv
+rw
+XI
+ak
 yg
 xg
 xg
@@ -28454,15 +28475,15 @@ Zy
 Zy
 Zy
 Zy
-DE
-se
+xh
+ch
 gM
 Wh
 bA
 bA
 bA
-bA
-EC
+mT
+Wh
 bA
 bA
 bA
@@ -28471,7 +28492,7 @@ Wh
 JV
 KX
 bA
-EC
+Wh
 wh
 Nm
 bA
@@ -28552,7 +28573,7 @@ Zy
 Zy
 Zy
 Zy
-DE
+xh
 Hr
 aO
 aO
@@ -28650,7 +28671,7 @@ Zy
 Zy
 Zy
 Zy
-DE
+xh
 Hr
 XE
 XE
@@ -28748,7 +28769,7 @@ Zy
 Zy
 Zy
 Zy
-DE
+xh
 Hr
 XE
 XE
@@ -28763,9 +28784,9 @@ HI
 aO
 XE
 XE
+vh
+Fj
 rh
-xh
-zT
 XE
 XE
 XE
@@ -28846,7 +28867,7 @@ Zy
 Zy
 Zy
 Zy
-DE
+xh
 Hr
 XE
 XE
@@ -28861,9 +28882,9 @@ HJ
 Hr
 XE
 XE
-MF
-xT
-sW
+mX
+sm
+kf
 XE
 XE
 XE
@@ -28944,7 +28965,7 @@ Zy
 Zy
 Zy
 Zy
-Ef
+xz
 Hr
 XE
 XE
@@ -28959,9 +28980,9 @@ Hr
 Hr
 XE
 XE
-hE
-Nn
-hH
+aB
+wN
+Xk
 XE
 XE
 XE
@@ -29042,7 +29063,7 @@ Zy
 Zy
 Zy
 Zy
-DE
+xh
 Hr
 XE
 XE
@@ -29130,17 +29151,17 @@ ih
 iW
 jX
 jX
-xf
+ya
 jX
 jX
 jX
 jX
 jX
-xf
+ya
 jX
 jX
 jX
-XI
+gj
 Hr
 XE
 XE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

![image](https://user-images.githubusercontent.com/6610922/164128489-2a0eb2e0-91bd-4054-88dd-a154d36c6712.png)


Also, add some 2x1 maint doors.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's weird that Minerva is the only shipside map that has one landing zone for ERT. Time to fix that. It's going to be a bit cramp during spawn, but no one bothers. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Add Minerva's starboard ERT shuttle landing zone
balance: Add Minerva's starboard ERT shuttle landing zone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
