### PR TITLE
Robotic surgery fixes.

### DIFF
--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -181,7 +181,7 @@
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient is braindead. No remedy possible."))
 		return
 
-	if(!H.has_working_organs() && !isrobot(H))
+	if(!H.has_working_organs() && !(H.species.species_flags & ROBOTIC_LIMBS))
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient's organs are too damaged to sustain life. Deliver patient to a MD for surgical intervention."))
 		return
 
@@ -192,10 +192,10 @@
 	var/mob/dead/observer/G = H.get_ghost()
 	if(istype(G))
 		notify_ghost(G, "<font size=3>Someone is trying to revive your body. Return to it if you want to be resurrected!</font>", ghost_sound = 'sound/effects/gladosmarinerevive.ogg', enter_text = "Enter", enter_link = "reentercorpse=1", source = H, action = NOTIFY_JUMP)
-	else if(!H.client)
+	//else if(!H.client)
 		//We couldn't find a suitable ghost, this means the person is not returning
-		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient has a DNR."))
-		return
+		//user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient has a DNR."))
+		//return
 
 	user.visible_message(span_notice("[user] starts setting up the paddles on [H]'s chest."),
 	span_notice("You start setting up the paddles on [H]'s chest."))
@@ -228,7 +228,7 @@
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient's brain has decayed too much. No remedy possible."))
 		return
 
-	if(!H.has_working_organs() && !isrobot(H))
+	if(!H.has_working_organs() && !(H.species.species_flags & ROBOTIC_LIMBS))
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Defibrillation failed. Patient's organs are too damaged to sustain life. Deliver patient to a MD for surgical intervention."))
 		return
 
@@ -237,7 +237,7 @@
 		if(braincase.limb_status & LIMB_DESTROYED)
 			user.visible_message("[icon2html(src, viewers(user))] \The [src] buzzes: Positronic brain missing, cannot reboot.")
 			return
-
+/*
 	if(!H.client) //Freak case, no client at all. This is a braindead mob (like a colonist)
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: No soul detected, Attempting to revive..."))
 
@@ -253,7 +253,7 @@
 	if(!H.client) //Freak case, no client at all. This is a braindead mob (like a colonist)
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Defibrillation failed. No soul detected."))
 		return
-
+*/
 	//At this point, the defibrillator is ready to work
 	if(!issynth(H))
 		H.adjustBruteLoss(-defib_heal_amt)

--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -192,10 +192,10 @@
 	var/mob/dead/observer/G = H.get_ghost()
 	if(istype(G))
 		notify_ghost(G, "<font size=3>Someone is trying to revive your body. Return to it if you want to be resurrected!</font>", ghost_sound = 'sound/effects/gladosmarinerevive.ogg', enter_text = "Enter", enter_link = "reentercorpse=1", source = H, action = NOTIFY_JUMP)
-	//else if(!H.client)
+	else if(!H.client)
 		//We couldn't find a suitable ghost, this means the person is not returning
-		//user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient has a DNR."))
-		//return
+		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient has a DNR."))
+		return
 
 	user.visible_message(span_notice("[user] starts setting up the paddles on [H]'s chest."),
 	span_notice("You start setting up the paddles on [H]'s chest."))
@@ -237,7 +237,7 @@
 		if(braincase.limb_status & LIMB_DESTROYED)
 			user.visible_message("[icon2html(src, viewers(user))] \The [src] buzzes: Positronic brain missing, cannot reboot.")
 			return
-/*
+
 	if(!H.client) //Freak case, no client at all. This is a braindead mob (like a colonist)
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: No soul detected, Attempting to revive..."))
 
@@ -253,7 +253,7 @@
 	if(!H.client) //Freak case, no client at all. This is a braindead mob (like a colonist)
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Defibrillation failed. No soul detected."))
 		return
-*/
+
 	//At this point, the defibrillator is ready to work
 	if(!issynth(H))
 		H.adjustBruteLoss(-defib_heal_amt)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -219,7 +219,6 @@
 	if(.)
 		I.pixel_x = initial(I.pixel_x) + rand(-6,6)
 		I.pixel_y = initial(I.pixel_y) + rand(-6,6)
