### PR TITLE
Deployables cannot be deployed on a tile with any structures or machinery, as opposed to only dense ones

### DIFF
--- a/code/datums/elements/deployable_item.dm
+++ b/code/datums/elements/deployable_item.dm
@@ -63,7 +63,7 @@
 		if(!ishuman(user) || CHECK_BITFIELD(item_to_deploy.flags_item, NODROP))
 			return
 
-		if(item_to_deploy.check_blocked_turf(location))
+		if(item_to_deploy.check_blocked_turf(location, dense_only = FALSE))
 			user.balloon_alert(user, "There is insufficient room to deploy [item_to_deploy]!")
 			return
 		if(user.do_actions)
@@ -74,7 +74,9 @@
 		var/newdir = user.dir //Save direction before the doafter for ease of deploy
 		if(!do_after(user, deploy_time, TRUE, item_to_deploy, BUSY_ICON_BUILD))
 			return
-
+		if(item_to_deploy.check_blocked_turf(location, dense_only = FALSE)) //Never trust conditions remaining the same when using do_after.
+			user.balloon_alert(user, "There is insufficient room to deploy [item_to_deploy]!")
+			return
 		user.temporarilyRemoveItemFromInventory(item_to_deploy)
 
 		item_to_deploy.UnregisterSignal(user, list(COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEUP, COMSIG_MOB_MOUSEDRAG, COMSIG_KB_RAILATTACHMENT, COMSIG_KB_UNDERRAILATTACHMENT, COMSIG_KB_UNLOADGUN, COMSIG_KB_FIREMODE,  COMSIG_MOB_CLICK_RIGHT)) //This unregisters Signals related to guns, its for safety

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -594,17 +594,20 @@
 /atom/movable/proc/handle_internal_lifeform(mob/lifeform_inside_me)
 	. = return_air()
 
-
-/atom/movable/proc/check_blocked_turf(turf/target)
+/**
+ * Checks if a turf is blocked by other objects or by being a dense turf.
+ * By default, only dense objects are taken into account, however if dense_only is FALSE, any machinery or structure being present will cause the turf to count as blocked.
+ **/
+/atom/movable/proc/check_blocked_turf(turf/target, dense_only = TRUE)
 	if(target.density)
 		return TRUE //Blocked; we can't proceed further.
 
 	for(var/obj/machinery/MA in target)
-		if(MA.density)
+		if(!dense_only || MA.density)
 			return TRUE //Blocked; we can't proceed further.
 
 	for(var/obj/structure/S in target)
-		if(S.density)
+		if(!dense_only || S.density)
 			return TRUE //Blocked; we can't proceed further.
 
 	return FALSE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. We're seeing an immense rise of people trying to do wacky stuff with deployables, mainly sentries, via using them in conjunction with objects that can vary their density and as such do not initially block placement, but can be used as cover afterwards via using whichever toggle said objects have. This removes this vector of wackyness and disallows deployables from being placed on tiles with any other structure or machinery present.
Additionally, improves the check during deployment to properly reflect the state after the do_after aswell, due to the possibility of people moving things onto the tile after starting deployment and the previous iteration only checking before the do_after.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less cheese tends to be good for the game. Except if you are a mouse.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Any machinery / structure on a tile now blocks deployable deployment, as opposed to only dense ones.
code: Deployables checking for blocking objects are now less prone to being bypassed during their do_after.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
