### PR TITLE
Adds and Replaces To_Chat() With Balloon_Alerts() in Drone, Hivelord, and Queen Abilities

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
@@ -77,6 +77,7 @@
 	var/mob/living/carbon/xenomorph/owner_xeno = owner
 	if(!owner_xeno.loc_weeds_type)
 		if(!silent)
+			owner.balloon_alert(owner, "Cannot sow, no weeds")
 			to_chat(owner, span_warning("Only weeds are fertile enough for our plants!"))
 		return FALSE
 
@@ -110,7 +111,7 @@
 		if(initial(current_plant.name) == plant_choice)
 			X.selected_plant = current_plant
 			break
-	to_chat(X, span_notice("We will now sow <b>[plant_choice]</b>."))
+	X.balloon_alert(X, "Sowing [plant_choice]")
 	update_button_icon()
 
 /datum/action/xeno_action/sow/alternate_action_activate()

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
@@ -78,7 +78,6 @@
 	if(!owner_xeno.loc_weeds_type)
 		if(!silent)
 			owner.balloon_alert(owner, "Cannot sow, no weeds")
-			to_chat(owner, span_warning("Only weeds are fertile enough for our plants!"))
 		return FALSE
 
 	var/turf/T = get_turf(owner)
@@ -111,7 +110,7 @@
 		if(initial(current_plant.name) == plant_choice)
 			X.selected_plant = current_plant
 			break
-	X.balloon_alert(X, "Sowing [plant_choice]")
+	X.balloon_alert(X, "[plant_choice]")
 	update_button_icon()
 
 /datum/action/xeno_action/sow/alternate_action_activate()

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -218,6 +218,7 @@
 
 	playsound(T, "alien_resin_build", 25)
 	var/obj/structure/xeno/resin_jelly_pod/pod = new(T)
+	to_chat(owner, span_xenonotice("We shape some resin into \a [pod]."))
 	add_cooldown()
 
 /datum/action/xeno_action/create_jelly

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -132,6 +132,7 @@
 
 /datum/action/xeno_action/build_tunnel/action_activate()
 	var/turf/T = get_turf(owner)
