### PR TITLE
Cancel stealth on losing stealth action

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -14,6 +14,11 @@
 	var/can_sneak_attack = FALSE
 	var/stealth_alpha_multiplier = 1
 
+/datum/action/xeno_action/stealth/remove_action(mob/living/L)
+	if(stealth)
+		cancel_stealth()
+	return ..()
+
 /datum/action/xeno_action/stealth/can_use_action(silent = FALSE, override_flags)
 	. = ..()
 	if(!.)


### PR DESCRIPTION
## About The Pull Request
Cancels xeno stealth when the owning mob loses the action.

## Why It's Good For The Game
bugfix

## Changelog
:cl:
fix: Hunters advancing to primordial while stealthed won't stay translucent
/:cl:
