### PR TITLE
Fix and improve end of round ghosts reveal

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -123,6 +123,8 @@ SUBSYSTEM_DEF(ticker)
 				addtimer(CALLBACK(SSvote, /datum/controller/subsystem/vote/proc/automatic_vote), 2 SECONDS)
 				addtimer(CALLBACK(src, .proc/Reboot), CONFIG_GET(number/vote_period) * 3 + 9 SECONDS)
 				Master.SetRunLevel(RUNLEVEL_POSTGAME)
+				for(var/client/C AS in GLOB.clients)
+					C.mob?.update_sight() // To reveal ghosts
 
 
 /datum/controller/subsystem/ticker/proc/setup()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -643,6 +643,10 @@ below 100 is not dizzy
 		clear_fullscreen("remote_view", 0)
 	update_pipe_vision()
 
+/mob/living/update_sight()
+	if(SSticker.current_state == GAME_STATE_FINISHED && !is_centcom_level(z)) //Reveal ghosts to remaining survivors
+		see_invisible = SEE_INVISIBLE_OBSERVER
+	return ..()
 
 /mob/living/proc/can_track(mob/living/user)
 	//basic fast checks go first. When overriding this proc, I recommend calling ..() at the end.

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -815,8 +815,6 @@
 /mob/proc/update_sight()
 	SEND_SIGNAL(src, COMSIG_MOB_UPDATE_SIGHT)
 	sync_lighting_plane_alpha()
-	if(SSticker.current_state == GAME_STATE_FINISHED && !is_centcom_level(z)) //Reveal ghosts to remaining survivors
-		see_invisible = SEE_INVISIBLE_OBSERVER
 
 /mob/proc/sync_lighting_plane_alpha()
 	if(!hud_used)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves the see invisible code to `/mob/living/` so it does not override observers toggle and calls it when the round ends so it actually works.

## Why It's Good For The Game

Fix good.

## Changelog
:cl:
fix: Fixed and improved end of round ghost reveal code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
