### PR TITLE
Nerfs door assemblies into unusable for combat situations

### DIFF
--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -350,6 +350,3 @@ obj/structure/door_assembly
 		if(2)
 			name = "Near Finished "
 	name += "[glass == 1 ? "Window " : ""][istext(glass) ? "[glass] Airlock" : base_name] Assembly"
-
-/obj/structure/door_assembly/attack_animal(mob/user)
-	return attack_alien(user)

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -5,6 +5,9 @@ obj/structure/door_assembly
 	icon_state = "door_as_0"
 	anchored = FALSE
 	density = TRUE
+	resistance_flags = XENO_DAMAGEABLE
+	throwpass = FALSE
+	max_integrity = 25
 	var/state = 0
 	var/base_icon_state = ""
 	var/base_name = "Airlock"
@@ -347,3 +350,13 @@ obj/structure/door_assembly
 		if(2)
 			name = "Near Finished "
 	name += "[glass == 1 ? "Window " : ""][istext(glass) ? "[glass] Airlock" : base_name] Assembly"
+
+/obj/structure/door_assembly/attack_animal(mob/user)
+	return attack_alien(user)
+
+/obj/structure/door_assembly/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
+	if(X.status_flags & INCORPOREAL)
+		return FALSE
+
+	SEND_SIGNAL(X, COMSIG_XENOMORPH_ATTACK_BARRICADE)
+	return ..()

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -7,7 +7,7 @@ obj/structure/door_assembly
 	density = TRUE
 	resistance_flags = XENO_DAMAGEABLE
 	throwpass = FALSE
-	max_integrity = 25
+	max_integrity = 50
 	var/state = 0
 	var/base_icon_state = ""
 	var/base_name = "Airlock"
@@ -353,10 +353,3 @@ obj/structure/door_assembly
 
 /obj/structure/door_assembly/attack_animal(mob/user)
 	return attack_alien(user)
-
-/obj/structure/door_assembly/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
-	if(X.status_flags & INCORPOREAL)
-		return FALSE
-
-	SEND_SIGNAL(X, COMSIG_XENOMORPH_ATTACK_BARRICADE)
-	return ..()


### PR DESCRIPTION
## About The Pull Request
Added
`resistance_flags = XENO_DAMAGEABLE`
`throwpass = FALSE`
`max_integrity = 50`
to door_assembly vars

All this = you can't shoot through door assemblies and xenos can slash through door assemblies like cheesecake.

This PR has been fully tested on a local build with zero (0) runtimes or errors.
![2022-04-28_14-53-50](https://user-images.githubusercontent.com/17747087/165757014-7e498f0b-1355-4140-8567-7596bda85c6d.gif)
## Why It's Good For The Game
Door assemblies cost the same amount as barricades but are quicker, cannot be damaged by xenos, and can be shot through. This essentially creates a stupid yet powerful use of door assemblies as better barricades.

This PR remedies that problem by making marines not able to shoot through them, making xenos able to slash them, and making the structure extremely fragile, thereby rendering it useless for a combat situation.

## Changelog
:cl: Vondiech
balance: Marines can no longer shoot through door assemblies.
balance: Xenos can now slash door assemblies.
balance: Door assemblies now extremely fragile in combat.
/:cl: