### PR TITLE
SG Minigun balance

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1105,19 +1105,8 @@ datum/ammo/bullet/revolver/tp44
 //================================================
 */
 
-/datum/ammo/bullet/smartgun
-	name = "smartgun bullet"
-	icon_state = "redbullet" //Red bullets to indicate friendly fire restriction
-	hud_state = "smartgun"
-	hud_state_empty = "smartgun_empty"
-	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
-	accurate_range = 15
-	damage = 20
-	penetration = 20
-	sundering = 1
-
 /datum/ammo/bullet/smartmachinegun
-	name = "smartgun bullet"
+	name = "smartmachinegun bullet"
 	icon_state = "redbullet" //Red bullets to indicate friendly fire restriction
 	hud_state = "smartgun"
 	hud_state_empty = "smartgun_empty"
@@ -1128,7 +1117,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 2
 
 /datum/ammo/bullet/smartminigun
-	name = "smartgun bullet"
+	name = "smartminigun bullet"
 	icon_state = "redbullet" //Red bullets to indicate friendly fire restriction
 	hud_state = "smartgun"
 	hud_state_empty = "smartgun_empty"
@@ -1136,7 +1125,7 @@ datum/ammo/bullet/revolver/tp44
 	accurate_range = 15
 	damage = 10
 	penetration = 15
-	sundering = 2
+	sundering = 1
 
 /datum/ammo/bullet/smartgun/lethal
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1123,9 +1123,9 @@ datum/ammo/bullet/revolver/tp44
 	hud_state_empty = "smartgun_empty"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	accurate_range = 15
-	damage = 10
+	damage = 15
 	penetration = 15
-	sundering = 1
+	sundering = 2
 
 /datum/ammo/bullet/smartgun/lethal
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -443,7 +443,6 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 
 	fire_delay = 0.1 SECONDS
 	windup_delay = 0.75 SECONDS
-	damage_mult = 0.8
 	scatter = -5
 	recoil = 0
 	recoil_unwielded = 4

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -441,7 +441,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	aim_slowdown = 1.5
 	actions_types = list()
 
-	fire_delay = 0.1 SECONDS
+	fire_delay = 0.15 SECONDS
 	windup_delay = 0.75 SECONDS
 	scatter = -5
 	recoil = 0

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -442,7 +442,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	actions_types = list()
 
 	fire_delay = 0.15 SECONDS
-	windup_delay = 0.75 SECONDS
+	windup_delay = 0.4 SECONDS
 	scatter = -5
 	recoil = 0
 	recoil_unwielded = 4

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -309,8 +309,8 @@
 	name = "\improper SG-85 powerpack"
 	desc = "A reinforced backpack heavy with the IFF altered ammunition, onboard micro generator, and extensive cooling system which enables the SG-85 gatling gun to operate. \nUse the SG-85 on the backpack itself to connect them."
 	icon_state = "powerpacksg"
-	current_rounds = 1000
-	max_rounds = 1000
+	current_rounds = 2000
+	max_rounds = 2000
 	caliber = CALIBER_10x26_CASELESS
 	default_ammo = /datum/ammo/bullet/smartminigun
 	flags_item_map_variant = null

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -309,8 +309,8 @@
 	name = "\improper SG-85 powerpack"
 	desc = "A reinforced backpack heavy with the IFF altered ammunition, onboard micro generator, and extensive cooling system which enables the SG-85 gatling gun to operate. \nUse the SG-85 on the backpack itself to connect them."
 	icon_state = "powerpacksg"
-	current_rounds = 2000
-	max_rounds = 2000
+	current_rounds = 1000
+	max_rounds = 1000
 	caliber = CALIBER_10x26_CASELESS
 	default_ammo = /datum/ammo/bullet/smartminigun
 	flags_item_map_variant = null

--- a/code/modules/vehicles/multitile/hardpoints.dm
+++ b/code/modules/vehicles/multitile/hardpoints.dm
@@ -443,22 +443,6 @@ Currently only has the tank hardpoints
 	P.fire_at(T, owner, src, P.ammo.max_range, P.ammo.shell_speed)
 	ammo.current_rounds--
 
-/obj/item/hardpoint/secondary/m56cupola
-	name = "M56 Cupola"
-	desc = "A secondary weapon for tanks that shoots bullets"
-
-	max_integrity = 350
-	point_cost = 50
-
-	icon_state = "m56_cupola"
-
-	disp_icon = "tank"
-	disp_icon_state = "m56cupola"
-
-	starter_ammo = /obj/item/ammo_magazine/tank/m56_cupola
-	max_clips = 1
-	max_angle = 90
-
 /obj/item/hardpoint/secondary/m56cupola/broken
 	obj_integrity = 0
 	buyable = FALSE
@@ -976,17 +960,6 @@ Currently only has the tank hardpoints
 	default_ammo = /datum/ammo/rocket/ap //Fun fact, AP rockets seem to be a straight downgrade from normal rockets. Maybe I'm missing something...
 	max_rounds = 5
 	point_cost = 100
-
-
-/obj/item/ammo_magazine/tank/m56_cupola
-	name = "M56 Cupola Magazine"
-	desc = "A secondary armament MG magazine"
-	caliber = CALIBER_10X28 //Correlates to smartguns
-	icon_state = "big_ammo_box"
-	w_class = 12
-	default_ammo = /datum/ammo/bullet/smartgun
-	max_rounds = 1000
-	point_cost = 10
 
 /obj/item/ammo_magazine/tank/tank_glauncher
 	name = "Grenade Launcher Magazine"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. SG minigun firerate from .1 -> .15
2. SG minigun windup delay from .75 -> .4
3. SG minigun damage multiplier from .8 -> 1
4. SG minigun damage per bullet from 10 -> 15
5. Removed smartgun type bullet and the tank weapon that used it (Both were unused)

## Why It's Good For The Game

1. Right now the minigun is a bit too fast
2. Windup delay was a copy paste from MJP's original minigun I forget to change (shouldn't affect too much)
3. The SG minigun has its own bullet type and doesn't need a damage multiplier (Another copy paste forget)
4. Less firerate means more damager per bullet to maintain a DPS similar to the SG-29
5. Unused, removed to reduce confusion between actual SG weapon ammo

## Changelog
:cl:
balance: SG minigun fires slower and does more damage
fix: SG minigun is now consumer safe and no longer bullies low end devices
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
