### PR TITLE
Prevents kitting undamaged limbs

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_organs.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_organs.dm
@@ -43,7 +43,7 @@
 				I.take_damage(rand(3,5))
 
 			//Moving makes open wounds get infected much faster
-			if(!E.limb_wound_status & LIMB_WOUND_DISINFECTED && E.brute_dam >= 20)
+			if(!(E.limb_wound_status & LIMB_WOUND_DISINFECTED) && E.brute_dam >= 20)
 				if(prob((E.brute_dam - (E.limb_wound_status & LIMB_WOUND_BANDAGED ? 50 : 0)) * 4))
 					E.germ_level++
 

--- a/code/modules/mob/living/carbon/human/life/handle_organs.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_organs.dm
@@ -43,8 +43,9 @@
 				I.take_damage(rand(3,5))
 
 			//Moving makes open wounds get infected much faster
-			if(prob((E.brute_dam - (E.limb_wound_status & LIMB_WOUND_BANDAGED ? 50 : 0)) * 4))
-				E.germ_level++
+			if(!E.limb_wound_status & LIMB_WOUND_DISINFECTED && E.brute_dam >= 20)
+				if(prob((E.brute_dam - (E.limb_wound_status & LIMB_WOUND_BANDAGED ? 50 : 0)) * 4))
+					E.germ_level++
 
 		if(E.name in list("l_leg", "l_foot", "r_leg", "r_foot") && !lying_angle)
 			if(!E.is_usable() || E.is_malfunctioning() || ( E.is_broken() && !(E.limb_status & LIMB_SPLINTED) && !(E.limb_status & LIMB_STABILIZED) ) )

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -791,7 +791,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 
 /datum/limb/proc/bandage()
-	if(limb_wound_status & LIMB_WOUND_BANDAGED)
+	if(limb_wound_status & LIMB_WOUND_BANDAGED || !brute_dam)
 		return 0
 	limb_wound_status ^= LIMB_WOUND_BANDAGED
 	return 1
@@ -802,7 +802,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return limb_wound_status & LIMB_WOUND_BANDAGED
 
 /datum/limb/proc/disinfect()
-	if(limb_wound_status & LIMB_WOUND_DISINFECTED)
+	if(limb_wound_status & LIMB_WOUND_DISINFECTED || (burn_dam < 20 && brute_dam < 20 && !germ_level))
 		return 0
 	limb_wound_status ^= LIMB_WOUND_DISINFECTED
 	return 1
@@ -820,7 +820,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return 1
 
 /datum/limb/proc/salve()
-	if(limb_wound_status & LIMB_WOUND_SALVED)
+	if(limb_wound_status & LIMB_WOUND_SALVED || !burn_dam)
 		return 0
 	limb_wound_status ^= LIMB_WOUND_SALVED
 	return 1

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -802,7 +802,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return limb_wound_status & LIMB_WOUND_BANDAGED
 
 /datum/limb/proc/disinfect()
-	if(limb_wound_status & LIMB_WOUND_DISINFECTED || (burn_dam < 20 && brute_dam < 20 && !germ_level))
+	if(limb_wound_status & LIMB_WOUND_DISINFECTED || (burn_dam < 20 && brute_dam < 20))
 		return 0
 	limb_wound_status ^= LIMB_WOUND_DISINFECTED
 	return 1


### PR DESCRIPTION
## About The Pull Request
Since wounds don't exist any more we can be more discerning about whether a limb needs kit treatment, beyond just whether it's bandaged or not. Don't bother bandaging if there's no brute damage, don't bother salving if there's no burns, and don't bother disinfecting if there's no chance to gain germs from current damage.
Also fixes movement germs being applied in a couple incorrect cases.

## Why It's Good For The Game
Helps avoid confusion and slowdown from kitting healthy limbs, both from direct apply and from cycling.

## Changelog
:cl:
fix: You can't kit undamaged limbs
/:cl:
