### PR TITLE
Adjust layer order for mob item rendering

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -402,14 +402,14 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define BELT_LAYER 19
 #define GLASSES_LAYER 18
 #define SUIT_LAYER 17 //Possible make this an overlay of somethign required to wear a belt?
-#define SUIT_STORE_LAYER 16
-#define BACK_LAYER 15
-#define HAIR_LAYER 14 //TODO: make part of head layer?
-#define EARS_LAYER 13
-#define FACEMASK_LAYER 12
-#define GOGGLES_LAYER 11	//For putting Ballistic goggles and potentially other things above masks
-#define HEAD_LAYER 10
-#define COLLAR_LAYER 9
+#define HAIR_LAYER 16 //TODO: make part of head layer?
+#define EARS_LAYER 15
+#define FACEMASK_LAYER 14
+#define GOGGLES_LAYER 13	//For putting Ballistic goggles and potentially other things above masks
+#define HEAD_LAYER 12
+#define COLLAR_LAYER 11
+#define SUIT_STORE_LAYER 10
+#define BACK_LAYER 9
 #define CAPE_LAYER 8
 #define HANDCUFF_LAYER 7
 #define L_HAND_LAYER 6


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The order in which equipped items are rendered on mobs is a little bit funky. Suit slot items and back items are currently rendered underneath everything head related. So if you have a large gun or backpack on, it appears underneath your hair or large helmet.

This PR means you get this:
![image](https://user-images.githubusercontent.com/7869430/164155166-4532d5ad-6805-47d3-a8b2-2dd44bf9cfe9.png)
Instead of this:
![image](https://user-images.githubusercontent.com/7869430/164155147-379b5904-e8a0-4960-9c2e-70a9d6d90c7f.png)

The system isn't perfect either way, as you still get issues with large guns (like the above RR) combined with large helmets like the jaeger causing clipping when facing downwards but in my opinion this is the lesser of two evils, as it results in significantly less clipping over all.
Also Jaeger helmets are bizarrely huge.

The ideal solution would be to have render order based on direction faced, or to have over/underlays that can apply to other item layers, but that's not something I would know how to manage.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Guns ramming into the back of your skull is jank.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Back and suitslot items render over head layers - guns will no longer grow into the back of your skull when stored.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
