### PR TITLE
Adds and Replaces To_Chat() With Balloon_Alerts() in Runner Abilities

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -450,7 +450,6 @@
 
 /datum/action/xeno_action/activable/snatch/use_ability(atom/A)
 	succeed_activate()
-	var/mob/living/carbon/xenomorph/X = A
 	if(!do_after(owner, 0.5 SECONDS, FALSE, A, BUSY_ICON_DANGER, extra_checks = CALLBACK(owner, /mob.proc/break_do_after_checks, list("health" = X.health))))
 		return FALSE
 	var/mob/living/carbon/human/victim = A
@@ -462,9 +461,10 @@
 			if(stolen_item)
 				break
 	if(!stolen_item)
-		victim.balloon_alert(X, "Snatch failed, too poor")
+		victim.balloon_alert(owner, "Snatch failed, too poor")
 		return fail_activate()
 	playsound(owner, 'sound/voice/alien_pounce2.ogg', 30)
+	victim.balloon_alert(owner, "Snatch succeeded")
 	victim.dropItemToGround(stolen_item, TRUE)
 	stolen_item.forceMove(owner)
 	stolen_appearance = mutable_appearance(stolen_item.icon, stolen_item.icon_state)

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -16,9 +16,11 @@
 
 	if(X.savage)
 		X.savage = FALSE
+		X.balloon_alert(X, "No longer savaging")
 		to_chat(X, span_xenowarning("We untense our muscles, and relax. We will no longer savage when pouncing."))
 	else
 		X.savage = TRUE
