### PR TITLE
Non-marine gun name tweaks, two other changes to marine guns

### DIFF
--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -202,11 +202,11 @@
 	starting_attachment_types = list(/obj/item/attachable/suppressor, /obj/item/attachable/flashlight) //Tacticool
 
 //-------------------------------------------------------
-//P-1911
+//M-1911
 
 /obj/item/weapon/gun/pistol/m1911
-	name = "\improper P-1911 service pistol"
-	desc = "A P-1911 chambered in .45 ACP. An archaic weapon, yet its popular and extremely reliable mechanism provided a template for many semi-automatic pistols to come."
+	name = "\improper M-1911 service pistol"
+	desc = "An M-1911 chambered in .45 ACP. An archaic weapon, yet its popular and extremely reliable mechanism provided a template for many semi-automatic pistols to come."
 	icon_state = "m1911"
 	item_state = "m1911"
 	caliber = CALIBER_45ACP //codex
@@ -227,7 +227,7 @@
 	recoil_unwielded = -1
 
 /obj/item/weapon/gun/pistol/m1911/custom
-	name = "\improper P-1911A1 custom pistol"
+	name = "\improper M-1911A1 custom pistol"
 	desc = "A handgun that has received several modifications. It seems to have been lovingly taken care of and passed down for generations. Lacks an auto magazine eject feature."
 	icon_state = "m1911c"
 	attachable_allowed = list(
@@ -244,10 +244,10 @@
 	fire_delay = 0.15 SECONDS
 
 //-------------------------------------------------------
-//P-22. Blocc
+//G-22. Blocc
 
 /obj/item/weapon/gun/pistol/g22
-	name = "\improper P-22 pistol"
+	name = "\improper G-22 pistol"
 	desc = "A popular police firearm in the modern day. Chambered in 9x19mm."
 	icon_state = "g22"
 	item_state = "g22"
@@ -268,7 +268,7 @@
 	fire_delay = 0.2 SECONDS
 
 /obj/item/weapon/gun/pistol/g22/tranq
-	name = "\improper P-22 custom pistol"
+	name = "\improper G-22 custom pistol"
 	desc = "A 20th century military firearm customized for special forces use, fires tranq darts to take down enemies nonlethally. It does not seem to accept any other attachments."
 	icon_state = "g22"
 	item_state = "g22"

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -394,10 +394,10 @@
 
 
 //-------------------------------------------------------
-//R-44, based off the SAA.
+//M-44, based off the SAA.
 
 /obj/item/weapon/gun/revolver/single_action/m44
-	name = "\improper R-44 SAA revolver"
+	name = "\improper M-44 SAA revolver"
 	desc = "A uncommon revolver occasionally carried by civilian law enforcement that's very clearly based off a modernized Single Action Army. Has to be manully primed with each shot. Uses .44 Magnum rounds."
 	icon_state = "m44"
 	item_state = "m44"

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -758,7 +758,7 @@
 	starting_attachment_types = list(/obj/item/attachable/verticalgrip, /obj/item/attachable/t42barrel, /obj/item/attachable/reddot)
 
 //-------------------------------------------------------
-//M41AE2 Heavy Pulse Rifle
+//PR41AE2 Heavy Pulse Rifle
 
 /obj/item/weapon/gun/rifle/m412l1_hpr
 	name = "\improper PR-412L1 heavy pulse rifle"
@@ -912,7 +912,7 @@
 	desc = "The primary rifle of many space pirates and militias, the Type 71 is a reliable rifle chambered in 7.62x39mm, firing in three round bursts to conserve ammunition."
 
 //-------------------------------------------------------
-//TX-16 AUTOMATIC SHOTGUN
+//SH-15 AUTOMATIC SHOTGUN
 
 /obj/item/weapon/gun/rifle/standard_autoshotgun
 	name = "\improper SH-15 automatic shotgun"
@@ -1167,11 +1167,11 @@
 
 
 //-------------------------------------------------------
-//GL-81 Auto-Sniper
+//SR-81 Auto-Sniper
 
 /obj/item/weapon/gun/rifle/standard_autosniper
-	name = "\improper GL-81 automatic sniper rifle"
-	desc = "The GL-81 is the TerraGov Marine Corps's automatic sniper rifle usually married to it's iconic NVG/KTLD scope combo. It's users use it for it's high rate of fire for it's class, and has decent performance in any range. Uses 8.6x70mm caseless with specialized pressures for IFF fire."
+	name = "\improper SR-81 automatic sniper rifle"
+	desc = "The SR-81 is the TerraGov Marine Corps's automatic sniper rifle usually married to it's iconic NVG/KTLD scope combo. It's users use it for it's high rate of fire for it's class, and has decent performance in any range. Uses 8.6x70mm caseless with specialized pressures for IFF fire."
 	icon_state = "t81"
 	item_state = "t81"
 	fire_sound = 'sound/weapons/guns/fire/sniper.ogg'

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -274,7 +274,7 @@
 //-------------------------------------------------------
 //A shotgun, how quaint.
 /obj/item/weapon/gun/shotgun/pump/cmb
-	name = "\improper SH-12 Paladin pump shotgun"
+	name = "\improper Paladin-12 pump shotgun"
 	desc = "A nine-round pump action shotgun. A shotgun used for hunting, home defence and police work, many versions of it exist and are used by just about anyone."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "pal12"

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -213,11 +213,11 @@
 	starting_attachment_types = list(/obj/item/attachable/suppressor) //Tacticool
 
 //-------------------------------------------------------
-//SMG-27, based on the grease gun
+//MP-27, based on the grease gun
 
 /obj/item/weapon/gun/smg/mp7
-	name = "\improper SMG-27 submachinegun"
-	desc = "An archaic design going back hundreds of years, the SMG-27 was common in its day. Today it sees limited use as cheap computer-printed replicas or family heirlooms, though it somehow got into the hands of colonial rebels."
+	name = "\improper MP-27 submachinegun"
+	desc = "An archaic design going back hundreds of years, the MP-27 was common in its day. Today it sees limited use as cheap computer-printed replicas or family heirlooms, though it somehow got into the hands of colonial rebels."
 	icon_state = "mp7"
 	item_state = "mp7"
 	caliber = CALIBER_46X30 //codex
@@ -331,7 +331,7 @@
 //GENERIC UZI //Based on the uzi submachinegun, of course.
 
 /obj/item/weapon/gun/smg/uzi
-	name = "\improper SMG-2 submachinegun"
+	name = "\improper MP-2 submachinegun"
 	desc = "A cheap, reliable design and manufacture make this ubiquitous submachinegun useful despite the age. Put the fire selector to full auto for maximum firepower. Use two if you really want to go ham."
 	icon_state = "uzi"
 	item_state = "uzi"

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -128,7 +128,7 @@
 	starting_attachment_types = list(/obj/item/attachable/reddot)
 
 //-------------------------------------------------------
-//M-25 SMG
+//SMG-25 SMG
 
 /obj/item/weapon/gun/smg/m25
 	name = "\improper SMG-25 submachinegun"

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -638,11 +638,11 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 
 
 //-------------------------------------------------------
-//RL-160 Recoilless Rifle. Its effectively an RPG codewise.
+//RR-160 Recoilless Rifle. Its effectively an RPG codewise.
 
 /obj/item/weapon/gun/launcher/rocket/recoillessrifle
-	name = "\improper RL-160 recoilless rifle"
-	desc = "The RL-160 recoilless rifle is a long range explosive ordanance device used by the TGMC used to fire explosive shells at far distances. Uses a variety of 67mm shells designed for various purposes."
+	name = "\improper RR-160 recoilless rifle"
+	desc = "The RR-160 recoilless rifle is a long range explosive ordanance device used by the TGMC used to fire explosive shells at far distances. Uses a variety of 67mm shells designed for various purposes."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "t160"
 	item_state = "t160"

--- a/code/modules/projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/magazines/pistols.dm
@@ -62,10 +62,10 @@
 	icon_state_mini = "mag_pistol_yellow"
 
 //-------------------------------------------------------
-//P-1911
+//M-1911
 
 /obj/item/ammo_magazine/pistol/m1911
-	name = "\improper P-1911 magazine (.45)"
+	name = "\improper M-1911 magazine (.45)"
 	default_ammo = /datum/ammo/bullet/pistol/heavy
 	caliber = CALIBER_45ACP
 	icon_state = "1911"
@@ -88,14 +88,14 @@
 //Beretta 92FS, the gun McClane carries around in Die Hard. Very similar to the service pistol, all around.
 
 /obj/item/ammo_magazine/pistol/g22
-	name = "\improper P-22 magazine (9mm)"
+	name = "\improper G-22 magazine (9mm)"
 	caliber = CALIBER_9X19
 	icon_state = "g22"
 	max_rounds = 15
 	default_ammo = /datum/ammo/bullet/pistol
 
 /obj/item/ammo_magazine/pistol/g22tranq
-	name = "\improper G22 tranq magazine (9mm)"
+	name = "\improper G-22 tranq magazine (9mm)"
 	caliber = CALIBER_9X19_TRANQUILIZER
 	icon_state = "g22"
 	max_rounds = 12

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -292,10 +292,10 @@
 	icon_state_mini = "mag_sniper"
 
 //-------------------------------------------------------
-//Marine magazine automatic sniper, or the GL-81.
+//Marine magazine automatic sniper, or the SR-81.
 /obj/item/ammo_magazine/rifle/autosniper
-	name = "\improper GL-81 automatic sniper rifle magazine"
-	desc = "A box magazine filled with low pressure 8.6x70mm rifle rounds for the GL-81."
+	name = "\improper SR-81 automatic sniper rifle magazine"
+	desc = "A box magazine filled with low pressure 8.6x70mm rifle rounds for the SR-81."
 	caliber = CALIBER_86X70
 	icon_state = "t81"
 	default_ammo = /datum/ammo/bullet/sniper/auto

--- a/code/modules/projectiles/magazines/smgs.dm
+++ b/code/modules/projectiles/magazines/smgs.dm
@@ -54,11 +54,11 @@
 	icon_state_mini = "mag_t90"
 
 //-------------------------------------------------------
-//SMG-27, based on the SMG-27, based on the M7.
+//SMG-27, based on the MP-27, based on the M7.
 
 /obj/item/ammo_magazine/smg/mp7
-	name = "\improper SMG-27 magazine (4.6x30mm)"
-	desc = "A 4.6mm magazine for the SMG-27."
+	name = "\improper MP-27 magazine (4.6x30mm)"
+	desc = "A 4.6mm magazine for the MP-27."
 	default_ammo = /datum/ammo/bullet/smg/ap
 	caliber = CALIBER_46X30
 	icon_state = "mp7"
@@ -105,8 +105,8 @@
 //GENERIC UZI //Based on the uzi submachinegun, of course.
 
 /obj/item/ammo_magazine/smg/uzi
-	name = "\improper SMG-2 magazine (9mm)"
-	desc = "A magazine for the SMG-2."
+	name = "\improper MP-2 magazine (9mm)"
+	desc = "A magazine for the MP-2."
 	caliber = CALIBER_9X21
 	icon_state = "uzi"
 	max_rounds = 32

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -366,13 +366,13 @@ WEAPONS
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/autosniper
-	name = "GL-81 IFF Auto Sniper kit"
+	name = "SR-81 IFF Auto Sniper kit"
 	contains = list(/obj/item/weapon/gun/rifle/standard_autosniper)
 	cost = 50
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/autosniper_regular
-	name = "GL-81 IFF sniper magazine"
+	name = "SR-81 IFF sniper magazine"
 	contains = list(/obj/item/ammo_magazine/rifle/autosniper)
 	cost = 3
 	available_against_xeno_only = TRUE
@@ -1574,7 +1574,7 @@ FACTORY
 	cost = 50
 
 /datum/supply_packs/factory/autosniper_magazine_refill
-	name = "GL-81 IFF Auto Sniper magazine assembly refill"
+	name = "SR-81 IFF Auto Sniper magazine assembly refill"
 	contains = list(/obj/item/factory_refill/auto_sniper_magazine_refill)
 	cost = 40
 


### PR DESCRIPTION
## About The Pull Request
Renames the following:
|      Old      |    New     |
|---------------|------------|
| P-1911        | M-1911     |
| P-1911A1      | M-1911A1   |
| P-22          | G-22       |
| R-44          | M-44       |
| SH-12 Paladin | Paladin-12 |
| SMG-27        | MP-27      |
| SMG-2         | MP-2       |
| RL-160        | RR-160     |

Also, renames the "GL-81" to the "SR-81", as it seems it should be.

SMG-25 not renamed in case that one guy does end up making it a marine gun.

## Why It's Good For The Game
It's called distinction.

## Changelog
:cl:
spellcheck: Renamed the SR-81 and related items, as they were erroneously labeled as "GL-81".
spellcheck: Renamed some of the non-marine weapons and related ammunition, since they wouldn't have to follow the TGMC's naming scheme.
/:cl:
