### PR TITLE
AMR tweaks

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -129,8 +129,8 @@
 
 //Define sniper laser multipliers
 
-#define SNIPER_LASER_DAMAGE_MULTIPLIER 1.7 //+70% damage vs the aimed target
-#define SNIPER_LASER_ARMOR_MULTIPLIER 1.7 //+70% penetration vs the aimed target
+#define SNIPER_LASER_DAMAGE_MULTIPLIER 1.5 //+50% damage vs the aimed target
+#define SNIPER_LASER_ARMOR_MULTIPLIER 1.5 //+50% penetration vs the aimed target
 
 //Define lasrifle
 #define ENERGY_STANDARD_AMMO_COST 20

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1004,13 +1004,16 @@ datum/ammo/bullet/revolver/tp44
 	hud_state_empty = "sniper_empty"
 	damage_falloff = 0
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SNIPER|AMMO_SUNDERING
-	accurate_range_min = 5
+	accurate_range_min = 7
 	shell_speed = 4
 	accurate_range = 30
 	max_range = 40
 	damage = 90
 	penetration = 80
 	sundering = 0
+
+/datum/ammo/bullet/shotgun/sx16_slug/on_hit_mob(mob/M, obj/projectile/P)
+	staggerstun(M, P, knockback = 2)
 
 /datum/ammo/bullet/sniper/incendiary
 	name = "incendiary sniper bullet"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1004,7 +1004,7 @@ datum/ammo/bullet/revolver/tp44
 	hud_state_empty = "sniper_empty"
 	damage_falloff = 0
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SNIPER|AMMO_SUNDERING
-	accurate_range_min = 7
+	accurate_range_min = 5
 	shell_speed = 4
 	accurate_range = 30
 	max_range = 40
@@ -1012,10 +1012,13 @@ datum/ammo/bullet/revolver/tp44
 	penetration = 80
 	sundering = 0
 
-/datum/ammo/bullet/shotgun/sx16_slug/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, knockback = 2)
+/datum/ammo/bullet/sniper/amr
+	accurate_range_min = 7
 
-/datum/ammo/bullet/sniper/incendiary
+/datum/ammo/bullet/sniper/amr/on_hit_mob(mob/M, obj/projectile/P)
+	staggerstun(M, P, max_range = 30, knockback = 2)
+
+/datum/ammo/bullet/sniper/amr/incendiary
 	name = "incendiary sniper bullet"
 	hud_state = "sniper_fire"
 	accuracy = 0
@@ -1027,7 +1030,7 @@ datum/ammo/bullet/revolver/tp44
 	penetration = 20
 	sundering = 5
 
-/datum/ammo/bullet/sniper/flak
+/datum/ammo/bullet/sniper/amr/flak
 	name = "flak sniper bullet"
 	hud_state = "sniper_flak"
 	damage = 90

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1038,7 +1038,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 25
 	airburst_multiplier	= 0.2
 
-/datum/ammo/bullet/sniper/flak/on_hit_mob(mob/victim, obj/projectile/proj)
+/datum/ammo/bullet/sniper/amr/flak/on_hit_mob(mob/victim, obj/projectile/proj)
 	airburst(victim, proj)
 
 /datum/ammo/bullet/sniper/svd

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -63,7 +63,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 
 	fire_delay = 2.5 SECONDS
 	burst_amount = 1
-	accuracy_mult = 1.50
+	accuracy_mult = 1.10
 	recoil = 2
 	scatter = 0
 

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -9,21 +9,21 @@
 	icon_state = "t26"
 	w_class = WEIGHT_CLASS_NORMAL
 	max_rounds = 15
-	default_ammo = /datum/ammo/bullet/sniper
+	default_ammo = /datum/ammo/bullet/sniper/amr
 	reload_delay = 3
 	icon_state_mini = "mag_sniper"
 
 
 /obj/item/ammo_magazine/sniper/incendiary
 	name = "\improper SR-26 incendiary magazine (10x28mm)"
-	default_ammo = /datum/ammo/bullet/sniper/incendiary
+	default_ammo = /datum/ammo/bullet/sniper/amr/incendiary
 	icon_state = "t26_inc"
 	icon_state_mini = "mag_sniper_red"
 	bonus_overlay = "t26_incend"
 
 /obj/item/ammo_magazine/sniper/flak
 	name = "\improper SR-26 flak magazine (10x28mm)"
-	default_ammo = /datum/ammo/bullet/sniper/flak
+	default_ammo = /datum/ammo/bullet/sniper/amr/flak
 	icon_state = "t26_flak"
 	icon_state_mini = "mag_sniper_blue"
 	bonus_overlay = "t26_flak"

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -736,8 +736,8 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 			BULLET_DEBUG("Point blank range (+25)")
 			. += 25
 		else if((proj.ammo.flags_ammo_behavior & AMMO_SNIPER) && proj.distance_travelled <= proj.ammo.accurate_range_min) //Snipers have accuracy falloff at closer range before point blank
-			BULLET_DEBUG("Sniper ammo, too close (-[(proj.ammo.accurate_range_min - proj.distance_travelled) * 5])")
-			. -= (proj.ammo.accurate_range_min - proj.distance_travelled) * 5
+			BULLET_DEBUG("Sniper ammo, too close (-[(proj.ammo.accurate_range_min - proj.distance_travelled) * 15])")
+			. -= (proj.ammo.accurate_range_min - proj.distance_travelled) * 15
 	else
 		BULLET_DEBUG("Too far (+[(proj.ammo.flags_ammo_behavior & AMMO_SNIPER) ? (proj.distance_travelled * 3) : (proj.distance_travelled * 5)])")
 		. -= (proj.ammo.flags_ammo_behavior & AMMO_SNIPER) ? (proj.distance_travelled * 3) : (proj.distance_travelled * 5) //Snipers have a smaller falloff constant due to longer max range


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Some tweaks aimmed at making the AMR slightly less oppressive without just nerfing it back into oblivion.

1. Reduced the laser damage and AP multiplier from 1.7 back to 1.5 (135 damage instead of 153, AP is stil a gorillion though)
2. Added a 2 tile knock back for smaller xenos. It's a god damn .50 cal sniper. This may actually help the beno in many cases though.

I have also decreased it's accuracy bonus from 1.5 to 1.1, increased it's accurate minimum range from 5 to 7, and greatly increased the accuracy malus for shooting under your minimum accurate range.

While the number look extreme, it's important to know how accuracy actually works. Currently the AMR has an accuracy of around 185%. This means it... hits 185% of the time, up to it's accurate range of 30 tiles (before having a negligible fall off). Under the WORST possible circumstances, its accuracy is still like 160%.

After the changes, it's still going to always hit at longer ranges, but at close range it might actually miss (about 65% to hit at 2 tiles, 95% at 4 tiles)... so it's still pretty rediculously accurate, but I need to really rework accuracy in general, which is out of scope of this PR.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
AMR is hugely unfun to play against, make it slightly less unforgiving.
Also make minimum accurate range actually mean something.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: AMR laser damage and AP multiplier reduced to 1.5 from 1.7.
balance: AMR has2 tile knockback against smaller targets. This can be a blessing and a curse.
balance: AMR accuracy and minimum accurate range nerfed, so that you MIGHT actually miss at very close range.
balance: Increased the penalty to firing under your minimim accurate range.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
