### PR TITLE
Synth changes, early synth differentiated, given unique skills and nerfs, and deletes PC from synth

### DIFF
--- a/code/__DEFINES/skills.dm
+++ b/code/__DEFINES/skills.dm
@@ -53,6 +53,7 @@
 #define SKILL_CONSTRUCTION_PLASTEEL 2	//plasteel barricade,(RO, SL)
 #define SKILL_CONSTRUCTION_ADVANCED 3	//windows and girder construction (combat engi, CO)
 #define SKILL_CONSTRUCTION_MASTER 4	//building machine&computer frames (MT, CE)
+#define SKILL_CONSTRUCTION_INHUMAN 5	//Early synth level.
 
 
 
@@ -63,6 +64,7 @@
 #define SKILL_ENGINEER_PLASTEEL 2	//plasteel barricade repair
 #define SKILL_ENGINEER_ENGI 3	//hacking&&planet engine fixing&&apc building (combat engi)
 #define SKILL_ENGINEER_MASTER 4	//Telecomms fixing, faster engine fixing (ST)
+#define SKILL_ENGINEER_INHUMAN 5	//Early synth level.
 //higher levels give faster engine repair.
 
 

--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -313,12 +313,12 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 
 /datum/skills/early_synthetic
 	name = "Early Synthetic"
-	engineer = SKILL_ENGINEER_MASTER
-	construction = SKILL_CONSTRUCTION_MASTER
+	engineer = SKILL_ENGINEER_INHUMAN
+	construction = SKILL_CONSTRUCTION_INHUMAN
 	firearms = SKILL_FIREARMS_UNTRAINED
-	medical = SKILL_MEDICAL_EXPERT
+	medical = SKILL_SURGERY_PROFESSIONAL
 	cqc = SKILL_CQC_MASTER
-	surgery = SKILL_SURGERY_EXPERT
+	surgery = SKILL_SURGERY_PROFESSIONAL
 	pilot = SKILL_PILOT_TRAINED
 	melee_weapons = SKILL_MELEE_DEFAULT
 	pistols = SKILL_PISTOLS_TRAINED

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -738,7 +738,6 @@
 		/obj/item/reagent_containers/hypospray/advanced/oxycodone,
 		/obj/item/tweezers,
 		/obj/item/tool/solderingtool,
-		/obj/item/tool/pickaxe/plasmacutter,
 	)
 
 /obj/effect/essentials_set/white_dress

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -861,7 +861,7 @@
 	return ..()
 
 
-/datum/species/early_synthetic //cosmetic differences only
+/datum/species/early_synthetic
 	name = "Early Synthetic"
 	name_plural = "Early Synthetics"
 	icobase = 'icons/mob/human_races/r_synthetic.dmi'
@@ -869,9 +869,10 @@
 	default_language_holder = /datum/language_holder/synthetic
 	unarmed_type = /datum/unarmed_attack/punch
 	rarity_value = 1.5
-	total_health = 125
-	brute_mod = 0.70
-	burn_mod = 0.70
+	slowdown = 1.15 //Slower than Late Synths.
+	total_health = 200 //Tough boys, very tough boys.
+	brute_mod = 0.6
+	burn_mod = 0.6
 
 	cold_level_1 = -1
 	cold_level_2 = -1


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
EARLY SYNTH CAHNGES
MAX HP 120->200
BRUTE/BURN MOD->.6
SURGERY/MED SKILL->3
CONSTRUCTION/ENGINEERING->5

Synths no longer get an essential PC.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Differentiates early/late synth. Variety.
PC should go, its absurd.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Essential PC removed, early synth now builds faster but is worse at medical than late synth.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
