### PR TITLE
ports the admin_delete proc

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -95,6 +95,8 @@ SUBSYSTEM_DEF(shuttle)
 				break
 
 /datum/controller/subsystem/shuttle/proc/getShuttle(id)
+	if(isnull(id) || id == "")
+		return
 	for(var/obj/docking_port/mobile/M in mobile)
 		if(M.id == id)
 			return M

--- a/code/modules/admin/debug_verbs.dm
+++ b/code/modules/admin/debug_verbs.dm
@@ -661,7 +661,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	set category = "Debug"
 	set name = "Delete"
 
-	if(!check_rights(R_SPAWN|R_DEBUG))
+	if(!check_rights(R_DEBUG))
 		return
 
 	admin_delete(A)

--- a/code/modules/admin/debug_verbs.dm
+++ b/code/modules/admin/debug_verbs.dm
@@ -336,28 +336,6 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	log_admin("[key_name(usr)] spawned [amount] x [chosen] at [AREACOORD(usr)]")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Spawn Atom") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-
-/datum/admins/proc/delete_atom(atom/A as obj|mob|turf in world)
-	set category = null
-	set name = "Delete"
-
-	if(!check_rights(R_DEBUG))
-		return
-
-	if(alert(src, "Are you sure you want to delete: [A]?", "Delete", "Yes", "No") != "Yes")
-		return
-
-	if(QDELETED(A))
-		return
-
-	var/turf/T = get_turf(A)
-
-	log_admin("[key_name(usr)] deleted [A]([A.type]) at [AREACOORD(T)].")
-	message_admins("[ADMIN_TPMONTY(usr)] deleted [A]([A.type]) at [ADMIN_VERBOSEJMP(T)].")
-
-	qdel(A)
-
-
 /datum/admins/proc/restart_controller(controller in list("Master", "Failsafe"))
 	set category = "Debug"
 	set name = "Restart Controller"
@@ -678,3 +656,12 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	dellog += "</ol>"
 
 	usr << browse(dellog.Join(), "window=dellog")
+
+/client/proc/cmd_admin_delete(atom/A as obj|mob|turf in world)
+	set category = "Debug"
+	set name = "Delete"
+
+	if(!check_rights(R_SPAWN|R_DEBUG))
+		return
+
+	admin_delete(A)

--- a/code/modules/admin/holder.dm
+++ b/code/modules/admin/holder.dm
@@ -351,7 +351,7 @@ GLOBAL_PROTECT(admin_verbs_asay)
 	/datum/admins/proc/reestablish_db_connection,
 	/datum/admins/proc/view_runtimes,
 	/client/proc/toggle_cdn,
-	/client/proc/cmd_admin_delete
+	/client/proc/cmd_admin_delete,
 	)
 GLOBAL_LIST_INIT(admin_verbs_debug, world.AVdebug())
 GLOBAL_PROTECT(admin_verbs_debug)

--- a/code/modules/admin/holder.dm
+++ b/code/modules/admin/holder.dm
@@ -345,13 +345,13 @@ GLOBAL_PROTECT(admin_verbs_asay)
 	/datum/admins/proc/delete_all,
 	/datum/admins/proc/generate_powernets,
 	/datum/admins/proc/debug_mob_lists,
-	/datum/admins/proc/delete_atom,
 	/datum/admins/proc/SDQL2_query,
 	/datum/admins/proc/restart_controller,
 	/datum/admins/proc/check_contents,
 	/datum/admins/proc/reestablish_db_connection,
 	/datum/admins/proc/view_runtimes,
-	/client/proc/toggle_cdn
+	/client/proc/toggle_cdn,
+	/client/proc/cmd_admin_delete
 	)
 GLOBAL_LIST_INIT(admin_verbs_debug, world.AVdebug())
 GLOBAL_PROTECT(admin_verbs_debug)

--- a/code/modules/admin/verbs/datumvars.dm
+++ b/code/modules/admin/verbs/datumvars.dm
@@ -646,7 +646,7 @@
 		var/datum/D = locate(href_list["delete"])
 		if(!istype(D))
 			to_chat(usr, span_warning("Unable to locate item."))
-		usr.client.holder.delete_atom(D)
+		usr.client.admin_delete(D)
 		if(isturf(D))  // show the turf that took its place
 			debug_variables(D)
 

--- a/code/modules/admin/view_variables/admin_delete.dm
+++ b/code/modules/admin/view_variables/admin_delete.dm
@@ -1,0 +1,24 @@
+/client/proc/admin_delete(datum/delete)
+	var/atom/atom_delete = delete
+	var/coords = ""
+	var/jmp_coords = ""
+	if(istype(atom_delete))
+		var/turf/turf_delete = get_turf(atom_delete)
+		if(turf_delete)
+			coords = "at [COORD(turf_delete)]"
+			jmp_coords = "at [ADMIN_COORDJMP(turf_delete)]"
+		else
+			jmp_coords = coords = "in nullspace"
+
+	if (tgui_alert(usr, "Are you sure you want to delete:\n[delete]\n[coords]?", "Confirmation", list("Yes", "No")) == "Yes")
+		log_admin("[key_name(usr)] deleted [delete] [coords]")
+		message_admins("[key_name_admin(usr)] deleted [delete] [jmp_coords]")
+		SSblackbox.record_feedback("tally", "admin_verb", 1, "Delete") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+		if(isturf(delete))
+			var/turf/turf_delete = delete
+			turf_delete.ScrapeAway()
+		else
+			vv_update_display(delete, "deleted", VV_MSG_DELETED)
+			qdel(delete)
+			if(!QDELETED(delete))
+				vv_update_display(delete, "deleted", "")

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -1022,6 +1022,7 @@
 #include "code\modules\admin\verbs\shuttlepanel.dm"
 #include "code\modules\admin\verbs\varedit.dm"
 #include "code\modules\admin\verbs\whitelist.dm"
+#include "code\modules\admin\view_variables\admin_delete.dm"
 #include "code\modules\admin\view_variables\filterrific.dm"
 #include "code\modules\admin\view_variables\greyscale_modify_menu.dm"
 #include "code\modules\admin\view_variables\mark_datum.dm"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

replaces `atom_delete` with `admin_delete`, which allows turf deletions upto the base turf (which still can't be removed)

also removes a null-caused stack_trace with the `getShuttle` proc because that was getting annoying

## Why It's Good For The Game

qol + admins should be able to delete walls

## Changelog
:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
