### PR TITLE
Expansion of PoS: Req change 2.0, Bigger Bar, 2x1 maint doors, medbay remap, maint hall in bow, and Condor's hazard signs

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -744,6 +744,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
+"cH" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "cI" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -1843,14 +1849,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
 "gz" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "gA" = (
 /obj/machinery/light{
@@ -2365,6 +2368,18 @@
 /obj/item/book/manual/chef_recipes,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
+"in" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 1
+	},
+/area/mainship/medical/medical_science)
 "io" = (
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/mono,
@@ -2594,12 +2609,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "je" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "jf" = (
@@ -3775,12 +3789,6 @@
 /turf/open/floor/mainship/black/full,
 /area/mainship/living/cafeteria_starboard)
 "mS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
@@ -4224,15 +4232,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "op" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "oq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
@@ -8460,6 +8465,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"BA" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
 "BD" = (
 /obj/machinery/door/poddoor/shutters/mainship/cell,
 /obj/machinery/door/airlock/mainship/research/glass/cell,
@@ -12689,6 +12702,14 @@
 	dir = 1
 	},
 /area/mainship/squads/general)
+"Ns" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "Nt" = (
 /turf/closed/wall/mainship/research/containment/wall/west,
 /area/mainship/medical/medical_science)
@@ -13588,10 +13609,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "PY" = (
@@ -16378,6 +16399,14 @@
 	},
 /turf/open/floor/mainship_hull,
 /area/space)
+"Yq" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "Yr" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mainship,
@@ -39688,7 +39717,7 @@ LR
 ng
 Io
 GS
-nH
+cH
 Fu
 Mb
 CM
@@ -40705,7 +40734,7 @@ ZX
 ZX
 Ul
 ZX
-Wb
+in
 RI
 ZX
 ZX
@@ -41211,7 +41240,7 @@ ch
 ZX
 Ne
 MF
-MF
+op
 MF
 MF
 hV
@@ -41728,7 +41757,7 @@ Qw
 Of
 YT
 kc
-mg
+Ns
 ei
 mg
 VJ
@@ -41977,7 +42006,7 @@ ad
 ad
 cu
 Mb
-ap
+qg
 ap
 YT
 NY
@@ -42234,7 +42263,7 @@ fq
 cu
 pr
 Mb
-op
+qg
 ap
 YT
 pt
@@ -42491,7 +42520,7 @@ az
 az
 az
 az
-gz
+qg
 ap
 YT
 Rv
@@ -42510,7 +42539,7 @@ ND
 Ct
 bd
 XU
-nH
+cH
 pd
 BK
 QM
@@ -42747,7 +42776,7 @@ US
 VT
 bw
 Yk
-ap
+ml
 mS
 ap
 YT
@@ -43004,8 +43033,8 @@ ap
 jM
 ap
 io
-ml
-Yf
+ap
+CB
 ap
 YT
 pM
@@ -43019,7 +43048,7 @@ BO
 JK
 XI
 eC
-Tc
+BA
 Tc
 Uh
 bd
@@ -43519,7 +43548,7 @@ sP
 ZA
 Zd
 KQ
-Yf
+gz
 ap
 bd
 dK
@@ -43790,7 +43819,7 @@ MP
 Fb
 VQ
 bd
-LM
+Yq
 aY
 JH
 bd
@@ -44810,7 +44839,7 @@ pZ
 hH
 eH
 hH
-Tc
+BA
 gw
 aY
 Zs

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -1163,9 +1163,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "dJ" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
-	},
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "dK" = (
@@ -2878,13 +2876,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "jK" = (
-/obj/effect/decal/siding{
-	dir = 6
-	},
-/turf/open/floor/mainship/terragov/east{
-	dir = 6
-	},
-/area/space)
+/obj/structure/sink,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "jL" = (
 /obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/door/firedoor/mainship,
@@ -4369,6 +4363,14 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"oI" = (
+/obj/effect/decal/siding{
+	dir = 10
+	},
+/turf/open/floor/mainship/terragov/east{
+	dir = 10
+	},
+/area/space)
 "oJ" = (
 /turf/open/floor/mainship/green/corner{
 	dir = 4
@@ -4753,6 +4755,10 @@
 	dir = 8
 	},
 /area/mainship/living/cryo_cells)
+"qf" = (
+/obj/structure/kitchenspike,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "qg" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -5173,10 +5179,10 @@
 /area/mainship/living/bridgebunks)
 "rH" = (
 /obj/effect/decal/siding{
-	dir = 10
+	dir = 6
 	},
 /turf/open/floor/mainship/terragov/east{
-	dir = 10
+	dir = 6
 	},
 /area/space)
 "rI" = (
@@ -6363,6 +6369,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
+"vk" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/wood,
+/area/mainship/hull/lower_hull)
 "vl" = (
 /obj/structure/closet/boxinggloves,
 /turf/open/floor/plating/mainship,
@@ -8311,6 +8321,10 @@
 /obj/docking_port/stationary/ert_big,
 /turf/open/space,
 /area/space)
+"Bf" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "Bg" = (
 /obj/machinery/marine_selector/gear/medic,
 /turf/open/floor/mainship/floor,
@@ -8668,10 +8682,10 @@
 /area/mainship/living/numbertwobunks)
 "BX" = (
 /obj/effect/decal/siding{
-	dir = 9
+	dir = 5
 	},
 /turf/open/floor/mainship/terragov/east{
-	dir = 9
+	dir = 5
 	},
 /area/space)
 "BY" = (
@@ -9798,10 +9812,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/airoom)
 "Fo" = (
-/obj/machinery/door/airlock/mainship/maint,
 /obj/structure/cable,
 /obj/machinery/door/firedoor/mainship,
 /obj/effect/ai_node,
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Fp" = (
@@ -10754,8 +10768,8 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
 "Ih" = (
-/obj/structure/sink,
-/turf/open/floor/plating/plating_catwalk,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Ii" = (
 /obj/structure/cable,
@@ -10962,10 +10976,10 @@
 /area/mainship/hallways/port_hallway)
 "IJ" = (
 /obj/effect/decal/siding{
-	dir = 1
+	dir = 9
 	},
 /turf/open/floor/mainship/terragov/east{
-	dir = 1
+	dir = 9
 	},
 /area/space)
 "IK" = (
@@ -10985,17 +10999,17 @@
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "IN" = (
-/obj/effect/decal/siding{
-	dir = 5
-	},
-/turf/open/floor/mainship/terragov/east{
-	dir = 5
-	},
-/area/space)
-"IO" = (
-/obj/structure/janitorialcart,
-/obj/item/tool/mop,
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket/janibucket,
+/obj/item/tool/wet_sign,
+/obj/item/tool/wet_sign,
+/obj/item/tool/wet_sign,
+/obj/item/storage/bag/trash,
 /turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
+"IO" = (
+/obj/machinery/gibber,
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "IP" = (
 /obj/structure/disposalpipe/segment,
@@ -11802,7 +11816,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/table/reinforced,
+/obj/item/tool/kitchen/knife/butcher,
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "KT" = (
 /obj/effect/landmark/start/job/squadmarine,
@@ -12049,8 +12065,12 @@
 /turf/open/floor/plating,
 /area/mainship/command/corporateliaison)
 "LK" = (
-/obj/effect/decal/siding,
-/turf/open/floor/mainship/terragov/east,
+/obj/effect/decal/siding{
+	dir = 1
+	},
+/turf/open/floor/mainship/terragov/east{
+	dir = 1
+	},
 /area/space)
 "LL" = (
 /obj/structure/cable,
@@ -12548,6 +12568,10 @@
 /obj/structure/ship_ammo/rocket/keeper,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"Nl" = (
+/obj/structure/closet/bodybag,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "Nm" = (
 /obj/item/paper/crumpled,
 /obj/item/paper/crumpled{
@@ -12596,13 +12620,20 @@
 	},
 /area/mainship/squads/general)
 "Ns" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/glass/bucket/janibucket,
-/obj/item/tool/wet_sign,
-/obj/item/tool/wet_sign,
-/obj/item/tool/wet_sign,
-/obj/item/storage/bag/trash,
-/turf/open/floor/plating/plating_catwalk,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/item/reagent_containers/food/snacks/meat{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/snacks/meat{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/snacks/meat{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Nt" = (
 /obj/machinery/vending/dinnerware,
@@ -12953,9 +12984,7 @@
 /turf/open/shuttle/escapepod/five,
 /area/mainship/command/self_destruct)
 "Oq" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 8
-	},
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "Or" = (
@@ -14567,6 +14596,10 @@
 	dir = 1
 	},
 /area/space)
+"Tn" = (
+/obj/effect/decal/siding,
+/turf/open/floor/mainship/terragov/east,
+/area/space)
 "Tp" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -15452,10 +15485,10 @@
 /turf/closed/wall/mainship/outer,
 /area/mainship/hallways/hangar/droppod)
 "Wg" = (
-/obj/machinery/door/airlock/multi_tile/mainship/maint{
+/obj/structure/cable,
+/obj/machinery/door/airlock/multi_tile/mainship/maint/free_access{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Wh" = (
@@ -16096,10 +16129,10 @@
 /area/mainship/squads/general)
 "XX" = (
 /obj/effect/decal/siding{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/mainship/terragov/east{
-	dir = 8
+	dir = 4
 	},
 /area/space)
 "XY" = (
@@ -16203,6 +16236,14 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
+"Yp" = (
+/obj/effect/decal/siding{
+	dir = 8
+	},
+/turf/open/floor/mainship/terragov/east{
+	dir = 8
+	},
+/area/space)
 "Yr" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mainship,
@@ -16415,10 +16456,10 @@
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/surgery_hallway)
 "YW" = (
-/turf/open/floor/mainship/terragov{
-	dir = 4
-	},
-/area/space)
+/obj/structure/closet/bodybag,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "YX" = (
 /obj/structure/cable,
 /obj/machinery/light{
@@ -16450,13 +16491,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "Zb" = (
-/obj/effect/decal/siding{
-	dir = 4
-	},
-/turf/open/floor/mainship/terragov/east{
-	dir = 4
-	},
-/area/space)
+/obj/structure/janitorialcart,
+/obj/item/tool/mop,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "Zc" = (
 /obj/effect/landmark/start/job/squadleader,
 /obj/effect/landmark/start/latejoin,
@@ -16496,6 +16534,11 @@
 	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
+"Zg" = (
+/turf/open/floor/mainship/terragov{
+	dir = 4
+	},
+/area/space)
 "Zh" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -36648,9 +36691,9 @@ fI
 fI
 Tm
 rc
-rc
-rc
-rc
+IJ
+Yp
+oI
 rc
 rc
 rc
@@ -36905,9 +36948,9 @@ fI
 fI
 Tm
 rc
-rc
-rc
-rc
+LK
+Zg
+Tn
 ad
 ad
 ad
@@ -37418,10 +37461,10 @@ fI
 fI
 fI
 Tm
-rc
-IJ
-YW
-LK
+Mb
+Mb
+Mb
+Mb
 ad
 Dz
 xl
@@ -37675,7 +37718,7 @@ aa
 fI
 fI
 Tm
-rc
+Mb
 IN
 Zb
 jK
@@ -37683,7 +37726,7 @@ ad
 Dz
 xl
 AL
-AL
+vk
 AL
 AL
 ej
@@ -37933,9 +37976,9 @@ fI
 fI
 Tm
 Mb
-Mb
-Mb
-Mb
+YW
+Nl
+Bf
 ad
 Dz
 xl
@@ -38199,7 +38242,7 @@ xl
 AL
 AL
 AL
-AL
+vk
 ej
 La
 ad
@@ -38447,9 +38490,9 @@ Lw
 Lw
 rc
 Mb
-VL
+qf
 KS
-VL
+Ih
 ad
 Dz
 RC
@@ -38467,7 +38510,7 @@ VL
 dK
 dx
 bZ
-bZ
+xR
 bZ
 bZ
 bZ
@@ -38725,10 +38768,10 @@ ad
 ad
 ad
 ad
-rj
+dJ
 ad
 ad
-rj
+dJ
 ad
 ad
 GM

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -179,12 +179,9 @@
 /turf/open/floor/plating,
 /area/mainship/living/cryo_cells)
 "aH" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 10
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/structure/window/framed/mainship/hull,
+/turf/open/floor/mainship_hull,
+/area/space)
 "aI" = (
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
@@ -223,17 +220,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "aP" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
-/area/mainship/hallways/hangar/droppod)
+/obj/effect/ai_node,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/space)
 "aR" = (
 /obj/item/clothing/head/warning_cone,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -417,10 +408,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "bt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "bv" = (
@@ -563,14 +557,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "bV" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/space)
 "bW" = (
 /obj/structure/sign/poster{
 	dir = 1
@@ -855,15 +844,11 @@
 /area/mainship/command/corporateliaison)
 "cP" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/turf/open/floor/plating/plating_catwalk,
+/area/space)
 "cQ" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -1427,9 +1412,7 @@
 	},
 /area/mainship/command/self_destruct)
 "eF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "eG" = (
@@ -1657,11 +1640,11 @@
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "ft" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
 /turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/area/mainship/hallways/hangar)
 "fu" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -1671,8 +1654,9 @@
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/generic/rnr,
-/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "fw" = (
@@ -1787,6 +1771,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "fQ" = (
@@ -2225,6 +2210,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "hi" = (
@@ -2462,6 +2448,12 @@
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/surgery_hallway)
+"ig" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/engineering/engine_core)
 "ii" = (
 /obj/structure/flora/pottedplant/twentyone,
 /turf/open/floor/mainship/black,
@@ -2876,7 +2868,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "jK" = (
-/obj/structure/sink,
+/obj/structure/sink{
+	dir = 1
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "jL" = (
@@ -2952,6 +2946,15 @@
 "jU" = (
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
+"jV" = (
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/engineering/engine_core)
 "jX" = (
 /obj/structure/closet/l3closet/virology,
 /obj/machinery/light{
@@ -3117,12 +3120,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "kC" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/bed/chair/wood/normal,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/obj/structure/window/framed/mainship/hull,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "kD" = (
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/plating/plating_catwalk,
@@ -3924,17 +3924,10 @@
 /area/space)
 "ne" = (
 /obj/effect/decal/warning_stripes/thin{
-	dir = 4
+	dir = 6
 	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/mainship,
-/obj/machinery/door_control/mainship/droppod,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
-/area/mainship/hallways/hangar/droppod)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "nh" = (
 /obj/effect/decal/warning_stripes/engineer,
 /obj/effect/decal/warning_stripes/box/small{
@@ -4001,15 +3994,16 @@
 "nv" = (
 /turf/open/floor/plating/icefloor/warnplate,
 /area/mainship/hallways/hangar)
+"ny" = (
+/obj/machinery/power/fusion_engine/preset,
+/turf/open/floor/mainship/mono,
+/area/mainship/engineering/engine_core)
 "nz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
-	},
-/obj/structure/bed/chair/wood/normal{
-	dir = 8
 	},
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
@@ -4323,7 +4317,7 @@
 	},
 /area/mainship/squads/general)
 "oA" = (
-/obj/machinery/light{
+/obj/structure/sign/poster{
 	dir = 1
 	},
 /turf/open/floor/mainship/mono,
@@ -4596,7 +4590,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "pt" = (
-/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "pw" = (
@@ -4719,11 +4715,11 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "pW" = (
-/obj/machinery/door/airlock/multi_tile/mainship/maint{
-	dir = 1
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
 	},
-/turf/open/space/basic,
-/area/mainship/hull/lower_hull)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar/droppod)
 "pX" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
@@ -4807,9 +4803,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "qo" = (
-/obj/structure/sign/poster{
-	dir = 1
-	},
+/obj/machinery/power/apc/mainship,
+/obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "qp" = (
@@ -5036,6 +5031,12 @@
 "rg" = (
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/starboard_hallway)
+"rh" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "ri" = (
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 10
@@ -6197,6 +6198,19 @@
 /obj/item/blueprints,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/ce_room)
+"uE" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/bed/chair/wood/normal{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "uF" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -6336,11 +6350,11 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/shipboard/weapon_room)
 "vg" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
 	},
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "vh" = (
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
@@ -6719,6 +6733,9 @@
 "wn" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
+	},
+/obj/machinery/door_control/mainship/droppod{
+	dir = 1
 	},
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 8
@@ -8067,9 +8084,12 @@
 /turf/open/floor/plating,
 /area/mainship/shipboard/firing_range)
 "Am" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/mainship/cargo,
-/area/mainship/engineering/engine_core)
+/obj/structure/cable,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/space)
 "An" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -8368,14 +8388,12 @@
 	},
 /area/mainship/shipboard/weapon_room)
 "Bm" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
+/obj/structure/cable,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/engineering/engine_core)
+/turf/open/floor/plating/plating_catwalk,
+/area/space)
 "Bn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8471,16 +8489,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "BB" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/structure/table/mainship,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "BD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -8493,6 +8506,13 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/glass/rag,
 /turf/open/floor/mainship/floor,
+/area/mainship/living/grunt_rnr)
+"BE" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/bed/chair/wood/normal{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "BF" = (
 /obj/machinery/disposal,
@@ -8975,22 +8995,15 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "CR" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
-/obj/structure/bed/chair/wood/normal{
-	dir = 1
-	},
-/obj/effect/ai_node,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "CS" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 2
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "CU" = (
@@ -9657,10 +9670,16 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "EG" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/table/mainship,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "EH" = (
 /obj/machinery/light{
 	dir = 1
@@ -9791,11 +9810,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Fl" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
 	},
-/area/mainship/engineering/engine_core)
+/obj/structure/cable,
+/obj/machinery/door/airlock/multi_tile/mainship/generic/rnr,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar)
 "Fm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10463,6 +10484,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
+"Hm" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/engineering/engine_core)
 "Hn" = (
 /obj/effect/landmark/start/job/pilotofficer,
 /obj/structure/bed,
@@ -10522,6 +10552,7 @@
 	dir = 9
 	},
 /obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "HA" = (
@@ -10545,7 +10576,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
 "HD" = (
@@ -10565,6 +10595,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/engine_core)
 "HF" = (
@@ -10578,6 +10609,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/lower_engineering)
 "HH" = (
@@ -10588,6 +10620,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/lower_engineering)
 "HJ" = (
@@ -11523,7 +11556,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Kj" = (
-/obj/effect/ai_node,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "Kk" = (
@@ -11954,6 +11990,7 @@
 	dir = 4
 	},
 /obj/machinery/firealarm,
+/obj/structure/cable,
 /turf/open/floor/mainship/orange{
 	dir = 5
 	},
@@ -12515,6 +12552,9 @@
 /obj/structure/bed/chair/wood/normal{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "Nf" = (
@@ -12859,7 +12899,6 @@
 /area/mainship/command/cic)
 "NY" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "NZ" = (
@@ -13167,11 +13206,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "OW" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/engineering/engine_core)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "OX" = (
 /obj/structure/table/mainship,
 /obj/item/storage/toolbox/mechanical,
@@ -13662,6 +13701,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 4
 	},
@@ -15163,6 +15203,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
 "Vd" = (
@@ -16018,10 +16059,7 @@
 	},
 /area/mainship/squads/general)
 "XI" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
+/obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "XJ" = (
@@ -41017,40 +41055,40 @@ fI
 fI
 fI
 fI
-fI
-fI
-fI
-fI
-fI
-fI
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+tG
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
 Mb
 Mb
 Mb
@@ -41274,40 +41312,40 @@ fI
 fI
 fI
 fI
-tG
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
+Tm
+Um
+Um
+Um
+Um
+Um
+Um
+Um
+Um
+Um
+Um
+Um
+Um
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
 Mb
 oX
 cu
@@ -41532,18 +41570,18 @@ fI
 fI
 fI
 Tm
-rc
-rc
-rc
-rc
-rc
-rc
-rc
-rc
-rc
-rc
-rc
-rc
+Um
+aP
+bV
+bV
+bV
+bV
+Am
+bV
+bV
+bV
+aP
+Um
 rc
 rc
 rc
@@ -41575,7 +41613,7 @@ qo
 rT
 Of
 IM
-Ow
+lQ
 lQ
 ei
 Zv
@@ -41789,8 +41827,8 @@ fI
 fI
 fI
 Tm
-rc
-rc
+Um
+bV
 Wf
 Wf
 Wf
@@ -41799,7 +41837,7 @@ Wf
 Wf
 Wf
 Wf
-ad
+cu
 ad
 ad
 ad
@@ -41827,12 +41865,12 @@ cu
 Mb
 ap
 hh
-sD
+Fl
 NY
 lQ
 nz
-Ed
-vg
+lQ
+lQ
 XI
 YT
 Zv
@@ -42046,8 +42084,8 @@ fI
 fI
 fI
 Tm
-rc
-rc
+Um
+bV
 Wf
 lX
 lX
@@ -42056,7 +42094,7 @@ lX
 lX
 lX
 Sl
-ao
+BB
 cu
 cu
 cu
@@ -42074,7 +42112,7 @@ cu
 cu
 cu
 cu
-eQ
+cu
 bD
 cu
 cu
@@ -42083,12 +42121,12 @@ fq
 pr
 Mb
 ap
-hh
+EG
 fv
 pt
-lQ
-Bx
-MF
+OW
+uE
+BE
 eF
 Kj
 YT
@@ -42303,17 +42341,17 @@ fI
 fI
 fI
 Tm
-rc
-rc
-Wf
-aP
+Um
+bV
+pW
+ae
 ae
 ae
 ae
 cE
 wn
 Wf
-ew
+Ek
 az
 az
 az
@@ -42339,14 +42377,14 @@ az
 az
 az
 az
-cP
+ap
 bt
-bV
-ft
-kC
-BB
-EG
-CR
+az
+ST
+rT
+IM
+IM
+Ow
 YT
 YT
 Zv
@@ -42560,8 +42598,8 @@ fI
 fI
 fI
 Tm
-rc
-rc
+Um
+bV
 Wf
 lX
 lX
@@ -42570,7 +42608,7 @@ lX
 cF
 Mf
 Sl
-fL
+cu
 az
 dL
 ap
@@ -42817,8 +42855,8 @@ aa
 aa
 aa
 Tm
-rc
-rc
+Um
+bV
 Wf
 lX
 lX
@@ -42922,7 +42960,7 @@ yQ
 zG
 it
 TG
-Qx
+zD
 EK
 Fi
 EK
@@ -43074,8 +43112,8 @@ aa
 aa
 aa
 Tm
-rc
-rc
+Um
+cP
 Wf
 ai
 ae
@@ -43179,11 +43217,11 @@ yI
 zI
 Mr
 zw
-Qx
+zD
 zD
 Aa
 zD
-zC
+jV
 cu
 ad
 rc
@@ -43331,8 +43369,8 @@ aa
 aa
 aa
 Tm
-rc
-rc
+Um
+bV
 Wf
 lX
 lX
@@ -43436,7 +43474,7 @@ yJ
 An
 Ce
 zw
-Qx
+zD
 zV
 Ab
 zV
@@ -43588,8 +43626,8 @@ aa
 aa
 aa
 Tm
-rc
-rc
+Um
+bV
 Wf
 lX
 lX
@@ -43598,7 +43636,7 @@ lX
 ab
 GV
 ci
-ap
+CR
 ci
 ap
 eJ
@@ -43693,7 +43731,7 @@ OP
 UL
 OP
 OP
-zD
+ig
 zV
 Ab
 zV
@@ -43845,8 +43883,8 @@ aa
 aa
 aa
 Tm
-rc
-rc
+Um
+bV
 Wf
 ha
 RQ
@@ -43855,7 +43893,7 @@ RQ
 iG
 YC
 CB
-hU
+CR
 fn
 ap
 eJ
@@ -43951,9 +43989,9 @@ Cg
 yq
 OL
 HA
-zD
-LL
-OW
+zV
+Ab
+zV
 zC
 cu
 ad
@@ -44102,8 +44140,8 @@ aa
 aa
 aa
 Tm
-rc
-rc
+Um
+bV
 Wf
 lX
 lX
@@ -44355,12 +44393,12 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-Tm
+tG
+Lw
+Lw
 rc
-rc
+Um
+bV
 Wf
 lX
 lX
@@ -44467,7 +44505,7 @@ zx
 HB
 zE
 Ao
-Am
+zD
 zC
 rW
 ad
@@ -44612,14 +44650,14 @@ aa
 aa
 fI
 fI
-tG
-Lw
-Lw
-rc
-rc
-rc
-Wf
-ne
+Tm
+Um
+Um
+Um
+Um
+bV
+pW
+RQ
 RQ
 RQ
 RQ
@@ -44722,10 +44760,10 @@ UI
 zf
 OL
 HC
-zD
-Fl
-zD
-Bm
+ny
+Ab
+zV
+zC
 dF
 ad
 rc
@@ -44870,11 +44908,11 @@ aa
 fI
 fI
 Tm
-rc
-rc
-rc
-rc
-rc
+Um
+aP
+bV
+bV
+aP
 Wf
 lX
 lX
@@ -45127,8 +45165,8 @@ aa
 fI
 fI
 Tm
-rc
-rc
+Um
+bV
 Pa
 Pa
 Pa
@@ -45384,8 +45422,8 @@ aa
 fI
 fI
 Tm
-rc
-rc
+Um
+bV
 Pa
 YU
 ml
@@ -45496,7 +45534,7 @@ Lo
 zD
 LL
 Qx
-zC
+Hm
 cu
 ad
 rc
@@ -45641,12 +45679,12 @@ aa
 fI
 fI
 Tm
-rc
-rc
+Um
+bV
 Pa
 ap
-bg
-an
+ne
+aO
 an
 an
 an
@@ -45898,8 +45936,8 @@ aa
 fI
 fI
 Tm
-rc
-rc
+Um
+cP
 Pa
 ap
 ca
@@ -46155,9 +46193,9 @@ aa
 fI
 fI
 Tm
-rc
-rc
-Pa
+Um
+bV
+ft
 ap
 ca
 bh
@@ -46412,9 +46450,9 @@ aa
 fI
 fI
 Tm
-rc
-rc
-Pa
+aH
+bV
+kC
 ap
 ca
 bh
@@ -46669,9 +46707,9 @@ aa
 fI
 fI
 Tm
-rc
-rc
-Pa
+aH
+bV
+kC
 aE
 ca
 bh
@@ -46926,9 +46964,9 @@ aa
 fI
 fI
 Tm
-rc
-rc
-Pa
+aH
+bV
+kC
 ap
 ca
 bh
@@ -47183,9 +47221,9 @@ aa
 fI
 fI
 Tm
-rc
-rc
-Pa
+Um
+bV
+ft
 ap
 ca
 bh
@@ -47440,8 +47478,8 @@ aa
 fI
 fI
 Tm
-rc
-rc
+Um
+cP
 Pa
 ap
 ca
@@ -47697,12 +47735,12 @@ aa
 fI
 fI
 Tm
-rc
-rc
+Um
+bV
 Pa
 ap
-aH
-bw
+ba
+aW
 bw
 bw
 bw
@@ -47720,8 +47758,8 @@ bh
 bh
 bh
 Xa
-Zd
-Yk
+jF
+sP
 ZA
 bh
 bh
@@ -47954,8 +47992,8 @@ aa
 fI
 fI
 Tm
-rc
-rc
+Um
+bV
 Pa
 Ub
 NL
@@ -48211,8 +48249,8 @@ aa
 fI
 fI
 Tm
-rc
-rc
+Um
+bV
 Pa
 Pa
 Pa
@@ -48468,11 +48506,11 @@ aa
 fI
 fI
 Tm
-rc
-rc
-rc
-rc
-rc
+Um
+aP
+bV
+bV
+aP
 Pa
 kB
 Ge
@@ -48724,12 +48762,12 @@ aa
 aa
 fI
 fI
-Ti
-jO
-jO
-rc
-rc
-rc
+Tm
+Um
+Um
+Um
+Um
+bV
 Pa
 kB
 Ge
@@ -48743,7 +48781,7 @@ az
 bP
 dV
 Xh
-bh
+Xa
 Zd
 Zd
 Zd
@@ -48981,13 +49019,13 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+Ti
+jO
+jO
 Tm
-rc
-rc
-Pa
+Um
+bV
+vg
 bi
 ak
 aJ
@@ -49000,8 +49038,8 @@ az
 ac
 CQ
 Sn
+nv
 bh
-ZA
 bh
 bh
 bh
@@ -49242,8 +49280,8 @@ aa
 aa
 aa
 Tm
-rc
-rc
+Um
+bV
 Pa
 aM
 aM
@@ -49257,7 +49295,7 @@ az
 Zx
 CQ
 XJ
-bh
+dE
 sP
 sP
 sP
@@ -49499,8 +49537,8 @@ aa
 aa
 aa
 Tm
-rc
-rc
+Um
+bV
 Pa
 wg
 as
@@ -49756,8 +49794,8 @@ aa
 aa
 aa
 Tm
-rc
-rc
+Um
+bV
 Pa
 at
 at
@@ -50013,8 +50051,8 @@ aa
 aa
 aa
 Tm
-rc
-rc
+Um
+bV
 Pa
 at
 at
@@ -50270,8 +50308,8 @@ aa
 aa
 aa
 Tm
-rc
-rc
+Um
+cP
 Pa
 aq
 aF
@@ -50290,8 +50328,8 @@ bh
 bh
 bh
 dE
-sP
-Bq
+ri
+Zd
 ZA
 bh
 bh
@@ -50527,8 +50565,8 @@ aa
 aa
 aa
 Tm
-rc
-rc
+Um
+bV
 Pa
 ah
 ah
@@ -50784,9 +50822,9 @@ aa
 aa
 aa
 Tm
-rc
-rc
-Pa
+Um
+bV
+vg
 au
 aw
 aK
@@ -51041,8 +51079,8 @@ aa
 aa
 aa
 Tm
-rc
-rc
+Um
+bV
 Pa
 kB
 kB
@@ -51298,8 +51336,8 @@ aa
 aa
 aa
 Tm
-rc
-rc
+Um
+bV
 Pa
 kB
 kB
@@ -51320,7 +51358,7 @@ cu
 cu
 JF
 dD
-ZA
+az
 az
 ap
 ct
@@ -51555,8 +51593,8 @@ aa
 aa
 aa
 Tm
-rc
-rc
+Um
+bV
 Pa
 Pa
 Pa
@@ -51565,7 +51603,7 @@ Pa
 Pa
 Pa
 Pa
-ad
+cu
 ad
 ad
 ad
@@ -51812,18 +51850,18 @@ aa
 aa
 aa
 Tm
-rc
-rc
-rc
-rc
-rc
-rc
-rc
-rc
-rc
-rc
-rc
-rc
+Um
+aP
+bV
+bV
+bV
+bV
+Bm
+bV
+bV
+bV
+aP
+Um
 rc
 rc
 rc
@@ -52068,25 +52106,25 @@ aa
 aa
 aa
 aa
-Ti
-jO
-jO
-jO
-jO
-jO
-jO
-jO
-jO
-jO
-jO
-jO
-jO
-jO
-jO
-jO
-jO
-jO
-jO
+Tm
+Um
+Um
+Um
+Um
+Um
+Um
+Um
+Um
+Um
+Um
+Um
+Um
+rc
+rc
+rc
+rc
+rc
+rc
 rc
 rc
 rc
@@ -52325,26 +52363,26 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-fI
-fI
-fI
-fI
-fI
-fI
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 Ti
+jO
+jO
+jO
+jO
+jO
+jO
+jO
+jO
+jO
+jO
+jO
+jO
+jO
+jO
+jO
+jO
+jO
+jO
+jO
 jO
 jO
 jO
@@ -54427,7 +54465,7 @@ sK
 rc
 ad
 fL
-pW
+bX
 Mb
 Mb
 Mb
@@ -56759,17 +56797,17 @@ eP
 IY
 IY
 IY
-IY
+nt
 ws
 XM
+IY
+IY
 IY
 nt
-IY
-IY
 ws
 XM
 XM
-XM
+rh
 Tg
 Ec
 Tg

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -105,8 +105,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "av" = (
-/turf/closed/wall/mainship,
-/area/space)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/mainship/maint,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "aw" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -385,10 +390,9 @@
 /area/mainship/hallways/hangar)
 "bq" = (
 /obj/structure/cable,
-/obj/structure/cable,
 /obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "bs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -584,11 +588,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
-"bW" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
-/area/mainship/hull/lower_hull)
 "bX" = (
 /obj/machinery/door/airlock/multi_tile/mainship/maint{
 	dir = 1
@@ -646,7 +645,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "ci" = (
@@ -1525,12 +1523,6 @@
 /obj/machinery/light,
 /turf/open/floor/mainship,
 /area/mainship/living/cafeteria_starboard)
-"eT" = (
-/obj/machinery/door/airlock/mainship/maint,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "eU" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
 	dir = 8;
@@ -1809,13 +1801,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/maint{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "fQ" = (
 /obj/structure/dropship_equipment/sentry_holder,
@@ -2804,7 +2794,6 @@
 /area/mainship/hallways/port_hallway)
 "je" = (
 /obj/structure/cable,
-/obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
@@ -2920,8 +2909,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "jy" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
@@ -3297,20 +3288,6 @@
 "kG" = (
 /obj/item/reagent_containers/jerrycan,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"kH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "kJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4269,6 +4246,7 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "nC" = (
@@ -4771,20 +4749,6 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
-"pm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar)
 "pn" = (
 /obj/structure/rack,
 /obj/item/tool/wrench,
@@ -4821,13 +4785,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"pr" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
 "pt" = (
 /obj/structure/table/mainship,
 /obj/machinery/microwave,
@@ -9583,7 +9540,7 @@
 	dir = 4
 	},
 /turf/closed/wall/mainship,
-/area/mainship/hallways/hangar)
+/area/mainship/hull/lower_hull)
 "DG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -41609,9 +41566,9 @@ aa
 aa
 aa
 Tm
-av
-av
-av
+rc
+rc
+rc
 Mb
 Zo
 ZX
@@ -41866,10 +41823,10 @@ Lw
 Lw
 Lw
 rc
+rc
+rc
+rc
 Mb
-bq
-cu
-cu
 ch
 ZX
 Ne
@@ -42123,10 +42080,10 @@ rc
 rc
 rc
 rc
+rc
+rc
+rc
 Mb
-cu
-Mb
-bW
 fP
 ZX
 ZX
@@ -42380,11 +42337,11 @@ rc
 rc
 rc
 rc
-ad
-cu
+rc
+rc
+rc
 Mb
-fL
-Zp
+sN
 YT
 qo
 Qw
@@ -42638,10 +42595,10 @@ ad
 ad
 ad
 ad
-cu
 Mb
-qg
-jx
+Mb
+Mb
+sN
 YT
 NY
 Qw
@@ -42890,14 +42847,14 @@ cu
 cu
 cu
 bt
-cu
+eQ
 cu
 fq
 fq
 cu
-pr
-Mb
-qg
+gp
+cu
+cu
 jx
 YT
 pt
@@ -43129,33 +43086,33 @@ cE
 Wf
 hc
 Mb
-az
-az
-az
-az
-az
-az
-az
-az
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
 DF
-eT
-az
-az
-az
-az
-az
-az
-az
-az
-az
-az
-az
-az
-az
-az
-az
-qg
-jx
+Gv
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+av
 YT
 Rv
 Qw
@@ -43926,7 +43883,7 @@ fl
 gf
 WB
 je
-ap
+ke
 bd
 cO
 BO
@@ -45210,8 +45167,8 @@ bh
 Mj
 sP
 nu
-kH
-qg
+kJ
+bq
 Kf
 nj
 dy
@@ -47266,8 +47223,8 @@ jM
 ap
 io
 ap
-pm
-rF
+Yf
+oC
 rF
 FC
 rF

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -8356,7 +8356,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "Al" = (
-/turf/open/floor/plating,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
 /area/mainship/shipboard/firing_range)
 "Am" = (
 /obj/machinery/computer/crew,

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -632,10 +632,6 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"ch" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lower_medical)
 "ci" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -842,13 +838,6 @@
 	},
 /turf/open/space,
 /area/space)
-"cL" = (
-/obj/machinery/light{
-	light_color = "#da2f1b"
-	},
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
 "cM" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
@@ -960,11 +949,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
-"de" = (
-/obj/machinery/holopad,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "dg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1238,14 +1222,6 @@
 	dir = 8
 	},
 /area/mainship/hallways/hangar)
-"dU" = (
-/obj/structure/table/mainship,
-/obj/item/reagent_containers/glass/beaker/biomass,
-/obj/item/storage/box/bodybags,
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/medical/lower_medical)
 "dV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -1390,10 +1366,6 @@
 	dir = 10
 	},
 /area/mainship/squads/general)
-"et" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
 "eu" = (
 /obj/machinery/vending/medical/shipside,
 /obj/machinery/light{
@@ -1821,6 +1793,12 @@
 	dir = 4
 	},
 /area/mainship/hallways/hangar)
+"fR" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/surgery_hallway)
 "fS" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -2293,6 +2271,14 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"hp" = (
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/glass/beaker/biomass,
+/obj/item/storage/box/bodybags,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "hq" = (
 /obj/machinery/power/fusion_engine/preset,
 /turf/open/floor/mainship/mono,
@@ -2325,6 +2311,13 @@
 	dir = 1
 	},
 /area/mainship/shipboard/firing_range)
+"hx" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "hy" = (
 /obj/structure/window/framed/mainship/white,
 /obj/machinery/door/firedoor/mainship{
@@ -2411,6 +2404,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"hM" = (
+/obj/effect/ai_node,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "hN" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -2454,6 +2453,11 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"hV" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "hW" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -2512,11 +2516,6 @@
 /obj/structure/flora/pottedplant/twentyone,
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
-"ik" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
 "il" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -3296,6 +3295,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"kW" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/surgery_hallway)
 "kX" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -3736,6 +3744,20 @@
 /obj/item/tool/pen,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
+"mo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "mp" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -4296,6 +4318,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"oj" = (
+/obj/machinery/door/airlock/mainship/medical/glass{
+	dir = 2
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/medical/lower_medical)
 "ol" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -4325,6 +4353,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"os" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "ot" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -4625,20 +4659,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
-"pp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
 "pq" = (
 /obj/machinery/vending/shared_vending/marine_engi,
 /obj/machinery/light{
@@ -4807,12 +4827,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
-"qc" = (
-/obj/effect/ai_node,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
 "qd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -5019,10 +5033,6 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
-"qO" = (
-/obj/machinery/cloning_console/vats,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "qP" = (
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/plating/mainship,
@@ -5126,6 +5136,10 @@
 "rm" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
+"rn" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/medical/surgery_hallway)
 "ro" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -7873,6 +7887,10 @@
 /obj/item/clothing/head/warning_cone,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"zr" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
 "zs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8401,12 +8419,6 @@
 /obj/docking_port/stationary/ert_big,
 /turf/open/space,
 /area/space)
-"Be" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
 "Bf" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/plating_catwalk,
@@ -9125,15 +9137,6 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
-"Da" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/surgery_hallway)
 "Db" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
@@ -10749,10 +10752,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
-"HP" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/medical/surgery_hallway)
 "HQ" = (
 /obj/machinery/door/poddoor/mainship/open/cic{
 	dir = 2
@@ -11945,6 +11944,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
+"KV" = (
+/obj/machinery/light{
+	light_color = "#da2f1b"
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "KW" = (
 /turf/closed/wall/mainship/research/containment/wall/corner{
 	dir = 8
@@ -12905,6 +12911,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"NM" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/surgery_hallway)
 "NN" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -13972,12 +13984,6 @@
 	dir = 5
 	},
 /area/mainship/squads/general)
-"QS" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
-	dir = 2
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/medical/lower_medical)
 "QT" = (
 /obj/machinery/telecomms/server/presets/requisitions,
 /turf/open/floor/mainship/tcomms,
@@ -14276,6 +14282,11 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"RL" = (
+/obj/machinery/holopad,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "RM" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
@@ -14372,6 +14383,10 @@
 /obj/machinery/telecomms/server/presets/bravo,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
+"RY" = (
+/obj/machinery/cloning_console/vats,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "RZ" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /obj/machinery/vending/uniform_supply,
@@ -14432,12 +14447,6 @@
 "Sl" = (
 /turf/closed/wall/mainship,
 /area/mainship/hallways/hangar/droppod)
-"Sm" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/surgery_hallway)
 "Sn" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/machinery/landinglight/ds2/delayone,
@@ -14840,9 +14849,6 @@
 "TE" = (
 /obj/machinery/optable,
 /obj/item/tank/anesthetic,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
@@ -15376,12 +15382,6 @@
 	dir = 1
 	},
 /area/mainship/hallways/aft_hallway)
-"Vm" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/surgery_hallway)
 "Vo" = (
 /turf/open/floor/mainship_hull/dir,
 /area/space)
@@ -16379,6 +16379,10 @@
 	},
 /turf/open/floor/grass,
 /area/mainship/living/cafeteria_starboard)
+"Yi" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "Yj" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -16405,13 +16409,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
-"Yn" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/ai_node,
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
 "Yp" = (
 /obj/effect/decal/siding{
 	dir = 8
@@ -39179,11 +39176,11 @@ IY
 IY
 IY
 IY
-Be
+os
 YM
 Tg
 Tg
-Yn
+hx
 Tg
 Tg
 El
@@ -39697,7 +39694,7 @@ NY
 YT
 Zv
 IZ
-HP
+rn
 dH
 KX
 Zv
@@ -39954,7 +39951,7 @@ TB
 YT
 Zv
 kr
-HP
+rn
 Gy
 RI
 Zv
@@ -40211,7 +40208,7 @@ Hc
 YT
 Zv
 IZ
-HP
+rn
 Gy
 yn
 Zv
@@ -40469,8 +40466,8 @@ YT
 Zv
 Vh
 Rj
-HP
-HP
+rn
+rn
 NG
 Ue
 GR
@@ -40729,7 +40726,7 @@ Zv
 Zv
 Zv
 Zv
-Da
+kW
 nn
 pE
 ir
@@ -40986,7 +40983,7 @@ fU
 Wb
 rs
 QF
-Vm
+fR
 nn
 QF
 ax
@@ -41235,7 +41232,7 @@ lQ
 Bx
 MF
 lQ
-ik
+hV
 YT
 Zv
 mt
@@ -41243,7 +41240,7 @@ ji
 ji
 ji
 Rn
-Sm
+NM
 ZX
 Zv
 nD
@@ -41492,7 +41489,7 @@ rT
 Bn
 IM
 Ow
-cL
+KV
 YT
 Zv
 hj
@@ -41500,7 +41497,7 @@ hD
 Hd
 qs
 QF
-Vm
+fR
 Xq
 Re
 SU
@@ -41757,7 +41754,7 @@ Zv
 Zv
 Zv
 Zv
-Da
+kW
 jm
 nn
 nD
@@ -42019,10 +42016,10 @@ jm
 nn
 nD
 iz
-qc
-et
-et
-et
+hM
+Yi
+Yi
+Yi
 nD
 uM
 uM
@@ -42276,7 +42273,7 @@ Ya
 TZ
 nD
 ek
-et
+Yi
 oR
 oS
 iL
@@ -43585,7 +43582,7 @@ Jo
 rR
 rm
 KE
-pp
+mo
 gL
 FD
 Nb
@@ -44060,7 +44057,7 @@ ap
 bd
 nO
 Xx
-dU
+hp
 fO
 JK
 fO
@@ -44316,7 +44313,7 @@ YS
 ap
 ga
 aI
-qO
+RY
 hH
 Ro
 sr
@@ -44331,7 +44328,7 @@ Ug
 WM
 BO
 hK
-et
+Yi
 jP
 pV
 Me
@@ -45102,7 +45099,7 @@ NQ
 YE
 Td
 wN
-et
+Yi
 iL
 iL
 Fp
@@ -45869,15 +45866,15 @@ cM
 oe
 ic
 TE
-de
+RL
 Zf
 bd
 ay
 Mt
 aY
 wx
-ch
-QS
+zr
+oj
 gL
 pa
 gL

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -324,6 +324,14 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"bf" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/start/job/requisitionsofficer,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "bg" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -390,9 +398,11 @@
 /area/mainship/hallways/hangar)
 "bq" = (
 /obj/machinery/line_nexter,
-/turf/open/floor/mainship/cargo/arrow{
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship{
 	dir = 8
 	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "br" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -546,6 +556,12 @@
 /obj/machinery/vending/snack,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
+"bT" = (
+/obj/machinery/vending/nanomed{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/aft_hallway)
 "bV" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -664,6 +680,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
 	},
+/obj/structure/sign/poster,
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 4
 	},
@@ -720,6 +737,10 @@
 	},
 /turf/open/space,
 /area/space)
+"cw" = (
+/obj/structure/supply_drop,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "cx" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/mono,
@@ -999,6 +1020,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
+"dn" = (
+/obj/structure/sign/evac,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "dp" = (
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/mono,
@@ -1097,11 +1122,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "dE" = (
-/obj/effect/attach_point/weapon/dropship2{
-	dir = 8;
-	icon_state = "equip_base_l_wing"
+/turf/open/floor/plating{
+	dir = 1;
+	icon_state = "warnplatecorner"
 	},
-/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "dF" = (
 /obj/structure/cable,
@@ -1159,11 +1183,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "dM" = (
-/obj/effect/attach_point/weapon/dropship2{
-	dir = 4;
-	icon_state = "equip_base_r_wing"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/dmg1,
 /area/mainship/hallways/hangar)
 "dN" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -1274,15 +1294,6 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
-"ee" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/line_nexter{
-	dir = 1
-	},
-/turf/open/floor/mainship/cargo,
-/area/mainship/squads/req)
 "ef" = (
 /obj/machinery/light{
 	dir = 1
@@ -1290,11 +1301,14 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "eh" = (
-/turf/open/floor/mainship/empty,
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ei" = (
-/obj/structure/sign/poster,
-/turf/open/floor/mainship/mono,
+/obj/machinery/status_display,
+/turf/closed/wall/mainship,
 /area/mainship/living/grunt_rnr)
 "ej" = (
 /obj/structure/barricade/metal{
@@ -1318,10 +1332,10 @@
 	},
 /area/mainship/squads/general)
 "em" = (
-/obj/machinery/computer/camera_advanced/overwatch/req,
-/obj/machinery/light{
-	light_color = "#da2f1b"
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/stack/conveyor/thirty,
+/obj/structure/rack,
+/obj/item/conveyor_switch_construct,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "en" = (
@@ -1471,34 +1485,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"eM" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/mainship,
-/obj/item/clipboard,
-/obj/item/paper{
-	pixel_x = 5
-	},
-/obj/item/tool/pen,
-/obj/item/storage/box/MRE{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/whistle,
-/obj/machinery/door_control/mainship/req{
-	pixel_y = -5
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "eN" = (
 /obj/machinery/light,
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
-"eO" = (
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
 "eP" = (
 /obj/structure/disposalpipe/segment/corner,
 /obj/structure/cable,
@@ -1551,6 +1542,13 @@
 	icon_state = "floor8"
 	},
 /area/mainship/command/self_destruct)
+"fa" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "fc" = (
 /obj/machinery/light,
 /obj/structure/closet/emcloset,
@@ -2009,10 +2007,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
-"gz" = (
-/obj/machinery/vending/engivend,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "gA" = (
 /obj/machinery/light{
 	dir = 4
@@ -2054,13 +2048,6 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
-"gI" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/vending/tool,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "gK" = (
 /obj/structure/target_stake,
 /obj/item/target,
@@ -2201,11 +2188,14 @@
 	},
 /area/mainship/medical/surgery_hallway)
 "hd" = (
-/obj/structure/noticeboard,
-/obj/structure/sign/ROsign{
+/obj/machinery/door/poddoor/railing{
+	dir = 2;
+	id = "supply_elevator_railing"
+	},
+/obj/machinery/computer/ordercomp,
+/turf/open/floor/mainship/cargo/arrow{
 	dir = 1
 	},
-/turf/closed/wall/mainship,
 /area/mainship/squads/req)
 "he" = (
 /obj/structure/cable,
@@ -2264,6 +2254,11 @@
 /obj/machinery/vending/weapon,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
+"hn" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "ho" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -2282,25 +2277,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"ht" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/mainship/req/ro{
-	dir = 2
-	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/item/tool/hand_labeler,
-/obj/item/tool/hand_labeler,
-/obj/item/tool/hand_labeler,
-/obj/machinery/door/window/secure/req{
-	dir = 2
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "hv" = (
 /obj/machinery/door/airlock/multi_tile/mainship/maint{
 	dir = 1
@@ -2393,6 +2369,13 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
+"hL" = (
+/obj/effect/landmark/start/job/shiptech,
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "hN" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -2401,6 +2384,13 @@
 	dir = 8
 	},
 /area/mainship/medical/medical_science)
+"hO" = (
+/obj/machinery/power/apc{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "hQ" = (
 /obj/machinery/door/airlock/mainship/generic/bathroom{
 	dir = 1
@@ -2429,13 +2419,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"hV" = (
-/obj/effect/landmark/start/job/shiptech,
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "hW" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -2455,6 +2438,14 @@
 	},
 /turf/open/floor/grass,
 /area/mainship/living/cafeteria_starboard)
+"hZ" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "ia" = (
 /turf/open/floor/mainship/research/containment/floor2{
 	dir = 6
@@ -2498,11 +2489,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"ip" = (
-/obj/structure/disposalpipe/segment,
-/mob/living/simple_animal/cat/martin,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "iq" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner{
@@ -2537,19 +2523,6 @@
 /obj/machinery/computer/shuttle/shuttle_control/dropship,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"iv" = (
-/obj/structure/table/mainship,
-/obj/structure/paper_bin,
-/obj/item/storage/fancy/cigar,
-/obj/item/tool/lighter/zippo,
-/obj/item/tool/pen,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"iw" = (
-/obj/structure/table/mainship,
-/obj/machinery/door_control/old/req,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "ix" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
@@ -2630,6 +2603,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
+"iJ" = (
+/mob/living/simple_animal/cat/martin,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "iK" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -2640,15 +2617,6 @@
 "iL" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
-"iM" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"iN" = (
-/obj/machinery/autolathe,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "iQ" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/mainship,
@@ -2694,13 +2662,6 @@
 	},
 /turf/open/floor/grass,
 /area/mainship/living/cafeteria_starboard)
-"iV" = (
-/obj/structure/rack,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/item/tool/weldpack,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "iW" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -2725,22 +2686,15 @@
 	},
 /area/mainship/command/corporateliaison)
 "iZ" = (
-/obj/structure/rack,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/adv,
+/obj/structure/largecrate/supply/supplies/water,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ja" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/machinery/light{
+	light_color = "#da2f1b"
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/area/mainship/hallways/hangar)
 "jb" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
@@ -2900,6 +2854,10 @@
 	dir = 8
 	},
 /area/space)
+"jH" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/mainship/squads/req)
 "jI" = (
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 8
@@ -3042,8 +3000,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "kf" = (
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/stripesquare,
+/turf/open/floor/mainship/terragov/north{
+	dir = 9
+	},
 /area/mainship/hallways/hangar)
 "kg" = (
 /obj/structure/target_stake,
@@ -3061,14 +3020,10 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/port_hallway)
 "kj" = (
-/obj/structure/window/framed/mainship/requisitions,
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id = "qm_warehouse";
-	name = "\improper Warehouse Shutters"
+/turf/open/floor/mainship/terragov/north{
+	dir = 1
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/area/mainship/hallways/hangar)
 "km" = (
 /obj/item/storage/box/pillbottles,
 /obj/item/storage/box/gloves{
@@ -3140,6 +3095,13 @@
 	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
+"kw" = (
+/obj/structure/rack,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/tool/weldpack,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "kz" = (
 /obj/structure/rack,
 /obj/structure/ob_ammo/warhead/incendiary,
@@ -3172,8 +3134,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/corporateliaison)
 "kE" = (
-/obj/machinery/vending/cargo_supply,
-/turf/open/floor/mainship/mono,
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/mainship,
 /area/mainship/squads/req)
 "kF" = (
 /obj/structure/disposalpipe/segment/corner{
@@ -3270,11 +3232,10 @@
 	},
 /area/mainship/squads/general)
 "kT" = (
-/obj/structure/bed/chair/wood/normal{
-	dir = 8
+/turf/open/floor/mainship/terragov/north{
+	dir = 5
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/area/mainship/hallways/hangar)
 "kU" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -3496,8 +3457,12 @@
 	},
 /area/mainship/command/cic)
 "ly" = (
-/obj/structure/closet/secure_closet/req_officer,
-/turf/open/floor/mainship/cargo,
+/obj/machinery/door/poddoor/railing{
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
 /area/mainship/squads/req)
 "lz" = (
 /obj/machinery/computer/camera_advanced/overwatch/alpha,
@@ -3520,7 +3485,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "lD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -3538,6 +3503,13 @@
 /obj/machinery/marine_selector/clothes/commander,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
+"lI" = (
+/obj/machinery/computer/ordercomp,
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "lJ" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
@@ -3622,14 +3594,6 @@
 /obj/structure/dropprop,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar/droppod)
-"lY" = (
-/obj/item/folder/black_random,
-/obj/item/tool/hand_labeler,
-/obj/item/tool/stamp/denied,
-/obj/item/tool/stamp/qm,
-/obj/structure/table/mainship,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "lZ" = (
 /obj/machinery/marine_selector/gear/engi,
 /obj/machinery/camera/autoname/mainship,
@@ -3656,16 +3620,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "me" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/mainship,
-/area/mainship/squads/req)
-"mf" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
-	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
-	},
+/obj/machinery/vending/cargo_supply,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "mg" = (
@@ -3741,13 +3696,16 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
-"mq" = (
-/obj/machinery/camera/autoname/mainship{
+"mr" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/shiptech,
-/turf/open/floor/mainship/cargo,
-/area/mainship/squads/req)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/aft_hallway)
 "ms" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -4021,13 +3979,6 @@
 "nn" = (
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/surgery_hallway)
-"np" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/landmark/start/job/requisitionsofficer,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "nq" = (
 /obj/machinery/door/firedoor/mainship,
 /obj/machinery/door/airlock/multi_tile/mainship/marine/general{
@@ -4053,10 +4004,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"nu" = (
-/obj/machinery/computer/supplycomp,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "nv" = (
 /turf/open/floor/plating/icefloor/warnplate,
 /area/mainship/hallways/hangar)
@@ -4104,6 +4051,25 @@
 	dir = 4
 	},
 /area/mainship/squads/general)
+"nF" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
+	},
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/machinery/door/window/secure/req{
+	dir = 2
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "nG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4275,11 +4241,6 @@
 	dir = 1
 	},
 /area/mainship/medical/medical_science)
-"og" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "oh" = (
 /obj/structure/table/mainship,
 /obj/item/clipboard{
@@ -4298,11 +4259,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"oj" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "ol" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -4320,10 +4276,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"op" = (
-/obj/docking_port/stationary/marine_dropship/crash_target,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "oq" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -4336,10 +4288,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"os" = (
-/obj/machinery/holopad,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "ot" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -4362,11 +4310,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "ow" = (
-/obj/machinery/power/apc/mainship{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/cable,
+/obj/structure/musician/piano,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "ox" = (
@@ -4385,68 +4329,61 @@
 	},
 /area/mainship/squads/general)
 "oA" = (
-/obj/structure/cable,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
-"oB" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "oC" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "oD" = (
-/obj/structure/rack,
-/obj/item/tool/wrench,
-/obj/item/tool/crowbar,
-/obj/item/tool/screwdriver,
-/obj/item/paper/factoryhowto,
 /obj/machinery/light{
-	dir = 8
+	light_color = "#da2f1b"
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar)
 "oE" = (
-/obj/structure/table/mainship,
-/obj/item/stack/sheet/wood/large_stack,
-/obj/item/stack/sheet/glass/reinforced{
-	amount = 30
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "supply_elevator_railing"
 	},
-/obj/item/stack/sheet/cardboard,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"oF" = (
-/obj/vehicle/ridden/powerloader,
-/turf/open/floor/mainship/cargo,
-/area/mainship/squads/req)
-"oG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/stack/conveyor/thirty,
-/obj/structure/rack,
-/obj/item/conveyor_switch_construct,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"oJ" = (
-/obj/machinery/vending/uniform_supply,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"oK" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
-/obj/machinery/vending/weapon,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"oL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 4
 	},
+/area/mainship/squads/req)
+"oF" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
+"oG" = (
+/obj/machinery/computer/camera_advanced/overwatch/req,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
+"oJ" = (
+/turf/open/floor/mainship/green/corner{
+	dir = 4
+	},
+/area/mainship/squads/req)
+"oK" = (
+/obj/vehicle/ridden/motorbike,
+/turf/open/floor/mainship/cargo,
+/area/mainship/squads/req)
+"oL" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "oM" = (
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
@@ -4516,7 +4453,10 @@
 /area/mainship/medical/medical_science)
 "oW" = (
 /obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
+/obj/machinery/light{
+	light_color = "#da2f1b"
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "oX" = (
 /obj/structure/cable,
@@ -4550,6 +4490,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
+"pb" = (
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "pc" = (
 /turf/open/floor/mainship/research/containment/floor1,
 /area/mainship/medical/medical_science)
@@ -4614,13 +4558,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "pn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/structure/rack,
+/obj/item/tool/wrench,
+/obj/item/tool/crowbar,
+/obj/item/tool/screwdriver,
+/obj/item/paper/factoryhowto,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "po" = (
@@ -4635,11 +4580,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "pq" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 5
-	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
+/obj/machinery/vending/shared_vending/marine_engi,
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
@@ -4655,12 +4598,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "pw" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/holopad,
-/turf/open/floor/mainship/floor,
+/obj/machinery/line_nexter{
+	dir = 2
+	},
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "px" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -4706,8 +4650,7 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/surgery_hallway)
 "pF" = (
-/obj/machinery/vending/MarineMed,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/green/corner,
 /area/mainship/squads/req)
 "pG" = (
 /obj/machinery/vending/MarineMed,
@@ -4737,6 +4680,13 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/command/self_destruct)
+"pQ" = (
+/obj/structure/noticeboard,
+/obj/structure/sign/ROsign{
+	dir = 1
+	},
+/turf/closed/wall/mainship,
+/area/mainship/squads/req)
 "pR" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
@@ -4766,6 +4716,12 @@
 /obj/machinery/faxmachine/research,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
+"pW" = (
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/mainship/hull/lower_hull)
 "pX" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
@@ -4837,8 +4793,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"qm" = (
+/obj/machinery/door_control/mainship/req{
+	id = "qm_warehouse";
+	name = "Requisition Warehouse Shutters"
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "qo" = (
-/obj/structure/cable,
 /obj/structure/sign/poster{
 	dir = 1
 	},
@@ -4856,6 +4818,16 @@
 	dir = 1
 	},
 /area/mainship/command/cic)
+"qr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/hallways/aft_hallway)
 "qs" = (
 /obj/structure/flora/pottedplant/twentyone,
 /turf/open/floor/wood,
@@ -5047,6 +5019,10 @@
 /obj/machinery/photocopier,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"re" = (
+/obj/machinery/cic_maptable,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "rf" = (
 /obj/machinery/computer/telecomms/server,
 /turf/open/floor/mainship/mono,
@@ -5076,8 +5052,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "ro" = (
-/obj/machinery/light,
-/turf/open/floor/mainship/floor,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "rp" = (
 /turf/open/floor/mainship/black,
@@ -5478,12 +5455,8 @@
 "sz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "sA" = (
@@ -5502,9 +5475,9 @@
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "sD" = (
-/obj/structure/musician/piano,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/obj/machinery/status_display,
+/turf/closed/wall/mainship,
+/area/mainship/hallways/hangar)
 "sE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -5687,11 +5660,10 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
 "te" = (
-/obj/machinery/light{
-	dir = 4
+/turf/open/floor/mainship/terragov/north{
+	dir = 8
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/area/mainship/hallways/hangar)
 "tf" = (
 /obj/effect/landmark/start/job/squadmarine,
 /turf/open/floor/mainship,
@@ -5763,9 +5735,8 @@
 /turf/closed/wall/mainship,
 /area/mainship/shipboard/weapon_room)
 "tr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
@@ -5812,9 +5783,6 @@
 /obj/item/folder/black,
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
-/obj/structure/sign/poster{
-	dir = 1
-	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "tx" = (
@@ -6098,6 +6066,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"uk" = (
+/obj/structure/sign/poster,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "ul" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -6199,12 +6171,10 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/starboard_umbilical)
 "uA" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
+/turf/open/floor/mainship/terragov{
+	dir = 1
 	},
-/turf/open/floor/mainship/cargo/arrow,
-/area/mainship/squads/req)
+/area/mainship/hallways/hangar)
 "uB" = (
 /obj/structure/closet/firecloset,
 /obj/item/clothing/mask/gas,
@@ -6242,12 +6212,10 @@
 /turf/closed/wall/mainship/outer,
 /area/mainship/hallways/starboard_umbilical)
 "uL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/turf/open/floor/mainship/terragov/north{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/hangar)
 "uM" = (
 /turf/closed/wall/mainship,
 /area/mainship/command/corporateliaison)
@@ -6283,6 +6251,14 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
+"uT" = (
+/obj/effect/decal/warning_stripes/engineer,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "uV" = (
 /turf/open/floor/carpet{
 	dir = 5;
@@ -6306,9 +6282,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/structure/sign/poster{
-	dir = 1
-	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "uY" = (
@@ -6322,9 +6295,10 @@
 /turf/open/floor/mainship/blue/full,
 /area/mainship/command/cic)
 "uZ" = (
-/obj/machinery/holopad,
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/terragov/north{
+	dir = 10
+	},
+/area/mainship/squads/req)
 "va" = (
 /obj/structure/closet/secure_closet/securecom,
 /obj/item/moneybag/vault,
@@ -6655,6 +6629,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
+"wb" = (
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/hallways/aft_hallway)
 "wc" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/black{
@@ -6718,22 +6698,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "wk" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 6
+/obj/machinery/door/poddoor/railing{
+	id = "supply_elevator_railing"
 	},
-/obj/structure/table/mainship,
-/obj/machinery/cell_charger,
-/obj/effect/spawner/random/powercell,
-/obj/effect/spawner/random/powercell,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
-"wl" = (
-/obj/machinery/vending/shared_vending/marine_engi,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "wm" = (
 /turf/open/floor/mainship/tcomms,
@@ -6958,11 +6926,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "wR" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "wS" = (
@@ -7326,11 +7293,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"xS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "xT" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/engineering/port_atmos)
@@ -7676,11 +7638,7 @@
 	},
 /area/mainship/engineering/ce_room)
 "yS" = (
-/obj/machinery/computer/ordercomp,
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/terragov/north,
 /area/mainship/squads/req)
 "yT" = (
 /obj/machinery/power/apc/mainship,
@@ -7727,14 +7685,10 @@
 /turf/open/floor/mainship/orange/corner,
 /area/mainship/engineering/ce_room)
 "yY" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
+/turf/open/floor/mainship/terragov/north{
+	dir = 6
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/squads/req)
 "yZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
@@ -7774,13 +7728,6 @@
 	dir = 8
 	},
 /area/mainship/living/cryo_cells)
-"ze" = (
-/obj/machinery/door_control/mainship/req{
-	id = "qm_warehouse";
-	name = "Requisition Warehouse Shutters"
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "zf" = (
 /obj/structure/flora/pottedplant/twentytwo,
 /turf/open/floor/mainship/mono,
@@ -7816,10 +7763,10 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/engineering/lower_engineering)
 "zk" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
 	},
-/turf/open/floor/mainship/stripesquare,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "zl" = (
 /obj/machinery/vending/snack,
@@ -8197,11 +8144,9 @@
 /turf/open/floor/mainship,
 /area/mainship/living/cafeteria_starboard)
 "AB" = (
-/obj/machinery/vending/armor_supply,
-/obj/machinery/light{
+/turf/open/floor/mainship/green{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "AC" = (
 /obj/machinery/door/airlock/mainship/maint,
@@ -8209,11 +8154,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
 "AD" = (
-/obj/machinery/door_control/mainship/req{
-	dir = 1;
-	id = "qm_warehouse";
-	name = "Requisition Warehouse Shutters"
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "AE" = (
@@ -8238,10 +8180,6 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/engineering/upper_engineering)
-"AH" = (
-/obj/machinery/status_display,
-/turf/closed/wall/mainship,
-/area/mainship/squads/req)
 "AI" = (
 /obj/machinery/body_scanconsole,
 /turf/open/floor/mainship/sterile/dark,
@@ -8315,6 +8253,14 @@
 "AV" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/pilotbunks)
+"AW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 1;
+	on = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "AX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -8847,12 +8793,6 @@
 /obj/structure/sign/electricshock,
 /turf/closed/wall/mainship,
 /area/mainship/squads/general)
-"Cq" = (
-/obj/structure/barricade/metal{
-	dir = 1
-	},
-/turf/open/floor/mainship/cargo,
-/area/mainship/squads/req)
 "Cr" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -8898,6 +8838,10 @@
 /obj/item/storage/fancy/cigarettes,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
+"Cz" = (
+/obj/docking_port/stationary/marine_dropship/crash_target,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "CA" = (
 /obj/effect/landmark/start/job/squadleader,
 /turf/open/floor/mainship/cargo/arrow{
@@ -8917,20 +8861,15 @@
 	},
 /area/mainship/hallways/hangar)
 "CC" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/status_display,
+/turf/closed/wall/mainship,
 /area/mainship/squads/req)
 "CD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/black/corner,
 /area/mainship/squads/general)
 "CE" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id = "qm_warehouse";
-	name = "\improper Warehouse Shutters"
-	},
+/obj/machinery/vending/lasgun,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "CF" = (
@@ -8953,11 +8892,16 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "CH" = (
+/obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
 	},
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
+/obj/structure/table/mainship,
+/obj/machinery/cell_charger,
+/obj/effect/spawner/random/powercell,
+/obj/effect/spawner/random/powercell,
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
@@ -9004,18 +8948,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "CP" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/structure/largecrate/guns,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/squads/req)
 "CQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -9138,16 +9073,14 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/port_hallway)
 "Dh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
 	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/hangar)
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "Di" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -9611,6 +9544,9 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
+"Er" = (
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "Es" = (
 /obj/machinery/light{
 	dir = 8
@@ -9767,11 +9703,17 @@
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
-"EV" = (
-/obj/structure/closet/crate/ammo,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+"ET" = (
 /obj/structure/cable,
-/turf/open/floor/mainship/cargo,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/mainship/squads/req)
+"EV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/status_display,
+/turf/closed/wall/mainship,
 /area/mainship/squads/req)
 "EW" = (
 /obj/machinery/portable_atmospherics/hydroponics,
@@ -9922,12 +9864,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "FA" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
 	},
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/hangar)
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "FB" = (
 /obj/machinery/firealarm{
 	dir = 8
@@ -10122,21 +10066,11 @@
 	},
 /area/mainship/squads/general)
 "Gi" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 1
-	},
+/obj/structure/largecrate/supply/supplies/mre,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Gj" = (
-/obj/machinery/gear{
-	id = "supply_elevator_gear"
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 10
-	},
+/obj/structure/largecrate/supply/ammo/standard_ammo,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Gk" = (
@@ -10199,20 +10133,11 @@
 	},
 /area/mainship/command/cic)
 "Gt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "supply_elevator_railing"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1
-	},
-/obj/machinery/door/airlock/multi_tile/mainship/marine/requisitions{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "Gu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -10254,6 +10179,29 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"GD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/obj/machinery/door/airlock/multi_tile/mainship/marine/requisitions{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/mainship/squads/req)
 "GE" = (
 /turf/closed/wall/mainship/research/containment/wall/corner{
 	dir = 1
@@ -10280,10 +10228,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "GH" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
-/obj/structure/cable,
+/obj/structure/largecrate/supply/supplies/flares,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "GJ" = (
@@ -10549,14 +10494,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"Hx" = (
-/obj/effect/decal/warning_stripes/engineer,
-/obj/effect/decal/warning_stripes/box/small{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/box/small,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "Hy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -10616,6 +10553,10 @@
 	},
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/engine_core)
+"HF" = (
+/obj/machinery/holopad,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "HG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -11027,6 +10968,10 @@
 	dir = 1
 	},
 /area/space)
+"IK" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "IL" = (
 /obj/structure/table/mainship,
 /obj/machinery/recharger,
@@ -11052,6 +10997,16 @@
 /obj/item/tool/mop,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"IP" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/hallways/aft_hallway)
 "IQ" = (
 /obj/machinery/firealarm{
 	dir = 4
@@ -11068,9 +11023,9 @@
 	},
 /area/space)
 "IT" = (
-/obj/structure/supply_drop,
+/obj/structure/cable,
 /turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/area/mainship/hallways/aft_hallway)
 "IU" = (
 /obj/effect/landmark/start/job/squadsmartgunner,
 /turf/open/floor/mainship,
@@ -11159,12 +11114,11 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "Jj" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/computer/ordercomp,
-/turf/open/floor/mainship/floor,
+/obj/machinery/vending/tool,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Jk" = (
 /obj/structure/bed/chair/comfy/black{
@@ -11262,10 +11216,9 @@
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "Ju" = (
-/obj/structure/closet/crate/weapon,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/turf/open/floor/mainship/cargo,
+/obj/structure/table/mainship,
+/obj/machinery/computer/supplydrop_console,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Jv" = (
 /obj/structure/disposalpipe/segment/corner{
@@ -11398,7 +11351,7 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
 "JN" = (
-/obj/structure/largecrate/supply/supplies/mre,
+/obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "JO" = (
@@ -11409,7 +11362,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "JP" = (
-/obj/structure/largecrate/guns/russian,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/tool/extinguisher,
+/obj/item/tool/extinguisher/mini,
+/obj/structure/rack,
+/obj/item/flashlight,
+/obj/item/flashlight,
+/obj/item/lightreplacer,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "JQ" = (
@@ -11420,9 +11380,8 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "JR" = (
-/turf/open/floor/mainship/green{
-	dir = 4
-	},
+/obj/structure/barricade/metal,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "JS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -11504,6 +11463,20 @@
 "Kb" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/commandbunks)
+"Kc" = (
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/obj/machinery/door/airlock/multi_tile/mainship/marine/requisitions{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/mainship/squads/req)
 "Kd" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
@@ -11589,11 +11562,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "Kp" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 8;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/floor,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Kq" = (
 /obj/structure/disposalpipe/junction,
@@ -11752,7 +11722,10 @@
 /turf/open/floor/mainship/red,
 /area/mainship/shipboard/weapon_room)
 "KG" = (
-/obj/structure/largecrate/supply/supplies/water,
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/obj/machinery/vending/weapon,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "KH" = (
@@ -11819,10 +11792,10 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "KR" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/ai_node,
+/obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "KS" = (
@@ -11855,11 +11828,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/medical/surgery_hallway)
 "KY" = (
-/obj/machinery/vending/nanomed{
-	dir = 4
-	},
+/obj/structure/largecrate/guns/merc,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/squads/req)
 "KZ" = (
 /obj/machinery/vending/weapon,
 /obj/structure/window/reinforced,
@@ -11880,8 +11851,24 @@
 "Lb" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/command/self_destruct)
-"Le" = (
-/obj/structure/largecrate/supply/supplies/flares,
+"Ld" = (
+/obj/structure/table/mainship,
+/obj/item/clipboard,
+/obj/item/paper{
+	pixel_x = 5
+	},
+/obj/item/tool/pen,
+/obj/item/storage/box/MRE{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/whistle,
+/obj/machinery/door_control/mainship/req{
+	pixel_y = -5
+	},
+/obj/machinery/light{
+	light_color = "#da2f1b"
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Lf" = (
@@ -11987,8 +11974,8 @@
 	},
 /area/mainship/medical/surgery_hallway)
 "Lv" = (
-/obj/docking_port/stationary/supply,
-/turf/open/floor/mainship/empty,
+/obj/machinery/computer/supplycomp,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Lw" = (
 /turf/open/floor/mainship_hull/dir{
@@ -12023,6 +12010,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"LC" = (
+/obj/structure/table/mainship,
+/obj/item/stack/sheet/wood/large_stack,
+/obj/item/stack/sheet/glass/reinforced{
+	amount = 30
+	},
+/obj/item/stack/sheet/cardboard,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "LE" = (
 /obj/machinery/light{
 	dir = 8
@@ -12105,7 +12101,10 @@
 /obj/structure/barricade/metal{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/obj/structure/cable,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
 /area/mainship/hull/lower_hull)
 "LT" = (
 /obj/machinery/mech_bay_recharge_port,
@@ -12291,11 +12290,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "Mw" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/floor,
+/obj/machinery/vending/engivend,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Mx" = (
 /turf/open/floor/plating/plating_catwalk,
@@ -12388,13 +12384,8 @@
 	},
 /area/mainship/shipboard/weapon_room)
 "MM" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 8;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
+/obj/docking_port/stationary/supply,
+/turf/open/floor/mainship/empty,
 /area/mainship/squads/req)
 "MO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -12501,10 +12492,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "Ne" = (
-/obj/machinery/firealarm,
-/obj/structure/cable,
+/obj/structure/bed/chair/wood/normal{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/area/mainship/living/grunt_rnr)
 "Nf" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner{
@@ -12665,6 +12657,14 @@
 	dir = 4
 	},
 /area/mainship/squads/general)
+"NA" = (
+/obj/structure/table/mainship,
+/obj/machinery/door_control/old/req,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "NC" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -12692,13 +12692,16 @@
 /area/mainship/medical/lower_medical)
 "NF" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/mainship/stripesquare,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "NG" = (
 /obj/machinery/door/airlock/mainship/medical/morgue{
@@ -12739,10 +12742,6 @@
 /obj/item/tool/taperoll/engineering,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"NK" = (
-/obj/structure/largecrate/guns/merc,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "NL" = (
 /obj/machinery/light{
 	dir = 4
@@ -12756,9 +12755,23 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
+"NO" = (
+/obj/structure/table/mainship,
+/obj/structure/paper_bin,
+/obj/item/storage/fancy/cigar,
+/obj/item/tool/lighter/zippo,
+/obj/item/tool/pen,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "NP" = (
-/obj/vehicle/ridden/motorbike,
-/turf/open/floor/mainship/cargo,
+/obj/structure/rack,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/adv,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "NQ" = (
 /obj/structure/disposalpipe/junction{
@@ -12815,8 +12828,9 @@
 /area/mainship/command/cic)
 "NY" = (
 /obj/structure/cable,
+/obj/machinery/power/apc/mainship,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/living/grunt_rnr)
 "NZ" = (
 /obj/structure/window/framed/mainship,
 /turf/open/floor/plating,
@@ -12998,17 +13012,7 @@
 	},
 /area/mainship/medical/lower_medical)
 "OA" = (
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1
-	},
-/obj/machinery/door/airlock/multi_tile/mainship/marine/requisitions{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/turf/open/floor/mainship/green,
 /area/mainship/squads/req)
 "OB" = (
 /turf/closed/wall/mainship/outer,
@@ -13263,7 +13267,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Pp" = (
-/turf/open/floor/mainship/green/corner,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
+	},
+/obj/structure/window/framed/mainship/requisitions,
+/turf/open/floor/plating,
 /area/mainship/squads/req)
 "Pq" = (
 /turf/open/floor/mainship/black{
@@ -13451,8 +13459,10 @@
 /turf/open/floor/grass,
 /area/mainship/living/cafeteria_starboard)
 "PV" = (
-/turf/open/floor/mainship/green,
-/area/mainship/squads/req)
+/turf/open/floor/mainship/green/corner{
+	dir = 8
+	},
+/area/mainship/hallways/aft_hallway)
 "PW" = (
 /turf/open/floor/mainship/black{
 	dir = 6
@@ -13521,11 +13531,10 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "Qi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/structure/shipmast{
+	pixel_y = 2
 	},
-/obj/machinery/light,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/green/full,
 /area/mainship/squads/req)
 "Qj" = (
 /obj/structure/cable,
@@ -13691,21 +13700,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "QA" = (
-/turf/open/floor/mainship/green/corner{
+/turf/open/floor/mainship/green{
 	dir = 8
 	},
-/area/mainship/hallways/starboard_hallway)
-"QB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/area/mainship/hallways/aft_hallway)
 "QC" = (
 /obj/machinery/alarm{
 	dir = 1
@@ -14026,10 +14024,10 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/weapon_room)
 "Ry" = (
-/obj/structure/shipmast{
-	pixel_y = 2
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/mainship/green/full,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "RA" = (
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
@@ -14073,6 +14071,13 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
+"RH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "RI" = (
 /obj/machinery/optable,
 /obj/machinery/light,
@@ -14296,10 +14301,11 @@
 	},
 /area/mainship/squads/general)
 "Sv" = (
-/obj/machinery/door/poddoor/railing{
-	id = "supply_elevator_railing"
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/obj/structure/closet/secure_closet/shiptech,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "Sw" = (
 /obj/machinery/door/airlock/mainship/engineering/storage{
@@ -14436,10 +14442,12 @@
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "SS" = (
-/turf/open/floor/mainship/green{
-	dir = 8
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
 	},
-/area/mainship/hallways/starboard_hallway)
+/turf/open/floor/mainship/cargo/arrow,
+/area/mainship/squads/req)
 "ST" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
@@ -14518,9 +14526,12 @@
 	},
 /area/mainship/shipboard/firing_range)
 "Tf" = (
-/turf/open/floor/mainship/green/corner{
-	dir = 4
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
 	},
+/obj/machinery/holopad,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "Tg" = (
 /obj/structure/cable,
@@ -14539,14 +14550,17 @@
 	},
 /area/space)
 "Tj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Tl" = (
-/obj/structure/window/framed/mainship/requisitions,
-/obj/machinery/door/poddoor/shutters/mainship/req/ro,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "Tm" = (
 /turf/open/floor/mainship_hull/dir{
@@ -14576,11 +14590,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
 "Ts" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/floor,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Tu" = (
 /obj/structure/orbital_cannon,
@@ -14650,16 +14662,28 @@
 	dir = 1
 	},
 /area/mainship/medical/lower_medical)
+"TF" = (
+/obj/machinery/line_nexter,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "TG" = (
 /obj/structure/window/framed/mainship,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mainship/engineering/lower_engine_monitoring)
 "TH" = (
-/obj/machinery/power/apc/mainship,
-/obj/structure/cable,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"TI" = (
+/obj/structure/sign/evac,
+/turf/open/floor/plating/mainship,
+/area/mainship/hallways/starboard_hallway)
 "TJ" = (
 /obj/structure/window/framed/mainship,
 /obj/machinery/door/firedoor/mainship{
@@ -14691,7 +14715,13 @@
 /turf/open/shuttle/escapepod/plain,
 /area/mainship/command/self_destruct)
 "TO" = (
-/obj/machinery/cic_maptable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "TP" = (
@@ -14726,11 +14756,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "TY" = (
-/obj/machinery/light{
-	light_color = "#da2f1b"
+/turf/open/floor/mainship/green{
+	dir = 1
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/area/mainship/squads/req)
 "TZ" = (
 /obj/machinery/light,
 /turf/open/floor/mainship/sterile/side,
@@ -14852,9 +14881,10 @@
 	},
 /area/mainship/shipboard/firing_range)
 "Ut" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/status_display,
-/turf/closed/wall/mainship,
+/obj/structure/closet/crate/ammo,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "Uu" = (
 /obj/structure/cable,
@@ -14891,12 +14921,12 @@
 /turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/firing_range)
 "UA" = (
-/obj/machinery/door/poddoor/railing{
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
+/obj/item/folder/black_random,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/stamp/denied,
+/obj/item/tool/stamp/qm,
+/obj/structure/table/mainship,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "UB" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -14991,6 +15021,10 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
+"UP" = (
+/obj/machinery/door/airlock/multi_tile/mainship/maint,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "UQ" = (
 /turf/open/floor/plating/mainship,
 /area/mainship/hull/lower_hull)
@@ -15029,8 +15063,12 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "UW" = (
-/obj/structure/rack,
-/obj/item/pizzabox/meat,
+/obj/machinery/door_control/mainship/req{
+	dir = 1;
+	id = "qm_warehouse";
+	name = "Requisition Warehouse Shutters"
+	},
+/obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "UX" = (
@@ -15095,11 +15133,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
 "Vd" = (
-/obj/machinery/door/poddoor/shutters/mainship/req/ro{
-	dir = 2
+/obj/machinery/door/poddoor/railing{
+	dir = 2;
+	id = "supply_elevator_railing"
 	},
-/obj/structure/window/framed/mainship/requisitions,
-/turf/open/floor/plating,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "Ve" = (
 /turf/open/floor/prison/kitchen,
@@ -15122,6 +15160,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/medical/surgery_hallway)
+"Vi" = (
+/obj/structure/rack,
+/obj/item/pizzabox/meat,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "Vj" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -15136,15 +15179,10 @@
 /turf/open/floor/mainship/black,
 /area/mainship/command/self_destruct)
 "Vl" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
+/turf/open/floor/mainship/green/corner{
+	dir = 1
 	},
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/hangar)
-"Vn" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/area/mainship/hallways/aft_hallway)
 "Vo" = (
 /turf/open/floor/mainship_hull/dir,
 /area/space)
@@ -15245,10 +15283,8 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/turf/open/floor/mainship/stripesquare,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "VG" = (
 /obj/machinery/door/poddoor/mainship/ammo{
@@ -15286,10 +15322,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "VM" = (
-/obj/vehicle/ridden/motorbike{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship{
+	dir = 1
 	},
-/turf/open/floor/mainship/cargo,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "VN" = (
 /obj/machinery/firealarm,
@@ -15311,10 +15348,13 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "VR" = (
-/turf/open/floor/mainship/green{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/mainship/squads/req)
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/pilotbunks)
 "VS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -15411,6 +15451,20 @@
 "Wf" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/hallways/hangar/droppod)
+"Wg" = (
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
+"Wh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "Wi" = (
 /obj/machinery/door/airlock/mainship/command/cic{
 	dir = 2
@@ -15457,10 +15511,12 @@
 	},
 /area/mainship/living/cryo_cells)
 "Wp" = (
-/turf/open/floor/mainship/green/corner{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/light{
+	light_color = "#da2f1b"
 	},
-/area/mainship/hallways/starboard_hallway)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/squads/req)
 "Wr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
@@ -15639,8 +15695,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "WS" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/turf/open/floor/mainship/empty,
 /area/mainship/squads/req)
 "WT" = (
 /obj/structure/window/reinforced/extratoughened{
@@ -15757,10 +15812,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Xn" = (
-/obj/machinery/light{
-	dir = 1
+/obj/vehicle/ridden/motorbike{
+	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "Xo" = (
 /obj/structure/disposalpipe/segment/corner,
@@ -15898,8 +15953,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/upper_engineering)
 "XD" = (
-/obj/structure/largecrate/supply/ammo/standard_ammo,
-/turf/open/floor/mainship/mono,
+/obj/structure/window/framed/mainship/requisitions,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro,
+/turf/open/floor/plating,
 /area/mainship/squads/req)
 "XF" = (
 /obj/structure/cable,
@@ -15929,7 +15985,10 @@
 	},
 /area/mainship/squads/general)
 "XI" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "XJ" = (
@@ -15960,14 +16019,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "XN" = (
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/tool/extinguisher,
-/obj/item/tool/extinguisher/mini,
-/obj/structure/rack,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/lightreplacer,
+/obj/structure/largecrate/guns/russian,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "XO" = (
@@ -16113,7 +16165,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Yg" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "Yh" = (
@@ -16168,6 +16222,10 @@
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"Yv" = (
+/obj/structure/closet/secure_closet/req_officer,
+/turf/open/floor/mainship/cargo,
+/area/mainship/squads/req)
 "Yw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -16233,9 +16291,10 @@
 	},
 /area/mainship/medical/lower_medical)
 "YF" = (
-/obj/structure/table/mainship,
-/obj/machinery/computer/supplydrop_console,
-/turf/open/floor/mainship/mono,
+/obj/structure/closet/crate/weapon,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "YG" = (
 /obj/structure/disposalpipe/segment/corner{
@@ -16313,6 +16372,14 @@
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"YQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "YR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -16353,13 +16420,12 @@
 	},
 /area/space)
 "YX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
+/obj/structure/cable,
+/obj/machinery/light{
+	light_color = "#da2f1b"
 	},
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/hangar)
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "YY" = (
 /turf/open/floor/mainship/black{
 	dir = 8
@@ -16528,6 +16594,10 @@
 	dir = 1
 	},
 /area/mainship/hallways/hangar)
+"ZB" = (
+/obj/machinery/autolathe,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "ZC" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner{
@@ -16562,7 +16632,10 @@
 /turf/open/floor/mainship,
 /area/mainship/living/cafeteria_starboard)
 "ZH" = (
-/obj/machinery/vending/lasgun,
+/obj/machinery/vending/armor_supply,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ZI" = (
@@ -16604,8 +16677,8 @@
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "ZO" = (
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
+/obj/vehicle/ridden/powerloader,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "ZP" = (
 /obj/structure/cable,
@@ -16624,10 +16697,12 @@
 	},
 /area/mainship/living/numbertwobunks)
 "ZR" = (
-/obj/machinery/power/apc{
-	dir = 8
+/obj/structure/window/framed/mainship/requisitions,
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id = "qm_warehouse";
+	name = "\improper Warehouse Shutters"
 	},
-/obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ZS" = (
@@ -16651,7 +16726,11 @@
 /turf/open/floor/grass,
 /area/mainship/living/cafeteria_starboard)
 "ZV" = (
-/obj/structure/largecrate/guns,
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id = "qm_warehouse";
+	name = "\improper Warehouse Shutters"
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ZW" = (
@@ -34983,34 +35062,34 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 fI
 fI
@@ -35240,34 +35319,34 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 fI
 fI
@@ -35497,34 +35576,34 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 fI
 fI
@@ -35754,34 +35833,34 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 fI
 fI
@@ -36011,34 +36090,34 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 fI
 fI
@@ -36268,34 +36347,34 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 fI
 fI
@@ -36525,34 +36604,34 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 fI
 fI
@@ -36782,34 +36861,34 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 fI
 fI
@@ -37039,34 +37118,34 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 fI
 fI
@@ -37296,34 +37375,34 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 fI
 fI
@@ -37553,34 +37632,34 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 aa
 aa
@@ -38067,34 +38146,34 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 aa
 aa
@@ -38324,34 +38403,34 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 aa
 aa
@@ -38377,7 +38456,7 @@ RC
 bq
 LS
 LS
-bq
+TF
 RC
 La
 ad
@@ -38588,27 +38667,27 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 aa
 aa
@@ -38631,10 +38710,10 @@ Oq
 ad
 ad
 ad
-rj
 ad
+bZ
+Wg
 ad
-rj
 ad
 ad
 ad
@@ -38845,27 +38924,27 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 aa
 aa
@@ -39102,27 +39181,27 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 aa
 aa
@@ -39359,27 +39438,27 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 aa
 aa
@@ -39616,27 +39695,27 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 aa
 aa
@@ -39873,27 +39952,27 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 aa
 aa
@@ -40130,27 +40209,27 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 aa
 aa
@@ -40387,27 +40466,27 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 aa
 aa
@@ -40644,27 +40723,27 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 aa
 aa
@@ -40684,7 +40763,7 @@ nC
 Xe
 Xe
 ST
-sD
+YT
 Zv
 rb
 fU
@@ -40935,13 +41014,13 @@ Mb
 Mb
 Zo
 Mb
-pt
+Ne
 lQ
 Bx
 MF
 lQ
 lQ
-kT
+YT
 Zv
 mt
 ji
@@ -41197,8 +41276,8 @@ rT
 Bn
 IM
 Ow
-lQ
-TY
+za
+YT
 Zv
 hj
 hD
@@ -41705,14 +41784,14 @@ cu
 Mb
 ap
 hh
-az
-pt
+sD
+NY
 lQ
 nz
 Ed
 vg
 XI
-ja
+YT
 Zv
 Ze
 fX
@@ -42537,7 +42616,7 @@ He
 sJ
 Im
 Gk
-bZ
+uk
 OP
 WX
 AU
@@ -44022,8 +44101,8 @@ ap
 ga
 aI
 aY
-uZ
-aY
+hH
+Ro
 sr
 TT
 NE
@@ -45071,7 +45150,7 @@ al
 bd
 gL
 wj
-gL
+FG
 PE
 WP
 WP
@@ -45328,7 +45407,7 @@ TK
 bd
 FE
 wj
-FG
+dn
 PE
 WP
 WP
@@ -45339,7 +45418,7 @@ WP
 WP
 WP
 WP
-WP
+TI
 PE
 Do
 AQ
@@ -46072,9 +46151,9 @@ bF
 jI
 YL
 kp
-FA
-Dh
-kf
+aB
+YS
+ap
 nk
 RP
 TW
@@ -46329,10 +46408,10 @@ ap
 bn
 ap
 ca
-Vl
+ap
 lO
 rF
-rF
+FC
 rF
 rF
 rF
@@ -46340,7 +46419,7 @@ FC
 Uc
 KR
 zk
-rF
+wb
 FC
 rF
 rF
@@ -46586,7 +46665,7 @@ or
 Gp
 Gq
 hr
-YX
+or
 nR
 Kg
 Kg
@@ -46597,7 +46676,7 @@ Kg
 po
 UC
 NF
-JL
+IP
 sz
 JL
 JL
@@ -46843,23 +46922,23 @@ ap
 ap
 ap
 ap
-Vl
+ap
+IT
 rF
 rF
 rF
 rF
+IT
+XG
 rF
 rF
+mr
+wb
+XG
+RO
 rF
 rF
-rF
-zk
-rF
-CP
-rF
-rF
-rF
-NY
+XG
 rF
 rF
 rF
@@ -47095,39 +47174,39 @@ bw
 bw
 bw
 lC
-ap
-ap
-eO
+ja
+az
+Ry
 ro
-AH
 Tl
 Tl
-qG
-qG
-qG
-qG
-qG
-qG
-qG
+Tl
+Tl
+Tl
+ro
+ro
+Wp
 qG
 qG
 Yy
-Gt
+GD
 qG
 qG
-Ne
+qG
+qG
+qG
+qG
+qG
+qG
+qG
+XD
+XD
 CC
-ZO
-ZO
-ZO
-ZO
-ZO
-CC
-CC
-ZO
-uF
+Er
+Er
+jy
 Uu
-oY
+jy
 PE
 WP
 WP
@@ -47353,22 +47432,22 @@ bJ
 eB
 ag
 oW
-ap
-Hx
-wl
-qG
-iv
-lY
+sD
+Ry
+Tl
+Dh
+wk
+wk
 ly
-mq
+wk
 wk
 oF
 VM
 kE
 oG
-oD
-TO
 kM
+TO
+re
 pn
 em
 me
@@ -47376,12 +47455,12 @@ Xn
 ZO
 CH
 Sv
-Sv
+Yv
 UA
-Sv
-Sv
+NO
+qG
 pq
-ZO
+uT
 jy
 Uu
 jy
@@ -47597,10 +47676,10 @@ bh
 bh
 bh
 bh
-bh
-bh
-bh
-dE
+Xa
+Zd
+Yk
+ZA
 bh
 bh
 bh
@@ -47609,36 +47688,36 @@ bh
 bh
 bh
 Ri
-kB
+ap
 ap
 kM
-gz
-qG
-iw
-np
-kM
-og
-xS
+Tl
+Vd
+WS
+WS
+WS
+WS
+WS
 oL
-oL
+Tl
 EV
 Ju
+kM
 Tj
-Tj
-Tj
-QB
+Ts
+Ts
 YF
 Ut
-kM
-ZO
+ET
+ET
 Ts
 eh
-eh
-eh
-eh
-eh
+IK
+bf
+NA
+qG
 Mw
-ZO
+kM
 jy
 Uu
 jy
@@ -47854,48 +47933,48 @@ bh
 bh
 bh
 bh
+nv
 bh
 bh
+ZA
 bh
-bh
-bh
-bh
-bh
-bh
-bh
-bh
+Xa
+Zd
+Zd
+Zd
+sH
 bh
 Ri
-kB
-ap
+kf
+te
+uZ
+Tl
+Vd
+WS
+WS
+WS
+WS
+WS
+oL
+Tl
+ZR
+cw
 kM
-gI
+RH
+Yy
+Yy
+Yy
+Yy
+Yy
+Yy
+Yy
+Kp
+kM
+iJ
+fa
 qG
-iM
-ip
-oB
-oj
-WS
-WS
-WS
-WS
-WS
-WS
-WS
-WS
-GH
-IT
-kj
-kM
-ZO
-Ts
-eh
-eh
-eh
-eh
-eh
 Jj
-ZO
+kM
 jy
 Uu
 jy
@@ -48111,48 +48190,48 @@ bh
 bh
 bh
 bh
+nv
+bh
+bh
+Bq
+Zd
+jF
 bh
 bh
 bh
-bh
-bh
-bh
-bh
-bh
-bh
-bh
+ZA
 bh
 gD
-kB
-ap
-yS
-qG
-hd
-eM
-nu
-kM
-Vn
-Yy
-Yy
-Yy
-Yy
-Yy
-Yy
-Yy
-Yy
-Vn
-kM
-CE
-kM
-ZO
-Gi
-eh
-eh
-Lv
-eh
-eh
+kj
 uA
-ZO
+yS
+Tl
+hd
+WS
+WS
+MM
+WS
+WS
+SS
+Tl
+ZV
+kM
+kM
+RH
+Yy
+Yy
+Yy
+Yy
+Yy
+Yy
+Yy
+Kp
+kM
+Lv
+Ld
+pQ
+qG
+lI
 jy
 Uu
 oY
@@ -48166,7 +48245,7 @@ WP
 WP
 WP
 WP
-WP
+TI
 PE
 jy
 FU
@@ -48368,6 +48447,7 @@ bh
 bh
 bh
 bh
+nv
 bh
 bh
 bh
@@ -48376,40 +48456,39 @@ bh
 bh
 bh
 bh
-bh
-bh
+ZA
 bh
 gM
-kB
-ap
+kT
+uL
+yY
+Tl
+Vd
+WS
+WS
+WS
+WS
+WS
+Tf
+Tl
+ZV
+Cz
 kM
-ee
-ht
-hV
-op
-os
-Vn
+YQ
 Yy
 Yy
 Yy
 Yy
 Yy
 Yy
-Yy
-Yy
-Vn
+jH
+Kp
+HF
 kM
-CE
-kM
-ZO
-Ts
-eh
-eh
-eh
-eh
-eh
+hL
+nF
 pw
-ZO
+kM
 jy
 Uu
 FF
@@ -48622,6 +48701,10 @@ bP
 dV
 Xh
 bh
+Zd
+Zd
+Zd
+jF
 bh
 bh
 bh
@@ -48630,22 +48713,25 @@ bh
 bh
 bh
 bh
-bh
-bh
-bh
-bh
-bh
+ZA
 bh
 gQ
 kB
-kB
+ap
 kM
-Cq
+Tl
 Vd
-iN
+WS
+WS
+WS
+WS
+WS
+oL
+Tl
+ZV
 kM
 kM
-Vn
+RH
 Yy
 Yy
 Yy
@@ -48653,20 +48739,13 @@ Yy
 Yy
 Yy
 Yy
-Yy
-Vn
+Kp
 kM
-CE
 kM
-ZO
-Ts
-eh
-eh
-eh
-eh
-eh
-Mw
-ZO
+ZB
+Pp
+JR
+kM
 jy
 Uu
 jy
@@ -48879,11 +48958,11 @@ ac
 CQ
 Sn
 bh
+ZA
 bh
 bh
 bh
-bh
-bh
+dM
 UM
 hA
 bh
@@ -48891,39 +48970,39 @@ bh
 bh
 bh
 bh
-bh
+ZA
 bh
 ho
-kB
-kB
-kM
-Cq
-Vd
-kM
-kM
+oD
+sD
+Ry
+Tl
+FA
+Gt
+Gt
 oE
-Vn
-Yy
-Yy
-Yy
-Yy
-Yy
-Yy
-Yy
-Yy
-Vn
+Gt
+Gt
+TH
+Tl
+ZR
 kM
-kj
 kM
-ZO
-Gj
+RH
+Yy
+Yy
+Yy
+Yy
+Yy
+Yy
+Yy
 Kp
-Kp
-MM
-Kp
-Kp
-mf
-ZO
+LC
+kM
+kM
+Pp
+JR
+kM
 jy
 Uu
 jy
@@ -49136,6 +49215,10 @@ Zx
 CQ
 XJ
 bh
+sP
+sP
+sP
+ri
 bh
 bh
 bh
@@ -49144,44 +49227,40 @@ bh
 bh
 bh
 bh
-bh
-bh
-bh
-bh
-bh
+ZA
 bh
 hz
-kB
-kB
-kM
-Cq
-Vd
-iV
-kM
-kM
-og
-Vn
-Vn
-Vn
-Vn
-Vn
-Vn
-Vn
-Vn
-og
-AD
+oD
+az
+Ry
+Tl
+Tl
+Tl
+Tl
+Tl
+Tl
+Tl
+Tl
+Tl
 qG
-ze
-ZO
-ZO
-ZO
-ZO
-ZO
-ZO
-ZO
-ZO
-ZO
-uF
+qm
+kM
+hZ
+AD
+AD
+AD
+AW
+Kp
+Kp
+Kp
+hn
+kM
+kM
+kw
+Pp
+JR
+kM
+jy
 yp
 RB
 wS
@@ -49396,6 +49475,7 @@ bh
 bh
 bh
 bh
+nv
 bh
 bh
 bh
@@ -49404,15 +49484,14 @@ bh
 bh
 bh
 bh
-bh
-bh
+ZA
 bh
 gM
 kB
 ap
 kM
-Cq
-Vd
+CE
+Gi
 iZ
 XN
 oK
@@ -49420,16 +49499,16 @@ pF
 AB
 oJ
 UW
-ZR
+qG
+Ry
 kM
-te
-kM
+Wh
 kM
 tr
-Qi
-qG
-Xn
-Vn
+kM
+hO
+Vi
+pb
 ZH
 JN
 KG
@@ -49437,7 +49516,7 @@ JP
 NP
 Pp
 JR
-Tf
+kM
 jy
 Hb
 jy
@@ -49653,48 +49732,48 @@ bh
 bh
 bh
 bh
+nv
+bh
+bh
+Yk
+sP
+ri
 bh
 bh
 bh
-bh
-bh
-bh
-bh
-bh
-bh
-bh
+ZA
 bh
 mj
 px
 cg
 kM
+CP
+Gj
+GH
+KY
 kM
-qG
-Tl
-Tl
-Tl
-Tl
-qG
-AH
-qG
-qG
-qG
-qG
-qG
-Yy
 OA
-AH
+Qi
+TY
+YX
 qG
-TH
-Vn
-ZV
+CC
+Yy
+Kc
+qG
+qG
+qG
+qG
+qG
+CC
+qG
 XD
-Le
-NK
-kM
-PV
+XD
+XD
+XD
+qG
 Ry
-VR
+kM
 jy
 Hb
 FF
@@ -49910,48 +49989,48 @@ bh
 bh
 bh
 bh
+nv
 bh
 bh
+ZA
 bh
-bh
-bh
-bh
-bh
-bh
-bh
-bh
+dE
+sP
+sP
+sP
+lM
 bh
 gC
 kB
 ca
 rF
 rF
-zk
+rF
 jN
 rF
 rF
+PV
+QA
+Vl
+IT
+bT
 rF
 rF
+IT
+wb
 rF
-rF
-rF
-rF
-KY
-zk
-rF
-uL
 FC
 RO
 rF
-NY
+rF
 rF
 jy
 jy
 jy
 jy
-QA
-SS
-Wp
+jy
+jy
+jy
 jy
 Hb
 jy
@@ -50167,10 +50246,10 @@ bh
 bh
 bh
 bh
-bh
-bh
-bh
-dM
+dE
+sP
+Bq
+ZA
 bh
 bh
 bh
@@ -50183,7 +50262,7 @@ dB
 cb
 rF
 rF
-zk
+rF
 kF
 JL
 JL
@@ -50195,8 +50274,8 @@ JL
 JL
 Yc
 VF
-Se
-yY
+qr
+Yc
 Yc
 JL
 JL
@@ -50440,7 +50519,7 @@ on
 ap
 oC
 rF
-zk
+XG
 kN
 FB
 XG
@@ -50451,8 +50530,8 @@ FB
 GG
 JO
 KU
-zk
 rF
+wb
 rF
 rF
 rF
@@ -51198,7 +51277,7 @@ cu
 cu
 JF
 dD
-az
+ZA
 az
 ap
 ct
@@ -51731,7 +51810,7 @@ AV
 AV
 vS
 Ws
-nG
+VR
 mD
 Ws
 AV
@@ -53250,15 +53329,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 aa
 aa
@@ -53503,19 +53582,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 aa
 aa
@@ -53760,19 +53839,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 aa
 aa
@@ -54017,19 +54096,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 aa
 aa
@@ -54274,19 +54353,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 aa
 aa
@@ -54304,7 +54383,8 @@ nd
 sK
 rc
 ad
-aL
+fL
+pW
 Mb
 Mb
 Mb
@@ -54316,9 +54396,8 @@ Mb
 Mb
 Mb
 Mb
-Mb
-Mb
-aL
+bZ
+Fq
 Mb
 sO
 Or
@@ -54531,14 +54610,14 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 fI
 fI
 fI
@@ -54788,14 +54867,14 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 fI
 fI
 fI
@@ -55049,10 +55128,10 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
 fI
 fI
 fI
@@ -55306,10 +55385,10 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
 fI
 fI
 fI
@@ -55563,10 +55642,10 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
 fI
 fI
 fI
@@ -55820,10 +55899,10 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
 fI
 fI
 fI
@@ -56077,10 +56156,10 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
 fI
 fI
 fI
@@ -56334,10 +56413,10 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
 fI
 fI
 fI
@@ -56375,7 +56454,7 @@ UQ
 UQ
 UQ
 Po
-Mb
+UP
 Zo
 SK
 WC
@@ -56632,7 +56711,7 @@ wV
 wV
 wV
 PM
-dJ
+bZ
 eP
 IY
 IY

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -438,6 +438,8 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "bC" = (
+/obj/machinery/power/apc/mainship,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/purple/side{
 	dir = 5
 	},
@@ -544,6 +546,9 @@
 /obj/machinery/door/airlock/multi_tile/mainship/research{
 	dir = 2;
 	name = "Research Chemical Lab"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/chemistry)
@@ -1278,6 +1283,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/medical/lower_medical)
 "ef" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/purple/side{
 	dir = 8
 	},
@@ -1710,6 +1719,11 @@
 	dir = 1
 	},
 /area/mainship/hallways/hangar/droppod)
+"fE" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "fF" = (
 /obj/structure/table/mainship,
 /obj/item/storage/box/gloves{
@@ -2162,6 +2176,13 @@
 	dir = 5
 	},
 /area/space)
+"hl" = (
+/obj/machinery/door/firedoor/mainship,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/hallways/port_hallway)
 "hm" = (
 /obj/machinery/light{
 	dir = 8
@@ -2520,6 +2541,16 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
+"iv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/port_hallway)
 "ix" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
@@ -2857,9 +2888,9 @@
 /area/mainship/hull/lower_hull)
 "jx" = (
 /obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/port_hallway)
 "jy" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
@@ -3132,6 +3163,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
@@ -4153,17 +4187,10 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
 "nB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "nC" = (
 /obj/machinery/holopad,
@@ -4253,6 +4280,13 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/engineering/lower_engineering)
+"nN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/port_hallway)
 "nO" = (
 /obj/machinery/researchcomp,
 /turf/open/floor/mainship/sterile/dark,
@@ -4494,6 +4528,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
+"oD" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "oE" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 8;
@@ -4614,9 +4654,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
@@ -5817,11 +5854,11 @@
 /area/mainship/engineering/port_atmos)
 "sZ" = (
 /obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
@@ -7127,7 +7164,6 @@
 	},
 /area/mainship/medical/lower_medical)
 "wU" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -7135,6 +7171,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/junction/flipped{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "wV" = (
@@ -7391,9 +7430,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/port_hallway)
@@ -8668,6 +8704,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"BC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "BD" = (
 /obj/machinery/door/poddoor/shutters/mainship/cell,
 /obj/machinery/door/airlock/mainship/research/glass/cell,
@@ -9167,8 +9210,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
 "Dg" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -10598,6 +10641,19 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
 /area/mainship/living/cafeteria_starboard)
+"Hg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/port_hallway)
 "Hh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -10606,24 +10662,21 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "Hi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
-"Hj" = (
-/obj/structure/disposalpipe/junction/flipped{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
+"Hj" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
 "Hk" = (
 /obj/structure/table/mainship,
 /obj/item/book/manual/security_space_law,
@@ -10963,10 +11016,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/ai_node,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "Ic" = (
@@ -11207,6 +11257,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"IL" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "IN" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -11875,10 +11931,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Kq" = (
-/obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "Kr" = (
@@ -14038,6 +14094,12 @@
 /obj/structure/bed/chair/wood/wings,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
+"QC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "QD" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -14847,6 +14909,7 @@
 	},
 /area/mainship/medical/lower_medical)
 "Td" = (
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -15208,6 +15271,7 @@
 /area/mainship/medical/lower_medical)
 "Uj" = (
 /obj/effect/ai_node,
+/obj/structure/disposalpipe/segment/corner,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "Uk" = (
@@ -15287,6 +15351,9 @@
 /area/mainship/squads/req)
 "Uu" = (
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "Uv" = (
@@ -16717,6 +16784,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/black/corner,
 /area/mainship/squads/general)
 "Yy" = (
@@ -37692,7 +37760,7 @@ oi
 bZ
 aD
 EN
-kY
+EN
 kY
 FT
 ad
@@ -43871,7 +43939,7 @@ pd
 EL
 ag
 Hh
-Df
+gL
 uM
 Hk
 Hl
@@ -44128,7 +44196,7 @@ ph
 XU
 AS
 wU
-Hj
+gL
 uM
 mi
 BN
@@ -44384,8 +44452,8 @@ XU
 XU
 XU
 gL
-Hi
-Df
+wj
+gL
 uM
 tI
 tI
@@ -44641,8 +44709,8 @@ FD
 gL
 gL
 gL
-nB
-Hj
+wj
+gL
 AM
 gL
 gL
@@ -44890,7 +44958,7 @@ Vm
 Vm
 eD
 eU
-MZ
+jx
 Wq
 MZ
 MZ
@@ -45147,15 +45215,15 @@ hH
 Tc
 hH
 aY
-gL
-gL
-gL
-gL
-gL
-gL
-gL
-gL
-wj
+Do
+nB
+Hi
+Hi
+Hi
+Hi
+Hi
+IL
+iv
 gL
 AM
 gL
@@ -45411,8 +45479,8 @@ YT
 YT
 YT
 YT
-gL
-wj
+QC
+iv
 gL
 PE
 PE
@@ -45662,14 +45730,14 @@ SR
 lP
 Zj
 bC
-Mt
+Df
 ef
 lF
 Zq
 al
 YT
-gL
-wj
+QC
+iv
 FG
 PE
 WP
@@ -45920,13 +45988,13 @@ NK
 Zj
 Zi
 Uj
-Mt
+Hj
 LI
 Mt
 TK
 en
-gL
-wj
+QC
+iv
 dn
 PE
 WP
@@ -46182,7 +46250,7 @@ eB
 Mt
 bn
 YT
-gL
+QC
 pa
 gL
 PE
@@ -46439,8 +46507,8 @@ Jb
 BJ
 Qk
 YT
-gL
-wj
+QC
+iv
 gL
 PE
 DS
@@ -46696,7 +46764,7 @@ gI
 Sq
 JU
 YT
-Om
+hl
 xF
 Om
 PE
@@ -46953,7 +47021,7 @@ rF
 rF
 rF
 rF
-gL
+QC
 pa
 gL
 PE
@@ -47210,8 +47278,8 @@ JL
 ea
 JL
 ea
-xd
-YG
+nN
+Hg
 FG
 PE
 WP
@@ -49524,8 +49592,8 @@ Pp
 JR
 kM
 jy
-Uu
-jy
+fE
+oD
 AR
 jy
 jy
@@ -49782,7 +49850,7 @@ JR
 kM
 jy
 yp
-RB
+BC
 wS
 RB
 Yd
@@ -51784,7 +51852,7 @@ bV
 kB
 kB
 az
-jx
+qg
 Mb
 Mb
 Mb
@@ -52041,7 +52109,7 @@ Pa
 Pa
 Pa
 Pa
-CB
+ci
 cu
 cu
 cu

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -68,6 +68,7 @@
 /area/mainship/hallways/hangar)
 "al" = (
 /obj/machinery/vending/MarineMed/Blood,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "am" = (
@@ -514,6 +515,7 @@
 /obj/machinery/door/airlock/mainship/medical/glass/CMO{
 	dir = 2
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/mainship/medical/surgery_hallway)
 "bN" = (
@@ -935,6 +937,7 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /obj/effect/landmark/start/job/researcher,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "dd" = (
@@ -1277,12 +1280,14 @@
 "ed" = (
 /obj/machinery/door/airlock/mainship/research/pen,
 /obj/machinery/door/firedoor/mainship,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "ef" = (
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "eh" = (
@@ -1336,6 +1341,7 @@
 "ep" = (
 /obj/machinery/door/airlock/mainship/medical/glass/CMO,
 /obj/machinery/door/firedoor/mainship,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/surgery_hallway)
 "eq" = (
@@ -1392,6 +1398,8 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/cmo,
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/mainship/medical/surgery_hallway)
 "eA" = (
@@ -1494,6 +1502,13 @@
 	},
 /turf/closed/wall/mainship,
 /area/mainship/hallways/hangar)
+"eU" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "eV" = (
 /obj/item/newspaper{
 	pixel_x = -10;
@@ -2308,6 +2323,8 @@
 /area/mainship/hallways/hangar)
 "hB" = (
 /obj/effect/ai_node,
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "hC" = (
@@ -2357,6 +2374,7 @@
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "hL" = (
@@ -2467,6 +2485,11 @@
 /obj/structure/flora/pottedplant/twentyone,
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
+"ij" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "il" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -2740,6 +2763,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "ji" = (
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/mainship/medical/surgery_hallway)
 "jj" = (
@@ -2911,6 +2935,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "jQ" = (
@@ -2948,6 +2973,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
@@ -3996,6 +4022,10 @@
 "nv" = (
 /turf/open/floor/plating/icefloor/warnplate,
 /area/mainship/hallways/hangar)
+"ny" = (
+/obj/structure/cable,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "nz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4003,6 +4033,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "nA" = (
@@ -4441,6 +4472,7 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
@@ -4593,6 +4625,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
+"pu" = (
+/obj/machinery/holopad,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "pw" = (
 /obj/machinery/light{
 	dir = 8
@@ -4947,6 +4984,10 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
+"qN" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/medical/surgery_hallway)
 "qP" = (
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/plating/mainship,
@@ -5451,6 +5492,12 @@
 /obj/machinery/marine_selector/clothes/leader,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
+"sy" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/surgery_hallway)
 "sz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
@@ -6372,6 +6419,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
@@ -6677,6 +6725,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/mainship/living/grunt_rnr)
 "wi" = (
@@ -7052,6 +7101,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "xi" = (
@@ -7984,6 +8034,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/mainship/living/grunt_rnr)
 "Aa" = (
@@ -8322,6 +8373,12 @@
 /obj/docking_port/stationary/ert_big,
 /turf/open/space,
 /area/space)
+"Be" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/surgery_hallway)
 "Bf" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/plating_catwalk,
@@ -8465,6 +8522,13 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
+"By" = (
+/obj/machinery/light{
+	light_color = "#da2f1b"
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "Bz" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
@@ -8512,6 +8576,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "BJ" = (
@@ -8534,6 +8599,7 @@
 /obj/item/healthanalyzer,
 /obj/item/storage/belt/medical,
 /obj/item/storage/belt/medical,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
@@ -8542,6 +8608,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "BL" = (
@@ -8593,6 +8660,7 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
@@ -8821,6 +8889,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/surgery_hallway)
 "Cu" = (
@@ -9063,6 +9132,7 @@
 	on = 1
 	},
 /mob/living/simple_animal/catslug/newt,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "Df" = (
@@ -9815,10 +9885,12 @@
 /obj/machinery/door/firedoor/mainship,
 /obj/effect/ai_node,
 /obj/machinery/door/airlock/mainship/maint/free_access,
+/obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Fp" = (
 /obj/structure/closet/secure_closet/medical3,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/medical_science)
 "Fq" = (
@@ -9832,6 +9904,11 @@
 /obj/machinery/telecomms/receiver/preset_right,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
+"Ft" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "Fv" = (
 /obj/structure/bed/chair/comfy{
 	dir = 1
@@ -10299,6 +10376,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "GR" = (
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/side{
 	dir = 6
 	},
@@ -10507,6 +10586,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"Hx" = (
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "Hy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -11048,6 +11131,7 @@
 /area/mainship/living/cryo_cells)
 "IV" = (
 /obj/machinery/door/airlock/mainship/maint,
+/obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/medical/surgery_hallway)
 "IW" = (
@@ -11512,6 +11596,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
+"Kh" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "Ki" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -11710,6 +11798,7 @@
 /obj/structure/bed/stool{
 	pixel_y = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "KD" = (
@@ -11772,6 +11861,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"KK" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "KM" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/mainship/hardened{
@@ -11991,6 +12086,7 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/engineering/lower_engineering)
 "Lu" = (
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/side{
 	dir = 9
 	},
@@ -12303,6 +12399,7 @@
 /area/mainship/engineering/engineering_workshop)
 "Mt" = (
 /obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "Mu" = (
@@ -12759,6 +12856,7 @@
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/surgery_hallway)
 "NH" = (
@@ -12791,6 +12889,15 @@
 /obj/item/tool/taperoll/engineering,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"NK" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/surgery_hallway)
 "NL" = (
 /obj/machinery/light{
 	dir = 4
@@ -12826,6 +12933,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
+/obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
@@ -13217,6 +13325,7 @@
 /obj/machinery/door/airlock/mainship/medical/glass{
 	dir = 2
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "Pc" = (
@@ -13348,6 +13457,8 @@
 /area/mainship/squads/general)
 "Pu" = (
 /obj/structure/closet/secure_closet/medical3,
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/corner{
 	dir = 8
 	},
@@ -13527,6 +13638,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/mainship/living/grunt_rnr)
 "PZ" = (
@@ -13616,6 +13728,7 @@
 /obj/item/storage/pill_bottle/packet/paracetamol,
 /obj/item/storage/pill_bottle/packet/paracetamol,
 /obj/item/storage/pill_bottle/packet/paracetamol,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/corner{
 	dir = 4
 	},
@@ -13973,6 +14086,8 @@
 /area/mainship/hallways/hangar)
 "Rj" = (
 /obj/effect/ai_node,
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/medical/surgery_hallway)
 "Rk" = (
@@ -13989,6 +14104,7 @@
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/surgery_hallway)
 "Ro" = (
@@ -14317,6 +14433,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
+"Sq" = (
+/obj/machinery/light,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
 "Sr" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -14681,6 +14802,9 @@
 /area/mainship/living/numbertwobunks)
 "TB" = (
 /obj/structure/sink,
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/mainship/living/grunt_rnr)
 "TC" = (
@@ -14744,6 +14868,7 @@
 /area/mainship/living/briefing)
 "TK" = (
 /obj/machinery/vending/medical/shipside,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "TL" = (
@@ -14859,6 +14984,9 @@
 /area/mainship/hallways/hangar/droppod)
 "Ue" = (
 /obj/effect/ai_node,
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/surgery_hallway)
 "Ug" = (
@@ -15045,6 +15173,7 @@
 "UJ" = (
 /obj/machinery/door/airlock/mainship/medical/or/or1,
 /obj/machinery/door/firedoor/mainship,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "UL" = (
@@ -15111,6 +15240,7 @@
 /area/mainship/engineering/lower_engineering)
 "UV" = (
 /obj/structure/disposalpipe/segment/corner,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "UW" = (
@@ -15715,6 +15845,7 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "WN" = (
@@ -15800,6 +15931,7 @@
 /obj/machinery/door/airlock/mainship/generic{
 	name = "Kitchen"
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "Xc" = (
@@ -16038,6 +16170,8 @@
 /area/mainship/squads/general)
 "XI" = (
 /obj/effect/ai_node,
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "XJ" = (
@@ -39022,11 +39156,11 @@ IY
 IY
 IY
 IY
-IY
+KK
 YM
 Tg
 Tg
-ql
+eU
 Tg
 Tg
 El
@@ -39536,11 +39670,11 @@ rD
 wa
 Nt
 ni
-ST
+NY
 YT
 Zv
 IZ
-Gy
+qN
 dH
 KX
 Zv
@@ -39789,15 +39923,15 @@ ad
 sN
 Mb
 lE
-Ve
+Ft
 wh
 PY
-Ve
+ny
 TB
 YT
 Zv
 kr
-Gy
+qN
 Gy
 RI
 Zv
@@ -40046,15 +40180,15 @@ ad
 sN
 Mb
 nN
-Ve
+ny
 wM
 QQ
 Ve
-Ve
+ny
 YT
 Zv
 IZ
-Gy
+qN
 Gy
 yn
 Zv
@@ -40303,17 +40437,17 @@ Mb
 sN
 Mb
 ou
-Ve
+Ft
 zZ
-Ve
-Ve
-Ve
+ny
+ny
+Ft
 YT
 Zv
 Vh
 Rj
-Gy
-Gy
+qN
+qN
 NG
 Ue
 GR
@@ -40572,7 +40706,7 @@ Zv
 Zv
 Zv
 Zv
-EH
+NK
 nn
 pE
 ir
@@ -40821,7 +40955,7 @@ ST
 nC
 Xe
 Xe
-ST
+NY
 YT
 Zv
 rb
@@ -40829,7 +40963,7 @@ fU
 Wb
 rs
 QF
-DU
+Be
 nn
 QF
 ax
@@ -41078,7 +41212,7 @@ lQ
 Bx
 MF
 lQ
-lQ
+ij
 YT
 Zv
 mt
@@ -41086,7 +41220,7 @@ ji
 ji
 ji
 Rn
-jm
+sy
 ZX
 Zv
 nD
@@ -41335,7 +41469,7 @@ rT
 Bn
 IM
 Ow
-za
+By
 YT
 Zv
 hj
@@ -41343,7 +41477,7 @@ hD
 Hd
 qs
 QF
-DU
+Be
 Xq
 Re
 SU
@@ -41592,7 +41726,7 @@ rT
 Of
 IM
 lQ
-lQ
+Hx
 ei
 Zv
 Zv
@@ -41600,7 +41734,7 @@ Zv
 Zv
 Zv
 Zv
-EH
+NK
 jm
 nn
 nD
@@ -41845,10 +41979,10 @@ ap
 hh
 Bm
 NY
-lQ
+Hx
 nz
-lQ
-lQ
+Hx
+Hx
 XI
 YT
 Zv
@@ -41863,9 +41997,9 @@ nn
 nD
 iz
 hB
-iL
-iL
-iL
+Kh
+Kh
+Kh
 nD
 uM
 uM
@@ -42119,7 +42253,7 @@ Ya
 TZ
 nD
 ek
-iL
+Kh
 oR
 oS
 iL
@@ -44172,9 +44306,9 @@ aY
 gG
 Ug
 WM
-aY
+BO
 hK
-iL
+Kh
 jP
 pV
 Me
@@ -44686,7 +44820,7 @@ aY
 gG
 BO
 WM
-aY
+BO
 Pb
 hB
 jT
@@ -44945,7 +45079,7 @@ NQ
 YE
 Td
 wN
-iL
+Kh
 iL
 iL
 Fp
@@ -45459,7 +45593,7 @@ UV
 YO
 bd
 Uj
-aY
+BO
 aY
 aY
 TK
@@ -45712,14 +45846,14 @@ cM
 oe
 ic
 TE
-Ro
+pu
 Zf
 bd
 ay
 Mt
 aY
 wx
-XU
+Sq
 bd
 gL
 wj

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -2,12 +2,6 @@
 "aa" = (
 /turf/open/space,
 /area/space)
-"ac" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
 "ad" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/hull/lower_hull)
@@ -143,6 +137,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"aB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/port_hallway)
 "aC" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -232,6 +233,12 @@
 /obj/machinery/light,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
+"aR" = (
+/obj/machinery/firealarm{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "aS" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/mainship/mono,
@@ -439,6 +446,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"bz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "bA" = (
 /obj/docking_port/stationary/marine_dropship/minidropship,
 /turf/open/floor/plating,
@@ -502,12 +518,6 @@
 "bL" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
-"bM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
 "bN" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -586,13 +596,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"bY" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/port_hallway)
 "bZ" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
@@ -1254,16 +1257,6 @@
 	dir = 8
 	},
 /area/mainship/hallways/hangar)
-"dT" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
 "dU" = (
 /turf/open/floor/mainship/research/containment/floor2{
 	dir = 5
@@ -1800,15 +1793,6 @@
 	},
 /turf/open/floor/mainship/black,
 /area/mainship/living/cafeteria_starboard)
-"fK" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
 "fL" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -2251,23 +2235,10 @@
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar/droppod)
-"hs" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
 "ht" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
-"hu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/wood,
-/area/mainship/living/commandbunks)
 "hv" = (
 /obj/machinery/door/airlock/multi_tile/mainship/maint{
 	dir = 1
@@ -2537,10 +2508,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
-"ig" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/mainship/living/commandbunks)
 "ii" = (
 /obj/structure/flora/pottedplant/twentyone,
 /turf/open/floor/mainship/black,
@@ -2606,6 +2573,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
+"iv" = (
+/obj/machinery/firealarm{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "ix" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
@@ -3016,6 +2989,16 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
+"jK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/port_hallway)
 "jL" = (
 /obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/door/firedoor/mainship,
@@ -3102,6 +3085,16 @@
 /area/mainship/living/grunt_rnr)
 "jY" = (
 /obj/machinery/computer/arcade,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
+"jZ" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "kb" = (
@@ -3228,16 +3221,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
-"ks" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
 "kt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3268,16 +3251,6 @@
 /obj/machinery/griddle,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/grunt_rnr)
-"ky" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
 "kz" = (
 /obj/structure/rack,
 /obj/structure/ob_ammo/warhead/incendiary,
@@ -3397,6 +3370,19 @@
 	dir = 4
 	},
 /area/mainship/squads/general)
+"kR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/port_hallway)
 "kT" = (
 /turf/open/floor/mainship/terragov/north{
 	dir = 4
@@ -4088,15 +4074,6 @@
 	icon_state = "carpetside"
 	},
 /area/mainship/living/commandbunks)
-"mU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
 "mV" = (
 /obj/machinery/telecomms/server/presets/charlie,
 /obj/machinery/camera/autoname/mainship,
@@ -4462,12 +4439,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
-"oc" = (
-/obj/machinery/firealarm{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
 "od" = (
 /obj/machinery/door/firedoor/mainship,
 /obj/machinery/holosign/surgery{
@@ -4493,12 +4464,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
-"og" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/bridgebunks)
 "oh" = (
 /obj/machinery/camera/autoname/mainship,
 /obj/machinery/chem_dispenser,
@@ -4700,16 +4665,6 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
-"oS" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/starboard_hallway)
 "oT" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/white{
@@ -4776,19 +4731,6 @@
 "pd" = (
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
-"pe" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
 "pf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4935,6 +4877,12 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
+"pE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "pF" = (
 /turf/open/floor/mainship/green/corner,
 /area/mainship/squads/req)
@@ -5053,19 +5001,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
-"qc" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
 "qd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -5196,17 +5131,6 @@
 /obj/item/tool/pen,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
-"qx" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
-/obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
 "qy" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/mainship/maint{
@@ -5343,6 +5267,13 @@
 	dir = 1
 	},
 /area/mainship/shipboard/firing_range)
+"qZ" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "ra" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/mono,
@@ -6654,6 +6585,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
+"uS" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "uT" = (
 /obj/effect/decal/warning_stripes/engineer,
 /obj/effect/decal/warning_stripes/box/small{
@@ -6761,6 +6697,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
+"vk" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "vl" = (
 /obj/structure/closet/boxinggloves,
 /turf/open/floor/plating/mainship,
@@ -7002,19 +6944,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
-"wa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
 "wb" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -8371,14 +8300,6 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"zU" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/port_hallway)
 "zV" = (
 /obj/machinery/power/fusion_engine/preset,
 /obj/structure/cable,
@@ -9118,6 +9039,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
+"Ci" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "Cj" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -9131,6 +9058,14 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
+"Ck" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "Cl" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/mono,
@@ -9385,6 +9320,17 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
+"Da" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "Db" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
@@ -10075,6 +10021,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
+"EM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "EN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
@@ -10113,6 +10066,15 @@
 	dir = 4
 	},
 /area/mainship/squads/req)
+"EU" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "EV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/status_display,
@@ -10224,12 +10186,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/airoom)
-"Fo" = (
-/obj/machinery/firealarm{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
 "Fp" = (
 /obj/machinery/light{
 	dir = 1
@@ -10731,12 +10687,18 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "GR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/obj/structure/disposalpipe/junction,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/hull/lower_hull)
 "GS" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/light{
@@ -11239,11 +11201,6 @@
 /obj/effect/landmark/start/job/ai,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
-"Ig" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
 "Ih" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/mainship/mono,
@@ -11491,13 +11448,6 @@
 	dir = 8
 	},
 /area/mainship/living/cafeteria_starboard)
-"IR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/obj/structure/disposalpipe/junction,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
 "IS" = (
 /obj/structure/lattice,
 /turf/closed/shuttle/ert{
@@ -11764,6 +11714,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
+"Jz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "JA" = (
 /obj/machinery/light{
 	dir = 4
@@ -13084,6 +13040,16 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_umbilical)
+"MY" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/hallways/starboard_hallway)
 "MZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -13629,14 +13595,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
-"Ow" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
 "Ox" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/numbertwobunks)
@@ -14548,6 +14506,10 @@
 	dir = 9
 	},
 /area/mainship/medical/lower_medical)
+"Rn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "Ro" = (
 /mob/living/simple_animal/corgi/walten,
 /obj/structure/disposalpipe/segment{
@@ -14893,13 +14855,6 @@
 "Sn" = (
 /turf/open/floor/plating/icefloor/warnplate,
 /area/mainship/hallways/hangar)
-"So" = (
-/obj/effect/decal/cleanable/blood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
 "Sp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -15282,12 +15237,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
-"TB" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
 "TC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -15420,6 +15369,16 @@
 	dir = 1
 	},
 /area/mainship/squads/req)
+"TZ" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "Ua" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner,
@@ -15714,6 +15673,19 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
+"UK" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "UL" = (
 /obj/machinery/door/firedoor/mainship,
 /obj/structure/cable,
@@ -15907,6 +15879,14 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
+"Vn" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/hallways/port_hallway)
 "Vo" = (
 /turf/open/floor/mainship_hull/dir,
 /area/space)
@@ -15976,6 +15956,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
+"Vx" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/hallways/port_hallway)
 "Vy" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/shuttle/shuttle_control/dropship,
@@ -16517,9 +16504,12 @@
 	},
 /area/mainship/hallways/hangar)
 "Xb" = (
-/obj/structure/cable,
-/turf/closed/wall/mainship/white,
-/area/mainship/medical/medical_science)
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "Xc" = (
 /obj/machinery/light{
 	dir = 1
@@ -16528,13 +16518,6 @@
 	dir = 8
 	},
 /area/mainship/squads/general)
-"Xd" = (
-/obj/machinery/door/firedoor/mainship,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/port_hallway)
 "Xe" = (
 /obj/structure/table/mainship,
 /obj/item/clipboard{
@@ -16635,6 +16618,12 @@
 	dir = 8
 	},
 /area/mainship/squads/general)
+"Xq" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/bridgebunks)
 "Xr" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -17012,6 +17001,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
+"Yn" = (
+/obj/machinery/door/firedoor/mainship,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/hallways/port_hallway)
 "Yp" = (
 /obj/effect/decal/siding{
 	dir = 8
@@ -39330,7 +39326,7 @@ bH
 ad
 bE
 VF
-So
+Xb
 ad
 dx
 oo
@@ -40106,7 +40102,7 @@ XU
 XU
 rj
 Mb
-pe
+UK
 bZ
 bZ
 bZ
@@ -40360,7 +40356,7 @@ LR
 ng
 Io
 GS
-dT
+jZ
 lj
 Mb
 CM
@@ -40620,28 +40616,28 @@ oz
 oz
 UF
 Mb
-pe
+UK
 bZ
 bZ
 mm
 WN
 Mb
 yV
-hs
-hs
-hs
+qZ
+qZ
+qZ
 Xr
-hs
+qZ
 iz
 cC
 iz
 iz
 iz
 iz
-Ow
-fK
+Ck
+EU
 Ps
-ky
+TZ
 fu
 fu
 WW
@@ -40877,13 +40873,13 @@ oz
 oz
 nS
 Mb
-qc
+GR
 cI
 aj
 Fh
 YI
 Mb
-pe
+UK
 bX
 Kb
 Kb
@@ -41372,7 +41368,7 @@ uo
 BD
 TD
 TV
-Xb
+ZX
 ZX
 ZX
 Ul
@@ -41397,20 +41393,20 @@ iz
 iz
 cC
 iz
-qx
+Da
 bZ
 Kb
 lm
 nb
-ig
-hu
+Rn
+Jz
 IE
 sg
 rw
 tC
 Kb
 JD
-og
+Xq
 sI
 Ew
 Zt
@@ -45243,7 +45239,7 @@ MZ
 MZ
 MZ
 MZ
-zU
+Vn
 MZ
 Ib
 Kq
@@ -45500,9 +45496,9 @@ Hj
 Hj
 Hj
 Hj
-bY
-ac
-ks
+Vx
+vk
+jK
 gL
 AM
 gL
@@ -45758,9 +45754,9 @@ YT
 YT
 YT
 YT
-bM
-ks
-Fo
+pE
+jK
+iv
 PE
 PE
 PE
@@ -46015,8 +46011,8 @@ lF
 Zq
 al
 YT
-mU
-ks
+bz
+jK
 FG
 PE
 WP
@@ -46272,8 +46268,8 @@ LI
 Mt
 TK
 en
-bM
-ks
+pE
+jK
 dn
 PE
 WP
@@ -46529,7 +46525,7 @@ eB
 Mt
 bn
 YT
-bM
+pE
 pa
 gL
 PE
@@ -46786,8 +46782,8 @@ Jb
 BJ
 Qk
 YT
-bM
-ks
+pE
+jK
 gL
 PE
 DS
@@ -47043,7 +47039,7 @@ gI
 Sq
 JU
 YT
-Xd
+Yn
 xF
 Om
 PE
@@ -47300,7 +47296,7 @@ rF
 rF
 rF
 FC
-bM
+pE
 pa
 gL
 PE
@@ -47557,8 +47553,8 @@ JL
 ea
 JL
 ea
-IR
-wa
+aB
+kR
 FG
 PE
 WP
@@ -49615,7 +49611,7 @@ JR
 kM
 jy
 Uu
-oc
+aR
 PE
 PE
 PE
@@ -49871,8 +49867,8 @@ Pp
 JR
 kM
 jy
-Ig
-TB
+uS
+Ci
 AR
 jy
 jy
@@ -50129,7 +50125,7 @@ JR
 kM
 jy
 yp
-GR
+EM
 wS
 RB
 Yd
@@ -50141,7 +50137,7 @@ RB
 xG
 RB
 CL
-oS
+MY
 RB
 GX
 mM

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -400,9 +400,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/maint/free_access{
-	dir = 1
-	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "bt" = (
@@ -3031,17 +3028,13 @@
 /area/mainship/shipboard/firing_range)
 "jR" = (
 /obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/mainship,
-/obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/maint/free_access{
-	dir = 1
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/engineering/engineering_workshop)
@@ -8425,9 +8418,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "Aw" = (
-/obj/structure/closet/firecloset,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/mainship/cargo,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/plating/mainship,
 /area/mainship/engineering/engineering_workshop)
 "Ax" = (
 /obj/structure/closet/crate,
@@ -14852,14 +14849,13 @@
 /area/mainship/squads/req)
 "Sw" = (
 /obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/engineering/engineering_workshop)
@@ -50379,7 +50375,7 @@ yx
 AX
 qB
 jv
-Aw
+yx
 OQ
 fL
 ad
@@ -50633,10 +50629,10 @@ OM
 OM
 Uy
 OM
-OQ
+Aw
 Sw
 jR
-OQ
+Aw
 OQ
 cu
 ad

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -16,6 +16,15 @@
 	dir = 8
 	},
 /area/mainship/hallways/hangar/droppod)
+"af" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/medical/lower_medical)
 "ag" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -136,6 +145,24 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
+"aD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	on = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
+"aE" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "aF" = (
 /turf/open/floor/mainship/cargo/arrow{
@@ -351,6 +378,12 @@
 /obj/machinery/door/airlock/multi_tile/mainship/maint/free_access{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "bt" = (
@@ -428,6 +461,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"bH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "bI" = (
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/hallways/hangar)
@@ -616,6 +658,16 @@
 	dir = 4
 	},
 /area/mainship/shipboard/weapon_room)
+"co" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "cq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -712,6 +764,16 @@
 "cB" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/hallways/port_umbilical)
+"cC" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "cD" = (
 /obj/machinery/loadout_vendor,
 /obj/machinery/light{
@@ -831,6 +893,16 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
+"cU" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 1;
+	on = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "cW" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/machinery/door/firedoor/mainship,
@@ -879,6 +951,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"de" = (
+/obj/machinery/firealarm,
+/turf/open/floor/mainship/mono,
+/area/mainship/engineering/lower_engineering)
 "dg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -979,6 +1055,13 @@
 	dir = 5
 	},
 /area/mainship/squads/general)
+"dt" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "du" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -1122,6 +1205,12 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
+"dQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "dR" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -1178,6 +1267,16 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"ec" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/medical/lower_medical)
 "ef" = (
 /turf/open/floor/mainship/sterile/purple/side{
 	dir = 8
@@ -1278,6 +1377,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"ez" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "eA" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -1475,6 +1580,7 @@
 /area/mainship/shipboard/firing_range)
 "fi" = (
 /obj/machinery/line_nexter,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "fj" = (
@@ -2111,6 +2217,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "hy" = (
@@ -2386,6 +2494,8 @@
 	dir = 1
 	},
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "is" = (
@@ -2426,6 +2536,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"iz" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "iA" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -2448,6 +2565,18 @@
 	dir = 8
 	},
 /area/mainship/medical/operating_room_one)
+"iD" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "iE" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -2492,6 +2621,16 @@
 	dir = 1
 	},
 /turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
+"iN" = (
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "iO" = (
 /obj/effect/ai_node,
@@ -2602,6 +2741,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "je" = (
@@ -2827,9 +2967,6 @@
 	},
 /area/mainship/shipboard/firing_range)
 "jR" = (
-/obj/machinery/door/airlock/mainship/engineering/storage{
-	dir = 8
-	},
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
@@ -2839,6 +2976,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/machinery/door/airlock/multi_tile/mainship/maint/free_access{
+	dir = 1
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/engineering/engineering_workshop)
@@ -3177,6 +3317,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "kZ" = (
@@ -3246,6 +3387,16 @@
 	dir = 1
 	},
 /area/mainship/medical/lower_medical)
+"lj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "lk" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/drinks/cans/aspen{
@@ -3337,6 +3488,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "lw" = (
@@ -3704,7 +3856,7 @@
 /area/mainship/medical/operating_room_one)
 "mD" = (
 /obj/machinery/holopad,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/white,
 /area/mainship/living/pilotbunks)
 "mE" = (
 /obj/structure/window/reinforced{
@@ -4055,7 +4207,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/white{
+	dir = 1
+	},
 /area/mainship/living/pilotbunks)
 "nH" = (
 /turf/open/floor/mainship/mono,
@@ -4117,6 +4271,16 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"nS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "nU" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -4125,7 +4289,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/white{
+	dir = 9
+	},
 /area/mainship/living/pilotbunks)
 "nV" = (
 /obj/structure/cable,
@@ -4241,6 +4407,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "op" = (
@@ -4266,6 +4433,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/medical/lower_medical)
 "ot" = (
@@ -4387,7 +4560,9 @@
 /area/mainship/living/grunt_rnr)
 "oT" = (
 /obj/machinery/vending/armor_supply,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/white{
+	dir = 1
+	},
 /area/mainship/living/pilotbunks)
 "oU" = (
 /obj/structure/bed/chair/sofa/left{
@@ -4477,7 +4652,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/white{
+	dir = 5
+	},
 /area/mainship/living/pilotbunks)
 "pk" = (
 /obj/structure/disposalpipe/segment/corner{
@@ -5020,6 +5197,12 @@
 /area/mainship/hallways/hangar)
 "rj" = (
 /obj/machinery/door/airlock/mainship/maint/free_access,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "rk" = (
@@ -5892,7 +6075,7 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/white,
 /area/mainship/living/pilotbunks)
 "tL" = (
 /obj/structure/mirror,
@@ -6203,6 +6386,10 @@
 /obj/item/blueprints,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/ce_room)
+"uE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "uF" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -7291,6 +7478,7 @@
 /obj/machinery/power/apc/mainship{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "xT" = (
@@ -7469,7 +7657,6 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
 "yv" = (
@@ -8407,6 +8594,10 @@
 	dir = 4
 	},
 /area/mainship/shipboard/weapon_room)
+"Bm" = (
+/obj/machinery/light,
+/turf/open/floor/mainship/white,
+/area/mainship/living/pilotbunks)
 "Bo" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/mainship{
@@ -8775,6 +8966,10 @@
 /obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/mainship/living/grunt_rnr)
+"Cy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "Cz" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/mainship/mono,
@@ -8918,7 +9113,7 @@
 	dir = 1
 	},
 /turf/open/floor/mainship/white{
-	dir = 1
+	dir = 8
 	},
 /area/mainship/living/pilotbunks)
 "CX" = (
@@ -9327,7 +9522,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/white/corner{
+	dir = 4
+	},
 /area/mainship/living/pilotbunks)
 "DU" = (
 /turf/open/floor/plating/dmg1,
@@ -9352,7 +9549,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/white{
+	dir = 1
+	},
 /area/mainship/living/pilotbunks)
 "DX" = (
 /obj/item/radio/intercom/general{
@@ -9365,6 +9564,12 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 8
 	},
@@ -9614,7 +9819,7 @@
 /obj/machinery/microwave,
 /obj/structure/table/mainship,
 /turf/open/floor/mainship/white{
-	dir = 5
+	dir = 8
 	},
 /area/mainship/living/pilotbunks)
 "EK" = (
@@ -9626,6 +9831,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
+"EN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "EO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/mainship/floor,
@@ -9937,6 +10146,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
+"FT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "FU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -10181,13 +10396,13 @@
 /turf/open/floor/plating,
 /area/mainship/squads/req)
 "GE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
 /turf/open/floor/prison/kitchen,
 /area/mainship/living/grunt_rnr)
 "GF" = (
@@ -10223,7 +10438,7 @@
 	dir = 8
 	},
 /turf/open/floor/mainship/white{
-	dir = 1
+	dir = 8
 	},
 /area/mainship/living/pilotbunks)
 "GK" = (
@@ -10231,7 +10446,9 @@
 	dir = 1;
 	on = 1
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/white{
+	dir = 4
+	},
 /area/mainship/living/pilotbunks)
 "GL" = (
 /turf/open/floor/plating,
@@ -10775,6 +10992,7 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
 "Ih" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/mainship/mono,
 /area/mainship/medical/lower_medical)
 "Ii" = (
@@ -10989,6 +11207,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"IN" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "IO" = (
 /obj/structure/morgue{
 	dir = 2
@@ -11589,6 +11817,9 @@
 "Kj" = (
 /obj/effect/landmark/start/job/researcher,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "Kk" = (
@@ -11621,6 +11852,9 @@
 "Kn" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "Ko" = (
@@ -11721,7 +11955,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
 "Kz" = (
@@ -11947,6 +12180,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 8
 	},
@@ -12347,6 +12581,9 @@
 "Mm" = (
 /mob/living/simple_animal/catslug/newt,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
 /turf/open/floor/mainship/sterile/purple/side{
 	dir = 4
 	},
@@ -12384,7 +12621,7 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "Mq" = (
-/obj/machinery/firealarm,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
 "Mr" = (
@@ -12460,7 +12697,7 @@
 /area/mainship/hallways/hangar)
 "ME" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/white/corner,
 /area/mainship/living/pilotbunks)
 "MF" = (
 /obj/structure/cable,
@@ -12729,6 +12966,12 @@
 /obj/structure/cable,
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
@@ -13073,6 +13316,12 @@
 /area/mainship/command/self_destruct)
 "Oq" = (
 /obj/machinery/door/airlock/mainship/maint/free_access,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/medical/lower_medical)
 "Or" = (
@@ -14132,6 +14381,20 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
+"RH" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "RI" = (
 /turf/open/floor/mainship/sterile/purple/side,
 /area/mainship/medical/medical_science)
@@ -14385,9 +14648,6 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "Sw" = (
-/obj/machinery/door/airlock/mainship/engineering/storage{
-	dir = 8
-	},
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
@@ -15100,6 +15360,12 @@
 "UF" = (
 /obj/structure/sink,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/prison/kitchen,
 /area/mainship/living/grunt_rnr)
 "UG" = (
@@ -15161,7 +15427,9 @@
 /obj/structure/table/mainship,
 /obj/item/weapon/combat_knife,
 /obj/item/storage/toolbox/mechanical,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/white{
+	dir = 8
+	},
 /area/mainship/living/pilotbunks)
 "UP" = (
 /obj/machinery/door/airlock/multi_tile/mainship/maint,
@@ -15298,8 +15566,8 @@
 /area/mainship/squads/general)
 "Vh" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
@@ -15460,7 +15728,6 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "VJ" = (
@@ -15508,7 +15775,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/mainship,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/white{
+	dir = 1
+	},
 /area/mainship/living/pilotbunks)
 "VS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -15599,7 +15868,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/white{
+	dir = 10
+	},
 /area/mainship/living/pilotbunks)
 "Wd" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -16294,7 +16565,9 @@
 "XY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/vending/weapon,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/white{
+	dir = 4
+	},
 /area/mainship/living/pilotbunks)
 "XZ" = (
 /obj/structure/table/mainship,
@@ -16491,6 +16764,9 @@
 /obj/machinery/marine_selector/gear/leader,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
+"YE" = (
+/turf/open/floor/mainship/white,
+/area/mainship/living/pilotbunks)
 "YF" = (
 /obj/structure/closet/crate/weapon,
 /obj/structure/cable,
@@ -16552,6 +16828,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/medical/lower_medical)
 "YN" = (
@@ -16720,6 +16998,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
+"Zn" = (
+/obj/machinery/door/airlock/mainship/maint/free_access,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "Zo" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -16777,6 +17065,9 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor/mainship,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/medical/medical_science)
 "Zw" = (
@@ -16797,6 +17088,11 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"Zy" = (
+/turf/open/floor/mainship/white{
+	dir = 4
+	},
+/area/mainship/living/pilotbunks)
 "Zz" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor/mainship,
@@ -37394,11 +37690,11 @@ pI
 VL
 oi
 bZ
-bZ
-bZ
+aD
+EN
 kY
 kY
-bZ
+FT
 ad
 Fv
 Md
@@ -37645,7 +37941,7 @@ Tm
 Zg
 hh
 Ih
-Ih
+ec
 Kw
 Dz
 xl
@@ -37655,7 +37951,7 @@ ej
 ej
 ej
 bZ
-ej
+dt
 ad
 Nm
 eV
@@ -37902,7 +38198,7 @@ Tm
 Zg
 IO
 Zb
-Ih
+af
 Kw
 Ea
 LS
@@ -37912,7 +38208,7 @@ LS
 LS
 LS
 bZ
-LS
+dQ
 ad
 BW
 HP
@@ -38159,7 +38455,7 @@ Tm
 Zg
 YW
 Zb
-Ih
+af
 Kw
 ES
 bZ
@@ -38169,7 +38465,7 @@ ej
 ej
 ej
 bZ
-ej
+dt
 ad
 jw
 EW
@@ -38416,17 +38712,17 @@ Tm
 Zg
 IO
 Zb
-Ih
+af
 Kw
 Iv
 bZ
 Gk
 LS
-bZ
-bZ
-bZ
-bZ
-Gk
+Cy
+uE
+uE
+uE
+iN
 ad
 Wj
 bZ
@@ -38673,7 +38969,7 @@ rc
 Zg
 qf
 KS
-Ih
+af
 Kw
 JM
 RC
@@ -38683,7 +38979,7 @@ oB
 TF
 bZ
 La
-bZ
+bH
 ad
 bE
 bZ
@@ -38695,7 +38991,7 @@ xR
 Lc
 DY
 fi
-oo
+cU
 lW
 ad
 LW
@@ -38940,7 +39236,7 @@ ad
 ad
 ad
 ad
-dJ
+Zn
 ad
 ad
 dJ
@@ -39189,23 +39485,23 @@ fX
 fX
 os
 YM
-ql
-Tg
+IN
+iz
 hx
-Tg
-Tg
-El
-Tg
-Tg
-Fl
-Tg
-Tg
-El
-Tg
-Tg
-Tg
-ql
-Tg
+iz
+iz
+cC
+iz
+iz
+aE
+iz
+iz
+RH
+iz
+iz
+iz
+iD
+iz
 iq
 Nw
 fL
@@ -39703,7 +39999,7 @@ Nt
 ni
 ZX
 oh
-MF
+rb
 IZ
 rn
 dH
@@ -39718,7 +40014,7 @@ ng
 Io
 GS
 hE
-Fu
+lj
 Mb
 CM
 bZ
@@ -40232,7 +40528,7 @@ mq
 En
 oz
 oz
-KW
+nS
 Mb
 Zo
 cI
@@ -40486,10 +40782,10 @@ XU
 im
 Cx
 GE
-KW
-KW
-KW
-KW
+ez
+ez
+ez
+co
 Mb
 CX
 Mb
@@ -42583,7 +42879,7 @@ PS
 Mb
 uX
 lv
-ao
+fL
 JF
 fL
 cu
@@ -42839,7 +43135,7 @@ SA
 He
 sJ
 Im
-Gk
+bZ
 uk
 OP
 WX
@@ -44337,11 +44633,11 @@ li
 MP
 fF
 Ft
+FD
 gL
 gL
 gL
-gL
-gL
+FD
 gL
 gL
 gL
@@ -45926,7 +46222,7 @@ SA
 Vu
 SA
 OL
-yP
+de
 Qp
 zj
 OL
@@ -51780,7 +52076,7 @@ XY
 DT
 ME
 GK
-pX
+Zy
 ox
 fj
 CK
@@ -52292,7 +52588,7 @@ Ra
 Br
 Ws
 DW
-ox
+Bm
 Ws
 Ra
 Br
@@ -52549,7 +52845,7 @@ Hn
 uN
 Ws
 nG
-pX
+YE
 Ws
 Hn
 uN

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -513,6 +513,7 @@
 /area/mainship/hallways/hangar)
 "bW" = (
 /obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/hull/lower_hull)
 "bX" = (
@@ -744,12 +745,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
-"cH" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
 "cI" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -1672,7 +1667,6 @@
 /obj/machinery/door/airlock/multi_tile/mainship/maint{
 	dir = 1
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/hull/lower_hull)
 "fQ" = (
@@ -2151,6 +2145,20 @@
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
+"hD" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
+"hE" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "hF" = (
 /obj/machinery/vending/cigarette,
 /obj/item/coin/iron,
@@ -2368,18 +2376,6 @@
 /obj/item/book/manual/chef_recipes,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
-"in" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 1
-	},
-/area/mainship/medical/medical_science)
 "io" = (
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/mono,
@@ -2636,6 +2632,14 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"ji" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "jj" = (
 /obj/machinery/marine_selector/gear/medic,
 /turf/open/floor/mainship,
@@ -3155,6 +3159,14 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"kW" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "kX" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -8465,14 +8477,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"BA" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
 "BD" = (
 /obj/machinery/door/poddoor/shutters/mainship/cell,
 /obj/machinery/door/airlock/mainship/research/glass/cell,
@@ -12702,14 +12706,6 @@
 	dir = 1
 	},
 /area/mainship/squads/general)
-"Ns" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/medical/lower_medical)
 "Nt" = (
 /turf/closed/wall/mainship/research/containment/wall/west,
 /area/mainship/medical/medical_science)
@@ -15342,6 +15338,18 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
+"Vq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 1
+	},
+/area/mainship/medical/medical_science)
 "Vr" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -16399,14 +16407,6 @@
 	},
 /turf/open/floor/mainship_hull,
 /area/space)
-"Yq" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/lower_medical)
 "Yr" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mainship,
@@ -39717,7 +39717,7 @@ LR
 ng
 Io
 GS
-cH
+hE
 Fu
 Mb
 CM
@@ -40734,7 +40734,7 @@ ZX
 ZX
 Ul
 ZX
-in
+Vq
 RI
 ZX
 ZX
@@ -41749,7 +41749,7 @@ rc
 ad
 cu
 Mb
-ao
+fL
 fL
 YT
 qo
@@ -41757,7 +41757,7 @@ Qw
 Of
 YT
 kc
-Ns
+ji
 ei
 mg
 VJ
@@ -42539,7 +42539,7 @@ ND
 Ct
 bd
 XU
-cH
+hE
 pd
 BK
 QM
@@ -43048,7 +43048,7 @@ BO
 JK
 XI
 eC
-BA
+hD
 Tc
 Uh
 bd
@@ -43819,7 +43819,7 @@ MP
 Fb
 VQ
 bd
-Yq
+kW
 aY
 JH
 bd
@@ -44839,7 +44839,7 @@ pZ
 hH
 eH
 hH
-BA
+hD
 gw
 aY
 Zs

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -390,15 +390,14 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "bs" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/multi_tile/mainship/maint/free_access{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/machinery/door/airlock/multi_tile/mainship/maint/free_access{
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
@@ -9753,7 +9752,6 @@
 /obj/structure/barricade/metal{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
@@ -13204,9 +13202,6 @@
 /area/mainship/hallways/hangar)
 "Nw" = (
 /obj/structure/cable,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
@@ -39588,7 +39583,7 @@ ad
 ad
 ad
 ad
-bZ
+fL
 bs
 ad
 ad

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -173,10 +173,9 @@
 	},
 /area/mainship/hallways/hangar)
 "aG" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 8
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/mainship/living/cryo_cells)
 "aH" = (
@@ -389,6 +388,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"bq" = (
+/obj/machinery/line_nexter,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/mainship/hull/lower_hull)
 "br" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -403,13 +408,9 @@
 /area/mainship/hallways/hangar)
 "bt" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/effect/ai_node,
+/obj/structure/disposalpipe/segment/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "bv" = (
@@ -450,21 +451,19 @@
 /obj/effect/attach_point/electronics/dropship1,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
-"bC" = (
-/obj/structure/bed/chair/wood/normal{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
 "bD" = (
 /obj/structure/cable,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
+"bE" = (
+/obj/machinery/vending/hydroseeds,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "bF" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -548,20 +547,26 @@
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "bV" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"bW" = (
+/obj/structure/sign/poster{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "bX" = (
-/obj/effect/decal/siding{
-	dir = 9
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
 	},
-/turf/open/floor/mainship/terragov/east{
-	dir = 9
-	},
-/area/space)
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "bY" = (
 /obj/structure/prop/mainship/hangar_stencil,
 /obj/effect/decal/warning_stripes/thin{
@@ -692,8 +697,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "ct" = (
-/obj/machinery/door/airlock/mainship/maint,
 /obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "cu" = (
@@ -718,13 +725,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "cy" = (
-/obj/effect/decal/siding{
-	dir = 1
-	},
-/turf/open/floor/mainship/terragov/east{
-	dir = 1
-	},
-/area/space)
+/turf/open/floor/mainship/floor,
+/area/mainship/hull/lower_hull)
 "cz" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile,
@@ -831,19 +833,25 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "cP" = (
-/obj/structure/barricade/metal{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
+"cQ" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"cQ" = (
-/obj/effect/decal/siding{
-	dir = 5
-	},
-/turf/open/floor/mainship/terragov/east{
-	dir = 5
-	},
-/area/space)
 "cR" = (
 /obj/effect/attach_point/weapon/dropship1{
 	dir = 8;
@@ -939,10 +947,9 @@
 /turf/open/floor/mainship/black/full,
 /area/mainship/command/self_destruct)
 "di" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 8
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/mainship/hull/lower_hull)
 "dj" = (
@@ -1031,6 +1038,12 @@
 	dir = 5
 	},
 /area/mainship/squads/general)
+"du" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "dv" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -1041,6 +1054,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"dx" = (
+/obj/machinery/grill/unwrenched,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "dy" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/side{
@@ -1128,7 +1145,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "dK" = (
-/obj/machinery/grill/unwrenched,
+/obj/item/reagent_containers/glass/fertilizer/ez,
+/obj/item/reagent_containers/glass/fertilizer/ez,
+/obj/item/tool/minihoe,
+/obj/item/tool/minihoe,
+/obj/item/tool/plantspray/weeds,
+/obj/item/tool/plantspray/weeds,
+/obj/structure/closet/crate/freezer,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "dL" = (
@@ -1154,9 +1177,8 @@
 	},
 /area/mainship/hallways/hangar)
 "dO" = (
-/obj/structure/bed/chair/comfy{
-	dir = 1
-	},
+/obj/structure/table/mainship,
+/obj/machinery/computer/emails,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "dP" = (
@@ -1205,7 +1227,6 @@
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 2
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "dX" = (
@@ -1271,6 +1292,16 @@
 "eh" = (
 /turf/open/floor/mainship/empty,
 /area/mainship/squads/req)
+"ei" = (
+/obj/structure/sign/poster,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
+"ej" = (
+/obj/structure/barricade/metal{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "ek" = (
 /obj/structure/table/mainship,
 /obj/item/camera,
@@ -1383,13 +1414,23 @@
 	dir = 9
 	},
 /area/mainship/command/self_destruct)
+"eF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "eG" = (
 /turf/open/floor/mainship/black{
 	dir = 1
 	},
 /area/mainship/command/self_destruct)
 "eH" = (
-/obj/machinery/light,
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "eI" = (
@@ -1479,6 +1520,13 @@
 	},
 /turf/closed/wall/mainship,
 /area/mainship/hallways/hangar)
+"eV" = (
+/obj/item/newspaper{
+	pixel_x = -10;
+	pixel_y = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "eW" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1613,13 +1661,10 @@
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "ft" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "fu" = (
 /obj/structure/disposalpipe/segment,
@@ -1627,12 +1672,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "fv" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
 	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/obj/machinery/door/airlock/multi_tile/mainship/generic/rnr,
+/obj/structure/cable,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "fw" = (
 /obj/structure/cable,
@@ -1741,11 +1786,13 @@
 /area/mainship/medical/lower_medical)
 "fP" = (
 /obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "fQ" = (
 /obj/structure/dropship_equipment/sentry_holder,
 /turf/open/floor/mainship/orange{
@@ -2098,13 +2145,16 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "gX" = (
-/obj/effect/decal/siding{
-	dir = 8
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/mainship/terragov/east{
-	dir = 8
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
 	},
-/area/space)
+/turf/open/floor/mainship/floor,
+/area/mainship/hull/lower_hull)
 "gY" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -2183,8 +2233,12 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/command/self_destruct)
 "hh" = (
-/turf/open/floor/wood,
-/area/mainship/hull/lower_hull)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "hi" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -2247,6 +2301,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"hv" = (
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
+	},
+/turf/open/floor/plating/mainship,
+/area/mainship/living/bridgebunks)
 "hw" = (
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
@@ -2413,13 +2473,6 @@
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/surgery_hallway)
-"ig" = (
-/obj/structure/closet/boxinggloves,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
 "ii" = (
 /obj/structure/flora/pottedplant/twentyone,
 /turf/open/floor/mainship/black,
@@ -2435,10 +2488,12 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "in" = (
-/turf/open/floor/mainship/terragov{
-	dir = 4
+/obj/structure/window/framed/mainship,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
 	},
-/area/space)
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "io" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
@@ -2679,6 +2734,13 @@
 /obj/item/storage/firstaid/adv,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"ja" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "jb" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
@@ -2774,13 +2836,12 @@
 	},
 /area/mainship/command/cic)
 "jr" = (
-/obj/effect/decal/siding{
-	dir = 4
+/obj/structure/table/mainship,
+/obj/machinery/reagentgrinder{
+	pixel_y = 5
 	},
-/turf/open/floor/mainship/terragov/east{
-	dir = 4
-	},
-/area/space)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "js" = (
 /obj/effect/landmark/start/job/squadleader,
 /turf/open/floor/mainship,
@@ -2858,6 +2919,14 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
+"jK" = (
+/obj/effect/decal/siding{
+	dir = 6
+	},
+/turf/open/floor/mainship/terragov/east{
+	dir = 6
+	},
+/area/space)
 "jL" = (
 /obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/door/firedoor/mainship,
@@ -2870,6 +2939,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/structure/sign/double/barsign,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "jN" = (
@@ -3070,11 +3140,6 @@
 	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
-"kx" = (
-/obj/structure/table/mainship,
-/obj/machinery/chem_dispenser/beer,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
 "kz" = (
 /obj/structure/rack,
 /obj/structure/ob_ammo/warhead/incendiary,
@@ -3099,6 +3164,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/bed/chair/wood/normal,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "kD" = (
@@ -3203,6 +3269,12 @@
 	dir = 4
 	},
 /area/mainship/squads/general)
+"kT" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "kU" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -3223,6 +3295,12 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/command/cic)
+"kY" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "kZ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner,
@@ -3449,14 +3527,10 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "lE" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
+/obj/structure/table/mainship,
+/obj/machinery/chem_dispenser/soda,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "lG" = (
 /turf/closed/wall/mainship,
 /area/mainship/command/telecomms)
@@ -3919,6 +3993,13 @@
 	dir = 10
 	},
 /area/mainship/squads/general)
+"ni" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "nj" = (
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 8
@@ -3980,11 +4061,16 @@
 /turf/open/floor/plating/icefloor/warnplate,
 /area/mainship/hallways/hangar)
 "nz" = (
-/obj/machinery/griddle,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/obj/structure/bed/chair/wood/normal{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "nA" = (
 /obj/structure/cable,
@@ -4001,9 +4087,15 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
 "nC" = (
-/obj/effect/decal/warning_stripes/thin,
-/turf/closed/wall/mainship,
-/area/mainship/hull/lower_hull)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/bed/stool,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "nD" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/medical_science)
@@ -4019,15 +4111,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
-"nH" = (
-/obj/structure/table/mainship,
-/obj/machinery/microwave,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
 "nI" = (
 /obj/machinery/optable,
 /obj/item/tank/anesthetic,
@@ -4081,10 +4164,8 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/engineering/lower_engineering)
 "nN" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/table/mainship,
+/obj/machinery/chem_dispenser/beer,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "nO" = (
@@ -4200,12 +4281,22 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "oh" = (
-/obj/item/paper/crumpled,
-/obj/item/paper/crumpled{
-	pixel_x = -4;
-	pixel_y = 8
+/obj/structure/table/mainship,
+/obj/item/clipboard{
+	pixel_x = 5
 	},
+/obj/structure/paper_bin{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/tool/pen,
 /turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
+"oi" = (
+/obj/structure/barricade/metal{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "oj" = (
 /obj/structure/disposalpipe/segment,
@@ -4256,30 +4347,28 @@
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
 "ou" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/head/chefhat,
+/obj/item/clothing/suit/chef/classic,
+/obj/item/tool/kitchen/rollingpin,
+/obj/item/book/manual/chef_recipes,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "ov" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/shuttle/shuttle_control/dropship/two,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "ow" = (
-/obj/machinery/door/airlock/mainship/maint,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/mainship,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/power/apc/mainship{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/area/mainship/living/grunt_rnr)
 "ox" = (
 /obj/machinery/light,
 /turf/open/floor/mainship/floor,
@@ -4296,9 +4385,12 @@
 	},
 /area/mainship/squads/general)
 "oA" = (
-/obj/structure/sign/double/barsign,
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/area/mainship/living/grunt_rnr)
 "oB" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/mono,
@@ -4559,11 +4651,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "pt" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/machinery/door/airlock/multi_tile/mainship/generic/rnr,
-/turf/open/floor/mainship/floor,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "pw" = (
 /obj/machinery/door/poddoor/railing{
@@ -4629,6 +4718,13 @@
 	dir = 8
 	},
 /area/mainship/shipboard/firing_range)
+"pI" = (
+/obj/structure/closet/boxinggloves,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "pJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -4742,18 +4838,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "qo" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/bed/chair/sofa/right,
-/obj/item/bedsheet/ce{
-	pixel_x = 6
-	},
+/obj/structure/cable,
 /obj/structure/sign/poster{
 	dir = 1
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/area/mainship/living/grunt_rnr)
 "qp" = (
 /obj/machinery/light{
 	dir = 4
@@ -5020,9 +5110,8 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "ru" = (
-/obj/structure/table/mainship,
-/obj/machinery/reagentgrinder{
-	pixel_y = 5
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
@@ -5077,13 +5166,14 @@
 	},
 /area/mainship/shipboard/firing_range)
 "rD" = (
-/obj/effect/decal/siding{
-	dir = 10
+/obj/machinery/processor{
+	pixel_y = 5
 	},
-/turf/open/floor/mainship/terragov/east{
-	dir = 10
+/obj/machinery/light{
+	dir = 8
 	},
-/area/space)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "rE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -5104,6 +5194,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
+"rH" = (
+/obj/effect/decal/siding{
+	dir = 10
+	},
+/turf/open/floor/mainship/terragov/east{
+	dir = 10
+	},
+/area/space)
 "rI" = (
 /obj/item/clothing/head/warning_cone,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -5173,9 +5271,8 @@
 /turf/open/floor/plating,
 /area/mainship/command/telecomms)
 "rT" = (
-/obj/structure/table/mainship,
-/obj/machinery/chem_dispenser/soda,
-/turf/open/floor/mainship/mono,
+/obj/structure/bed/chair/wood/normal,
+/turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "rW" = (
 /obj/structure/cable,
@@ -5404,6 +5501,10 @@
 /obj/item/storage/donut_box,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
+"sD" = (
+/obj/structure/musician/piano,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "sE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -6016,11 +6117,9 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/weapon_room)
 "uo" = (
-/obj/structure/barricade/metal{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/obj/machinery/griddle,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/grunt_rnr)
 "up" = (
 /obj/structure/prop/mainship/cannon_cables,
 /turf/open/floor/plating/mainship,
@@ -6257,12 +6356,10 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/shipboard/weapon_room)
 "vg" = (
-/obj/structure/table/mainship,
-/obj/item/tool/kitchen/tray,
-/obj/item/tool/kitchen/knife,
-/obj/item/storage/box/tgmc_mre,
-/obj/item/book/manual/chef_recipes,
-/turf/open/floor/mainship/mono,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "vh" = (
 /obj/structure/bed,
@@ -6550,10 +6647,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "wa" = (
-/obj/machinery/power/apc/mainship{
-	dir = 4
+/obj/structure/table/mainship,
+/obj/machinery/microwave,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "wc" = (
@@ -6594,9 +6693,11 @@
 	},
 /area/mainship/hallways/hangar)
 "wh" = (
-/obj/effect/decal/siding,
-/turf/open/floor/mainship/terragov/east,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "wi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -6663,13 +6764,9 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "wq" = (
-/obj/effect/decal/siding{
-	dir = 6
-	},
-/turf/open/floor/mainship/terragov/east{
-	dir = 6
-	},
-/area/space)
+/obj/effect/decal/warning_stripes/thin,
+/turf/closed/wall/mainship,
+/area/mainship/hull/lower_hull)
 "wr" = (
 /turf/closed/wall/mainship,
 /area/mainship/hallways/aft_hallway)
@@ -6826,9 +6923,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
 "wM" = (
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "wN" = (
 /obj/structure/window/framed/mainship/white,
 /turf/open/floor/mainship/sterile/dark,
@@ -6999,6 +7101,10 @@
 	dir = 8
 	},
 /area/mainship/squads/general)
+"xl" = (
+/obj/structure/barricade/metal,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "xm" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -7218,7 +7324,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "xS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
@@ -7326,10 +7432,10 @@
 /turf/open/floor/engine,
 /area/mainship/engineering/port_atmos)
 "yi" = (
-/obj/structure/barricade/metal{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "yj" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -7639,6 +7745,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
+"za" = (
+/obj/machinery/light{
+	light_color = "#da2f1b"
+	},
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "zb" = (
 /obj/machinery/alarm,
 /turf/open/floor/mainship/mono,
@@ -7915,17 +8027,14 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/engineering/engineering_workshop)
 "zZ" = (
-/obj/structure/table/mainship,
-/obj/item/clipboard{
-	pixel_x = 5
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/structure/paper_bin{
-	pixel_x = 7;
-	pixel_y = 6
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/item/tool/pen,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "Aa" = (
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 4
@@ -8137,6 +8246,9 @@
 /obj/machinery/body_scanconsole,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
+"AL" = (
+/turf/open/floor/wood,
+/area/mainship/hull/lower_hull)
 "AM" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -8203,15 +8315,6 @@
 "AV" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/pilotbunks)
-"AW" = (
-/obj/machinery/processor{
-	pixel_y = 5
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
 "AX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -8273,7 +8376,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "Bi" = (
-/obj/machinery/door/airlock/mainship/maint,
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/plating/mainship,
 /area/mainship/living/bridgebunks)
@@ -8316,9 +8418,15 @@
 /area/mainship/engineering/engine_core)
 "Bn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+	dir = 4
 	},
-/turf/open/floor/prison/kitchen,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/table/mainship,
+/obj/item/storage/box/matches,
+/obj/item/storage/fancy/cigar,
+/turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "Bo" = (
 /obj/machinery/light{
@@ -8386,14 +8494,16 @@
 	},
 /area/mainship/squads/general)
 "Bx" = (
-/obj/structure/bed/stool,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/obj/structure/bed/chair/wood/normal{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "Bz" = (
 /obj/structure/disposalpipe/segment,
@@ -8401,9 +8511,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "BB" = (
-/obj/structure/bed/chair/wood/normal{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -8411,14 +8518,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/table/mainship,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "BD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/table/mainship,
-/obj/machinery/computer/emails,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/glass/rag,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/grunt_rnr)
 "BF" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -8606,9 +8721,13 @@
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "BX" = (
-/obj/structure/bed/chair/wood/wings,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
+/obj/effect/decal/siding{
+	dir = 9
+	},
+/turf/open/floor/mainship/terragov/east{
+	dir = 9
+	},
+/area/space)
 "BY" = (
 /turf/open/floor/mainship/black{
 	dir = 9
@@ -8908,8 +9027,12 @@
 /area/mainship/hallways/hangar)
 "CR" = (
 /obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/obj/structure/bed/chair/wood/normal{
 	dir = 1
 	},
+/obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "CS" = (
@@ -9129,6 +9252,10 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/command/cic)
+"Dw" = (
+/obj/structure/bed/chair/sofa/left,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "Dy" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -9143,6 +9270,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
+"Dz" = (
+/obj/structure/bed/chair/wood/wings,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "DA" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -9381,12 +9512,6 @@
 	dir = 1
 	},
 /area/mainship/medical/lower_medical)
-"Ea" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/prison/kitchen,
-/area/mainship/living/grunt_rnr)
 "Eb" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/mainship/sterile/side{
@@ -9435,10 +9560,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_umbilical)
 "Ej" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 8
-	},
-/obj/machinery/door/airlock/mainship/maint,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -9586,10 +9707,8 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "EG" = (
-/obj/structure/bed/chair/wood/normal{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/table/mainship,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "EH" = (
@@ -9601,7 +9720,9 @@
 	},
 /area/mainship/medical/surgery_hallway)
 "EI" = (
-/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
 "EJ" = (
@@ -9633,13 +9754,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
-"EP" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
 "EQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9742,24 +9856,30 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/airoom)
 "Fo" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/door/airlock/mainship/maint,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/mainship,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Fp" = (
 /obj/structure/closet/secure_closet/medical3,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/medical_science)
+"Fq" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "Fr" = (
 /obj/machinery/telecomms/receiver/preset_right,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "Fv" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/paper/crumpled{
-	pixel_x = -4;
-	pixel_y = 8
+/obj/structure/bed/chair/comfy{
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
@@ -10186,6 +10306,9 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
+"GL" = (
+/turf/open/floor/plating,
+/area/mainship/living/cryo_cells)
 "GM" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -10689,12 +10812,9 @@
 /obj/effect/landmark/start/job/ai,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
-"Ig" = (
-/obj/machinery/door/airlock/mainship/maint,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/mainship,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+"Ih" = (
+/obj/structure/sink,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "Ii" = (
 /obj/structure/cable,
@@ -10808,10 +10928,7 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "Iv" = (
-/obj/machinery/vending/hydroseeds,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/vending/hydronutrients,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Iw" = (
@@ -10903,8 +11020,13 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "IJ" = (
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/obj/effect/decal/siding{
+	dir = 1
+	},
+/turf/open/floor/mainship/terragov/east{
+	dir = 1
+	},
+/area/space)
 "IL" = (
 /obj/structure/table/mainship,
 /obj/machinery/recharger,
@@ -10914,25 +11036,22 @@
 /turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/lower_medical)
 "IM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 1;
-	on = 1
-	},
-/turf/open/floor/prison/kitchen,
+/obj/structure/table/mainship,
+/turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "IN" = (
-/obj/structure/table/mainship,
-/obj/item/clothing/suit/chef/classic,
-/obj/item/tool/kitchen/rollingpin,
-/obj/item/clothing/head/chefhat,
-/obj/item/clothing/gloves/latex,
-/obj/item/reagent_containers/food/drinks/shaker,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/obj/effect/decal/siding{
+	dir = 5
+	},
+/turf/open/floor/mainship/terragov/east{
+	dir = 5
+	},
+/area/space)
 "IO" = (
-/obj/structure/sink,
-/turf/open/floor/prison/kitchen,
-/area/mainship/living/grunt_rnr)
+/obj/structure/janitorialcart,
+/obj/item/tool/mop,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "IQ" = (
 /obj/machinery/firealarm{
 	dir = 4
@@ -11418,7 +11537,7 @@
 /area/mainship/hull/lower_hull)
 "Kj" = (
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "Kk" = (
 /obj/structure/closet/crate,
@@ -11534,12 +11653,8 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "Kw" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/obj/structure/sign/custodian,
+/turf/closed/wall/mainship/outer,
 /area/mainship/hull/lower_hull)
 "Kx" = (
 /obj/structure/cable,
@@ -11710,6 +11825,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
+"KS" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "KT" = (
 /obj/effect/landmark/start/job/squadmarine,
 /obj/structure/cable,
@@ -11750,6 +11871,12 @@
 	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
+"La" = (
+/obj/structure/bed/chair/wood/wings{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "Lb" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/command/self_destruct)
@@ -11917,13 +12044,6 @@
 /obj/effect/landmark/start/latejoin,
 /turf/open/floor/mainship,
 /area/mainship/living/cryo_cells)
-"LI" = (
-/obj/structure/window/framed/mainship,
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/mainship/living/grunt_rnr)
 "LJ" = (
 /obj/structure/window/framed/mainship,
 /obj/machinery/door/poddoor/shutters/mainship/corporate,
@@ -11932,6 +12052,10 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/command/corporateliaison)
+"LK" = (
+/obj/effect/decal/siding,
+/turf/open/floor/mainship/terragov/east,
+/area/space)
 "LL" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/cargo/arrow{
@@ -11977,6 +12101,12 @@
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /turf/open/floor/wood,
 /area/mainship/medical/surgery_hallway)
+"LS" = (
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "LT" = (
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/mainship/tcomms,
@@ -12039,6 +12169,16 @@
 	dir = 5
 	},
 /area/mainship/squads/general)
+"Md" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/paper/crumpled{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "Me" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/med_data/laptop,
@@ -12198,8 +12338,10 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
 "MF" = (
-/obj/structure/bed/stool,
-/turf/open/floor/mainship/mono,
+/obj/structure/bed/chair/wood/normal{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "MG" = (
 /obj/structure/table/mainship,
@@ -12415,8 +12557,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "Nm" = (
-/obj/item/newspaper{
-	pixel_x = -10;
+/obj/item/paper/crumpled,
+/obj/item/paper/crumpled{
+	pixel_x = -4;
 	pixel_y = 8
 	},
 /turf/open/floor/mainship/mono,
@@ -12460,12 +12603,19 @@
 	dir = 1
 	},
 /area/mainship/squads/general)
-"Nt" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+"Ns" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket/janibucket,
+/obj/item/tool/wet_sign,
+/obj/item/tool/wet_sign,
+/obj/item/tool/wet_sign,
+/obj/item/storage/bag/trash,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"Nt" = (
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "Nu" = (
 /obj/effect/landmark/start/job/squadengineer,
 /obj/machinery/camera/autoname/mainship{
@@ -12700,13 +12850,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "Of" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/prison/kitchen,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/table/mainship,
+/turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "Og" = (
 /obj/structure/table/reinforced,
@@ -12778,12 +12929,21 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"Oo" = (
+/turf/open/floor/plating,
+/area/mainship/hull/lower_hull)
 "Op" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
 /turf/open/shuttle/escapepod/five,
 /area/mainship/command/self_destruct)
+"Oq" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "Or" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 2
@@ -12816,7 +12976,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "Ow" = (
-/turf/open/floor/prison/kitchen,
+/obj/structure/bed/chair/wood/normal{
+	dir = 1
+	},
+/turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "Ox" = (
 /turf/closed/wall/mainship,
@@ -13305,12 +13468,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "PY" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/structure/sink{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "PZ" = (
 /turf/open/floor/mainship/research/containment/floor2{
 	dir = 9
@@ -13635,15 +13797,12 @@
 /turf/closed/wall/mainship,
 /area/mainship/command/self_destruct)
 "QQ" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 1;
+	on = 1
 	},
-/obj/structure/bed/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/grass,
-/area/mainship/living/cafeteria_starboard)
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "QR" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -13886,6 +14045,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
+"RC" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "RE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -14276,12 +14441,8 @@
 	},
 /area/mainship/hallways/starboard_hallway)
 "ST" = (
-/obj/item/tool/mop,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/area/mainship/living/grunt_rnr)
 "SU" = (
 /obj/machinery/vending/snack,
 /obj/item/coin/iron,
@@ -14456,9 +14617,9 @@
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "TB" = (
-/obj/structure/janitorialcart,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/obj/structure/sink,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "TC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -14475,9 +14636,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "TD" = (
-/obj/structure/bed/chair/sofa/left,
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/food/snacks/cheeseburger,
 /turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/area/mainship/living/grunt_rnr)
 "TE" = (
 /obj/machinery/optable,
 /obj/item/tank/anesthetic,
@@ -14547,6 +14709,13 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
+"TV" = (
+/obj/structure/table/mainship,
+/obj/item/tool/kitchen/tray,
+/obj/item/tool/kitchen/knife,
+/obj/item/storage/box/tgmc_mre,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "TW" = (
 /obj/machinery/smartfridge/chemistry,
 /obj/machinery/door/firedoor/mainship,
@@ -14556,6 +14725,12 @@
 /obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"TY" = (
+/obj/machinery/light{
+	light_color = "#da2f1b"
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "TZ" = (
 /obj/machinery/light,
 /turf/open/floor/mainship/sterile/side,
@@ -14927,14 +15102,8 @@
 /turf/open/floor/plating,
 /area/mainship/squads/req)
 "Ve" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/glass/bucket/janibucket,
-/obj/item/tool/wet_sign,
-/obj/item/tool/wet_sign,
-/obj/item/tool/wet_sign,
-/obj/item/storage/bag/trash,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "Vf" = (
 /obj/effect/landmark/start/job/squadcorpsman,
 /turf/open/floor/mainship,
@@ -15520,6 +15689,12 @@
 	icon_state = "warnplatecorner"
 	},
 /area/mainship/hallways/hangar)
+"Xb" = (
+/obj/machinery/door/airlock/mainship/generic{
+	name = "Kitchen"
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "Xc" = (
 /obj/machinery/light{
 	dir = 1
@@ -15529,11 +15704,9 @@
 	},
 /area/mainship/squads/general)
 "Xe" = (
-/obj/machinery/line_nexter,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
-/area/mainship/hull/lower_hull)
+/obj/structure/bed/stool,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "Xf" = (
 /obj/structure/table/mainship,
 /turf/open/floor/mainship,
@@ -15573,6 +15746,16 @@
 	dir = 4
 	},
 /area/mainship/medical/lower_medical)
+"Xl" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/bed/chair/sofa/right,
+/obj/item/bedsheet/ce{
+	pixel_x = 6
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "Xn" = (
 /obj/machinery/light{
 	dir = 1
@@ -15746,10 +15929,8 @@
 	},
 /area/mainship/squads/general)
 "XI" = (
-/obj/machinery/door/airlock/mainship/generic{
-	name = "Kitchen"
-	},
-/turf/open/floor/mainship/mono,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "XJ" = (
 /obj/effect/decal/warning_stripes/thin,
@@ -15862,9 +16043,13 @@
 	},
 /area/mainship/squads/general)
 "XX" = (
-/obj/structure/window/framed/mainship/hull,
-/turf/open/space/basic,
-/area/mainship/hull/lower_hull)
+/obj/effect/decal/siding{
+	dir = 8
+	},
+/turf/open/floor/mainship/terragov/east{
+	dir = 8
+	},
+/area/space)
 "XY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/vending/weapon,
@@ -16102,14 +16287,13 @@
 /area/mainship/hallways/hangar)
 "YM" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "YN" = (
 /obj/effect/ai_node,
@@ -16164,15 +16348,10 @@
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/surgery_hallway)
 "YW" = (
-/obj/item/reagent_containers/glass/fertilizer/ez,
-/obj/item/reagent_containers/glass/fertilizer/ez,
-/obj/item/tool/minihoe,
-/obj/item/tool/minihoe,
-/obj/item/tool/plantspray/weeds,
-/obj/item/tool/plantspray/weeds,
-/obj/structure/closet/crate/freezer,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/turf/open/floor/mainship/terragov{
+	dir = 4
+	},
+/area/space)
 "YX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -16205,9 +16384,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "Zb" = (
-/obj/structure/barricade/metal,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
+/obj/effect/decal/siding{
+	dir = 4
+	},
+/turf/open/floor/mainship/terragov/east{
+	dir = 4
+	},
+/area/space)
 "Zc" = (
 /obj/effect/landmark/start/job/squadleader,
 /obj/effect/landmark/start/latejoin,
@@ -16461,6 +16644,9 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/bed/stool{
 	pixel_y = 8
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/grass,
 /area/mainship/living/cafeteria_starboard)
@@ -36122,20 +36308,20 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
 fI
 fI
-fI
-fI
-fI
-fI
-fI
-aa
-aa
 tG
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
+Lw
 Lw
 Lw
 Lw
@@ -36379,20 +36565,20 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
 fI
 fI
-fI
-fI
-fI
-fI
-fI
-aa
-aa
 Tm
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
 rc
 rc
 rc
@@ -36636,34 +36822,34 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
-fI
-fI
-fI
-fI
-fI
-fI
-fI
 fI
 fI
 Tm
 rc
+rc
+rc
+rc
+ad
+ad
+ad
 Qc
 Qc
-XX
-ad
-XX
 Qc
 Qc
 ad
 ad
 ad
+Qc
+Qc
+ad
+Qc
+Qc
+Qc
 ad
 ad
-ad
+Qc
+Qc
+Qc
 ad
 ad
 ad
@@ -36893,36 +37079,36 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
-fI
-fI
-fI
-fI
-fI
-fI
-fI
 fI
 fI
 Tm
 rc
-Qc
-BD
+BX
+XX
+rH
+ad
+pI
+VL
+oi
+oi
+oi
+oi
+VL
+kY
+ad
 dO
 Fv
+Md
 bZ
 bZ
 bZ
-ad
-ig
-VL
 yi
 yi
+bZ
+bZ
+bZ
 yi
 yi
-VL
 ad
 fL
 gt
@@ -37150,36 +37336,36 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
-fI
-fI
-fI
-fI
-aa
-fI
-fI
 fI
 fI
 Tm
 rc
-Qc
-zZ
+IJ
+YW
+LK
+ad
+Dz
+xl
+AL
+AL
+AL
+AL
+ej
+La
+ad
 oh
 Nm
+eV
 VL
 EW
 EW
-ad
-BX
-Zb
-hh
-hh
-hh
-hh
-cP
+EW
+bZ
+EW
+EW
+EW
+bZ
+bZ
 ad
 LA
 LU
@@ -37407,36 +37593,36 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-fI
-fI
-fI
-fI
-aa
-fI
-fI
 fI
 fI
 Tm
 rc
-Qc
+IN
+Zb
+jK
+ad
+Dz
+xl
+AL
+AL
+AL
+AL
+ej
+La
+ad
+bW
+VL
+VL
+VL
+VL
+VL
+VL
 bZ
 VL
 VL
 VL
-VL
-eH
-ad
-BX
-Zb
-hh
-hh
-hh
-hh
-cP
+EW
+bZ
 ad
 gt
 LV
@@ -37661,39 +37847,39 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 fI
 fI
-fI
-fI
-aa
-aa
 aa
 fI
 fI
 Tm
-rc
+Mb
+Mb
+Mb
+Mb
 ad
-qo
+Dz
+xl
+AL
+AL
+AL
+AL
+ej
+La
+ad
+Xl
 bZ
 EW
 VL
 EW
 EW
-ad
-BX
-Zb
-hh
-hh
-hh
-hh
-cP
+EW
+bZ
+EW
+EW
+EW
+bZ
+bZ
 ad
 LW
 UQ
@@ -37918,39 +38104,39 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-fI
-fI
 fI
 fI
 aa
-aa
-aa
-aa
-aa
+fI
+fI
 Tm
-rc
-Qc
-TD
+Mb
+IO
+Ns
+Ih
+ad
+Dz
+xl
+AL
+AL
+AL
+AL
+ej
+La
+ad
+Dw
 bZ
 bZ
 VL
 bZ
 bZ
-ad
-BX
-Zb
-hh
-hh
-hh
-hh
-cP
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
 ad
 LW
 ta
@@ -38175,38 +38361,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 tG
 Lw
 Lw
 Lw
 Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
-Lw
 rc
-rc
-Qc
-wM
+Mb
+VL
+KS
+VL
+ad
+Dz
+RC
+bq
+LS
+LS
+bq
+RC
+La
+ad
 Iv
+bE
 bZ
 VL
-YW
 dK
-ad
-BX
-VL
-Xe
-uo
-uo
-Xe
+dx
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
 xR
 ad
 LW
@@ -38432,23 +38618,23 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 Tm
-bX
-gX
-rD
-rc
 ad
 ad
 ad
 ad
 ad
 ad
+Kw
+ad
+Oq
 ad
 ad
 ad
+rj
+ad
+ad
+rj
 ad
 ad
 ad
@@ -38689,25 +38875,25 @@ fI
 fI
 fI
 fI
-fI
-fI
-aa
 Tm
-cy
-in
-wh
-rc
 ad
-PY
+cQ
+IY
+IY
+IY
+IY
+IY
+IY
+IY
 YM
-XM
-XM
-Nt
-XM
-XM
-ws
-XM
-XM
+Tg
+Tg
+ql
+Tg
+Tg
+El
+Tg
+Tg
 dW
 Tg
 Tg
@@ -38946,17 +39132,17 @@ fI
 fI
 fI
 fI
-fI
-fI
-aa
 Tm
-cQ
-jr
-wq
-rc
 ad
+sN
+Mb
+Mb
+Mb
+wq
+Mb
+Mb
 Fo
-Zp
+Mb
 Zv
 Zv
 IV
@@ -38981,7 +39167,7 @@ bZ
 nJ
 Mb
 fL
-GM
+du
 Pf
 Hs
 Pj
@@ -39203,17 +39389,17 @@ fI
 fI
 fI
 fI
-fI
-fI
-aa
 Tm
-rc
-rc
-rc
-rc
 ad
+sN
+Mb
+jr
+rD
+wa
+Nt
+ni
 ST
-Zp
+YT
 Zv
 IZ
 Gy
@@ -39237,10 +39423,8 @@ bZ
 bZ
 Wy
 Mb
-Mb
-aL
-Mb
-Mb
+fL
+bX
 Mb
 Mb
 Mb
@@ -39251,7 +39435,9 @@ Mb
 Mb
 Mb
 Mb
-aL
+Mb
+bZ
+Fq
 Mb
 tp
 tp
@@ -39458,19 +39644,19 @@ aa
 fI
 fI
 fI
-fI
-fI
-fI
-fI
-aa
-Tm
-rc
-rc
-rc
+tG
+Lw
 rc
 ad
+sN
+Mb
+lE
+Ve
+wh
+PY
+Ve
 TB
-Zp
+YT
 Zv
 kr
 Gy
@@ -39715,19 +39901,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-tG
-Lw
-rc
-rc
-rc
+Tm
 rc
 rc
 ad
+sN
+Mb
+nN
 Ve
-Zp
+wM
+QQ
+Ve
+Ve
+YT
 Zv
 IZ
 Gy
@@ -39751,8 +39937,8 @@ aj
 Fh
 YI
 Mb
-CX
-Mb
+Zp
+bX
 Kb
 Kb
 cW
@@ -39764,7 +39950,7 @@ Kb
 Kb
 Kb
 Bi
-sV
+hv
 sV
 sV
 sV
@@ -39972,19 +40158,19 @@ aa
 aa
 aa
 aa
-tG
-Lw
-Lw
+Tm
+rc
 rc
 Mb
+sN
 Mb
-ad
-ad
-ad
-ad
-ad
-Mb
-Zp
+ou
+Ve
+zZ
+Ve
+Ve
+Ve
+YT
 Zv
 Vh
 Rj
@@ -40232,16 +40418,16 @@ aa
 Tm
 rc
 rc
-rc
 Mb
-lE
-Tg
-Tg
-Tg
-Tg
-Tg
-Tg
-Kw
+eH
+Mb
+YT
+uo
+BD
+TD
+TV
+Xb
+YT
 Zv
 Zv
 Zv
@@ -40489,16 +40675,16 @@ aa
 Tm
 rc
 rc
-rc
 Mb
 Zo
 Mb
-Mb
+ow
+ST
 nC
-Mb
-Mb
-Ig
-Mb
+Xe
+Xe
+ST
+sD
 Zv
 rb
 fU
@@ -40747,15 +40933,15 @@ Mb
 Mb
 Mb
 Mb
-Mb
 Zo
-YT
-ru
-AW
-nH
-nN
-IJ
-YT
+Mb
+pt
+lQ
+Bx
+MF
+lQ
+lQ
+kT
 Zv
 mt
 ji
@@ -41004,15 +41190,15 @@ Mb
 oX
 cu
 cu
-cu
-ou
-YT
+fP
+Mb
+oA
 rT
 Bn
-Ea
+IM
 Ow
-IO
-YT
+lQ
+TY
 Zv
 hj
 hD
@@ -41260,16 +41446,16 @@ rc
 Mb
 cu
 Mb
+cy
+gX
 Mb
-Mb
-ow
-YT
-kx
+qo
+rT
 Of
 IM
 Ow
-Ow
-YT
+lQ
+ei
 Zv
 Zv
 Zv
@@ -41518,15 +41704,15 @@ ad
 cu
 Mb
 ap
-ap
-fP
-YT
-YT
+hh
+az
+pt
+lQ
 nz
-IN
+Ed
 vg
 XI
-YT
+ja
 Zv
 Ze
 fX
@@ -41775,13 +41961,13 @@ fq
 pr
 Mb
 ap
-ap
+hh
 fv
 pt
-wa
+lQ
 Bx
 MF
-MF
+eF
 Kj
 YT
 Zv
@@ -42031,7 +42217,7 @@ az
 az
 az
 az
-ap
+cP
 bt
 bV
 ft
@@ -42290,12 +42476,12 @@ bw
 DX
 ap
 YS
-ap
-LI
-lQ
+in
+ST
+rT
 Cy
 EN
-EP
+Ow
 YT
 Zr
 Zv
@@ -42547,12 +42733,12 @@ ap
 ca
 fS
 YS
-ap
-LI
+in
+ST
 lQ
 Ed
 Ed
-lQ
+za
 YT
 bd
 LN
@@ -42804,10 +42990,10 @@ gf
 WB
 je
 jM
-oA
-YT
+az
+ru
 bl
-bC
+Ow
 bS
 cf
 YT
@@ -43061,7 +43247,7 @@ ZA
 Zd
 Yf
 YS
-ap
+az
 YT
 YT
 YT
@@ -51014,7 +51200,7 @@ JF
 dD
 az
 az
-az
+ap
 ct
 az
 az
@@ -51022,8 +51208,8 @@ az
 az
 az
 az
-Mb
-aL
+bZ
+bX
 Mb
 Mb
 lo
@@ -53081,7 +53267,7 @@ aa
 aa
 Ti
 jO
-jO
+rc
 rc
 rc
 rc
@@ -53338,8 +53524,8 @@ aa
 aa
 fI
 fI
-fI
-Ti
+Tm
+rc
 rc
 rc
 rc
@@ -53595,10 +53781,10 @@ aa
 aa
 fI
 fI
-fI
-fI
-fI
 Tm
+rc
+rc
+rc
 rc
 rc
 rc
@@ -53852,10 +54038,10 @@ aa
 aa
 fI
 fI
-fI
-fI
-fI
 Tm
+rc
+rc
+rc
 db
 jG
 rq
@@ -54109,10 +54295,10 @@ aa
 aa
 fI
 fI
-fI
-fI
-fI
 Tm
+rc
+rc
+rc
 ge
 nd
 sK
@@ -54366,10 +54552,10 @@ fI
 fI
 fI
 fI
-fI
-fI
-fI
 Tm
+rc
+rc
+rc
 hk
 pY
 sL
@@ -54623,12 +54809,12 @@ fI
 fI
 fI
 fI
-fI
-fI
-fI
-Ti
-jO
-jO
+Tm
+rc
+rc
+rc
+rc
+rc
 rc
 rc
 ad
@@ -54880,13 +55066,13 @@ fI
 fI
 fI
 fI
-fI
-fI
-fI
-fI
-fI
-fI
-Tm
+Ti
+jO
+jO
+jO
+jO
+jO
+rc
 rc
 ad
 gt
@@ -55697,7 +55883,7 @@ hb
 Ee
 Yh
 ZU
-QQ
+Ff
 iU
 Yh
 hX
@@ -55954,7 +56140,7 @@ Qn
 Mb
 Mb
 Mb
-Mb
+Oo
 di
 Mb
 Mb
@@ -56194,17 +56380,17 @@ Zo
 SK
 WC
 SK
-SK
+GL
 aG
 SK
 WC
 SK
-SK
+GL
 aG
 SK
 WC
 SK
-SK
+GL
 aG
 SK
 WC

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -69,6 +69,9 @@
 "al" = (
 /obj/machinery/vending/MarineMed/Blood,
 /obj/structure/cable,
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "am" = (
@@ -629,6 +632,10 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"ch" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
 "ci" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -835,6 +842,13 @@
 	},
 /turf/open/space,
 /area/space)
+"cL" = (
+/obj/machinery/light{
+	light_color = "#da2f1b"
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "cM" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
@@ -946,6 +960,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"de" = (
+/obj/machinery/holopad,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "dg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1219,6 +1238,14 @@
 	dir = 8
 	},
 /area/mainship/hallways/hangar)
+"dU" = (
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/glass/beaker/biomass,
+/obj/item/storage/box/bodybags,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "dV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -1363,6 +1390,10 @@
 	dir = 10
 	},
 /area/mainship/squads/general)
+"et" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "eu" = (
 /obj/machinery/vending/medical/shipside,
 /obj/machinery/light{
@@ -1502,13 +1533,6 @@
 	},
 /turf/closed/wall/mainship,
 /area/mainship/hallways/hangar)
-"eU" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/ai_node,
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
 "eV" = (
 /obj/item/newspaper{
 	pixel_x = -10;
@@ -2325,6 +2349,9 @@
 /obj/effect/ai_node,
 /obj/structure/cable,
 /obj/structure/cable,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "hC" = (
@@ -2485,7 +2512,7 @@
 /obj/structure/flora/pottedplant/twentyone,
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
-"ij" = (
+"ik" = (
 /obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -2970,9 +2997,6 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "jT" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
@@ -4022,10 +4046,6 @@
 "nv" = (
 /turf/open/floor/plating/icefloor/warnplate,
 /area/mainship/hallways/hangar)
-"ny" = (
-/obj/structure/cable,
-/turf/open/floor/prison/kitchen,
-/area/mainship/living/grunt_rnr)
 "nz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4605,6 +4625,20 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
+"pp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "pq" = (
 /obj/machinery/vending/shared_vending/marine_engi,
 /obj/machinery/light{
@@ -4625,11 +4659,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
-"pu" = (
-/obj/machinery/holopad,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "pw" = (
 /obj/machinery/light{
 	dir = 8
@@ -4778,6 +4807,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
+"qc" = (
+/obj/effect/ai_node,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "qd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4984,10 +5019,10 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
-"qN" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/medical/surgery_hallway)
+"qO" = (
+/obj/machinery/cloning_console/vats,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "qP" = (
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/plating/mainship,
@@ -5492,12 +5527,6 @@
 /obj/machinery/marine_selector/clothes/leader,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
-"sy" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/surgery_hallway)
 "sz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
@@ -6609,11 +6638,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "vQ" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "vR" = (
 /obj/structure/bed/stool{
 	pixel_y = 8
@@ -8374,11 +8402,11 @@
 /turf/open/space,
 /area/space)
 "Be" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/surgery_hallway)
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "Bf" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/plating_catwalk,
@@ -8520,13 +8548,6 @@
 /obj/structure/bed/chair/wood/normal{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
-"By" = (
-/obj/machinery/light{
-	light_color = "#da2f1b"
-	},
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "Bz" = (
@@ -9104,6 +9125,15 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
+"Da" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/surgery_hallway)
 "Db" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
@@ -9521,7 +9551,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "DZ" = (
-/obj/machinery/cloning_console/vats,
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/glass/beaker/cryomix,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -9904,11 +9935,6 @@
 /obj/machinery/telecomms/receiver/preset_right,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
-"Ft" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/prison/kitchen,
-/area/mainship/living/grunt_rnr)
 "Fv" = (
 /obj/structure/bed/chair/comfy{
 	dir = 1
@@ -10451,13 +10477,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "Hc" = (
-/obj/structure/table/mainship,
-/obj/item/storage/box/bodybags,
-/obj/item/reagent_containers/glass/beaker/biomass,
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/medical/lower_medical)
+/obj/structure/cable,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "Hd" = (
 /obj/structure/bed/chair/wood/wings{
 	dir = 1
@@ -10586,10 +10608,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"Hx" = (
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
 "Hy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -10731,6 +10749,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
+"HP" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/medical/surgery_hallway)
 "HQ" = (
 /obj/machinery/door/poddoor/mainship/open/cic{
 	dir = 2
@@ -11596,10 +11618,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
-"Kh" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
 "Ki" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -11861,12 +11879,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
-"KK" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
 "KM" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/mainship/hardened{
@@ -12181,7 +12193,7 @@
 	},
 /area/mainship/engineering/engine_core)
 "LN" = (
-/obj/machinery/cloning/vats,
+/obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/mainship/sterile/corner{
 	dir = 1
 	},
@@ -12332,7 +12344,7 @@
 /area/mainship/command/corporateliaison)
 "Mj" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/mainship,
+/obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -12519,9 +12531,7 @@
 /area/mainship/hallways/aft_hallway)
 "MP" = (
 /obj/structure/cable,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/power/apc/mainship,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -12889,15 +12899,6 @@
 /obj/item/tool/taperoll/engineering,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"NK" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/surgery_hallway)
 "NL" = (
 /obj/machinery/light{
 	dir = 4
@@ -13033,6 +13034,7 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/storage/surgical_tray,
+/obj/structure/cable,
 /obj/machinery/power/apc/mainship,
 /turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/lower_medical)
@@ -13322,10 +13324,10 @@
 /turf/closed/wall/mainship/outer,
 /area/mainship/hallways/hangar)
 "Pb" = (
+/obj/structure/cable,
 /obj/machinery/door/airlock/mainship/medical/glass{
 	dir = 2
 	},
-/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "Pc" = (
@@ -13459,6 +13461,9 @@
 /obj/structure/closet/secure_closet/medical3,
 /obj/structure/cable,
 /obj/structure/cable,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/mainship/sterile/corner{
 	dir = 8
 	},
@@ -13837,11 +13842,9 @@
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "Qw" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/medical/lower_medical)
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "Qx" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -13969,6 +13972,12 @@
 	dir = 5
 	},
 /area/mainship/squads/general)
+"QS" = (
+/obj/machinery/door/airlock/mainship/medical/glass{
+	dir = 2
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/medical/lower_medical)
 "QT" = (
 /obj/machinery/telecomms/server/presets/requisitions,
 /turf/open/floor/mainship/tcomms,
@@ -14423,6 +14432,12 @@
 "Sl" = (
 /turf/closed/wall/mainship,
 /area/mainship/hallways/hangar/droppod)
+"Sm" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/surgery_hallway)
 "Sn" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/machinery/landinglight/ds2/delayone,
@@ -14433,11 +14448,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
-"Sq" = (
-/obj/machinery/light,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lower_medical)
 "Sr" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -14833,6 +14843,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -15365,6 +15376,12 @@
 	dir = 1
 	},
 /area/mainship/hallways/aft_hallway)
+"Vm" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/surgery_hallway)
 "Vo" = (
 /turf/open/floor/mainship_hull/dir,
 /area/space)
@@ -16092,9 +16109,11 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/obj/machinery/cloning/vats,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "Xy" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -16386,6 +16405,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
+"Yn" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "Yp" = (
 /obj/effect/decal/siding{
 	dir = 8
@@ -16678,9 +16704,6 @@
 /obj/item/storage/box/gloves{
 	pixel_x = -5;
 	pixel_y = -5
-	},
-/obj/machinery/alarm{
-	dir = 4
 	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
@@ -39156,18 +39179,18 @@ IY
 IY
 IY
 IY
-KK
+Be
 YM
 Tg
 Tg
-eU
+Yn
 Tg
 Tg
 El
 Tg
 Tg
 dW
-Tg
+ql
 Tg
 El
 Tg
@@ -39674,7 +39697,7 @@ NY
 YT
 Zv
 IZ
-qN
+HP
 dH
 KX
 Zv
@@ -39923,15 +39946,15 @@ ad
 sN
 Mb
 lE
-Ft
+vQ
 wh
 PY
-ny
+Hc
 TB
 YT
 Zv
 kr
-qN
+HP
 Gy
 RI
 Zv
@@ -39960,7 +39983,7 @@ Xr
 XM
 Tg
 El
-ql
+Tg
 Tg
 Tg
 Tg
@@ -40180,15 +40203,15 @@ ad
 sN
 Mb
 nN
-ny
+Hc
 wM
 QQ
 Ve
-ny
+Hc
 YT
 Zv
 IZ
-qN
+HP
 Gy
 yn
 Zv
@@ -40437,17 +40460,17 @@ Mb
 sN
 Mb
 ou
-Ft
+vQ
 zZ
-ny
-ny
-Ft
+Hc
+Hc
+vQ
 YT
 Zv
 Vh
 Rj
-qN
-qN
+HP
+HP
 NG
 Ue
 GR
@@ -40706,7 +40729,7 @@ Zv
 Zv
 Zv
 Zv
-NK
+Da
 nn
 pE
 ir
@@ -40963,7 +40986,7 @@ fU
 Wb
 rs
 QF
-Be
+Vm
 nn
 QF
 ax
@@ -41212,7 +41235,7 @@ lQ
 Bx
 MF
 lQ
-ij
+ik
 YT
 Zv
 mt
@@ -41220,7 +41243,7 @@ ji
 ji
 ji
 Rn
-sy
+Sm
 ZX
 Zv
 nD
@@ -41469,7 +41492,7 @@ rT
 Bn
 IM
 Ow
-By
+cL
 YT
 Zv
 hj
@@ -41477,7 +41500,7 @@ hD
 Hd
 qs
 QF
-Be
+Vm
 Xq
 Re
 SU
@@ -41726,7 +41749,7 @@ rT
 Of
 IM
 lQ
-Hx
+Qw
 ei
 Zv
 Zv
@@ -41734,7 +41757,7 @@ Zv
 Zv
 Zv
 Zv
-NK
+Da
 jm
 nn
 nD
@@ -41979,10 +42002,10 @@ ap
 hh
 Bm
 NY
-Hx
+Qw
 nz
-Hx
-Hx
+Qw
+Qw
 XI
 YT
 Zv
@@ -41996,10 +42019,10 @@ jm
 nn
 nD
 iz
-hB
-Kh
-Kh
-Kh
+qc
+et
+et
+et
 nD
 uM
 uM
@@ -42253,7 +42276,7 @@ Ya
 TZ
 nD
 ek
-Kh
+et
 oR
 oS
 iL
@@ -43014,10 +43037,10 @@ za
 YT
 bd
 LN
-Hc
+JK
 fO
 fO
-Qw
+fO
 Rd
 BO
 Hu
@@ -43562,7 +43585,7 @@ Jo
 rR
 rm
 KE
-KD
+pp
 gL
 FD
 Nb
@@ -44036,8 +44059,8 @@ YS
 ap
 bd
 nO
-JK
-fO
+Xx
+dU
 fO
 JK
 fO
@@ -44293,7 +44316,7 @@ YS
 ap
 ga
 aI
-aY
+qO
 hH
 Ro
 sr
@@ -44308,7 +44331,7 @@ Ug
 WM
 BO
 hK
-Kh
+et
 jP
 pV
 Me
@@ -45079,7 +45102,7 @@ NQ
 YE
 Td
 wN
-Kh
+et
 iL
 iL
 Fp
@@ -45338,7 +45361,7 @@ bd
 bd
 ef
 aY
-vQ
+aY
 al
 bd
 gL
@@ -45846,17 +45869,17 @@ cM
 oe
 ic
 TE
-pu
+de
 Zf
 bd
 ay
 Mt
 aY
 wx
-Sq
-bd
+ch
+QS
 gL
-wj
+pa
 gL
 PE
 WP
@@ -46616,8 +46639,8 @@ wb
 FC
 rF
 rF
-rF
-Xx
+oC
+FC
 rF
 rF
 rF
@@ -47137,7 +47160,7 @@ rF
 rF
 rF
 rF
-rF
+XG
 rF
 rF
 jy

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -397,10 +397,6 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "bC" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_one)
 "bD" = (
@@ -801,18 +797,6 @@
 	},
 /turf/open/space,
 /area/space)
-"cM" = (
-/obj/structure/window/framed/mainship/white,
-/obj/machinery/door/poddoor/shutters/mainship{
-	dir = 1;
-	id = "or1privacyshutter";
-	name = "\improper Privacy Shutters"
-	},
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/prison/whitegreen/corner{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
 "cN" = (
 /obj/structure/closet/toolcloset,
 /obj/machinery/light,
@@ -1032,7 +1016,7 @@
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/operating_room_one)
 "du" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -1441,6 +1425,7 @@
 	name = "modifed holopad"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "eP" = (
@@ -1975,12 +1960,12 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "gH" = (
-/obj/machinery/chem_master,
-/obj/item/reagent_containers/glass/beaker/bluespace,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship{
+	dir = 1
 	},
-/area/mainship/medical/operating_room_one)
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
 "gI" = (
 /obj/structure/window/framed/mainship/white,
 /obj/machinery/door/firedoor/mainship,
@@ -2082,6 +2067,7 @@
 /obj/machinery/door/airlock/multi_tile/mainship/maint{
 	dir = 1
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/hull/lower_hull)
 "gY" = (
@@ -2151,7 +2137,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "hi" = (
@@ -2443,6 +2428,7 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "ii" = (
@@ -4044,7 +4030,6 @@
 	},
 /area/mainship/medical/medical_science)
 "np" = (
-/obj/structure/cable,
 /obj/structure/table/mainship,
 /obj/machinery/reagentgrinder,
 /obj/item/stack/sheet/mineral/phoron,
@@ -4177,10 +4162,8 @@
 	name = "\improper Privacy Shutters"
 	},
 /obj/machinery/door/firedoor/mainship,
-/turf/open/floor/prison/whitegreen/corner{
-	dir = 1
-	},
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
 "nJ" = (
 /obj/machinery/power/smes/preset,
 /obj/structure/cable,
@@ -4310,7 +4293,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/operating_room_one)
 "oe" = (
 /obj/machinery/firealarm,
 /obj/structure/reagent_dispensers/fueltank,
@@ -8731,10 +8714,6 @@
 /obj/item/reagent_containers/glass/rag,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/grunt_rnr)
-"BE" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_one)
 "BF" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -9928,13 +9907,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
-"Fd" = (
-/obj/machinery/power/apc/mainship,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/operating_room_one)
 "Ff" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/bed/stool{
@@ -11756,7 +11728,7 @@
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/operating_room_one)
 "Kn" = (
 /obj/machinery/body_scanconsole,
 /turf/open/floor/mainship/sterile/corner{
@@ -12700,7 +12672,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/operating_room_one)
 "MT" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner{
@@ -14155,7 +14127,7 @@
 /obj/machinery/door/airlock/mainship/medical/glass{
 	dir = 2
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "Re" = (
 /turf/open/floor/mainship/sterile/corner{
@@ -14244,18 +14216,6 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/shipboard/firing_range)
-"Rt" = (
-/obj/structure/window/framed/mainship/white,
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/poddoor/shutters/mainship{
-	dir = 1;
-	id = "or2privacyshutter";
-	name = "\improper Privacy Shutters"
-	},
-/turf/open/floor/prison/whitegreen/corner{
-	dir = 1
-	},
-/area/mainship/medical/operating_room_two)
 "Ru" = (
 /obj/item/trash/cigbutt,
 /turf/open/floor/mainship/black,
@@ -14791,10 +14751,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/prison/whitegreen/corner{
-	dir = 1
-	},
-/area/mainship/medical/operating_room_one)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "Te" = (
 /turf/open/floor/mainship/red{
 	dir = 4
@@ -14876,12 +14834,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"Tt" = (
-/obj/structure/window/framed/mainship/white,
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/poddoor/shutters/opened/medbay,
-/turf/open/floor/plating/platebotc,
-/area/mainship/medical/operating_room_one)
 "Tu" = (
 /obj/structure/orbital_cannon,
 /obj/machinery/light/small{
@@ -15150,6 +15102,7 @@
 /area/mainship/medical/lower_medical)
 "Uj" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "Uk" = (
@@ -15973,9 +15926,7 @@
 	id = "or2privacyshutter";
 	name = "\improper Privacy Shutters"
 	},
-/turf/open/floor/prison/whitegreen/corner{
-	dir = 4
-	},
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
 "WK" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -16650,7 +16601,7 @@
 	},
 /obj/structure/window/framed/mainship/white,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_one)
+/area/mainship/medical/lower_medical)
 "YF" = (
 /obj/structure/closet/crate/weapon,
 /obj/structure/cable,
@@ -16719,14 +16670,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
-"YO" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/operating_room_one)
 "YP" = (
 /obj/item/radio/intercom/general,
 /turf/closed/wall/mainship,
@@ -16838,10 +16781,13 @@
 	},
 /area/mainship/medical/surgery_hallway)
 "Zf" = (
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
-/area/mainship/medical/operating_room_one)
+/area/mainship/medical/lower_medical)
 "Zg" = (
 /turf/open/floor/mainship/terragov{
 	dir = 4
@@ -16856,12 +16802,13 @@
 "Zi" = (
 /obj/effect/ai_node,
 /obj/structure/disposalpipe/segment/corner,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_one)
+/area/mainship/medical/lower_medical)
 "Zj" = (
 /obj/structure/closet/secure_closet/chemical,
 /turf/open/floor/mainship/sterile/corner,
-/area/mainship/medical/operating_room_one)
+/area/mainship/medical/lower_medical)
 "Zk" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -42157,7 +42104,7 @@ ad
 ad
 cu
 Mb
-qg
+jx
 hh
 Bm
 NY
@@ -45253,8 +45200,8 @@ SD
 BO
 DG
 VJ
-bd
-bd
+SJ
+SJ
 SJ
 SJ
 NQ
@@ -45510,13 +45457,13 @@ xK
 fs
 DG
 zr
-cM
+nI
 dt
 iC
 SR
 UV
-Fd
-bC
+lY
+gG
 np
 ef
 lF
@@ -45772,13 +45719,13 @@ od
 OC
 Tb
 UV
-YO
+lY
 Zi
 Uj
 eO
 Uj
 ih
-TK
+gH
 bd
 gL
 wj
@@ -46024,18 +45971,18 @@ aY
 Ww
 DG
 JM
-cM
-aY
+nI
+bC
 mC
 TE
 RL
 Zf
-BE
+zM
 aY
 Mt
 aY
 zM
-zr
+TK
 bd
 gL
 pa
@@ -46275,7 +46222,7 @@ TW
 gn
 RU
 qR
-Rt
+WJ
 TR
 Tc
 Ww
@@ -46287,7 +46234,7 @@ Ty
 Og
 UV
 Zj
-gH
+BJ
 PB
 vn
 PB
@@ -46538,13 +46485,13 @@ lN
 Ii
 Ui
 lN
-bd
-bd
+SJ
+SJ
 SJ
 UV
 UV
-SJ
-Tt
+bd
+gI
 xS
 Sq
 gI

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -2,21 +2,6 @@
 "aa" = (
 /turf/open/space,
 /area/space)
-"ab" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 1
-	},
-/area/mainship/hallways/hangar/droppod)
-"ac" = (
-/obj/machinery/vending/nanomed,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "ad" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/hull/lower_hull)
@@ -31,28 +16,20 @@
 	dir = 8
 	},
 /area/mainship/hallways/hangar/droppod)
-"ag" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 5
+"af" = (
+/obj/machinery/autodoc,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/area/mainship/medical/lower_medical)
 "ah" = (
 /obj/structure/ship_ammo/minirocket/illumination,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "ai" = (
-/obj/machinery/vending/nanomed,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
-/area/mainship/hallways/hangar/droppod)
+/obj/structure/window/framed/mainship/hull,
+/turf/open/floor/mainship_hull,
+/area/space)
 "aj" = (
 /obj/machinery/firealarm{
 	dir = 8
@@ -63,16 +40,15 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/item/reagent_containers/jerrycan,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "al" = (
-/obj/machinery/vending/MarineMed/Blood,
-/obj/structure/cable,
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
+/obj/structure/sink{
+	dir = 1
 	},
-/turf/open/floor/mainship/sterile/side,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 8
+	},
 /area/mainship/medical/lower_medical)
 "am" = (
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -97,11 +73,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "aq" = (
-/obj/item/radio/intercom/general,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
-/area/mainship/hallways/hangar)
+/obj/effect/ai_node,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "ar" = (
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
@@ -118,36 +94,43 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/machinery/camera/autoname/mainship,
 /obj/structure/ship_ammo/rocket/widowmaker,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"av" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
 "aw" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/structure/ship_ammo/rocket/widowmaker,
-/turf/open/floor/mainship/mono,
+/obj/structure/ship_ammo/rocket/banshee,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "ax" = (
 /obj/machinery/cryopod/right,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "ay" = (
-/obj/machinery/computer/med_data,
-/turf/open/floor/mainship/sterile/side{
+/obj/structure/cable,
+/obj/machinery/light/small{
 	dir = 1
 	},
-/area/mainship/medical/lower_medical)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "az" = (
 /turf/closed/wall/mainship,
 /area/mainship/hallways/hangar)
 "aA" = (
-/turf/open/floor/mainship/cargo/arrow,
-/area/mainship/hallways/hangar)
-"aB" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -161,16 +144,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "aD" = (
-/obj/structure/window/framed/mainship/white,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/sterile,
+/obj/effect/landmark/start/job/medicalofficer,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/surgery_hallway)
-"aE" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/item/storage/backpack/marine/engineerpack,
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/cargo,
-/area/mainship/hallways/hangar)
 "aF" = (
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 8
@@ -183,28 +159,21 @@
 /turf/open/floor/plating,
 /area/mainship/living/cryo_cells)
 "aH" = (
-/obj/effect/ai_node,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"aI" = (
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/lower_medical)
 "aJ" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar)
+/obj/structure/window/framed/mainship/canterbury,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "aK" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
 /obj/structure/ship_ammo/rocket/banshee,
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "aL" = (
 /obj/machinery/door/airlock/mainship/maint,
@@ -216,37 +185,36 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "aN" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "aO" = (
 /obj/effect/decal/warning_stripes/thin{
-	dir = 4
+	dir = 5
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "aP" = (
-/obj/structure/cable,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
-"aR" = (
-/obj/item/clothing/head/warning_cone,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"aQ" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
 "aS" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/machinery/landinglight/ds1/delayone,
+/obj/structure/closet/firecloset,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "aT" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/machinery/landinglight/ds1,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "aU" = (
@@ -256,21 +224,14 @@
 	},
 /area/mainship/command/self_destruct)
 "aV" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/machinery/landinglight/ds1/delaythree,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"aW" = (
 /obj/effect/decal/warning_stripes/thin{
-	dir = 8
+	dir = 10
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "aX" = (
-/obj/structure/cable,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
@@ -278,49 +239,55 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "aZ" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/machinery/landinglight/ds1/delaytwo,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"ba" = (
+/obj/machinery/vending/nanomed,
 /obj/effect/decal/warning_stripes/thin{
-	dir = 10
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"bb" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/machinery/landinglight/ds1/delayone,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"bc" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/thin{
-	dir = 6
+	dir = 8
 	},
-/turf/open/floor/stairs/rampbottom{
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/mainship/hallways/hangar/droppod)
+"ba" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
+"bb" = (
+/obj/item/radio/intercom/general,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/mainship/hallways/hangar/droppod)
+"bc" = (
+/obj/structure/sign/poster{
 	dir = 1
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
 	},
 /area/mainship/hallways/hangar)
 "bd" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/lower_medical)
 "be" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/jerrycan,
-/obj/item/reagent_containers/jerrycan,
-/obj/item/reagent_containers/jerrycan,
-/obj/item/reagent_containers/jerrycan,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "bf" = (
 /obj/structure/bed/chair/office/dark{
@@ -332,78 +299,6 @@
 /area/mainship/squads/req)
 "bg" = (
 /obj/effect/decal/warning_stripes/thin{
-	dir = 6
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"bh" = (
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
-"bi" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/item/reagent_containers/jerrycan,
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
-"bk" = (
-/obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
-	dir = 1
-	},
-/turf/closed/wall/mainship,
-/area/mainship/command/self_destruct)
-"bl" = (
-/obj/machinery/computer/arcade,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
-"bm" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/landinglight/ds1/delaythree{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"bn" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"bo" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"bp" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"bq" = (
-/obj/machinery/line_nexter,
-/obj/structure/cable,
-/obj/machinery/power/apc/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
-"br" = (
-/obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -414,33 +309,72 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"bt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+"bh" = (
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
+"bi" = (
+/obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/item/reagent_containers/jerrycan,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
+"bk" = (
+/obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
+	dir = 1
+	},
+/turf/closed/wall/mainship,
+/area/mainship/command/self_destruct)
+"bl" = (
+/obj/item/radio/intercom/general,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/mainship/hallways/hangar)
+"bo" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/mainship,
+/obj/structure/ship_ammo/rocket/widowmaker,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar)
+"bp" = (
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar)
+"bq" = (
+/obj/machinery/line_nexter,
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
+"bt" = (
+/obj/structure/cable,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
+"bu" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "bv" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/chemistry)
+/obj/machinery/optable,
+/obj/item/tank/anesthetic,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
 "bw" = (
 /obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"bx" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/machinery/landinglight/ds2/delaytwo{
 	dir = 8
 	},
 /turf/open/floor/mainship/mono,
@@ -449,26 +383,30 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/landinglight/ds2/delaythree{
+/obj/machinery/landinglight/ds2{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "bA" = (
-/obj/effect/attach_point/weapon/dropship1,
+/obj/docking_port/stationary/marine_dropship/minidropship,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "bB" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating,
+/obj/structure/dropship_equipment/weapon/minirocket_pod,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
-"bD" = (
+"bC" = (
 /obj/structure/cable,
-/obj/machinery/light/small{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
+"bD" = (
+/obj/structure/dropship_equipment/weapon/minirocket_pod,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "bE" = (
 /obj/machinery/vending/hydroseeds,
 /obj/machinery/light{
@@ -477,43 +415,32 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "bF" = (
+/obj/structure/prop/mainship/hangar_stencil,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/machinery/landinglight/ds1/delaytwo{
+/obj/effect/decal/warning_stripes/thin,
+/obj/machinery/landinglight/ds1/delayone{
 	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"bG" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"bH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "bI" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/mainship/cargo,
+/turf/open/floor/mainship/cargo/arrow,
 /area/mainship/hallways/hangar)
 "bJ" = (
+/obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/landinglight/ds2/delayone{
+/obj/machinery/landinglight/ds2/delaytwo{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "bL" = (
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/area/mainship/medical/operating_room_two)
 "bM" = (
 /obj/machinery/door/airlock/mainship/medical/glass/CMO{
 	dir = 2
@@ -525,39 +452,33 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/machinery/landinglight/ds1{
+/obj/machinery/landinglight/ds1/delaythree{
 	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"bO" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "bP" = (
-/obj/machinery/firealarm,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "bQ" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/mainship/maint,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/sign/pods,
+/turf/closed/wall/mainship,
 /area/mainship/hallways/hangar)
 "bR" = (
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct,
 /turf/closed/wall/mainship,
 /area/mainship/command/self_destruct)
 "bS" = (
-/obj/machinery/vending/snack,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/obj/effect/ai_node,
+/turf/open/floor/mainship/cargo/arrow,
+/area/mainship/hallways/hangar)
 "bT" = (
 /obj/machinery/vending/nanomed{
 	dir = 4
@@ -565,10 +486,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "bV" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
+/obj/machinery/door_control/mainship/ammo{
+	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "bW" = (
 /obj/structure/sign/poster{
@@ -582,63 +503,63 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"bY" = (
-/obj/structure/prop/mainship/hangar_stencil,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "bZ" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "ca" = (
-/obj/effect/decal/warning_stripes/thin,
-/turf/open/floor/mainship/mono,
+/obj/structure/dropship_equipment/electronics/spotlights,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
 /area/mainship/hallways/hangar)
 "cb" = (
-/obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
-	dir = 4
+	dir = 5
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"cc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/camera/autoname/mainship{
+/obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/mainship/hallways/hangar/droppod)
+"cc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "cf" = (
-/obj/machinery/vending/cola,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 1
+	},
+/area/mainship/hallways/hangar/droppod)
+"cg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 1
+	},
+/area/mainship/hallways/hangar/droppod)
+"ch" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
-"cg" = (
-/obj/structure/prop/mainship/hangar_stencil/two,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
+/obj/machinery/vending/MarineMed,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
 	},
-/obj/effect/decal/warning_stripes/thin,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/area/mainship/medical/lower_medical)
 "ci" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/turf/open/floor/stairs/rampbottom{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "cj" = (
 /obj/item/ammo_magazine/rifle,
@@ -653,15 +574,6 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
-"ck" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/machinery/landinglight/ds2{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "cl" = (
 /obj/item/clothing/head/warning_cone,
 /turf/open/floor/mainship/mono,
@@ -670,7 +582,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/landinglight/ds1/delaytwo{
+/obj/machinery/landinglight/ds1/delaythree{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
@@ -684,21 +596,56 @@
 	dir = 4
 	},
 /area/mainship/shipboard/weapon_room)
-"cp" = (
-/obj/machinery/door/airlock/mainship/medical/glass/chemistry{
-	dir = 2
+"co" = (
+/obj/structure/table/mainship,
+/obj/item/storage/box/gloves{
+	pixel_x = 6;
+	pixel_y = 8
 	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
+/obj/item/storage/box/masks{
+	pixel_x = 2;
+	pixel_y = -1
 	},
-/obj/structure/disposalpipe/segment,
+/obj/item/storage/syringe_case/regular{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/mass_spectrometer,
+/obj/item/reagent_scanner,
+/obj/item/storage/pill_bottle/packet/paracetamol,
+/obj/item/storage/pill_bottle/packet/paracetamol,
+/obj/item/storage/pill_bottle/packet/paracetamol,
+/obj/item/storage/pill_bottle/packet/paracetamol,
+/obj/item/storage/pill_bottle/packet/paracetamol,
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/turf/open/floor/mainship/sterile/corner{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
+"cp" = (
+/obj/machinery/bodyscanner{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "cq" = (
-/obj/structure/dropship_equipment/weapon/minirocket_pod,
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar/droppod)
 "cr" = (
 /obj/machinery/door/airlock/mainship/security/checkpoint{
 	dir = 8
@@ -713,12 +660,19 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "ct" = (
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/airlock/multi_tile/mainship/maint{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 1
+	},
+/area/mainship/hallways/hangar/droppod)
 "cu" = (
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
@@ -745,11 +699,15 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "cy" = (
+/obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/hull/lower_hull)
 "cz" = (
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "cA" = (
 /obj/machinery/door/firedoor/mainship,
@@ -779,22 +737,18 @@
 /area/mainship/squads/general)
 "cE" = (
 /obj/effect/decal/warning_stripes/thin{
-	dir = 5
-	},
-/obj/effect/decal/warning_stripes/thin{
 	dir = 8
+	},
+/obj/machinery/door_control/mainship/droppod{
+	dir = 1
 	},
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 8
 	},
 /area/mainship/hallways/hangar/droppod)
 "cF" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 1
-	},
+/obj/structure/sign/poster,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar/droppod)
 "cG" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -806,7 +760,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "cH" = (
-/obj/machinery/researchcomp,
+/obj/machinery/alarm{
+	dir = 1
+	},
+/obj/machinery/iv_drip,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "cI" = (
@@ -815,6 +772,12 @@
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/hull/lower_hull)
+"cJ" = (
+/obj/machinery/computer/med_data,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "cK" = (
 /obj/effect/step_trigger/teleporter/random{
 	affect_ghosts = 1;
@@ -839,10 +802,17 @@
 /turf/open/space,
 /area/space)
 "cM" = (
-/obj/structure/cable,
-/obj/machinery/holopad,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
+/obj/structure/window/framed/mainship/white,
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 1;
+	id = "or1privacyshutter";
+	name = "\improper Privacy Shutters"
+	},
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
 "cN" = (
 /obj/structure/closet/toolcloset,
 /obj/machinery/light,
@@ -853,8 +823,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "cP" = (
-/obj/structure/window/framed/mainship/hull,
-/turf/open/floor/mainship/mono,
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/item/storage/backpack/marine/engineerpack,
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "cQ" = (
 /obj/structure/disposalpipe/segment/corner{
@@ -866,22 +838,21 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "cR" = (
-/obj/effect/attach_point/weapon/dropship1{
-	dir = 8;
-	icon_state = "equip_base_l_wing"
-	},
 /turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
+	dir = 5
 	},
 /area/mainship/hallways/hangar)
 "cS" = (
-/obj/structure/dropship_equipment/operatingtable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/orange{
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/area/mainship/hallways/hangar)
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 1
+	},
+/area/mainship/hallways/hangar/droppod)
 "cT" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/gas,
@@ -908,19 +879,18 @@
 /area/mainship/command/self_destruct)
 "cZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "da" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 4;
-	on = 1
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 1
-	},
+/obj/machinery/light,
+/obj/machinery/cic_maptable/droppod_maptable,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar/droppod)
 "db" = (
 /obj/effect/decal/siding{
@@ -941,6 +911,9 @@
 /obj/effect/ai_node,
 /obj/effect/landmark/start/job/researcher,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "dd" = (
@@ -949,6 +922,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"de" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "dg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1026,17 +1004,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
 "dr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/door/poddoor/mainship/droppod{
+	dir = 2
 	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 5
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/hangar/droppod)
 "ds" = (
 /obj/structure/table/mainship,
@@ -1056,31 +1027,26 @@
 	dir = 5
 	},
 /area/mainship/squads/general)
+"dt" = (
+/obj/machinery/bioprinter/stocked,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "du" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"dv" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 10
-	},
-/obj/effect/ai_node,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "dx" = (
 /obj/machinery/grill/unwrenched,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "dy" = (
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "dz" = (
 /turf/open/floor/mainship_hull/dir{
@@ -1088,14 +1054,22 @@
 	},
 /area/space)
 "dA" = (
-/obj/item/radio/intercom/general,
-/turf/closed/wall/mainship,
+/obj/structure/rack,
+/obj/item/reagent_containers/jerrycan,
+/obj/item/reagent_containers/jerrycan,
+/obj/item/reagent_containers/jerrycan,
+/obj/item/reagent_containers/jerrycan,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "dB" = (
+/obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "dC" = (
 /obj/structure/closet/crate,
@@ -1115,9 +1089,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "dE" = (
-/turf/open/floor/plating{
-	dir = 1;
-	icon_state = "warnplatecorner"
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 10
 	},
 /area/mainship/hallways/hangar)
 "dF" = (
@@ -1170,17 +1143,24 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "dL" = (
-/obj/item/reagent_containers/jerrycan,
+/obj/structure/cable,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/area/mainship/hallways/hangar/droppod)
 "dM" = (
-/turf/open/floor/plating/dmg1,
+/obj/docking_port/stationary/marine_dropship/cas,
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "dN" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/landinglight/ds1/delaythree{
+/obj/machinery/landinglight/ds1{
 	dir = 4
 	},
 /turf/open/floor/mainship/cargo/arrow{
@@ -1201,36 +1181,27 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
-"dQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar)
 "dR" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/machinery/landinglight/ds1/delaythree{
+/obj/machinery/landinglight/ds1/delaytwo{
 	dir = 8
 	},
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 8
 	},
 /area/mainship/hallways/hangar)
+"dU" = (
+/obj/structure/bed/chair/sofa{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "dV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating/plating_catwalk,
+/obj/effect/decal/warning_stripes/thin,
+/obj/machinery/landinglight/ds2/delaythree,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "dW" = (
 /obj/structure/cable,
@@ -1241,16 +1212,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "dX" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
-"dY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 4;
-	on = 1
+/obj/structure/cable,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 1
+	},
+/area/mainship/hallways/hangar/droppod)
 "ea" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -1262,23 +1231,10 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/landinglight/ds1{
+/obj/machinery/landinglight/ds1/delayone{
 	dir = 4
 	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
-/area/mainship/hallways/hangar)
-"ec" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/machinery/landinglight/ds1/delaytwo{
-	dir = 8
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "ed" = (
 /obj/machinery/door/airlock/mainship/research/pen,
@@ -1287,11 +1243,13 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "ef" = (
+/obj/structure/closet/firecloset,
 /obj/machinery/light{
-	dir = 1
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
 /area/mainship/medical/lower_medical)
 "eh" = (
 /obj/structure/cable,
@@ -1367,34 +1325,34 @@
 	},
 /area/mainship/squads/general)
 "eu" = (
-/obj/machinery/vending/medical/shipside,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/corner{
-	dir = 1
-	},
-/area/mainship/medical/chemistry)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
 "ew" = (
 /obj/structure/cable,
 /obj/machinery/light/small,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "ex" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/machinery/landinglight/ds2,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 5
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"ey" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
-	},
 /obj/structure/cable,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/mainship/hallways/hangar/droppod)
+"ey" = (
+/obj/structure/cable,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "ez" = (
 /obj/structure/bed/chair/office/dark{
@@ -1406,28 +1364,28 @@
 /turf/open/floor/wood,
 /area/mainship/medical/surgery_hallway)
 "eA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
-"eB" = (
 /obj/effect/decal/warning_stripes/thin{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/landinglight/ds2/delaytwo{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"eC" = (
+/obj/effect/landmark/start/job/medicalofficer,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
+"eD" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "eE" = (
 /turf/open/floor/mainship/black{
 	dir = 9
 	},
 /area/mainship/command/self_destruct)
-"eF" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
 "eG" = (
 /turf/open/floor/mainship/black{
 	dir = 1
@@ -1445,7 +1403,6 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -1454,36 +1411,38 @@
 	},
 /area/mainship/squads/general)
 "eJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/effect/decal/warning_stripes/thin,
+/obj/machinery/landinglight/ds1/delayone,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "eK" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/landinglight/ds1/delayone{
+/obj/machinery/landinglight/ds1/delaytwo{
 	dir = 4
 	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"eL" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "eN" = (
 /obj/machinery/light,
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"eO" = (
+/obj/machinery/holopad{
+	active_power_usage = 60;
+	desc = "It's a floor-mounted device for projecting holographic images. This one appears to have a smaller lense";
+	holo_range = 3;
+	idle_power_usage = 3;
+	name = "modifed holopad"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "eP" = (
 /obj/structure/disposalpipe/segment/corner,
 /obj/structure/cable,
@@ -1495,15 +1454,24 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"eR" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/landinglight/ds1/delaytwo{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "eS" = (
 /obj/machinery/light,
 /turf/open/floor/mainship,
 /area/mainship/living/cafeteria_starboard)
 "eT" = (
-/obj/machinery/alarm{
-	dir = 4
-	},
-/turf/closed/wall/mainship,
+/obj/machinery/door/airlock/mainship/maint,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "eV" = (
 /obj/item/newspaper{
@@ -1544,16 +1512,16 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "fc" = (
-/obj/machinery/light,
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating/plating_catwalk,
+/obj/item/clothing/head/warning_cone,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "fd" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/mainship/floor,
+/obj/effect/decal/warning_stripes/thin,
+/obj/machinery/landinglight/ds1/delaytwo,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "fe" = (
 /obj/structure/table/mainship,
@@ -1568,16 +1536,6 @@
 	dir = 5
 	},
 /area/mainship/command/cic)
-"ff" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
 "fg" = (
 /obj/machinery/marine_selector/clothes/medic,
 /obj/machinery/light{
@@ -1598,30 +1556,28 @@
 /area/mainship/engineering/port_atmos)
 "fl" = (
 /obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/landinglight/ds1/delayone{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/landinglight/ds1/delaythree{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "fm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/item/clothing/head/warning_cone,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "fn" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/machinery/light{
+/obj/item/clothing/head/warning_cone,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/stairs/rampbottom{
-	dir = 1
-	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "fo" = (
 /obj/machinery/holopad,
@@ -1645,17 +1601,17 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "fs" = (
-/obj/machinery/light,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
 	},
-/turf/open/floor/mainship/sterile/side,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "ft" = (
 /obj/effect/decal/warning_stripes/thin{
-	dir = 6
+	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "fu" = (
@@ -1671,11 +1627,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
+/area/mainship/living/grunt_rnr)
 "fw" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/stairs/rampbottom{
+	dir = 1
+	},
 /area/mainship/hallways/hangar)
 "fx" = (
 /obj/machinery/door/firedoor/mainship,
@@ -1700,17 +1662,6 @@
 	dir = 8
 	},
 /area/mainship/squads/general)
-"fB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/cargo,
-/area/mainship/hallways/hangar)
 "fC" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -1721,12 +1672,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "fD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/poddoor/mainship/droppod{
+/obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/stripesquare,
+/turf/open/floor/stairs/rampbottom{
+	dir = 1
+	},
 /area/mainship/hallways/hangar/droppod)
 "fG" = (
 /obj/machinery/self_destruct/rod,
@@ -1747,7 +1700,7 @@
 /turf/open/floor/mainship/black,
 /area/mainship/living/cafeteria_starboard)
 "fK" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/junction/flipped{
 	dir = 4
 	},
 /turf/open/floor/mainship/sterile/side{
@@ -1764,19 +1717,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "fN" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
-"fO" = (
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/medical/lower_medical)
 "fP" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -1799,12 +1743,6 @@
 	dir = 1
 	},
 /area/mainship/medical/surgery_hallway)
-"fS" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "fT" = (
 /obj/machinery/door/airlock/mainship/generic/bathroom{
 	dir = 1
@@ -1824,38 +1762,21 @@
 /turf/open/floor/wood,
 /area/mainship/medical/surgery_hallway)
 "fV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/thin,
+/obj/machinery/landinglight/ds2/delayone,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "fW" = (
-/obj/structure/cable,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/hangar)
 "fX" = (
-/obj/item/storage/box/pillbottles,
-/obj/item/storage/box/gloves{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/storage/box/pillbottles,
-/obj/item/storage/box/beakers{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/obj/structure/table/mainship,
+/obj/structure/cable,
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/storage/surgical_tray,
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
@@ -1877,16 +1798,11 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/living/briefing)
 "ga" = (
-/obj/structure/window/framed/mainship/white,
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/lower_medical)
-"gb" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/area/mainship/medical/lower_medical)
 "gc" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/security/marinemainship{
@@ -1901,10 +1817,9 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/machinery/landinglight/ds2/delaytwo{
+/obj/machinery/landinglight/ds2/delayone{
 	dir = 8
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "ge" = (
@@ -1919,25 +1834,20 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/decal/warning_stripes/thin,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/landinglight/ds1/delaythree{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "gh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/poddoor/mainship/droppod{
+	dir = 2
 	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/hangar/droppod)
 "gi" = (
 /obj/machinery/vending/cola,
@@ -1948,19 +1858,23 @@
 	dir = 10
 	},
 /area/space)
-"gl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar)
 "gm" = (
 /obj/machinery/suit_storage_unit/carbon_unit,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_umbilical)
+"gn" = (
+/obj/structure/cable,
+/obj/machinery/iv_drip,
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/corner,
+/area/mainship/medical/operating_room_two)
 "go" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "gp" = (
@@ -1994,9 +1908,18 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"gu" = (
+/obj/structure/cable,
+/obj/structure/bed/chair/wood/wings{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "gw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/mainship/sterile/dark,
+/obj/machinery/iv_drip,
+/turf/open/floor/mainship/sterile/side{
+	dir = 5
+	},
 /area/mainship/medical/lower_medical)
 "gx" = (
 /obj/structure/window/reinforced,
@@ -2009,6 +1932,16 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
+"gz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "gA" = (
 /obj/machinery/light{
 	dir = 4
@@ -2018,22 +1951,13 @@
 	},
 /area/mainship/squads/general)
 "gC" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/landinglight/ds2/delayone{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
+/obj/structure/dropship_equipment/weapon/heavygun,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "gD" = (
-/obj/effect/decal/warning_stripes/thin{
+/turf/open/floor/mainship/terragov/north{
 	dir = 1
 	},
-/obj/machinery/landinglight/ds2/delaytwo{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "gE" = (
 /obj/structure/window/framed/mainship/requisitions,
@@ -2045,10 +1969,23 @@
 	},
 /area/mainship/command/self_destruct)
 "gG" = (
-/obj/machinery/bodyscanner{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
+"gH" = (
+/obj/machinery/chem_master,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/operating_room_one)
+"gI" = (
+/obj/structure/window/framed/mainship/white,
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/poddoor/shutters/opened/medbay,
+/turf/open/floor/plating/platebotc,
 /area/mainship/medical/lower_medical)
 "gK" = (
 /obj/structure/target_stake,
@@ -2062,13 +1999,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "gM" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
+/turf/open/floor/mainship/terragov/north{
+	dir = 5
 	},
-/obj/machinery/landinglight/ds2/delaythree{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "gN" = (
 /obj/structure/disposalpipe/segment{
@@ -2076,18 +2009,26 @@
 	},
 /turf/closed/wall/mainship,
 /area/mainship/squads/general)
+"gO" = (
+/obj/structure/bed/chair/sofa/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "gP" = (
 /obj/machinery/vending/weapon,
 /turf/open/floor/mainship/red/full,
 /area/mainship/command/cic)
 "gQ" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/obj/machinery/door_control/mainship/ammo{
+	dir = 8
+	},
+/turf/open/floor/stairs/rampbottom{
 	dir = 1
 	},
-/obj/machinery/landinglight/ds2{
-	dir = 1
-	},
-/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "gR" = (
 /obj/machinery/door/poddoor/mainship,
@@ -2110,11 +2051,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_umbilical)
 "gU" = (
-/obj/vehicle/ridden/powerloader,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
 	},
-/turf/open/floor/mainship/cargo,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/mainship/cargo/arrow,
 /area/mainship/hallways/hangar)
 "gV" = (
 /obj/structure/rack,
@@ -2127,15 +2070,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_umbilical)
 "gW" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/vehicle/ridden/powerloader,
-/turf/open/floor/mainship/cargo,
+/turf/open/floor/mainship/cargo/arrow,
 /area/mainship/hallways/hangar)
 "gX" = (
-/obj/structure/cable,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -2153,42 +2093,24 @@
 "gZ" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "ha" = (
-/obj/item/radio/intercom/general,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
 "hb" = (
 /obj/machinery/cryopod/right,
 /turf/open/floor/mainship/cargo,
 /area/mainship/living/cryo_cells)
 "hc" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table/mainship,
-/obj/item/stack/sheet/mineral/phoron{
-	amount = 25;
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/tool/hand_labeler,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/obj/machinery/alarm{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/corner{
-	dir = 4
-	},
-/area/mainship/medical/surgery_hallway)
+/obj/structure/cable,
+/obj/machinery/light/small,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar/droppod)
 "hd" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 2;
@@ -2262,36 +2184,21 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"ho" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/landinglight/ds2/delayone{
-	dir = 1
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
 "hp" = (
-/obj/structure/table/mainship,
-/obj/item/reagent_containers/glass/beaker/biomass,
-/obj/item/storage/box/bodybags,
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/medical/lower_medical)
+/obj/structure/cable,
+/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar/droppod)
 "hq" = (
 /obj/machinery/power/fusion_engine/preset,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
 "hr" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/area/mainship/hallways/hangar/droppod)
 "hv" = (
 /obj/machinery/door/airlock/multi_tile/mainship/maint{
 	dir = 1
@@ -2319,32 +2226,29 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "hy" = (
-/obj/structure/window/framed/mainship/white,
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/operating_room_two)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "hz" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/landinglight/ds2/delaytwo{
-	dir = 1
+/obj/machinery/light{
+	light_color = "#da2f1b"
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "hA" = (
-/obj/docking_port/stationary/marine_dropship/crash_target,
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar/droppod)
 "hB" = (
-/obj/effect/ai_node,
 /obj/structure/cable,
-/obj/structure/cable,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "hC" = (
@@ -2367,11 +2271,17 @@
 	},
 /area/mainship/squads/general)
 "hG" = (
-/obj/machinery/sleeper,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/structure/cable,
+/obj/machinery/door/airlock/mainship/maint,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "hH" = (
-/turf/open/floor/mainship/sterile,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
 /area/mainship/medical/lower_medical)
 "hI" = (
 /obj/structure/table/mainship,
@@ -2388,14 +2298,8 @@
 /turf/closed/wall/mainship,
 /area/mainship/squads/general)
 "hK" = (
-/obj/machinery/door/airlock/mainship/research/glass/wing{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
+/turf/closed/wall/mainship/white,
 /area/mainship/medical/medical_science)
 "hL" = (
 /obj/effect/landmark/start/job/shiptech,
@@ -2405,7 +2309,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "hM" = (
-/obj/effect/ai_node,
 /obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
@@ -2425,6 +2328,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"hP" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/aft_hallway)
 "hQ" = (
 /obj/machinery/door/airlock/mainship/generic/bathroom{
 	dir = 1
@@ -2434,28 +2343,25 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
-"hR" = (
-/obj/machinery/door/airlock/mainship/medical/or/or2{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
 "hT" = (
-/obj/machinery/autodoc,
-/turf/open/floor/mainship/sterile/dark,
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
 /area/mainship/medical/lower_medical)
 "hU" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "hV" = (
 /obj/structure/cable,
 /obj/structure/cable,
+/obj/machinery/light{
+	light_color = "#da2f1b"
+	},
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "hW" = (
@@ -2483,6 +2389,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ia" = (
@@ -2492,16 +2401,26 @@
 /area/mainship/medical/medical_science)
 "ib" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
-"ic" = (
-/turf/closed/wall/mainship/white,
-/area/mainship/medical/operating_room_two)
 "id" = (
-/obj/machinery/chem_master,
-/obj/machinery/firealarm,
-/obj/item/reagent_containers/glass/beaker/bluespace,
-/turf/open/floor/mainship/sterile/corner,
+/obj/structure/table/mainship,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/tool/weldingtool/largetank,
+/obj/item/tool/weldingtool/largetank,
+/obj/item/clothing/head/welding,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
 /area/mainship/medical/surgery_hallway)
 "ie" = (
 /obj/machinery/door/airlock/mainship/maint{
@@ -2512,14 +2431,35 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
+"if" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
+"ih" = (
+/obj/effect/ai_node,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "ii" = (
 /obj/structure/flora/pottedplant/twentyone,
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
-"il" = (
+"ik" = (
+/obj/machinery/vending/MarineMed/Blood,
+/obj/structure/cable,
 /obj/machinery/camera/autoname/mainship{
-	dir = 8
+	dir = 4
 	},
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/surgery_hallway)
+"il" = (
+/obj/machinery/door/airlock/mainship/maint,
+/obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "im" = (
@@ -2527,14 +2467,14 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "in" = (
-/obj/structure/window/framed/mainship,
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
+/obj/structure/window/framed/mainship,
 /turf/open/floor/plating,
-/area/mainship/hallways/hangar)
+/area/mainship/living/grunt_rnr)
 "io" = (
-/obj/machinery/holopad,
+/obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "iq" = (
@@ -2566,11 +2506,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engine_monitoring)
-"iu" = (
-/obj/structure/table/mainship,
-/obj/machinery/computer/shuttle/shuttle_control/dropship,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "ix" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
@@ -2582,11 +2517,8 @@
 	},
 /area/mainship/shipboard/firing_range)
 "iy" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/thin,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -2604,14 +2536,22 @@
 	},
 /area/mainship/command/cic)
 "iB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/poddoor/mainship/ammo{
+	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/hangar)
+"iC" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/operating_room_one)
 "iD" = (
 /obj/machinery/camera/autoname/mainship,
 /obj/machinery/chem_dispenser,
@@ -2633,13 +2573,10 @@
 /area/mainship/squads/general)
 "iG" = (
 /obj/structure/cable,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 5
+/obj/machinery/door/poddoor/mainship/droppod{
+	dir = 2
 	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
-	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/hangar/droppod)
 "iH" = (
 /obj/structure/largecrate/random/case,
@@ -2656,21 +2593,24 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "iK" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 10
-	},
-/obj/item/clothing/head/warning_cone,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "iL" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
+"iO" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/surgery_hallway)
 "iQ" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
 "iR" = (
-/obj/structure/dropship_equipment/electronics/spotlights,
+/obj/structure/dropship_equipment/operatingtable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/orange{
@@ -2738,9 +2678,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ja" = (
-/obj/machinery/light{
-	light_color = "#da2f1b"
-	},
+/obj/structure/cable,
+/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "jb" = (
@@ -2758,11 +2698,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "je" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "jf" = (
 /obj/structure/bed/chair/office/dark{
@@ -2773,13 +2715,9 @@
 	},
 /area/mainship/command/cic)
 "jg" = (
-/obj/machinery/firealarm{
-	dir = 8
-	},
-/obj/structure/dropship_equipment/mg_holder,
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
+/obj/structure/cable,
+/obj/machinery/light/small,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "jh" = (
 /obj/machinery/light/small,
@@ -2860,8 +2798,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "jx" = (
-/obj/machinery/dropship_part_fabricator,
-/turf/open/floor/mainship/cargo,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "jy" = (
 /turf/open/floor/mainship/mono,
@@ -2891,9 +2830,8 @@
 	},
 /area/mainship/command/corporateliaison)
 "jF" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 6
-	},
+/obj/effect/attach_point/electronics/dropship1,
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "jG" = (
 /obj/effect/decal/siding{
@@ -2904,15 +2842,19 @@
 	},
 /area/space)
 "jH" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/mainship/squads/req)
-"jI" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 8
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
 	},
-/obj/effect/decal/warning_stripes/thin{
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/stairs/rampbottom{
 	dir = 1
+	},
+/area/mainship/hallways/hangar)
+"jI" = (
+/obj/machinery/landinglight/ds1{
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -2938,14 +2880,10 @@
 /turf/open/floor/plating,
 /area/mainship/command/telecomms)
 "jM" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/obj/structure/sign/double/barsign,
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "jN" = (
 /turf/open/floor/mainship/floor,
@@ -2957,11 +2895,10 @@
 /area/space)
 "jP" = (
 /obj/machinery/holopad,
-/obj/effect/ai_node,
-/obj/machinery/light{
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "jQ" = (
@@ -2997,13 +2934,26 @@
 /area/mainship/squads/general)
 "jT" = (
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
+/obj/effect/ai_node,
+/obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "jU" = (
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
+"jV" = (
+/obj/structure/cable,
+/obj/machinery/holosign_switch{
+	id = "or2sign";
+	pixel_x = 5;
+	pixel_y = 10
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/operating_room_two)
 "jX" = (
 /obj/structure/closet/l3closet/virology,
 /obj/machinery/light{
@@ -3014,21 +2964,15 @@
 "jY" = (
 /turf/closed/wall/mainship/research/containment/wall/corner,
 /area/mainship/medical/medical_science)
-"jZ" = (
-/obj/structure/closet/toolcloset,
+"kb" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"kb" = (
-/obj/docking_port/stationary/marine_dropship/minidropship,
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "kc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
+/obj/machinery/iv_drip,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "kd" = (
@@ -3039,15 +2983,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "ke" = (
-/obj/item/clothing/head/warning_cone,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 5
-	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "kf" = (
 /turf/open/floor/mainship/terragov/north{
-	dir = 9
+	dir = 8
 	},
 /area/mainship/hallways/hangar)
 "kg" = (
@@ -3066,33 +3007,38 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/port_hallway)
 "kj" = (
-/turf/open/floor/mainship/terragov/north{
+/turf/open/floor/mainship/terragov{
 	dir = 1
 	},
 /area/mainship/hallways/hangar)
+"kk" = (
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "km" = (
-/obj/item/storage/box/pillbottles,
-/obj/item/storage/box/gloves{
-	pixel_x = 6;
-	pixel_y = 8
+/obj/machinery/holopad{
+	active_power_usage = 60;
+	desc = "It's a floor-mounted device for projecting holographic images. This one appears to have a smaller lense";
+	holo_range = 3;
+	idle_power_usage = 3;
+	name = "modifed holopad"
 	},
-/obj/item/storage/box/beakers{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/storage/box/pillbottles,
-/obj/item/storage/box/beakers{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/machinery/camera/autoname/mainship{
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
+"kn" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/structure/table/mainship,
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/medical/chemistry)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
 "ko" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -3102,13 +3048,8 @@
 	},
 /area/mainship/squads/general)
 "kp" = (
-/obj/structure/prop/mainship/hangar_stencil,
-/obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/machinery/landinglight/ds1/delaythree{
-	dir = 8
+	dir = 9
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -3129,10 +3070,18 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/medical/surgery_hallway)
-"ks" = (
-/obj/machinery/vending/MarineMed,
+"kt" = (
+/obj/machinery/status_display,
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/lower_medical)
+"ku" = (
+/obj/structure/table/mainship,
+/obj/item/defibrillator,
+/obj/item/defibrillator,
+/obj/item/defibrillator,
+/obj/machinery/recharger,
 /turf/open/floor/mainship/sterile/side{
-	dir = 4
+	dir = 8
 	},
 /area/mainship/medical/lower_medical)
 "kv" = (
@@ -3169,11 +3118,8 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "kC" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar/droppod)
+/turf/open/floor/mainship_hull,
+/area/mainship/hull/lower_hull)
 "kD" = (
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/plating/plating_catwalk,
@@ -3196,41 +3142,29 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "kG" = (
-/obj/structure/dropship_equipment/weapon/minirocket_pod,
+/obj/item/reagent_containers/jerrycan,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "kH" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/landinglight/ds1{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 1
-	},
-/area/mainship/hallways/hangar)
-"kI" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 1
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "kJ" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/landinglight/ds1/delaytwo{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 1
-	},
+/obj/structure/cable,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "kL" = (
 /obj/structure/window/reinforced{
@@ -3278,7 +3212,7 @@
 /area/mainship/squads/general)
 "kT" = (
 /turf/open/floor/mainship/terragov/north{
-	dir = 5
+	dir = 4
 	},
 /area/mainship/hallways/hangar)
 "kU" = (
@@ -3291,8 +3225,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "kV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "kW" = (
@@ -3332,12 +3268,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "lb" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "lc" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
@@ -3535,21 +3468,30 @@
 	},
 /area/mainship/command/cic)
 "lC" = (
-/obj/item/clothing/head/warning_cone,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
+/obj/machinery/light{
+	light_color = "#da2f1b"
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "lD" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "lE" = (
 /obj/structure/table/mainship,
 /obj/machinery/chem_dispenser/soda,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
+"lF" = (
+/obj/structure/table/mainship,
+/obj/item/mass_spectrometer,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "lG" = (
 /turf/closed/wall/mainship,
 /area/mainship/command/telecomms)
@@ -3579,42 +3521,69 @@
 /obj/machinery/computer/emails,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
-"lM" = (
-/turf/open/floor/plating{
-	dir = 4;
-	icon_state = "warnplatecorner"
-	},
-/area/mainship/hallways/hangar)
 "lN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/structure/window/framed/mainship/white,
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "lO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/aft_hallway)
+/obj/machinery/firealarm,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "lQ" = (
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "lR" = (
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
+"lS" = (
+/obj/structure/table/mainship,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 7
+	},
+/obj/item/storage/firstaid/fire{
+	pixel_x = 7
+	},
+/obj/item/storage/firstaid/o2{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/storage/firstaid/rad{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/storage/firstaid/adv{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/firstaid/adv{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/storage/firstaid/adv{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/surgery_hallway)
 "lT" = (
 /obj/machinery/door/airlock/mainship/command/FCDRoffice,
 /obj/machinery/door/firedoor/mainship,
@@ -3631,9 +3600,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "lU" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/surgery_hallway)
+/obj/machinery/vending/nanomed,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "lV" = (
 /obj/structure/cable,
 /obj/machinery/light/small,
@@ -3648,14 +3617,17 @@
 /obj/structure/dropprop,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar/droppod)
+"lY" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "lZ" = (
 /obj/machinery/marine_selector/gear/engi,
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
-"ma" = (
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lower_medical)
 "mb" = (
 /obj/structure/toilet,
 /obj/structure/mirror,
@@ -3682,14 +3654,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "mh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 1;
+	on = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "mi" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -3697,15 +3666,9 @@
 /area/mainship/command/corporateliaison)
 "mj" = (
 /obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/landinglight/ds2{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "mk" = (
 /obj/structure/window/reinforced/tinted{
@@ -3720,8 +3683,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/commandbunks)
 "ml" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -3755,7 +3718,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "mp" = (
@@ -3765,20 +3727,23 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "mr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "ms" = (
 /obj/effect/decal/warning_stripes/thin{
-	dir = 8
+	dir = 9
 	},
-/obj/structure/ship_ammo/rocket/banshee,
+/obj/structure/ship_ammo/rocket/keeper,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "mt" = (
@@ -3829,6 +3794,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"mC" = (
+/obj/machinery/optable,
+/obj/item/tank/anesthetic,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
 "mD" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship/floor,
@@ -3927,6 +3897,17 @@
 	},
 /turf/open/floor/mainship/black/full,
 /area/mainship/living/cafeteria_starboard)
+"mS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "mT" = (
 /turf/open/floor/carpet{
 	dir = 10;
@@ -3997,10 +3978,12 @@
 	},
 /area/space)
 "ne" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/item/reagent_containers/jerrycan,
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "nh" = (
 /obj/effect/decal/warning_stripes/engineer,
@@ -4020,16 +4003,30 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "nj" = (
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 8
-	},
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access,
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side{
+	dir = 9
+	},
 /area/mainship/medical/lower_medical)
 "nk" = (
-/turf/closed/wall/mainship/white,
-/area/mainship/medical/chemistry)
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/adv,
+/obj/machinery/door_control{
+	dir = 4;
+	id = "or2privacyshutter";
+	name = "Privacy Shutters"
+	},
+/obj/item/reagent_containers/spray/surgery,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/operating_room_two)
+"nl" = (
+/obj/machinery/autodoc_console,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "nm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /obj/structure/sign/poster{
@@ -4040,11 +4037,32 @@
 "nn" = (
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/surgery_hallway)
+"no" = (
+/obj/machinery/researchcomp,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/medical_science)
+"np" = (
+/obj/structure/cable,
+/obj/structure/table/mainship,
+/obj/machinery/reagentgrinder,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "nq" = (
 /obj/machinery/door/firedoor/mainship,
 /obj/machinery/door/airlock/multi_tile/mainship/marine/general{
 	dir = 2
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "nr" = (
@@ -4065,8 +4083,20 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"nu" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/landinglight/ds1{
+	dir = 1
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "nv" = (
-/turf/open/floor/plating/icefloor/warnplate,
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "nz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4076,6 +4106,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/bed/chair/wood/wings{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "nA" = (
@@ -4137,16 +4170,17 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
 "nI" = (
-/obj/machinery/optable,
-/obj/item/tank/anesthetic,
-/obj/structure/cable,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/window/framed/mainship/white,
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 1;
+	id = "or1privacyshutter";
+	name = "\improper Privacy Shutters"
 	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 1
 	},
-/area/mainship/medical/operating_room_two)
+/area/mainship/medical/lower_medical)
 "nJ" = (
 /obj/machinery/power/smes/preset,
 /obj/structure/cable,
@@ -4161,15 +4195,9 @@
 /area/mainship/medical/surgery_hallway)
 "nL" = (
 /obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/landinglight/ds2/delaytwo{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "nM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4194,9 +4222,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "nO" = (
-/turf/open/floor/mainship/sterile/corner{
-	dir = 1
-	},
+/obj/machinery/holopad,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "nP" = (
 /obj/structure/table/mainship,
@@ -4219,15 +4247,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "nR" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/aft_hallway)
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "nU" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -4258,6 +4280,10 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
+"nY" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/mainship/squads/req)
 "nZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -4266,28 +4292,30 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "oa" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "ob" = (
 /obj/structure/cable,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "od" = (
-/obj/machinery/bioprinter/stocked,
-/turf/open/floor/mainship/sterile/corner{
-	dir = 8
+/obj/machinery/holopad{
+	active_power_usage = 60;
+	desc = "It's a floor-mounted device for projecting holographic images. This one appears to have a smaller lense";
+	holo_range = 3;
+	idle_power_usage = 3;
+	name = "modifed holopad"
 	},
-/area/mainship/medical/operating_room_two)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "oe" = (
-/obj/structure/sink{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/operating_room_two)
+/obj/machinery/firealarm,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "of" = (
 /obj/structure/table/mainship,
 /obj/item/folder/white,
@@ -4319,11 +4347,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "oj" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
-	dir = 2
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/medical/lower_medical)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar)
 "ol" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -4338,14 +4365,24 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
 "on" = (
-/obj/effect/ai_node,
+/obj/machinery/dropship_part_fabricator,
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/hangar)
+"op" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "oq" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
 	},
-/obj/item/clothing/head/warning_cone,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "or" = (
@@ -4409,12 +4446,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
-"oD" = (
-/obj/machinery/light{
-	light_color = "#da2f1b"
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
 "oE" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 8;
@@ -4523,20 +4554,13 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "oV" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
+/obj/structure/table/mainship,
+/obj/machinery/faxmachine/research,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "oW" = (
-/obj/effect/ai_node,
-/obj/machinery/light{
-	light_color = "#da2f1b"
-	},
-/turf/open/floor/mainship/mono,
+/obj/machinery/status_display,
+/turf/closed/wall/mainship,
 /area/mainship/hallways/hangar)
 "oX" = (
 /obj/structure/cable,
@@ -4611,13 +4635,6 @@
 	dir = 6
 	},
 /area/mainship/medical/medical_science)
-"pi" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/start/job/researcher,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/medical_science)
 "pj" = (
 /obj/machinery/vending/uniform_supply,
 /obj/machinery/light{
@@ -4637,6 +4654,17 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
+"pm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "pn" = (
 /obj/structure/rack,
 /obj/item/tool/wrench,
@@ -4649,16 +4677,18 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "po" = (
-/obj/structure/disposalpipe/segment/corner,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
+"pp" = (
+/obj/structure/table/woodentable,
+/obj/item/storage/fancy/cigar,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "pq" = (
 /obj/machinery/vending/shared_vending/marine_engi,
 /obj/machinery/light{
@@ -4674,9 +4704,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "pt" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "pw" = (
@@ -4689,10 +4721,12 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "px" = (
+/obj/structure/prop/mainship/hangar_stencil/two,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/turf/open/floor/mainship/floor,
+/obj/effect/decal/warning_stripes/thin,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "py" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -4756,6 +4790,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
+"pM" = (
+/obj/machinery/computer/arcade,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "pP" = (
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
 	dir = 8
@@ -4794,16 +4835,23 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "pV" = (
-/obj/structure/table/mainship,
-/obj/machinery/faxmachine/research,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "pW" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "pX" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
@@ -4815,6 +4863,9 @@
 	dir = 4
 	},
 /area/space)
+"pZ" = (
+/turf/open/floor/mainship/sterile,
+/area/mainship/medical/lower_medical)
 "qa" = (
 /obj/machinery/light{
 	dir = 8
@@ -4835,14 +4886,15 @@
 	dir = 8
 	},
 /area/mainship/living/cryo_cells)
+"qe" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "qf" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "qg" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -4886,6 +4938,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"qn" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "qo" = (
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
@@ -4975,21 +5032,9 @@
 "qC" = (
 /turf/closed/wall/mainship,
 /area/mainship/squads/general)
-"qD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "qE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/cargo,
+/obj/structure/bed/roller,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "qF" = (
 /obj/structure/table/mainship,
@@ -5033,6 +5078,20 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
+"qL" = (
+/obj/structure/bed/chair/sofa{
+	dir = 1
+	},
+/obj/machinery/light{
+	light_color = "#da2f1b"
+	},
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
+"qO" = (
+/turf/open/floor/mainship/sterile/side{
+	dir = 6
+	},
+/area/mainship/medical/lower_medical)
 "qP" = (
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/plating/mainship,
@@ -5045,13 +5104,12 @@
 /turf/open/floor/plating,
 /area/mainship/command/telecomms)
 "qR" = (
-/obj/structure/bed/stool{
-	pixel_y = 8
-	},
+/obj/structure/closet/secure_closet/medical2,
+/obj/item/storage/surgical_tray,
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
-/area/mainship/medical/chemistry)
+/area/mainship/medical/operating_room_two)
 "qT" = (
 /turf/closed/shuttle/ert{
 	icon_state = "leftengine_2";
@@ -5116,9 +5174,13 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/starboard_hallway)
 "ri" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "rj" = (
 /obj/machinery/door/airlock/mainship/maint,
@@ -5157,9 +5219,13 @@
 	},
 /area/space)
 "rr" = (
-/obj/machinery/status_display,
-/turf/closed/wall/mainship/white,
-/area/mainship/living/grunt_rnr)
+/obj/machinery/bodyscanner{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "rs" = (
 /obj/structure/table/mainship,
 /obj/machinery/chem_dispenser/soda{
@@ -5168,19 +5234,21 @@
 /turf/open/floor/wood,
 /area/mainship/medical/surgery_hallway)
 "rt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/item/clothing/head/warning_cone,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
-"ru" = (
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
+"ru" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/area/mainship/hallways/hangar)
 "rv" = (
 /obj/structure/closet/secure_closet/bar/captain,
 /turf/open/floor/wood,
@@ -5213,6 +5281,17 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
+"rA" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 1
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "rB" = (
 /obj/docking_port/stationary/escape_pod/escape_shuttle{
 	dir = 1
@@ -5269,11 +5348,10 @@
 	},
 /area/space)
 "rI" = (
-/obj/item/clothing/head/warning_cone,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/door/poddoor/mainship/ammo{
+	dir = 2
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/hangar)
 "rK" = (
 /obj/structure/safe,
@@ -5337,7 +5415,22 @@
 /turf/open/floor/plating,
 /area/mainship/command/telecomms)
 "rT" = (
-/obj/structure/bed/chair/wood/normal,
+/obj/structure/bed/chair/wood/wings,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
+"rU" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
+"rV" = (
+/obj/structure/bed/chair/sofa{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "rW" = (
@@ -5389,10 +5482,6 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/starboard_hallway)
-"se" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
 "sf" = (
 /obj/structure/bed/chair/wood/wings{
 	dir = 4
@@ -5414,6 +5503,7 @@
 /obj/structure/bed/chair/wood/wings{
 	dir = 8
 	},
+/obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "si" = (
@@ -5491,11 +5581,10 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/engineering/port_atmos)
 "sr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/effect/decal/warning_stripes/thin,
+/obj/machinery/landinglight/ds1,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "ss" = (
 /obj/machinery/cryopod/right,
 /obj/machinery/alarm,
@@ -5514,7 +5603,6 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -5564,8 +5652,10 @@
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "sD" = (
-/obj/machinery/status_display,
-/turf/closed/wall/mainship,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "sE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -5580,10 +5670,13 @@
 /turf/closed/wall/mainship/outer,
 /area/mainship/hallways/starboard_hallway)
 "sH" = (
-/turf/open/floor/plating{
-	dir = 8;
-	icon_state = "warnplatecorner"
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
 	},
+/obj/machinery/landinglight/ds1/delaythree{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "sI" = (
 /obj/machinery/door/airlock/mainship/command/officer{
@@ -5750,7 +5843,7 @@
 /area/mainship/living/pilotbunks)
 "te" = (
 /turf/open/floor/mainship/terragov/north{
-	dir = 8
+	dir = 10
 	},
 /area/mainship/hallways/hangar)
 "tf" = (
@@ -5823,6 +5916,13 @@
 "tp" = (
 /turf/closed/wall/mainship,
 /area/mainship/shipboard/weapon_room)
+"tq" = (
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/glass/beaker/cryomix,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "tr" = (
 /obj/machinery/light{
 	dir = 4
@@ -6192,7 +6292,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "ur" = (
-/obj/structure/dropship_equipment/electronics/spotlights,
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/obj/structure/dropship_equipment/mg_holder,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
@@ -6260,9 +6363,7 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/starboard_umbilical)
 "uA" = (
-/turf/open/floor/mainship/terragov{
-	dir = 1
-	},
+/turf/open/floor/mainship/terragov/north,
 /area/mainship/hallways/hangar)
 "uB" = (
 /obj/structure/closet/firecloset,
@@ -6302,7 +6403,7 @@
 /area/mainship/hallways/starboard_umbilical)
 "uL" = (
 /turf/open/floor/mainship/terragov/north{
-	dir = 4
+	dir = 6
 	},
 /area/mainship/hallways/hangar)
 "uM" = (
@@ -6384,10 +6485,10 @@
 /turf/open/floor/mainship/blue/full,
 /area/mainship/command/cic)
 "uZ" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 10
-	},
-/area/mainship/squads/req)
+/obj/effect/decal/warning_stripes/thin,
+/obj/machinery/landinglight/ds1/delaythree,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "va" = (
 /obj/structure/closet/secure_closet/securecom,
 /obj/item/moneybag/vault,
@@ -6405,10 +6506,11 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/stern_hallway)
 "vd" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/surgery_hallway)
+/obj/effect/decal/warning_stripes/thin,
+/obj/machinery/landinglight/ds1/delayone,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "ve" = (
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 1
@@ -6418,10 +6520,6 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/cargo,
 /area/mainship/shipboard/weapon_room)
-"vg" = (
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar)
 "vh" = (
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
@@ -6459,10 +6557,23 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
 "vn" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/table/mainship,
+/obj/item/storage/box/beakers{
+	pixel_x = -7;
+	pixel_y = 7
 	},
-/obj/structure/cable,
+/obj/item/storage/box/pillbottles{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/storage/box/syringes{
+	pixel_x = -7
+	},
+/obj/item/storage/box/autoinjectors{
+	pixel_x = 7
+	},
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
@@ -6558,12 +6669,25 @@
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
+"vz" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/vending/medical/shipside,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 8
+	},
+/area/mainship/medical/surgery_hallway)
 "vA" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_umbilical)
 "vB" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/cargo/arrow,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "vC" = (
 /obj/machinery/vending/engineering,
@@ -6657,13 +6781,10 @@
 /turf/open/floor/prison/kitchen,
 /area/mainship/living/grunt_rnr)
 "vR" = (
-/obj/structure/bed/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/surgery_hallway)
+/obj/effect/decal/warning_stripes/thin,
+/obj/machinery/landinglight/ds2,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "vS" = (
 /obj/machinery/door/airlock/mainship/generic/pilot/bunk{
 	dir = 8
@@ -6756,12 +6877,14 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "wg" = (
-/obj/structure/sign/poster{
-	dir = 1
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
 	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
+/obj/effect/ai_node,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
 	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "wh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -6799,16 +6922,14 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "wn" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
-/obj/machinery/door_control/mainship/droppod{
+/obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
-/area/mainship/hallways/hangar/droppod)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "wo" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -6860,18 +6981,6 @@
 /obj/item/uav_turret/droid,
 /turf/open/floor/mainship/orange/full,
 /area/mainship/command/cic)
-"wu" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 8
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
 "ww" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/mainship/black{
@@ -6879,7 +6988,12 @@
 	},
 /area/mainship/squads/general)
 "wx" = (
-/obj/effect/landmark/start/job/medicalofficer,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "wy" = (
@@ -6887,7 +7001,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_umbilical)
 "wz" = (
-/obj/machinery/camera/autoname/mainship{
+/obj/machinery/firealarm{
 	dir = 4
 	},
 /turf/open/floor/mainship/floor,
@@ -6915,8 +7029,11 @@
 	},
 /area/mainship/squads/general)
 "wC" = (
-/obj/machinery/computer/camera_advanced/remote_fob,
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -6995,9 +7112,17 @@
 /turf/open/floor/prison/kitchen,
 /area/mainship/living/grunt_rnr)
 "wN" = (
-/obj/structure/window/framed/mainship/white,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/landinglight/ds1/delaythree{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "wO" = (
 /obj/structure/table/mainship,
 /obj/item/explosive/grenade/training,
@@ -7039,10 +7164,10 @@
 /area/mainship/hallways/starboard_hallway)
 "wT" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/side,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "wU" = (
 /obj/structure/disposalpipe/segment,
@@ -7181,14 +7306,10 @@
 	},
 /area/mainship/squads/general)
 "xo" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/stairs/rampbottom{
-	dir = 1
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "xp" = (
 /obj/machinery/door/airlock/mainship/generic/corporate/quarters,
@@ -7338,15 +7459,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/upper_engineering)
 "xK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/landmark/start/job/medicalofficer,
+/obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "xL" = (
 /obj/structure/bed/chair/office/dark{
@@ -7383,12 +7500,27 @@
 /obj/item/radio,
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/port_umbilical)
+"xQ" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "xR" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"xS" = (
+/obj/machinery/door/poddoor/shutters/opened/medbay,
+/obj/structure/window/framed/mainship/white,
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/plating/platebotc,
+/area/mainship/medical/lower_medical)
 "xT" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/engineering/port_atmos)
@@ -7505,6 +7637,14 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine,
 /area/mainship/engineering/port_atmos)
+"yl" = (
+/obj/machinery/power/apc/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "ym" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/window/framed/mainship/hull,
@@ -7693,13 +7833,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
 "yO" = (
-/obj/machinery/computer/cryopod{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/corner{
+/obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
-/area/mainship/medical/surgery_hallway)
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "yP" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
@@ -7734,8 +7875,14 @@
 	},
 /area/mainship/engineering/ce_room)
 "yS" = (
-/turf/open/floor/mainship/terragov/north,
-/area/mainship/squads/req)
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "yT" = (
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
@@ -7781,10 +7928,11 @@
 /turf/open/floor/mainship/orange/corner,
 /area/mainship/engineering/ce_room)
 "yY" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 6
+/obj/effect/attach_point/electronics/dropship1,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
 	},
-/area/mainship/squads/req)
+/area/mainship/hallways/hangar)
 "yZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
@@ -7796,8 +7944,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "za" = (
-/obj/machinery/light{
-	light_color = "#da2f1b"
+/obj/structure/bed/chair/sofa{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
@@ -7859,8 +8007,12 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/engineering/lower_engineering)
 "zk" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
@@ -7881,14 +8033,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "zq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/effect/attach_point/weapon/dropship1,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
 	},
-/obj/item/clothing/head/warning_cone,
-/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "zr" = (
-/obj/structure/cable,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "zs" = (
@@ -7940,10 +8090,8 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/engineering/lower_engineering)
 "zB" = (
-/obj/machinery/door_control/mainship/ammo{
-	dir = 8
-	},
-/turf/open/floor/mainship/floor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "zC" = (
 /turf/closed/wall/mainship,
@@ -8003,6 +8151,10 @@
 /obj/machinery/vending/engivend,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"zM" = (
+/obj/machinery/chem_dispenser,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "zN" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/mainship/mono,
@@ -8093,10 +8245,10 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/engineering/engine_core)
 "Ac" = (
-/obj/machinery/smartfridge/chemistry,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/surgery_hallway)
+/obj/machinery/light,
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "Ad" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -8158,14 +8310,9 @@
 /turf/open/floor/plating,
 /area/mainship/shipboard/firing_range)
 "Am" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "An" = (
@@ -8190,10 +8337,9 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/machinery/landinglight/ds2{
+/obj/machinery/landinglight/ds2/delaythree{
 	dir = 8
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "As" = (
@@ -8288,8 +8434,8 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/engineering/upper_engineering)
-"AI" = (
-/obj/machinery/body_scanconsole,
+"AK" = (
+/obj/machinery/cloning_console/vats,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "AL" = (
@@ -8472,7 +8618,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/multi_tile/mainship/generic/rnr,
 /turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
+/area/mainship/living/grunt_rnr)
 "Bn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8480,17 +8626,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/table/mainship,
 /obj/item/storage/box/matches,
-/obj/item/storage/fancy/cigar,
+/obj/item/storage/fancy/cigarettes,
+/obj/structure/table/woodentable,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "Bo" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
+/obj/machinery/power/apc/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "Bp" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -8502,9 +8648,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Bq" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 5
-	},
+/obj/machinery/light,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "Br" = (
 /obj/machinery/light{
@@ -8557,7 +8703,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/bed/chair/wood/normal{
+/obj/structure/bed/chair/wood/wings{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -8568,7 +8714,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "BB" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
@@ -8586,15 +8731,15 @@
 /obj/item/reagent_containers/glass/rag,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/grunt_rnr)
+"BE" = (
+/obj/machinery/chem_dispenser,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
 "BF" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/corner{
-	dir = 1
-	},
-/area/mainship/medical/operating_room_two)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "BG" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -8613,26 +8758,8 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "BJ" = (
-/obj/structure/table/mainship,
-/obj/item/storage/belt/combatLifesaver,
-/obj/item/storage/belt/combatLifesaver,
-/obj/item/storage/belt/combatLifesaver,
-/obj/item/storage/belt/medical{
-	pixel_y = 9
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 9
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 9
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 9
-	},
-/obj/item/healthanalyzer,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
-/obj/structure/cable,
+/obj/machinery/chem_master,
+/obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
@@ -8649,55 +8776,6 @@
 /obj/item/clothing/head/modular/marine,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cafeteria_starboard)
-"BM" = (
-/obj/structure/table/mainship,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 7
-	},
-/obj/item/storage/firstaid/fire{
-	pixel_x = 7
-	},
-/obj/item/storage/firstaid/o2{
-	pixel_x = 4;
-	pixel_y = 7
-	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/storage/firstaid/rad{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/storage/firstaid/adv{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/storage/firstaid/adv{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/obj/item/storage/firstaid/adv{
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = 1
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
 "BN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -8865,14 +8943,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
-"Ck" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "Cl" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/mono,
@@ -8920,35 +8990,31 @@
 /area/mainship/command/airoom)
 "Ct" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/ai_node,
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
 /area/mainship/medical/surgery_hallway)
 "Cu" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
-	},
 /obj/structure/ship_ammo/rocket/keeper,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "Cv" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/mainship/maint,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/mono,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"Cw" = (
+/obj/machinery/cloning/vats,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "Cx" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/mainship/medical/surgery_hallway)
-"Cy" = (
-/obj/structure/table/mainship,
-/obj/item/storage/fancy/cigarettes,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
 "Cz" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/mainship/mono,
@@ -8960,16 +9026,8 @@
 	},
 /area/mainship/living/cryo_cells)
 "CB" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
 /obj/structure/cable,
-/obj/machinery/door_control/mainship/droppod{
-	dir = 8
-	},
-/turf/open/floor/stairs/rampbottom{
-	dir = 1
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "CC" = (
 /obj/machinery/status_display,
@@ -9017,9 +9075,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "CI" = (
-/obj/machinery/status_display,
-/turf/closed/wall/mainship/white,
-/area/mainship/medical/chemistry)
+/obj/machinery/bioprinter/stocked,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
 "CJ" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -9063,24 +9121,18 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "CQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "CR" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
-	},
-/obj/structure/bed/chair/wood/normal{
-	dir = 4
 	},
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
@@ -9137,6 +9189,10 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
+"Da" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "Db" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
@@ -9166,6 +9222,9 @@
 	},
 /mob/living/simple_animal/catslug/newt,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "Df" = (
@@ -9383,23 +9442,19 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/starboard_umbilical)
 "DF" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"DG" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
+/obj/machinery/alarm{
 	dir = 4
 	},
+/turf/closed/wall/mainship,
+/area/mainship/hallways/hangar)
+"DG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "DH" = (
 /obj/machinery/disposal,
@@ -9519,10 +9574,8 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
 "DU" = (
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/surgery_hallway)
+/turf/open/floor/plating/dmg1,
+/area/mainship/hallways/hangar)
 "DV" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -9546,22 +9599,33 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
 "DX" = (
-/obj/structure/prop/mainship/hangar_stencil,
-/obj/effect/decal/warning_stripes/thin,
-/obj/effect/decal/warning_stripes/thin{
+/obj/item/radio/intercom/general{
 	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "DZ" = (
-/obj/structure/table/mainship,
-/obj/item/reagent_containers/glass/beaker/cryomix,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
+"Ea" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment/corner,
 /turf/open/floor/mainship/sterile/side{
-	dir = 1
+	dir = 4
 	},
 /area/mainship/medical/lower_medical)
 "Eb" = (
-/obj/machinery/chem_dispenser,
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -9575,7 +9639,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "Ed" = (
-/obj/structure/bed/chair/wood/normal{
+/obj/structure/bed/chair/sofa/right{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -9758,19 +9822,15 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "EG" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/bed/chair/wood/normal{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
-"EH" = (
+/obj/vehicle/ridden/powerloader,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/hangar)
+"EH" = (
+/obj/structure/window/framed/mainship/white,
+/turf/open/floor/mainship/sterile,
 /area/mainship/medical/surgery_hallway)
 "EI" = (
 /obj/machinery/door/airlock/multi_tile/mainship/maint{
@@ -9798,9 +9858,7 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "EN" = (
-/obj/structure/table/mainship,
-/obj/item/toy/deck,
-/obj/item/storage/donut_box,
+/obj/structure/table/woodentable,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "EO" = (
@@ -9820,6 +9878,12 @@
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
+"ES" = (
+/obj/machinery/vending/MarineMed,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
 "ET" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -9851,6 +9915,12 @@
 	dir = 8
 	},
 /area/mainship/squads/general)
+"Fb" = (
+/obj/machinery/sleeper,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "Fc" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -9858,6 +9928,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
+"Fd" = (
+/obj/machinery/power/apc/mainship,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/operating_room_one)
 "Ff" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/bed/stool{
@@ -9923,10 +10000,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Fp" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/medical_science)
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/vehicle/ridden/powerloader,
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/hangar)
 "Fq" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/multi_tile/mainship/maint{
@@ -9964,18 +10043,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
-"Fy" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
-/obj/machinery/vending/MarineMed,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
 "Fz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -10131,26 +10198,32 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
 "Ga" = (
+/obj/effect/decal/warning_stripes/thin,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Gb" = (
+/obj/effect/decal/warning_stripes/thin,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Gc" = (
-/obj/effect/decal/warning_stripes/thin,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Gd" = (
-/obj/effect/decal/warning_stripes/thin,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Ge" = (
-/obj/structure/dropship_equipment/weapon/rocket_pod,
-/turf/open/floor/mainship/floor,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/machinery/landinglight/ds2/delaytwo{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Gf" = (
 /obj/machinery/light{
@@ -10160,12 +10233,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "Gg" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 4;
-	on = 1
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
 	},
-/turf/open/floor/mainship/cargo,
+/obj/machinery/landinglight/ds2{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Gh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -10197,30 +10272,25 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Gl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/mainship/cargo/arrow,
-/area/mainship/hallways/hangar)
-"Gm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/cargo/arrow,
-/area/mainship/hallways/hangar)
-"Go" = (
-/obj/effect/decal/warning_stripes/thin,
+/obj/machinery/computer/camera_advanced/remote_fob,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"Gp" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
+"Gm" = (
+/obj/item/storage/box/sentry,
+/obj/structure/rack,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
+"Go" = (
+/obj/structure/dropship_equipment/electronics/spotlights,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/orange{
+	dir = 8
 	},
+/area/mainship/hallways/hangar)
+"Gp" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
@@ -10229,11 +10299,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Gq" = (
+/obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Gr" = (
@@ -10264,9 +10335,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
 "Gv" = (
-/obj/structure/dropship_equipment/weapon/heavygun,
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
+/obj/machinery/door/airlock/mainship/maint,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "Gw" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -10290,18 +10363,10 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "GC" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "GD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -10312,13 +10377,15 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/mainship/squads/req)
 "GE" = (
@@ -10337,7 +10404,6 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "GG" = (
@@ -10388,6 +10454,13 @@
 	dir = 9
 	},
 /area/mainship/squads/general)
+"GO" = (
+/obj/structure/window/framed/mainship,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/mainship/living/grunt_rnr)
 "GP" = (
 /obj/structure/table/mainship,
 /obj/machinery/light{
@@ -10397,13 +10470,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
 "GQ" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 1;
-	on = 1
-	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/area/mainship/hull/lower_hull)
 "GR" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -10416,17 +10487,22 @@
 /obj/item/pizzabox/meat,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"GU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
+"GT" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/surgery_hallway)
+"GU" = (
+/obj/structure/cable,
+/turf/closed/wall/mainship/outer,
+/area/mainship/hull/lower_hull)
 "GV" = (
-/obj/machinery/door/poddoor/mainship/droppod{
+/obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
-/turf/open/floor/mainship/stripesquare,
+/turf/open/floor/stairs/rampbottom{
+	dir = 1
+	},
 /area/mainship/hallways/hangar/droppod)
 "GX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -10599,11 +10675,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "Hu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "Hv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -10879,12 +10956,6 @@
 /area/mainship/hull/lower_hull)
 "Ii" = (
 /obj/structure/cable,
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 2
-	},
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -11092,16 +11163,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"IL" = (
-/obj/structure/table/mainship,
-/obj/machinery/recharger,
-/obj/item/defibrillator,
-/obj/item/defibrillator,
-/obj/item/defibrillator,
-/turf/open/floor/mainship/sterile/corner,
-/area/mainship/medical/lower_medical)
 "IM" = (
-/obj/structure/table/mainship,
+/obj/item/toy/deck,
+/obj/structure/table/woodentable,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "IN" = (
@@ -11118,14 +11182,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "IP" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/turf/open/floor/mainship/stripesquare,
+/obj/structure/disposalpipe/junction,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "IQ" = (
 /obj/machinery/firealarm{
@@ -11246,6 +11307,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "Jl" = (
@@ -11429,12 +11491,16 @@
 "JG" = (
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
-"JI" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+"JH" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side{
 	dir = 9
 	},
-/turf/open/floor/mainship/floor,
+/area/mainship/medical/lower_medical)
+"JI" = (
+/obj/effect/decal/warning_stripes/thin,
+/obj/machinery/landinglight/ds2/delaytwo,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "JJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11450,11 +11516,32 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "JK" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/table/mainship,
+/obj/item/storage/belt/combatLifesaver,
+/obj/item/storage/belt/combatLifesaver,
+/obj/item/storage/belt/combatLifesaver,
+/obj/item/storage/belt/medical{
+	pixel_y = 9
 	},
+/obj/item/storage/belt/medical{
+	pixel_y = 9
+	},
+/obj/item/storage/belt/medical{
+	pixel_y = 9
+	},
+/obj/item/storage/belt/medical{
+	pixel_y = 9
+	},
+/obj/item/healthanalyzer,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/structure/cable,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
 /turf/open/floor/mainship/sterile/side{
-	dir = 8
+	dir = 4
 	},
 /area/mainship/medical/lower_medical)
 "JL" = (
@@ -11465,12 +11552,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "JM" = (
-/obj/structure/disposalpipe/segment/corner{
+/obj/machinery/bodyscanner{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
+/area/mainship/medical/lower_medical)
 "JN" = (
 /obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/mono,
@@ -11494,8 +11580,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "JQ" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/mainship{
+/obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
 /turf/open/floor/mainship/floor,
@@ -11517,6 +11602,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "JV" = (
@@ -11611,6 +11697,14 @@
 /obj/structure/cable,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
+"Kf" = (
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access,
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile,
+/area/mainship/medical/lower_medical)
 "Kg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11630,8 +11724,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Kj" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
+/obj/structure/bed/chair/sofa/right{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -11654,24 +11747,22 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "Km" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/storage/surgical_tray,
-/obj/machinery/power/apc/mainship{
-	dir = 1
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/cable,
+/obj/structure/closet/secure_closet/medical2,
+/obj/item/storage/box/gloves,
+/obj/item/storage/surgical_tray,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
+"Kn" = (
+/obj/machinery/body_scanconsole,
 /turf/open/floor/mainship/sterile/corner{
 	dir = 4
 	},
-/area/mainship/medical/operating_room_two)
-"Kn" = (
-/obj/machinery/iv_drip,
-/obj/machinery/firealarm{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/corner,
-/area/mainship/medical/operating_room_two)
+/area/mainship/medical/lower_medical)
 "Ko" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -11816,6 +11907,9 @@
 	pixel_y = 8
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "KD" = (
@@ -11829,6 +11923,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "KE" = (
@@ -11886,12 +11981,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "KN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/poddoor/mainship/ammo{
+/obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
-/turf/open/floor/mainship/stripesquare,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/stairs/rampbottom{
+	dir = 1
+	},
 /area/mainship/hallways/hangar)
 "KO" = (
 /obj/machinery/vending/weapon,
@@ -11916,11 +12013,19 @@
 /obj/machinery/vending/weapon,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
+"KQ" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/landinglight/ds1{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "KR" = (
 /obj/effect/ai_node,
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "KS" = (
@@ -11945,12 +12050,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "KV" = (
-/obj/machinery/light{
-	light_color = "#da2f1b"
+/obj/effect/attach_point/weapon/dropship1{
+	dir = 8;
+	icon_state = "equip_base_l_wing"
 	},
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/mainship/hallways/hangar)
 "KW" = (
 /turf/closed/wall/mainship/research/containment/wall/corner{
 	dir = 8
@@ -12005,6 +12112,17 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"Le" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/landinglight/ds1/delaytwo{
+	dir = 1
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "Lf" = (
 /obj/machinery/door/poddoor/mainship,
 /turf/open/floor/mainship/mono,
@@ -12105,8 +12223,11 @@
 /area/mainship/engineering/lower_engineering)
 "Lu" = (
 /obj/structure/cable,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/mainship/sterile/side{
-	dir = 9
+	dir = 1
 	},
 /area/mainship/medical/surgery_hallway)
 "Lv" = (
@@ -12155,6 +12276,17 @@
 /obj/item/stack/sheet/cardboard,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"LD" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/bodyscanner{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "LE" = (
 /obj/machinery/light{
 	dir = 8
@@ -12198,12 +12330,21 @@
 	dir = 8
 	},
 /area/mainship/engineering/engine_core)
-"LN" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/turf/open/floor/mainship/sterile/corner{
-	dir = 1
+"LM" = (
+/obj/structure/table/mainship,
+/obj/item/storage/box/bodybags,
+/obj/item/reagent_containers/glass/beaker/biomass,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
 	},
 /area/mainship/medical/lower_medical)
+"LN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/item/clothing/head/warning_cone,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar)
 "LO" = (
 /obj/structure/rack,
 /obj/structure/ob_ammo/warhead/plasmaloss,
@@ -12319,14 +12460,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Me" = (
-/obj/structure/table/mainship,
-/obj/machinery/computer/med_data/laptop,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/medical_science)
-"Mf" = (
-/obj/structure/sign/poster,
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/droppod)
 "Mg" = (
 /obj/structure/target_stake,
 /obj/item/target,
@@ -12349,12 +12484,10 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "Mj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 9
 	},
-/area/mainship/medical/lower_medical)
+/area/mainship/hallways/hangar)
 "Mk" = (
 /obj/machinery/firealarm{
 	dir = 1
@@ -12365,6 +12498,11 @@
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
+"Mm" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction/flipped,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "Mn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -12416,8 +12554,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "Mt" = (
-/obj/effect/ai_node,
-/obj/structure/cable,
+/obj/machinery/vending/medical/shipside,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "Mu" = (
@@ -12466,8 +12603,7 @@
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
 "MD" = (
-/obj/item/storage/box/sentry,
-/obj/structure/rack,
+/obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "ME" = (
@@ -12475,7 +12611,7 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
 "MF" = (
-/obj/structure/bed/chair/wood/normal{
+/obj/structure/bed/chair/wood/wings{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -12536,54 +12672,41 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "MP" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/mainship,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/lower_medical)
-"MQ" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 9
-	},
-/area/mainship/medical/lower_medical)
-"MR" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/adv{
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/item/reagent_containers/spray/surgery{
-	pixel_x = 12;
-	pixel_y = 2
-	},
-/obj/item/clothing/mask/breath/medical,
-/obj/item/storage/box/gloves{
-	pixel_x = -5;
-	pixel_y = -5
-	},
-/obj/machinery/alarm{
-	dir = 4
-	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
-/area/mainship/medical/operating_room_two)
-"MT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/area/mainship/medical/lower_medical)
+"MQ" = (
+/obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/vending/nanomed,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/landinglight/ds1/delaythree{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/side{
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/mainship/hallways/hangar)
+"MR" = (
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/holosign/surgery{
+	id = "or1sign"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/mainship/medical/or/or1{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
+"MT" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "MU" = (
 /obj/machinery/firealarm,
@@ -12610,6 +12733,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_umbilical)
+"MZ" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start/job/researcher,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/medical_science)
 "Na" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -12640,11 +12770,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "Ne" = (
-/obj/structure/bed/chair/wood/normal{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/structure/bed/chair/wood/wings{
+	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
@@ -12683,21 +12813,24 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_umbilical)
 "Ni" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/landinglight/ds1/delaythree{
+	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
 /area/mainship/hallways/hangar)
 "Nj" = (
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_umbilical)
 "Nk" = (
-/obj/structure/ship_ammo/rocket/keeper,
-/turf/open/floor/mainship/floor,
+/obj/docking_port/stationary/marine_dropship/hangar/one,
+/obj/docking_port/stationary/marine_dropship/crash_target,
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "Nl" = (
 /obj/structure/closet/bodybag,
@@ -12731,10 +12864,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
-"Np" = (
-/obj/machinery/light,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "Nq" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship/black{
@@ -12780,10 +12909,11 @@
 	},
 /area/mainship/living/cryo_cells)
 "Nv" = (
-/obj/effect/attach_point/weapon/dropship1,
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 1
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
 	},
+/obj/item/clothing/head/warning_cone,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Nw" = (
 /obj/structure/cable,
@@ -12837,32 +12967,23 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
 "ND" = (
-/obj/machinery/door/airlock/mainship/medical/glass/chemistry{
-	dir = 2
-	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
+/obj/machinery/iv_drip,
+/turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/surgery_hallway)
 "NE" = (
-/obj/effect/landmark/start/job/medicalofficer,
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "NF" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "NG" = (
@@ -12906,8 +13027,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "NL" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -12943,13 +13064,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "NQ" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/structure/sign/chemistry,
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/operating_room_one)
 "NR" = (
 /obj/machinery/door/firedoor/mainship,
 /obj/machinery/door/poddoor/mainship/open/cic,
@@ -12962,9 +13079,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/cic)
 "NS" = (
-/mob/living/simple_animal/corgi/walten,
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/lower_medical)
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/obj/item/clothing/head/warning_cone,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "NT" = (
 /obj/machinery/door/poddoor/shutters/mainship/open/checkpoint/south,
 /obj/machinery/door/firedoor/mainship,
@@ -13039,17 +13159,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/table/mainship,
+/obj/item/storage/donut_box,
+/obj/structure/table/woodentable,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "Og" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/storage/surgical_tray,
 /obj/structure/cable,
-/obj/machinery/power/apc/mainship,
-/turf/open/floor/mainship/sterile/corner,
-/area/mainship/medical/lower_medical)
+/obj/machinery/iv_drip,
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/operating_room_one)
 "Oh" = (
 /obj/machinery/door/airlock/mainship/generic/corporate{
 	dir = 8
@@ -13068,10 +13189,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "Oi" = (
-/obj/effect/attach_point/electronics/dropship1,
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 1
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
 	},
+/obj/machinery/landinglight/ds2/delaytwo{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Oj" = (
 /obj/structure/window/reinforced,
@@ -13158,7 +13282,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "Ow" = (
-/obj/structure/bed/chair/wood/normal{
+/obj/structure/bed/chair/wood/wings{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -13170,21 +13294,27 @@
 /turf/closed/wall/mainship,
 /area/mainship/hallways/starboard_umbilical)
 "Oz" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/landinglight/ds1/delaytwo{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
 	},
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "OA" = (
 /turf/open/floor/mainship/green,
 /area/mainship/squads/req)
 "OB" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/shipboard/weapon_room)
+"OC" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
 "OD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -13320,6 +13450,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"OY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/hallways/aft_hallway)
 "OZ" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -13337,9 +13476,13 @@
 /area/mainship/hallways/hangar)
 "Pb" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/research/glass/wing{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "Pc" = (
@@ -13367,6 +13510,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"Pg" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/surgery_hallway)
 "Ph" = (
 /obj/machinery/light{
 	dir = 1
@@ -13470,15 +13617,12 @@
 	},
 /area/mainship/squads/general)
 "Pu" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/structure/cable,
-/obj/structure/cable,
+/obj/structure/table/mainship,
+/obj/machinery/computer/med_data/laptop,
 /obj/machinery/light{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/mainship/sterile/corner{
-	dir = 8
-	},
+/turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/medical_science)
 "Pv" = (
 /obj/structure/target_stake,
@@ -13499,18 +13643,11 @@
 	},
 /area/mainship/command/self_destruct)
 "Pz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "warnplatecorner"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction/yjunc{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/area/mainship/hallways/hangar)
 "PA" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic/garden{
 	dir = 2
@@ -13518,8 +13655,12 @@
 /turf/open/floor/grass,
 /area/mainship/living/cafeteria_starboard)
 "PB" = (
-/obj/machinery/vending/medical/shipside,
-/turf/open/floor/mainship/sterile/corner,
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
 /area/mainship/medical/lower_medical)
 "PC" = (
 /obj/machinery/telecomms/processor/preset_one,
@@ -13586,10 +13727,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
 "PO" = (
-/obj/item/radio/intercom/general{
-	dir = 8
+/turf/open/floor/plating{
+	dir = 4;
+	icon_state = "warnplatecorner"
 	},
-/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "PP" = (
 /turf/open/floor/mainship/black{
@@ -13617,12 +13758,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
 "PT" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/clothing/head/warning_cone,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/hallways/hangar)
 "PU" = (
 /obj/machinery/light{
 	dir = 1
@@ -13643,13 +13784,14 @@
 	},
 /area/mainship/squads/general)
 "PX" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "PY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -13663,11 +13805,6 @@
 	dir = 9
 	},
 /area/mainship/medical/medical_science)
-"Qa" = (
-/obj/machinery/light,
-/obj/machinery/cic_maptable/droppod_maptable,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
 "Qb" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/machinery/holopad,
@@ -13678,14 +13815,13 @@
 /turf/open/floor/mainship_hull,
 /area/mainship/hull/lower_hull)
 "Qd" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
 	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 6
-	},
-/area/mainship/medical/lower_medical)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "Qe" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/item/clothing/glasses/welding,
@@ -13722,36 +13858,12 @@
 	},
 /area/mainship/squads/general)
 "Qk" = (
-/obj/structure/table/mainship,
-/obj/item/storage/box/gloves{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/storage/box/masks{
-	pixel_x = 2;
-	pixel_y = -1
-	},
-/obj/item/storage/syringe_case/regular{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/mass_spectrometer,
-/obj/item/reagent_scanner,
-/obj/item/storage/pill_bottle/packet/paracetamol,
-/obj/item/storage/pill_bottle/packet/paracetamol,
-/obj/item/storage/pill_bottle/packet/paracetamol,
-/obj/item/storage/pill_bottle/packet/paracetamol,
-/obj/item/storage/pill_bottle/packet/paracetamol,
-/obj/structure/cable,
+/obj/structure/closet/secure_closet/chemical,
 /turf/open/floor/mainship/sterile/corner{
 	dir = 4
 	},
 /area/mainship/medical/lower_medical)
 "Ql" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -13801,19 +13913,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
-"Qq" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/mainship{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
-/area/mainship/hallways/hangar/droppod)
 "Qr" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -13861,15 +13960,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
-"Qy" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/machinery/landinglight/ds1/delaythree{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "Qz" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
@@ -13880,16 +13970,31 @@
 	},
 /area/mainship/hallways/aft_hallway)
 "QC" = (
-/obj/machinery/alarm{
-	dir = 1
-	},
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "QD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor/stairs/rampbottom{
+	dir = 1
+	},
 /area/mainship/hallways/hangar)
+"QE" = (
+/obj/structure/cable,
+/obj/structure/sink,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/operating_room_two)
 "QF" = (
 /obj/structure/window/framed/mainship/white,
 /obj/machinery/door/firedoor/mainship{
@@ -13918,15 +14023,11 @@
 	},
 /area/mainship/squads/general)
 "QJ" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
+/obj/item/clothing/head/warning_cone,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/stairs/rampbottom{
-	dir = 1
-	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "QK" = (
 /obj/structure/cable,
@@ -13946,15 +14047,6 @@
 /obj/structure/sign/prop3,
 /turf/closed/wall/mainship,
 /area/mainship/living/cryo_cells)
-"QM" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/landinglight/ds1/delaytwo{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "QN" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship,
@@ -14020,11 +14112,13 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "QY" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
 	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/landinglight/ds2{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "QZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -14058,25 +14152,16 @@
 	},
 /area/mainship/shipboard/weapon_room)
 "Rd" = (
-/turf/open/floor/mainship/sterile/side{
-	dir = 9
+/obj/machinery/door/airlock/mainship/medical/glass{
+	dir = 2
 	},
+/turf/open/floor/mainship/mono,
 /area/mainship/medical/lower_medical)
 "Re" = (
 /turf/open/floor/mainship/sterile/corner{
 	dir = 8
 	},
 /area/mainship/medical/surgery_hallway)
-"Rf" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/machinery/landinglight/ds2/delaytwo{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "Rg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -14091,13 +14176,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/command/self_destruct)
 "Ri" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
+/turf/open/floor/mainship/terragov/north{
+	dir = 9
 	},
-/obj/machinery/landinglight/ds2{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Rj" = (
 /obj/effect/ai_node,
@@ -14109,6 +14190,7 @@
 /obj/machinery/firealarm{
 	dir = 1
 	},
+/obj/machinery/iv_drip,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/surgery_hallway)
 "Rn" = (
@@ -14123,7 +14205,7 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/surgery_hallway)
 "Ro" = (
-/obj/machinery/holopad,
+/mob/living/simple_animal/corgi/walten,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "Rp" = (
@@ -14163,35 +14245,37 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/shipboard/firing_range)
 "Rt" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table/mainship,
-/obj/item/stack/sheet/mineral/phoron{
-	amount = 25;
-	pixel_x = 3;
-	pixel_y = 3
+/obj/structure/window/framed/mainship/white,
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 1;
+	id = "or2privacyshutter";
+	name = "\improper Privacy Shutters"
 	},
-/obj/item/tool/hand_labeler,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/obj/machinery/alarm{
+/turf/open/floor/prison/whitegreen/corner{
 	dir = 1
 	},
-/turf/open/floor/mainship/sterile/corner{
-	dir = 4
-	},
-/area/mainship/medical/chemistry)
+/area/mainship/medical/operating_room_two)
 "Ru" = (
 /obj/item/trash/cigbutt,
 /turf/open/floor/mainship/black,
 /area/mainship/living/cafeteria_starboard)
-"Rw" = (
-/obj/machinery/autodoc_console,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
+"Rv" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
+"Rw" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/landinglight/ds2/delaytwo{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "Rx" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -14235,8 +14319,12 @@
 	},
 /area/mainship/squads/general)
 "RF" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/machinery/landinglight/ds2/delaythree,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/landinglight/ds2/delaythree{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "RG" = (
@@ -14249,13 +14337,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
-"RH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "RI" = (
 /obj/machinery/optable,
 /obj/machinery/light,
@@ -14283,10 +14364,17 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "RL" = (
-/obj/machinery/holopad,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/machinery/holosign_switch{
+	id = "or1sign";
+	pixel_x = 5;
+	pixel_y = 10
+	},
+/turf/closed/wall/mainship/white{
+	desc = "A huge chunk of metal used to seperate space from the ship";
+	name = "Outer Hull";
+	resistance_flags = 3
+	},
+/area/mainship/medical/operating_room_one)
 "RM" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
@@ -14302,7 +14390,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/machinery/landinglight/ds1/delayone{
+/obj/machinery/landinglight/ds1{
 	dir = 8
 	},
 /turf/open/floor/mainship/mono,
@@ -14313,11 +14401,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
-"RP" = (
-/obj/structure/window/framed/mainship/white,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/chemistry)
 "RQ" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -14336,33 +14419,33 @@
 	},
 /area/mainship/living/cryo_cells)
 "RS" = (
-/obj/machinery/landinglight/ds1/delaythree{
+/obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/thin{
+/obj/machinery/landinglight/ds1/delaytwo{
 	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "RT" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/power/apc/mainship{
+/obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/corner{
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/storage/surgical_tray,
+/turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
 /area/mainship/medical/surgery_hallway)
 "RU" = (
-/obj/machinery/chem_master,
-/obj/machinery/firealarm,
-/obj/item/reagent_containers/glass/beaker/bluespace,
-/turf/open/floor/mainship/sterile/corner,
-/area/mainship/medical/chemistry)
+/obj/structure/table/reinforced,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/storage/box/gloves,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/operating_room_two)
 "RV" = (
 /obj/machinery/door/poddoor/mainship/umbilical/south{
 	dir = 8
@@ -14370,11 +14453,10 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/shipboard/weapon_room)
 "RW" = (
-/obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/landinglight/ds2/delaytwo{
+/obj/machinery/landinglight/ds2/delaythree{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
@@ -14384,9 +14466,14 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "RY" = (
-/obj/machinery/cloning_console/vats,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/landinglight/ds2{
+	dir = 1
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar)
 "RZ" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /obj/machinery/vending/uniform_supply,
@@ -14428,8 +14515,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "Sh" = (
-/obj/structure/sign/pods,
-/turf/closed/wall/mainship,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/landinglight/ds2/delayone{
+	dir = 1
+	},
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "Si" = (
 /obj/machinery/firealarm,
@@ -14445,32 +14537,36 @@
 	},
 /area/mainship/living/cafeteria_starboard)
 "Sl" = (
-/turf/closed/wall/mainship,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
+"Sm" = (
+/obj/structure/bed/stool,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "Sn" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/machinery/landinglight/ds2/delayone,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/icefloor/warnplate,
 /area/mainship/hallways/hangar)
 "Sp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
+"Sq" = (
+/obj/machinery/smartfridge/chemistry,
+/turf/open/floor/plating/platebotc,
+/area/mainship/medical/lower_medical)
 "Sr" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/machinery/landinglight/ds2/delaytwo{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar)
 "Ss" = (
 /obj/machinery/roomba,
 /turf/open/floor/mainship,
@@ -14540,15 +14636,8 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/starboard_umbilical)
 "SD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 5
-	},
+/obj/effect/landmark/start/job/medicalofficer,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "SE" = (
 /obj/structure/target_stake,
@@ -14564,7 +14653,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/machinery/landinglight/ds2/delaythree{
+/obj/machinery/landinglight/ds2/delaytwo{
 	dir = 8
 	},
 /turf/open/floor/mainship/mono,
@@ -14576,13 +14665,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
 "SJ" = (
-/obj/machinery/body_scanconsole,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/operating_room_one)
 "SK" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/cryo_cells)
@@ -14622,12 +14706,18 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "SR" = (
-/obj/structure/window/framed/mainship/white,
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/adv,
+/obj/item/reagent_containers/spray/surgery,
+/obj/machinery/door_control{
+	dir = 4;
+	id = "or1privacyshutter";
+	name = "Privacy Shutters"
 	},
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/operating_room_one)
 "SS" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 1;
@@ -14639,8 +14729,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "SU" = (
-/obj/machinery/vending/snack,
-/obj/item/coin/iron,
+/obj/machinery/computer/cryopod{
+	dir = 8
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "SW" = (
@@ -14678,35 +14769,32 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "Tb" = (
-/obj/machinery/iv_drip,
-/obj/machinery/firealarm,
-/turf/open/floor/mainship/sterile/corner{
-	dir = 1
-	},
-/area/mainship/medical/lower_medical)
-"Tc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/side{
+/obj/structure/sink{
 	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/operating_room_one)
+"Tc" = (
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
 	},
 /area/mainship/medical/lower_medical)
 "Td" = (
-/obj/machinery/light{
+/obj/structure/cable,
+/obj/machinery/door/airlock/mainship/medical/glass/chemistry,
+/obj/machinery/door/firedoor,
+/obj/effect/ai_node,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/corner{
-	dir = 4
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 1
 	},
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/operating_room_one)
 "Te" = (
 /turf/open/floor/mainship/red{
 	dir = 4
@@ -14739,8 +14827,11 @@
 "Tj" = (
 /obj/structure/cable,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
@@ -14785,6 +14876,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"Tt" = (
+/obj/structure/window/framed/mainship/white,
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/poddoor/shutters/opened/medbay,
+/turf/open/floor/plating/platebotc,
+/area/mainship/medical/operating_room_one)
 "Tu" = (
 /obj/structure/orbital_cannon,
 /obj/machinery/light/small{
@@ -14796,18 +14893,32 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
+"Tw" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
 "Tx" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/firing_range)
+"Ty" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/storage/box/gloves,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/operating_room_one)
 "Tz" = (
-/obj/structure/cable,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 1
-	},
+/obj/machinery/light,
+/obj/structure/table/mainship,
+/obj/machinery/computer/droppod_control,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar/droppod)
 "TA" = (
 /obj/structure/bed/chair/office/dark{
@@ -14847,13 +14958,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "TE" = (
-/obj/machinery/optable,
-/obj/item/tank/anesthetic,
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/operating_room_one)
 "TF" = (
 /obj/machinery/line_nexter,
 /turf/open/floor/mainship/mono,
@@ -14884,8 +14991,7 @@
 /turf/open/floor/plating,
 /area/mainship/living/briefing)
 "TK" = (
-/obj/machinery/vending/medical/shipside,
-/obj/structure/cable,
+/obj/machinery/light,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "TL" = (
@@ -14915,6 +15021,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "TP" = (
@@ -14925,9 +15034,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
+"TR" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/body_scanconsole,
+/turf/open/floor/mainship/sterile/corner,
+/area/mainship/medical/lower_medical)
 "TT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 1;
+	dir = 4;
 	on = 1
 	},
 /turf/open/floor/mainship/sterile/dark,
@@ -14940,10 +15056,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "TW" = (
-/obj/machinery/smartfridge/chemistry,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/operating_room_two)
 "TX" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
@@ -14955,6 +15069,7 @@
 /area/mainship/squads/req)
 "TZ" = (
 /obj/machinery/light,
+/obj/machinery/iv_drip,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/surgery_hallway)
 "Ua" = (
@@ -14970,31 +15085,32 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
 "Ub" = (
-/obj/structure/closet/firecloset,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Uc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/landinglight/ds2{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/hangar)
 "Ud" = (
 /obj/structure/cable,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
+/obj/machinery/power/apc/mainship{
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/effect/ai_node,
+/obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 4
 	},
@@ -15007,21 +15123,44 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/surgery_hallway)
 "Ug" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
-"Uj" = (
-/obj/machinery/computer/crew,
-/turf/open/floor/mainship/sterile/corner{
+/obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
+/obj/machinery/landinglight/ds2/delayone{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
+"Uh" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
+"Ui" = (
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile,
+/area/mainship/medical/lower_medical)
+"Uj" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "Uk" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
+"Ul" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
 "Um" = (
 /turf/closed/wall/mainship/outer,
 /area/space)
@@ -15049,10 +15188,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "Ur" = (
-/obj/machinery/light,
-/obj/structure/table/mainship,
-/obj/machinery/computer/droppod_control,
-/turf/open/floor/mainship/mono,
+/turf/closed/wall/mainship,
 /area/mainship/hallways/hangar/droppod)
 "Us" = (
 /obj/structure/disposalpipe/segment{
@@ -15128,7 +15264,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/landinglight/ds2{
+/obj/machinery/landinglight/ds2/delayone{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
@@ -15137,7 +15273,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/junction,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "UD" = (
@@ -15160,9 +15295,17 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "UG" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/lower_medical)
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/landinglight/ds2/delaytwo{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "UH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -15187,12 +15330,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
-"UJ" = (
-/obj/machinery/door/airlock/mainship/medical/or/or1,
-/obj/machinery/door/firedoor/mainship,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "UL" = (
 /obj/machinery/door/firedoor/mainship,
 /obj/structure/cable,
@@ -15200,7 +15337,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engine_monitoring)
 "UM" = (
-/obj/docking_port/stationary/marine_dropship/cas,
+/obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "UN" = (
@@ -15230,12 +15367,9 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
 "US" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/structure/closet/toolcloset,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "UT" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 2
@@ -15256,10 +15390,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
 "UV" = (
-/obj/structure/disposalpipe/segment/corner,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/turf/closed/wall/mainship/white{
+	desc = "A huge chunk of metal used to seperate space from the ship";
+	name = "Outer Hull";
+	resistance_flags = 3
+	},
+/area/mainship/medical/operating_room_one)
 "UW" = (
 /obj/machinery/door_control/mainship/req{
 	dir = 1;
@@ -15270,10 +15406,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "UX" = (
-/obj/machinery/landinglight/ds1/delaytwo{
+/obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/thin{
+/obj/machinery/landinglight/ds1/delayone{
 	dir = 8
 	},
 /turf/open/floor/mainship/mono,
@@ -15365,11 +15501,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Vj" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/machinery/landinglight/ds1/delaythree{
-	dir = 4
+/obj/effect/ai_node,
+/obj/machinery/light{
+	light_color = "#da2f1b"
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -15395,7 +15529,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/machinery/landinglight/ds2/delayone{
+/obj/machinery/landinglight/ds2{
 	dir = 8
 	},
 /turf/open/floor/mainship/mono,
@@ -15441,23 +15575,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
 "Vy" = (
-/obj/docking_port/stationary/marine_dropship/hangar/one,
-/obj/docking_port/stationary/marine_dropship/crash_target,
-/turf/open/floor/plating,
+/obj/structure/table/mainship,
+/obj/machinery/computer/shuttle/shuttle_control/dropship,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Vz" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
-"VA" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/landinglight/ds1/delaythree{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "VC" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic/cryo{
 	dir = 1
@@ -15482,14 +15607,15 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "VG" = (
-/obj/machinery/door/poddoor/mainship/ammo{
+/obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
-/turf/open/floor/mainship/stripesquare,
+/turf/open/floor/stairs/rampbottom{
+	dir = 1
+	},
 /area/mainship/hallways/hangar)
 "VH" = (
 /obj/structure/cable,
@@ -15504,14 +15630,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "VJ" = (
-/obj/machinery/vending/nanomed{
-	dir = 8
+/obj/machinery/light{
+	light_color = "#da2f1b"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
+/turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "VK" = (
 /obj/structure/lattice,
@@ -15527,10 +15649,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
-"VN" = (
-/obj/machinery/firealarm,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "VO" = (
 /obj/machinery/vending/weapon,
 /turf/open/floor/mainship/mono,
@@ -15542,9 +15660,12 @@
 	},
 /area/mainship/command/self_destruct)
 "VQ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/turf/open/floor/mainship/sterile/dark,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
 /area/mainship/medical/lower_medical)
 "VR" = (
 /obj/structure/disposalpipe/segment{
@@ -15561,11 +15682,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "VT" = (
-/obj/machinery/camera/autoname/mainship{
+/obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -15577,6 +15701,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"VV" = (
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "VW" = (
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
@@ -15636,9 +15765,17 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
 "Wd" = (
-/obj/machinery/sleep_console,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "We" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -15748,10 +15885,11 @@
 	},
 /area/mainship/command/self_destruct)
 "Ww" = (
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/side,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "Wx" = (
 /obj/machinery/door/airlock/mainship/command,
@@ -15790,13 +15928,9 @@
 /area/mainship/hallways/stern_hallway)
 "WB" = (
 /obj/effect/decal/warning_stripes/thin{
-	dir = 4
+	dir = 5
 	},
-/obj/effect/decal/warning_stripes/thin,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/landinglight/ds1/delaythree{
-	dir = 4
-	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "WC" = (
@@ -15819,10 +15953,7 @@
 	},
 /area/mainship/living/cryo_cells)
 "WG" = (
-/obj/machinery/firealarm{
-	dir = 4
-	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "WH" = (
 /obj/structure/disposalpipe/segment,
@@ -15835,11 +15966,17 @@
 /turf/open/floor/mainship,
 /area/mainship/living/cafeteria_starboard)
 "WJ" = (
-/obj/structure/disposalpipe/segment/corner,
-/obj/structure/cable,
-/obj/machinery/holopad,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/chemistry)
+/obj/structure/window/framed/mainship/white,
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 1;
+	id = "or2privacyshutter";
+	name = "\improper Privacy Shutters"
+	},
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 4
+	},
+/area/mainship/medical/operating_room_two)
 "WK" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -15858,12 +15995,12 @@
 	},
 /area/mainship/squads/general)
 "WM" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
-/obj/effect/ai_node,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "WN" = (
 /obj/machinery/power/fusion_engine/preset,
@@ -15940,8 +16077,8 @@
 /turf/open/space/basic,
 /area/space)
 "Xa" = (
-/turf/open/floor/plating{
-	icon_state = "warnplatecorner"
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 6
 	},
 /area/mainship/hallways/hangar)
 "Xb" = (
@@ -15973,9 +16110,9 @@
 	},
 /area/mainship/command/self_destruct)
 "Xh" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/machinery/landinglight/ds2/delaytwo,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating{
+	icon_state = "warnplatecorner"
+	},
 /area/mainship/hallways/hangar)
 "Xi" = (
 /turf/open/floor/mainship/black/corner{
@@ -15992,14 +16129,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "Xk" = (
-/obj/structure/table/mainship,
-/obj/item/healthanalyzer,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
+/obj/machinery/computer/crew,
 /turf/open/floor/mainship/sterile/side{
-	dir = 4
+	dir = 1
 	},
 /area/mainship/medical/lower_medical)
 "Xl" = (
@@ -16092,9 +16224,15 @@
 	},
 /area/mainship/command/self_destruct)
 "Xv" = (
-/obj/machinery/door/airlock/mainship/maint,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/mainship,
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Xw" = (
@@ -16106,13 +16244,8 @@
 	},
 /area/mainship/squads/general)
 "Xx" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/cloning/vats,
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
+/obj/machinery/body_scanconsole,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "Xy" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -16161,11 +16294,16 @@
 /turf/open/floor/plating,
 /area/mainship/squads/req)
 "XF" = (
-/obj/structure/cable,
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "XG" = (
 /obj/machinery/light{
 	dir = 4
@@ -16194,9 +16332,10 @@
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "XJ" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/machinery/landinglight/ds2,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating{
+	dir = 1;
+	icon_state = "warnplatecorner"
+	},
 /area/mainship/hallways/hangar)
 "XK" = (
 /obj/structure/closet/crate,
@@ -16283,6 +16422,7 @@
 /area/mainship/hallways/starboard_umbilical)
 "XU" = (
 /obj/machinery/light,
+/obj/machinery/iv_drip,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "XV" = (
@@ -16315,21 +16455,17 @@
 /turf/open/floor/wood,
 /area/mainship/medical/surgery_hallway)
 "Ya" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/surgery_hallway)
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "Yb" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/machinery/door_control/mainship/ammo{
-	dir = 8
-	},
-/turf/open/floor/stairs/rampbottom{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "Yc" = (
 /obj/structure/disposalpipe/segment,
@@ -16358,13 +16494,14 @@
 /turf/open/floor/mainship,
 /area/mainship/living/cafeteria_starboard)
 "Yf" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/landinglight/ds1{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "Yg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -16390,9 +16527,12 @@
 /turf/open/shuttle/escapepod/four,
 /area/mainship/command/self_destruct)
 "Yk" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 9
+/obj/structure/prop/mainship/hangar_stencil,
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
 	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Yl" = (
 /obj/effect/landmark/start/job/squadcorpsman,
@@ -16486,24 +16626,31 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "YC" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/mainship/droppod{
+/obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
-/turf/open/floor/mainship/stripesquare,
+/obj/structure/cable,
+/obj/machinery/door_control/mainship/droppod{
+	dir = 8
+	},
+/turf/open/floor/stairs/rampbottom{
+	dir = 1
+	},
 /area/mainship/hallways/hangar/droppod)
 "YD" = (
 /obj/machinery/marine_selector/gear/leader,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "YE" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
+/obj/machinery/door/poddoor/shutters/opened/medbay{
+	dir = 2
 	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
 	},
-/area/mainship/medical/lower_medical)
+/obj/structure/window/framed/mainship/white,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
 "YF" = (
 /obj/structure/closet/crate/weapon,
 /obj/structure/cable,
@@ -16550,7 +16697,7 @@
 	},
 /area/mainship/squads/general)
 "YL" = (
-/obj/machinery/landinglight/ds1{
+/obj/machinery/landinglight/ds1/delaythree{
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -16573,25 +16720,25 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "YO" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/mainship/sterile/corner{
-	dir = 8
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
 	},
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/operating_room_one)
 "YP" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/mainship/maint,
-/turf/open/floor/mainship/mono,
+/obj/item/radio/intercom/general,
+/turf/closed/wall/mainship,
 /area/mainship/hull/lower_hull)
 "YQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "YR" = (
@@ -16606,28 +16753,29 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "YS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/sign/double/barsign,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "YT" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/grunt_rnr)
 "YU" = (
-/obj/structure/closet/emcloset,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "YV" = (
-/obj/structure/disposalpipe/segment/corner,
-/obj/structure/cable,
-/obj/machinery/holopad,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/surgery_hallway)
+/obj/structure/prop/mainship/hangar_stencil,
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/landinglight/ds1/delaythree{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "YW" = (
 /obj/structure/closet/bodybag,
 /obj/effect/decal/cleanable/blood,
@@ -16679,31 +16827,21 @@
 	},
 /area/mainship/hallways/hangar)
 "Ze" = (
-/obj/machinery/vending/medical/shipside,
+/obj/structure/cable,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/storage/surgical_tray,
 /turf/open/floor/mainship/sterile/corner{
 	dir = 1
 	},
 /area/mainship/medical/surgery_hallway)
 "Zf" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/adv{
-	pixel_x = 6;
-	pixel_y = -2
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
 	},
-/obj/item/reagent_containers/spray/surgery{
-	pixel_x = 12;
-	pixel_y = 2
-	},
-/obj/item/clothing/mask/breath/medical,
-/obj/item/storage/box/gloves{
-	pixel_x = -5;
-	pixel_y = -5
-	},
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/operating_room_one)
 "Zg" = (
 /turf/open/floor/mainship/terragov{
 	dir = 4
@@ -16715,15 +16853,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
+"Zi" = (
+/obj/effect/ai_node,
+/obj/structure/disposalpipe/segment/corner,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
 "Zj" = (
-/obj/machinery/bioprinter/stocked,
-/obj/machinery/alarm{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/corner{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
+/obj/structure/closet/secure_closet/chemical,
+/turf/open/floor/mainship/sterile/corner,
+/area/mainship/medical/operating_room_one)
 "Zk" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -16756,9 +16894,28 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"Zq" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "Zr" = (
-/turf/closed/wall/mainship/white,
-/area/mainship/living/grunt_rnr)
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
+"Zs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "Zt" = (
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
@@ -16784,24 +16941,29 @@
 	},
 /area/mainship/command/self_destruct)
 "Zx" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "Zz" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/holosign/surgery{
+	id = "or1sign"
 	},
-/obj/machinery/power/apc/mainship{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/door/airlock/mainship/medical/or/or2{
+	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/corner{
-	dir = 8
-	},
-/area/mainship/medical/chemistry)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
 "ZA" = (
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 1
@@ -35031,30 +35193,30 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 aa
 aa
@@ -35303,7 +35465,7 @@ fI
 fI
 fI
 fI
-aa
+fI
 fI
 fI
 fI
@@ -35560,7 +35722,7 @@ fI
 fI
 fI
 fI
-aa
+fI
 fI
 fI
 fI
@@ -35817,7 +35979,7 @@ fI
 fI
 fI
 fI
-aa
+fI
 fI
 fI
 fI
@@ -36074,7 +36236,7 @@ fI
 fI
 fI
 fI
-aa
+fI
 fI
 fI
 fI
@@ -36331,7 +36493,7 @@ fI
 fI
 fI
 fI
-aa
+fI
 fI
 fI
 fI
@@ -36588,7 +36750,7 @@ fI
 fI
 fI
 fI
-aa
+fI
 fI
 fI
 fI
@@ -36845,7 +37007,7 @@ fI
 fI
 fI
 fI
-aa
+fI
 fI
 fI
 fI
@@ -37102,7 +37264,7 @@ fI
 fI
 fI
 fI
-aa
+fI
 fI
 fI
 fI
@@ -37359,7 +37521,7 @@ fI
 fI
 fI
 fI
-aa
+fI
 fI
 fI
 fI
@@ -37616,7 +37778,7 @@ fI
 fI
 fI
 fI
-aa
+fI
 fI
 fI
 fI
@@ -37873,15 +38035,15 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 aa
 aa
@@ -38115,30 +38277,30 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 fI
 fI
 aa
@@ -39935,8 +40097,8 @@ aa
 aa
 fI
 fI
-fI
 tG
+Lw
 Lw
 rc
 ad
@@ -40192,8 +40354,8 @@ aa
 aa
 aa
 aa
-aa
 Tm
+rc
 rc
 rc
 ad
@@ -40449,8 +40611,8 @@ aa
 aa
 aa
 aa
-aa
 Tm
+rc
 rc
 rc
 Mb
@@ -40706,8 +40868,8 @@ aa
 aa
 aa
 aa
-aa
 Tm
+rc
 rc
 rc
 Mb
@@ -40956,7 +41118,6 @@ fI
 fI
 fI
 fI
-fI
 aa
 aa
 aa
@@ -40965,6 +41126,7 @@ aa
 aa
 aa
 Tm
+rc
 rc
 rc
 Mb
@@ -41186,7 +41348,6 @@ fI
 fI
 fI
 fI
-fI
 tG
 Lw
 Lw
@@ -41221,6 +41382,7 @@ Lw
 Lw
 Lw
 Lw
+rc
 Mb
 Mb
 Mb
@@ -41266,7 +41428,7 @@ Kb
 to
 Dm
 Jm
-Jm
+qn
 Jt
 Kb
 Jp
@@ -41443,8 +41605,8 @@ fI
 fI
 fI
 fI
-fI
 Tm
+Um
 ad
 ad
 ad
@@ -41456,7 +41618,7 @@ ad
 ad
 ad
 ad
-ad
+kC
 rc
 rc
 rc
@@ -41489,7 +41651,7 @@ rT
 Bn
 IM
 Ow
-KV
+Qw
 YT
 Zv
 hj
@@ -41700,20 +41862,20 @@ fI
 fI
 fI
 fI
-fI
 Tm
+Um
+aq
+cu
+cu
+cu
+cu
+bt
+cu
+cu
+cu
+aq
 ad
-aH
-cu
-cu
-cu
-cu
-bD
-cu
-cu
-cu
-aH
-ad
+kC
 rc
 rc
 rc
@@ -41744,8 +41906,8 @@ Mb
 qo
 rT
 Of
-IM
-lQ
+EN
+Ow
 Qw
 ei
 Zv
@@ -41754,9 +41916,9 @@ Zv
 Zv
 Zv
 Zv
-kW
+fR
 jm
-nn
+Pg
 nD
 nD
 pf
@@ -41957,10 +42119,10 @@ fI
 fI
 fI
 fI
-fI
 Tm
+Um
+cu
 ad
-cu
 Wf
 Wf
 Wf
@@ -41968,8 +42130,8 @@ Wf
 Wf
 Wf
 Wf
-Wf
-cu
+ha
+ad
 ad
 ad
 ad
@@ -41995,13 +42157,13 @@ ad
 ad
 cu
 Mb
-ap
+qg
 hh
 Bm
 NY
 Qw
 nz
-Qw
+gu
 Qw
 XI
 YT
@@ -42009,11 +42171,11 @@ Zv
 Ze
 fX
 RT
+vz
 Zv
-yO
 Lu
 jm
-nn
+GT
 nD
 iz
 hM
@@ -42214,66 +42376,66 @@ fI
 fI
 fI
 fI
-fI
 Tm
+Um
+cu
 ad
-cu
-Wf
 lX
 lX
 lX
 lX
 lX
 lX
+Ur
 Sl
-pW
 cu
 cu
 cu
-bD
+bt
 cu
 cu
 cu
 cu
-bD
+bt
 JF
 ao
 JF
-aX
+ey
 cu
 cu
 cu
 cu
 cu
-bD
+bt
 cu
 cu
 fq
 fq
+cu
 pr
 Mb
-ap
+op
 Am
 fv
 pt
 BB
 CR
-EG
-eF
+lQ
+EN
 Kj
 YT
 Zv
 Eb
 jm
-YV
+jm
 ND
-vd
+Zv
 Ct
-Ya
+jm
 TZ
 nD
 ek
-Yi
+de
 oR
 oS
 iL
@@ -42471,19 +42633,19 @@ fI
 fI
 fI
 fI
-fI
 Tm
-ad
+Um
 cu
-kC
+aX
 ae
 ae
 ae
 ae
+cb
 cE
-wn
 Wf
-Ek
+hc
+Mb
 az
 az
 az
@@ -42492,9 +42654,8 @@ az
 az
 az
 az
-az
+DF
 eT
-Xv
 az
 az
 az
@@ -42509,25 +42670,26 @@ az
 az
 az
 az
+az
+gz
 ap
-bt
-az
-ST
-rT
-IM
-IM
-Ow
-YT
+GO
+Rv
+lQ
+lQ
+lQ
+EN
+qL
 YT
 Zv
 id
-vR
-hc
-QF
-DU
-lU
-GU
-nn
+jm
+jm
+ik
+Zv
+fR
+jm
+GT
 nD
 nD
 ed
@@ -42728,62 +42890,62 @@ fI
 fI
 fI
 fI
-fI
 Tm
+Um
+cu
 ad
-cu
-Wf
 lX
 lX
 lX
 lX
+cf
 cF
-Mf
-Sl
-cu
-az
-dL
-ap
-fS
+Ur
+ha
+Mb
+kG
 ap
 ml
 ap
+YU
 ap
 ap
 ap
-hU
+ap
+qg
+Hu
 Bo
 JQ
 wz
 WG
 aN
-QY
 cl
 cl
-Ub
-YU
-jZ
-DF
+aS
+aP
+US
+VT
 bw
-DX
+Yk
 ap
-YS
+mS
+ap
 in
 ST
-rT
-Cy
+lQ
 EN
-Ow
+EN
+pp
+dU
 YT
-Zr
 Zv
-Zv
-Ac
+lS
+jm
 aD
-Zv
+iO
 EH
-lU
-GU
+fR
+jm
 Rk
 nD
 jX
@@ -42985,20 +43147,19 @@ aa
 aa
 aa
 aa
-aa
 Tm
-ad
+Um
 cu
-Wf
+ad
 lX
 lX
 lX
 lX
+cg
 da
-Qa
-Sl
+Ur
+hp
 bQ
-Sh
 ap
 ap
 ap
@@ -43013,35 +43174,36 @@ ap
 ar
 ar
 ap
-dL
+kG
 ap
 ap
 ap
 ap
 ap
 ap
-bn
+jM
 ap
-ca
-fS
+io
+ml
+Yf
 YS
-in
-ST
-lQ
+YT
+pM
+Sm
 Ed
-Ed
+rV
 za
+gO
 YT
 bd
-LN
 JK
-fO
-fO
-fO
+aY
+eC
+Ul
 Rd
-BO
-Hu
-ma
+Uh
+aY
+QC
 nD
 nD
 xh
@@ -43242,62 +43404,62 @@ aa
 aa
 aa
 aa
-aa
 Tm
+Um
+ay
 ad
-aP
-Wf
-ai
+aZ
 ae
 ae
 ae
+cq
 dr
 GV
 ci
 fw
-QJ
 kB
-dY
-bg
+oq
+CQ
 kU
 kU
-bO
-cm
-Vj
-kU
+eb
 eK
 cm
+kU
+DZ
+eK
+MQ
 dN
 eb
-bO
-cm
-Vj
-kU
 eK
 cm
-Vj
 kU
+DZ
+eK
+cm
+kU
+Wd
 fl
 gf
 WB
 je
-jM
-az
-ru
-bl
-Ow
-bS
-cf
+ap
+YT
+YT
+YT
+YT
+YT
+YT
+YT
 YT
 bd
-DZ
+co
+aQ
+aQ
+Tw
+bd
+lY
 aY
-aY
-aY
-aY
-aY
-BO
-Hu
 XU
 nD
 iD
@@ -43499,37 +43661,36 @@ aa
 aa
 aa
 aa
-aa
 Tm
-ad
+Um
 cu
-Wf
+ad
 lX
 lX
 lX
 lX
+ct
 gh
 fD
 xo
-gl
-xo
+KN
+lb
 go
 fd
-aZ
 bh
 bh
+Xh
+Zd
 Xa
-Zd
-jF
 sP
 sP
+KV
 cR
-Bq
 Zd
 Zd
 Zd
 Zd
-jF
+Xa
 sP
 sP
 sP
@@ -43537,29 +43698,30 @@ sP
 sP
 ZA
 Zd
+KQ
 Yf
-YS
-az
-YT
-YT
-YT
-YT
-YT
-YT
+ap
 bd
-Mj
-BO
-XF
-XF
-XF
-XF
-BO
-Hu
+bd
+bd
+bd
+bd
+kt
+bd
+bd
+bd
+bd
+bd
+bd
+bd
+bd
+kk
+aY
 QC
 nD
 As
 KC
-iL
+Da
 fK
 EL
 gL
@@ -43756,27 +43918,26 @@ aa
 aa
 aa
 aa
-aa
 Tm
-ad
+Um
 cu
-Wf
+ad
 lX
 lX
 lX
 lX
-ab
+cS
+dr
 GV
-ci
-vg
-ci
+CB
+VG
 ap
+Zx
 eJ
-aS
 bh
 bh
+Sn
 nv
-bA
 bh
 bh
 bh
@@ -43794,24 +43955,25 @@ bh
 bh
 ZA
 ZA
+xQ
 PX
 mh
-GQ
-Zr
-Zr
-Zr
-Zr
-rr
-Zr
 bd
+Zr
+yl
+LD
+ku
+rr
+VQ
+af
 MP
+Fb
+VQ
+Cw
+LM
+Zq
+JH
 aY
-VQ
-VQ
-VQ
-VQ
-BO
-Hu
 cH
 nD
 of
@@ -44013,27 +44175,26 @@ aa
 aa
 aa
 aa
-aa
 Tm
-ad
+Um
 cu
-Wf
-ha
+ad
+bb
 RQ
 RQ
 RQ
+dL
 iG
 YC
 CB
-vg
-fn
+jH
 ap
-eJ
-aT
+Zx
+sr
 Zd
 Zd
+Xa
 jF
-bB
 bh
 bh
 bh
@@ -44051,30 +44212,31 @@ bh
 bh
 ZA
 ZA
-QM
-YS
-ap
+eR
+Yf
+qE
 bd
+tq
 nO
 Xx
-hp
-fO
-JK
-fO
-MQ
 aY
-dX
+Xx
 aY
-dX
+nl
 aY
+Xx
+aY
+AK
+aY
+gG
 BO
-Hu
-cH
+aY
+QC
 nD
 mc
 De
-oS
-pi
+iL
+Me
 nD
 gL
 Hi
@@ -44270,23 +44432,22 @@ aa
 aa
 aa
 aa
-aa
 Tm
-ad
+Um
 cu
-Wf
+ad
 lX
 lX
 lX
 lX
+dX
 Tz
 Ur
-Sl
+hr
 YP
-dA
 ap
-eJ
-aV
+Zx
+uZ
 ZA
 bh
 bh
@@ -44307,30 +44468,31 @@ bh
 bh
 bh
 sP
-lM
-VA
-YS
-ap
+PO
+sH
+Yf
+qE
+bd
 ga
-aI
-RY
-hH
+BO
+aY
+aY
 Ro
-sr
+aY
 TT
 NE
-hH
-wx
-hG
+aY
+aY
+aY
 aY
 gG
-Ug
-WM
 BO
+aY
+TK
 hK
-Yi
+no
 jP
-pV
+iL
 Me
 nD
 BH
@@ -44524,26 +44686,25 @@ aa
 aa
 aa
 aa
-aa
 tG
 Lw
 Lw
 rc
+Um
+cu
 ad
-cu
-Wf
 lX
 lX
 lX
 lX
-Tz
-Mf
-Sl
-cu
-az
-VN
-eJ
-aZ
+dX
+cF
+Ur
+ha
+Mb
+lO
+Zx
+fd
 ZA
 bh
 bh
@@ -44563,32 +44724,33 @@ bh
 bh
 bh
 bh
-Yk
+Mj
 sP
+nu
 kH
-fB
-hU
+qg
+Kf
 nj
 dy
-cz
-cz
-cz
-US
+BO
+BO
+BO
+BO
 gZ
 cz
-NS
-UG
-Wd
-Ro
-AI
-gZ
-Hu
-XU
+BO
+BO
+BO
+BO
+Ww
+eD
+aY
+zr
 nD
-nD
-nD
-nD
-nD
+no
+if
+oS
+MZ
 nD
 FE
 Ib
@@ -44610,8 +44772,8 @@ yU
 II
 xd
 xd
-xd
-Sr
+II
+YG
 gL
 xD
 tR
@@ -44781,26 +44943,25 @@ aa
 aa
 aa
 fI
-fI
 Tm
-ad
+Um
 ad
 ad
 ad
 cu
-kC
+aX
 RQ
 RQ
 RQ
 RQ
+ex
 Ud
-Qq
-Sl
-cu
-az
+Ur
+ha
+Mb
 ap
+Zx
 eJ
-aS
 ZA
 bh
 bh
@@ -44811,7 +44972,7 @@ bh
 bh
 bh
 bh
-Vy
+Nk
 bh
 bh
 bh
@@ -44822,25 +44983,26 @@ bh
 bh
 ZA
 bh
-kI
-qE
+rA
+kJ
 ap
+pZ
 hH
-aI
-aY
-hH
+Tc
+ch
+ES
 gw
 kc
-BO
+Zs
 wx
+qO
 hH
-wx
 hT
-aY
-gG
-BO
+rU
+Ea
+av
 WM
-BO
+Mm
 Pb
 hB
 jT
@@ -45038,26 +45200,25 @@ aa
 aa
 aa
 fI
-fI
 Tm
+Um
+aq
+cu
+cu
+aq
 ad
-aH
-cu
-cu
-aH
-Wf
 lX
 lX
 lX
 lX
 lX
 lX
-Sl
-fL
-az
-ac
-eJ
-aT
+Ur
+hA
+Mb
+lU
+Zx
+sr
 ZA
 bh
 bh
@@ -45077,32 +45238,33 @@ bh
 bh
 bh
 bh
-Bq
+cR
 Zd
+Le
 kJ
 qE
-ap
-bd
-IL
-ks
-Fy
+TW
+TW
+TW
+TW
+TW
 Xk
 SD
-Qd
+BO
 DG
 VJ
-Oz
-Rw
-DG
+bd
+bd
+SJ
 SJ
 NQ
 YE
 Td
-wN
-Yi
-iL
-iL
-Fp
+nD
+nD
+nD
+nD
+nD
 nD
 gL
 wj
@@ -45295,14 +45457,13 @@ aa
 aa
 aa
 fI
-fI
 Tm
-ad
+Um
 cu
+ad
 Pa
 Pa
 Pa
-Pa
 az
 az
 az
@@ -45310,11 +45471,11 @@ az
 az
 az
 az
-YP
-az
+hG
+Mb
+sD
 Zx
-eJ
-aV
+uZ
 ZA
 bh
 bh
@@ -45335,33 +45496,34 @@ bh
 bh
 bh
 Zd
+Pz
 sH
-VA
-YS
-ap
+Yf
+qE
+TW
 nk
-nk
+kn
 CI
-nk
-nk
+WJ
+cJ
 xK
 fs
-ic
-ic
-ic
-ic
-ic
+DG
+zr
+cM
+dt
+iC
 SR
-UJ
-SR
-bd
-bd
+UV
+Fd
+bC
+np
 ef
-aY
-aY
+lF
+Zq
 al
 bd
-gL
+FE
 wj
 FG
 PE
@@ -45552,30 +45714,29 @@ aa
 aa
 aa
 fI
-fI
 Tm
-ad
+Um
 cu
-Pa
+ad
+aP
 YU
 ml
-fS
 ap
 ap
-ml
+YU
 ap
 ap
 ap
-ml
+YU
+qg
 hU
 oa
-se
-eJ
-aZ
+Zx
+fd
 sP
 sP
 sP
-Oi
+yY
 bh
 bh
 bh
@@ -45593,32 +45754,33 @@ bh
 bh
 ZA
 ZA
+KQ
 Yf
-YS
 ap
-nk
+TW
+QE
 eu
 km
 Zz
-nk
+BF
 MT
 wT
 hy
 BF
 MR
 od
-ic
+OC
 Tb
 UV
 YO
-bd
+Zi
 Uj
-BO
-aY
-aY
+eO
+Uj
+ih
 TK
 bd
-FE
+gL
 wj
 dn
 PE
@@ -45809,30 +45971,29 @@ aa
 aa
 aa
 fI
-fI
 Tm
-ad
+Um
 cu
-Pa
+ad
 ap
+aT
+ft
+an
+an
+an
+an
+an
+an
+an
 ft
 aO
-an
-an
-an
-an
-an
-an
-an
-aO
-ag
-hU
-eJ
-bb
+qg
+Zx
+vd
 bh
 bh
 bh
-Nv
+zq
 bh
 bh
 bh
@@ -45850,31 +46011,32 @@ bh
 bh
 ZA
 ZA
-PX
-YS
-Np
-nk
+xQ
+Yf
+ap
+TW
+jV
 bv
 bL
 WJ
 cp
-Pz
-Ck
-hR
+aY
+Ww
+DG
 JM
 cM
-oe
-ic
+aY
+mC
 TE
 RL
 Zf
-bd
-ay
+BE
+aY
 Mt
 aY
-wx
+zM
 zr
-oj
+bd
 gL
 pa
 gL
@@ -46066,13 +46228,12 @@ aa
 aa
 aa
 fI
-fI
 Tm
+Um
+ay
 ad
-aP
-Pa
 ap
-ca
+io
 bh
 bh
 bh
@@ -46082,24 +46243,24 @@ bh
 bh
 bh
 bh
-bn
-se
-eJ
-aT
+jM
+oa
+Zx
+sr
 bh
 bh
 bh
 sP
-ri
+dE
 Zd
 Zd
 Zd
-Yk
+Mj
 sP
 sP
 sP
 sP
-ri
+dE
 Zd
 Zd
 Zd
@@ -46107,28 +46268,29 @@ Zd
 Zd
 ZA
 sP
-iu
-YS
 ap
-nk
+Yf
+ap
+TW
+gn
 RU
 qR
 Rt
-nk
+TR
 Tc
 Ww
-hy
+DG
 Kn
 nI
 Km
-ic
+Ty
 Og
-wu
+UV
 Zj
-bd
+gH
 PB
 vn
-BM
+PB
 BJ
 Qk
 bd
@@ -46323,13 +46485,12 @@ aa
 aa
 aa
 fI
-fI
 Tm
-ad
+Um
 cu
-bV
+aH
 ap
-ca
+io
 bh
 bh
 bh
@@ -46339,54 +46500,55 @@ bh
 bh
 bh
 bh
-bn
-hU
-eJ
-ba
-bm
-bF
-bY
-bN
-Qy
-bF
-RN
-bN
-dR
-ec
-RN
-bN
-Qy
-UX
-RN
-YL
+jM
+qg
+Zx
+aV
+wN
 RS
 bF
+RN
+bN
+RS
+UX
+RN
+Ni
+dR
+UX
+RN
+bN
+Oz
+UX
 jI
 YL
+RS
+Xv
+jI
+YV
 kp
-aB
-YS
+Yf
 ap
-nk
-RP
 TW
-RP
-nk
+TW
+TW
+TW
+TW
+bd
 lN
 Ii
-ic
-ic
-ic
-ic
-ic
+Ui
+lN
 bd
 bd
-bd
-bd
-bd
-bd
-bd
-bd
+SJ
+UV
+UV
+SJ
+Tt
+xS
+Sq
+gI
+xS
 bd
 bd
 Om
@@ -46580,13 +46742,12 @@ aa
 aa
 aa
 fI
-fI
 Tm
-Qc
+ai
 cu
-cP
+aJ
 ap
-ca
+io
 bh
 bh
 bh
@@ -46596,53 +46757,54 @@ bh
 bh
 bh
 bh
-bn
-hU
+jM
+qg
+pV
 fN
 eA
-eL
-Ga
 Gc
 Ga
+Gc
+zB
 cZ
 cc
 fm
-rt
 ar
 ar
-oq
+Nv
 an
 an
 an
 an
+PT
 ke
-on
 ap
-bn
+jM
 ap
-ca
+io
 ap
-lO
+pm
+rF
 rF
 FC
 rF
-rF
-rF
+RO
 FC
-Uc
+wb
+rF
 KR
 zk
-wb
+hP
+RO
 FC
-rF
 rF
 oC
-FC
 rF
 rF
 rF
 rF
-FC
+rF
+rF
 rF
 rF
 rF
@@ -46837,55 +46999,55 @@ aa
 aa
 aa
 fI
-fI
 Tm
-Qc
+ai
 cu
+aJ
 cP
-aE
-ca
+io
 bh
 bh
 bh
 bh
-kb
+bA
 bh
 bh
 bh
 bh
-bn
-hU
-Ni
+jM
+qg
+pW
 ap
-bo
+yO
 an
-cb
+dB
 ap
-eN
+Ac
 az
+EG
 gU
 Gl
 wC
 iy
 Go
 iR
-cS
 jp
 jp
-lb
+Qd
 or
 or
+XF
 Gp
 Gq
-hr
 or
-nR
+bu
 Kg
 Kg
 Kg
 Kg
 Kg
 Kg
+OY
 po
 UC
 NF
@@ -47094,13 +47256,12 @@ aa
 aa
 aa
 fI
-fI
 Tm
-Qc
+ai
 cu
-cP
+aJ
 ap
-ca
+io
 bh
 bh
 bh
@@ -47110,51 +47271,52 @@ bh
 bh
 bh
 bh
-bn
-hU
-Ni
+jM
+qg
+pW
 ap
-bp
+yS
 bw
-cg
+px
 ap
-fc
+Bq
 az
+Fp
 gW
 Gm
 MD
 io
 ca
 ur
-jg
 fQ
 fQ
-bn
+jM
+ap
+Vy
 ap
 ap
 ap
 ap
-ap
-ap
+qg
+rF
+rF
+rF
+rF
+rF
 IT
-rF
-rF
-rF
-rF
-IT
-XG
+wb
 rF
 rF
 mr
-wb
+rF
 XG
-RO
-rF
-rF
 XG
 rF
 rF
+XG
 rF
+rF
+XG
 rF
 rF
 XG
@@ -47351,13 +47513,12 @@ aa
 aa
 aa
 fI
-fI
 Tm
-ad
+Um
 cu
-bV
+aH
 ap
-ca
+io
 bh
 bh
 bh
@@ -47367,29 +47528,30 @@ bh
 bh
 bh
 bh
-bn
-hU
+jM
+qg
+ri
 GC
 lD
-gb
-Gb
 Gd
 Gb
+Gd
+Cv
 ib
-ff
-lD
-zq
+GC
+LN
 kB
 kB
-iK
+NS
 bw
 bw
 bw
 bw
+QJ
 lC
-ja
 az
-Ry
+sD
+kM
 ro
 Tl
 Tl
@@ -47608,13 +47770,12 @@ aa
 aa
 aa
 fI
-fI
 Tm
+Um
+ay
 ad
-aP
-Pa
 ap
-ca
+io
 bh
 bh
 bh
@@ -47624,29 +47785,30 @@ bh
 bh
 bh
 bh
-bn
-hU
+jM
+qg
+be
 CQ
 bg
-br
+UB
 bJ
 RW
 by
 UB
-bJ
-Rf
+Ge
+RW
 by
 UB
-bJ
-eB
+Oi
+RW
 by
 UB
-bJ
-eB
-ag
+Oi
+aO
+Vj
 oW
 sD
-Ry
+kM
 Tl
 Dh
 wk
@@ -47865,14 +48027,13 @@ aa
 aa
 aa
 fI
-fI
 Tm
-ad
+Um
 cu
-Pa
+ad
 ap
+aV
 ba
-aW
 bw
 bw
 bw
@@ -47880,17 +48041,17 @@ bw
 bw
 bw
 bw
-aW
-aB
-se
-dQ
+ba
+kp
+oa
+rt
+JI
+bh
+bh
+bh
+bh
 Xh
-bh
-bh
-bh
-bh
 Xa
-jF
 sP
 ZA
 bh
@@ -47900,7 +48061,8 @@ bh
 bh
 bh
 bh
-Ri
+QY
+ap
 ap
 ap
 kM
@@ -48122,45 +48284,45 @@ aa
 aa
 aa
 fI
-fI
 Tm
-ad
+Um
 cu
-Pa
+ad
+aS
 Ub
 NL
-il
 ap
 ap
-NL
+Ub
 ap
 ap
 ap
-NL
-hU
+Ub
 qg
-hU
-CQ
+kb
+qg
+be
+fV
+bh
+bh
+bh
+bh
 Sn
-bh
-bh
-bh
-bh
-nv
 bh
 bh
 ZA
 bh
-Xa
+Xh
 Zd
 Zd
 Zd
-sH
+Pz
 bh
+QY
 Ri
 kf
 te
-uZ
+kM
 Tl
 Vd
 WS
@@ -48173,7 +48335,7 @@ Tl
 ZR
 cw
 kM
-RH
+YQ
 Yy
 Yy
 Yy
@@ -48379,14 +48541,13 @@ aa
 aa
 aa
 fI
-fI
 Tm
-ad
+Um
 cu
+ad
 Pa
 Pa
 Pa
-Pa
 az
 az
 az
@@ -48394,30 +48555,31 @@ az
 az
 az
 az
-aL
+il
+YP
 dA
 be
-CQ
-XJ
+vR
 bh
 bh
 bh
 bh
-nv
+Sn
 bh
 bh
-Bq
+cR
 Zd
-jF
+Xa
 bh
 bh
 bh
 ZA
 bh
+Rw
 gD
 kj
 uA
-yS
+kM
 Tl
 hd
 WS
@@ -48430,7 +48592,7 @@ Tl
 ZV
 kM
 kM
-RH
+YQ
 Yy
 Yy
 Yy
@@ -48636,31 +48798,30 @@ aa
 aa
 aa
 fI
-fI
 Tm
+Um
+aq
+cu
+cu
+aq
 ad
-aH
-cu
-cu
-aH
-Pa
 kB
-Ge
+bp
 kB
-cq
+bB
 kB
-Gv
+gC
 az
-fL
-az
-bG
+qg
+Mb
+nR
+bP
 dV
-RF
 bh
 bh
 bh
 bh
-nv
+Sn
 bh
 bh
 bh
@@ -48671,10 +48832,11 @@ bh
 bh
 ZA
 bh
+RF
 gM
 kT
 uL
-yY
+kM
 Tl
 Vd
 WS
@@ -48686,15 +48848,15 @@ Tf
 Tl
 ZV
 Cz
-kM
+qe
 YQ
 Yy
 Yy
 Yy
+nY
 Yy
 Yy
 Yy
-jH
 Kp
 HF
 kM
@@ -48893,31 +49055,30 @@ aa
 aa
 aa
 fI
-fI
 Tm
-ad
+Um
 ad
 ad
 ad
 cu
-Pa
+ad
 kB
-Ge
+bp
 ap
-kG
+bD
 ap
-Gv
+gC
 az
-cu
-az
+CB
+Mb
+oe
 bP
-dV
+JI
 Xh
+Zd
+Zd
+Zd
 Xa
-Zd
-Zd
-Zd
-jF
 bh
 bh
 bh
@@ -48928,8 +49089,9 @@ bh
 bh
 ZA
 bh
-gQ
+RY
 kB
+ap
 ap
 kM
 Tl
@@ -48944,7 +49106,7 @@ Tl
 ZV
 kM
 kM
-RH
+YQ
 Yy
 Yy
 Yy
@@ -49150,34 +49312,33 @@ aa
 aa
 aa
 aa
-aa
 Ti
 jO
 jO
 Tm
-ad
+Um
 cu
+aX
 ne
 bi
 ak
-aJ
 an
-ag
+aO
 kB
 az
-cu
-az
-ac
-CQ
+CB
+Mb
+lU
+be
+fV
 Sn
-nv
 bh
 bh
 bh
 bh
+DU
 dM
 UM
-hA
 bh
 bh
 bh
@@ -49185,10 +49346,11 @@ bh
 bh
 ZA
 bh
-ho
-oD
+Sh
+hz
+oW
 sD
-Ry
+kM
 Tl
 FA
 Gt
@@ -49201,7 +49363,7 @@ Tl
 ZR
 kM
 kM
-RH
+YQ
 Yy
 Yy
 Yy
@@ -49410,28 +49572,27 @@ aa
 aa
 aa
 aa
-aa
 Tm
-ad
+Um
 cu
-Pa
+ad
 aM
 aM
 aM
 aM
-Gg
+eN
 az
 az
-YP
-az
-Zx
-CQ
+hG
+Mb
+sD
+be
+vR
 XJ
+sP
+sP
+sP
 dE
-sP
-sP
-sP
-ri
 bh
 bh
 bh
@@ -49442,10 +49603,11 @@ bh
 bh
 ZA
 bh
+Sr
 hz
-oD
 az
-Ry
+sD
+kM
 Tl
 Tl
 Tl
@@ -49667,28 +49829,27 @@ aa
 aa
 aa
 aa
-aa
 Tm
-ad
+Um
 cu
-Pa
-wg
+ad
+bc
 as
 as
 ap
-aR
+fc
+rI
 VG
-ci
-hU
-QJ
+qg
+fw
 ap
-CQ
-RF
+be
+dV
 bh
 bh
 bh
 bh
-nv
+Sn
 bh
 bh
 bh
@@ -49699,8 +49860,9 @@ bh
 bh
 ZA
 bh
-gM
+RF
 kB
+ap
 ap
 kM
 CE
@@ -49924,41 +50086,41 @@ aa
 aa
 aa
 aa
-aa
 Tm
-ad
+Um
 cu
-Pa
+ad
 at
 at
 at
+bI
 aA
 iB
 KN
-xo
-qD
-xo
+iK
+KN
+oj
 kV
 JI
-Xh
 bh
 bh
 bh
 bh
-nv
+Sn
 bh
 bh
-Yk
+Mj
 sP
-ri
+dE
 bh
 bh
 bh
 ZA
 bh
+Uc
 mj
 px
-cg
+ap
 kM
 CP
 Gj
@@ -50181,41 +50343,41 @@ aa
 aa
 aa
 aa
-aa
 Tm
-ad
+Um
 cu
-Pa
+ad
 at
 at
 at
+bS
 vB
-bH
+rI
 VG
 ci
-fw
-ci
+VG
 ap
+ru
 fV
+bh
+bh
+bh
+bh
 Sn
-bh
-bh
-bh
-bh
-nv
 bh
 bh
 ZA
 bh
-dE
+XJ
 sP
 sP
 sP
-lM
+PO
 bh
-gC
+Ug
 kB
-ca
+io
+ap
 rF
 rF
 rF
@@ -50438,29 +50600,28 @@ aa
 aa
 aa
 aa
-aa
 Tm
+Um
+ay
 ad
-aP
-Pa
-aq
+bl
 aF
 aF
 ap
+fn
 rI
-VG
+gQ
 Yb
 QD
-bc
-dB
-an
-ex
+ap
+ap
+vR
 bh
 bh
 bh
 bh
+XJ
 dE
-ri
 Zd
 ZA
 bh
@@ -50470,9 +50631,10 @@ bh
 bh
 bh
 bh
+UG
 nL
 dB
-cb
+ap
 rF
 rF
 rF
@@ -50695,42 +50857,42 @@ aa
 aa
 aa
 aa
-aa
 Tm
-ad
+Um
 cu
-Pa
+ad
 ah
 ah
 ah
 ah
-bI
+fW
 az
 az
-Cv
+ja
 az
-jx
-aA
-dv
-bx
-Vr
-ck
+nL
+an
+wg
 SH
 gd
 Vr
-ck
+Ar
 SH
-bx
+gd
+Gg
+Ar
+SH
+gd
 Vr
 Ar
 SH
-bx
+gd
 Vr
-ck
-aB
-on
+kp
+ke
 ap
-oC
+ke
+rF
 rF
 XG
 kN
@@ -50754,8 +50916,8 @@ Iw
 jy
 VX
 jy
-PT
-YN
+Xs
+VV
 jy
 FJ
 jy
@@ -50952,31 +51114,31 @@ aa
 aa
 aa
 aa
-aa
 Tm
-ad
+Um
 cu
-ne
+aX
+bo
 au
 aw
 aK
 ms
 Cu
-Nk
 az
-fL
-az
-ar
-aA
-VT
-ap
-NL
+qg
+Mb
+on
+bI
+jM
 ap
 ap
 ap
 ap
-PO
-NL
+ap
+ap
+ap
+ap
+ap
 ap
 ap
 ap
@@ -51209,11 +51371,10 @@ aa
 aa
 aa
 aa
-aa
 Tm
-ad
+Um
 cu
-Pa
+ad
 kB
 kB
 ap
@@ -51221,28 +51382,29 @@ ap
 ap
 kB
 az
-ew
-az
-az
-az
-az
-az
-az
-az
-az
-az
-az
-az
-az
+jg
+Mb
+ar
+bI
+wn
 ap
-ap
-ap
-ap
-NL
 Ub
-YU
-jZ
-NL
+ap
+ap
+ap
+DX
+ap
+Ub
+ap
+ap
+ap
+ap
+Ub
+aS
+aP
+US
+Ub
+ap
 ap
 rF
 XG
@@ -51269,7 +51431,7 @@ Kk
 NU
 XH
 eI
-IX
+uO
 YY
 qC
 qC
@@ -51466,42 +51628,42 @@ aa
 aa
 aa
 aa
-aa
 Tm
+Um
+cu
 ad
-cu
-Pa
 kB
 kB
 kB
-zB
+bV
 kB
 kB
 az
-ao
-cu
-cu
-cu
-cu
-aX
-cu
-cu
-cu
-cu
-JF
-dD
-az
-az
-ap
-ct
-az
-az
-az
-az
-az
-az
+jx
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+Gv
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
+Mb
 bZ
 bX
+Mb
 Mb
 Mb
 lo
@@ -51723,42 +51885,42 @@ aa
 aa
 aa
 aa
-aa
 Tm
-ad
-cu
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
+Um
 cu
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-fL
+Pa
+Pa
+Pa
+Pa
+Pa
+Pa
+Pa
+CB
+cu
+cu
+cu
+cu
 ey
-aX
-cu
-eQ
 cu
 cu
-bD
+cu
+cu
+JF
+GQ
+JF
+ey
+cu
+cu
+cu
+cu
+bt
 cu
 cu
 cu
 fL
-fW
+Ya
+YB
 YB
 YB
 lV
@@ -51980,29 +52142,29 @@ aa
 aa
 aa
 aa
-aa
 Tm
+Um
+aq
+cu
+cu
+cu
+cu
+ey
+cu
+cu
+cu
+aq
 ad
-aH
-cu
-cu
-cu
-cu
-aX
-cu
-cu
-cu
-aH
 ad
-rc
-rc
-rc
-rc
-rc
-rc
-rc
-rc
 ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+GU
 ad
 ad
 ad
@@ -52237,8 +52399,8 @@ aa
 aa
 aa
 aa
-aa
 Tm
+Um
 ad
 ad
 ad
@@ -52250,7 +52412,7 @@ ad
 ad
 ad
 ad
-ad
+kC
 rc
 rc
 rc
@@ -52494,7 +52656,6 @@ aa
 aa
 aa
 aa
-aa
 Ti
 jO
 jO
@@ -52529,6 +52690,7 @@ jO
 jO
 jO
 jO
+rc
 rc
 rc
 ad
@@ -52755,7 +52917,6 @@ aa
 aa
 aa
 aa
-aa
 fI
 fI
 fI
@@ -52787,6 +52948,7 @@ aa
 aa
 aa
 Tm
+rc
 rc
 ad
 gp
@@ -53012,7 +53174,6 @@ aa
 aa
 aa
 aa
-aa
 fI
 fI
 fI
@@ -53044,6 +53205,7 @@ aa
 aa
 aa
 Tm
+rc
 rc
 ad
 eQ
@@ -53299,8 +53461,8 @@ aa
 aa
 aa
 aa
-aa
 Tm
+rc
 rc
 ad
 ad
@@ -53541,7 +53703,6 @@ aa
 aa
 aa
 aa
-aa
 fI
 fI
 fI
@@ -53558,6 +53719,7 @@ aa
 aa
 aa
 Ti
+jO
 jO
 rc
 rc
@@ -53794,7 +53956,6 @@ aa
 aa
 aa
 aa
-aa
 fI
 fI
 fI
@@ -53814,6 +53975,7 @@ aa
 aa
 aa
 aa
+fI
 fI
 fI
 Tm
@@ -54051,7 +54213,6 @@ aa
 aa
 aa
 aa
-aa
 fI
 fI
 fI
@@ -54071,6 +54232,7 @@ aa
 aa
 aa
 aa
+fI
 fI
 fI
 Tm

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -16,12 +16,13 @@
 	dir = 8
 	},
 /area/mainship/hallways/hangar/droppod)
-"af" = (
-/obj/machinery/autodoc,
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
+"ag" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/mainship/medical/lower_medical)
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "ah" = (
 /obj/structure/ship_ammo/minirocket/illumination,
 /turf/open/floor/mainship/cargo,
@@ -43,13 +44,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "al" = (
-/obj/structure/sink{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/corner{
+/turf/open/floor/mainship/sterile/purple/corner{
 	dir = 8
 	},
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/chemistry)
 "am" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/storage/backpack/marine/engineerpack,
@@ -98,12 +96,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "av" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
+/turf/closed/wall/mainship,
+/area/space)
 "aw" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -112,9 +106,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "ax" = (
-/obj/machinery/cryopod/right,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
+/obj/structure/musician/piano,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "ay" = (
 /obj/structure/cable,
 /obj/machinery/light/small{
@@ -143,10 +137,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"aD" = (
-/obj/effect/landmark/start/job/medicalofficer,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/surgery_hallway)
 "aF" = (
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 8
@@ -202,10 +192,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "aQ" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
+/obj/machinery/vending/snack,
+/obj/machinery/light,
+/turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "aS" = (
 /obj/structure/closet/firecloset,
@@ -319,6 +308,10 @@
 /obj/item/reagent_containers/jerrycan,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"bj" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "bk" = (
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
 	dir = 1
@@ -331,6 +324,10 @@
 	dir = 8
 	},
 /area/mainship/hallways/hangar)
+"bn" = (
+/obj/machinery/chem_dispenser,
+/turf/open/floor/mainship/sterile/purple/side,
+/area/mainship/medical/chemistry)
 "bo" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -344,10 +341,15 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "bq" = (
-/obj/machinery/line_nexter,
 /obj/structure/cable,
-/obj/machinery/power/apc/mainship{
-	dir = 8
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
+"bs" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/multi_tile/mainship/maint/free_access{
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
@@ -379,6 +381,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"bx" = (
+/obj/machinery/vending/medical/shipside,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "by" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -397,17 +405,16 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "bC" = (
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_one)
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 5
+	},
+/area/mainship/medical/chemistry)
 "bD" = (
 /obj/structure/dropship_equipment/weapon/minirocket_pod,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "bE" = (
-/obj/machinery/vending/hydroseeds,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/structure/kitchenspike,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "bF" = (
@@ -434,16 +441,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"bK" = (
+/obj/structure/barricade/metal,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "bL" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
-"bM" = (
-/obj/machinery/door/airlock/mainship/medical/glass/CMO{
-	dir = 2
-	},
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/mainship/medical/surgery_hallway)
 "bN" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -453,6 +457,16 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"bO" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/storage/surgical_tray,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/corner{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "bP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -481,6 +495,16 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
+"bU" = (
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/obj/machinery/door/airlock/multi_tile/mainship/research{
+	dir = 2;
+	name = "Research Chemical Lab"
+	},
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/chemistry)
 "bV" = (
 /obj/machinery/door_control/mainship/ammo{
 	dir = 8
@@ -488,10 +512,8 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "bW" = (
-/obj/structure/sign/poster{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
+/obj/structure/cable,
+/turf/open/floor/mainship/floor,
 /area/mainship/hull/lower_hull)
 "bX" = (
 /obj/machinery/door/airlock/multi_tile/mainship/maint{
@@ -544,14 +566,15 @@
 	},
 /area/mainship/hallways/hangar/droppod)
 "ch" = (
-/obj/machinery/light{
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/vending/MarineMed,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "ci" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -592,43 +615,6 @@
 	dir = 4
 	},
 /area/mainship/shipboard/weapon_room)
-"co" = (
-/obj/structure/table/mainship,
-/obj/item/storage/box/gloves{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/storage/box/masks{
-	pixel_x = 2;
-	pixel_y = -1
-	},
-/obj/item/storage/syringe_case/regular{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/mass_spectrometer,
-/obj/item/reagent_scanner,
-/obj/item/storage/pill_bottle/packet/paracetamol,
-/obj/item/storage/pill_bottle/packet/paracetamol,
-/obj/item/storage/pill_bottle/packet/paracetamol,
-/obj/item/storage/pill_bottle/packet/paracetamol,
-/obj/item/storage/pill_bottle/packet/paracetamol,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/corner{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
-"cp" = (
-/obj/machinery/bodyscanner{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/lower_medical)
 "cq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -695,14 +681,17 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "cy" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/floor,
-/area/mainship/hull/lower_hull)
-"cz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/turf/closed/wall/mainship/research/containment/wall/corner{
 	dir = 4
 	},
+/area/mainship/medical/medical_science)
+"cz" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "cA" = (
@@ -755,13 +744,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
-"cH" = (
-/obj/machinery/alarm{
-	dir = 1
-	},
-/obj/machinery/iv_drip,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lower_medical)
 "cI" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -769,7 +751,7 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hull/lower_hull)
 "cJ" = (
-/obj/machinery/computer/med_data,
+/obj/machinery/body_scanconsole,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -797,15 +779,21 @@
 	},
 /turf/open/space,
 /area/space)
+"cM" = (
+/obj/machinery/body_scanconsole,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/operating_room_one)
 "cN" = (
 /obj/structure/closet/toolcloset,
 /obj/machinery/light,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "cO" = (
-/obj/structure/sink,
-/turf/open/floor/mainship/mono,
-/area/mainship/command/corporateliaison)
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "cP" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/storage/backpack/marine/engineerpack,
@@ -884,33 +872,12 @@
 	dir = 9
 	},
 /area/space)
-"dc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/obj/effect/landmark/start/job/researcher,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
 "dd" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
-"de" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
 "dg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1011,12 +978,6 @@
 	dir = 5
 	},
 /area/mainship/squads/general)
-"dt" = (
-/obj/machinery/bioprinter/stocked,
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/medical/operating_room_one)
 "du" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -1024,8 +985,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "dx" = (
-/obj/machinery/grill/unwrenched,
-/turf/open/floor/mainship/mono,
+/obj/structure/bed/chair/wood/wings,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "dy" = (
 /obj/structure/cable,
@@ -1091,15 +1052,14 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "dH" = (
-/obj/item/autopsy_scanner,
-/obj/item/tool/surgery/retractor,
-/obj/item/tool/surgery/circular_saw,
-/obj/item/tool/surgery/cautery,
-/obj/item/tool/surgery/hemostat,
-/obj/item/tool/surgery/scalpel,
-/obj/structure/table/mainship,
-/turf/open/floor/mainship/mono,
-/area/mainship/medical/surgery_hallway)
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start/job/researcher,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 8
+	},
+/area/mainship/medical/medical_science)
 "dI" = (
 /obj/structure/disposalpipe/segment/corner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1117,15 +1077,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "dK" = (
-/obj/item/reagent_containers/glass/fertilizer/ez,
-/obj/item/reagent_containers/glass/fertilizer/ez,
-/obj/item/tool/minihoe,
-/obj/item/tool/minihoe,
-/obj/item/tool/plantspray/weeds,
-/obj/item/tool/plantspray/weeds,
-/obj/structure/closet/crate/freezer,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/glass/beaker/cryomix,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "dL" = (
 /obj/structure/cable,
 /obj/effect/decal/warning_stripes/thin{
@@ -1152,10 +1109,9 @@
 	},
 /area/mainship/hallways/hangar)
 "dO" = (
-/obj/structure/table/mainship,
-/obj/machinery/computer/emails,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/obj/structure/sign/nosmoking_2,
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/operating_room_two)
 "dP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -1177,24 +1133,20 @@
 	},
 /area/mainship/hallways/hangar)
 "dU" = (
-/obj/structure/bed/chair/sofa{
-	dir = 1
+/turf/open/floor/mainship/research/containment/floor2{
+	dir = 5
 	},
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/area/mainship/medical/medical_science)
 "dV" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/machinery/landinglight/ds2/delaythree,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "dW" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/obj/structure/table/mainship,
+/obj/item/camera,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "dX" = (
 /obj/structure/cable,
 /obj/effect/decal/warning_stripes/thin{
@@ -1204,6 +1156,11 @@
 	dir = 1
 	},
 /area/mainship/hallways/hangar/droppod)
+"dY" = (
+/obj/machinery/light,
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
 "ea" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -1220,21 +1177,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"ed" = (
-/obj/machinery/door/airlock/mainship/research/pen,
-/obj/machinery/door/firedoor/mainship,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
 "ef" = (
-/obj/structure/closet/firecloset,
-/obj/machinery/light{
+/turf/open/floor/mainship/sterile/purple/side{
 	dir = 8
 	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/chemistry)
 "eh" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -1242,24 +1189,22 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ei" = (
-/obj/machinery/status_display,
-/turf/closed/wall/mainship,
-/area/mainship/living/grunt_rnr)
-"ej" = (
-/obj/structure/barricade/metal{
-	dir = 1
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
+"ej" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "ek" = (
-/obj/structure/table/mainship,
-/obj/item/camera,
-/obj/item/tool/extinguisher,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/storage/box/monkeycubes,
-/obj/machinery/vending/nanomed,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
+/obj/structure/bed/stool,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "el" = (
 /obj/item/trash/cigbutt,
 /turf/open/floor/mainship/black{
@@ -1274,21 +1219,15 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "en" = (
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/mainship/mono,
-/area/mainship/command/corporateliaison)
+/obj/machinery/status_display,
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/chemistry)
 "eo" = (
 /obj/structure/table/mainship,
 /obj/effect/spawner/random/tool,
 /obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_umbilical)
-"ep" = (
-/obj/machinery/door/airlock/mainship/medical/glass/CMO,
-/obj/machinery/door/firedoor/mainship,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/surgery_hallway)
 "eq" = (
 /obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/mono,
@@ -1338,15 +1277,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"ez" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/start/job/cmo,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/mainship/medical/surgery_hallway)
 "eA" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -1354,13 +1284,24 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"eC" = (
-/obj/effect/landmark/start/job/medicalofficer,
-/obj/effect/ai_node,
+"eB" = (
+/obj/machinery/vending/medical/shipside,
 /turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
+"eC" = (
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
 /area/mainship/medical/lower_medical)
 "eD" = (
-/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
@@ -1376,13 +1317,14 @@
 	},
 /area/mainship/command/self_destruct)
 "eH" = (
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
 /obj/structure/cable,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
+/turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
+/area/mainship/medical/lower_medical)
 "eI" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -1416,18 +1358,6 @@
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
-"eO" = (
-/obj/machinery/holopad{
-	active_power_usage = 60;
-	desc = "It's a floor-mounted device for projecting holographic images. This one appears to have a smaller lense";
-	holo_range = 3;
-	idle_power_usage = 3;
-	name = "modifed holopad"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "eP" = (
 /obj/structure/disposalpipe/segment/corner,
 /obj/structure/cable,
@@ -1458,12 +1388,17 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"eV" = (
-/obj/item/newspaper{
-	pixel_x = -10;
-	pixel_y = 8
+"eU" = (
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
+	dir = 8;
+	name = "Medical Storage"
 	},
-/turf/open/floor/mainship/mono,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
+"eV" = (
+/obj/structure/closet/bodybag,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "eW" = (
 /obj/machinery/light/small{
@@ -1521,6 +1456,11 @@
 	dir = 5
 	},
 /area/mainship/command/cic)
+"ff" = (
+/obj/structure/table/woodentable,
+/obj/item/toy/deck,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "fg" = (
 /obj/machinery/marine_selector/clothes/medic,
 /obj/machinery/light{
@@ -1532,6 +1472,10 @@
 /obj/structure/closet/lasertag/blue,
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
+"fi" = (
+/obj/machinery/line_nexter,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "fj" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/shipboard/firing_range)
@@ -1590,7 +1534,9 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
 	},
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/side{
+	dir = 9
+	},
 /area/mainship/medical/lower_medical)
 "ft" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -1604,15 +1550,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"fv" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/grunt_rnr)
 "fw" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -1666,6 +1603,31 @@
 	dir = 1
 	},
 /area/mainship/hallways/hangar/droppod)
+"fF" = (
+/obj/structure/table/mainship,
+/obj/item/storage/box/gloves{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/storage/box/masks{
+	pixel_x = 2;
+	pixel_y = -1
+	},
+/obj/item/storage/syringe_case/regular{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/mass_spectrometer,
+/obj/item/reagent_scanner,
+/obj/item/storage/pill_bottle/packet/paracetamol,
+/obj/item/storage/pill_bottle/packet/paracetamol,
+/obj/item/storage/pill_bottle/packet/paracetamol,
+/obj/item/storage/pill_bottle/packet/paracetamol,
+/obj/item/storage/pill_bottle/packet/paracetamol,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
 "fG" = (
 /obj/machinery/self_destruct/rod,
 /turf/open/floor/mainship/tcomms,
@@ -1684,37 +1646,28 @@
 	},
 /turf/open/floor/mainship/black,
 /area/mainship/living/cafeteria_starboard)
-"fK" = (
-/obj/structure/disposalpipe/junction/flipped{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 10
-	},
-/area/mainship/medical/medical_science)
 "fL" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "fM" = (
-/obj/structure/toilet,
-/obj/structure/mirror,
-/turf/open/floor/mainship/mono,
-/area/mainship/command/corporateliaison)
+/obj/machinery/status_display,
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/operating_room_two)
 "fN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "fP" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
+	},
 /obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/floor,
 /area/mainship/hull/lower_hull)
 "fQ" = (
 /obj/structure/dropship_equipment/sentry_holder,
@@ -1723,11 +1676,12 @@
 	},
 /area/mainship/hallways/hangar)
 "fR" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
+/obj/machinery/cryopod/right,
+/obj/machinery/light{
+	dir = 8
 	},
-/area/mainship/medical/surgery_hallway)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "fT" = (
 /obj/machinery/door/airlock/mainship/generic/bathroom{
 	dir = 1
@@ -1739,13 +1693,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/commandbunks)
 "fU" = (
-/obj/structure/table/mainship,
-/obj/item/storage/box/donkpockets,
-/obj/structure/sink{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/mainship/medical/surgery_hallway)
+/obj/machinery/status_display,
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/medical_science)
 "fV" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/machinery/landinglight/ds2/delayone,
@@ -1759,35 +1709,18 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "fX" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/storage/surgical_tray,
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/medical/surgery_hallway)
-"fY" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/obj/machinery/door/window{
-	dir = 2
-	},
-/obj/machinery/shower{
-	pixel_y = 16
-	},
 /turf/open/floor/plating/plating_catwalk,
+/area/mainship/medical/lower_medical)
+"fY" = (
+/obj/machinery/atm,
+/turf/closed/wall/mainship,
 /area/mainship/command/corporateliaison)
 "fZ" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/mainship/cargo,
 /area/mainship/living/briefing)
-"ga" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/lower_medical)
 "gc" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/security/marinemainship{
@@ -1893,15 +1826,7 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"gu" = (
-/obj/structure/cable,
-/obj/structure/bed/chair/wood/wings{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
 "gw" = (
-/obj/machinery/iv_drip,
 /turf/open/floor/mainship/sterile/side{
 	dir = 5
 	},
@@ -1953,25 +1878,14 @@
 	dir = 10
 	},
 /area/mainship/command/self_destruct)
-"gG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "gH" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lower_medical)
+/obj/structure/closet/secure_closet/chemical,
+/turf/open/floor/mainship/sterile/purple/corner,
+/area/mainship/medical/chemistry)
 "gI" = (
-/obj/structure/window/framed/mainship/white,
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/poddoor/shutters/opened/medbay,
+/obj/machinery/smartfridge/chemistry,
 /turf/open/floor/plating/platebotc,
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/chemistry)
 "gK" = (
 /obj/structure/target_stake,
 /obj/item/target,
@@ -1995,11 +1909,11 @@
 /turf/closed/wall/mainship,
 /area/mainship/squads/general)
 "gO" = (
-/obj/structure/bed/chair/sofa/corner{
+/obj/machinery/bodyscanner{
 	dir = 8
 	},
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "gP" = (
 /obj/machinery/vending/weapon,
 /turf/open/floor/mainship/red/full,
@@ -2061,15 +1975,10 @@
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/hallways/hangar)
 "gX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/multi_tile/mainship/maint{
-	dir = 1
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
-/area/mainship/hull/lower_hull)
+/obj/structure/table/mainship,
+/obj/machinery/recharger,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "gY" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -2078,10 +1987,10 @@
 /area/mainship/command/cic)
 "gZ" = (
 /obj/structure/cable,
-/obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "ha" = (
@@ -2133,22 +2042,15 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/command/self_destruct)
 "hh" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/closet/secure_closet/personal/morgue,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/area/mainship/medical/lower_medical)
 "hi" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
-"hj" = (
-/obj/structure/bed/chair/wood/wings,
-/turf/open/floor/wood,
-/area/mainship/medical/surgery_hallway)
 "hk" = (
 /obj/effect/decal/siding{
 	dir = 5
@@ -2184,6 +2086,10 @@
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar/droppod)
+"ht" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/mainship/mono,
+/area/mainship/command/corporateliaison)
 "hv" = (
 /obj/machinery/door/airlock/multi_tile/mainship/maint{
 	dir = 1
@@ -2206,8 +2112,8 @@
 "hx" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/effect/ai_node,
 /obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "hy" = (
@@ -2219,7 +2125,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/side{
+	dir = 6
+	},
 /area/mainship/medical/lower_medical)
 "hz" = (
 /obj/machinery/light{
@@ -2232,19 +2140,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar/droppod)
 "hB" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/research/containment/floor2{
+	dir = 6
+	},
 /area/mainship/medical/medical_science)
 "hC" = (
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
-"hD" = (
-/obj/structure/table/woodentable,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/wood,
-/area/mainship/medical/surgery_hallway)
 "hF" = (
 /obj/machinery/vending/cigarette,
 /obj/item/coin/iron,
@@ -2283,9 +2186,11 @@
 /turf/closed/wall/mainship,
 /area/mainship/squads/general)
 "hK" = (
-/obj/structure/cable,
-/turf/closed/wall/mainship/white,
-/area/mainship/medical/medical_science)
+/obj/machinery/door/airlock/mainship/medical/free_access{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
 "hL" = (
 /obj/effect/landmark/start/job/shiptech,
 /obj/structure/bed/chair/office/dark{
@@ -2294,18 +2199,25 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "hM" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
-"hN" = (
-/obj/machinery/camera/autoname/mainship{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/mainship/research/containment/floor2{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/bed/chair/wood/wings{
 	dir = 8
 	},
-/area/mainship/medical/medical_science)
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
+"hN" = (
+/obj/structure/table/mainship,
+/obj/item/tool/kitchen/tray,
+/obj/item/tool/kitchen/knife,
+/obj/item/storage/box/tgmc_mre,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "hO" = (
 /obj/machinery/power/apc{
 	dir = 8
@@ -2320,19 +2232,30 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "hQ" = (
-/obj/machinery/door/airlock/mainship/generic/bathroom{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/command/corporateliaison)
-"hT" = (
-/obj/machinery/vending/uniform_supply,
-/turf/open/floor/mainship/sterile/side{
+/obj/machinery/holopad,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
+"hS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/bed/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
+"hT" = (
+/obj/structure/table/mainship,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "hU" = (
 /obj/machinery/camera/autoname/mainship{
@@ -2342,13 +2265,16 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "hV" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/machinery/light{
-	light_color = "#da2f1b"
+/obj/machinery/door/airlock/mainship/research/pen{
+	dir = 1
 	},
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/obj/machinery/door/firedoor/mainship{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "hW" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -2368,6 +2294,10 @@
 	},
 /turf/open/floor/grass,
 /area/mainship/living/cafeteria_starboard)
+"hY" = (
+/obj/structure/bed/chair/sofa/corner,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "hZ" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -2380,10 +2310,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ia" = (
-/turf/open/floor/mainship/research/containment/floor2{
-	dir = 6
-	},
-/area/mainship/medical/medical_science)
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "ib" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
@@ -2395,18 +2325,12 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "id" = (
-/obj/structure/table/mainship,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/tool/weldingtool/largetank,
-/obj/item/tool/weldingtool/largetank,
-/obj/item/clothing/head/welding,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
+/obj/machinery/computer/med_data,
+/obj/machinery/light{
+	dir = 8
 	},
-/area/mainship/medical/surgery_hallway)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "ie" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 2
@@ -2416,48 +2340,30 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
-"if" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
-"ih" = (
-/obj/effect/ai_node,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "ii" = (
 /obj/structure/flora/pottedplant/twentyone,
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
-"ik" = (
-/obj/machinery/vending/MarineMed/Blood,
+"ij" = (
+/obj/effect/ai_node,
 /obj/structure/cable,
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/surgery_hallway)
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "il" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "im" = (
-/obj/machinery/cryopod,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
-"in" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/structure/window/framed/mainship,
-/turf/open/floor/plating,
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/head/chefhat,
+/obj/item/clothing/suit/chef/classic,
+/obj/item/tool/kitchen/rollingpin,
+/obj/item/book/manual/chef_recipes,
+/turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "io" = (
 /obj/effect/decal/warning_stripes/thin,
@@ -2471,10 +2377,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"ir" = (
-/obj/machinery/light,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
 "is" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -2492,6 +2394,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engine_monitoring)
+"iu" = (
+/obj/machinery/power/apc/mainship,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "ix" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
@@ -2508,11 +2415,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"iz" = (
-/obj/structure/closet/secure_closet/guncabinet/incendiary,
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
 "iA" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -2530,21 +2432,11 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/hangar)
 "iC" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
+/obj/machinery/bioprinter/stocked,
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
 /area/mainship/medical/operating_room_one)
-"iD" = (
-/obj/machinery/camera/autoname/mainship,
-/obj/machinery/chem_dispenser,
-/turf/open/floor/mainship/sterile/corner{
-	dir = 1
-	},
-/area/mainship/medical/medical_science)
 "iE" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -2584,13 +2476,24 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"iL" = (
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
+"iM" = (
+/obj/structure/sink{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "iO" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/surgery_hallway)
+/obj/effect/ai_node,
+/obj/machinery/iv_drip,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
+"iP" = (
+/obj/structure/bed/chair/sofa/right,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "iQ" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/mainship,
@@ -2623,10 +2526,17 @@
 	},
 /area/mainship/command/corporateliaison)
 "iT" = (
-/turf/closed/wall/mainship/research/containment/wall/corner{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/area/mainship/medical/medical_science)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/item/storage/box/matches,
+/obj/item/storage/fancy/cigarettes,
+/obj/structure/table/woodentable,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "iU" = (
 /obj/structure/bed/stool{
 	pixel_y = 8
@@ -2712,10 +2622,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"ji" = (
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/mainship/medical/surgery_hallway)
 "jj" = (
 /obj/machinery/marine_selector/gear/medic,
 /turf/open/floor/mainship,
@@ -2730,8 +2636,14 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "jm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/surgery_hallway)
+/area/mainship/medical/lower_medical)
 "jn" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -2763,12 +2675,10 @@
 	},
 /area/mainship/command/cic)
 "jr" = (
-/obj/structure/table/mainship,
-/obj/machinery/reagentgrinder{
-	pixel_y = 5
+/turf/closed/wall/mainship/research/containment/wall/corner{
+	dir = 1
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/area/mainship/medical/medical_science)
 "js" = (
 /obj/effect/landmark/start/job/squadleader,
 /turf/open/floor/mainship,
@@ -2783,6 +2693,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"jw" = (
+/obj/machinery/gibber,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "jx" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -2854,12 +2768,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
-"jK" = (
-/obj/structure/sink{
-	dir = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
 "jL" = (
 /obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/door/firedoor/mainship,
@@ -2880,13 +2788,15 @@
 	},
 /area/space)
 "jP" = (
-/obj/machinery/holopad,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/table/mainship,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
+/area/mainship/medical/lower_medical)
 "jQ" = (
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 8
@@ -2919,10 +2829,8 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "jT" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
+/obj/machinery/door_display/research_cell/cell{
+	dir = 1
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
@@ -2940,16 +2848,14 @@
 	dir = 1
 	},
 /area/mainship/medical/operating_room_two)
-"jX" = (
-/obj/structure/closet/l3closet/virology,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
+"jW" = (
+/obj/structure/bed/chair/sofa,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "jY" = (
-/turf/closed/wall/mainship/research/containment/wall/corner,
-/area/mainship/medical/medical_science)
+/obj/machinery/computer/arcade,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "kb" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -2958,9 +2864,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "kc" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/structure/table/mainship,
+/obj/item/storage/box/bodybags,
+/obj/item/reagent_containers/glass/beaker/biomass,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 1
+	},
+/area/mainship/medical/chemistry)
 "kd" = (
 /obj/structure/cable,
 /obj/machinery/camera/autoname/mainship{
@@ -2984,13 +2894,19 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
 "kh" = (
-/obj/machinery/atm,
-/turf/closed/wall/mainship,
-/area/mainship/command/corporateliaison)
+/obj/machinery/cloning/vats,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/chemistry)
 "ki" = (
-/obj/structure/closet/firecloset,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/mainship/cargo,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "kj" = (
 /turf/open/floor/mainship/terragov{
@@ -2998,14 +2914,27 @@
 	},
 /area/mainship/hallways/hangar)
 "kk" = (
-/obj/structure/cable,
+/obj/structure/table/mainship,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/tool/weldingtool/largetank,
+/obj/item/tool/weldingtool/largetank,
+/obj/item/clothing/head/welding,
 /obj/machinery/light{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
 /area/mainship/medical/lower_medical)
+"kl" = (
+/obj/structure/bed/chair/wood/wings{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "km" = (
 /obj/machinery/holopad{
 	active_power_usage = 60;
@@ -3040,36 +2969,27 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "kq" = (
-/obj/structure/closet/emcloset,
-/obj/item/clothing/mask/gas,
-/obj/machinery/firealarm{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
-/turf/open/floor/mainship/cargo,
-/area/mainship/hallways/port_hallway)
-"kr" = (
-/obj/structure/morgue{
-	dir = 2
-	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/medical/surgery_hallway)
+/area/mainship/hallways/port_hallway)
 "kt" = (
-/obj/machinery/status_display,
-/turf/closed/wall/mainship/white,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/autodoc_console,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "ku" = (
-/obj/structure/table/mainship,
-/obj/item/defibrillator,
-/obj/item/defibrillator,
-/obj/item/defibrillator,
-/obj/machinery/recharger,
+/obj/machinery/cloning_console/vats,
 /turf/open/floor/mainship/sterile/side{
-	dir = 8
+	dir = 1
 	},
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/chemistry)
 "kv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -3083,6 +3003,10 @@
 /obj/item/tool/weldpack,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"kx" = (
+/obj/machinery/griddle,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/grunt_rnr)
 "kz" = (
 /obj/structure/rack,
 /obj/structure/ob_ammo/warhead/incendiary,
@@ -3217,15 +3141,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
-"kW" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/surgery_hallway)
 "kX" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -3236,7 +3151,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "kZ" = (
 /obj/structure/cable,
@@ -3299,20 +3214,12 @@
 /obj/structure/window/framed/mainship/hull,
 /turf/open/floor/plating,
 /area/mainship/command/cic)
-"lj" = (
-/obj/structure/rack,
-/obj/item/tool/crowbar,
-/obj/effect/spawner/random/toolbox,
-/obj/item/stack/cable_coil,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/assembly/timer,
-/obj/item/assembly/infra,
+"li" = (
+/obj/machinery/vending/MarineMed/Blood,
 /turf/open/floor/mainship/sterile/side{
-	dir = 8
+	dir = 1
 	},
-/area/mainship/medical/medical_science)
+/area/mainship/medical/lower_medical)
 "lk" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/drinks/cans/aspen{
@@ -3383,14 +3290,6 @@
 	dir = 9
 	},
 /area/mainship/command/cic)
-"lr" = (
-/obj/machinery/door_display/research_cell/cell{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/medical/medical_science)
 "ls" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/security/marinemainship_network,
@@ -3466,18 +3365,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"lE" = (
-/obj/structure/table/mainship,
-/obj/machinery/chem_dispenser/soda,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
 "lF" = (
-/obj/structure/table/mainship,
-/obj/item/mass_spectrometer,
-/turf/open/floor/mainship/sterile/side{
+/obj/structure/closet/firecloset,
+/obj/machinery/light{
 	dir = 8
 	},
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 8
+	},
+/area/mainship/medical/chemistry)
 "lG" = (
 /turf/closed/wall/mainship,
 /area/mainship/command/telecomms)
@@ -3515,61 +3411,29 @@
 /obj/machinery/firealarm,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"lQ" = (
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+"lP" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/adv,
+/obj/item/reagent_containers/spray/surgery,
+/obj/machinery/door_control{
+	dir = 4;
+	id = "or1privacyshutter";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/operating_room_one)
 "lR" = (
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "lS" = (
-/obj/structure/table/mainship,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 7
-	},
-/obj/item/storage/firstaid/fire{
-	pixel_x = 7
-	},
-/obj/item/storage/firstaid/o2{
-	pixel_x = 4;
-	pixel_y = 7
-	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/storage/firstaid/rad{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/storage/firstaid/adv{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/storage/firstaid/adv{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/obj/item/storage/firstaid/adv{
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = 1
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/area/mainship/medical/surgery_hallway)
+/obj/machinery/autodoc,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "lT" = (
 /obj/machinery/door/airlock/mainship/command/FCDRoffice,
 /obj/machinery/door/firedoor/mainship,
@@ -3598,6 +3462,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"lW" = (
+/obj/structure/bed/chair/wood/wings{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "lX" = (
 /obj/structure/droppod,
 /obj/structure/dropprop,
@@ -3605,9 +3475,8 @@
 /area/mainship/hallways/hangar/droppod)
 "lY" = (
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment/corner,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "lZ" = (
 /obj/machinery/marine_selector/gear/engi,
@@ -3619,13 +3488,6 @@
 /obj/structure/mirror,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/commandbunks)
-"mc" = (
-/obj/structure/closet/secure_closet/medical1,
-/obj/machinery/firealarm,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/medical_science)
 "md" = (
 /obj/structure/flora/pottedplant/twentyone,
 /obj/machinery/camera/autoname/mainship,
@@ -3635,10 +3497,14 @@
 /obj/machinery/vending/cargo_supply,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"mf" = (
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/operating_room_one)
 "mg" = (
-/obj/machinery/light,
-/turf/open/floor/mainship/mono,
-/area/mainship/command/corporateliaison)
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "mh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -3712,6 +3578,15 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
+"mq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "mr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -3733,14 +3608,28 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "mt" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/shower{
+	dir = 8
 	},
-/turf/open/floor/wood,
-/area/mainship/medical/surgery_hallway)
-"mu" = (
-/turf/closed/wall/mainship/research/containment/wall/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/mainship/sterile,
 /area/mainship/medical/medical_science)
+"mu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/glass/rag,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/grunt_rnr)
 "mv" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/camera_advanced/overwatch/charlie,
@@ -3755,6 +3644,10 @@
 	dir = 8
 	},
 /area/mainship/command/cic)
+"mx" = (
+/obj/structure/sign/nosmoking_2,
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/operating_room_one)
 "my" = (
 /obj/machinery/light{
 	dir = 8
@@ -3781,8 +3674,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "mC" = (
-/obj/machinery/optable,
-/obj/item/tank/anesthetic,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_one)
 "mD" = (
@@ -3971,6 +3862,15 @@
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"ng" = (
+/obj/structure/table/mainship,
+/obj/machinery/microwave,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "nh" = (
 /obj/effect/decal/warning_stripes/engineer,
 /obj/effect/decal/warning_stripes/box/small{
@@ -3982,12 +3882,10 @@
 	},
 /area/mainship/squads/general)
 "ni" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/machinery/light{
+/turf/closed/wall/mainship/research/containment/wall/corner{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/area/mainship/medical/medical_science)
 "nj" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -4009,10 +3907,6 @@
 	dir = 1
 	},
 /area/mainship/medical/operating_room_two)
-"nl" = (
-/obj/machinery/autodoc_console,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "nm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /obj/structure/sign/poster{
@@ -4020,28 +3914,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
-"nn" = (
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/surgery_hallway)
-"no" = (
-/obj/machinery/researchcomp,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/medical_science)
-"np" = (
-/obj/structure/table/mainship,
-/obj/machinery/reagentgrinder,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/medical/lower_medical)
 "nq" = (
 /obj/machinery/door/firedoor/mainship,
 /obj/machinery/door/airlock/multi_tile/mainship/marine/general{
@@ -4083,19 +3955,17 @@
 /obj/effect/attach_point/weapon/dropship1,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
-"nz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
+"nx" = (
+/obj/effect/ai_node,
 /obj/structure/cable,
-/obj/structure/bed/chair/wood/wings{
-	dir = 8
-	},
-/turf/open/floor/wood,
+/turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
+"nz" = (
+/obj/structure/table/mainship,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/donkpockets,
+/turf/open/floor/wood,
+/area/mainship/medical/chemistry)
 "nA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -4110,19 +3980,32 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
-"nC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+"nB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/bed/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/port_hallway)
+"nC" = (
+/obj/machinery/holopad,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
+"nD" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/bed/chair/wood/wings{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
-"nD" = (
-/turf/closed/wall/mainship/white,
-/area/mainship/medical/medical_science)
 "nE" = (
 /turf/open/floor/mainship/black{
 	dir = 4
@@ -4154,15 +4037,16 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
+"nH" = (
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "nI" = (
-/obj/structure/window/framed/mainship/white,
-/obj/machinery/door/poddoor/shutters/mainship{
-	dir = 1;
-	id = "or1privacyshutter";
-	name = "\improper Privacy Shutters"
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 4
+	},
 /area/mainship/medical/operating_room_one)
 "nJ" = (
 /obj/machinery/power/smes/preset,
@@ -4172,10 +4056,6 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/hull/lower_hull)
-"nK" = (
-/obj/structure/closet/secure_closet/CMO,
-/turf/open/floor/wood,
-/area/mainship/medical/surgery_hallway)
 "nL" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -4199,29 +4079,13 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/engineering/lower_engineering)
-"nN" = (
-/obj/structure/table/mainship,
-/obj/machinery/chem_dispenser/beer,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
 "nO" = (
-/obj/machinery/holopad,
-/obj/structure/cable,
+/obj/machinery/researchcomp,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "nP" = (
-/obj/structure/table/mainship,
-/obj/structure/paper_bin,
-/obj/item/clipboard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/tool/pen,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/open/floor/wood,
-/area/mainship/medical/surgery_hallway)
+/area/mainship/medical/medical_science)
 "nQ" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -4283,13 +4147,15 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "od" = (
-/obj/machinery/holopad{
-	active_power_usage = 60;
-	desc = "It's a floor-mounted device for projecting holographic images. This one appears to have a smaller lense";
-	holo_range = 3;
-	idle_power_usage = 3;
-	name = "modifed holopad"
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/holosign/surgery{
+	id = "or1sign"
 	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/mainship/medical/or/or1{
+	dir = 1
+	},
+/obj/structure/cable,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/sterile/dark,
@@ -4300,40 +4166,40 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "of" = (
-/obj/structure/table/mainship,
-/obj/item/folder/white,
-/obj/machinery/power/apc/mainship,
-/obj/structure/cable,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/bed/chair/sofa{
+	dir = 8
 	},
-/turf/open/floor/mainship/sterile/side{
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
+"oh" = (
+/obj/machinery/camera/autoname/mainship,
+/obj/machinery/chem_dispenser,
+/turf/open/floor/mainship/sterile/purple/corner{
 	dir = 1
 	},
 /area/mainship/medical/medical_science)
-"oh" = (
-/obj/structure/table/mainship,
-/obj/item/clipboard{
-	pixel_x = 5
-	},
-/obj/structure/paper_bin{
-	pixel_x = 7;
-	pixel_y = 6
-	},
-/obj/item/tool/pen,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
 "oi" = (
-/obj/structure/barricade/metal{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/item/paper/crumpled{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "oj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"ok" = (
+/obj/structure/table/woodentable,
+/obj/item/book/manual/medical_diagnostics_manual,
+/obj/item/megaphone,
+/obj/item/clothing/glasses/hud/health,
+/turf/open/floor/wood,
+/area/mainship/medical/medical_science)
 "ol" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -4351,6 +4217,12 @@
 /obj/machinery/dropship_part_fabricator,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"oo" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "op" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -4378,7 +4250,7 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
+/area/mainship/medical/lower_medical)
 "ot" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -4386,24 +4258,20 @@
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
 "ou" = (
-/obj/structure/table/mainship,
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/head/chefhat,
-/obj/item/clothing/suit/chef/classic,
-/obj/item/tool/kitchen/rollingpin,
-/obj/item/book/manual/chef_recipes,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/turf/closed/wall/mainship/research/containment/wall/north,
+/area/mainship/medical/medical_science)
 "ov" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/shuttle/shuttle_control/dropship/two,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "ow" = (
-/obj/structure/musician/piano,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/obj/structure/table/mainship,
+/obj/item/tool/extinguisher,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/storage/box/monkeycubes,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "ox" = (
 /obj/machinery/light,
 /turf/open/floor/mainship/floor,
@@ -4419,12 +4287,19 @@
 	dir = 9
 	},
 /area/mainship/squads/general)
-"oA" = (
-/obj/structure/sign/poster{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
+"oz" = (
+/turf/open/floor/prison/kitchen,
 /area/mainship/living/grunt_rnr)
+"oB" = (
+/obj/item/reagent_containers/glass/fertilizer/ez,
+/obj/item/reagent_containers/glass/fertilizer/ez,
+/obj/item/tool/minihoe,
+/obj/item/tool/minihoe,
+/obj/item/tool/plantspray/weeds,
+/obj/item/tool/plantspray/weeds,
+/obj/structure/closet/crate/freezer,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "oC" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
@@ -4458,9 +4333,7 @@
 /obj/effect/decal/siding{
 	dir = 10
 	},
-/turf/open/floor/mainship/terragov/east{
-	dir = 10
-	},
+/turf/open/floor/mainship_hull,
 /area/space)
 "oJ" = (
 /turf/open/floor/mainship/green/corner{
@@ -4484,73 +4357,51 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/command/self_destruct)
-"oN" = (
-/obj/machinery/flasher{
-	id = "Containment Cell 3";
-	pixel_y = 30
-	},
-/turf/open/floor/mainship/research/containment/floor2{
-	dir = 1
-	},
-/area/mainship/medical/medical_science)
-"oO" = (
-/turf/open/floor/mainship/research/containment/floor2{
-	dir = 5
-	},
-/area/mainship/medical/medical_science)
 "oP" = (
-/turf/closed/wall/mainship/research/containment/wall/purple{
-	dir = 1
-	},
-/area/mainship/medical/medical_science)
-"oQ" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/medical_science)
+/obj/item/toy/deck,
+/obj/structure/table/woodentable,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "oR" = (
-/obj/machinery/light{
+/obj/structure/bed/chair/wood/wings{
 	dir = 4
 	},
-/obj/machinery/holopad,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
-"oS" = (
-/obj/structure/table/mainship,
-/obj/structure/paper_bin,
-/obj/item/clipboard{
-	pixel_x = -6;
-	pixel_y = 1
-	},
-/obj/item/tool/pen,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "oT" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
 "oU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
+/obj/structure/bed/chair/sofa/left{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "oV" = (
-/obj/structure/table/mainship,
-/obj/machinery/faxmachine/research,
-/turf/open/floor/mainship/sterile/dark,
+/obj/machinery/chem_master,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 1
+	},
 /area/mainship/medical/medical_science)
 "oW" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mainship,
 /area/mainship/hallways/hangar)
 "oX" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
+/obj/structure/table/mainship,
+/obj/item/folder/white,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 1
+	},
+/area/mainship/medical/medical_science)
 "oY" = (
 /obj/structure/sign/evac,
 /turf/open/floor/mainship/mono,
@@ -4581,43 +4432,29 @@
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"pc" = (
-/turf/open/floor/mainship/research/containment/floor1,
-/area/mainship/medical/medical_science)
 "pd" = (
-/turf/open/floor/mainship/research/containment/floor2{
-	dir = 4
-	},
-/area/mainship/medical/medical_science)
-"pe" = (
-/obj/machinery/door/poddoor/shutters/mainship/cell,
-/obj/machinery/door/airlock/mainship/research/glass/cell,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/medical_science)
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "pf" = (
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/medical/medical_science)
-"pg" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/corner{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/area/mainship/medical/medical_science)
-"ph" = (
-/obj/structure/disposalpipe/segment/corner,
+/obj/item/storage/donut_box,
+/obj/structure/table/woodentable,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
+"pg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 6
-	},
-/area/mainship/medical/medical_science)
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
+"ph" = (
+/obj/structure/sign/double/barsign,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "pj" = (
 /obj/machinery/vending/uniform_supply,
 /obj/machinery/light{
@@ -4668,10 +4505,14 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "pp" = (
-/obj/structure/table/woodentable,
-/obj/item/storage/fancy/cigar,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/chemistry)
 "pq" = (
 /obj/machinery/vending/shared_vending/marine_engi,
 /obj/machinery/light{
@@ -4687,13 +4528,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "pt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/obj/structure/table/mainship,
+/obj/machinery/microwave,
+/turf/open/floor/wood,
+/area/mainship/medical/chemistry)
 "pw" = (
 /obj/machinery/light{
 	dir = 8
@@ -4718,36 +4556,25 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
 "pz" = (
-/turf/open/floor/mainship/research/containment/floor2{
-	dir = 10
-	},
-/area/mainship/medical/medical_science)
+/obj/structure/table/mainship,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "pA" = (
-/obj/machinery/light/small,
-/turf/open/floor/mainship/research/containment/floor2,
-/area/mainship/medical/medical_science)
+/obj/structure/bed/stool,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "pB" = (
 /obj/structure/prop/mainship/mapping_computer,
 /turf/open/floor/mainship/red{
 	dir = 9
 	},
 /area/mainship/command/cic)
-"pC" = (
-/obj/machinery/door/airlock/mainship/medical/glass/research{
-	name = "\improper Animal Control Closet"
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
 "pD" = (
-/obj/structure/closet/secure_closet/animal,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
-"pE" = (
-/obj/machinery/door/airlock/mainship/medical/glass/free_access{
-	dir = 2
+/obj/structure/bed/chair/wood/wings{
+	dir = 1
 	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/surgery_hallway)
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "pF" = (
 /turf/open/floor/mainship/green/corner,
 /area/mainship/squads/req)
@@ -4761,11 +4588,9 @@
 	},
 /area/mainship/shipboard/firing_range)
 "pI" = (
-/obj/structure/closet/boxinggloves,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/table/mainship,
+/obj/machinery/computer/emails,
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "pJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -4774,12 +4599,22 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
 "pM" = (
-/obj/machinery/computer/arcade,
-/obj/machinery/light{
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 1
+	},
+/area/mainship/medical/chemistry)
+"pN" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
+"pO" = (
+/obj/machinery/status_display,
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/operating_room_one)
 "pP" = (
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
 	dir = 8
@@ -4797,9 +4632,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
 "pS" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/ai_node,
 /turf/open/floor/carpet{
 	dir = 6;
@@ -4874,9 +4706,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "qf" = (
-/obj/structure/kitchenspike,
+/obj/structure/morgue/crematorium,
+/obj/machinery/crema_switch{
+	pixel_x = 24
+	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/area/mainship/medical/lower_medical)
 "qg" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -4927,10 +4762,10 @@
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "qo" = (
-/obj/machinery/power/apc/mainship,
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/obj/structure/table/mainship,
+/obj/machinery/chem_dispenser/soda,
+/turf/open/floor/wood,
+/area/mainship/medical/chemistry)
 "qp" = (
 /obj/machinery/light{
 	dir = 4
@@ -4954,9 +4789,15 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/aft_hallway)
 "qs" = (
-/obj/structure/flora/pottedplant/twentyone,
-/turf/open/floor/wood,
-/area/mainship/medical/surgery_hallway)
+/obj/machinery/door/airlock/multi_tile/mainship/research{
+	dir = 2;
+	name = "Research Wing"
+	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/purple/side,
+/area/mainship/medical/medical_science)
 "qt" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/item/seeds/goldappleseed,
@@ -5062,19 +4903,14 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "qL" = (
-/obj/structure/bed/chair/sofa{
-	dir = 1
-	},
-/obj/machinery/light{
-	light_color = "#da2f1b"
-	},
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/obj/machinery/firealarm,
+/obj/structure/closet/secure_closet/medical1,
+/turf/open/floor/mainship/sterile/purple/corner,
+/area/mainship/medical/medical_science)
 "qO" = (
-/turf/open/floor/mainship/sterile/side{
-	dir = 6
-	},
-/area/mainship/medical/lower_medical)
+/obj/structure/closet/l3closet/virology,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "qP" = (
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/plating/mainship,
@@ -5129,12 +4965,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "rb" = (
-/obj/structure/table/mainship,
-/obj/machinery/microwave{
-	pixel_y = 5
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/mainship/medical/surgery_hallway)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "rc" = (
 /turf/open/floor/mainship_hull,
 /area/space)
@@ -5166,9 +5002,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "rj" = (
-/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/area/mainship/living/grunt_rnr)
 "rk" = (
 /obj/machinery/light{
 	dir = 1
@@ -5182,9 +5018,17 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "rn" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/medical/surgery_hallway)
+/obj/structure/table/mainship,
+/obj/structure/paper_bin,
+/obj/item/clipboard{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/item/tool/pen,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 8
+	},
+/area/mainship/medical/medical_science)
 "ro" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -5202,20 +5046,11 @@
 	},
 /area/space)
 "rr" = (
-/obj/machinery/bodyscanner{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/medical/lower_medical)
-"rs" = (
-/obj/structure/table/mainship,
-/obj/machinery/chem_dispenser/soda{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/mainship/medical/surgery_hallway)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "rt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -5293,15 +5128,6 @@
 	dir = 8
 	},
 /area/mainship/shipboard/firing_range)
-"rD" = (
-/obj/machinery/processor{
-	pixel_y = 5
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
 "rE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -5323,19 +5149,29 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "rH" = (
-/obj/effect/decal/siding{
-	dir = 6
-	},
-/turf/open/floor/mainship/terragov/east{
-	dir = 6
-	},
-/area/space)
+/obj/item/autopsy_scanner,
+/obj/item/tool/surgery/retractor,
+/obj/item/tool/surgery/circular_saw,
+/obj/item/tool/surgery/cautery,
+/obj/item/tool/surgery/hemostat,
+/obj/item/tool/surgery/scalpel,
+/obj/structure/table/mainship,
+/turf/open/floor/mainship/mono,
+/area/mainship/medical/lower_medical)
 "rI" = (
 /obj/machinery/door/poddoor/mainship/ammo{
 	dir = 2
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/hangar)
+"rJ" = (
+/obj/structure/cable,
+/obj/machinery/iv_drip,
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/operating_room_one)
 "rK" = (
 /obj/structure/safe,
 /obj/item/moneybag,
@@ -5397,25 +5233,17 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/command/telecomms)
-"rT" = (
-/obj/structure/bed/chair/wood/wings,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
 "rU" = (
-/obj/machinery/vending/snack,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "rV" = (
-/obj/structure/bed/chair/sofa{
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/area/mainship/medical/chemistry)
 "rW" = (
 /obj/structure/cable,
 /obj/machinery/camera/autoname/mainship{
@@ -5899,13 +5727,6 @@
 "tp" = (
 /turf/closed/wall/mainship,
 /area/mainship/shipboard/weapon_room)
-"tq" = (
-/obj/structure/table/mainship,
-/obj/item/reagent_containers/glass/beaker/cryomix,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/lower_medical)
 "tr" = (
 /obj/machinery/light{
 	dir = 4
@@ -6261,9 +6082,10 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/weapon_room)
 "uo" = (
-/obj/machinery/griddle,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/grunt_rnr)
+/turf/closed/wall/mainship/research/containment/wall/purple{
+	dir = 1
+	},
+/area/mainship/medical/medical_science)
 "up" = (
 /obj/structure/prop/mainship/cannon_cables,
 /turf/open/floor/plating/mainship,
@@ -6531,36 +6353,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
-"vk" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/wood,
-/area/mainship/hull/lower_hull)
 "vl" = (
 /obj/structure/closet/boxinggloves,
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
-"vn" = (
-/obj/structure/table/mainship,
-/obj/item/storage/box/beakers{
-	pixel_x = -7;
-	pixel_y = 7
-	},
-/obj/item/storage/box/pillbottles{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/storage/box/syringes{
-	pixel_x = -7
-	},
-/obj/item/storage/box/autoinjectors{
-	pixel_x = 7
-	},
-/obj/item/tool/hand_labeler,
-/obj/item/tool/hand_labeler,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
 "vo" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -6652,17 +6448,6 @@
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
-"vz" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/vending/medical/shipside,
-/turf/open/floor/mainship/sterile/corner{
-	dir = 8
-	},
-/area/mainship/medical/surgery_hallway)
 "vA" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_umbilical)
@@ -6759,10 +6544,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "vQ" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/prison/kitchen,
-/area/mainship/living/grunt_rnr)
+/turf/open/floor/mainship/research/containment/floor2{
+	dir = 9
+	},
+/area/mainship/medical/medical_science)
 "vR" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/machinery/landinglight/ds2,
@@ -6809,21 +6594,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
-"vY" = (
-/obj/structure/bed/chair/sofa/left{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
-"wa" = (
-/obj/structure/table/mainship,
-/obj/machinery/microwave,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
 "wb" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -6870,12 +6640,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "wh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/prison/kitchen,
-/area/mainship/living/grunt_rnr)
+/turf/open/floor/mainship/research/containment/floor2{
+	dir = 8
+	},
+/area/mainship/medical/medical_science)
 "wi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -6930,10 +6701,6 @@
 	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
-"wq" = (
-/obj/effect/decal/warning_stripes/thin,
-/turf/closed/wall/mainship,
-/area/mainship/hull/lower_hull)
 "wr" = (
 /turf/closed/wall/mainship,
 /area/mainship/hallways/aft_hallway)
@@ -6964,6 +6731,13 @@
 /obj/item/uav_turret/droid,
 /turf/open/floor/mainship/orange/full,
 /area/mainship/command/cic)
+"wu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "ww" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/mainship/black{
@@ -7086,14 +6860,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
 "wM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison/kitchen,
-/area/mainship/living/grunt_rnr)
+/turf/open/floor/mainship/research/containment/floor1,
+/area/mainship/medical/medical_science)
 "wN" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -7150,17 +6918,20 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/side{
+	dir = 5
+	},
 /area/mainship/medical/lower_medical)
 "wU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "wV" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -7246,14 +7017,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
 "xh" = (
-/obj/machinery/door/airlock/mainship/research/pen,
-/obj/machinery/door/firedoor/mainship,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "xi" = (
 /turf/open/floor/mainship/ntlogo/nt3,
 /area/mainship/squads/general)
@@ -7273,8 +7044,12 @@
 	},
 /area/mainship/squads/general)
 "xl" = (
-/obj/structure/barricade/metal,
-/turf/open/floor/plating/plating_catwalk,
+/obj/item/paper/crumpled,
+/obj/item/paper/crumpled{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "xm" = (
 /obj/structure/disposalpipe/segment,
@@ -7442,11 +7217,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/upper_engineering)
 "xK" = (
-/obj/effect/landmark/start/job/medicalofficer,
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 1
+	},
 /area/mainship/medical/lower_medical)
 "xL" = (
 /obj/structure/bed/chair/office/dark{
@@ -7493,17 +7269,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "xR" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/line_nexter,
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship{
+	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"xS" = (
-/obj/machinery/door/poddoor/shutters/opened/medbay,
-/obj/structure/window/framed/mainship/white,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/plating/platebotc,
-/area/mainship/medical/lower_medical)
 "xT" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/engineering/port_atmos)
@@ -7604,12 +7376,6 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine,
 /area/mainship/engineering/port_atmos)
-"yi" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
 "yj" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
@@ -7621,22 +7387,18 @@
 /turf/open/floor/engine,
 /area/mainship/engineering/port_atmos)
 "yl" = (
-/obj/machinery/power/apc/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/medical/lower_medical)
+/obj/structure/sign/nosmoking_2,
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/medical_science)
 "ym" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/window/framed/mainship/hull,
 /turf/open/floor/plating,
 /area/mainship/engineering/port_atmos)
 "yn" = (
-/obj/structure/closet/secure_closet/personal/morgue,
-/turf/open/floor/mainship/mono,
-/area/mainship/medical/surgery_hallway)
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/purple/side,
+/area/mainship/medical/medical_science)
 "yo" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /turf/open/floor/engine,
@@ -7743,6 +7505,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"yB" = (
+/obj/machinery/light/small,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "yC" = (
 /obj/structure/table/mainship,
 /obj/machinery/microwave{
@@ -7927,11 +7693,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "za" = (
-/obj/structure/bed/chair/sofa{
-	dir = 8
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/turf/open/floor/mainship/sterile/side{
+	dir = 9
+	},
+/area/mainship/medical/chemistry)
 "zb" = (
 /obj/machinery/alarm,
 /turf/open/floor/mainship/mono,
@@ -7997,6 +7766,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "zl" = (
@@ -8022,7 +7792,9 @@
 	},
 /area/mainship/hallways/hangar)
 "zr" = (
-/turf/open/floor/mainship/sterile/side,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 8
+	},
 /area/mainship/medical/lower_medical)
 "zs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -8134,10 +7906,6 @@
 /obj/machinery/vending/engivend,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"zM" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "zN" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/mainship/mono,
@@ -8175,9 +7943,6 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"zU" = (
-/turf/closed/wall/mainship/research/containment/wall/west,
-/area/mainship/medical/medical_science)
 "zV" = (
 /obj/machinery/power/fusion_engine/preset,
 /obj/structure/cable,
@@ -8209,15 +7974,10 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/engineering/engineering_workshop)
 "zZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/turf/open/floor/mainship/research/containment/floor2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/prison/kitchen,
-/area/mainship/living/grunt_rnr)
+/area/mainship/medical/medical_science)
 "Aa" = (
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 4
@@ -8293,11 +8053,12 @@
 /turf/open/floor/plating,
 /area/mainship/shipboard/firing_range)
 "Am" = (
-/obj/structure/disposalpipe/segment/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/machinery/computer/crew,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "An" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -8326,12 +8087,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "As" = (
-/obj/machinery/chem_master,
-/obj/item/reagent_containers/glass/beaker/bluespace,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/medical_science)
+/obj/structure/table/woodentable,
+/obj/item/storage/fancy/cigar,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "At" = (
 /obj/machinery/autolathe,
 /turf/open/floor/mainship/mono,
@@ -8417,12 +8176,52 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/engineering/upper_engineering)
+"AH" = (
+/obj/structure/table/mainship,
+/obj/item/storage/belt/combatLifesaver,
+/obj/item/storage/belt/combatLifesaver,
+/obj/item/storage/belt/combatLifesaver,
+/obj/item/storage/belt/medical{
+	pixel_y = 9
+	},
+/obj/item/storage/belt/medical{
+	pixel_y = 9
+	},
+/obj/item/storage/belt/medical{
+	pixel_y = 9
+	},
+/obj/item/storage/belt/medical{
+	pixel_y = 9
+	},
+/obj/item/healthanalyzer,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
+"AJ" = (
+/obj/machinery/computer/cryopod{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "AK" = (
-/obj/machinery/cloning_console/vats,
+/obj/machinery/sleeper,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "AL" = (
-/turf/open/floor/wood,
+/obj/item/newspaper{
+	pixel_x = -10;
+	pixel_y = 8
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "AM" = (
 /obj/machinery/door/firedoor/mainship{
@@ -8471,11 +8270,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/starboard_hallway)
 "AS" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment/corner,
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
@@ -8548,10 +8343,11 @@
 /obj/docking_port/stationary/ert_big,
 /turf/open/space,
 /area/space)
-"Bf" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
+"Be" = (
+/turf/open/floor/mainship/sterile/side{
+	dir = 10
+	},
+/area/mainship/medical/lower_medical)
 "Bg" = (
 /obj/machinery/marine_selector/gear/medic,
 /turf/open/floor/mainship/floor,
@@ -8594,26 +8390,6 @@
 	dir = 4
 	},
 /area/mainship/shipboard/weapon_room)
-"Bm" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/structure/cable,
-/obj/machinery/door/airlock/multi_tile/mainship/generic/rnr,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/grunt_rnr)
-"Bn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/item/storage/box/matches,
-/obj/item/storage/fancy/cigarettes,
-/obj/structure/table/woodentable,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
 "Bo" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/mainship{
@@ -8679,41 +8455,22 @@
 	dir = 6
 	},
 /area/mainship/squads/general)
-"Bx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/bed/chair/wood/wings{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
 "Bz" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"BB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
 "BD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/door/poddoor/shutters/mainship/cell,
+/obj/machinery/door/airlock/mainship/research/glass/cell,
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/mainship/research,
+/area/mainship/medical/medical_science)
+"BE" = (
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/table/mainship,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/grunt_rnr)
+/area/mainship/medical/chemistry)
 "BF" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -8726,35 +8483,44 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "BH" = (
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/obj/machinery/sleep_console,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "BI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
+"BJ" = (
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 4
+	},
+/area/mainship/medical/chemistry)
+"BK" = (
+/obj/structure/bed/chair/wood/wings,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
-"BJ" = (
-/obj/machinery/chem_master,
-/obj/item/reagent_containers/glass/beaker/bluespace,
-/turf/open/floor/mainship/sterile/side{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/area/mainship/medical/lower_medical)
-"BK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "BL" = (
 /obj/item/reagent_containers/food/snacks/grown/poppy,
 /obj/item/clothing/head/modular/marine,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cafeteria_starboard)
+"BM" = (
+/obj/structure/barricade/metal{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "BN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -8833,14 +8599,16 @@
 /obj/item/tool/pen,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
+"BW" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/closet/bodybag,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "BX" = (
-/obj/effect/decal/siding{
-	dir = 5
-	},
-/turf/open/floor/mainship/terragov/east{
-	dir = 5
-	},
-/area/space)
+/obj/structure/table/mainship,
+/obj/machinery/computer/med_data/laptop,
+/turf/open/floor/mainship/mono,
+/area/mainship/medical/lower_medical)
 "BY" = (
 /turf/open/floor/mainship/black{
 	dir = 9
@@ -8968,12 +8736,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/airoom)
 "Ct" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/surgery_hallway)
+/obj/machinery/light,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
 "Cu" = (
 /obj/structure/ship_ammo/rocket/keeper,
 /turf/open/floor/mainship/floor,
@@ -8983,17 +8748,16 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "Cw" = (
-/obj/machinery/cloning/vats,
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 1
 	},
 /area/mainship/medical/lower_medical)
 "Cx" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/mainship/medical/surgery_hallway)
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "Cz" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/mainship/mono,
@@ -9107,14 +8871,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "CR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/structure/bed/chair{
+	dir = 8
 	},
 /turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/area/mainship/medical/chemistry)
 "CS" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 2
@@ -9168,10 +8929,6 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
-"Da" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
 "Db" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
@@ -9194,18 +8951,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
-"De" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 8;
-	on = 1
-	},
-/mob/living/simple_animal/catslug/newt,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
 "Df" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9338,9 +9083,14 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/command/cic)
 "Dw" = (
-/obj/structure/bed/chair/sofa/left,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 5
+	},
+/area/mainship/medical/lower_medical)
 "Dy" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -9356,8 +9106,16 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
 "Dz" = (
-/obj/structure/bed/chair/wood/wings,
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/table/mainship,
+/obj/item/clipboard{
+	pixel_x = 5
+	},
+/obj/structure/paper_bin{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/tool/pen,
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "DA" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -9433,7 +9191,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 8
+	},
 /area/mainship/medical/lower_medical)
 "DH" = (
 /obj/machinery/disposal,
@@ -9583,6 +9343,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"DY" = (
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/mainship/hull/lower_hull)
 "DZ" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -9594,21 +9363,15 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Ea" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment/corner,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
-"Eb" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/mainship,
-/turf/open/floor/mainship/sterile/side{
+/obj/structure/sign/poster{
 	dir = 1
 	},
-/area/mainship/medical/surgery_hallway)
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
+"Eb" = (
+/obj/machinery/status_display,
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/lower_medical)
 "Ec" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -9618,11 +9381,17 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "Ed" = (
-/obj/structure/bed/chair/sofa/right{
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/obj/structure/cable,
+/obj/machinery/bodyscanner{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/chemistry)
 "Ee" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/cafeteria_starboard)
@@ -9676,6 +9445,13 @@
 /obj/structure/table/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"En" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 1;
+	on = 1
+	},
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "Eo" = (
 /obj/structure/toilet{
 	dir = 4
@@ -9808,9 +9584,9 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "EH" = (
-/obj/structure/window/framed/mainship/white,
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/surgery_hallway)
+/obj/machinery/iv_drip,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "EI" = (
 /obj/machinery/door/airlock/multi_tile/mainship/maint{
 	dir = 1
@@ -9830,14 +9606,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
 "EL" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/machinery/door/airlock/multi_tile/mainship/research,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
-"EN" = (
-/obj/structure/table/woodentable,
+/obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "EO" = (
@@ -9858,11 +9627,15 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "ES" = (
-/obj/machinery/vending/MarineMed,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/area/mainship/medical/lower_medical)
+/obj/structure/bed/chair/sofa/right,
+/obj/item/bedsheet/ce{
+	pixel_x = 6
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "ET" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -9876,7 +9649,23 @@
 /turf/closed/wall/mainship,
 /area/mainship/squads/req)
 "EW" = (
-/obj/machinery/portable_atmospherics/hydroponics,
+/obj/item/reagent_containers/food/snacks/meat{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/snacks/meat{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/snacks/meat{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/snacks/meat{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "EX" = (
@@ -9895,10 +9684,10 @@
 	},
 /area/mainship/squads/general)
 "Fb" = (
-/obj/machinery/sleeper,
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "Fc" = (
 /obj/structure/disposalpipe/segment,
@@ -9939,9 +9728,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
 "Fk" = (
-/obj/structure/bed/chair/sofa/corner,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "Fl" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -9963,14 +9755,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/airoom)
-"Fo" = (
-/obj/structure/cable,
-/obj/machinery/door/firedoor/mainship,
-/obj/effect/ai_node,
-/obj/machinery/door/airlock/mainship/maint/free_access,
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
 "Fp" = (
 /obj/machinery/light{
 	dir = 1
@@ -9989,11 +9773,28 @@
 /obj/machinery/telecomms/receiver/preset_right,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
-"Fv" = (
-/obj/structure/bed/chair/comfy{
+"Ft" = (
+/obj/structure/window/framed/mainship/white,
+/obj/machinery/door/firedoor/mainship{
 	dir = 1
 	},
+/obj/machinery/door/poddoor/shutters/opened/medbay{
+	dir = 1
+	},
+/turf/open/floor/plating/platebotc,
+/area/mainship/medical/lower_medical)
+"Fu" = (
+/obj/structure/cable,
 /turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
+"Fv" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket/janibucket,
+/obj/item/tool/wet_sign,
+/obj/item/tool/wet_sign,
+/obj/item/tool/wet_sign,
+/obj/item/storage/bag/trash,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "Fw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10045,12 +9846,6 @@
 "FD" = (
 /obj/machinery/light{
 	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
-"FE" = (
-/obj/machinery/light{
-	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
@@ -10254,6 +10049,12 @@
 /obj/structure/rack,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"Gn" = (
+/obj/structure/barricade/metal{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "Go" = (
 /obj/structure/dropship_equipment/electronics/spotlights,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -10323,8 +10124,10 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "Gy" = (
-/turf/open/floor/mainship/mono,
-/area/mainship/medical/surgery_hallway)
+/obj/structure/table/mainship,
+/obj/machinery/computer/med_data/laptop,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "GA" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
@@ -10361,10 +10164,15 @@
 /turf/open/floor/plating,
 /area/mainship/squads/req)
 "GE" = (
-/turf/closed/wall/mainship/research/containment/wall/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/area/mainship/medical/medical_science)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "GF" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -10426,13 +10234,6 @@
 	dir = 9
 	},
 /area/mainship/squads/general)
-"GO" = (
-/obj/structure/window/framed/mainship,
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/mainship/living/grunt_rnr)
 "GP" = (
 /obj/structure/table/mainship,
 /obj/machinery/light{
@@ -10447,23 +10248,13 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"GR" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 6
-	},
-/area/mainship/medical/surgery_hallway)
 "GS" = (
-/obj/structure/table/woodentable,
-/obj/item/pizzabox/meat,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
-"GT" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/surgery_hallway)
+/area/mainship/living/grunt_rnr)
 "GU" = (
 /obj/structure/cable,
 /turf/closed/wall/mainship/outer,
@@ -10500,6 +10291,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
+"GZ" = (
+/obj/machinery/light{
+	light_color = "#da2f1b"
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "Ha" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -10528,15 +10326,22 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "Hc" = (
-/obj/structure/cable,
-/turf/open/floor/prison/kitchen,
-/area/mainship/living/grunt_rnr)
-"Hd" = (
-/obj/structure/bed/chair/wood/wings{
+/obj/machinery/flasher{
+	id = "Containment Cell 3";
+	pixel_y = 30
+	},
+/turf/open/floor/mainship/research/containment/floor2{
 	dir = 1
 	},
-/turf/open/floor/wood,
-/area/mainship/medical/surgery_hallway)
+/area/mainship/medical/medical_science)
+"Hd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 1
+	},
+/area/mainship/medical/medical_science)
 "He" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -10559,22 +10364,15 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
 /area/mainship/living/cafeteria_starboard)
-"Hg" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
 "Hh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 4;
-	on = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "Hi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -10614,12 +10412,28 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
+"Hm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "Hn" = (
 /obj/effect/landmark/start/job/pilotofficer,
 /obj/structure/bed,
 /obj/structure/mirror,
 /turf/open/floor/wood,
 /area/mainship/living/pilotbunks)
+"Hp" = (
+/obj/machinery/light{
+	light_color = "#da2f1b"
+	},
+/obj/machinery/bodyscanner{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/operating_room_one)
 "Hq" = (
 /obj/structure/table/mainship,
 /obj/item/storage/donut_box,
@@ -10660,6 +10474,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"Hx" = (
+/obj/structure/closet/boxinggloves,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "Hy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -10745,6 +10566,15 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/lower_engineering)
+"HI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 5
+	},
+/area/mainship/medical/medical_science)
 "HJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
@@ -10801,6 +10631,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
+"HP" = (
+/obj/structure/closet/bodybag,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "HQ" = (
 /obj/machinery/door/poddoor/mainship/open/cic{
 	dir = 2
@@ -10887,9 +10721,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "Ib" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
@@ -10898,6 +10729,10 @@
 	},
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "Ic" = (
@@ -10923,9 +10758,8 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
 "Ih" = (
-/obj/effect/decal/cleanable/blood,
 /turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/area/mainship/medical/lower_medical)
 "Ii" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -10983,9 +10817,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_umbilical)
 "Io" = (
-/obj/structure/bed/chair/sofa/right,
+/obj/machinery/vending/dinnerware,
 /turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/area/mainship/living/grunt_rnr)
 "Ip" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -11032,7 +10866,7 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "Iv" = (
-/obj/machinery/vending/hydronutrients,
+/obj/structure/bed/chair/sofa/left,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Iw" = (
@@ -11047,6 +10881,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
+"Ix" = (
+/turf/open/floor/mainship/sterile/side{
+	dir = 6
+	},
+/area/mainship/medical/lower_medical)
 "Iy" = (
 /obj/structure/bed/stool{
 	pixel_y = 8
@@ -11127,32 +10966,18 @@
 /obj/effect/decal/siding{
 	dir = 9
 	},
-/turf/open/floor/mainship/terragov/east{
-	dir = 9
-	},
+/turf/open/floor/mainship_hull,
 /area/space)
 "IK" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"IM" = (
-/obj/item/toy/deck,
-/obj/structure/table/woodentable,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
-"IN" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/glass/bucket/janibucket,
-/obj/item/tool/wet_sign,
-/obj/item/tool/wet_sign,
-/obj/item/tool/wet_sign,
-/obj/item/storage/bag/trash,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
 "IO" = (
-/obj/machinery/gibber,
+/obj/structure/morgue{
+	dir = 2
+	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/area/mainship/medical/lower_medical)
 "IP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11183,11 +11008,6 @@
 /obj/effect/landmark/start/job/squadsmartgunner,
 /turf/open/floor/mainship,
 /area/mainship/living/cryo_cells)
-"IV" = (
-/obj/machinery/door/airlock/mainship/maint,
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/medical/surgery_hallway)
 "IW" = (
 /obj/machinery/light{
 	dir = 1
@@ -11205,27 +11025,52 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "IZ" = (
-/obj/structure/morgue{
-	dir = 2
+/obj/structure/rack,
+/obj/item/tool/crowbar,
+/obj/effect/spawner/random/toolbox,
+/obj/item/stack/cable_coil,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/medical/surgery_hallway)
+/obj/item/assembly/timer,
+/obj/item/assembly/infra,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 8
+	},
+/area/mainship/medical/medical_science)
 "Ja" = (
+/obj/structure/closet/secure_closet/CMO,
+/turf/open/floor/wood,
+/area/mainship/medical/medical_science)
+"Jb" = (
 /obj/structure/table/mainship,
-/obj/machinery/door_control/mainship/research/lockdown{
+/obj/item/storage/box/beakers{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/storage/box/pillbottles{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/storage/box/syringes{
 	pixel_x = -7
 	},
-/obj/item/book/manual/medical_diagnostics_manual,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/megaphone,
-/turf/open/floor/wood,
-/area/mainship/medical/surgery_hallway)
-"Jc" = (
-/obj/machinery/light/small{
+/obj/item/storage/box/autoinjectors{
+	pixel_x = 7
+	},
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/mass_spectrometer,
+/turf/open/floor/mainship/sterile/purple/side{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/area/mainship/medical/chemistry)
+"Jc" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "Jd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
@@ -11464,9 +11309,51 @@
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "JH" = (
-/obj/structure/cable,
+/obj/structure/table/mainship,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 7
+	},
+/obj/item/storage/firstaid/fire{
+	pixel_x = 7
+	},
+/obj/item/storage/firstaid/o2{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/storage/firstaid/rad{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/storage/firstaid/adv{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/firstaid/adv{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/storage/firstaid/adv{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = 3
+	},
 /turf/open/floor/mainship/sterile/side{
-	dir = 9
+	dir = 4
 	},
 /area/mainship/medical/lower_medical)
 "JI" = (
@@ -11488,33 +11375,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "JK" = (
-/obj/structure/table/mainship,
-/obj/item/storage/belt/combatLifesaver,
-/obj/item/storage/belt/combatLifesaver,
-/obj/item/storage/belt/combatLifesaver,
-/obj/item/storage/belt/medical{
-	pixel_y = 9
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 9
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 9
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 9
-	},
-/obj/item/healthanalyzer,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
 /obj/structure/cable,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "JL" = (
 /obj/structure/disposalpipe/segment,
@@ -11524,11 +11389,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "JM" = (
-/obj/machinery/bodyscanner{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "JN" = (
 /obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/mono,
@@ -11577,6 +11440,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
+"JU" = (
+/obj/structure/window/framed/mainship/white,
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/poddoor/shutters/opened/medbay,
+/obj/structure/sign/chemistry,
+/turf/open/floor/plating/platebotc,
+/area/mainship/medical/chemistry)
 "JV" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -11683,6 +11553,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
+"Kh" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "Ki" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -11696,11 +11570,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Kj" = (
-/obj/structure/bed/chair/sofa/right{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/obj/effect/landmark/start/job/researcher,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "Kk" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
@@ -11719,22 +11592,20 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "Km" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/window/framed/mainship/white,
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 1;
+	id = "or1privacyshutter";
+	name = "\improper Privacy Shutters"
 	},
-/obj/structure/closet/secure_closet/medical2,
-/obj/item/storage/box/gloves,
-/obj/item/storage/surgical_tray,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_one)
 "Kn" = (
-/obj/machinery/body_scanconsole,
-/turf/open/floor/mainship/sterile/corner{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "Ko" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -11810,9 +11681,8 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "Kw" = (
-/obj/structure/sign/custodian,
 /turf/closed/wall/mainship/outer,
-/area/mainship/hull/lower_hull)
+/area/mainship/medical/lower_medical)
 "Kx" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner{
@@ -11872,18 +11742,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "KC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/bed/stool{
-	pixel_y = 8
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
+/obj/structure/table/woodentable,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "KD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -11945,6 +11806,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"KK" = (
+/mob/living/simple_animal/cat/Runtime,
+/turf/open/floor/wood,
+/area/mainship/medical/medical_science)
 "KM" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/mainship/hardened{
@@ -11995,19 +11860,15 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "KR" = (
-/obj/effect/ai_node,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "KS" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/tool/kitchen/knife/butcher,
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/area/mainship/medical/lower_medical)
 "KT" = (
 /obj/effect/landmark/start/job/squadmarine,
 /obj/structure/cable,
@@ -12031,15 +11892,14 @@
 	},
 /area/mainship/hallways/hangar)
 "KW" = (
-/turf/closed/wall/mainship/research/containment/wall/corner{
+/obj/structure/cable,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
+"KX" = (
+/turf/open/floor/mainship/sterile/purple/corner{
 	dir = 8
 	},
 /area/mainship/medical/medical_science)
-"KX" = (
-/obj/structure/table/mainship,
-/obj/machinery/computer/med_data/laptop,
-/turf/open/floor/mainship/mono,
-/area/mainship/medical/surgery_hallway)
 "KY" = (
 /obj/structure/largecrate/guns/merc,
 /turf/open/floor/mainship/mono,
@@ -12056,14 +11916,24 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "La" = (
-/obj/structure/bed/chair/wood/wings{
-	dir = 1
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Lb" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/command/self_destruct)
+"Lc" = (
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/mainship/hull/lower_hull)
 "Ld" = (
 /obj/structure/table/mainship,
 /obj/item/clipboard,
@@ -12171,9 +12041,14 @@
 /obj/structure/prop/mainship/sensor_computer2,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
+"Lq" = (
+/obj/machinery/chem_dispenser,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
 "Lr" = (
-/turf/closed/wall/mainship/research/containment/wall/purple,
-/area/mainship/medical/medical_science)
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "Ls" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -12194,14 +12069,8 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/engineering/lower_engineering)
 "Lu" = (
-/obj/structure/cable,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/surgery_hallway)
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
 "Lv" = (
 /obj/machinery/computer/supplycomp,
 /turf/open/floor/mainship/mono,
@@ -12249,15 +12118,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "LD" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/bodyscanner{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
+/obj/machinery/body_scanconsole,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "LE" = (
 /obj/machinery/light{
@@ -12280,6 +12142,16 @@
 /obj/effect/landmark/start/latejoin,
 /turf/open/floor/mainship,
 /area/mainship/living/cryo_cells)
+"LI" = (
+/obj/machinery/holopad{
+	active_power_usage = 60;
+	desc = "It's a floor-mounted device for projecting holographic images. This one appears to have a smaller lense";
+	holo_range = 3;
+	idle_power_usage = 3;
+	name = "modifed holopad"
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
 "LJ" = (
 /obj/structure/window/framed/mainship,
 /obj/machinery/door/poddoor/shutters/mainship/corporate,
@@ -12292,10 +12164,8 @@
 /obj/effect/decal/siding{
 	dir = 1
 	},
-/turf/open/floor/mainship/terragov/east{
-	dir = 1
-	},
-/area/space)
+/turf/closed/wall/mainship,
+/area/mainship/medical/lower_medical)
 "LL" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/cargo/arrow{
@@ -12303,11 +12173,8 @@
 	},
 /area/mainship/engineering/engine_core)
 "LM" = (
-/obj/structure/table/mainship,
-/obj/item/storage/box/bodybags,
-/obj/item/reagent_containers/glass/beaker/biomass,
 /turf/open/floor/mainship/sterile/side{
-	dir = 8
+	dir = 1
 	},
 /area/mainship/medical/lower_medical)
 "LN" = (
@@ -12346,18 +12213,16 @@
 	},
 /area/mainship/squads/general)
 "LR" = (
-/obj/structure/table/mainship,
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
-/turf/open/floor/wood,
-/area/mainship/medical/surgery_hallway)
+/obj/machinery/processor{
+	pixel_y = 5
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "LS" = (
-/obj/structure/barricade/metal{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "LT" = (
 /obj/machinery/mech_bay_recharge_port,
@@ -12422,18 +12287,10 @@
 	},
 /area/mainship/squads/general)
 "Md" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/paper/crumpled{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/turf/open/floor/mainship/mono,
+/obj/structure/janitorialcart,
+/obj/item/tool/mop,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"Me" = (
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/medical_science)
 "Mg" = (
 /obj/structure/target_stake,
 /obj/item/target,
@@ -12471,10 +12328,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
 "Mm" = (
+/mob/living/simple_animal/catslug/newt,
 /obj/structure/cable,
-/obj/structure/disposalpipe/junction/flipped,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 4
+	},
+/area/mainship/medical/medical_science)
 "Mn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -12526,9 +12385,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "Mt" = (
-/obj/machinery/vending/medical/shipside,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/chemistry)
 "Mu" = (
 /obj/machinery/telecomms/bus/preset_four,
 /turf/open/floor/mainship/tcomms,
@@ -12571,6 +12429,11 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/stern_hallway)
+"MB" = (
+/obj/structure/table/mainship,
+/obj/machinery/chem_dispenser/beer,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "MC" = (
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
@@ -12583,11 +12446,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
 "MF" = (
-/obj/structure/bed/chair/wood/wings{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "MG" = (
 /obj/structure/table/mainship,
 /obj/item/tank/oxygen/red,
@@ -12644,9 +12505,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "MP" = (
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
+/obj/effect/landmark/start/job/medicalofficer,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "MQ" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -12660,15 +12520,6 @@
 	},
 /area/mainship/hallways/hangar)
 "MR" = (
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/holosign/surgery{
-	id = "or1sign"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mainship/medical/or/or1{
-	dir = 1
-	},
-/obj/structure/cable,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/sterile/dark,
@@ -12678,7 +12529,7 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/lower_medical)
 "MU" = (
 /obj/machinery/firealarm,
@@ -12706,12 +12557,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_umbilical)
 "MZ" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/start/job/researcher,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/medical_science)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/port_hallway)
 "Na" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -12742,14 +12591,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "Ne" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/bed/chair/wood/wings{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/obj/structure/closet/secure_closet/animal,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "Nf" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner{
@@ -12804,17 +12649,10 @@
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
-"Nl" = (
-/obj/structure/closet/bodybag,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
 "Nm" = (
-/obj/item/paper/crumpled,
-/obj/item/paper/crumpled{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/turf/open/floor/mainship/mono,
+/obj/structure/closet/bodybag,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "Nn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -12851,26 +12689,9 @@
 	dir = 1
 	},
 /area/mainship/squads/general)
-"Ns" = (
-/obj/effect/decal/cleanable/blood/gibs,
-/obj/item/reagent_containers/food/snacks/meat{
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/snacks/meat{
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/snacks/meat{
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
 "Nt" = (
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/turf/closed/wall/mainship/research/containment/wall/west,
+/area/mainship/medical/medical_science)
 "Nu" = (
 /obj/effect/landmark/start/job/squadengineer,
 /obj/machinery/camera/autoname/mainship{
@@ -12939,10 +12760,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
 "ND" = (
-/obj/structure/cable,
-/obj/machinery/iv_drip,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/surgery_hallway)
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "NE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -12959,15 +12780,15 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "NG" = (
-/obj/machinery/door/airlock/mainship/medical/morgue{
-	dir = 2
+/obj/structure/table/woodentable,
+/obj/structure/paper_bin,
+/obj/item/clipboard{
+	pixel_x = -6;
+	pixel_y = 2
 	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/surgery_hallway)
+/obj/item/tool/pen,
+/turf/open/floor/wood,
+/area/mainship/medical/medical_science)
 "NH" = (
 /obj/structure/cable,
 /obj/machinery/camera/autoname/mainship{
@@ -12998,6 +12819,16 @@
 /obj/item/tool/taperoll/engineering,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"NK" = (
+/obj/structure/cable,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/operating_room_one)
 "NL" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -13005,11 +12836,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "NM" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/surgery_hallway)
+/area/mainship/medical/medical_science)
 "NN" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -13036,9 +12864,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "NQ" = (
-/obj/structure/sign/chemistry,
-/turf/closed/wall/mainship/white,
-/area/mainship/medical/operating_room_one)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "NR" = (
 /obj/machinery/door/firedoor/mainship,
 /obj/machinery/door/poddoor/mainship/open/cic,
@@ -13089,9 +12918,10 @@
 /turf/closed/wall/mainship,
 /area/mainship/command/cic)
 "NY" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/obj/structure/table/mainship,
+/obj/machinery/chem_dispenser/beer,
+/turf/open/floor/wood,
+/area/mainship/medical/chemistry)
 "NZ" = (
 /obj/structure/window/framed/mainship,
 /turf/open/floor/plating,
@@ -13110,8 +12940,13 @@
 	},
 /area/mainship/squads/general)
 "Oc" = (
-/turf/closed/wall/mainship/research/containment/wall/south,
-/area/mainship/medical/medical_science)
+/obj/machinery/door/airlock/mainship/generic{
+	name = "Kitchen"
+	},
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "Od" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
@@ -13125,23 +12960,24 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "Of" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/camera/autoname{
 	dir = 4
 	},
-/obj/item/storage/donut_box,
-/obj/structure/table/woodentable,
+/obj/machinery/firealarm{
+	dir = 4
+	},
 /turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/area/mainship/medical/chemistry)
 "Og" = (
-/obj/structure/cable,
-/obj/machinery/iv_drip,
-/obj/machinery/power/apc/mainship{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/storage/box/gloves,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
 	},
-/turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/operating_room_one)
 "Oh" = (
 /obj/machinery/door/airlock/mainship/generic/corporate{
@@ -13221,7 +13057,7 @@
 "Oq" = (
 /obj/machinery/door/airlock/mainship/maint/free_access,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
+/area/mainship/medical/lower_medical)
 "Or" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 2
@@ -13253,12 +13089,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
-"Ow" = (
-/obj/structure/bed/chair/wood/wings{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
 "Ox" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/numbertwobunks)
@@ -13281,10 +13111,15 @@
 /turf/closed/wall/mainship/outer,
 /area/mainship/shipboard/weapon_room)
 "OC" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
+/obj/machinery/holopad{
+	active_power_usage = 60;
+	desc = "It's a floor-mounted device for projecting holographic images. This one appears to have a smaller lense";
+	holo_range = 3;
+	idle_power_usage = 3;
+	name = "modifed holopad"
 	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_one)
 "OD" = (
@@ -13447,16 +13282,9 @@
 /turf/closed/wall/mainship/outer,
 /area/mainship/hallways/hangar)
 "Pb" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/mainship/research/glass/wing{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/window/framed/mainship/white,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
+/area/mainship/medical/lower_medical)
 "Pc" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner{
@@ -13482,10 +13310,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"Pg" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/surgery_hallway)
 "Ph" = (
 /obj/machinery/light{
 	dir = 1
@@ -13589,19 +13413,25 @@
 	},
 /area/mainship/squads/general)
 "Pu" = (
-/obj/structure/table/mainship,
-/obj/machinery/computer/med_data/laptop,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/medical_science)
+/obj/machinery/cic_maptable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "Pv" = (
 /obj/structure/target_stake,
 /obj/item/target,
 /obj/item/clothing/suit/storage/militia,
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
+"Pw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/bed/stool,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "Px" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -13627,13 +13457,12 @@
 /turf/open/floor/grass,
 /area/mainship/living/cafeteria_starboard)
 "PB" = (
-/obj/structure/bed/chair/office/dark{
+/obj/machinery/chem_master,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/turf/open/floor/mainship/sterile/purple/side{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/chemistry)
 "PC" = (
 /obj/machinery/telecomms/processor/preset_one,
 /turf/open/floor/mainship/tcomms,
@@ -13766,17 +13595,15 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "PY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/prison/kitchen,
-/area/mainship/living/grunt_rnr)
-"PZ" = (
 /turf/open/floor/mainship/research/containment/floor2{
-	dir = 9
+	dir = 10
 	},
 /area/mainship/medical/medical_science)
+"PZ" = (
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/food/snacks/cheeseburger,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "Qb" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/machinery/holopad,
@@ -13830,11 +13657,12 @@
 	},
 /area/mainship/squads/general)
 "Qk" = (
-/obj/structure/closet/secure_closet/chemical,
-/turf/open/floor/mainship/sterile/corner{
+/obj/machinery/chem_master,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/turf/open/floor/mainship/sterile/purple/corner{
 	dir = 4
 	},
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/chemistry)
 "Ql" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13925,9 +13753,8 @@
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "Qw" = (
-/obj/structure/cable,
 /turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/area/mainship/medical/chemistry)
 "Qx" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -13941,11 +13768,10 @@
 	dir = 8
 	},
 /area/mainship/hallways/aft_hallway)
-"QC" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lower_medical)
+"QB" = (
+/obj/structure/bed/chair/wood/wings,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "QD" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -13967,13 +13793,6 @@
 	dir = 1
 	},
 /area/mainship/medical/operating_room_two)
-"QF" = (
-/obj/structure/window/framed/mainship/white,
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/surgery_hallway)
 "QG" = (
 /obj/vehicle/ridden/powerloader,
 /turf/open/floor/mainship/cargo,
@@ -14019,6 +13838,11 @@
 /obj/structure/sign/prop3,
 /turf/closed/wall/mainship,
 /area/mainship/living/cryo_cells)
+"QM" = (
+/obj/structure/table/woodentable,
+/obj/item/storage/donut_box,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "QN" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship,
@@ -14034,12 +13858,9 @@
 /turf/closed/wall/mainship,
 /area/mainship/command/self_destruct)
 "QQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 1;
-	on = 1
-	},
-/turf/open/floor/prison/kitchen,
-/area/mainship/living/grunt_rnr)
+/obj/machinery/light/small,
+/turf/open/floor/mainship/research/containment/floor2,
+/area/mainship/medical/medical_science)
 "QR" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -14124,16 +13945,13 @@
 	},
 /area/mainship/shipboard/weapon_room)
 "Rd" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
-	dir = 2
-	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
-"Re" = (
-/turf/open/floor/mainship/sterile/corner{
-	dir = 8
-	},
-/area/mainship/medical/surgery_hallway)
+"Rf" = (
+/obj/machinery/door/airlock/mainship/medical/glass/free_access,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "Rg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -14153,31 +13971,33 @@
 	},
 /area/mainship/hallways/hangar)
 "Rj" = (
-/obj/effect/ai_node,
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
 /obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/medical/surgery_hallway)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 4
+	},
+/area/mainship/medical/medical_science)
 "Rk" = (
-/obj/machinery/firealarm{
-	dir = 1
-	},
-/obj/machinery/iv_drip,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/surgery_hallway)
-"Rn" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
-	dir = 2;
-	name = "\improper Break Room"
-	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
+/obj/machinery/status_display,
+/turf/closed/wall/mainship,
+/area/mainship/living/grunt_rnr)
+"Rm" = (
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/surgery_hallway)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 9
+	},
+/area/mainship/medical/lower_medical)
 "Ro" = (
 /mob/living/simple_animal/corgi/walten,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "Rp" = (
@@ -14221,12 +14041,9 @@
 /turf/open/floor/mainship/black,
 /area/mainship/living/cafeteria_starboard)
 "Rv" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/obj/machinery/vending/snack,
+/turf/open/floor/wood,
+/area/mainship/medical/chemistry)
 "Rw" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -14266,10 +14083,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "RC" = (
+/obj/machinery/vending/hydroseeds,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "RE" = (
 /obj/structure/cable,
@@ -14298,10 +14116,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "RI" = (
-/obj/machinery/optable,
-/obj/machinery/light,
-/turf/open/floor/mainship/mono,
-/area/mainship/medical/surgery_hallway)
+/turf/open/floor/mainship/sterile/purple/side,
+/area/mainship/medical/medical_science)
 "RJ" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
@@ -14324,16 +14140,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "RL" = (
-/obj/machinery/holosign_switch{
-	id = "or1sign";
-	pixel_x = 5;
-	pixel_y = 10
-	},
-/turf/closed/wall/mainship/white{
-	desc = "A huge chunk of metal used to seperate space from the ship";
-	name = "Outer Hull";
-	resistance_flags = 3
-	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/operating_room_one)
 "RM" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -14388,16 +14196,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "RT" = (
-/obj/machinery/camera/autoname/mainship{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/storage/surgical_tray,
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/medical/surgery_hallway)
+/obj/machinery/iv_drip,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "RU" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/breath/medical,
@@ -14484,9 +14289,16 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "Si" = (
-/obj/machinery/firealarm,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 10
+	},
+/area/mainship/medical/lower_medical)
 "Sj" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/closed/wall/mainship,
@@ -14503,9 +14315,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
 "Sm" = (
-/obj/structure/bed/stool,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/chemistry)
 "Sn" = (
 /turf/open/floor/plating/icefloor/warnplate,
 /area/mainship/hallways/hangar)
@@ -14515,9 +14330,11 @@
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "Sq" = (
-/obj/machinery/smartfridge/chemistry,
+/obj/structure/window/framed/mainship/white,
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/poddoor/shutters/opened/medbay,
 /turf/open/floor/plating/platebotc,
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/chemistry)
 "Sr" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -14596,8 +14413,15 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/starboard_umbilical)
 "SD" = (
-/obj/effect/landmark/start/job/medicalofficer,
-/turf/open/floor/mainship/sterile/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/corner{
+	dir = 4
+	},
 /area/mainship/medical/lower_medical)
 "SE" = (
 /obj/structure/target_stake,
@@ -14666,13 +14490,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "SR" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/adv,
-/obj/item/reagent_containers/spray/surgery,
-/obj/machinery/door_control{
-	dir = 4;
-	id = "or1privacyshutter";
-	name = "Privacy Shutters"
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
@@ -14686,14 +14506,15 @@
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/squads/req)
 "ST" = (
+/obj/structure/sign/nosmoking_2,
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/chemistry)
+"SU" = (
+/obj/structure/sign/poster{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
-"SU" = (
-/obj/machinery/computer/cryopod{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
 "SW" = (
 /turf/closed/shuttle/ert{
 	icon_state = "rightengine_2";
@@ -14717,6 +14538,14 @@
 /obj/item/weapon/gun/rifle/standard_carbine,
 /turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/firing_range)
+"SZ" = (
+/obj/structure/sign/chemistry,
+/turf/closed/wall/mainship/white{
+	desc = "A huge chunk of metal used to seperate space from the ship";
+	name = "Outer Hull";
+	resistance_flags = 3
+	},
+/area/mainship/medical/chemistry)
 "Ta" = (
 /obj/machinery/marine_selector/clothes,
 /obj/structure/window/reinforced,
@@ -14730,13 +14559,10 @@
 /area/mainship/squads/general)
 "Tb" = (
 /obj/structure/cable,
-/obj/structure/sink{
-	dir = 1
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
 	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/side,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_one)
 "Tc" = (
 /turf/open/floor/mainship/sterile/side{
@@ -14744,15 +14570,10 @@
 	},
 /area/mainship/medical/lower_medical)
 "Td" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/mainship/medical/glass/chemistry,
-/obj/machinery/door/firedoor,
-/obj/effect/ai_node,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
 	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/chemistry)
 "Te" = (
 /turf/open/floor/mainship/red{
 	dir = 4
@@ -14805,8 +14626,8 @@
 /area/space)
 "Tn" = (
 /obj/effect/decal/siding,
-/turf/open/floor/mainship/terragov/east,
-/area/space)
+/turf/closed/wall/mainship,
+/area/mainship/medical/lower_medical)
 "Tp" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -14846,12 +14667,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "Tw" = (
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/corner{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 6
 	},
 /area/mainship/medical/lower_medical)
 "Tx" = (
@@ -14859,9 +14682,12 @@
 /turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/firing_range)
 "Ty" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/mask/breath/medical,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/medical2,
 /obj/item/storage/box/gloves,
+/obj/item/storage/surgical_tray,
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
@@ -14882,13 +14708,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
-"TB" = (
-/obj/structure/sink,
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/prison/kitchen,
-/area/mainship/living/grunt_rnr)
 "TC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -14905,16 +14724,15 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "TD" = (
-/obj/structure/table/mainship,
-/obj/item/reagent_containers/food/snacks/cheeseburger,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/turf/closed/wall/mainship/research/containment/wall/purple,
+/area/mainship/medical/medical_science)
 "TE" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side,
+/obj/machinery/optable,
+/obj/item/tank/anesthetic,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_one)
 "TF" = (
-/obj/machinery/line_nexter,
+/obj/machinery/grill/unwrenched,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "TG" = (
@@ -14943,9 +14761,11 @@
 /turf/open/floor/plating,
 /area/mainship/living/briefing)
 "TK" = (
-/obj/machinery/light,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lower_medical)
+/obj/machinery/light{
+	light_color = "#da2f1b"
+	},
+/turf/open/floor/mainship/sterile/purple/side,
+/area/mainship/medical/chemistry)
 "TL" = (
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/black{
@@ -14990,9 +14810,14 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/body_scanconsole,
 /turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/lower_medical)
+"TS" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "TT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
@@ -15001,12 +14826,8 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "TV" = (
-/obj/structure/table/mainship,
-/obj/item/tool/kitchen/tray,
-/obj/item/tool/kitchen/knife,
-/obj/item/storage/box/tgmc_mre,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/turf/closed/wall/mainship/research/containment/wall/corner,
+/area/mainship/medical/medical_science)
 "TW" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/operating_room_two)
@@ -15019,11 +14840,6 @@
 	dir = 1
 	},
 /area/mainship/squads/req)
-"TZ" = (
-/obj/machinery/light,
-/obj/machinery/iv_drip,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/surgery_hallway)
 "Ua" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner,
@@ -15068,12 +14884,22 @@
 	},
 /area/mainship/hallways/hangar/droppod)
 "Ue" = (
-/obj/effect/ai_node,
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/start/job/cmo,
+/turf/open/floor/wood,
+/area/mainship/medical/medical_science)
+"Uf" = (
+/obj/machinery/light{
+	light_color = "#da2f1b"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/surgery_hallway)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "Ug" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -15084,9 +14910,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Uh" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/sterile/dark,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/corner{
+	dir = 4
+	},
 /area/mainship/medical/lower_medical)
 "Ui" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
@@ -15101,19 +14930,27 @@
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "Uj" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/chemistry)
 "Uk" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "Ul" = (
+/obj/machinery/door/airlock/mainship/research/pen,
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lower_medical)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "Um" = (
 /turf/closed/wall/mainship/outer,
 /area/space)
@@ -15244,9 +15081,10 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "UF" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/obj/structure/sink,
+/obj/structure/cable,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "UG" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -15428,8 +15266,8 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "Ve" = (
-/turf/open/floor/prison/kitchen,
-/area/mainship/living/grunt_rnr)
+/turf/closed/wall/mainship/research/containment/wall/south,
+/area/mainship/medical/medical_science)
 "Vf" = (
 /obj/effect/landmark/start/job/squadcorpsman,
 /turf/open/floor/mainship,
@@ -15442,12 +15280,12 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
 "Vh" = (
-/obj/structure/morgue/crematorium,
-/obj/machinery/crema_switch{
-	pixel_x = 24
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/medical/surgery_hallway)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "Vi" = (
 /obj/structure/rack,
 /obj/item/pizzabox/meat,
@@ -15469,6 +15307,11 @@
 	dir = 1
 	},
 /area/mainship/hallways/aft_hallway)
+"Vm" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "Vo" = (
 /turf/open/floor/mainship_hull/dir,
 /area/space)
@@ -15492,11 +15335,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "Vt" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/mainship/medical/surgery_hallway)
+/obj/structure/table/mainship,
+/obj/machinery/chem_dispenser/soda,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "Vu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -15536,6 +15378,16 @@
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
+"VA" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/storage/surgical_tray,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "VC" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic/cryo{
 	dir = 1
@@ -15584,16 +15436,21 @@
 /area/mainship/hallways/port_hallway)
 "VJ" = (
 /obj/machinery/light{
-	light_color = "#da2f1b"
+	dir = 8
 	},
-/turf/open/floor/mainship/sterile/side,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
 /area/mainship/medical/lower_medical)
 "VK" = (
 /obj/structure/lattice,
 /turf/open/space,
 /area/space)
 "VL" = (
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/bed/chair/comfy{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "VM" = (
 /obj/structure/cable,
@@ -15613,12 +15470,8 @@
 	},
 /area/mainship/command/self_destruct)
 "VQ" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
+/obj/machinery/vending/cola,
+/turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "VR" = (
 /obj/structure/disposalpipe/segment{
@@ -15704,12 +15557,14 @@
 	},
 /area/mainship/squads/general)
 "Wb" = (
-/obj/structure/table/mainship,
-/obj/machinery/chem_dispenser/beer{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/mainship/medical/surgery_hallway)
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 1
+	},
+/area/mainship/medical/medical_science)
 "Wc" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -15742,11 +15597,12 @@
 /area/mainship/hallways/hangar/droppod)
 "Wg" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/multi_tile/mainship/maint/free_access{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "Wh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -15760,6 +15616,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
+"Wj" = (
+/obj/structure/table/reinforced,
+/obj/item/tool/kitchen/knife/butcher,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "Wk" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
@@ -15806,6 +15667,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
+"Wq" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/port_hallway)
 "Wr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
@@ -15842,7 +15709,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/lower_medical)
 "Wx" = (
 /obj/machinery/door/airlock/mainship/command,
@@ -15946,10 +15813,9 @@
 	},
 /area/mainship/squads/general)
 "WM" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/mainship/sterile/side{
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/corner{
 	dir = 4
 	},
 /area/mainship/medical/lower_medical)
@@ -16033,12 +15899,9 @@
 	},
 /area/mainship/hallways/hangar)
 "Xb" = (
-/obj/machinery/door/airlock/mainship/generic{
-	name = "Kitchen"
-	},
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/medical_science)
 "Xc" = (
 /obj/machinery/light{
 	dir = 1
@@ -16048,9 +15911,16 @@
 	},
 /area/mainship/squads/general)
 "Xe" = (
-/obj/structure/bed/stool,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/obj/structure/table/mainship,
+/obj/item/clipboard{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/structure/paper_bin,
+/obj/item/tool/pen,
+/obj/machinery/holopad,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "Xf" = (
 /obj/structure/table/mainship,
 /turf/open/floor/mainship,
@@ -16080,20 +15950,23 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "Xk" = (
-/obj/machinery/computer/crew,
+/obj/machinery/bodyscanner{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
 /area/mainship/medical/lower_medical)
 "Xl" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/bed/chair/sofa/right,
-/obj/item/bedsheet/ce{
-	pixel_x = 6
-	},
-/turf/open/floor/mainship/mono,
+/obj/structure/table/mainship,
+/obj/machinery/faxmachine/research,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
+"Xm" = (
+/turf/open/floor/wood,
 /area/mainship/hull/lower_hull)
 "Xn" = (
 /obj/vehicle/ridden/motorbike{
@@ -16137,11 +16010,6 @@
 	dir = 8
 	},
 /area/mainship/squads/general)
-"Xq" = (
-/turf/open/floor/mainship/sterile/side{
-	dir = 10
-	},
-/area/mainship/medical/surgery_hallway)
 "Xr" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -16195,7 +16063,11 @@
 	},
 /area/mainship/squads/general)
 "Xx" = (
-/obj/machinery/body_scanconsole,
+/obj/structure/table/mainship,
+/obj/item/defibrillator,
+/obj/item/defibrillator,
+/obj/item/defibrillator,
+/obj/item/defibrillator,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "Xy" = (
@@ -16277,11 +16149,12 @@
 	},
 /area/mainship/squads/general)
 "XI" = (
-/obj/effect/ai_node,
 /obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/sterile/side{
+	dir = 6
+	},
+/area/mainship/medical/lower_medical)
 "XJ" = (
 /turf/open/floor/plating{
 	dir = 1;
@@ -16372,10 +16245,8 @@
 /turf/open/floor/mainship/red/full,
 /area/mainship/hallways/starboard_umbilical)
 "XU" = (
-/obj/machinery/light,
-/obj/machinery/iv_drip,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lower_medical)
+/turf/closed/wall/mainship,
+/area/mainship/living/grunt_rnr)
 "XV" = (
 /obj/effect/landmark/start/job/squadsmartgunner,
 /obj/effect/landmark/start/latejoin,
@@ -16388,23 +16259,21 @@
 	},
 /area/mainship/squads/general)
 "XX" = (
-/obj/effect/decal/siding{
-	dir = 4
-	},
-/turf/open/floor/mainship/terragov/east{
-	dir = 4
-	},
-/area/space)
+/obj/machinery/optable,
+/turf/open/floor/mainship/mono,
+/area/mainship/medical/lower_medical)
 "XY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/vending/weapon,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
 "XZ" = (
-/obj/structure/bed/roller,
-/obj/item/bedsheet/green,
-/turf/open/floor/wood,
-/area/mainship/medical/surgery_hallway)
+/obj/structure/table/mainship,
+/obj/machinery/reagentgrinder{
+	pixel_y = 5
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "Ya" = (
 /obj/structure/cable,
 /obj/machinery/light/small{
@@ -16469,8 +16338,11 @@
 /area/mainship/living/cafeteria_starboard)
 "Yi" = (
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
+/obj/structure/bed/chair/wood/wings{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "Yj" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -16504,9 +16376,7 @@
 /obj/effect/decal/siding{
 	dir = 8
 	},
-/turf/open/floor/mainship/terragov/east{
-	dir = 8
-	},
+/turf/open/floor/mainship_hull,
 /area/space)
 "Yr" = (
 /obj/machinery/status_display,
@@ -16592,16 +16462,6 @@
 /obj/machinery/marine_selector/gear/leader,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
-"YE" = (
-/obj/machinery/door/poddoor/shutters/opened/medbay{
-	dir = 2
-	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/structure/window/framed/mainship/white,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "YF" = (
 /obj/structure/closet/crate/weapon,
 /obj/structure/cable,
@@ -16663,9 +16523,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
+/area/mainship/medical/lower_medical)
 "YN" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
@@ -16696,12 +16555,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "YS" = (
-/obj/structure/sign/double/barsign,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/machinery/vending/coffee,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
 "YT" = (
-/turf/closed/wall/mainship,
-/area/mainship/living/grunt_rnr)
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/chemistry)
 "YU" = (
 /obj/machinery/light{
 	dir = 8
@@ -16720,10 +16579,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "YW" = (
-/obj/structure/closet/bodybag,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
+/obj/structure/morgue{
+	dir = 2
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/medical/lower_medical)
 "YX" = (
 /obj/structure/cable,
 /obj/machinery/light{
@@ -16755,10 +16618,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "Zb" = (
-/obj/structure/janitorialcart,
-/obj/item/tool/mop,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/medical/lower_medical)
 "Zc" = (
 /obj/effect/landmark/start/job/squadleader,
 /obj/effect/landmark/start/latejoin,
@@ -16770,29 +16632,26 @@
 	},
 /area/mainship/hallways/hangar)
 "Ze" = (
-/obj/structure/cable,
 /obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/storage/surgical_tray,
-/turf/open/floor/mainship/sterile/corner{
-	dir = 1
-	},
-/area/mainship/medical/surgery_hallway)
-"Zf" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/lower_medical)
-"Zg" = (
-/turf/open/floor/mainship/terragov{
 	dir = 4
 	},
-/area/space)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
+"Zf" = (
+/obj/machinery/holosign_switch{
+	id = "or1sign";
+	pixel_x = 5;
+	pixel_y = 10
+	},
+/turf/closed/wall/mainship/white{
+	desc = "A huge chunk of metal used to seperate space from the ship";
+	name = "Outer Hull";
+	resistance_flags = 3
+	},
+/area/mainship/medical/chemistry)
+"Zg" = (
+/turf/closed/wall/mainship,
+/area/mainship/medical/lower_medical)
 "Zh" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -16800,15 +16659,20 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "Zi" = (
-/obj/effect/ai_node,
-/obj/structure/disposalpipe/segment/corner,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 1
+	},
+/area/mainship/medical/chemistry)
 "Zj" = (
-/obj/structure/closet/secure_closet/chemical,
-/turf/open/floor/mainship/sterile/corner,
-/area/mainship/medical/lower_medical)
+/turf/closed/wall/mainship/white{
+	desc = "A huge chunk of metal used to seperate space from the ship";
+	name = "Outer Hull";
+	resistance_flags = 3
+	},
+/area/mainship/medical/chemistry)
 "Zk" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -16842,17 +16706,21 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Zq" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/side{
+/obj/structure/table/mainship,
+/obj/machinery/reagentgrinder,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/turf/open/floor/mainship/sterile/purple/side{
 	dir = 8
 	},
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/chemistry)
 "Zr" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/turf/open/floor/mainship/sterile/corner{
+/obj/machinery/vending/MarineMed,
+/turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
 /area/mainship/medical/lower_medical)
@@ -16876,8 +16744,12 @@
 	},
 /area/mainship/squads/general)
 "Zv" = (
-/turf/closed/wall/mainship/white,
-/area/mainship/medical/surgery_hallway)
+/obj/machinery/door/airlock/mainship/maint,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/mainship,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/medical/medical_science)
 "Zw" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -16998,6 +16870,10 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
+"ZN" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/wood,
+/area/mainship/hull/lower_hull)
 "ZO" = (
 /obj/vehicle/ridden/powerloader,
 /turf/open/floor/mainship/cargo,
@@ -17060,11 +16936,8 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "ZX" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/surgery_hallway)
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/medical_science)
 "ZY" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship/black{
@@ -35167,14 +35040,14 @@ fI
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 aa
 aa
 aa
@@ -35424,10 +35297,10 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
 fI
 fI
 fI
@@ -35681,10 +35554,10 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
 fI
 fI
 fI
@@ -35938,10 +35811,10 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
 fI
 fI
 fI
@@ -36195,10 +36068,10 @@ fI
 fI
 fI
 fI
-aa
-aa
-aa
-aa
+fI
+fI
+fI
+fI
 fI
 fI
 fI
@@ -37226,20 +37099,11 @@ fI
 fI
 fI
 Tm
-rc
+Zg
 LK
 Zg
 Tn
-ad
-ad
-ad
-Qc
-Qc
-Qc
-Qc
-ad
-ad
-ad
+Kw
 Qc
 Qc
 ad
@@ -37248,6 +37112,15 @@ Qc
 Qc
 ad
 ad
+Qc
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+Qc
 Qc
 Qc
 Qc
@@ -37483,33 +37356,33 @@ fI
 fI
 fI
 Tm
-rc
+Zg
 BX
 XX
 rH
-ad
+Kw
 pI
 VL
 oi
-oi
-oi
-oi
-VL
+bZ
+bZ
+bZ
 kY
+kY
+bZ
 ad
-dO
 Fv
 Md
-bZ
-bZ
-bZ
-yi
-yi
-bZ
-bZ
-bZ
-yi
-yi
+iM
+ad
+Hx
+LS
+Gn
+Gn
+Gn
+Gn
+LS
+TS
 ad
 fL
 gt
@@ -37740,33 +37613,33 @@ fI
 fI
 fI
 Tm
-Mb
-Mb
-Mb
-Mb
-ad
+Zg
+hh
+Ih
+Ih
+Kw
 Dz
 xl
 AL
-AL
-AL
-AL
+LS
 ej
-La
+ej
+ej
+bZ
+ej
 ad
-oh
 Nm
 eV
-VL
-EW
-EW
-EW
-bZ
-EW
-EW
-EW
-bZ
-bZ
+bj
+ad
+dx
+bK
+Xm
+Xm
+Xm
+Xm
+BM
+lW
 ad
 LA
 LU
@@ -37997,33 +37870,33 @@ aa
 fI
 fI
 Tm
-Mb
-IN
+Zg
+IO
 Zb
-jK
-ad
-Dz
-xl
-AL
-vk
-AL
-AL
-ej
-La
-ad
-bW
-VL
-VL
-VL
-VL
-VL
-VL
+Ih
+Kw
+Ea
+LS
+LS
+LS
+LS
+LS
+LS
 bZ
-VL
-VL
-VL
-EW
+LS
+ad
+BW
+HP
 bZ
+ad
+dx
+bK
+Xm
+ZN
+Xm
+Xm
+BM
+lW
 ad
 gt
 LV
@@ -38254,33 +38127,33 @@ aa
 fI
 fI
 Tm
-Mb
+Zg
 YW
-Nl
-Bf
-ad
-Dz
-xl
-AL
-AL
-AL
-AL
+Zb
+Ih
+Kw
+ES
+bZ
 ej
-La
+LS
+ej
+ej
+ej
+bZ
+ej
 ad
-Xl
-bZ
+jw
 EW
-VL
-EW
-EW
-EW
-bZ
-EW
-EW
-EW
-bZ
-bZ
+yB
+ad
+dx
+bK
+Xm
+Xm
+Xm
+Xm
+BM
+lW
 ad
 LW
 UQ
@@ -38496,12 +38369,12 @@ fI
 fI
 fI
 fI
+fI
 aa
 aa
-aa
-aa
-aa
-aa
+fI
+fI
+fI
 aa
 aa
 aa
@@ -38511,33 +38384,33 @@ aa
 fI
 fI
 Tm
-Mb
+Zg
 IO
-Ns
+Zb
 Ih
+Kw
+Iv
+bZ
+Gk
+LS
+bZ
+bZ
+bZ
+bZ
+Gk
 ad
-Dz
-xl
-AL
-AL
-AL
-vk
-ej
-La
+Wj
+bZ
+Kh
 ad
-Dw
-bZ
-bZ
-VL
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
+dx
+bK
+Xm
+Xm
+Xm
+ZN
+BM
+lW
 ad
 LW
 ta
@@ -38753,7 +38626,7 @@ fI
 fI
 fI
 fI
-aa
+fI
 aa
 aa
 aa
@@ -38768,33 +38641,33 @@ Lw
 Lw
 Lw
 rc
-Mb
+Zg
 qf
 KS
 Ih
-ad
-Dz
+Kw
+JM
 RC
-bq
+bZ
 LS
-LS
+oB
 TF
-RC
+bZ
 La
+bZ
 ad
-Iv
 bE
 bZ
-VL
-dK
+Kh
+ad
 dx
-bZ
+oo
 xR
-bZ
-bZ
-bZ
-bZ
-xR
+Lc
+DY
+fi
+oo
+lW
 ad
 LW
 UQ
@@ -39010,7 +38883,7 @@ fI
 fI
 fI
 fI
-aa
+fI
 aa
 aa
 aa
@@ -39025,32 +38898,32 @@ ad
 ad
 ad
 ad
-ad
+Kw
+Kw
+Kw
+Oq
 Kw
 ad
-Oq
+ad
+dJ
+ad
+ad
+ad
+ad
+ad
+dJ
+ad
+ad
+dJ
+ad
 ad
 ad
 ad
 ad
 bZ
-Wg
+bs
 ad
 ad
-ad
-ad
-ad
-ad
-dJ
-ad
-ad
-ad
-ad
-ad
-dJ
-ad
-ad
-dJ
 ad
 ad
 GM
@@ -39267,8 +39140,8 @@ fI
 fI
 fI
 fI
-aa
-aa
+fI
+fI
 aa
 aa
 fI
@@ -39282,12 +39155,12 @@ cQ
 IY
 IY
 IY
-IY
-IY
-IY
+fX
+fX
+fX
 os
 YM
-Tg
+ql
 Tg
 hx
 Tg
@@ -39295,14 +39168,14 @@ Tg
 El
 Tg
 Tg
-dW
-ql
+Fl
+Tg
 Tg
 El
 Tg
 Tg
 Tg
-Tg
+ql
 Tg
 iq
 Nw
@@ -39524,8 +39397,8 @@ fI
 fI
 fI
 fI
-aa
-aa
+fI
+fI
 aa
 aa
 fI
@@ -39536,29 +39409,29 @@ fI
 Tm
 ad
 sN
-Mb
-Mb
-Mb
-wq
-Mb
-Mb
-Fo
-Mb
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
 Zv
-Zv
-IV
-Zv
-Zv
-Zv
-Zv
-Zv
-Zv
-Zv
-Zv
-Zv
-Mb
-Mb
-Mb
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+XU
+XU
+XU
+XU
+XU
+XU
+XU
 rj
 Mb
 Zp
@@ -39781,7 +39654,7 @@ fI
 fI
 fI
 fI
-aa
+fI
 aa
 aa
 aa
@@ -39793,30 +39666,30 @@ fI
 Tm
 ad
 sN
-Mb
+ZX
 jr
-rD
-wa
+Nt
+Nt
 Nt
 ni
-NY
-YT
-Zv
+ZX
+oh
+MF
 IZ
 rn
 dH
 KX
-Zv
+nP
 Ja
-nK
-Zv
+ZX
+XU
 XZ
 LR
-Zv
+ng
 Io
 GS
-bZ
-bZ
+nH
+Fu
 Mb
 CM
 bZ
@@ -40038,7 +39911,7 @@ fI
 fI
 fI
 fI
-aa
+fI
 aa
 aa
 aa
@@ -40050,28 +39923,28 @@ Lw
 rc
 ad
 sN
-Mb
-lE
+ZX
+ou
 vQ
 wh
 PY
-Hc
-TB
-YT
-Zv
-kr
-rn
+Ve
+ZX
+oV
+Kj
+NM
+Xl
 Gy
 RI
-Zv
 nP
-ez
-bM
+nP
+ZX
+XU
 Vt
 Cx
-Zv
+Hm
 Fk
-vY
+KW
 Jc
 UF
 Mb
@@ -40307,30 +40180,30 @@ rc
 rc
 ad
 sN
-Mb
-nN
+ZX
+ou
 Hc
 wM
 QQ
 Ve
-Hc
-YT
-Zv
-IZ
-rn
-Gy
+ZX
+oX
+Kn
+NM
+NM
+NM
 yn
-Zv
-Zv
-ep
-Zv
-Zv
-Zv
-Zv
-Mb
-Mb
-Mb
-Mb
+ok
+KK
+ZX
+XU
+MB
+KW
+mq
+En
+oz
+oz
+KW
 Mb
 Zo
 cI
@@ -40564,29 +40437,29 @@ rc
 rc
 Mb
 sN
-Mb
+ZX
 ou
-vQ
+dU
 zZ
-Hc
-Hc
-vQ
-YT
-Zv
+hB
+Ve
+ZX
+qL
+Mm
 Vh
 Rj
-rn
-rn
+HI
+RI
 NG
 Ue
-GR
-QF
+ZX
+XU
 im
-nD
+Cx
 GE
-zU
-zU
-zU
+KW
+KW
+KW
 KW
 Mb
 CX
@@ -40820,26 +40693,26 @@ rc
 rc
 rc
 Mb
-eH
-Mb
-YT
+Zo
+ZX
+cy
 uo
 BD
 TD
 TV
 Xb
-YT
-Zv
-Zv
-Zv
-Zv
-Zv
-Zv
-kW
-nn
-pE
-ir
-nD
+ZX
+ZX
+Ul
+ZX
+Wb
+RI
+ZX
+ZX
+ZX
+XU
+XU
+kx
 mu
 PZ
 hN
@@ -41073,35 +40946,35 @@ aa
 aa
 aa
 Tm
-rc
-rc
-rc
+av
+av
+av
 Mb
 Zo
-Mb
+ZX
 ow
-ST
+dW
 nC
 Xe
-Xe
-NY
-YT
-Zv
+jT
+ZX
+qO
+NM
 rb
 fU
 Wb
-rs
-QF
+RI
+ZX
 fR
-nn
-QF
+ZX
+XU
 ax
-nD
-mu
-oN
-pc
+nH
+Pw
 pA
-Oc
+pA
+pA
+nx
 uM
 uM
 kD
@@ -41331,34 +41204,34 @@ Lw
 Lw
 rc
 Mb
-Mb
-Mb
-Mb
-Zo
-Mb
+bq
+cu
+cu
+ch
+ZX
 Ne
-lQ
-Bx
 MF
-lQ
+MF
+MF
+MF
 hV
-YT
-Zv
+rU
+NQ
 mt
-ji
-ji
-ji
-Rn
+ZX
+Wb
+RI
+ZX
 NM
 ZX
-Zv
+XU
 nD
-nD
-mu
-oO
+pd
+hS
+oR
 pd
 ia
-Oc
+GZ
 uM
 iS
 jB
@@ -41588,32 +41461,32 @@ rc
 rc
 rc
 Mb
-oX
 cu
-cu
-fP
 Mb
-oA
-rT
-Bn
-IM
-Ow
-Qw
-YT
-Zv
-hj
-hD
+bW
+fP
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+yl
+ZX
+ZX
+ZX
 Hd
 qs
-QF
-fR
-Xq
-Re
+ZX
+Rf
+ZX
+XU
 SU
-nD
+QB
 iT
 oP
-pe
+pD
 Lr
 jY
 uM
@@ -41844,35 +41717,35 @@ rc
 rc
 rc
 rc
-Mb
+ad
 cu
 Mb
-cy
-gX
-Mb
+ao
+fL
+YT
 qo
-rT
-Of
-EN
-Ow
 Qw
+Of
+YT
+kc
+mg
 ei
-Zv
-Zv
-Zv
-Zv
-Zv
-Zv
-fR
-jm
-Pg
-nD
-nD
+mg
+VJ
+mg
+Rm
+Be
+AJ
+aY
+bd
+XU
+iu
+QB
 pf
-pf
-pf
-lr
-nD
+KC
+pD
+Lr
+pN
 uM
 lk
 pS
@@ -42104,35 +41977,35 @@ ad
 ad
 cu
 Mb
-jx
-hh
-Bm
+ap
+ap
+YT
 NY
 Qw
 nz
-gu
-Qw
-XI
 YT
-Zv
+kh
+aY
 Ze
-fX
+aY
+Ze
+aY
 RT
-vz
-Zv
+EH
+EH
 Lu
-jm
-GT
-nD
-iz
+bd
+XU
+Fu
+Lr
 hM
 Yi
-Yi
-Yi
-nD
+Lr
+ij
+wu
 uM
-uM
-kh
+jA
+jA
 jA
 IA
 pT
@@ -42362,34 +42235,34 @@ cu
 pr
 Mb
 op
-Am
-fv
-pt
-BB
-CR
-lQ
-EN
-Kj
+ap
 YT
-Zv
+pt
+Qw
+CR
+YT
+ku
+aY
 Eb
-jm
+Pb
+Eb
+aY
 jm
 ND
-Zv
+ND
 Ct
-jm
-TZ
-nD
+bd
+XU
+jY
 ek
-de
+xh
 oR
-oS
-iL
-nD
-cO
+oR
+pd
+wu
+uM
 jA
-hQ
+jA
 jA
 is
 Jd
@@ -42620,34 +42493,34 @@ az
 az
 gz
 ap
-GO
-Rv
-lQ
-lQ
-lQ
-EN
-qL
 YT
-Zv
+Rv
+Qw
+Qw
+hK
+Mt
+aY
+Am
+Pu
 id
+aY
 jm
-jm
-ik
-Zv
-fR
-jm
-GT
-nD
-nD
-ed
-nD
-nD
-pC
-nD
-fM
-mg
+ND
+ND
+Ct
+bd
+XU
+nH
+pd
+BK
+QM
+KC
+pD
+Uf
 uM
-en
+jA
+jA
+jA
 qj
 pU
 qh
@@ -42877,32 +42750,32 @@ Yk
 ap
 mS
 ap
-in
-ST
-lQ
-EN
-EN
-pp
-dU
 YT
-Zv
-lS
-jm
-aD
+ST
+en
+YT
+YT
+pp
+aY
+aY
+Rd
+aY
+aY
+RT
 iO
 EH
-fR
-jm
+Lu
+bd
 Rk
-nD
-jX
+nH
+pd
 BK
-oQ
-nD
+KC
+ff
 pD
-nD
+wu
 fY
-jA
+ht
 uM
 uM
 xp
@@ -43133,31 +43006,31 @@ ap
 io
 ml
 Yf
-YS
+ap
 YT
 pM
 Sm
 Ed
 rV
 za
-gO
-YT
-bd
+BO
+BO
+BO
 JK
-aY
+XI
 eC
-Ul
-Rd
+Tc
+Tc
 Uh
-aY
-QC
-nD
-nD
+bd
+XU
+iP
+KC
 xh
-nD
-nD
-nD
-nD
+kl
+kl
+pd
+wu
 uM
 uM
 uM
@@ -43391,29 +43264,29 @@ gf
 WB
 je
 ap
-YT
-YT
-YT
-YT
-YT
-YT
-YT
-YT
 bd
-co
-aQ
-aQ
-Tw
-bd
-lY
+cO
+BO
+LD
 aY
+lS
+aY
+AK
+aY
+Fb
+aQ
+bd
+bd
+Eb
+bd
+bd
 XU
-nD
-iD
+jW
+KC
 BI
-lj
 pg
-nD
+pg
+pg
 ki
 kq
 sZ
@@ -43649,29 +43522,29 @@ KQ
 Yf
 ap
 bd
-bd
-bd
-bd
-bd
+dK
+BO
+gO
+hQ
 kt
-bd
-bd
-bd
-bd
-bd
-bd
-bd
-bd
-kk
 aY
-QC
-nD
+BH
+aY
+Fb
+YS
+bd
+bO
+VA
+kk
+bd
+XU
+jW
 As
 KC
-Da
-fK
+KC
+pd
 EL
-gL
+ag
 Hh
 Df
 uM
@@ -43907,27 +43780,27 @@ PX
 mh
 bd
 Zr
-yl
+BO
 LD
-ku
+aY
 rr
-VQ
-af
+aY
+MP
 MP
 Fb
 VQ
-Cw
+bd
 LM
-Zq
-JH
 aY
-cH
-nD
+JH
+bd
+XU
+hY
 of
-dc
+of
 oU
 ph
-Hg
+XU
 AS
 wU
 Hj
@@ -44163,28 +44036,28 @@ eR
 Yf
 qE
 bd
-tq
-nO
-Xx
-aY
-Xx
-aY
-nl
-aY
-Xx
-aY
-AK
-aY
-gG
+Zr
 BO
-aY
-QC
-nD
-mc
-De
-iL
-Me
-nD
+Xx
+hT
+rr
+nO
+MP
+MP
+Fb
+dY
+bd
+bx
+MP
+AH
+bd
+XU
+XU
+XU
+Rk
+XU
+XU
+XU
 gL
 Hi
 Df
@@ -44420,31 +44293,31 @@ sH
 Yf
 qE
 bd
-ga
+Zr
 BO
-aY
-aY
+gX
+jP
 Ro
-aY
+nO
 TT
 NE
-aY
-aY
-aY
-aY
-gG
-BO
-aY
-TK
-hK
-no
-jP
-iL
-Me
-nD
-BH
-Hi
-Df
+Fb
+Lu
+Ft
+li
+MP
+fF
+Ft
+gL
+gL
+gL
+gL
+gL
+gL
+gL
+gL
+nB
+Hj
 AM
 gL
 gL
@@ -44681,25 +44554,25 @@ nj
 dy
 BO
 BO
-BO
-BO
+lY
+BF
 gZ
 cz
-BO
-BO
-BO
-BO
-Ww
+Wg
+Vm
+eU
+Vm
+Vm
 eD
-aY
-zr
-nD
-no
-if
-oS
+eU
 MZ
-nD
-FE
+Wq
+MZ
+MZ
+MZ
+MZ
+MZ
+MZ
 Ib
 Kq
 Kr
@@ -44935,27 +44808,27 @@ kJ
 ap
 pZ
 hH
+eH
+hH
 Tc
-ch
-ES
 gw
-kc
+aY
 Zs
 wx
-qO
+aY
+Ix
+aY
 hH
-hT
-rU
-Ea
-av
-WM
-Mm
-Pb
-hB
-jT
-oV
-Pu
-nD
+Tc
+hH
+aY
+gL
+gL
+gL
+gL
+gL
+gL
+gL
 gL
 wj
 gL
@@ -45191,28 +45064,28 @@ Le
 kJ
 qE
 TW
-TW
+dO
 TW
 TW
 TW
 Xk
-SD
-BO
+aY
+Cw
 DG
-VJ
+aY
+Hp
+SJ
+mx
 SJ
 SJ
-SJ
-SJ
-NQ
-YE
+YT
 Td
-nD
-nD
-nD
-nD
-nD
-nD
+bU
+Sq
+YT
+YT
+YT
+YT
 gL
 wj
 gL
@@ -45455,22 +45328,22 @@ WJ
 cJ
 xK
 fs
-DG
+Si
 zr
-nI
-dt
+cM
+Km
 iC
 SR
-UV
-lY
-gG
-np
+lP
+Zj
+bC
+Mt
 ef
 lF
 Zq
 al
-bd
-FE
+YT
+gL
 wj
 FG
 PE
@@ -45713,20 +45586,20 @@ BF
 MT
 wT
 hy
-BF
+WM
 MR
 od
 OC
 Tb
-UV
-lY
+NK
+Zj
 Zi
 Uj
-eO
-Uj
-ih
-gH
-bd
+Mt
+LI
+Mt
+TK
+en
 gL
 wj
 dn
@@ -45966,24 +45839,24 @@ jV
 bv
 bL
 WJ
-cp
+LM
 aY
 Ww
-DG
-JM
-nI
-bC
+SD
+aY
+mf
+Km
 mC
 TE
 RL
 Zf
-zM
-aY
+BE
+Lq
 Mt
-aY
-zM
-TK
-bd
+eB
+Mt
+bn
+YT
 gL
 pa
 gL
@@ -46225,23 +46098,23 @@ qR
 WJ
 TR
 Tc
-Ww
-DG
-Kn
+Dw
+Tw
+Tc
 nI
 Km
 Ty
 Og
-UV
+rJ
 Zj
+gH
+PB
 BJ
-PB
-vn
-PB
+Jb
 BJ
 Qk
-bd
-Si
+YT
+gL
 wj
 gL
 PE
@@ -46477,7 +46350,7 @@ Yf
 ap
 TW
 TW
-TW
+fM
 TW
 TW
 bd
@@ -46488,16 +46361,16 @@ lN
 SJ
 SJ
 SJ
+pO
 UV
-UV
-bd
-gI
-xS
+SZ
+Zj
+Sq
 Sq
 gI
-xS
-bd
-bd
+Sq
+JU
+YT
 Om
 xF
 Om

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -2,6 +2,12 @@
 "aa" = (
 /turf/open/space,
 /area/space)
+"ac" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "ad" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/hull/lower_hull)
@@ -144,6 +150,9 @@
 /obj/structure/disposalpipe/segment/corner,
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "aD" = (
@@ -401,6 +410,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "bv" = (
@@ -492,6 +502,12 @@
 "bL" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
+"bM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "bN" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -534,11 +550,12 @@
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/hallways/hangar)
 "bT" = (
-/obj/machinery/vending/nanomed{
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "bU" = (
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 1
@@ -569,6 +586,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"bY" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/hallways/port_hallway)
 "bZ" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
@@ -911,6 +935,9 @@
 "cW" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/machinery/door/firedoor/mainship,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/commandbunks)
 "cX" = (
@@ -1227,6 +1254,16 @@
 	dir = 8
 	},
 /area/mainship/hallways/hangar)
+"dT" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "dU" = (
 /turf/open/floor/mainship/research/containment/floor2{
 	dir = 5
@@ -1387,7 +1424,6 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "ez" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison/kitchen,
@@ -1664,6 +1700,8 @@
 "fu" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "fw" = (
@@ -1719,11 +1757,6 @@
 	dir = 1
 	},
 /area/mainship/hallways/hangar/droppod)
-"fE" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
 "fF" = (
 /obj/structure/table/mainship,
 /obj/item/storage/box/gloves{
@@ -1767,6 +1800,15 @@
 	},
 /turf/open/floor/mainship/black,
 /area/mainship/living/cafeteria_starboard)
+"fK" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "fL" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -1786,6 +1828,9 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/maint{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hull/lower_hull)
@@ -1967,6 +2012,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "gA" = (
@@ -2176,13 +2224,6 @@
 	dir = 5
 	},
 /area/space)
-"hl" = (
-/obj/machinery/door/firedoor/mainship,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/port_hallway)
 "hm" = (
 /obj/machinery/light{
 	dir = 8
@@ -2210,13 +2251,29 @@
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar/droppod)
+"hs" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "ht" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
+"hu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "hv" = (
 /obj/machinery/door/airlock/multi_tile/mainship/maint{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/living/bridgebunks)
@@ -2480,6 +2537,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
+"ig" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "ii" = (
 /obj/structure/flora/pottedplant/twentyone,
 /turf/open/floor/mainship/black,
@@ -2515,8 +2576,12 @@
 	dir = 1
 	},
 /obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "is" = (
@@ -2541,16 +2606,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
-"iv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
 "ix" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
@@ -2781,6 +2836,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "jf" = (
@@ -2887,10 +2945,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "jx" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "jy" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
@@ -3169,6 +3228,16 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
+"ks" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/port_hallway)
 "kt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3199,6 +3268,16 @@
 /obj/machinery/griddle,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/grunt_rnr)
+"ky" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "kz" = (
 /obj/structure/rack,
 /obj/structure/ob_ammo/warhead/incendiary,
@@ -3256,6 +3335,9 @@
 	},
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "kJ" = (
@@ -3266,6 +3348,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "kL" = (
@@ -3804,11 +3889,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
@@ -3989,14 +4074,29 @@
 "mS" = (
 /obj/structure/cable,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "mT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/carpet{
 	dir = 10;
 	icon_state = "carpetside"
 	},
 /area/mainship/living/commandbunks)
+"mU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "mV" = (
 /obj/machinery/telecomms/server/presets/charlie,
 /obj/machinery/camera/autoname/mainship,
@@ -4042,6 +4142,9 @@
 /area/mainship/shipboard/firing_range)
 "nb" = (
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
 /turf/open/floor/carpet{
 	icon_state = "carpetside"
 	},
@@ -4188,10 +4291,10 @@
 /area/mainship/living/pilotbunks)
 "nB" = (
 /obj/structure/disposalpipe/segment/corner{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/area/mainship/hallways/hangar)
 "nC" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship/sterile/dark,
@@ -4280,13 +4383,6 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/engineering/lower_engineering)
-"nN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/obj/structure/disposalpipe/junction,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
 "nO" = (
 /obj/machinery/researchcomp,
 /turf/open/floor/mainship/sterile/dark,
@@ -4366,6 +4462,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
+"oc" = (
+/obj/machinery/firealarm{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "od" = (
 /obj/machinery/door/firedoor/mainship,
 /obj/machinery/holosign/surgery{
@@ -4391,6 +4493,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
+"og" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/bridgebunks)
 "oh" = (
 /obj/machinery/camera/autoname/mainship,
 /obj/machinery/chem_dispenser,
@@ -4528,12 +4636,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
-"oD" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
 "oE" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 8;
@@ -4598,6 +4700,16 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
+"oS" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/hallways/starboard_hallway)
 "oT" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/white{
@@ -4664,6 +4776,19 @@
 "pd" = (
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
+"pe" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "pf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4714,6 +4839,9 @@
 	},
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "pn" = (
@@ -4733,6 +4861,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "pp" = (
@@ -4924,6 +5053,19 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
+"qc" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "qd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -5010,15 +5152,14 @@
 	},
 /area/mainship/command/cic)
 "qr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
+/obj/machinery/vending/MarineMed,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/aft_hallway)
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "qs" = (
 /obj/machinery/door/airlock/multi_tile/mainship/research{
 	dir = 2;
@@ -5055,6 +5196,17 @@
 /obj/item/tool/pen,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
+"qx" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "qy" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/mainship/maint{
@@ -5420,9 +5572,15 @@
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "rL" = (
-/obj/structure/bookcase,
-/turf/open/floor/wood,
-/area/mainship/living/commandbunks)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/hallways/aft_hallway)
 "rM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -5489,7 +5647,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "rX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "rY" = (
@@ -5793,6 +5953,9 @@
 "sR" = (
 /obj/structure/closet/firecloset,
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "sS" = (
@@ -5922,6 +6085,7 @@
 	dir = 8
 	},
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "tj" = (
@@ -5959,6 +6123,9 @@
 /obj/structure/flora/pottedplant/ten,
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "tp" = (
@@ -6835,6 +7002,19 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
+"wa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/port_hallway)
 "wb" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -7349,6 +7529,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/red{
 	dir = 6
 	},
@@ -7747,6 +7928,10 @@
 /area/mainship/engineering/engineering_workshop)
 "yB" = (
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "yC" = (
@@ -7893,6 +8078,9 @@
 	dir = 1
 	},
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "yW" = (
@@ -8183,6 +8371,14 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"zU" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/hallways/port_hallway)
 "zV" = (
 /obj/machinery/power/fusion_engine/preset,
 /obj/structure/cable,
@@ -8618,14 +8814,15 @@
 /obj/machinery/firealarm{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/rack,
 /obj/structure/ob_ammo/ob_fuel,
 /obj/structure/ob_ammo/ob_fuel,
 /obj/structure/ob_ammo/ob_fuel,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/red{
 	dir = 4
 	},
@@ -8704,13 +8901,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"BC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/obj/structure/disposalpipe/junction,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
 "BD" = (
 /obj/machinery/door/poddoor/shutters/mainship/cell,
 /obj/machinery/door/airlock/mainship/research/glass/cell,
@@ -9005,10 +9195,9 @@
 	},
 /area/mainship/medical/lower_medical)
 "Cx" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/prison/kitchen,
-/area/mainship/living/grunt_rnr)
+/obj/structure/disposalpipe/segment/corner,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/aft_hallway)
 "Cy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/mainship/mono,
@@ -9101,6 +9290,12 @@
 	dir = 4
 	},
 /obj/machinery/power/apc,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "CN" = (
@@ -9165,6 +9360,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "CY" = (
@@ -9207,11 +9408,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
 "Df" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/port_hallway)
 "Dg" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -9582,6 +9782,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "DW" = (
@@ -10000,7 +10201,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/mainship/living/grunt_rnr)
 "Fl" = (
@@ -10024,6 +10224,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/airoom)
+"Fo" = (
+/obj/machinery/firealarm{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "Fp" = (
 /obj/machinery/light{
 	dir = 1
@@ -10439,7 +10645,6 @@
 /turf/open/floor/plating,
 /area/mainship/squads/req)
 "GE" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
@@ -10462,11 +10667,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "GG" = (
-/obj/machinery/alarm{
-	dir = 8
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/port_hallway)
 "GH" = (
 /obj/structure/largecrate/supply/supplies/flares,
 /turf/open/floor/mainship/mono,
@@ -10525,6 +10730,13 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"GR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "GS" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/light{
@@ -10641,19 +10853,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
 /area/mainship/living/cafeteria_starboard)
-"Hg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
 "Hh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -10668,15 +10867,15 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "Hi" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
-"Hj" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
+"Hj" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "Hk" = (
 /obj/structure/table/mainship,
 /obj/item/book/manual/security_space_law,
@@ -10703,7 +10902,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/mainship/living/grunt_rnr)
 "Hn" = (
@@ -11041,6 +11239,11 @@
 /obj/effect/landmark/start/job/ai,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
+"Ig" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "Ih" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/mainship/mono,
@@ -11257,12 +11460,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"IL" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
 "IN" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -11294,6 +11491,13 @@
 	dir = 8
 	},
 /area/mainship/living/cafeteria_starboard)
+"IR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/port_hallway)
 "IS" = (
 /obj/structure/lattice,
 /turf/closed/shuttle/ert{
@@ -11367,11 +11571,11 @@
 	},
 /area/mainship/medical/chemistry)
 "Jc" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/prison/kitchen,
-/area/mainship/living/grunt_rnr)
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
 "Jd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
@@ -11573,6 +11777,12 @@
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/thin,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "JC" = (
@@ -11586,6 +11796,8 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/red{
 	dir = 5
 	},
@@ -11852,10 +12064,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "Kh" = (
 /obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Ki" = (
@@ -12182,10 +12398,10 @@
 /turf/open/floor/mainship,
 /area/mainship/living/cryo_cells)
 "KU" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/ai_node,
+/obj/machinery/alarm{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "KV" = (
@@ -12198,9 +12414,11 @@
 	},
 /area/mainship/hallways/hangar)
 "KW" = (
-/obj/structure/cable,
-/turf/open/floor/prison/kitchen,
-/area/mainship/living/grunt_rnr)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "KX" = (
 /turf/open/floor/mainship/sterile/purple/corner{
 	dir = 8
@@ -13411,6 +13629,14 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
+"Ow" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "Ox" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/numbertwobunks)
@@ -13586,6 +13812,7 @@
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/aft_hallway)
 "OZ" = (
@@ -13725,6 +13952,8 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "Pt" = (
@@ -13914,6 +14143,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "PY" = (
@@ -14094,12 +14326,6 @@
 /obj/structure/bed/chair/wood/wings,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
-"QC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
 "QD" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -14208,14 +14434,14 @@
 "QV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
 /obj/structure/disposalpipe/junction,
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "QW" = (
@@ -14268,6 +14494,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/red{
 	dir = 4
 	},
@@ -14666,6 +14893,13 @@
 "Sn" = (
 /turf/open/floor/plating/icefloor/warnplate,
 /area/mainship/hallways/hangar)
+"So" = (
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "Sp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -15048,6 +15282,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
+"TB" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "TC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -15407,6 +15647,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "UD" = (
@@ -15772,12 +16015,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "VF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hull/lower_hull)
 "VG" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -16241,6 +16486,12 @@
 	},
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "WX" = (
@@ -16277,6 +16528,13 @@
 	dir = 8
 	},
 /area/mainship/squads/general)
+"Xd" = (
+/obj/machinery/door/firedoor/mainship,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/hallways/port_hallway)
 "Xe" = (
 /obj/structure/table/mainship,
 /obj/item/clipboard{
@@ -16384,6 +16642,10 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Xs" = (
@@ -16399,6 +16661,12 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/mainship,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "Xu" = (
@@ -16690,6 +16958,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "Yg" = (
@@ -16777,6 +17048,8 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "Yx" = (
@@ -17231,6 +17504,12 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
@@ -38793,7 +39072,7 @@ uE
 iN
 ad
 Wj
-bZ
+KW
 Kh
 ad
 dx
@@ -39050,8 +39329,8 @@ La
 bH
 ad
 bE
-bZ
-Kh
+VF
+So
 ad
 dx
 oo
@@ -39307,7 +39586,7 @@ ad
 Zn
 ad
 ad
-dJ
+Zn
 ad
 ad
 ad
@@ -39827,7 +40106,7 @@ XU
 XU
 rj
 Mb
-Zp
+pe
 bZ
 bZ
 bZ
@@ -40081,7 +40360,7 @@ LR
 ng
 Io
 GS
-hE
+dT
 lj
 Mb
 CM
@@ -40334,35 +40613,35 @@ nP
 ZX
 XU
 Vt
-Cx
+oz
 Hm
 Fk
-KW
-Jc
+oz
+oz
 UF
 Mb
-Zp
+pe
 bZ
 bZ
 mm
 WN
 Mb
 yV
-XM
-XM
-XM
+hs
+hs
+hs
 Xr
-XM
-Tg
-El
-Tg
-Tg
-Tg
-Tg
-ql
-Tg
+hs
+iz
+cC
+iz
+iz
+iz
+iz
+Ow
+fK
 Ps
-Ec
+ky
 fu
 fu
 WW
@@ -40591,20 +40870,20 @@ KK
 ZX
 XU
 MB
-KW
+oz
 mq
 En
 oz
 oz
 nS
 Mb
-Zo
+qc
 cI
 aj
 Fh
 YI
 Mb
-Zp
+pe
 bX
 Kb
 Kb
@@ -40848,7 +41127,7 @@ Ue
 ZX
 XU
 im
-Cx
+oz
 GE
 ez
 ez
@@ -41114,24 +41393,24 @@ Oc
 Mb
 aC
 Yw
-Tg
-Tg
-El
-Tg
-CV
+iz
+iz
+cC
+iz
+qx
 bZ
 Kb
 lm
 nb
-rw
-rw
+ig
+hu
 IE
 sg
 rw
 tC
 Kb
 JD
-rG
+og
 sI
 Ew
 Zt
@@ -41381,7 +41660,7 @@ Kb
 Nc
 sk
 rx
-rL
+sm
 rZ
 sh
 rw
@@ -42114,7 +42393,7 @@ ad
 cu
 Mb
 fL
-fL
+Zp
 YT
 qo
 Qw
@@ -42371,7 +42650,7 @@ ad
 cu
 Mb
 qg
-ap
+jx
 YT
 NY
 Qw
@@ -42628,7 +42907,7 @@ cu
 pr
 Mb
 qg
-ap
+jx
 YT
 pt
 Qw
@@ -42885,7 +43164,7 @@ az
 az
 az
 qg
-ap
+jx
 YT
 Rv
 Qw
@@ -43142,7 +43421,7 @@ bw
 Yk
 ml
 mS
-ap
+nB
 YT
 ST
 en
@@ -43398,7 +43677,7 @@ jM
 ap
 io
 ap
-CB
+bT
 ap
 YT
 pM
@@ -44172,7 +44451,7 @@ xQ
 PX
 mh
 bd
-Zr
+qr
 BO
 LD
 aY
@@ -44707,7 +44986,7 @@ gL
 gL
 FD
 gL
-gL
+AM
 gL
 wj
 gL
@@ -44958,13 +45237,13 @@ Vm
 Vm
 eD
 eU
-jx
+Df
 Wq
 MZ
 MZ
 MZ
 MZ
-MZ
+zU
 MZ
 Ib
 Kq
@@ -45216,14 +45495,14 @@ Tc
 hH
 aY
 Do
-nB
-Hi
-Hi
-Hi
-Hi
-Hi
-IL
-iv
+GG
+Hj
+Hj
+Hj
+Hj
+bY
+ac
+ks
 gL
 AM
 gL
@@ -45479,9 +45758,9 @@ YT
 YT
 YT
 YT
-QC
-iv
-gL
+bM
+ks
+Fo
 PE
 PE
 PE
@@ -45730,14 +46009,14 @@ SR
 lP
 Zj
 bC
-Df
+Hi
 ef
 lF
 Zq
 al
 YT
-QC
-iv
+mU
+ks
 FG
 PE
 WP
@@ -45988,13 +46267,13 @@ NK
 Zj
 Zi
 Uj
-Hj
+Jc
 LI
 Mt
 TK
 en
-QC
-iv
+bM
+ks
 dn
 PE
 WP
@@ -46250,7 +46529,7 @@ eB
 Mt
 bn
 YT
-QC
+bM
 pa
 gL
 PE
@@ -46507,8 +46786,8 @@ Jb
 BJ
 Qk
 YT
-QC
-iv
+bM
+ks
 gL
 PE
 DS
@@ -46764,7 +47043,7 @@ gI
 Sq
 JU
 YT
-hl
+Xd
 xF
 Om
 PE
@@ -47012,16 +47291,16 @@ RO
 FC
 rF
 oC
+FC
+rF
+wb
 rF
 rF
 rF
 rF
 rF
-rF
-rF
-rF
-rF
-QC
+FC
+bM
 pa
 gL
 PE
@@ -47271,15 +47550,15 @@ JL
 JL
 wR
 JL
-JL
+rL
 JL
 JL
 JL
 ea
 JL
 ea
-nN
-Hg
+IR
+wa
 FG
 PE
 WP
@@ -47518,18 +47797,18 @@ rF
 rF
 IT
 wb
-rF
-rF
+FB
+Cx
 mr
 rF
-XG
-XG
-rF
 rF
 XG
 rF
 rF
 XG
+rF
+wb
+FB
 rF
 rF
 XG
@@ -49336,7 +49615,7 @@ JR
 kM
 jy
 Uu
-jy
+oc
 PE
 PE
 PE
@@ -49592,8 +49871,8 @@ Pp
 JR
 kM
 jy
-fE
-oD
+Ig
+TB
 AR
 jy
 jy
@@ -49605,7 +49884,7 @@ iI
 HW
 jy
 Fx
-jy
+AR
 jy
 FU
 jy
@@ -49850,7 +50129,7 @@ JR
 kM
 jy
 yp
-BC
+GR
 wS
 RB
 Yd
@@ -49862,7 +50141,7 @@ RB
 xG
 RB
 CL
-RB
+oS
 RB
 GX
 mM
@@ -50119,7 +50398,7 @@ BG
 jy
 jy
 Xs
-jy
+AR
 jy
 jy
 Ym
@@ -50601,11 +50880,11 @@ PV
 QA
 Vl
 IT
-bT
+wb
 rF
 rF
 IT
-wb
+rF
 rF
 FC
 RO
@@ -50858,11 +51137,11 @@ MO
 Yc
 xm
 Yc
-JL
+rL
 JL
 Yc
-VF
-qr
+Se
+Se
 Yc
 Yc
 JL
@@ -51115,11 +51394,11 @@ rF
 oC
 XG
 FB
-GG
+wb
 JO
 KU
+XG
 rF
-wb
 rF
 rF
 rF

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -179,9 +179,11 @@
 /turf/open/floor/plating,
 /area/mainship/living/cryo_cells)
 "aH" = (
-/obj/structure/window/framed/mainship/hull,
-/turf/open/floor/mainship_hull,
-/area/space)
+/obj/effect/ai_node,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "aI" = (
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
@@ -220,11 +222,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "aP" = (
-/obj/effect/ai_node,
 /obj/structure/cable,
-/obj/structure/cable,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plating/plating_catwalk,
-/area/space)
+/area/mainship/hull/lower_hull)
 "aR" = (
 /obj/item/clothing/head/warning_cone,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -557,9 +560,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "bV" = (
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/space)
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "bW" = (
 /obj/structure/sign/poster{
 	dir = 1
@@ -843,12 +848,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "cP" = (
-/obj/structure/cable,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/space)
+/obj/structure/window/framed/mainship/hull,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "cQ" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -1640,8 +1642,8 @@
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "ft" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -2252,6 +2254,10 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"hq" = (
+/obj/machinery/power/fusion_engine/preset,
+/turf/open/floor/mainship/mono,
+/area/mainship/engineering/engine_core)
 "hr" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -2448,9 +2454,12 @@
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/surgery_hallway)
-"ig" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
+"ie" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
@@ -2946,15 +2955,6 @@
 "jU" = (
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
-"jV" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/engineering/engine_core)
 "jX" = (
 /obj/structure/closet/l3closet/virology,
 /obj/machinery/light{
@@ -3120,9 +3120,11 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "kC" = (
-/obj/structure/window/framed/mainship/hull,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar/droppod)
 "kD" = (
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/plating/plating_catwalk,
@@ -3923,10 +3925,10 @@
 	},
 /area/space)
 "ne" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 6
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "nh" = (
 /obj/effect/decal/warning_stripes/engineer,
@@ -3994,10 +3996,6 @@
 "nv" = (
 /turf/open/floor/plating/icefloor/warnplate,
 /area/mainship/hallways/hangar)
-"ny" = (
-/obj/machinery/power/fusion_engine/preset,
-/turf/open/floor/mainship/mono,
-/area/mainship/engineering/engine_core)
 "nz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4715,11 +4713,11 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "pW" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
-	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar/droppod)
+/area/mainship/hull/lower_hull)
 "pX" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/living/pilotbunks)
@@ -5031,12 +5029,6 @@
 "rg" = (
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/starboard_hallway)
-"rh" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
 "ri" = (
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 10
@@ -6198,19 +6190,6 @@
 /obj/item/blueprints,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/ce_room)
-"uE" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/structure/bed/chair/wood/normal{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
 "uF" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -6350,9 +6329,7 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/shipboard/weapon_room)
 "vg" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
-	},
+/obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "vh" = (
@@ -8085,11 +8062,15 @@
 /area/mainship/shipboard/firing_range)
 "Am" = (
 /obj/structure/cable,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/disposalpipe/segment/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "An" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -8388,12 +8369,13 @@
 	},
 /area/mainship/shipboard/weapon_room)
 "Bm" = (
-/obj/structure/cable,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/space)
+/obj/structure/cable,
+/obj/machinery/door/airlock/multi_tile/mainship/generic/rnr,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar)
 "Bn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8489,11 +8471,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "BB" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "BD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -8506,13 +8488,6 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/glass/rag,
 /turf/open/floor/mainship/floor,
-/area/mainship/living/grunt_rnr)
-"BE" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/bed/chair/wood/normal{
-	dir = 4
-	},
-/turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "BF" = (
 /obj/machinery/disposal,
@@ -8995,9 +8970,18 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "CR" = (
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/bed/chair/wood/normal{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "CS" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 2
@@ -9670,16 +9654,12 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "EG" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+/obj/structure/disposalpipe/segment,
+/obj/structure/bed/chair/wood/normal{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "EH" = (
 /obj/machinery/light{
 	dir = 1
@@ -9810,13 +9790,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Fl" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
 /obj/structure/cable,
-/obj/machinery/door/airlock/multi_tile/mainship/generic/rnr,
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
+/obj/structure/disposalpipe/segment,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "Fm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10484,15 +10462,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
-"Hm" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
-	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/engineering/engine_core)
 "Hn" = (
 /obj/effect/landmark/start/job/pilotofficer,
 /obj/structure/bed,
@@ -12528,6 +12497,15 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_umbilical)
+"Na" = (
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/engineering/engine_core)
 "Nb" = (
 /obj/machinery/firealarm{
 	dir = 4
@@ -13206,11 +13184,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "OW" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/engineering/engine_core)
 "OX" = (
 /obj/structure/table/mainship,
 /obj/item/storage/toolbox/mechanical,
@@ -41313,18 +41291,18 @@ fI
 fI
 fI
 Tm
-Um
-Um
-Um
-Um
-Um
-Um
-Um
-Um
-Um
-Um
-Um
-Um
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 rc
 rc
 rc
@@ -41570,18 +41548,18 @@ fI
 fI
 fI
 Tm
-Um
-aP
-bV
-bV
-bV
-bV
-Am
-bV
-bV
-bV
-aP
-Um
+ad
+aH
+cu
+cu
+cu
+cu
+bD
+cu
+cu
+cu
+aH
+ad
 rc
 rc
 rc
@@ -41827,8 +41805,8 @@ fI
 fI
 fI
 Tm
-Um
-bV
+ad
+cu
 Wf
 Wf
 Wf
@@ -41865,7 +41843,7 @@ cu
 Mb
 ap
 hh
-Fl
+Bm
 NY
 lQ
 nz
@@ -42084,8 +42062,8 @@ fI
 fI
 fI
 Tm
-Um
-bV
+ad
+cu
 Wf
 lX
 lX
@@ -42094,7 +42072,7 @@ lX
 lX
 lX
 Sl
-BB
+pW
 cu
 cu
 cu
@@ -42121,12 +42099,12 @@ fq
 pr
 Mb
 ap
-EG
+Am
 fv
 pt
-OW
-uE
-BE
+BB
+CR
+EG
 eF
 Kj
 YT
@@ -42341,9 +42319,9 @@ fI
 fI
 fI
 Tm
-Um
-bV
-pW
+ad
+cu
+kC
 ae
 ae
 ae
@@ -42598,8 +42576,8 @@ fI
 fI
 fI
 Tm
-Um
-bV
+ad
+cu
 Wf
 lX
 lX
@@ -42855,8 +42833,8 @@ aa
 aa
 aa
 Tm
-Um
-bV
+ad
+cu
 Wf
 lX
 lX
@@ -43112,8 +43090,8 @@ aa
 aa
 aa
 Tm
-Um
-cP
+ad
+aP
 Wf
 ai
 ae
@@ -43221,7 +43199,7 @@ zD
 zD
 Aa
 zD
-jV
+Na
 cu
 ad
 rc
@@ -43369,8 +43347,8 @@ aa
 aa
 aa
 Tm
-Um
-bV
+ad
+cu
 Wf
 lX
 lX
@@ -43626,8 +43604,8 @@ aa
 aa
 aa
 Tm
-Um
-bV
+ad
+cu
 Wf
 lX
 lX
@@ -43636,7 +43614,7 @@ lX
 ab
 GV
 ci
-CR
+vg
 ci
 ap
 eJ
@@ -43731,7 +43709,7 @@ OP
 UL
 OP
 OP
-ig
+OW
 zV
 Ab
 zV
@@ -43883,8 +43861,8 @@ aa
 aa
 aa
 Tm
-Um
-bV
+ad
+cu
 Wf
 ha
 RQ
@@ -43893,7 +43871,7 @@ RQ
 iG
 YC
 CB
-CR
+vg
 fn
 ap
 eJ
@@ -44140,8 +44118,8 @@ aa
 aa
 aa
 Tm
-Um
-bV
+ad
+cu
 Wf
 lX
 lX
@@ -44397,8 +44375,8 @@ tG
 Lw
 Lw
 rc
-Um
-bV
+ad
+cu
 Wf
 lX
 lX
@@ -44651,12 +44629,12 @@ aa
 fI
 fI
 Tm
-Um
-Um
-Um
-Um
-bV
-pW
+ad
+ad
+ad
+ad
+cu
+kC
 RQ
 RQ
 RQ
@@ -44760,7 +44738,7 @@ UI
 zf
 OL
 HC
-ny
+hq
 Ab
 zV
 zC
@@ -44908,11 +44886,11 @@ aa
 fI
 fI
 Tm
-Um
-aP
-bV
-bV
-aP
+ad
+aH
+cu
+cu
+aH
 Wf
 lX
 lX
@@ -45165,8 +45143,8 @@ aa
 fI
 fI
 Tm
-Um
-bV
+ad
+cu
 Pa
 Pa
 Pa
@@ -45422,8 +45400,8 @@ aa
 fI
 fI
 Tm
-Um
-bV
+ad
+cu
 Pa
 YU
 ml
@@ -45534,7 +45512,7 @@ Lo
 zD
 LL
 Qx
-Hm
+ie
 cu
 ad
 rc
@@ -45679,11 +45657,11 @@ aa
 fI
 fI
 Tm
-Um
-bV
+ad
+cu
 Pa
 ap
-ne
+ft
 aO
 an
 an
@@ -45936,8 +45914,8 @@ aa
 fI
 fI
 Tm
-Um
-cP
+ad
+aP
 Pa
 ap
 ca
@@ -46193,9 +46171,9 @@ aa
 fI
 fI
 Tm
-Um
+ad
+cu
 bV
-ft
 ap
 ca
 bh
@@ -46450,9 +46428,9 @@ aa
 fI
 fI
 Tm
-aH
-bV
-kC
+Qc
+cu
+cP
 ap
 ca
 bh
@@ -46707,9 +46685,9 @@ aa
 fI
 fI
 Tm
-aH
-bV
-kC
+Qc
+cu
+cP
 aE
 ca
 bh
@@ -46964,9 +46942,9 @@ aa
 fI
 fI
 Tm
-aH
-bV
-kC
+Qc
+cu
+cP
 ap
 ca
 bh
@@ -47221,9 +47199,9 @@ aa
 fI
 fI
 Tm
-Um
+ad
+cu
 bV
-ft
 ap
 ca
 bh
@@ -47478,8 +47456,8 @@ aa
 fI
 fI
 Tm
-Um
-cP
+ad
+aP
 Pa
 ap
 ca
@@ -47735,8 +47713,8 @@ aa
 fI
 fI
 Tm
-Um
-bV
+ad
+cu
 Pa
 ap
 ba
@@ -47992,8 +47970,8 @@ aa
 fI
 fI
 Tm
-Um
-bV
+ad
+cu
 Pa
 Ub
 NL
@@ -48249,8 +48227,8 @@ aa
 fI
 fI
 Tm
-Um
-bV
+ad
+cu
 Pa
 Pa
 Pa
@@ -48506,11 +48484,11 @@ aa
 fI
 fI
 Tm
-Um
-aP
-bV
-bV
-aP
+ad
+aH
+cu
+cu
+aH
 Pa
 kB
 Ge
@@ -48763,11 +48741,11 @@ aa
 fI
 fI
 Tm
-Um
-Um
-Um
-Um
-bV
+ad
+ad
+ad
+ad
+cu
 Pa
 kB
 Ge
@@ -49023,9 +49001,9 @@ Ti
 jO
 jO
 Tm
-Um
-bV
-vg
+ad
+cu
+ne
 bi
 ak
 aJ
@@ -49280,8 +49258,8 @@ aa
 aa
 aa
 Tm
-Um
-bV
+ad
+cu
 Pa
 aM
 aM
@@ -49537,8 +49515,8 @@ aa
 aa
 aa
 Tm
-Um
-bV
+ad
+cu
 Pa
 wg
 as
@@ -49794,8 +49772,8 @@ aa
 aa
 aa
 Tm
-Um
-bV
+ad
+cu
 Pa
 at
 at
@@ -50051,8 +50029,8 @@ aa
 aa
 aa
 Tm
-Um
-bV
+ad
+cu
 Pa
 at
 at
@@ -50308,8 +50286,8 @@ aa
 aa
 aa
 Tm
-Um
-cP
+ad
+aP
 Pa
 aq
 aF
@@ -50565,8 +50543,8 @@ aa
 aa
 aa
 Tm
-Um
-bV
+ad
+cu
 Pa
 ah
 ah
@@ -50822,9 +50800,9 @@ aa
 aa
 aa
 Tm
-Um
-bV
-vg
+ad
+cu
+ne
 au
 aw
 aK
@@ -51079,8 +51057,8 @@ aa
 aa
 aa
 Tm
-Um
-bV
+ad
+cu
 Pa
 kB
 kB
@@ -51336,8 +51314,8 @@ aa
 aa
 aa
 Tm
-Um
-bV
+ad
+cu
 Pa
 kB
 kB
@@ -51593,8 +51571,8 @@ aa
 aa
 aa
 Tm
-Um
-bV
+ad
+cu
 Pa
 Pa
 Pa
@@ -51850,18 +51828,18 @@ aa
 aa
 aa
 Tm
-Um
-aP
-bV
-bV
-bV
-bV
-Bm
-bV
-bV
-bV
-aP
-Um
+ad
+aH
+cu
+cu
+cu
+cu
+aX
+cu
+cu
+cu
+aH
+ad
 rc
 rc
 rc
@@ -52107,18 +52085,18 @@ aa
 aa
 aa
 Tm
-Um
-Um
-Um
-Um
-Um
-Um
-Um
-Um
-Um
-Um
-Um
-Um
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 rc
 rc
 rc
@@ -56807,7 +56785,7 @@ nt
 ws
 XM
 XM
-rh
+Fl
 Tg
 Ec
 Tg


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

PoS has additional changes. Mapper self wants to continue to improve map.

PoS is symmetrical in profile.
![PoS](https://user-images.githubusercontent.com/6610922/164957032-aca0055e-044f-4aeb-87dd-35afcb393231.png)


PoS's req has been flip. This is so that belt is closer to Alamo if anyone running req wants to deliver it to Alamo.

![image](https://user-images.githubusercontent.com/6610922/164563674-58ff193b-11ae-40e3-9c4e-11b87e6292d0.png)

PoS' bar increases. Also, boxing ring is near bar in case if anyone wants to fight the old fashion way.

Radically change medbay to integrate bar better. Also, two cryotubes.
![image](https://user-images.githubusercontent.com/6610922/164957019-7817bcc7-954b-4ae5-8f7e-d209fcbe4ee5.png)

PoS's Condor landing zone has hazard tiles to indicate where it lands.

![image](https://user-images.githubusercontent.com/6610922/164563731-81cb4953-5577-4225-9809-9f987ced574c.png)

PoS now has 2x1 maint doors.

PoS has maint in its bow.

![image](https://user-images.githubusercontent.com/6610922/164786251-01555286-4dae-4604-af0a-6aa50f15b74a.png)

PoS has more generators.

![image](https://user-images.githubusercontent.com/6610922/164786349-8e5be3f8-8146-4d9a-a189-6f09e385bec7.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

For req, it makes it easier to move stuff to Alamo.

For medbay, it is to make traffic easier and fix the issues with current medbay.

For bar and boxing, they exist for RP purposes.

For Condor landing zone, I have done it for Alamo, so why not for Condor?

For 2x1 maint doors, it's to not make marines and xenos choke on 1 tile.

For the bow maint hall, it's to deal with camping in tadpole landing zone. I know who you are.

For generators, more power is good.

Hydro increases for space.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: more generators in PoS
add: maint hall in PoS' bow
balance: PoS now has two cryotubes
balance: PoS now has more surgical trays
expansion: PoS's req has been flip. This is so that belt is closer to Alamo if anyone running req wants to deliver it to Alamo.
expansion: PoS' bar increases. Also, boxing ring is near bar in case if anyone wants to fight the old fashion way.
expansion: PoS' medbay has been remapped for the greater good
add: PoS's Condor landing zone has hazard tiles to indicate where it lands.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
