### PR TITLE
Remove sentry kit near FOB drone and additional map stuff

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -10308,13 +10308,6 @@
 	dir = 4
 	},
 /area/mainship/medical/lower_medical)
-"He" = (
-/obj/structure/rack,
-/obj/item/storage/box/sentry,
-/turf/open/floor/mainship/red{
-	dir = 8
-	},
-/area/mainship/living/briefing)
 "Hf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -24328,7 +24321,7 @@ Dn
 Cg
 Np
 Gn
-He
+Gn
 HU
 tt
 Jx

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -783,9 +783,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "cx" = (
-/obj/machinery/vending/armor_supply,
+/obj/machinery/vending/weapon,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/squads/req)
 "cy" = (
 /turf/closed/wall/mainship/research/containment/wall/corner{
 	dir = 4
@@ -827,15 +827,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"cD" = (
-/obj/machinery/loadout_vendor,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "cE" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -1138,21 +1129,11 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/hangar/droppod)
 "ds" = (
-/obj/structure/table/mainship,
-/obj/item/tool/screwdriver,
-/obj/item/tool/screwdriver,
-/obj/item/tool/screwdriver,
-/obj/item/tool/crowbar,
-/obj/item/tool/crowbar,
-/obj/item/tool/crowbar,
-/obj/item/tool/hand_labeler,
-/obj/item/tool/hand_labeler,
-/obj/item/tool/hand_labeler,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/mainship/black{
-	dir = 5
+	dir = 1
 	},
 /area/mainship/squads/general)
 "dt" = (
@@ -1571,12 +1552,10 @@
 	},
 /area/mainship/medical/lower_medical)
 "eI" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/black{
 	dir = 8
 	},
@@ -2143,9 +2122,9 @@
 	},
 /area/mainship/medical/lower_medical)
 "gx" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/mainship/cargo,
-/area/mainship/squads/general)
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "gy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -2475,9 +2454,18 @@
 	},
 /area/mainship/medical/medical_science)
 "hC" = (
-/obj/machinery/vending/uniform_supply,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/shipboard/firing_range)
 "hD" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -2567,6 +2555,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "hP" = (
@@ -3128,8 +3117,11 @@
 	},
 /area/mainship/squads/req)
 "jA" = (
-/turf/open/floor/mainship/mono,
-/area/mainship/command/corporateliaison)
+/obj/structure/cable,
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/mainship/shipboard/firing_range)
 "jB" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
@@ -3558,11 +3550,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "kL" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/mainship/cargo,
-/area/mainship/squads/general)
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "kM" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
@@ -4211,11 +4205,10 @@
 /turf/open/floor/mainship/white,
 /area/mainship/living/pilotbunks)
 "mE" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/mainship/black{
+	dir = 8
 	},
-/obj/structure/window/reinforced,
-/turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
 "mF" = (
 /obj/structure/table/mainship,
@@ -4397,6 +4390,7 @@
 	dir = 1
 	},
 /obj/effect/decal/warning_stripes/box/small,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/black{
 	dir = 10
 	},
@@ -4451,7 +4445,6 @@
 /obj/machinery/door/airlock/multi_tile/mainship/marine/general{
 	dir = 2
 	},
-/obj/structure/cable,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "nr" = (
@@ -4767,18 +4760,15 @@
 /turf/open/floor/wood,
 /area/mainship/medical/medical_science)
 "ol" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/shipboard/firing_range)
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/structure/table/reinforced,
+/turf/open/floor/mainship/black,
+/area/mainship/squads/general)
 "om" = (
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
 	dir = 8
@@ -4832,10 +4822,18 @@
 /turf/open/floor/cult,
 /area/medical/morgue)
 "ot" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/black,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/structure/table/reinforced,
+/turf/open/floor/mainship/black{
+	dir = 10
+	},
 /area/mainship/squads/general)
 "ou" = (
 /turf/closed/wall/mainship/research/containment/wall/north,
@@ -4868,6 +4866,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/black{
 	dir = 9
 	},
@@ -5039,9 +5038,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "pb" = (
-/obj/machinery/vending/uniform_supply,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/obj/machinery/loadout_vendor,
+/turf/open/floor/mainship/black{
+	dir = 9
+	},
+/area/mainship/squads/general)
 "pc" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
@@ -5326,7 +5327,15 @@
 	},
 /area/mainship/squads/general)
 "qb" = (
-/obj/structure/cable,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/facepaint/green,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/item/tool/hand_labeler,
+/obj/structure/table/reinforced,
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
 "qd" = (
@@ -5591,6 +5600,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/red{
 	dir = 1
 	},
@@ -5771,17 +5781,11 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/hallways/starboard_hallway)
 "rC" = (
-/obj/structure/cable,
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 8
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/mainship/black{
+	dir = 9
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/blackgeneric{
-	name = "\improper Firing Range Airlock"
-	},
-/turf/open/floor/mainship/red{
-	dir = 8
-	},
-/area/mainship/shipboard/firing_range)
+/area/mainship/squads/general)
 "rE" = (
 /obj/item/radio/intercom/general{
 	dir = 1
@@ -6032,15 +6036,11 @@
 	},
 /area/mainship/squads/general)
 "su" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
+/obj/structure/cable,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "sv" = (
 /obj/structure/bed/chair/comfy/black{
@@ -6341,6 +6341,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "ts" = (
@@ -6794,9 +6795,8 @@
 /turf/open/floor/wood,
 /area/mainship/living/pilotbunks)
 "uO" = (
-/obj/structure/cable,
 /turf/open/floor/mainship/black{
-	dir = 10
+	dir = 1
 	},
 /area/mainship/squads/general)
 "uP" = (
@@ -7398,6 +7398,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
 "wF" = (
+/obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/black{
 	dir = 1
 	},
@@ -9003,8 +9004,13 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/starboard_umbilical)
 "Bk" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
+/obj/machinery/loadout_vendor,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
 /area/mainship/squads/general)
 "Bl" = (
 /obj/structure/cable,
@@ -9491,11 +9497,10 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "CO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/loadout_vendor,
+/turf/open/floor/mainship/black{
+	dir = 10
 	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "CQ" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -10906,8 +10911,9 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/black{
-	dir = 9
+	dir = 5
 	},
 /area/mainship/squads/general)
 "GP" = (
@@ -11870,7 +11876,6 @@
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "Jn" = (
-/obj/structure/cable,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
 	},
@@ -12125,9 +12130,14 @@
 /turf/open/floor/cult,
 /area/medical/morgue)
 "JN" = (
-/obj/machinery/vending/MarineMed,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/obj/machinery/loadout_vendor,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/black{
+	dir = 9
+	},
+/area/mainship/squads/general)
 "JO" = (
 /obj/machinery/power/apc{
 	dir = 8
@@ -12509,7 +12519,6 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
-/obj/machinery/vending/weapon,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "KH" = (
@@ -12816,6 +12825,7 @@
 	dir = 1
 	},
 /obj/effect/decal/warning_stripes/box/small,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/black{
 	dir = 8
 	},
@@ -12936,8 +12946,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor/mainship/black{
-	dir = 1
+	dir = 9
 	},
 /area/mainship/squads/general)
 "LR" = (
@@ -13141,11 +13153,11 @@
 	},
 /area/mainship/shipboard/firing_range)
 "Mz" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/red{
-	dir = 8
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/area/mainship/shipboard/firing_range)
+/turf/open/floor/mainship/cargo,
+/area/mainship/squads/general)
 "MA" = (
 /obj/machinery/door/firedoor/mainship,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -13430,10 +13442,10 @@
 	},
 /area/mainship/squads/general)
 "Nr" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/black{
 	dir = 1
 	},
@@ -13810,6 +13822,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor/mainship/black{
 	dir = 5
 	},
@@ -14278,9 +14292,11 @@
 /area/mainship/shipboard/firing_range)
 "PG" = (
 /obj/item/trash/cigbutt,
-/turf/open/floor/mainship/black{
-	dir = 5
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
 "PH" = (
 /obj/machinery/telecomms/processor/preset_three,
@@ -14413,8 +14429,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/rack,
-/obj/item/storage/box/sentry,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Qe" = (
@@ -14465,11 +14479,9 @@
 /turf/open/floor/mainship/green/full,
 /area/mainship/squads/req)
 "Qj" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/black{
 	dir = 6
 	},
@@ -14486,6 +14498,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/mainship,
+/obj/structure/cable,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "Qm" = (
@@ -14551,6 +14564,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/black{
 	dir = 1
 	},
@@ -15076,7 +15090,6 @@
 /area/medical/morgue)
 "RZ" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
-/obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "Sa" = (
@@ -15177,8 +15190,10 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
+/obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor/mainship/black{
-	dir = 8
+	dir = 4
 	},
 /area/mainship/squads/general)
 "Sv" = (
@@ -15376,9 +15391,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/mainship/black/corner{
-	dir = 1
-	},
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "SY" = (
 /obj/structure/table/mainship,
@@ -15489,9 +15502,9 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
 "Tq" = (
-/obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/black{
-	dir = 6
+	dir = 8
 	},
 /area/mainship/squads/general)
 "Tr" = (
@@ -16125,11 +16138,8 @@
 /turf/open/floor/mainship,
 /area/mainship/living/cryo_cells)
 "Vg" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/mainship/cargo,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/ntlogo/nt3,
 /area/mainship/squads/general)
 "Vh" = (
 /obj/structure/cable,
@@ -16141,6 +16151,7 @@
 "Vi" = (
 /obj/structure/rack,
 /obj/item/pizzabox/meat,
+/obj/item/facepaint/green,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Vj" = (
@@ -16236,6 +16247,7 @@
 	dir = 9
 	},
 /obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
 "Vw" = (
@@ -16365,10 +16377,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/mainship/living/chapel)
-"VO" = (
-/obj/machinery/vending/weapon,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
 "VP" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/black{
@@ -16411,11 +16419,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"VV" = (
-/obj/effect/ai_node,
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
 "VW" = (
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
@@ -16776,13 +16779,11 @@
 /turf/closed/wall/mainship,
 /area/mainship/engineering/lower_engine_monitoring)
 "WY" = (
-/obj/machinery/loadout_vendor,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/mainship/black{
-	dir = 9
-	},
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
 "WZ" = (
 /obj/structure/lattice,
@@ -16908,6 +16909,7 @@
 	pixel_x = -8;
 	pixel_y = 3
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/black{
 	dir = 8
 	},
@@ -17027,21 +17029,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
-"XH" = (
-/obj/structure/table/mainship,
-/obj/item/tool/screwdriver,
-/obj/item/tool/screwdriver,
-/obj/item/tool/screwdriver,
-/obj/item/tool/crowbar,
-/obj/item/tool/crowbar,
-/obj/item/tool/crowbar,
-/obj/item/tool/hand_labeler,
-/obj/item/tool/hand_labeler,
-/obj/item/tool/hand_labeler,
-/turf/open/floor/mainship/black{
-	dir = 9
-	},
-/area/mainship/squads/general)
 "XI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -17150,12 +17137,6 @@
 /obj/effect/landmark/start/latejoin,
 /turf/open/floor/mainship,
 /area/mainship/living/cryo_cells)
-"XW" = (
-/obj/machinery/holopad,
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "XX" = (
 /turf/open/floor/cult,
 /area/medical/morgue)
@@ -17441,6 +17422,9 @@
 /area/medical/morgue)
 "YN" = (
 /obj/effect/ai_node,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "YP" = (
@@ -17648,10 +17632,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "Zu" = (
-/obj/machinery/loadout_vendor,
-/turf/open/floor/mainship/black{
-	dir = 10
+/obj/structure/window/reinforced{
+	dir = 1
 	},
+/obj/structure/window/reinforced,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
 "Zv" = (
 /obj/structure/cable,
@@ -17748,7 +17733,6 @@
 /turf/open/floor/mainship,
 /area/mainship/living/cafeteria_starboard)
 "ZH" = (
-/obj/machinery/vending/armor_supply,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -41891,7 +41875,7 @@ pA
 lj
 uM
 Yw
-jA
+jB
 pv
 ks
 dZ
@@ -42153,8 +42137,8 @@ Jg
 mn
 mY
 uM
-jA
-jA
+jB
+jB
 Kb
 Kb
 Kb
@@ -42406,8 +42390,8 @@ lj
 uM
 Yw
 jE
-jA
-jA
+jB
+jB
 mL
 uM
 lQ
@@ -42662,8 +42646,8 @@ pd
 lj
 uM
 lk
-jA
-jA
+jB
+jB
 tE
 pT
 oN
@@ -50612,14 +50596,14 @@ qG
 Ry
 kM
 Kp
-kM
+cx
 tr
-kM
+gx
 hO
 Vi
-pb
+kM
 ZH
-JN
+kM
 KG
 JP
 NP
@@ -51650,8 +51634,8 @@ Iw
 jy
 VX
 jy
-Xs
-VV
+kL
+jy
 jy
 FJ
 jy
@@ -51906,14 +51890,14 @@ Al
 Us
 NU
 NU
-PR
+qC
 Ql
 nq
-PR
 qC
-cx
-VO
-hC
+qC
+qC
+qC
+qC
 qC
 Fg
 DC
@@ -52163,14 +52147,14 @@ Uz
 RJ
 Kk
 NU
-XH
+BY
 eI
-uO
-YY
-qC
-qC
-qC
-qC
+IX
+pb
+Bk
+CO
+JN
+CO
 qC
 nm
 iE
@@ -52179,9 +52163,9 @@ SM
 nZ
 qC
 Iu
-Bk
+Wz
 jl
-CO
+CF
 LF
 qC
 nm
@@ -52422,12 +52406,12 @@ SY
 NZ
 ds
 su
-Tq
+MC
 PG
-cD
-Zu
 WY
 Zu
+WY
+Mz
 qC
 fg
 WL
@@ -52674,17 +52658,17 @@ CK
 CK
 qV
 IG
-hW
+hC
 pH
 jQ
 GN
 Su
-uO
-BY
-gx
-mE
-Vg
-kL
+PW
+PP
+nE
+PW
+PP
+tQ
 hJ
 qC
 Vb
@@ -52931,17 +52915,17 @@ Pv
 CK
 qV
 IG
-ol
+hW
 Te
 Te
 LQ
-jl
+mE
 ot
-jl
-jl
-MC
-wF
-xn
+rC
+YY
+IX
+BY
+Tq
 Ku
 BY
 Gh
@@ -53191,12 +53175,12 @@ IG
 hW
 Tx
 NZ
-LQ
+Nr
 RZ
-qb
-QN
+MC
+uO
 jl
-xn
+jl
 SX
 Ss
 xn
@@ -53449,7 +53433,7 @@ hW
 nW
 NU
 Qt
-jl
+Uv
 qb
 wF
 jl
@@ -53705,10 +53689,10 @@ IG
 hW
 ZK
 NZ
-LQ
-Uv
-qb
-QN
+Nr
+jl
+MC
+uO
 jl
 Pl
 KZ
@@ -53960,12 +53944,12 @@ PF
 NU
 hw
 Jn
-Mz
-rC
+pH
+jQ
 Nr
-ob
-qb
-jl
+Uv
+ol
+wF
 jl
 jU
 KP
@@ -54217,8 +54201,8 @@ iQ
 qz
 qY
 Vv
-Te
-Te
+jA
+jA
 Ol
 nE
 Qj
@@ -54226,8 +54210,8 @@ PP
 nE
 PW
 PP
-XW
-Bw
+Nz
+PW
 PP
 Ob
 nE
@@ -55254,7 +55238,7 @@ Ec
 Pc
 qC
 Pt
-xi
+Vg
 jU
 Ta
 wi

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -8893,10 +8893,13 @@
 /turf/closed/wall/mainship/gray,
 /area/sulaco/hangar/storage)
 "aTt" = (
-/obj/structure/rack,
-/obj/item/storage/box/sentry,
+/obj/effect/decal/warning_stripes/engineer,
+/obj/effect/decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/box/small,
 /turf/open/floor/prison,
-/area/sulaco/hangar/storage)
+/area/sulaco/hallway/lower_main_hall)
 "aTw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -56679,7 +56682,7 @@ jtC
 aGy
 aWG
 xKR
-aWG
+aTt
 pIP
 fVo
 xzB
@@ -65667,7 +65670,7 @@ aPF
 aPF
 aPF
 kOr
-aTt
+pWS
 pWS
 sFd
 pWS

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -8159,8 +8159,6 @@
 /turf/open/floor/mainship/blue,
 /area/mainship/squads/delta)
 "cdi" = (
-/obj/item/storage/box/sentry,
-/obj/structure/rack,
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/repair_bay)
@@ -19675,13 +19673,6 @@
 	},
 /area/mainship/medical/lower_medical)
 "wAa" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/metal/large_stack,
-/obj/item/stack/sheet/metal/large_stack,
-/obj/item/stack/sheet/metal/large_stack,
-/obj/item/stack/sheet/metal/large_stack,
-/obj/item/stack/sheet/plasteel/medium_stack,
-/obj/item/stack/sheet/plasteel/medium_stack,
 /obj/structure/window/reinforced{
 	dir = 8
 	},

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -975,7 +975,7 @@
 	products = list(
 		/obj/structure/closet/crate/mortar_ammo/mortar_kit = 1,
 		/obj/structure/closet/crate/mortar_ammo/howitzer_kit = 1,
-		/obj/item/storage/box/sentry = 3,
+		/obj/item/storage/box/sentry = 4,
 		/obj/item/storage/box/tl102 = 1,
 		/obj/structure/largecrate/supply/weapons/standard_atgun = 1,
 		/obj/item/weapon/gun/heavymachinegun = 1,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

All sentries shall spawn inside TerraGovTech Engineer System Vendor; to do that, I remove the sentry kit near FOB drone and just add an additional sentry kit in the TerraGovTech Engineer System Vendor.

![image](https://user-images.githubusercontent.com/6610922/167684489-15aed651-b5f2-4d92-8400-641be8f155c7.png)

Made some PoS' prep QoL by adding green facepaint near vendors since people would want to use it for coloring.
![image](https://user-images.githubusercontent.com/6610922/167684781-803d0425-7e8d-45b1-8768-c6e4a2d6b011.png)


Remove 5 stacks of metal and 3 stacks of  plasteel near Theseus' FOB drone.
![image](https://user-images.githubusercontent.com/6610922/167684650-f910f48f-9a37-4afa-8a82-968b5c0eb7ba.png)


Remove extra crowbars and screwdrivers in all prep if needed since we don't need it to dissemable Jaegar.
![image](https://user-images.githubusercontent.com/6610922/167684609-6cad6b75-873e-488b-b874-24d0c0f148bd.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The sentry kit next to FOB drone is a relic of an old time, so it makes senes to consolidate all the sentry kits into one place.

PoS' prep got an additional change since I saw Minerva has green facepaint for marines to use and PoS has none, so I added that. Also, deleted the vendors that lurk outside of prep to fit the ship's aesthetics.

The Theseus' metal and plasteel surplus is a surprise. Since no one delete the metal and plasteel when contributor let metal and plasteel spawn inside FOB drone, this makes Theseus spawn with more supplies. Most interesting.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: additional sentry kit in the TerraGovTech Engineer System Vendor; now engineers can acquire all four sentry kits in the vendor
del: sentry kit near FOB drone
add: green facepaint in PoS' prep
del: Theseus' metal and plasteel surplus near FOB drone
del: extra crowbars and screwdrivers in all prep if needed since we don't need it to dissemable Jaegar
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
