### PR TITLE
Makes robot repair automatically select next damaged limb

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -483,10 +483,11 @@ GLOBAL_LIST(cable_radial_layer_list)
 		return ..()
 
 	var/datum/limb/affecting = user.client.prefs.toggles_gameplay & RADIAL_MEDICAL ? radial_medical(H, user) : H.get_limb(user.zone_selected)
+
 	if(!affecting)
 		return TRUE
 
-	if(affecting.limb_status != LIMB_ROBOT)
+	if(!(affecting.limb_status & LIMB_ROBOT))
 		balloon_alert(user, "Limb not robotic")
 		return TRUE
 
@@ -502,19 +503,28 @@ GLOBAL_LIST(cable_radial_layer_list)
 	if(H == user)
 		repair_time *= 3
 
-	user.visible_message(span_notice("[user] starts to fix some of the wires in [H == user ? "[H.p_their()]" : "[H]'s"] [affecting.display_name]."),\
+	user.visible_message(span_notice("[user] starts to fix some of the wires in [H]'s [affecting.display_name]."),\
 		span_notice("You start fixing some of the wires in [H == user ? "your" : "[H]'s"] [affecting.display_name]."))
 
-	while(affecting.burn_dam && do_after(user, repair_time, TRUE, src, BUSY_ICON_BUILD) && use(1))
-		user.visible_message(span_warning("\The [user] fixes some wires in [H == user ? "[H.p_their()]" : "[H]'s"] [affecting.display_name] with \the [src]."), \
-			span_warning("You patch some wires in [H == user ? "your" : "[H]'s"] [affecting.display_name]."))
+	while(do_after(user, repair_time, TRUE, src, BUSY_ICON_BUILD) && use(1))
+		user.visible_message(span_warning("\The [user] fixes some wires in \the [H]'s [affecting.display_name] with [src]."), \
+			span_warning("You patch some wires in \the [H]'s [affecting.display_name]."))
 		if(affecting.heal_limb_damage(0, 15, robo_repair = TRUE, updating_health = TRUE))
 			H.UpdateDamageIcon()
 		if(!amount)
 			return TRUE
+		if(!affecting.burn_dam)
+			var/previous_limb = affecting
+			for(var/datum/limb/checked_limb AS in H.limbs)
+				if(!(checked_limb.limb_status & LIMB_ROBOT))
+					continue
+				if(!checked_limb.burn_dam)
+					continue
+				affecting = checked_limb
+			if(previous_limb == affecting)
+				H.balloon_alert(user, "Burns fully repaired.")
+				break
 	return TRUE
-
-
 
 ///////////////////////////////////////////////
 // Cable laying procedures


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Robot repair with cable coil and welder automatically selects next damaged limb.

Also kind of normalizes some of the repair code.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Less monotonous clicking.
## Changelog
:cl:
qol: robot repair automatically starts repairing the next damaged limb
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
