### PR TITLE
fix defib fumble time

### DIFF
--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -157,7 +157,7 @@
 	if(skill < SKILL_MEDICAL_PRACTICED)
 		user.visible_message(span_notice("[user] fumbles around figuring out how to use [src]."),
 		span_notice("You fumble around figuring out how to use [src]."))
-		var/fumbling_time = SKILL_TASK_AVERAGE - ( SKILL_TASK_VERY_EASY * ( SKILL_MEDICAL_PRACTICED - skill ) ) // 3 seconds with medical skill, 5 without
+		var/fumbling_time = SKILL_TASK_AVERAGE - (SKILL_TASK_VERY_EASY * skill) // 3 seconds with medical skill, 5 without
 		if(!do_after(user, fumbling_time, TRUE, H, BUSY_ICON_UNSKILLED))
 			return
 	else


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixed defib fumble time for unskilled mobs.

So it turns out that fumble time for defibbing someone was written... poorly.

If you have medical skill of 2 or above (corpman) you ignore fumble time entirely. If you're below 2 however, you have a fumble time of three seconds for medical skill 1 (SL's), or ONE SECOND for medical skill 0 (ungas).

I have no idea why it was like this, it's the only fumble check written in this way and it's written correctly in the same file by the same PR... but it's been like this for 2 years.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Literal greyshirts knowing how to use defibs better than people with basic medical training is bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Mobs with 0 medical skill will no longer know how to operate defibs better than those with basic medical training.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
