### PR TITLE
Moving TAT and Mobile HMG (Non-IFF hmg) From weapons vendor to Engineering Vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -66,8 +66,6 @@
 			/obj/item/ammo_magazine/standard_gpmg = -1,
 			/obj/item/weapon/gun/standard_mmg = 5,
 			/obj/item/ammo_magazine/standard_mmg = -1,
-			/obj/item/weapon/gun/heavymachinegun = 1,
-			/obj/item/ammo_magazine/heavymachinegun = 10,
 		),
 		"Sidearm" = list(
 			/obj/item/weapon/gun/pistol/standard_pistol = -1,
@@ -99,7 +97,6 @@
 			/obj/item/ammo_magazine/flamer_tank/backtank = 4,
 			/obj/item/ammo_magazine/flamer_tank/large = 20,
 			/obj/item/ammo_magazine/flamer_tank = 20,
-			/obj/structure/largecrate/supply/weapons/standard_atgun = 1,
 			/obj/item/tool/extinguisher = -1,
 			/obj/item/tool/extinguisher/mini = -1,
 			/obj/item/weapon/shield/riot/marine = 6,
@@ -976,6 +973,9 @@
 		/obj/structure/closet/crate/mortar_ammo/howitzer_kit = 1,
 		/obj/item/storage/box/sentry = 3,
 		/obj/item/storage/box/tl102 = 1,
+		/obj/structure/largecrate/supply/weapons/standard_atgun = 1,
+		/obj/item/weapon/gun/heavymachinegun = 1,
+		/obj/item/ammo_magazine/heavymachinegun = 10,
 	)
 
 	prices = list()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Moves the typepaths for TAT and the Non-IFF hmg (including it's ammo) from weapon vendor to engineer vendor, 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The reason why I'm moving them is because due to the fact that they're available normally in the weapons vendor it can be achieved in crash, TAT doesn't get additonal ammo aside from the shells it gets roundstart, nor does HMG get any extra ammo due to the lack of req, but it doesn't matter when TAT & HMG are only pulled out when marines finally get the nuke and double down their defenses with both of these tools. 

Marines already get a ton of sentries ontop of engineers being able to vend a teleporter for A BACKPACK EQUIPMENT SLOT, not even spending any points to actually affect the amount of materials or sentries they can get, which I will address in another pr
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Moved TAT & non-IFF HMG from weapons vendor to Engineering vendor (The ones with mortar and howitzer.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
