### PR TITLE
Turret stuff - less broken edition

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -36,6 +36,10 @@
 #define INTENT_NUMBER_GRAB 2
 #define INTENT_NUMBER_HARM 3
 
+//turret minimum construction distance defines
+#define XENO_MIN_TURRET_DISTANCE 6
+#define MARINE_MIN_TURRET_DISTANCE 4
+
 //Ammo defines for gun/projectile related things.
 //flags_ammo_behavior
 #define AMMO_EXPLOSIVE (1<<0)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -513,11 +513,22 @@ GLOBAL_REAL_VAR(list/stack_trace_storage)
 		if(istype(A, type))
 			. += A
 
-
-/proc/is_blocked_turf(turf/T)
+/**
+ * Detects whether a turf is blocked by something
+ * Returns TRUE if yes, null if not.
+ * * Args:
+ * * T: Turf that is being checked
+ * * source: optional, if supplied this atom is ignored from being considered in the blocking check. Intended to avoid detecting oneself if used with other objects.
+ * * ignore_mobs: Optional, if TRUE ignores mobs.
+**/
+/proc/is_blocked_turf(turf/T, atom/source, ignore_mobs)
 	if(T.density)
 		return TRUE
 	for(var/atom/A in T)
+		if(A == source)
+			continue
+		if(ignore_mobs && ismob(A))
+			continue
 		if(A.density)
 			return TRUE
 

--- a/code/datums/elements/deployable_item.dm
+++ b/code/datums/elements/deployable_item.dm
@@ -69,6 +69,19 @@
 		if(user.do_actions)
 			user.balloon_alert(user, "You are already doing something!")
 			return
+		if(deploy_type in typesof(/obj/machinery/deployable/mounted/sentry))
+			for(var/obj/machinery/deployable/mounted/sentry/sentry AS in GLOB.marine_turrets)
+				var/turf/sentry_turf = get_turf(sentry)
+				var/turf/this_turf = get_turf(location)
+				if(!sentry_turf) //Sentry has some issue that got it nullspaced, ignore.
+					continue
+				if(!this_turf)
+					return
+				if(this_turf.z != sentry_turf.z)	//get_dist works across zs and could scuff things if it checked shipside turrets too.
+					continue
+				if(get_dist(this_turf, sentry_turf) < MARINE_MIN_TURRET_DISTANCE)
+					user.balloon_alert(user, "Too close to other sentries, minimum distance is [MARINE_MIN_TURRET_DISTANCE].")
+					return
 		user.balloon_alert(user, "You start deploying...")
 		user.setDir(get_dir(user, location)) //Face towards deploy location for ease of deploy.
 		var/newdir = user.dir //Save direction before the doafter for ease of deploy
@@ -77,6 +90,19 @@
 		if(item_to_deploy.check_blocked_turf(location)) //Never trust conditions remaining the same when using do_after.
 			user.balloon_alert(user, "There is insufficient room to deploy [item_to_deploy]!")
 			return
+		if(deploy_type in typesof(/obj/machinery/deployable/mounted/sentry))
+			for(var/obj/machinery/deployable/mounted/sentry/sentry AS in GLOB.marine_turrets)
+				var/turf/sentry_turf = get_turf(sentry)
+				var/turf/this_turf = get_turf(location)
+				if(!sentry_turf) //Sentry has some issue that got it nullspaced, ignore.
+					continue
+				if(!this_turf)
+					return
+				if(this_turf.z != sentry_turf.z)	//get_dist works across zs and could scuff things if it checked shipside turrets too.
+					continue
+				if(get_dist(this_turf, sentry_turf) < MARINE_MIN_TURRET_DISTANCE)
+					user.balloon_alert(user, "Too close to other sentries, minimum distance is [MARINE_MIN_TURRET_DISTANCE].")
+					return
 		user.temporarilyRemoveItemFromInventory(item_to_deploy)
 
 		item_to_deploy.UnregisterSignal(user, list(COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEUP, COMSIG_MOB_MOUSEDRAG, COMSIG_KB_RAILATTACHMENT, COMSIG_KB_UNDERRAILATTACHMENT, COMSIG_KB_UNLOADGUN, COMSIG_KB_FIREMODE,  COMSIG_MOB_CLICK_RIGHT)) //This unregisters Signals related to guns, its for safety

--- a/code/datums/elements/deployable_item.dm
+++ b/code/datums/elements/deployable_item.dm
@@ -69,10 +69,10 @@
 		if(user.do_actions)
 			user.balloon_alert(user, "You are already doing something!")
 			return
+		var/turf/this_turf = get_turf(location)
 		if(deploy_type in typesof(/obj/machinery/deployable/mounted/sentry))
 			for(var/obj/machinery/deployable/mounted/sentry/sentry AS in GLOB.marine_turrets)
 				var/turf/sentry_turf = get_turf(sentry)
-				var/turf/this_turf = get_turf(location)
 				if(!sentry_turf) //Sentry has some issue that got it nullspaced, ignore.
 					continue
 				if(!this_turf)
@@ -93,7 +93,6 @@
 		if(deploy_type in typesof(/obj/machinery/deployable/mounted/sentry))
 			for(var/obj/machinery/deployable/mounted/sentry/sentry AS in GLOB.marine_turrets)
 				var/turf/sentry_turf = get_turf(sentry)
-				var/turf/this_turf = get_turf(location)
 				if(!sentry_turf) //Sentry has some issue that got it nullspaced, ignore.
 					continue
 				if(!this_turf)

--- a/code/datums/elements/deployable_item.dm
+++ b/code/datums/elements/deployable_item.dm
@@ -74,7 +74,9 @@
 		var/newdir = user.dir //Save direction before the doafter for ease of deploy
 		if(!do_after(user, deploy_time, TRUE, item_to_deploy, BUSY_ICON_BUILD))
 			return
-
+		if(item_to_deploy.check_blocked_turf(location)) //Never trust conditions remaining the same when using do_after.
+			user.balloon_alert(user, "There is insufficient room to deploy [item_to_deploy]!")
+			return
 		user.temporarilyRemoveItemFromInventory(item_to_deploy)
 
 		item_to_deploy.UnregisterSignal(user, list(COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEUP, COMSIG_MOB_MOUSEDRAG, COMSIG_KB_RAILATTACHMENT, COMSIG_KB_UNDERRAILATTACHMENT, COMSIG_KB_UNLOADGUN, COMSIG_KB_FIREMODE,  COMSIG_MOB_CLICK_RIGHT)) //This unregisters Signals related to guns, its for safety

--- a/code/game/objects/machinery/doors/airlock.dm
+++ b/code/game/objects/machinery/doors/airlock.dm
@@ -442,16 +442,21 @@
 	if(istype(closeOther, /obj/machinery/door/airlock) && !closeOther.density)
 		closeOther.close()
 
-/obj/machinery/door/airlock/close(forced = FALSE)
+/obj/machinery/door/airlock/close(forced = FALSE, autoclosing = FALSE)
 	if(operating || welded || locked)
 		return
 	if(!forced)
 		if(!hasPower() || wires.is_cut(WIRE_BOLTS))
 			return
+	if(is_blocked_turf(get_turf(src), src, TRUE))
+		if(autoclose && autoclosing)
+			addtimer(CALLBACK(src, .proc/autoclose), normalspeed ? 150 + openspeed : 5)
+		return
 	if(safe)
 		for(var/turf/turf AS in locs)
 			if(locate(/mob/living) in turf)
-				addtimer(CALLBACK(src, .proc/close), 6 SECONDS)
+				if(autoclosing)
+					addtimer(CALLBACK(src, .proc/close), 6 SECONDS)
 				return
 
 	for(var/turf/turf in locs)

--- a/code/game/objects/machinery/doors/airlock_types.dm
+++ b/code/game/objects/machinery/doors/airlock_types.dm
@@ -881,7 +881,7 @@
 /obj/machinery/door/airlock/dropship_hatch/ex_act(severity)
 	return
 
-/obj/machinery/door/airlock/dropship_hatch/close(forced=0)
+/obj/machinery/door/airlock/dropship_hatch/close(forced = FALSE, autoclosing = FALSE)
 	if(forced)
 		for(var/mob/living/L in loc)
 			step(L, pick(EAST,WEST)) // bump them off the tile