+		X.balloon_alert(X, "Now savage on pounce")
 		to_chat(X, "We ready ourselves for a killing stroke. We will savage when pouncing.[X.savage_used ? " However, we're not quite yet able to savage again." : ""]")
 	update_button_icon()
 
@@ -37,15 +39,18 @@
 		return
 
 	if(savage_used)
+		src.balloon_alert(src, "Cannot savage, cooldown")
 		to_chat(src, span_xenowarning("We're too tired to savage right now."))
 		return
 
 	if(stagger)
+		src.balloon_alert(src, "Cannot savage, staggered")
 		to_chat(src, span_xenodanger("We're too disoriented from the shock to savage!"))
 		return
 
 	playsound(src, "alien_roar[rand(1,6)]", 50)
 	use_plasma(10) //Base cost of the Savage
+	src.balloon_alert(src, "Savage succeeded")
 	visible_message(span_danger("\ [src] savages [M]!"), \
 	span_xenodanger("We savage [M]!"), null, 5)
 	var/extra_dam = max(15, plasma_stored * 0.15)
@@ -62,6 +67,7 @@
 	if(!savage_used)//sanity check/safeguard
 		return
 	savage_used = FALSE
+	src.balloon_alert(src, "Savage ready")
 	to_chat(src, span_xenowarning("<b>We can now savage our victims again.</b>"))
 	playsound(src, 'sound/effects/xeno_newlarva.ogg', 50, 0, 1)
 	update_action_buttons()
@@ -123,8 +129,10 @@
 			if(X.plasma_stored >= 10)
 				INVOKE_ASYNC(X, /mob/living/carbon/xenomorph/.proc/Savage, M)
 			else
+				X.balloon_alert(X, "Cannot savage, no plasma")
 				to_chat(X, span_xenodanger("We attempt to savage our victim, but we need [10-X.plasma_stored] more plasma."))
 		else
+			X.balloon_alert(X, "Cannot savage, not ready")
 			to_chat(X, span_xenodanger("We attempt to savage our victim, but we aren't yet ready."))
 
 	playsound(X.loc, 'sound/voice/alien_pounce.ogg', 25, TRUE)
@@ -150,6 +158,7 @@
 	return X.xeno_caste.pounce_delay
 
 /datum/action/xeno_action/activable/pounce/on_cooldown_finish()
+	owner.balloon_alert(owner, "Pounce ready")
 	to_chat(owner, span_xenodanger("We're ready to pounce again."))
 	playsound(owner, 'sound/effects/xeno_newlarva.ogg', 25, 0, 1)
 	var/mob/living/carbon/xenomorph/X = owner
@@ -227,12 +236,13 @@
 
 	if(evade_active) //Can't evade while we're already evading.
 		if(!silent)
-			to_chat(owner, span_xenodanger("We're already taking evasive action!"))
+			owner.balloon_alert(owner, "Already evading")
 		return FALSE
 
 /datum/action/xeno_action/evasion/action_activate()
 	var/mob/living/carbon/xenomorph/runner/R = owner
 
+	R.balloon_alert(R, "Begin evasion: [RUNNER_EVASION_DURATION * 0.1] sec.")
 	to_chat(R, span_highdanger("We take evasive action, making us impossible to hit with projectiles for the next [RUNNER_EVASION_DURATION * 0.1] seconds."))
 
 	addtimer(CALLBACK(src, .proc/evasion_deactivate), RUNNER_EVASION_DURATION)
@@ -267,6 +277,7 @@
 
 	evasion_stacks = max(0, evasion_stacks - proj.damage) //We lose evasion stacks equal to the burn damage
 	if(evasion_stacks)
+		owner.balloon_alert(owner, "Evasion reduced, damaged")
 		to_chat(owner, span_danger("The searing fire compromises our ability to dodge![RUNNER_EVASION_COOLDOWN_REFRESH_THRESHOLD - evasion_stacks > 0 ? " We must dodge [RUNNER_EVASION_COOLDOWN_REFRESH_THRESHOLD - evasion_stacks] more projectile damage before Evasion's cooldown refreshes." : ""]"))
 	else //If all of our evasion stacks have burnt away, cancel out
 		evasion_deactivate()
@@ -277,8 +288,7 @@
 
 	var/mob/living/carbon/xenomorph/runner/R = owner
 	evasion_stacks = 0 //We lose all evasion stacks
-	if(evasion_stacks)
-		to_chat(R, span_danger("Being on fire compromises our ability to dodge! We have lost all evasion stacks!"))
+	to_chat(R, span_danger("Being on fire compromises our ability to dodge! We have lost all evasion stacks!"))
 
 ///After getting hit with an Evasion disabling debuff, this is where we check to see if evasion is active, and if we actually have debuff stacks
 /datum/action/xeno_action/evasion/proc/evasion_debuff_check(datum/source, amount)
@@ -310,12 +320,14 @@
 	evade_active = FALSE //Evasion is no longer active
 
 	evasion_stacks = 0
+	owner.balloon_alert(owner, "Evasion ended")
 	owner.visible_message(span_warning("[owner] stops moving erratically."), \
 	span_highdanger("We stop moving erratically; projectiles will hit us normally again!"))
 	owner.playsound_local(owner, 'sound/voice/hiss5.ogg', 50)
 
 
 /datum/action/xeno_action/evasion/on_cooldown_finish()
+	owner.balloon_alert(owner, "Evasion ready")
 	to_chat(owner, span_xenodanger("We are able to take evasive action again."))
 	owner.playsound_local(owner, 'sound/effects/xeno_newlarva.ogg', 25, 0, 1)
 
@@ -383,12 +395,13 @@
 	X.do_jitter_animation(4000)
 
 	if(evasion_stacks >= evasion_stack_target && cooldown_remaining()) //We have more evasion stacks than needed to refresh our cooldown, while being on cooldown.
+		X.balloon_alert(X, "Evasion refreshed")
 		to_chat(X, span_highdanger("Our success spurs us to continue our evasive maneuvers!"))
 		clear_streaks = FALSE //We just scored a streak so we're not clearing our streaks on cooldown finish
 		evasion_streak++ //Increment our streak count
 		clear_cooldown() //Clear our cooldown
 		if(evasion_streak > 3) //Easter egg shoutout
-			to_chat(X, span_xenodanger("Damn we're good."))
+			X.balloon_alert(X, "Damn we're good.")
 
 	var/turf/T = get_turf(X) //location of after image SFX
 	playsound(T, pick('sound/effects/throw.ogg','sound/effects/alien_tail_swipe1.ogg', 'sound/effects/alien_tail_swipe2.ogg'), 25, 1) //sound effects
@@ -427,11 +440,12 @@
 		return
 	if(!owner.Adjacent(A))
 		if(!silent)
-			to_chat(owner, span_xenodanger("Our target must be adjacent!"))
+			owner.balloon_alert(owner, "Cannot snatch, too far")
+			to_chat(owner, span_xenodanger("Our snatch target must be adjacent!"))
 		return FALSE
 	if(!ishuman(A))
 		if(!silent)
-			to_chat(owner, span_xenowarning("You cannot steal from that target"))
+			owner.balloon_alert(owner, "Cannot snatch")
 		return FALSE
 
 /datum/action/xeno_action/activable/snatch/use_ability(atom/A)
@@ -448,7 +462,7 @@
 			if(stolen_item)
 				break
 	if(!stolen_item)
-		to_chat(owner, span_xenowarning("They are too poor, and have nothing to steal!"))
+		victim.balloon_alert(X, "Snatch failed, too poor")
 		return fail_activate()
 	playsound(owner, 'sound/voice/alien_pounce2.ogg', 30)
 	victim.dropItemToGround(stolen_item, TRUE)

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -461,7 +461,7 @@
 			if(stolen_item)
 				break
 	if(!stolen_item)
-		victim.balloon_alert(owner, "Snatch failed, too poor")
+		victim.balloon_alert(owner, "Snatch failed, no item")
 		return fail_activate()
 	playsound(owner, 'sound/voice/alien_pounce2.ogg', 30)
 	victim.balloon_alert(owner, "Snatch succeeded")

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -450,6 +450,7 @@
 
 /datum/action/xeno_action/activable/snatch/use_ability(atom/A)
 	succeed_activate()
+	var/mob/living/carbon/xenomorph/X = A
 	if(!do_after(owner, 0.5 SECONDS, FALSE, A, BUSY_ICON_DANGER, extra_checks = CALLBACK(owner, /mob.proc/break_do_after_checks, list("health" = X.health))))
 		return FALSE
 	var/mob/living/carbon/human/victim = A

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -17,11 +17,9 @@
 	if(X.savage)
 		X.savage = FALSE
 		X.balloon_alert(X, "No longer savaging")
-		to_chat(X, span_xenowarning("We untense our muscles, and relax."))
 	else
 		X.savage = TRUE
 		X.balloon_alert(X, "Will savage on pounce")
-		to_chat(X, "We ready ourselves for a killing stroke.[X.savage_used ? " However, we're not quite yet able to savage again." : ""]")
 	update_button_icon()
 
 /datum/action/xeno_action/toggle_savage/update_button_icon()
@@ -39,16 +37,15 @@
 		return
 
 	if(savage_used)
-		src.balloon_alert(src, "Cannot savage, cooldown")
+		to_chat(src, span_xenowarning("We're too tired to savage right now."))
 		return
 
 	if(stagger)
-		src.balloon_alert(src, "Cannot savage, staggered")
+		to_chat(src, span_xenodanger("We're too disoriented from the shock to savage!"))
 		return
 
 	playsound(src, "alien_roar[rand(1,6)]", 50)
 	use_plasma(10) //Base cost of the Savage
-	src.balloon_alert(src, "Savage succeeded")
 	visible_message(span_danger("\ [src] savages [M]!"), \
 	span_xenodanger("We savage [M]!"), null, 5)
 	var/extra_dam = max(15, plasma_stored * 0.15)
@@ -65,7 +62,6 @@
 	if(!savage_used)//sanity check/safeguard
 		return
 	savage_used = FALSE
-	src.balloon_alert(src, "Savage ready")
 	to_chat(src, span_xenowarning("<b>We can now savage our victims again.</b>"))
 	playsound(src, 'sound/effects/xeno_newlarva.ogg', 50, 0, 1)
 	update_action_buttons()
@@ -155,7 +151,6 @@
 	return X.xeno_caste.pounce_delay
 
 /datum/action/xeno_action/activable/pounce/on_cooldown_finish()
-	owner.balloon_alert(owner, "Pounce ready")
 	to_chat(owner, span_xenodanger("We're ready to pounce again."))
 	playsound(owner, 'sound/effects/xeno_newlarva.ogg', 25, 0, 1)
 	var/mob/living/carbon/xenomorph/X = owner
@@ -318,13 +313,10 @@
 
 	evasion_stacks = 0
 	owner.balloon_alert(owner, "Evasion ended")
-	owner.visible_message(span_warning("[owner] stops moving erratically."), \
-	span_highdanger("We stop moving erratically; projectiles will hit us normally again!"))
 	owner.playsound_local(owner, 'sound/voice/hiss5.ogg', 50)
 
 
 /datum/action/xeno_action/evasion/on_cooldown_finish()
-	owner.balloon_alert(owner, "Evasion ready")
 	to_chat(owner, span_xenodanger("We are able to take evasive action again."))
 	owner.playsound_local(owner, 'sound/effects/xeno_newlarva.ogg', 25, 0, 1)
 
@@ -393,7 +385,6 @@
 
 	if(evasion_stacks >= evasion_stack_target && cooldown_remaining()) //We have more evasion stacks than needed to refresh our cooldown, while being on cooldown.
 		X.balloon_alert(X, "Evasion refreshed")
-		to_chat(X, span_highdanger("Our success spurs us to continue our evasive maneuvers!"))
 		clear_streaks = FALSE //We just scored a streak so we're not clearing our streaks on cooldown finish
 		evasion_streak++ //Increment our streak count
 		clear_cooldown() //Clear our cooldown
@@ -437,7 +428,7 @@
 		return
 	if(!owner.Adjacent(A))
 		if(!silent)
-			owner.balloon_alert(owner, "Cannot snatch, not adjacent")
+			owner.balloon_alert(owner, "Cannot reach")
 		return FALSE
 	if(!ishuman(A))
 		if(!silent)
@@ -461,7 +452,6 @@
 		victim.balloon_alert(owner, "Snatch failed, no item")
 		return fail_activate()
 	playsound(owner, 'sound/voice/alien_pounce2.ogg', 30)
-	victim.balloon_alert(owner, "Snatch succeeded")
 	victim.dropItemToGround(stolen_item, TRUE)
 	stolen_item.forceMove(owner)
 	stolen_appearance = mutable_appearance(stolen_item.icon, stolen_item.icon_state)

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -17,11 +17,11 @@
 	if(X.savage)
 		X.savage = FALSE
 		X.balloon_alert(X, "No longer savaging")
-		to_chat(X, span_xenowarning("We untense our muscles, and relax. We will no longer savage when pouncing."))
+		to_chat(X, span_xenowarning("We untense our muscles, and relax."))
 	else
 		X.savage = TRUE
-		X.balloon_alert(X, "Now savage on pounce")
-		to_chat(X, "We ready ourselves for a killing stroke. We will savage when pouncing.[X.savage_used ? " However, we're not quite yet able to savage again." : ""]")
+		X.balloon_alert(X, "Will savage on pounce")
+		to_chat(X, "We ready ourselves for a killing stroke.[X.savage_used ? " However, we're not quite yet able to savage again." : ""]")
 	update_button_icon()
 
 /datum/action/xeno_action/toggle_savage/update_button_icon()
@@ -40,12 +40,10 @@
 
 	if(savage_used)
 		src.balloon_alert(src, "Cannot savage, cooldown")
-		to_chat(src, span_xenowarning("We're too tired to savage right now."))
 		return
 
 	if(stagger)
 		src.balloon_alert(src, "Cannot savage, staggered")
-		to_chat(src, span_xenodanger("We're too disoriented from the shock to savage!"))
 		return
 
 	playsound(src, "alien_roar[rand(1,6)]", 50)
@@ -130,10 +128,9 @@
 				INVOKE_ASYNC(X, /mob/living/carbon/xenomorph/.proc/Savage, M)
 			else
 				X.balloon_alert(X, "Cannot savage, no plasma")
-				to_chat(X, span_xenodanger("We attempt to savage our victim, but we need [10-X.plasma_stored] more plasma."))
+				to_chat(X, span_xenodanger("We attempt to savage our victim but we need at least [10-X.plasma_stored] more plasma."))
 		else
 			X.balloon_alert(X, "Cannot savage, not ready")
-			to_chat(X, span_xenodanger("We attempt to savage our victim, but we aren't yet ready."))
 
 	playsound(X.loc, 'sound/voice/alien_pounce.ogg', 25, TRUE)
 
@@ -440,8 +437,7 @@
 		return
 	if(!owner.Adjacent(A))
 		if(!silent)
-			owner.balloon_alert(owner, "Cannot snatch, too far")
-			to_chat(owner, span_xenodanger("Our snatch target must be adjacent!"))
+			owner.balloon_alert(owner, "Cannot snatch, not adjacent")
 		return FALSE
 	if(!ishuman(A))
 		if(!silent)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Runner abilities now have balloon alerts.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Shamelessly copy pasting what RipGrayson said in their (now closed) PR:

> We're moving away from the philosophy of needing to stare at chat in order to see what's going on, runechat did it for speech, balloon_alerts do it for actions. It's just so much easier to see what's going on by looking at your character than it is to dig around in a bunch of text.

> On the aesthetic side it actually looks really cool to see overhead notifications like "Franklin Ramis fixes the internal wiring of platinum miner" or "Queen (236) starts emitting pheremones", it makes us look very smooth.

> So by implementing this not only do we look fancy, but it also enhances team cooperation because xenos/marines can see what their teammates are doing while being focused on combat. (Not that they couldn't before, they would just have to scroll through chat, which made it impractical).

## Changelog
:cl:
qol: Runner actions now have balloon alerts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
