### PR TITLE
Fixes Hunter disguise rendering under weeds

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -210,7 +210,7 @@
 	name = "Disguise"
 	mechanics_text = "Disguise yourself as the enemy. Uses plasma to move."
 	///the regular appearance of the hunter
-	var/mob/old_appearance
+	var/atom/old_appearance
 
 /datum/action/xeno_action/stealth/disguise/action_activate()
 	if(stealth)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -210,7 +210,7 @@
 	name = "Disguise"
 	mechanics_text = "Disguise yourself as the enemy. Uses plasma to move."
 	///the regular appearance of the hunter
-	var/mutable_appearance/old_appearance
+	var/old_appearance
 
 /datum/action/xeno_action/stealth/disguise/action_activate()
 	if(stealth)
@@ -237,9 +237,10 @@
 /datum/action/xeno_action/stealth/disguise/handle_stealth()
 	var/mob/living/carbon/xenomorph/xenoowner = owner
 	var/datum/action/xeno_action/activable/hunter_mark/mark = xenoowner.actions_by_path[/datum/action/xeno_action/activable/hunter_mark]
+	var/old_layer = xenoowner.layer
 	xenoowner.appearance = mark.marked_target.appearance
 	//Retaining old rendering layer to prevent rendering under objects.
-	xenoowner.layer = old_appearance.layer
+	xenoowner.layer = old_layer
 	xenoowner.underlays.Cut()
 	xenoowner.use_plasma(owner.m_intent == MOVE_INTENT_WALK ? HUNTER_STEALTH_WALK_PLASMADRAIN : HUNTER_STEALTH_RUN_PLASMADRAIN)
 	//If we have 0 plasma after expending stealth's upkeep plasma, end stealth.

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -210,7 +210,7 @@
 	name = "Disguise"
 	mechanics_text = "Disguise yourself as the enemy. Uses plasma to move."
 	///the regular appearance of the hunter
-	var/old_appearance
+	var/mob/old_appearance
 
 /datum/action/xeno_action/stealth/disguise/action_activate()
 	if(stealth)
@@ -238,6 +238,8 @@
 	var/mob/living/carbon/xenomorph/xenoowner = owner
 	var/datum/action/xeno_action/activable/hunter_mark/mark = xenoowner.actions_by_path[/datum/action/xeno_action/activable/hunter_mark]
 	xenoowner.appearance = mark.marked_target.appearance
+	//Retaining old rendering layer to prevent rendering under objects.
+	xenoowner.layer = old_appearance.layer
 	xenoowner.underlays.Cut()
 	xenoowner.use_plasma(owner.m_intent == MOVE_INTENT_WALK ? HUNTER_STEALTH_WALK_PLASMADRAIN : HUNTER_STEALTH_RUN_PLASMADRAIN)
 	//If we have 0 plasma after expending stealth's upkeep plasma, end stealth.

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -210,7 +210,7 @@
 	name = "Disguise"
 	mechanics_text = "Disguise yourself as the enemy. Uses plasma to move."
 	///the regular appearance of the hunter
-	var/atom/old_appearance
+	var/mutable_appearance/old_appearance
 
 /datum/action/xeno_action/stealth/disguise/action_activate()
 	if(stealth)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Title.

Retains hunter rendering layer (i.e. MOB_LAYER) across appearances to prevent practical invisibility when disguising as an object that renders below weeds.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

No more invisibility for Primo Hunter.

Fixes #10167.

## Changelog
:cl:
fix: Disguised Hunter now appears above objects (e.g. weeds) regardless of what it is disguised as.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
