### PR TITLE
Swapping attachments keeps the old attachment in-hand

### DIFF
--- a/code/datums/components/attachment_handler.dm
+++ b/code/datums/components/attachment_handler.dm
@@ -74,20 +74,26 @@
 		QDEL_NULL(attachment)
 		return
 
+	var/obj/item/old_attachment = slots[slot]
+
 	finish_handle_attachment(attachment, attachment_data, attacher)
 
 	if(!attacher)
 		return
 	attacher.temporarilyRemoveItemFromInventory(attachment)
 
+	//Re-try putting old attachment into hands, now that we've cleared them
+	if(old_attachment)
+	attacher.put_in_hands(old_attachment)
+
 
 ///Finishes setting up the attachment. This is where the attachment actually attaches. This can be called directly to bypass any checks to directly attach an object.
 /datum/component/attachment_handler/proc/finish_handle_attachment(obj/item/attachment, list/attachment_data, mob/attacker)
 	var/slot = attachment_data[SLOT]
 
-	var/obj/item/old_attachment = slots[slot]
-	if(old_attachment) //Checks for an attachment in the current slot.
-		finish_detach(old_attachment, attachment_data_by_slot[slot], attacker) //Removes the current attachment.
+	if(slots[slot]) //Checks for an attachment in the current slot.
+		var/obj/item/current_attachment = slots[slot]
+		finish_detach(current_attachment, attachment_data_by_slot[slot], attacker) //Removes the current attachment.
 
 	attachment.forceMove(parent)
 	slots[slot] = attachment
@@ -110,9 +116,6 @@
 	update_parent_overlay()
 	if(!CHECK_BITFIELD(attachment_data[FLAGS_ATTACH_FEATURES], ATTACH_APPLY_ON_MOB))
 		return
-
-	//Re-try putting old attachment into hands, now that we've cleared them
-	attacker.put_in_hands(old_attachment)
 
 	if(!ismob(parent_obj.loc))
 		return

--- a/code/datums/components/attachment_handler.dm
+++ b/code/datums/components/attachment_handler.dm
@@ -84,7 +84,7 @@
 
 	//Re-try putting old attachment into hands, now that we've cleared them
 	if(old_attachment)
-	attacher.put_in_hands(old_attachment)
+		attacher.put_in_hands(old_attachment)
 
 
 ///Finishes setting up the attachment. This is where the attachment actually attaches. This can be called directly to bypass any checks to directly attach an object.

--- a/code/datums/components/attachment_handler.dm
+++ b/code/datums/components/attachment_handler.dm
@@ -86,8 +86,8 @@
 	var/slot = attachment_data[SLOT]
 
 	if(slots[slot]) //Checks for an attachment in the current slot.
-		var/obj/item/current_attachment = slots[slot]
-		finish_detach(current_attachment, attachment_data_by_slot[slot], attacker) //Removes the current attachment.
+		var/obj/item/old_attachment = slots[slot]
+		finish_detach(old_attachment, attachment_data_by_slot[slot], attacker) //Removes the current attachment.
 
 	attachment.forceMove(parent)
 	slots[slot] = attachment
@@ -110,6 +110,9 @@
 	update_parent_overlay()
 	if(!CHECK_BITFIELD(attachment_data[FLAGS_ATTACH_FEATURES], ATTACH_APPLY_ON_MOB))
 		return
+
+	//Re-try putting old attachment into hands, now that we've cleared them
+	user.put_in_hands(old_attachment)
 
 	if(!ismob(parent_obj.loc))
 		return

--- a/code/datums/components/attachment_handler.dm
+++ b/code/datums/components/attachment_handler.dm
@@ -112,7 +112,7 @@
 		return
 
 	//Re-try putting old attachment into hands, now that we've cleared them
-	user.put_in_hands(old_attachment)
+	attacker.put_in_hands(old_attachment)
 
 	if(!ismob(parent_obj.loc))
 		return

--- a/code/datums/components/attachment_handler.dm
+++ b/code/datums/components/attachment_handler.dm
@@ -85,8 +85,8 @@
 /datum/component/attachment_handler/proc/finish_handle_attachment(obj/item/attachment, list/attachment_data, mob/attacker)
 	var/slot = attachment_data[SLOT]
 
-	if(slots[slot]) //Checks for an attachment in the current slot.
-		var/obj/item/old_attachment = slots[slot]
+	var/obj/item/old_attachment = slots[slot]
+	if(old_attachment) //Checks for an attachment in the current slot.
 		finish_detach(old_attachment, attachment_data_by_slot[slot], attacker) //Removes the current attachment.
 
 	attachment.forceMove(parent)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Per title. Previously, the old attachment would be dropped on the floor.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Mainly just QOL; having to pick up some very small icons from under you each time you swap an attachment can get really tedious when trying out builds or whatever. Also sucks for flamers. I've wanted this for quite a while, and it's a oneline change, so

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: When swapping an attachment, the old attachment now goes into your hand instead of on the floor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
