### PR TITLE
Injector buff

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -109,7 +109,7 @@ GLOBAL_LIST_INIT(medic_gear_listed_products, list(
 		/obj/item/reagent_containers/hypospray/autoinjector/combat_advanced = list(CAT_MEDSUP, "Injector (Advanced)", 5, "black"),
 		/obj/item/reagent_containers/hypospray/autoinjector/quickclotplus = list(CAT_MEDSUP, "Injector (QuickclotPlus)", 1, "orange"),
 		/obj/item/reagent_containers/hypospray/autoinjector/peridaxon_plus = list(CAT_MEDSUP, "Injector (Peridaxon Plus)", 1, "orange"),
-		/obj/item/reagent_containers/hypospray/autoinjector/synaptizine = list(CAT_MEDSUP, "Injector (Synaptizine)", 1, "orange"),
+		/obj/item/reagent_containers/hypospray/autoinjector/synaptizine = list(CAT_MEDSUP, "Injector (Synaptizine)", 4, "orange"),
 		/obj/item/reagent_containers/hypospray/autoinjector/neuraline = list(CAT_MEDSUP, "Injector (Neuraline)", 14, "orange"),
 		/obj/item/reagent_containers/hypospray/advanced = list(CAT_MEDSUP, "Advanced hypospray", 2, "black"),
 		/obj/item/reagent_containers/hypospray/advanced/big = list(CAT_MEDSUP, "Big hypospray", 10, "black"),

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -109,7 +109,7 @@ GLOBAL_LIST_INIT(medic_gear_listed_products, list(
 		/obj/item/reagent_containers/hypospray/autoinjector/combat_advanced = list(CAT_MEDSUP, "Injector (Advanced)", 5, "black"),
 		/obj/item/reagent_containers/hypospray/autoinjector/quickclotplus = list(CAT_MEDSUP, "Injector (QuickclotPlus)", 1, "orange"),
 		/obj/item/reagent_containers/hypospray/autoinjector/peridaxon_plus = list(CAT_MEDSUP, "Injector (Peridaxon Plus)", 1, "orange"),
-		/obj/item/reagent_containers/hypospray/autoinjector/synaptizine = list(CAT_MEDSUP, "Injector (Synaptizine)", 4, "orange"),
+		/obj/item/reagent_containers/hypospray/autoinjector/synaptizine = list(CAT_MEDSUP, "Injector (Synaptizine)", 1, "orange"),
 		/obj/item/reagent_containers/hypospray/autoinjector/neuraline = list(CAT_MEDSUP, "Injector (Neuraline)", 14, "orange"),
 		/obj/item/reagent_containers/hypospray/advanced = list(CAT_MEDSUP, "Advanced hypospray", 2, "black"),
 		/obj/item/reagent_containers/hypospray/advanced/big = list(CAT_MEDSUP, "Big hypospray", 10, "black"),

--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -4,12 +4,12 @@
 	desc = "An autoinjector containing... table salt? <i>\"For any client assistance, please contact the coderbus\" is written on the back.</i>"
 	icon_state = "autoinjector"
 	item_state = "hypo"
-	amount_per_transfer_from_this = 15
+	amount_per_transfer_from_this = 10
 	w_class = WEIGHT_CLASS_TINY
-	volume = 15
+	volume = 30
 	skilllock = 0
 	init_reagent_flags = DRAWABLE
-	list_reagents = list(/datum/reagent/consumable/sodiumchloride = 15)
+	list_reagents = list(/datum/reagent/consumable/sodiumchloride = 30)
 
 /obj/item/reagent_containers/hypospray/autoinjector/update_icon()
 	if(!(reagents.total_volume) && is_drawable())
@@ -38,13 +38,13 @@
 	name = "tricordrazine autoinjector"
 	desc = "An autoinjector loaded with 3 doses of tricordrazine, a weak general use medicine for treating damage."
 	icon_state = "autoinjector-4"
-	amount_per_transfer_from_this = 5
-	list_reagents = list(/datum/reagent/medicine/tricordrazine = 15)
+	list_reagents = list(/datum/reagent/medicine/tricordrazine = 30)
 
 /obj/item/reagent_containers/hypospray/autoinjector/combat
 	name = "combat autoinjector"
 	desc = "An autoinjector loaded with two doses of healing and painkilling chemicals. Intended for use in active combat."
 	icon_state = "autoinjector-4"
+	amount_per_transfer_from_this = 15
 	volume = 30
 	list_reagents = list(
 		/datum/reagent/medicine/bicaridine = 10,
@@ -57,6 +57,7 @@
 	name = "Advanced combat autoinjector"
 	desc = "An autoinjector loaded with two doses of advanced healing and painkilling chemicals. Intended for use in active combat."
 	icon_state = "autoinjector-7"
+	amount_per_transfer_from_this = 30
 	volume = 30
 	list_reagents = list(
 		/datum/reagent/medicine/meralyne = 10,
@@ -103,15 +104,13 @@
 	name = "dylovene autoinjector"
 	desc = "An auto-injector loaded with 3 doses of dylovene, an anti-toxin agent useful in cases of poisoning, overdoses and toxin build-up."
 	icon_state = "autoinjector-1"
-	amount_per_transfer_from_this = 5
-	list_reagents = list(/datum/reagent/medicine/dylovene = 15)
+	list_reagents = list(/datum/reagent/medicine/dylovene = 30)
 
 /obj/item/reagent_containers/hypospray/autoinjector/tramadol
 	name = "tramadol autoinjector"
 	desc = "An auto-injector loaded with 3 doses of tramadol, an effective painkiller for normal wounds."
 	icon_state = "autoinjector-10"
-	amount_per_transfer_from_this = 5
-	list_reagents = list(/datum/reagent/medicine/tramadol = 15)
+	list_reagents = list(/datum/reagent/medicine/tramadol = 30)
 
 /obj/item/reagent_containers/hypospray/autoinjector/oxycodone
 	name = "oxycodone autoinjector"
@@ -125,20 +124,19 @@
 	name = "kelotane autoinjector"
 	desc = "An auto-injector loaded with 3 doses of kelotane, a common burn medicine."
 	icon_state = "autoinjector-5"
-	amount_per_transfer_from_this = 5
-	list_reagents = list(/datum/reagent/medicine/kelotane = 15)
+	list_reagents = list(/datum/reagent/medicine/kelotane = 30)
 
 /obj/item/reagent_containers/hypospray/autoinjector/bicaridine
 	name = "bicaridine autoinjector"
 	desc = "An auto-injector loaded with 3 doses of bicaridine, a common brute and circulatory damage medicine."
 	icon_state = "autoinjector-3"
-	amount_per_transfer_from_this = 5
-	list_reagents = list(/datum/reagent/medicine/bicaridine = 15)
+	list_reagents = list(/datum/reagent/medicine/bicaridine = 30)
 
 /obj/item/reagent_containers/hypospray/autoinjector/inaprovaline
 	name = "inaprovaline autoinjector"
 	desc = "An auto-injector loaded with 15 units of inaprovaline, an emergency stabilization medicine for patients in critical condition."
 	icon_state = "autoinjector-9"
+	amount_per_transfer_from_this = 15
 	list_reagents = list(/datum/reagent/medicine/inaprovaline = 15)
 
 /obj/item/reagent_containers/hypospray/autoinjector/spaceacillin

--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -68,9 +68,9 @@
 	name = "quick-clot autoinjector"
 	desc = "An autoinjector loaded with three doses of quick-clot, a chemical designed to pause all bleeding. Renew doses as needed."
 	icon_state = "autoinjector-7"
-	amount_per_transfer_from_this = 10
-	volume = 30
-	list_reagents = list(/datum/reagent/medicine/quickclot = 30)
+	amount_per_transfer_from_this = 5
+	volume = 15
+	list_reagents = list(/datum/reagent/medicine/quickclot = 15)
 
 /obj/item/reagent_containers/hypospray/autoinjector/quickclotplus
 	name = "quick-clot plus autoinjector"
@@ -235,7 +235,7 @@
 	amount_per_transfer_from_this = 5
 	volume = 15
 	list_reagents = list(
-		/datum/reagent/medicine/peridaxon = 3,
+		/datum/reagent/medicine/peridaxon = 15,
 	)
 
 /obj/item/reagent_containers/hypospray/autoinjector/peridaxon_plus


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Doubles the volume of basic injectors (Bica, Kelo, Trico, Trama, Dylo), to 30, as well as default transfer rate, to 10. (also makes QC and Peri injectors identical)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Nobody uses basic injectors, since for same space you can have 1 pill bottle (240u), 1 pill packet (120u), 1 bottle (60u) or 2 injectors (30u). Injector being identical to _single_ pill is meh. Now they'll be used more, and allow some more med meta instead of every sane marine running around with pill bottles.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
balance: basic injectors now have double the meds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
