### PR TITLE
Revert "Deployables cannot be deployed on a tile with any structures or machinery, as opposed to only dense ones"

### DIFF
--- a/code/datums/elements/deployable_item.dm
+++ b/code/datums/elements/deployable_item.dm
@@ -63,7 +63,7 @@
 		if(!ishuman(user) || CHECK_BITFIELD(item_to_deploy.flags_item, NODROP))
 			return
 
-		if(item_to_deploy.check_blocked_turf(location, dense_only = FALSE))
+		if(item_to_deploy.check_blocked_turf(location))
 			user.balloon_alert(user, "There is insufficient room to deploy [item_to_deploy]!")
 			return
 		if(user.do_actions)
@@ -74,9 +74,7 @@
 		var/newdir = user.dir //Save direction before the doafter for ease of deploy
 		if(!do_after(user, deploy_time, TRUE, item_to_deploy, BUSY_ICON_BUILD))
 			return
-		if(item_to_deploy.check_blocked_turf(location, dense_only = FALSE)) //Never trust conditions remaining the same when using do_after.
-			user.balloon_alert(user, "There is insufficient room to deploy [item_to_deploy]!")
-			return
+
 		user.temporarilyRemoveItemFromInventory(item_to_deploy)
 
 		item_to_deploy.UnregisterSignal(user, list(COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEUP, COMSIG_MOB_MOUSEDRAG, COMSIG_KB_RAILATTACHMENT, COMSIG_KB_UNDERRAILATTACHMENT, COMSIG_KB_UNLOADGUN, COMSIG_KB_FIREMODE,  COMSIG_MOB_CLICK_RIGHT)) //This unregisters Signals related to guns, its for safety

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -594,20 +594,17 @@
 /atom/movable/proc/handle_internal_lifeform(mob/lifeform_inside_me)
 	. = return_air()
 
-/**
- * Checks if a turf is blocked by other objects or by being a dense turf.
- * By default, only dense objects are taken into account, however if dense_only is FALSE, any machinery or structure being present will cause the turf to count as blocked.
- **/
-/atom/movable/proc/check_blocked_turf(turf/target, dense_only = TRUE)
+
+/atom/movable/proc/check_blocked_turf(turf/target)
 	if(target.density)
 		return TRUE //Blocked; we can't proceed further.
 
 	for(var/obj/machinery/MA in target)
-		if(!dense_only || MA.density)
+		if(MA.density)
 			return TRUE //Blocked; we can't proceed further.
 
 	for(var/obj/structure/S in target)
-		if(!dense_only || S.density)
+		if(S.density)
 			return TRUE //Blocked; we can't proceed further.
 
 	return FALSE


### PR DESCRIPTION
Reverts tgstation/TerraGov-Marine-Corps#10152

Causes a whole bunch of issues. #10165

Makes a significant percentage of turfs invalid for deployables, due to things like patches of grass, pipes, wires, light fixtures etc.

This needs to be done differently to work.