### PR TITLE
Shuffles LV-624 nuke disk generators, removes a shutter

### DIFF
--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -5030,7 +5030,6 @@
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/spaceport)
 "bUp" = (
-/obj/effect/landmark/nuke_spawn,
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
@@ -9764,9 +9763,9 @@
 	},
 /area/lv624/lazarus/sleep_female)
 "hLs" = (
-/obj/machinery/computer/nuke_disk_generator/red,
-/turf/open/floor/wood,
-/area/lv624/lazarus/corporate_affairs)
+/obj/effect/landmark/nuke_spawn,
+/turf/open/floor/tile/dark,
+/area/lv624/ground/sand6)
 "hMa" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
@@ -15544,6 +15543,7 @@
 /area/lv624/ground/jungle8)
 "oHK" = (
 /obj/item/frame/table/wood,
+/obj/machinery/computer/nuke_disk_generator/red,
 /turf/open/floor/wood,
 /area/lv624/lazarus/bar)
 "oHO" = (
@@ -17865,10 +17865,10 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/quartstorage/outdoors)
 "rDc" = (
-/obj/structure/table,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/computer/nuke_disk_generator/green,
 /turf/open/floor/tile/green/greentaupe{
 	dir = 5
 	},
@@ -18075,7 +18075,7 @@
 /area/lv624/ground/sand8)
 "rNb" = (
 /obj/effect/decal/cleanable/cobweb,
-/obj/machinery/computer/nuke_disk_generator/green,
+/obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/armory)
 "rNs" = (
@@ -40679,7 +40679,7 @@ haS
 oUs
 dUQ
 vqz
-hLs
+pJt
 pJt
 oGQ
 uGM
@@ -53483,7 +53483,7 @@ aeV
 afv
 aog
 agB
-agB
+hLs
 agB
 agB
 aiD

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -3619,7 +3619,6 @@
 "bfS" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
-/obj/effect/landmark/nuke_spawn,
 /turf/open/floor/tile/red/yellowfull,
 /area/lv624/ground/sand4)
 "bfU" = (
@@ -13215,6 +13214,7 @@
 "lOD" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
+/obj/effect/landmark/nuke_spawn,
 /turf/open/floor/engine/cult{
 	dir = 2
 	},

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -3619,6 +3619,7 @@
 "bfS" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
+/obj/effect/landmark/nuke_spawn,
 /turf/open/floor/tile/red/yellowfull,
 /area/lv624/ground/sand4)
 "bfU" = (
@@ -9164,11 +9165,6 @@
 /obj/structure/jungle/vines/heavy,
 /turf/closed/wall,
 /area/lv624/ground/jungle4)
-"gSD" = (
-/obj/structure/jungle/vines,
-/obj/structure/window/framed/colony,
-/turf/open/floor/plating,
-/area/lv624/ground/jungle9)
 "gSY" = (
 /obj/structure/jungle/vines,
 /obj/machinery/door/airlock/sandstone{
@@ -9765,9 +9761,10 @@
 	},
 /area/lv624/lazarus/sleep_female)
 "hLs" = (
-/obj/effect/landmark/nuke_spawn,
-/turf/open/floor/tile/dark,
-/area/lv624/ground/sand6)
+/obj/structure/jungle/vines,
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating,
+/area/lv624/ground/jungle9)
 "hMa" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
@@ -49012,7 +49009,7 @@ xMs
 aES
 aES
 rpf
-gSD
+hLs
 jQr
 pdN
 vcl
@@ -53486,7 +53483,7 @@ aeV
 afv
 aog
 agB
-hLs
+agB
 agB
 agB
 aiD

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -8548,9 +8548,6 @@
 	name = "Corporate Dome"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/corporate_affairs)
 "ghC" = (
@@ -9167,6 +9164,11 @@
 /obj/structure/jungle/vines/heavy,
 /turf/closed/wall,
 /area/lv624/ground/jungle4)
+"gSD" = (
+/obj/structure/jungle/vines,
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating,
+/area/lv624/ground/jungle9)
 "gSY" = (
 /obj/structure/jungle/vines,
 /obj/machinery/door/airlock/sandstone{
@@ -11555,12 +11557,13 @@
 	},
 /area/lv624/lazarus/research)
 "jQr" = (
-/obj/structure/window/framed/colony,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
 /area/lv624/lazarus/fitness)
 "jQy" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
@@ -15903,8 +15906,8 @@
 /turf/open/floor,
 /area/lv624/ground/river2)
 "pdN" = (
-/obj/machinery/door/airlock/mainship/medical/glass/free_access{
-	dir = 4;
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1;
 	name = "\improper Leisure Dome"
 	},
 /turf/open/floor/tile/purple/whitepurple{
@@ -41023,7 +41026,7 @@ xTG
 cIl
 cIl
 cIl
-osS
+uGM
 sHv
 ghS
 ghS
@@ -41377,7 +41380,7 @@ eYL
 cIl
 cIl
 cIl
-osS
+uGM
 jhE
 gKi
 xRq
@@ -48832,7 +48835,7 @@ vUs
 xjn
 vcl
 vcl
-vUs
+wgH
 xPn
 the
 wgH
@@ -49008,8 +49011,8 @@ aES
 xMs
 aES
 aES
-aET
 rpf
+gSD
 jQr
 pdN
 vcl


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.
Green is in hydro, red is in bar dome, nuke generator itself has been moved into caves.

## Why It's Good For The Game

Currently both Green and Red disk are free disks for marines since they weren't balanced with the idea of LZs being used, this PR fixes that and also moves the nuke generator into xeno held territory like the other maps.

## Changelog
:cl:
balance: Shuffled the locations of nuke disk generators on LV624 to be less biased.
fix: Removed some duplicate LZ shutters from corporate dome
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