-	I.do_drop_animation(src)
 
 /**
  * For when the item will be immediately placed in a loc other than the ground.

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -834,10 +834,7 @@
 
 	blood_color = "#EEEEEE"
 
-	has_organ = list(
-		"heart" =    /datum/internal_organ/heart/prosthetic,
-		"brain" =    /datum/internal_organ/brain/prosthetic,
-		)
+	has_organ = list()
 
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	see_in_dark = 8
@@ -890,10 +887,7 @@
 
 	blood_color = "#EEEEEE"
 	hair_color = "#000000"
-	has_organ = list(
-		"heart" =    /datum/internal_organ/heart/prosthetic,
-		"brain" =    /datum/internal_organ/brain/prosthetic,
-		)
+	has_organ = list()
 
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	see_in_dark = 8

--- a/code/modules/organs/limb_objects.dm
+++ b/code/modules/organs/limb_objects.dm
@@ -69,7 +69,6 @@
 	icon_state = "head_m"
 	resistance_flags = UNACIDABLE
 	var/mob/living/brain/brainmob
-	var/brain_op_stage = 0
 	var/brain_item_type = /obj/item/organ/brain
 	var/braindeath_on_decap = 1 //whether the brainmob dies when head is decapitated (used by synthetics)
 
@@ -123,59 +122,13 @@
 		H.mind.transfer_to(brainmob)
 	brainmob.container = src
 
-/obj/item/limb/head/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/tool/surgery/scalpel))
-		switch(brain_op_stage)
-			if(0)
-				user.visible_message(span_warning("[brainmob] is beginning to have [brainmob.p_their()] head cut open with [I] by [user]."), \
-									span_warning("You cut [brainmob]'s head open with [I]!"))
-				to_chat(brainmob, span_warning("[user] begins to cut open your head with [I]!"))
-
-				brain_op_stage = 1
-			if(2)
-				user.visible_message(span_warning("[brainmob] is having [brainmob.p_their()] connections to the brain delicately severed with [I] by [user]."), \
-									span_warning("You cut [brainmob]'s head open with [I]!"))
-				to_chat(brainmob, span_warning("[user] begins to cut open your head with [I]!"))
-
-				brain_op_stage = 3.0
-			else
-				return ..()
-	else if(istype(I, /obj/item/tool/surgery/circular_saw))
-		switch(brain_op_stage)
-			if(1)
-				user.visible_message(span_warning("[brainmob] has [brainmob.p_their()] head sawed open with [I] by [user]."), \
-							span_warning("You saw [brainmob]'s head open with [I]!"))
-				to_chat(brainmob, span_warning("[user] saw open your head with [I]!"))
-				brain_op_stage = 2
-			if(3)
-				user.visible_message(span_warning("[brainmob] has [brainmob.p_their()] spine's connection to the brain severed with [I] by [user]."), \
-									span_warning("You sever [brainmob]'s brain's connection to the spine with [I]!"))
-				to_chat(brainmob, span_warning("[user] severs your brain's connection to the spine with [I]!"))
-
-				log_combat(user, brainmob, "debrained", I, "(INTENT: [uppertext(user.a_intent)])")
-
-				//TODO: ORGAN REMOVAL UPDATE.
-				var/obj/item/organ/brain/B = new brain_item_type(loc)
-				if(brainmob.stat != DEAD)
-					brainmob.death() //brain mob doesn't survive outside a head
-				B.transfer_identity(brainmob)
-
-				brain_op_stage = 4.0
-			else
-				return ..()
-	else
-		return ..()
-
-
 //synthetic head, allowing brain mob inside to talk
 /obj/item/limb/head/synth
 	name = "synthetic head"
-	brain_item_type = /obj/item/organ/brain/prosthetic
+	brain_item_type = null
 	braindeath_on_decap = 0
 
 /obj/item/limb/head/robotic
 	name = "robotic head"
-	icon = 'icons/mob/human_races/r_robot.dmi'
-	icon_state = "head_dead"
-	brain_item_type = /obj/item/organ/brain/prosthetic
+	brain_item_type = null
 	braindeath_on_decap = 0

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -797,11 +797,12 @@ Note that amputating the affected organ does in fact remove the infection from t
 	reset_limb_surgeries()
 
 	var/obj/organ	//Dropped limb object
+	var/mob/living/carbon/human/H
 	switch(body_part)
 		if(HEAD)
-			if(owner.species.species_flags & IS_SYNTHETIC) //special head for synth to allow brainmob to talk without an MMI
+			if(issynth(H)) //special head for synth to allow brainmob to talk without an MMI
 				organ = new /obj/item/limb/head/synth(owner.loc, owner)
-			else if(owner.species.species_flags & ROBOTIC_LIMBS)
+			else if(isrobot(H))
 				organ = new /obj/item/limb/head/robotic(owner.loc, owner)
 			else
 				organ = new /obj/item/limb/head(owner.loc, owner)

--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -138,7 +138,7 @@
 
 
 /datum/surgery_step/head/attach
-	allowed_tools = list(/obj/item/limb/head/synth = 100)
+	allowed_tools = list(/obj/item/limb/head/synth = 100, /obj/item/limb/head/robotic = 100)
 	can_infect = 0
 	min_duration = 60
 	max_duration = 80
@@ -160,12 +160,13 @@
 
 	//Update our dear victim to have a head again
 
-	var/obj/item/limb/head/synth/B = tool
+	var/obj/item/limb/head/B = tool
 
 	affected.robotize()
 	target.updatehealth()
 	target.update_body()
 	target.UpdateDamageIcon()
+	target.update_hair()
 
 	//Prepare mind datum
 	if(B.brainmob?.mind)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Synthetics no longer have organs.
Head reattach surgery works on combat robots now.
You can now see all three robotic species (Combat Robot, Synth, Early Synth) head items when they've been decapitated.


## Why It's Good For The Game

Fixes are good.

## Changelog
:cl:
fix: Synths no longer have organs that they cannot fix
fix: Combat robots can now have their heads reattached.
fix: You can now actually see synthetic/robotic heads on the ground for retrieval.
fix: Head reattachment surgery no longer makes you bald.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
