### PR TITLE
Makes broken lungs worse than bruised ones

### DIFF
--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -210,14 +210,14 @@
 			owner.drip(10)
 		if(prob(15))
 			owner.emote("me", 1, "gasps for air!")
-			owner.Losebreath(10)
+			owner.Losebreath(4)
 	else if(is_broken())
 		if(prob(30))
 			owner.emote("me", 1, "coughs up blood!")
 			owner.drip(10)
 		if(prob(50))
 			owner.emote("me", 1, "gasps for air!")
-			owner.Losebreath(4)
+			owner.Losebreath(10)
 
 /datum/internal_organ/lungs/prosthetic
 	robotic = ORGAN_ROBOT


### PR DESCRIPTION
## About The Pull Request
Apparently bruised lungs just caused way more losebreath than broken lungs and will just kill you if you don't have exceptional luck. Reverses that.

## Why It's Good For The Game
worse wounds are worse than less worse wounds

## Changelog
:cl:
fix: Broken lungs are worse than bruised lungs now.
/:cl: