### PR TITLE
Return bleeding visibility on examine

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -277,6 +277,8 @@
 			if(wound_flavor_text["[temp.display_name]"])
 				wound_flavor_text["[temp.display_name]"] += "!</span>\n"
 		else
+			if(temp.limb_status & LIMB_BLEEDING)
+				is_bleeding["[temp.display_name]"] = 1
 			var/healthy = TRUE
 			var/brute_desc = ""
 			switch(temp.brute_dam)
@@ -317,7 +319,7 @@
 
 			var/overall_desc = ""
 			if(healthy)
-				overall_desc = "[t_He] has a healthy [temp.display_name]."
+				overall_desc = span_notice("[t_He] has a healthy [temp.display_name].")
 			else
 				overall_desc = "[t_He] has a [germ_desc][temp.display_name]"
 				if(brute_desc || burn_desc)
@@ -325,8 +327,8 @@
 					if(brute_desc && burn_desc)
 						overall_desc += " and "
 					overall_desc += burn_desc
-				overall_desc += "."
-			wound_flavor_text["[temp.display_name]"] = span_warning(overall_desc + "\n")
+				overall_desc = span_warning(overall_desc + " ")
+			wound_flavor_text["[temp.display_name]"] = overall_desc + "\n"
 
 	//Handles the text strings being added to the actual description.
 	//If they have something that covers the limb, and it is not missing, put flavortext.  If it is covered but bleeding, add other flavortext.

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -327,7 +327,7 @@
 					if(brute_desc && burn_desc)
 						overall_desc += " and "
 					overall_desc += burn_desc
-				overall_desc = span_warning(overall_desc + " ")
+				overall_desc = span_warning(overall_desc + ".")
 			wound_flavor_text["[temp.display_name]"] = overall_desc + "\n"
 
 	//Handles the text strings being added to the actual description.


### PR DESCRIPTION
## About The Pull Request
Pre-wound removal you could see if someone was bleeding through clothing on examine but I forgot to include that in the overhaul oops.

## Why It's Good For The Game
h

## Changelog
:cl:
fix: You can see bleeding on human examine again.
/:cl: