### PR TITLE
Fix some throwable togglable light sources being unslashable

### DIFF
--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -37,6 +37,13 @@
 	update_action_button_icons()
 	update_icon()
 
+/obj/item/clothing/head/hardhat/attack_alien(mob/living/carbon/xenomorph/X, isrightclick = FALSE)
+	if(turn_light(X, FALSE) != CHECKS_PASSED)
+		return
+	playsound(loc, "alien_claw_metal", 25, 1)
+	X.do_attack_animation(src, ATTACK_EFFECT_CLAW)
+	to_chat(X, span_warning("We disable the metal thing's lights.") )
+
 /obj/item/clothing/head/hardhat/update_icon()
 	. = ..()
 	icon_state = "hardhat[light_on]_[hardhat_color]"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. At this time only includes hardhats.

Do feel free to point out other instances of this kind of exploitative light based tomfoolery, and if possible I will add them to this PR.

## Why It's Good For The Game

Consistency good. 

## Changelog
:cl:
fix: Fixed hardhats not turning off on xeno slash like flashlights.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