+	var/mob/living/carbon/xenomorph/hivelord/X = owner
 
 	X.balloon_alert(X, "Digging...")
 	owner.visible_message(span_xenonotice("[owner] begins digging out a tunnel entrance."), \
@@ -144,7 +145,6 @@
 	if(!can_use_action(TRUE))
 		return fail_activate()
 
-	var/mob/living/carbon/xenomorph/hivelord/X = owner
 	T.balloon_alert(X, "Dug tunnel")
 	X.visible_message(span_xenonotice("\The [X] digs out a tunnel entrance."), \
 	span_xenonotice("We dig out a tunnel, connecting it to our network."), null, 5)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -57,7 +57,6 @@
 	speed_activated = TRUE
 	if(!silent)
 		owner.balloon_alert(owner, "Resin walk active")
-		to_chat(owner, span_notice("We become one with the resin. We feel the urge to run!"))
 	if(walker.loc_weeds_type)
 		speed_bonus_active = TRUE
 		walker.add_movespeed_modifier(type, TRUE, 0, NONE, TRUE, -1.5)
@@ -68,7 +67,6 @@
 	var/mob/living/carbon/xenomorph/walker = owner
 	if(!silent)
 		owner.balloon_alert(owner, "Resin walk ended")
-		to_chat(owner, span_warning("We feel less in tune with the resin."))
 	if(speed_bonus_active)
 		walker.remove_movespeed_modifier(type)
 		speed_bonus_active = FALSE
@@ -81,7 +79,6 @@
 	var/mob/living/carbon/xenomorph/walker = owner
 	if(!isturf(walker.loc) || !walker.check_plasma(10, TRUE))
 		owner.balloon_alert(owner, "Resin walk ended, no plasma")
-		to_chat(owner, span_warning("We feel dizzy as the world slows down."))
 		resinwalk_off(TRUE)
 		return
 	if(walker.loc_weeds_type)
@@ -135,17 +132,16 @@
 	var/mob/living/carbon/xenomorph/hivelord/X = owner
 
 	X.balloon_alert(X, "Digging...")
-	owner.visible_message(span_xenonotice("[owner] begins digging out a tunnel entrance."), \
+	X.visible_message(span_xenonotice("[X] begins digging out a tunnel entrance."), \
 	span_xenonotice("We begin digging out a tunnel entrance."), null, 5)
-	if(!do_after(owner, HIVELORD_TUNNEL_DIG_TIME, TRUE, T, BUSY_ICON_BUILD))
+	if(!do_after(X, HIVELORD_TUNNEL_DIG_TIME, TRUE, T, BUSY_ICON_BUILD))
 		X.balloon_alert(X, "Digging aborted")
-		to_chat(owner, span_warning("Our tunnel caves in as we stop digging it."))
 		return fail_activate()
 
 	if(!can_use_action(TRUE))
 		return fail_activate()
 
-	T.balloon_alert(X, "Dug tunnel")
+	T.balloon_alert(X, "Tunnel dug")
 	X.visible_message(span_xenonotice("\The [X] digs out a tunnel entrance."), \
 	span_xenonotice("We dig out a tunnel, connecting it to our network."), null, 5)
 	var/obj/structure/xeno/tunnel/newt = new(T)
@@ -222,7 +218,6 @@
 
 	playsound(T, "alien_resin_build", 25)
 	var/obj/structure/xeno/resin_jelly_pod/pod = new(T)
-	pod.balloon_alert("Pod successfully placed")
 	add_cooldown()
 
 /datum/action/xeno_action/create_jelly
@@ -293,7 +288,7 @@
 	var/dist = get_dist(owner, target)
 	if(dist > heal_range)
 		if(!silent)
-			target.balloon_alert(owner, "Cannot heal, too far")
+			target.balloon_alert(owner, "Cannot reach")
 			to_chat(owner, span_warning("Too far for our reach... We need to be [dist - heal_range] steps closer!"))
 		return FALSE
 	else if(!line_of_sight(owner, target))
@@ -309,7 +304,6 @@
 
 	owner.face_atom(target) //Face the target so we don't look stupid
 
-	target.balloon_alert(owner, "Infusion succeeded")
 	owner.visible_message(span_xenodanger("\the [owner] infuses [target] with mysterious energy!"), \
 	span_xenodanger("We empower [target] with our [src]!"))
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -124,6 +124,7 @@
 
 /datum/action/xeno_action/build_tunnel/on_cooldown_finish()
 	var/mob/living/carbon/xenomorph/X = owner
+	to_chat(X, span_notice("We are ready to dig a tunnel again."))
 	return ..()
 
 /datum/action/xeno_action/build_tunnel/action_activate()

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -124,7 +124,6 @@
 
 /datum/action/xeno_action/build_tunnel/on_cooldown_finish()
 	var/mob/living/carbon/xenomorph/X = owner
-	X.balloon_alert(X, "Dig tunnel ready")
 	return ..()
 
 /datum/action/xeno_action/build_tunnel/action_activate()

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -385,20 +385,20 @@
 	var/mob/living/carbon/xenomorph/receiver = target
 	if(!CHECK_BITFIELD(use_state_flags|override_flags, XACT_IGNORE_DEAD_TARGET) && receiver.stat == DEAD)
 		if(!silent)
-			reciever.balloon_alert(owner, "Cannot give plasma, dead")
+			receiver.balloon_alert(owner, "Cannot give plasma, dead")
 		return FALSE
 	if(!(receiver.xeno_caste.caste_flags & CASTE_CAN_BE_GIVEN_PLASMA))
 		if(!silent)
-			reciever.balloon_alert(owner, "Cannot give plasma")
+			receiver.balloon_alert(owner, "Cannot give plasma")
 			return FALSE
 	var/mob/living/carbon/xenomorph/giver = owner
 	if(giver.z != receiver.z)
 		if(!silent)
-			reciever.balloon_alert(owner, "Cannot give plasma, too far")
+			receiver.balloon_alert(owner, "Cannot give plasma, too far")
 		return FALSE
 	if(receiver.plasma_stored >= receiver.xeno_caste.plasma_max)
 		if(!silent)
-			reciever.balloon_alert(owner, "Cannot give plasma, full")
+			receiver.balloon_alert(owner, "Cannot give plasma, full")
 		return FALSE
 
 
@@ -407,7 +407,7 @@
 	add_cooldown()
 	receiver.gain_plasma(300)
 	succeed_activate()
-	reciever.balloon_alert_to_viewers("Plasma given from Queen")
+	receiver.balloon_alert_to_viewers("Plasma given from Queen")
 
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -497,7 +497,6 @@
 	if(T.health <= 0)
 		return
 
-	T.balloon_alert(X, "Deevolve succeeded")
 	T.balloon_alert(T, "Queen deevolution")
 	to_chat(T, span_xenowarning("The Queen deevolved us for the following reason: [reason]"))
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -70,6 +70,7 @@
 	keybind_signal = COMSIG_XENOABILITY_SCREECH
 
 /datum/action/xeno_action/activable/screech/on_cooldown_finish()
+	owner.balloon_alert(owner, "Screech ready")
 	to_chat(owner, span_warning("We feel our throat muscles vibrate. We are ready to screech again."))
 	return ..()
 
@@ -322,7 +323,8 @@
 
 	if(xeno_ruler.xeno_caste.queen_leader_limit <= length(xeno_ruler.hive.xeno_leader_list))
 		if(feedback)
-			to_chat(xeno_ruler, span_xenowarning("We currently have [length(xeno_ruler.hive.xeno_leader_list)] promoted leaders. We may not maintain additional leaders until our power grows."))
+			xeno_ruler.balloon_alert(xeno_ruler, "No more leadership slots")
+			to_chat(xeno_ruler, span_xenowarning("We currently have the maximum of [length(xeno_ruler.hive.xeno_leader_list)] promoted leaders. We may not maintain additional leaders until our power grows."))
 		return
 
 	set_xeno_leader(selected_xeno, feedback)
@@ -331,7 +333,9 @@
 /datum/action/xeno_action/set_xeno_lead/proc/unset_xeno_leader(mob/living/carbon/xenomorph/selected_xeno, feedback = TRUE)
 	var/mob/living/carbon/xenomorph/xeno_ruler = owner
 	if(feedback)
+		xeno_ruler.balloon_alert(xeno_ruler, "Xeno demoted")
 		to_chat(xeno_ruler, span_xenonotice("We've demoted [selected_xeno] from Lead."))
+		selected_xeno.balloon_alert(selected_xeno, "Leadership removed")
 		to_chat(selected_xeno, span_xenoannounce("[xeno_ruler] has demoted us from Hive Leader. Our leadership rights and abilities have waned."))
 	selected_xeno.hive.remove_leader(selected_xeno)
 	selected_xeno.hud_set_queen_overwatch()
@@ -343,10 +347,12 @@
 	var/mob/living/carbon/xenomorph/xeno_ruler = owner
 	if(!(selected_xeno.xeno_caste.caste_flags & CASTE_CAN_BE_LEADER))
 		if(feedback)
-			to_chat(xeno_ruler, span_xenowarning("This caste is unfit to lead."))
+			xeno_ruler.balloon_alert(xeno_ruler, "Xeno cannot lead")
 		return
 	if(feedback)
+		xeno_ruler.balloon_alert(xeno_ruler, "Xeno promoted")
 		to_chat(xeno_ruler, span_xenonotice("We've selected [selected_xeno] as a Hive Leader."))
+		selected_xeno.balloon_alert(selected_xeno, "Promoted to leader")
 		to_chat(selected_xeno, span_xenoannounce("[xeno_ruler] has selected us as a Hive Leader. The other Xenomorphs must listen to us. We will also act as a beacon for the Queen's pheromones."))
 
 	xeno_ruler.hive.add_leader(selected_xeno)
@@ -379,20 +385,20 @@
 	var/mob/living/carbon/xenomorph/receiver = target
 	if(!CHECK_BITFIELD(use_state_flags|override_flags, XACT_IGNORE_DEAD_TARGET) && receiver.stat == DEAD)
 		if(!silent)
-			to_chat(owner, span_warning("It's too late, this one has already kicked the bucket."))
+			reciever.balloon_alert(owner, "Cannot give plasma, dead")
 		return FALSE
 	if(!(receiver.xeno_caste.caste_flags & CASTE_CAN_BE_GIVEN_PLASMA))
 		if(!silent)
-			to_chat(owner, span_warning("We can't give that caste plasma."))
+			reciever.balloon_alert(owner, "Cannot give plasma")
 			return FALSE
 	var/mob/living/carbon/xenomorph/giver = owner
 	if(giver.z != receiver.z)
 		if(!silent)
-			to_chat(giver, span_warning("They are too far away to do this."))
+			reciever.balloon_alert(owner, "Cannot give plasma, too far")
 		return FALSE
 	if(receiver.plasma_stored >= receiver.xeno_caste.plasma_max)
 		if(!silent)
-			to_chat(giver, span_warning("[receiver] is at full plasma."))
+			reciever.balloon_alert(owner, "Cannot give plasma, full")
 		return FALSE
 
 
@@ -401,8 +407,7 @@
 	add_cooldown()
 	receiver.gain_plasma(300)
 	succeed_activate()
-	to_chat(owner, span_xenonotice("We transfer some plasma to [target]."))
-	to_chat(receiver, span_xenonotice("We feel our plasma reserves increase. Bless the Queen!"))
+	reciever.balloon_alert_to_viewers("Plasma given from Queen")
 
 
 // ***************************************
@@ -451,7 +456,7 @@
 /datum/action/xeno_action/deevolve/action_activate()
 	var/mob/living/carbon/xenomorph/queen/X = owner
 	if(!X.observed_xeno)
-		to_chat(X, span_warning("We must overwatch the xeno we want to de-evolve."))
+		X.balloon_alert(X, "Must overwatch to deevolve")
 		return
 
 	var/mob/living/carbon/xenomorph/T = X.observed_xeno
@@ -459,19 +464,19 @@
 		return
 
 	if(T.is_ventcrawling)
-		to_chat(X, span_warning("[T] can't be deevolved here."))
+		T.balloon_alert(X, "Cannot deevolve, ventcrawling")
 		return
 
 	if(!isturf(T.loc))
-		to_chat(X, span_warning("[T] can't be deevolved here."))
+		T.balloon_alert(X, "Cannot deevolve here")
 		return
 
 	if(T.health <= 0)
-		to_chat(X, span_warning("[T] is too weak to be deevolved."))
+		T.balloon_alert(X, "Cannot deevolve, too weak")
 		return
 
 	if(!T.xeno_caste.deevolves_to)
-		to_chat(X, span_xenowarning("[T] can't be deevolved."))
+		T.balloon_alert(X, "Cannot deevolve")
 		return
 
 	var/datum/xeno_caste/new_caste = GLOB.xeno_caste_datums[T.xeno_caste.deevolves_to][XENO_UPGRADE_ZERO]
@@ -482,7 +487,7 @@
 
 	var/reason = stripped_input(X, "Provide a reason for deevolving this xenomorph, [T]")
 	if(isnull(reason))
-		to_chat(X, span_xenowarning("You must provide a reason for deevolving [T]."))
+		T.balloon_alert(X, "De-evolution reason required")
 		return
 
 	if(!X.check_concious_state() || !X.check_plasma(600) || X.observed_xeno != T)
@@ -497,7 +502,9 @@
 	if(T.health <= 0)
 		return
 
-	to_chat(T, span_xenowarning("The queen is deevolving us for the following reason: [reason]"))
+	T.balloon_alert(X, "Deevolve succeeded")
+	T.balloon_alert(T, "Queen deevolution")
+	to_chat(T, span_xenowarning("The Queen deevolved us for the following reason: [reason]"))
 
 	T.do_evolve(new_caste.caste_type_path, new_caste.caste_name, TRUE)
 
@@ -507,4 +514,4 @@
 	GLOB.round_statistics.total_xenos_created-- //so an evolved xeno doesn't count as two.
 	SSblackbox.record_feedback("tally", "round_statistics", -1, "total_xenos_created")
 	qdel(T)
-	X.use_plasma(600)
+	succeed_activate()

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -70,7 +70,6 @@
 	keybind_signal = COMSIG_XENOABILITY_SCREECH
 
 /datum/action/xeno_action/activable/screech/on_cooldown_finish()
-	owner.balloon_alert(owner, "Screech ready")
 	to_chat(owner, span_warning("We feel our throat muscles vibrate. We are ready to screech again."))
 	return ..()
 
@@ -324,7 +323,6 @@
 	if(xeno_ruler.xeno_caste.queen_leader_limit <= length(xeno_ruler.hive.xeno_leader_list))
 		if(feedback)
 			xeno_ruler.balloon_alert(xeno_ruler, "No more leadership slots")
-			to_chat(xeno_ruler, span_xenowarning("We currently have the maximum of [length(xeno_ruler.hive.xeno_leader_list)] promoted leaders. We may not maintain additional leaders until our power grows."))
 		return
 
 	set_xeno_leader(selected_xeno, feedback)
@@ -334,9 +332,7 @@
 	var/mob/living/carbon/xenomorph/xeno_ruler = owner
 	if(feedback)
 		xeno_ruler.balloon_alert(xeno_ruler, "Xeno demoted")
-		to_chat(xeno_ruler, span_xenonotice("We've demoted [selected_xeno] from Lead."))
 		selected_xeno.balloon_alert(selected_xeno, "Leadership removed")
-		to_chat(selected_xeno, span_xenoannounce("[xeno_ruler] has demoted us from Hive Leader. Our leadership rights and abilities have waned."))
 	selected_xeno.hive.remove_leader(selected_xeno)
 	selected_xeno.hud_set_queen_overwatch()
 	selected_xeno.handle_xeno_leader_pheromones(xeno_ruler)
@@ -351,7 +347,6 @@
 		return
 	if(feedback)
 		xeno_ruler.balloon_alert(xeno_ruler, "Xeno promoted")
-		to_chat(xeno_ruler, span_xenonotice("We've selected [selected_xeno] as a Hive Leader."))
 		selected_xeno.balloon_alert(selected_xeno, "Promoted to leader")
 		to_chat(selected_xeno, span_xenoannounce("[xeno_ruler] has selected us as a Hive Leader. The other Xenomorphs must listen to us. We will also act as a beacon for the Queen's pheromones."))
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Some more balloon alerts. This time for drones, and their fatter cousins.

With all these balloon alerts, we'll need to see if any accidentally conflict and overlap.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Shamelessly copy pasting what RipGrayson said in their (now closed) PR:

> We're moving away from the philosophy of needing to stare at chat in order to see what's going on, runechat did it for speech, balloon_alerts do it for actions. It's just so much easier to see what's going on by looking at your character than it is to dig around in a bunch of text.

> On the aesthetic side it actually looks really cool to see overhead notifications like "Franklin Ramis fixes the internal wiring of platinum miner" or "Queen (236) starts emitting pheremones", it makes us look very smooth.

> So by implementing this not only do we look fancy, but it also enhances team cooperation because xenos/marines can see what their teammates are doing while being focused on combat. (Not that they couldn't before, they would just have to scroll through chat, which made it impractical).

## Changelog
:cl:
qol: Drones, Hivelords, and Queens now have balloon alerts for their abilities.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
