### PR TITLE
Removes Xeno Ability to Instantly Extinguish On Fire Humans With Help Intent

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -208,6 +208,9 @@
 
 	switch(X.a_intent)
 		if(INTENT_HELP)
+			if(on_fire)
+				X.visible_message(span_danger("[X] stares at [src]."), span_notice("We stare at the roasting [src], toasty."), null, 5)
+				return FALSE
 			X.visible_message(span_notice("\The [X] caresses [src] with its scythe-like arm."), \
 			span_notice("We caress [src] with our scythe-like arm."), null, 5)
 			return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -208,12 +208,6 @@
 
 	switch(X.a_intent)
 		if(INTENT_HELP)
-			if(on_fire)
-				playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, TRUE, 7)
-				ExtinguishMob()
-				X.visible_message(span_danger("[X] effortlessly extinguishes the fire on [src]!"),
-					span_notice("We extinguished the fire on [src]."), null, 5)
-				return TRUE
 			X.visible_message(span_notice("\The [X] caresses [src] with its scythe-like arm."), \
 			span_notice("We caress [src] with our scythe-like arm."), null, 5)
 			return FALSE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Removes ancient ability of xenos that allowed them to instantly extinguish human marines with a single click of the help intent.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Xeno extinguishing marines is one of the last remaining relics of the capture days. Back when marines would instead flame themselves and thus kill themselves to avoid capture.

Now, it's just a bald (e.g., me) xeno misclick if accidently on help intent and giving marines a free instant fire extinguish.

Xenos should not be helping marines by reducing damage on them. If a marine is on fire, let them burn.

This will not effect xenos helping other xenos to extinguish their flames. Only between xenos and animals.

## Changelog
:cl:
balance: Xenos on help intent no longer extinguish their sworn enemies and instead watches them burn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
