### PR TITLE
Give robotic limbs in medbay spawn

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -6274,6 +6274,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "ve" = (
@@ -6499,12 +6501,10 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "vR" = (
-/obj/structure/table/mainship,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/surplus_limbs,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "vS" = (
@@ -8882,6 +8882,10 @@
 /area/mainship/medical/operating_room_one)
 "CP" = (
 /obj/machinery/bioprinter/stocked,
+/obj/item/robot_parts/l_arm,
+/obj/item/robot_parts/l_leg,
+/obj/item/robot_parts/r_arm,
+/obj/item/robot_parts/r_leg,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_one)
 "CS" = (
@@ -10275,6 +10279,10 @@
 /area/mainship/medical/operating_room_two)
 "GT" = (
 /obj/machinery/bioprinter/stocked,
+/obj/item/robot_parts/l_arm,
+/obj/item/robot_parts/l_leg,
+/obj/item/robot_parts/r_arm,
+/obj/item/robot_parts/r_leg,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
 "GU" = (

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -10975,8 +10975,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "gPy" = (
-/obj/structure/closet/secure_closet/medical_doctor,
 /obj/machinery/alarm,
+/obj/structure/closet/secure_closet/surplus_limbs,
 /turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/surgery_hallway)
 "gPB" = (
@@ -16651,6 +16651,10 @@
 /area/mainship/living/starboard_emb)
 "qJa" = (
 /obj/machinery/bioprinter/stocked,
+/obj/item/robot_parts/l_arm,
+/obj/item/robot_parts/l_leg,
+/obj/item/robot_parts/r_arm,
+/obj/item/robot_parts/r_leg,
 /turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/operating_room_one)
 "qJm" = (
@@ -18687,6 +18691,10 @@
 /area/mainship/shipboard/firing_range)
 "uEg" = (
 /obj/machinery/bioprinter/stocked,
+/obj/item/robot_parts/l_arm,
+/obj/item/robot_parts/l_leg,
+/obj/item/robot_parts/r_arm,
+/obj/item/robot_parts/r_leg,
 /turf/open/floor/mainship/sterile/corner{
 	dir = 8
 	},

--- a/code/game/objects/structures/crates_lockers/closets/secure/cm_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cm_closets.dm
@@ -455,6 +455,30 @@
 		new /obj/item/clothing/suit/storage/snow_suit/doctor(src)
 		new /obj/item/clothing/mask/rebreather/scarf(src)
 
+//SURPLUS CYBORG LIMBS CLOSET
+/obj/structure/closet/secure_closet/surplus_limbs
+	name = "surplus cyborg limbs locker"
+	req_access = list(ACCESS_MARINE_MEDBAY)
+	icon_state = "secure_locked_medical"
+	icon_closed = "secure_unlocked_medical"
+	icon_locked = "secure_locked_medical"
+	icon_opened = "secure_open_medical"
+	icon_broken = "secure_broken_medical"
+	icon_off = "secure_closed_medical"
+
+/obj/structure/closet/secure_closet/surplus_limbs/PopulateContents()
+	new /obj/item/robot_parts/l_arm(src)
+	new /obj/item/robot_parts/l_arm(src)
+	new /obj/item/robot_parts/l_arm(src)
+	new /obj/item/robot_parts/r_arm(src)
+	new /obj/item/robot_parts/r_arm(src)
+	new /obj/item/robot_parts/r_arm(src)
+	new /obj/item/robot_parts/l_leg(src)
+	new /obj/item/robot_parts/l_leg(src)
+	new /obj/item/robot_parts/l_leg(src)
+	new /obj/item/robot_parts/r_leg(src)
+	new /obj/item/robot_parts/r_leg(src)
+	new /obj/item/robot_parts/r_leg(src)
 
 //ALAMAYER CARGO CLOSET
 /obj/structure/closet/secure_closet/req_officer


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Shipside's robotic limb printer spawns with a robotic left and right arm and left and right leg.

Shipside's medbay storage spawns with a locker with 3 of each limb.

Only give to Theseus and Minerva since PoS PR might map conflict and I hate that and let Derrick work on Sulaco.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

As I played CM's medical doctor (shocking, right?) and prepared for field surgery, I forgot to print out robotic limbs. I then thought to myself, "Why do I need to print out robotic limbs every round when I can just make a freaking locker AND make robotic limbs a spawn item?"

It reduces prep time for surgery and negligence of duty for people like me. It also makes sense from a gameplay and lore perspective: if people know that marines are going to lose limbs, why not have them ready before deployment starts? Robotic limbs aren't going to expire any time soon.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: robotic limbs spawning in round start; you can find them on robotic limb printer and medbay storage's surplus cyborg limb locker. Only for Theseus and Minerva for mapping reasons
qol: round start robotic limbs
balance: makes it easier to do field surgery with backpacks full of robotic limbs without breaking a sweat, but that's already expected
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
