### PR TITLE
Mostly reverts AMR state to pre nerf/buffs, with minor changes.

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -131,6 +131,7 @@
 
 #define SNIPER_LASER_DAMAGE_MULTIPLIER 1.5 //+55% damage vs the aimed target
 #define SNIPER_LASER_ARMOR_MULTIPLIER 1.5 //+50% penetration vs the aimed target
+#define SNIPER_LASER_SLOWDOWN_STACKS 3
 
 //Define lasrifle
 #define ENERGY_STANDARD_AMMO_COST 20

--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -129,7 +129,7 @@
 
 //Define sniper laser multipliers
 
-#define SNIPER_LASER_DAMAGE_MULTIPLIER 1.5 //+55% damage vs the aimed target
+#define SNIPER_LASER_DAMAGE_MULTIPLIER 1.5 //+50% damage vs the aimed target
 #define SNIPER_LASER_ARMOR_MULTIPLIER 1.5 //+50% penetration vs the aimed target
 #define SNIPER_LASER_SLOWDOWN_STACKS 3 // Slowdown applied on hit vs the aimed target.
 

--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -131,7 +131,7 @@
 
 #define SNIPER_LASER_DAMAGE_MULTIPLIER 1.5 //+55% damage vs the aimed target
 #define SNIPER_LASER_ARMOR_MULTIPLIER 1.5 //+50% penetration vs the aimed target
-#define SNIPER_LASER_SLOWDOWN_STACKS 3
+#define SNIPER_LASER_SLOWDOWN_STACKS 3 // Slowdown applied on hit vs the aimed target.
 
 //Define lasrifle
 #define ENERGY_STANDARD_AMMO_COST 20

--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -129,8 +129,8 @@
 
 //Define sniper laser multipliers
 
-#define SNIPER_LASER_DAMAGE_MULTIPLIER 1.7 //+70% damage vs the aimed target
-#define SNIPER_LASER_ARMOR_MULTIPLIER 1.7 //+70% penetration vs the aimed target
+#define SNIPER_LASER_DAMAGE_MULTIPLIER 1.55 //+55% damage vs the aimed target
+#define SNIPER_LASER_ARMOR_MULTIPLIER 1.5 //+50% penetration vs the aimed target
 
 //Define lasrifle
 #define ENERGY_STANDARD_AMMO_COST 20

--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -129,7 +129,7 @@
 
 //Define sniper laser multipliers
 
-#define SNIPER_LASER_DAMAGE_MULTIPLIER 1.55 //+55% damage vs the aimed target
+#define SNIPER_LASER_DAMAGE_MULTIPLIER 1.5 //+55% damage vs the aimed target
 #define SNIPER_LASER_ARMOR_MULTIPLIER 1.5 //+50% penetration vs the aimed target
 
 //Define lasrifle

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1008,8 +1008,8 @@ datum/ammo/bullet/revolver/tp44
 	shell_speed = 4
 	accurate_range = 30
 	max_range = 40
-	damage = 80
-	penetration = 60
+	damage = 90
+	penetration = 50
 	sundering = 15
 
 /datum/ammo/bullet/sniper/incendiary

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1009,8 +1009,8 @@ datum/ammo/bullet/revolver/tp44
 	accurate_range = 30
 	max_range = 40
 	damage = 90
-	penetration = 80
-	sundering = 0
+	penetration = 40
+	sundering = 5
 
 /datum/ammo/bullet/sniper/incendiary
 	name = "incendiary sniper bullet"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1008,9 +1008,9 @@ datum/ammo/bullet/revolver/tp44
 	shell_speed = 4
 	accurate_range = 30
 	max_range = 40
-	damage = 90
-	penetration = 40
-	sundering = 5
+	damage = 80
+	penetration = 60
+	sundering = 15
 
 /datum/ammo/bullet/sniper/incendiary
 	name = "incendiary sniper bullet"

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -894,6 +894,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 			if(proj.shot_from && src == proj.shot_from.sniper_target(src))
 				damage *= SNIPER_LASER_DAMAGE_MULTIPLIER
 				proj.penetration *= SNIPER_LASER_ARMOR_MULTIPLIER
+				add_slowdown(SNIPER_LASER_SLOWDOWN_STACKS)
 			if(living_hard_armor)
 				living_hard_armor = max(0, living_hard_armor - (living_hard_armor * proj.penetration * 0.01)) //AP reduces a % of hard armor.
 			if(living_soft_armor)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces damage from 153 to around 120 when lased, massively reduces pen overall.
Damge stays at 90, pen reduced to 50 compared to pre change AMR, so armor actually matters in some cases.
Reduces damage/pen to old values, before david changes.
Adds back the 15 sunder and slowdown on hit.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Moves the AMR back to being a long range support tool rather than a big dick killing machine, overall.

Changes compared to pre nerf/buff AMR is because I personally believe scope movement should stay gone, and I think it needs minor compensation with slightly more damage overall, and the pen nerf compared to old one is nearly non-noticeable overall IMO, I think defoonders and crushers should feel the difference. Otherwise, I think this PR is better than alternatives.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: AMR mostly reverted to pre david touch state, has 90 damage and 135 when lased, pen down to 50, it slows down on hit again. Lase reverted to 1.5x. Sunder returned.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