--- a/code/game/objects/machinery/doors/door.dm
+++ b/code/game/objects/machinery/doors/door.dm
@@ -204,10 +204,14 @@
 	if(autoclose)
 		addtimer(CALLBACK(src, .proc/autoclose), normalspeed ? 150 + openspeed : 5)
 
-/obj/machinery/door/proc/close()
+/obj/machinery/door/proc/close(forced = FALSE, autoclosing = FALSE)
 	if(density)
 		return TRUE
 	if(operating)
+		return FALSE
+	if(is_blocked_turf(get_turf(src), src))
+		if(autoclose && autoclosing)
+			addtimer(CALLBACK(src, .proc/autoclose), normalspeed ? 150 + openspeed : 5)
 		return FALSE
 	operating = TRUE
 
@@ -235,7 +239,7 @@
 
 /obj/machinery/door/proc/autoclose()
 	if(!density && !operating && !locked && !welded && autoclose)
-		close()
+		close(autoclosing = TRUE)
 
 /obj/machinery/door/morgue
 	icon = 'icons/obj/doors/doormorgue.dmi'

--- a/code/game/objects/machinery/doors/firedoor.dm
+++ b/code/game/objects/machinery/doors/firedoor.dm
@@ -259,7 +259,7 @@
 			nextstate = null
 			close()
 
-/obj/machinery/door/firedoor/close()
+/obj/machinery/door/firedoor/close(forced = FALSE, autoclosing = FALSE)
 	latetoggle()
 	return ..()
 

--- a/code/game/objects/machinery/doors/multi_tile.dm
+++ b/code/game/objects/machinery/doors/multi_tile.dm
@@ -2,10 +2,14 @@
 /obj/machinery/door/airlock/multi_tile
 	width = 2
 
-/obj/machinery/door/airlock/multi_tile/close() //Nasty as hell O(n^2) code but unfortunately necessary
+/obj/machinery/door/airlock/multi_tile/close(forced = FALSE, autoclosing = FALSE) //Nasty as hell O(n^2) code but unfortunately necessary
 	for(var/turf/T in locs)
 		for(var/obj/vehicle/multitile/M in T)
 			if(M) return FALSE
+		if(is_blocked_turf(T, src))
+			if(autoclose && autoclosing)
+				addtimer(CALLBACK(src, .proc/autoclose), normalspeed ? 150 + openspeed : 5)
+			return FALSE
 
 	return ..()
 
@@ -375,7 +379,7 @@
 	. = ..()
 	update_filler_turfs()
 
-/obj/machinery/door/airlock/multi_tile/mainship/close()
+/obj/machinery/door/airlock/multi_tile/mainship/close(forced = FALSE, autoclosing = FALSE)
 	. = ..()
 	update_filler_turfs()
 
@@ -399,7 +403,7 @@
 /obj/machinery/door/airlock/multi_tile/mainship/dropshiprear/ex_act(severity)
 	return
 
-/obj/machinery/door/airlock/multi_tile/mainship/dropshiprear/close(forced=0)
+/obj/machinery/door/airlock/multi_tile/mainship/dropshiprear/close(forced = FALSE, autoclosing = FALSE)
 	if(forced)
 		for(var/turf/T in get_filler_turfs())
 			for(var/mob/living/L in T)

--- a/code/game/objects/machinery/doors/poddoor.dm
+++ b/code/game/objects/machinery/doors/poddoor.dm
@@ -28,7 +28,7 @@
 	if(anchored && current_turf && density)
 		current_turf.flags_atom &= ~AI_BLOCKED
 
-/obj/machinery/door/poddoor/close()
+/obj/machinery/door/poddoor/close(forced = FALSE, autoclosing = FALSE)
 	. = ..()
 	var/turf/current_turf = get_turf(src)
 	if(anchored && current_turf && density)

--- a/code/game/objects/machinery/doors/railing.dm
+++ b/code/game/objects/machinery/doors/railing.dm
@@ -78,7 +78,7 @@
 	if(current_turf)
 		current_turf.flags_atom &= ~AI_BLOCKED
 
-/obj/machinery/door/poddoor/railing/close()
+/obj/machinery/door/poddoor/railing/close(forced = FALSE, autoclosing = FALSE)
 	if (!SSticker || operating || density)
 		return FALSE
 

--- a/code/game/objects/machinery/doors/shutters.dm
+++ b/code/game/objects/machinery/doors/shutters.dm
@@ -37,7 +37,7 @@
 	if(autoclose)
 		addtimer(CALLBACK(src, .proc/autoclose), 150)
 
-/obj/machinery/door/poddoor/shutters/close()
+/obj/machinery/door/poddoor/shutters/close(forced = FALSE, autoclosing = FALSE)
 	if(operating)
 		return
 	operating = TRUE

--- a/code/game/objects/machinery/doors/windowdoor.dm
+++ b/code/game/objects/machinery/doors/windowdoor.dm
@@ -112,7 +112,7 @@
 	return TRUE
 
 
-/obj/machinery/door/window/close(forced = DOOR_NOT_FORCED)
+/obj/machinery/door/window/close(forced = FALSE, autoclosing = FALSE)
 	if(operating)
 		return FALSE
 	switch(forced)

--- a/code/modules/mining/remote_fob/remote_fob_actions_misc.dm
+++ b/code/modules/mining/remote_fob/remote_fob_actions_misc.dm
@@ -152,8 +152,30 @@
 			else
 				to_chat(owner, span_warning("No space here for a sentry."))
 				return
+	for(var/obj/machinery/deployable/mounted/sentry/sentry AS in GLOB.marine_turrets)
+		var/turf/sentry_turf = get_turf(sentry)
+		if(!sentry_turf) //Sentry has some issue that got it nullspaced, ignore.
+			continue
+		if(!buildplace)
+			return
+		if(buildplace.z != sentry_turf.z)	//get_dist works across zs and could scuff things if it checked shipside turrets too.
+			continue
+		if(get_dist(buildplace, sentry_turf) < MARINE_MIN_TURRET_DISTANCE)
+			to_chat(owner, span_warning("Too close to other sentries, minimum distance is [MARINE_MIN_TURRET_DISTANCE]."))
+			return
 	if(!do_after(fobdrone, 3 SECONDS, FALSE, buildplace, BUSY_ICON_BUILD))
 		return
+	for(var/obj/machinery/deployable/mounted/sentry/sentry AS in GLOB.marine_turrets)
+		var/turf/sentry_turf = get_turf(sentry)
+		if(!sentry_turf) //Sentry has some issue that got it nullspaced, ignore.
+			continue
+		if(!buildplace)
+			return
+		if(buildplace.z != sentry_turf.z)	//get_dist works across zs and could scuff things if it checked shipside turrets too.
+			continue
+		if(get_dist(buildplace, sentry_turf) < MARINE_MIN_TURRET_DISTANCE)
+			to_chat(owner, span_warning("Too close to other sentries, minimum distance is [MARINE_MIN_TURRET_DISTANCE]."))
+			return
 	console.sentry_remaining -= 1
 	var/obj/item/weapon/gun/sentry/big_sentry/premade/new_gun = new(buildplace)
 	new_gun.loc.setDir(fobdrone.dir)

--- a/code/modules/mining/remote_fob/remote_fob_actions_misc.dm
+++ b/code/modules/mining/remote_fob/remote_fob_actions_misc.dm
@@ -161,7 +161,7 @@
 		if(buildplace.z != sentry_turf.z)	//get_dist works across zs and could scuff things if it checked shipside turrets too.
 			continue
 		if(get_dist(buildplace, sentry_turf) < MARINE_MIN_TURRET_DISTANCE)
-			to_chat(owner, span_warning("Too close to other sentries, minimum distance is [MARINE_MIN_TURRET_DISTANCE]."))
+			to_chat(owner, span_warning("This location is too close to other sentries, minimum distance is [MARINE_MIN_TURRET_DISTANCE]."))
 			return
 	if(!do_after(fobdrone, 3 SECONDS, FALSE, buildplace, BUSY_ICON_BUILD))
 		return
