### PR TITLE
Three minor gun fixes

### DIFF
--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -648,7 +648,7 @@
 		if(item_to_stock.loc == user) //Inside the mob's inventory
 			if(item_to_stock.flags_item & WIELDED)
 				item_to_stock.unwield(user)
-			user.temporarilyRemoveItemFromInventory(item_to_stock)
+			user.transferItemToLoc(item_to_stock, src)
 
 		if(istype(item_to_stock.loc, /obj/item/storage)) //inside a storage item
 			var/obj/item/storage/S = item_to_stock.loc

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -79,9 +79,7 @@
 		var/obj/item/weapon/gun/gun = I
 		if(!CHECK_BITFIELD(gun.reciever_flags, AMMO_RECIEVER_MAGAZINES))
 			return ..()
-		if(!gun.reload(src, user))
-			return
-		gun.RegisterSignal(src, COMSIG_ITEM_REMOVED_INVENTORY, /obj/item/weapon/gun.proc/drop_connected_mag)
+		gun.reload(src, user)
 		return
 
 	if(!CHECK_BITFIELD(flags_magazine, MAGAZINE_REFILLABLE)) //and a refillable magazine

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1147,6 +1147,7 @@
 		update_ammo_count()
 		update_icon()
 		to_chat(user, span_notice("You reload [src] with [new_mag]."))
+		RegisterSignal(new_mag, COMSIG_ITEM_REMOVED_INVENTORY, /obj/item/weapon/gun.proc/drop_connected_mag)
 		return TRUE
 
 

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1038,9 +1038,9 @@
 					var/obj/item/ammo_magazine/handful_to_fill = chamber_items[1]
 					var/list/obj/item/objects_to_eject = list(handful_to_fill)
 					for(var/obj/item/ammo_magazine/handful_to_eject in chamber_items)
-						if(handful_to_eject == handful_to_fill)
+						if(handful_to_eject == handful_to_fill || !handful_to_eject)
 							continue
-						if(handful_to_eject.default_ammo != handful_to_fill.default_ammo)
+						if(!handful_to_fill || handful_to_eject.default_ammo != handful_to_fill.default_ammo)
 							handful_to_fill = handful_to_eject
 							objects_to_eject += handful_to_fill
 							continue


### PR DESCRIPTION
## About The Pull Request
The signal for a gun to disconnect from a worn mag only fires when the mag is moved from the mob to another location, so since restocking vending leaves it in the mob and qdels it wasn't disconnecting properly. Makes restocking move the item into the vendor first to fix that. Also moved the signal register into reload itself so that it's included in a tactical reload, and adds code to handle nulls in list when retrieving handfuls eg from revolvers.

## Why It's Good For The Game
Fixes #10201 
Fixes #10104 
Fixes #9231 

## Changelog
:cl:
fix: Restocking a back-mounted ammo (power packs, fuel tanks) will now properly disconnect them from any loaded weapons.
fix: Flamers won't stay connected to fuel tanks across time and space after you do a tactical reload.
fix: Revolvers won't sometimes jam after firing the first few bullets and opening the chamber.
/:cl: