### PR TITLE
Disable phoron miners on hijack

### DIFF
--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -55,6 +55,7 @@
 	. = ..()
 	SSminimaps.add_marker(src, z, hud_flags = MINIMAP_FLAG_ALL, iconstate = "miner_[mineral_value >= PLATINUM_CRATE_SELL_AMOUNT ? "platinum" : "phoron"]_off")
 	start_processing()
+	RegisterSignal(SSdcs, COMSIG_GLOB_DROPSHIP_HIJACKED, .proc/disable_on_hijack)
 
 /obj/machinery/miner/update_icon()
 	switch(miner_status)
@@ -257,7 +258,7 @@
 	start_processing()
 
 /obj/machinery/miner/process()
-	if(miner_status != MINER_RUNNING)
+	if(miner_status != MINER_RUNNING || mineral_value == 0)
 		stop_processing()
 		SSminimaps.remove_marker(src)
 		SSminimaps.add_marker(src, z, hud_flags = MINIMAP_FLAG_ALL, iconstate = "miner_[mineral_value >= PLATINUM_CRATE_SELL_AMOUNT ? "platinum" : "phoron"]_off")
@@ -318,3 +319,9 @@
 			SSminimaps.add_marker(src, z, hud_flags = MINIMAP_FLAG_ALL, iconstate = "miner_[mineral_value >= PLATINUM_CRATE_SELL_AMOUNT ? "platinum" : "phoron"]_on")
 			miner_status = MINER_RUNNING
 	update_icon()
+
+///Called via global signal to prevent perpetual mining
+/obj/machinery/miner/proc/disable_on_hijack()
+	mineral_value = 0
+	miner_integrity = 0
+	set_miner_status()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Permanently disables phoron miners on global hijack signal.

## Why It's Good For The Game

Fix good. Seems like a bug when there is no possible way for xenos to prevent tad from fixing miners even if they were to go around and disable them all before hijacking (that is if the dropship locking window even allows).

## Changelog
:cl:
fix: Fixed phoron miners continuing to function after hijack.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
