### PR TITLE
Harvester fixes and qol

### DIFF
--- a/code/datums/components/harvester.dm
+++ b/code/datums/components/harvester.dm
@@ -1,9 +1,9 @@
-#define MAX_LOADABLE_REAGENT_AMOUNT 60
+#define MAX_LOADABLE_REAGENT_AMOUNT 30
 #define NO_REAGENT_COLOR "#FFFFFF"
 
 /datum/component/harvester
 	///reagent selected for actions
-	var/selected_reagent
+	var/datum/reagent/selected_reagent
 	///Loaded reagent
 	var/datum/reagent/loaded_reagent
 	///List of loadable reagents
@@ -22,7 +22,6 @@
 		return COMPONENT_INCOMPATIBLE
 
 	reagent_select_action = new
-
 	var/obj/item/item_parent = parent
 	item_parent.actions += reagent_select_action
 
@@ -69,32 +68,32 @@
 		return
 
 	if(!isreagentcontainer(cont) || istype(cont, /obj/item/reagent_containers/pill))
-		to_chat(user, span_rose("[cont] isn't compatible with [source]."))
+		user.balloon_alert(user, "[cont]: not compatible with [source].")
 		return
 
 	var/obj/item/reagent_containers/container = cont
 
 	if(!container.reagents.total_volume)
-		to_chat(user, span_rose("Empty container."))
+		user.balloon_alert(user, "[cont.name]: empty...")
 		return
 
 	if(length(container.reagents.reagent_list) > 1)
-		to_chat(user, span_rose("The solution needs to contain only a single type of reagent."))
+		user.balloon_alert(user, "Solution can contain only a single reagent.")
 		return
 
 	var/datum/reagent/reagent_to_load = container.reagents.reagent_list[1].type
+	var/reagent_name = initial(reagent_to_load.name)
 
 	if(!loadable_reagents[reagent_to_load])
-		to_chat(user, span_rose("Incompatible reagent. Check the reagents list for which you can use."))
+		user.balloon_alert(user, "[reagent_name]: incompatible reagent. Check weapon description.")
 		return
 
 	if(loaded_reagents[reagent_to_load] > MAX_LOADABLE_REAGENT_AMOUNT)
-		to_chat(user, span_rose("[reagent_to_load] storage is full."))
+		user.balloon_alert(user, "[reagent_name]: full")
 		return
 
-	to_chat(user, span_notice("You begin filling up [source] with [reagent_to_load]."))
+	user.balloon_alert(user, "[reagent_name]: filling up...")
 	if(!do_after(user, 1 SECONDS, TRUE, source, BUSY_ICON_BAR, null, PROGRESS_BRASS))
-		to_chat(user, span_rose("Reservoir for [reagent_to_load] is full."))
 		return
 
 	if(!loaded_reagents[reagent_to_load])
@@ -103,24 +102,27 @@
 	var/added_amount = min(container.reagents.total_volume, MAX_LOADABLE_REAGENT_AMOUNT - loaded_reagents[reagent_to_load])
 	container.reagents.remove_reagent(reagent_to_load, added_amount)
 	loaded_reagents[reagent_to_load] += added_amount
-	to_chat(user, span_rose("You load [added_amount]u. It now holds [loaded_reagents[reagent_to_load]]u."))
+	user.balloon_alert(user, "[reagent_name]: [loaded_reagents[reagent_to_load]]u.")
 	if(length(loaded_reagents) == 1)
 		update_selected_reagent(reagent_to_load)
 
 ///Handles behavior when activating the weapon
 /datum/component/harvester/proc/activate_blade_async(datum/source, mob/user)
+	var/obj/item/item_parent = parent
+	var/reagent_name = initial(selected_reagent.name)
+
 	if(loaded_reagent)
-		to_chat(user, span_rose("The blade is powered with [initial(loaded_reagent.name)]. Stab a creature to release the substance."))
+		user.balloon_alert(user, "powered with [initial(loaded_reagent.name)]")
 		return
 
 	if(!selected_reagent)
-		to_chat(user, span_rose("Select a reagent."))
+		user.balloon_alert(user, "Select a reagent.")
 		return
 
 	var/use_amount = loadable_reagents[selected_reagent]
 
 	if(loaded_reagents[selected_reagent] < use_amount)
-		to_chat(user, span_rose("Not enough substance."))
+		user.balloon_alert(user, "[reagent_name]: not enough")
 		return
 
 	if(user.do_actions)
@@ -135,6 +137,7 @@
 	loaded_reagents[selected_reagent] -= use_amount
 	if(!loaded_reagents[selected_reagent])
 		loaded_reagents -= selected_reagent
+	user.balloon_alert(user, "powered with [reagent_name]")
 
 ///Handles behavior when attacking a mob
 /datum/component/harvester/proc/attack_async(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
@@ -189,7 +192,7 @@
 
 	if(!loaded_reagents[loaded_reagent])
 		update_selected_reagent(null)
-		to_chat(user, span_rose("You have ran out of [initial(loaded_reagent.name)]."))
+		user.balloon_alert(user, "[initial(loaded_reagent.name)]: empty")
 	loaded_reagent = null
 
 #undef MAX_LOADABLE_REAGENT_AMOUNT
@@ -230,7 +233,6 @@
 
 /datum/action/harvester/reagent_select/update_button_icon()
 	. = ..()
-	button.overlays -= selected_reagent_overlay
 	button.overlays += selected_reagent_overlay
 
 #undef NO_REAGENT_COLOR

--- a/code/datums/components/harvester.dm
+++ b/code/datums/components/harvester.dm
@@ -21,8 +21,9 @@
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
 
-	reagent_select_action = new
 	var/obj/item/item_parent = parent
+
+	reagent_select_action = new
 	item_parent.actions += reagent_select_action
 
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/examine)

--- a/code/datums/components/harvester.dm
+++ b/code/datums/components/harvester.dm
@@ -69,31 +69,30 @@
 		return
 
 	if(!isreagentcontainer(cont) || istype(cont, /obj/item/reagent_containers/pill))
-		user.balloon_alert(user, "[cont]: not compatible with [source].")
+		user.balloon_alert(user, "incompatible")
 		return
 
 	var/obj/item/reagent_containers/container = cont
 
 	if(!container.reagents.total_volume)
-		user.balloon_alert(user, "[cont.name]: empty...")
+		user.balloon_alert(user, "empty")
 		return
 
 	if(length(container.reagents.reagent_list) > 1)
-		user.balloon_alert(user, "Solution can contain only a single reagent.")
+		user.balloon_alert(user, "homogeneous mixture required")
 		return
 
 	var/datum/reagent/reagent_to_load = container.reagents.reagent_list[1].type
-	var/reagent_name = initial(reagent_to_load.name)
 
 	if(!loadable_reagents[reagent_to_load])
-		user.balloon_alert(user, "[reagent_name]: incompatible reagent. Check weapon description.")
+		user.balloon_alert(user, "incompatible reagent, check description")
 		return
 
 	if(loaded_reagents[reagent_to_load] > MAX_LOADABLE_REAGENT_AMOUNT)
-		user.balloon_alert(user, "[reagent_name]: full")
+		user.balloon_alert(user, "full")
 		return
 
-	user.balloon_alert(user, "[reagent_name]: filling up...")
+	user.balloon_alert(user, "filling up...")
 	if(!do_after(user, 1 SECONDS, TRUE, source, BUSY_ICON_BAR, null, PROGRESS_BRASS))
 		return
 
@@ -103,7 +102,7 @@
 	var/added_amount = min(container.reagents.total_volume, MAX_LOADABLE_REAGENT_AMOUNT - loaded_reagents[reagent_to_load])
 	container.reagents.remove_reagent(reagent_to_load, added_amount)
 	loaded_reagents[reagent_to_load] += added_amount
-	user.balloon_alert(user, "[reagent_name]: [loaded_reagents[reagent_to_load]]u.")
+	user.balloon_alert(user, "[loaded_reagents[reagent_to_load]]u")
 	if(length(loaded_reagents) == 1)
 		update_selected_reagent(reagent_to_load)
 
@@ -111,18 +110,17 @@
 /datum/component/harvester/proc/activate_blade_async(datum/source, mob/user)
 
 	if(loaded_reagent)
-		user.balloon_alert(user, "Loaded: [initial(loaded_reagent.name)]")
+		user.balloon_alert(user, "[initial(loaded_reagent.name)]")
 		return
 
 	if(!selected_reagent)
-		user.balloon_alert(user, "Select a reagent.")
+		user.balloon_alert(user, "no reagent")
 		return
 
 	var/use_amount = loadable_reagents[selected_reagent]
-	var/reagent_name = initial(selected_reagent.name)
 
 	if(loaded_reagents[selected_reagent] < use_amount)
-		user.balloon_alert(user, "[reagent_name]: not enough")
+		user.balloon_alert(user, "insufficient liquid")
 		return
 
 	if(user.do_actions)
@@ -137,7 +135,7 @@
 	loaded_reagents[selected_reagent] -= use_amount
 	if(!loaded_reagents[selected_reagent])
 		loaded_reagents -= selected_reagent
-	user.balloon_alert(user, "Loaded: [reagent_name]")
+	user.balloon_alert(user, "loaded")
 
 ///Handles behavior when attacking a mob
 /datum/component/harvester/proc/attack_async(datum/source, mob/living/target, mob/living/user, obj/item/weapon)

--- a/code/datums/components/harvester.dm
+++ b/code/datums/components/harvester.dm
@@ -108,11 +108,9 @@
 
 ///Handles behavior when activating the weapon
 /datum/component/harvester/proc/activate_blade_async(datum/source, mob/user)
-	var/obj/item/item_parent = parent
-	var/reagent_name = initial(selected_reagent.name)
 
 	if(loaded_reagent)
-		user.balloon_alert(user, "powered with [initial(loaded_reagent.name)]")
+		user.balloon_alert(user, "Loaded: [initial(loaded_reagent.name)]")
 		return
 
 	if(!selected_reagent)
@@ -120,6 +118,7 @@
 		return
 
 	var/use_amount = loadable_reagents[selected_reagent]
+	var/reagent_name = initial(selected_reagent.name)
 
 	if(loaded_reagents[selected_reagent] < use_amount)
 		user.balloon_alert(user, "[reagent_name]: not enough")
@@ -137,7 +136,7 @@
 	loaded_reagents[selected_reagent] -= use_amount
 	if(!loaded_reagents[selected_reagent])
 		loaded_reagents -= selected_reagent
-	user.balloon_alert(user, "powered with [reagent_name]")
+	user.balloon_alert(user, "Loaded: [reagent_name]")
 
 ///Handles behavior when attacking a mob
 /datum/component/harvester/proc/attack_async(datum/source, mob/living/target, mob/living/user, obj/item/weapon)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Fixes harvester storing 60 instead of 30 units of a reagent, along with some text prompts.
Updates text prompts from chat messages to runechat.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
More clarity and fixes unintentional buff.
## Changelog
:cl:
balance: fixes harvester storing 60 instead of 30 of each reagent
qol: updates harvester messages to runechat instead of chat
fix: select reagent button icon no longer disappears sometimes when re-equipping the weapon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
