### PR TITLE
Moves nuke out of silo fog

### DIFF
--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -13214,7 +13214,6 @@
 "lOD" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
-/obj/effect/landmark/nuke_spawn,
 /turf/open/floor/engine/cult{
 	dir = 2
 	},
@@ -13370,6 +13369,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/ground/ruin)
+"lYu" = (
+/obj/effect/landmark/nuke_spawn,
+/turf/open/floor/tile/dark,
+/area/lv624/ground/sand6)
 "lYB" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 2
@@ -53482,7 +53485,7 @@ aeZ
 aeV
 afv
 aog
-agB
+lYu
 agB
 agB
 agB


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Apparently I overlooked that the nuke I moved in this https://github.com/tgstation/TerraGov-Marine-Corps/pull/10109 PR has been accidentally relocated inside silo fog. While this isn't a huge issue during Nuclear War it keep marines from getting it during Crash.

I have moved it to the crashed ship, which is not covered by fog.

## Why It's Good For The Game

It's nice for marines to actually complete their objectives during Crash,

## Changelog
:cl:
fix: The nuke generator on LV is no longer inside silo fog
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