@@ -174,7 +174,7 @@
 		if(buildplace.z != sentry_turf.z)	//get_dist works across zs and could scuff things if it checked shipside turrets too.
 			continue
 		if(get_dist(buildplace, sentry_turf) < MARINE_MIN_TURRET_DISTANCE)
-			to_chat(owner, span_warning("Too close to other sentries, minimum distance is [MARINE_MIN_TURRET_DISTANCE]."))
+			to_chat(owner, span_warning("This location is too close to other sentries, minimum distance is [MARINE_MIN_TURRET_DISTANCE]."))
 			return
 	console.sentry_remaining -= 1
 	var/obj/item/weapon/gun/sentry/big_sentry/premade/new_gun = new(buildplace)

--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -178,7 +178,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 		return FALSE
 
 	for(var/obj/structure/xeno/xeno_turret/turret AS in GLOB.xeno_resin_turrets)
-		if(get_dist(turret, buyer) < 6)
+		if(get_dist(turret, buyer) < XENO_MIN_TURRET_DISTANCE)
 			if(!silent)
 				to_chat(buyer, span_xenowarning("Another turret is too close!"))
 			return FALSE

--- a/code/modules/projectiles/guns/sentries.dm
+++ b/code/modules/projectiles/guns/sentries.dm
@@ -84,7 +84,7 @@
 /obj/item/weapon/gun/sentry/big_sentry/dropship
 	ammo_datum_type = /datum/ammo/bullet/turret/gauss
 	sentry_iff_signal = TGMC_LOYALIST_IFF
-	flags_item = IS_DEPLOYABLE|TWOHANDED|DEPLOY_ON_INITIALIZE
+	flags_item = IS_DEPLOYABLE|TWOHANDED|DEPLOY_ON_INITIALIZE|DEPLOYED_NO_PICKUP
 	var/obj/structure/dropship_equipment/sentry_holder/deployment_system
 	turret_flags = TURRET_HAS_CAMERA|TURRET_IMMOBILE
 	density = FALSE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Addresses issues discussed in #10152 in a better way than that PR which had a major oversight causing some less than wanted behavior.

Firstly, doors no longer close when dense objects are located on their tile. For mobs, it still varies depending on if the safeties are on or off, although this is not the case for dense objects (The alternative would be to just crush any solid object on their tile when closing which while funny may be annoying to deal with if it happens accidentally, and not more effective than this version).
Additionally, to combat tad turretbussing and simillar methods, aswell as taking into account xenomorph turrets already having a minimum distance to avoid pretty much what marine turret stacking achieves, marine turrets now have a minimum deploy distance they require from eachother simillar to xeno turrets, although theirs is lower (marine turret: 4 tiles for now, xeno turret: 6 as before). Anything lower would be too low to effectively combat the problem and I did not want to make it any higher than neccessary, though 5 was on my mind before. We'll see how it goes with 4 for now.. Regardless, this should be a sweet spot that should not interfere with using sentries in their intended way (usually one covering a given area to alert marines and deter weaker xenos), whilst preventing stacking a bunch of turrets together. This affects normal sentries aswell as build-a-sentries, although not other deployables like deployable MG nests or other things of that kind. Note, you can still run the tad with turrets, but will be limited to less coverage than before.

Also once again adds the improvement to sentry deployment because that was the one part in the PR that wasn't broken but got reverted anyways.

Edit:
Thanks to someone talking about this and me not having seen the related issue before, this also fixes sentries being undeployable from dropship attachments. As there was no proper handling for this in the attachment point, I assume this to have been a bug. Fixes #9431 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The era of the tad turret bus has been long enough. This should reduce the sheer oppressiveness of it as a mobile turret platform aswell as other situations with major sentry stacking, while keeping their general purpose aswell as options in place.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Once again makes sentries less likely to bypass their turf placement conditions since it got reverted.
balance: Doors no longer close when a dense object is blocking them.
balance: Marine turrets have a minimum placement distance of four tiles, akin to xenomorph turrets, for which it is six.
fix: Dropship attachment sentries are unremovably affixed to them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
