### PR TITLE
Fixes attachments not spawning with their own attachments

### DIFF
--- a/code/datums/components/attachment_handler.dm
+++ b/code/datums/components/attachment_handler.dm
@@ -34,7 +34,7 @@
 	var/obj/parent_object = parent
 	if(length(starting_attachments) && parent_object.loc) //Attaches starting attachments if the object is not instantiated in nullspace. If it is created in null space, such as in a loadout vendor. It wont create default attachments.
 		for(var/starting_attachment_type in starting_attachments)
-			attach_without_user(attachment = new starting_attachment_type())
+			attach_without_user(attachment = new starting_attachment_type(parent_object))
 
 	update_parent_overlay()
 


### PR DESCRIPTION
## About The Pull Request
Guns spawn their attachments into nullspace. If a gun spawns into nullspace, it doesn't generate attachments. So, make them spawn their attachments inside the gun instead.
Closes #10135 

## Why It's Good For The Game
Bugfix

## Changelog
:cl:
fix: Default attachments which have their own attachments (miniflamer's the most common you'd notice) now spawn those attachments correctly
/:cl: