### PR TITLE
TAT tweaks

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1490,7 +1490,7 @@ datum/ammo/bullet/revolver/tp44
 	hud_state = "shell_he"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING|AMMO_PASS_THROUGH_TURF|AMMO_PASS_THROUGH_MOVABLE
 	shell_speed = 4
-	damage = 160
+	damage = 200
 	penetration = 40
 	sundering = 65
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1482,6 +1482,9 @@ datum/ammo/bullet/revolver/tp44
 /datum/ammo/rocket/atgun_shell/drop_nade(turf/T)
 	explosion(T, 0, 2, 3, 2)
 
+/datum/ammo/rocket/atgun_shell/on_hit_turf(turf/T, obj/projectile/P)
+	P.proj_max_range -= 10
+
 /datum/ammo/rocket/atgun_shell/apcr
 	name = "tungsten penetrator"
 	hud_state = "shell_he"
@@ -1492,7 +1495,18 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 65
 
 /datum/ammo/rocket/atgun_shell/apcr/drop_nade(turf/T)
-	explosion(T, 0, 0, 1, 0)
+	explosion(T, 0, 0, 0, 1)
+
+/datum/ammo/rocket/atgun_shell/apcr/on_hit_mob(mob/M, obj/projectile/P)
+	drop_nade(get_turf(M))
+	P.proj_max_range -= 5
+	staggerstun(M, P, max_range = 20, stagger = 0.5, slowdown = 0.5, knockback = 2, shake = 1,  hard_size_threshold = 3)
+
+/datum/ammo/rocket/atgun_shell/apcr/on_hit_obj(obj/O, obj/projectile/P)
+	P.proj_max_range -= 5
+
+/datum/ammo/rocket/atgun_shell/apcr/on_hit_turf(turf/T, obj/projectile/P)
+	P.proj_max_range -= 5
 
 /datum/ammo/rocket/atgun_shell/he
 	name = "high velocity high explosive shell"
@@ -1505,6 +1519,8 @@ datum/ammo/bullet/revolver/tp44
 /datum/ammo/rocket/atgun_shell/he/drop_nade(turf/T)
 	explosion(T, 0, 3, 5, 0)
 
+/datum/ammo/rocket/atgun_shell/he/on_hit_turf(turf/T, obj/projectile/P)
+	drop_nade(T)
 /*
 //================================================
 					Energy Ammo

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -579,8 +579,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 
 /obj/projectile/proc/scan_a_turf(turf/turf_to_scan, cardinal_move)
 	if(turf_to_scan.density) //Handle wall hit.
-		if((ammo.flags_ammo_behavior & (AMMO_EXPLOSIVE|AMMO_PASS_THROUGH_TURF)) != (AMMO_EXPLOSIVE|AMMO_PASS_THROUGH_TURF))
-			ammo.on_hit_turf(turf_to_scan, src)
+		ammo.on_hit_turf(turf_to_scan, src)
 		turf_to_scan.bullet_act(src)
 		return !(ammo.flags_ammo_behavior & AMMO_PASS_THROUGH_TURF)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the behavior of TAT ammo.

APCR no longer causes an explosion, just a 1 tile flash (same as AP rockets). This was causing it to do around 240-260 damage instead of 160. Instead, it will do a short (0.5) stagger, slow and 2 tile knockback. **Direct damage has been buffed to 200 as well.** So a net 40-60 (depending on armour) damage nerf, as well as no AOE.

Additionally, for both APCR and APHE, their piercing behavior has been changed so that every time they pierce something, their max range is reduced. This stops the silliness of projectiles blasting into the distance and possibly killing benos through like 20 tiles of solid rock by fluke.
For APHE this is 10 tiles per pierce,
For APCR this is 5 tiles per pierce.

So for example, you shoot through a 2 tile deep resin wall that is 7 tiles away from you with APHE. This means you've effectively travelled 27 tiles, so you'll reach your max 3 tiles later.

I have also reverted #9843 as APHE no longer trigger explosions on turfs at all (and APCR doesn't matter anymore), so this extra code isn't needed.

If you think this nerfs APCR too much, let me know.

Edit: Also forgot the most important part. This also fixes a bug where apcr can explode 3 (possibly more) times per shot.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes APCR less oppressive.
Makes piercing less janky.
Multiple explosions per shot is bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: APCR TAT rounds no longer trigger light explosions, this reduces it's damage from around 260 to 160.
add: APCR and APHE TAT are now slowed by anything they pierce, reducing the total distance they can travel.
fix: Fix a bug where APCR TAT rounds can explode multiple times.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
