### PR TITLE
Nuclear War Nerf: change spawn rate from 2.5 to 2

### DIFF
--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/infestation/distress/nuclear_war
 	name = "Nuclear War"
 	config_tag = "Nuclear War"
-	silo_scaling = 2.5
+	silo_scaling = 2
 
 /datum/game_mode/infestation/distress/nuclear_war/post_setup()
 	. = ..()
@@ -32,7 +32,7 @@
 		message_admins("Round finished: [MODE_INFESTATION_X_MINOR]")
 		round_finished = MODE_INFESTATION_X_MINOR
 		return TRUE
-	
+
 	if(planet_nuked == INFESTATION_NUKE_COMPLETED)
 		message_admins("Round finished: [MODE_INFESTATION_X_MINOR]") //marines managed to nuke the colony
 		round_finished = MODE_INFESTATION_M_MINOR


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

MJP approves. Not sure if Bravemole approves. This will make them a bit less oppressive but still challenging. We can remove this nerf if marines are not getting a decent challenge.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: change spawn rate from 2.5 to 2 in Nuclear War
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
