### PR TITLE
Adds and Replaces To_Chat() With Balloon_Alerts() in Plasmacutter Interactions

### DIFF
--- a/code/game/objects/items/tools/mining_tools.dm
+++ b/code/game/objects/items/tools/mining_tools.dm
@@ -145,10 +145,11 @@
 /obj/item/tool/pickaxe/plasmacutter/proc/fizzle_message(mob/user)
 	playsound(src, 'sound/machines/buzz-two.ogg', 25, 1)
 	if(!cell)
-		to_chat(user, span_warning("[src]'s has no battery installed!"))
+		balloon_alert(user, "No battery installed")
 	else if(!powered)
-		to_chat(user, span_warning("[src] is turned off!"))
+		balloon_alert(user, "Turned off")
 	else
+		balloon_alert(user, "Insufficient charge")
 		to_chat(user, span_warning("The plasma cutter has inadequate charge remaining! Replace or recharge the battery. <b>Charge Remaining: [cell.charge]/[cell.maxcharge]</b>"))
 
 /obj/item/tool/pickaxe/plasmacutter/proc/start_cut(mob/user, name = "", atom/source, charge_amount = PLASMACUTTER_BASE_COST, custom_string, no_string, SFX = TRUE)
@@ -164,10 +165,11 @@
 		spark_system.attach(source)
 		spark_system.start(source)
 	if(!no_string)
+		balloon_alert(user, "Cutting...")
 		if(custom_string)
-			to_chat(user, span_notice("[custom_string] <b>Charge Remaining: [cell.charge]/[cell.maxcharge]</b>"))
+			to_chat(user, span_notice(custom_string))
 		else
-			to_chat(user, span_notice("You start cutting apart the [name] with [src]. <b>Charge Remaining: [cell.charge]/[cell.maxcharge]</b>"))
+			to_chat(user, span_notice("You start cutting apart the [name] with [src]."))
 	return TRUE
 
 /obj/item/tool/pickaxe/plasmacutter/proc/cut_apart(mob/user, name = "", atom/source, charge_amount = PLASMACUTTER_BASE_COST, custom_string)
@@ -179,10 +181,11 @@
 	spark_system.attach(source)
 	spark_system.start(source)
 	use_charge(user, charge_amount, FALSE)
+	balloon_alert(user, "Charge Remaining: [cell.charge]/[cell.maxcharge]")
 	if(custom_string)
-		to_chat(user, span_notice("[custom_string]<b>Charge Remaining: [cell.charge]/[cell.maxcharge]</b>"))
+		to_chat(user, span_notice(custom_string))
 	else
-		to_chat(user, span_notice("You cut apart the [name] with [src]. <b>Charge Remaining: [cell.charge]/[cell.maxcharge]</b>"))
+		to_chat(user, span_notice("You cut apart the [name] with [src]."))
 
 /obj/item/tool/pickaxe/plasmacutter/proc/debris(location, metal = 0, rods = 0, wood = 0, wires = 0, shards = 0, plasteel = 0)
 	if(metal)
@@ -203,7 +206,7 @@
 /obj/item/tool/pickaxe/plasmacutter/proc/use_charge(mob/user, amount = PLASMACUTTER_BASE_COST, mention_charge = TRUE)
 	cell.charge -= min(cell.charge, amount)
 	if(mention_charge)
-		to_chat(user, span_notice("<b>Charge Remaining: [cell.charge]/[cell.maxcharge]</b>"))
+		balloon_alert(user, "Charge Remaining: [cell.charge]/[cell.maxcharge]")
 	update_plasmacutter()
 
 /obj/item/tool/pickaxe/plasmacutter/proc/calc_delay(mob/user)
@@ -230,6 +233,7 @@
 			powered = FALSE
 			if(!silent)
 				playsound(loc, 'sound/weapons/saberoff.ogg', 25)
+				balloon_alert(user, "Insufficient charge")
 				to_chat(user, span_warning("The plasma cutter abruptly shuts down due to a lack of power!"))
 		force = 5
 		damtype = BRUTE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

A few more balloon alerts for plasmacutter actions. I prefer to keep to_chats with messages particularly flavorful.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Shamelessly copy pasting what RipGrayson said in their (now closed) PR:

> We're moving away from the philosophy of needing to stare at chat in order to see what's going on, runechat did it for speech, balloon_alerts do it for actions. It's just so much easier to see what's going on by looking at your character than it is to dig around in a bunch of text.

> On the aesthetic side it actually looks really cool to see overhead notifications like "Franklin Ramis fixes the internal wiring of platinum miner" or "Queen (236) starts emitting pheremones", it makes us look very smooth.

> So by implementing this not only do we look fancy, but it also enhances team cooperation because xenos/marines can see what their teammates are doing while being focused on combat. (Not that they couldn't before, they would just have to scroll through chat, which made it impractical).

## Changelog
:cl:
qol: Added balloon alerts for plasma cutter interactions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
