### PR TITLE
Fixes bleeding prosthetics

### DIFF
--- a/code/game/objects/items/tools/soldering_tool.dm
+++ b/code/game/objects/items/tools/soldering_tool.dm
@@ -13,7 +13,7 @@
 	if(!affecting)
 		return TRUE
 
-	if(affecting.limb_status != LIMB_ROBOT)
+	if(!CHECK_BITFIELD(affecting.limb_status, LIMB_ROBOT))
 		balloon_alert(user, "Limb not robotic")
 		return TRUE
 

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -251,7 +251,7 @@
 
 
 	//Sync the organ's damage with its wounds
-	update_damages()
+	update_bleeding()
 
 	//If limb took enough damage, try to cut or tear it off
 
@@ -283,7 +283,7 @@
 	burn_dam = max(0, burn_dam - burn)
 
 	//Sync the organ's damage with its wounds
-	update_damages()
+	update_bleeding()
 	if(updating_health)
 		owner.updatehealth()
 
@@ -526,12 +526,12 @@ Note that amputating the affected organ does in fact remove the infection from t
 			W.process()
 
 	// sync the organ's bleeding-ness and icon
-	update_damages()
+	update_bleeding()
 	if (update_icon())
 		owner.UpdateDamageIcon(1)
 
 //Updates BLEEDING status.
-/datum/limb/proc/update_damages()
+/datum/limb/proc/update_bleeding()
 	if(limb_status & LIMB_ROBOT || owner.species.species_flags & NO_BLOOD)
 		return
 	var/is_bleeding = FALSE
@@ -689,7 +689,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	brute_dam = 0
 	burn_dam = 0
 	limb_wound_status = NONE
-	update_damages()
+	update_bleeding()
 
 	//we reset the surgery related variables
 	reset_limb_surgeries()

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -532,15 +532,14 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 //Updates BLEEDING status.
 /datum/limb/proc/update_damages()
+	if(limb_status & LIMB_ROBOT || owner.species.species_flags & NO_BLOOD)
+		return
 	var/is_bleeding = FALSE
-	var/mob/living/carbon/human/H
-	if(istype(owner,/mob/living/carbon/human))
-		H = owner
 
 	if(brute_dam > 5 && !(limb_wound_status & LIMB_WOUND_BANDAGED))
 		is_bleeding = TRUE
 
-	if(surgery_open_stage && !(limb_wound_status & LIMB_WOUND_CLAMPED) && (H && !(H.species.species_flags & NO_BLOOD)))	//things tend to bleed if they are CUT OPEN
+	if(surgery_open_stage && !(limb_wound_status & LIMB_WOUND_CLAMPED))	//things tend to bleed if they are CUT OPEN
 		is_bleeding = TRUE
 
 	if(is_bleeding)

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -248,6 +248,7 @@
 	affected.surgery_open_stage = 0
 	affected.germ_level = 0
 	affected.remove_limb_flags(LIMB_BLEEDING)
+	DISABLE_BITFIELD(affected.limb_wound_status, LIMB_WOUND_CLAMPED) //Once the incision is closed, any clamping we did doesn't matter
 
 /datum/surgery_step/generic/cauterize/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, leaving a small burn on [target]'s [affected.display_name] with \the [tool]!"), \


### PR DESCRIPTION
## About The Pull Request
Missed adjusting a bit of bleeding code during the wounds removal, oops.
Closes #10178 , which was a combination of this bug and soldering code not checking a bitflag correctly.
Also removes wound clamping on surgery finish, since otherwise that hung around forever.

## Why It's Good For The Game
bugfix

## Changelog
:cl:
fix: Robotic limbs are firmly incapable of bleeding.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
