### PR TITLE
Cheaper ZX

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -361,7 +361,7 @@ WEAPONS
 /datum/supply_packs/weapons/zx76
 	name = "ZX-76 Twin-Barrled Burst Shotgun"
 	contains = list(/obj/item/weapon/gun/shotgun/zx76)
-	cost = 100
+	cost = 70
 
 /datum/supply_packs/weapons/shotguntracker
 	name = "12 Gauge Tracker Shells"


### PR DESCRIPTION
## About The Pull Request

Makes ZX-76, the double-barreled cargo shotgun, cheaper. 70 points.

## Why It's Good For The Game

Compared to any other cargo weapons, the price for ZX is absurdly high. For other weapons, ammo costs some points too, but ZX ~~sucks~~ doesn't perform better than other weps most of the time . No IFF/Aim, and for CQC even the minigun is a better alternative. Lower price would make is at least somewhat viable.

## Changelog
:cl:
balance: reduced ZX-76 shotgun price significantly
/:cl:

