### PR TITLE
Armor Check Refactor (Now With Manual Merge Conflict Resolution)

### DIFF
--- a/code/datums/weather/weather_types/acid_rain.dm
+++ b/code/datums/weather/weather_types/acid_rain.dm
@@ -48,7 +48,7 @@
 /datum/weather/acid_rain/weather_act(mob/living/L)
 	if(L.stat == DEAD)
 		return
-	var/resist = L.getarmor(null, "acid")
+	var/resist = L.get_soft_armor("acid")
 	if(prob(max(0,100-resist)))
 		L.adjustFireLoss(7)
 		to_chat(L, span_boldannounce("You feel the acid rain melting you away!"))

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -103,11 +103,11 @@
 
 	next_move_slowdown += slow_amt
 	var/datum/limb/affecting = get_limb(BODY_ZONE_PRECISE_L_FOOT)
-	var/armor_block = run_armor_check(affecting, "acid")
+	var/armor_block = get_soft_armor("acid", affecting)
 	INVOKE_ASYNC(affecting, /datum/limb/.proc/take_damage_limb, 0, acid_damage/2, FALSE, FALSE, armor_block)
 
 	affecting = get_limb(BODY_ZONE_PRECISE_R_FOOT)
-	armor_block = run_armor_check(affecting, "acid")
+	armor_block = get_soft_armor("acid", affecting)
 	INVOKE_ASYNC(affecting, /datum/limb/.proc/take_damage_limb, 0, acid_damage/2, FALSE, FALSE, armor_block, TRUE)
 
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -301,7 +301,7 @@
 				break
 			if(!affected_limbs.Find(X.name) )
 				continue
-			armor_block = H.run_armor_check(X, "acid")
+			armor_block = H.get_soft_armor("acid", X)
 			if(istype(X) && X.take_damage_limb(0, rand(raw_damage * 0.75, raw_damage * 1.25), blocked = armor_block))
 				H.UpdateDamageIcon()
 			limb_count++

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -361,7 +361,7 @@
 		if(!target_zone || rand(40))
 			target_zone = "chest"
 		if(launched && CHECK_BITFIELD(resistance_flags, ON_FIRE) && !L.on_fire)
-			var/armor_block = L.run_armor_check(target_zone, "fire")
+			var/armor_block = L.get_soft_armor("fire", target_zone)
 			L.apply_damage(rand(throwforce*0.75,throwforce*1.25), BURN, target_zone, armor_block, updating_health = TRUE) //Do more damage if launched from a proper launcher and active
 
 	// Flares instantly burn out nodes when thrown at them.

--- a/code/game/objects/items/reagent_containers/food/drinks/bottle.dm
+++ b/code/game/objects/items/reagent_containers/food/drinks/bottle.dm
@@ -48,8 +48,8 @@
 	var/armor_duration = 0 //The more force the bottle has, the longer the duration.
 
 	//Calculating duration and calculating damage.
-	armor_block = target.run_armor_check(affecting, "melee")
-	armor_duration = duration + force - target.getarmor(affecting, "melee")
+	armor_block = target.get_soft_armor("melee", affecting)
+	armor_duration = duration + force - armor_block
 
 	//Apply the damage!
 	target.apply_damage(force, BRUTE, affecting, armor_block)

--- a/code/game/objects/items/reagent_containers/syringes.dm
+++ b/code/game/objects/items/reagent_containers/syringes.dm
@@ -238,7 +238,7 @@
 		if((user != target) && !H.check_shields(COMBAT_TOUCH_ATTACK, 14, "melee"))
 			return
 
-		if (target != user && prob(target.getarmor(target_zone, "melee")))
+		if (target != user && prob(target.get_soft_armor("melee", target_zone)))
 			visible_message(span_danger("[user] tries to stab [target] in \the [hit_area] with [src], but the attack is deflected by armor!"))
 			user.temporarilyRemoveItemFromInventory(src)
 			qdel(src)

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -61,7 +61,7 @@
 	playsound(src, 'sound/effects/barbed_wire_movement.ogg', 25, 1)
 	var/armor_block = null
 	var/def_zone = ran_zone()
-	armor_block = M.run_armor_check(def_zone, "melee")
+	armor_block = M.get_soft_armor("melee", def_zone)
 	M.apply_damage(RAZORWIRE_BASE_DAMAGE, BRUTE, def_zone, armor_block, TRUE, updating_health = TRUE)
 	razorwire_tangle(M)
 
@@ -114,7 +114,7 @@
 	visible_message(span_danger("[entangled] disentangles from [src]!"))
 	playsound(src, 'sound/effects/barbed_wire_movement.ogg', 25, TRUE)
 	var/def_zone = ran_zone()
-	var/armor_block = entangled.run_armor_check(def_zone, "melee")
+	var/armor_block = entangled.get_soft_armor("melee", def_zone)
 	entangled.apply_damage(RAZORWIRE_BASE_DAMAGE * RAZORWIRE_MIN_DAMAGE_MULT_MED, BRUTE, def_zone, armor_block, TRUE, updating_health = TRUE) //Apply damage as we tear free
 	return TRUE
 

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -196,7 +196,7 @@
 	unbuckle_mob(occupant)
 
 	var/def_zone = ran_zone()
-	var/blocked = occupant.run_armor_check(def_zone, "melee")
+	var/blocked = occupant.get_soft_armor("melee", def_zone)
 	occupant.throw_at(A, 3, propelled)
 	occupant.apply_effect(6, STUN, blocked)
 	occupant.apply_effect(6, WEAKEN, blocked)
@@ -207,7 +207,7 @@
 	if(isliving(A))
 		var/mob/living/victim = A
 		def_zone = ran_zone()
-		blocked = victim.run_armor_check(def_zone, "melee")
+		blocked = victim.get_soft_armor("melee", def_zone)
 		victim.apply_effect(6, STUN, blocked)
 		victim.apply_effect(6, WEAKEN, blocked)
 		victim.apply_effect(6, STUTTER, blocked)

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -105,7 +105,7 @@
 			occupant.throw_at(A, 3, propelled)
 
 		var/def_zone = ran_zone()
-		var/blocked = occupant.run_armor_check(def_zone, "melee")
+		var/blocked = occupant.get_soft_armor("melee", def_zone)
 		occupant.throw_at(A, 3, propelled)
 		occupant.apply_effect(6, STUN, blocked)
 		occupant.apply_effect(6, WEAKEN, blocked)
@@ -116,7 +116,7 @@
 		if(isliving(A))
 			var/mob/living/victim = A
 			def_zone = ran_zone()
-			blocked = victim.run_armor_check(def_zone, "melee")
+			blocked = victim.get_soft_armor("melee", def_zone)
 			victim.apply_effect(6, STUN, blocked)
 			victim.apply_effect(6, WEAKEN, blocked)
 			victim.apply_effect(6, STUTTER, blocked)

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -1,3 +1,4 @@
+#define LAVA_TILE_BURN_DAMAGE 20
 
 //turfs with density = FALSE
 /turf/open
@@ -395,7 +396,7 @@
 				continue
 
 			if(!L.on_fire || L.getFireLoss() <= 200)
-				L.take_overall_damage(null, 20, clamp(L.getarmor(null, "fire"), 0, 80))
+				L.take_overall_damage(0, LAVA_TILE_BURN_DAMAGE, clamp(L.get_soft_armor("fire"), 0, 80))
 				if(!CHECK_BITFIELD(L.flags_pass, PASSFIRE))//Pass fire allow to cross lava without igniting
 					L.adjust_fire_stacks(20)
 					L.IgniteMob()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -127,7 +127,7 @@
 
 	var/b_loss = 0
 	var/f_loss = 0
-	var/armor = getarmor(null, "bomb") * 0.01
+	var/armor = get_soft_armor("bomb") * 0.01 //Gets average bomb armor over all limbs.
 
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
@@ -178,7 +178,7 @@
 		var/damage = M.melee_damage
 		var/dam_zone = pick("chest", "l_hand", "r_hand", "l_leg", "r_leg")
 		var/datum/limb/affecting = get_limb(ran_zone(dam_zone))
-		var/armor = run_armor_check(affecting, "melee")
+		var/armor = get_soft_armor("melee", affecting)
 		apply_damage(damage, BRUTE, affecting, armor, updating_health = TRUE)
 
 /mob/living/carbon/human/show_inv(mob/living/user)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -105,7 +105,7 @@
 			var/damage = rand(1, max_dmg)
 
 			var/datum/limb/affecting = get_limb(ran_zone(H.zone_selected))
-			var/armor_block = run_armor_check(affecting, "melee")
+			var/armor_block = get_soft_armor("melee", affecting)
 
 			playsound(loc, attack.attack_sound, 25, TRUE)
 
@@ -160,7 +160,7 @@
 			var/randn = rand(1, 100) + skills.getRating("cqc") * 5 - H.skills.getRating("cqc") * 5
 
 			if (randn <= 25)
-				apply_effect(3, WEAKEN, run_armor_check(affecting, "melee"))
+				apply_effect(3, WEAKEN, get_soft_armor("melee", affecting))
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
 				visible_message(span_danger("[H] has pushed [src]!"), null, null, 5)
 				log_combat(user, src, "pushed")

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -345,7 +345,7 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 	damage = damage / partcount //damage all limbs equally.
 	while(parts.len)
 		var/datum/limb/picked = pick_n_take(parts)
-		apply_damage(damage, damagetype, picked, run_armor_check(picked, armortype), sharp, edge, updating_health)
+		apply_damage(damage, damagetype, picked, get_soft_armor(picked, armortype), sharp, edge, updating_health)
 
 ////////////////////////////////////////////
 

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -345,7 +345,7 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 	damage = damage / partcount //damage all limbs equally.
 	while(parts.len)
 		var/datum/limb/picked = pick_n_take(parts)
-		apply_damage(damage, damagetype, picked, get_soft_armor(picked, armortype), sharp, edge, updating_health)
+		apply_damage(damage, damagetype, picked, get_soft_armor(armortype, picked), sharp, edge, updating_health)
 
 ////////////////////////////////////////////
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -32,29 +32,6 @@ Contains most of the procs that are called when a mob is attacked by something
 	return ..()
 
 
-/mob/living/carbon/human/getarmor(def_zone, type)
-	var/armorval = 0
-	var/total = 0
-
-	if(def_zone)
-		if(isorgan(def_zone))
-			return getarmor_organ(def_zone, type)
-		var/datum/limb/affecting = get_limb(def_zone)
-		return getarmor_organ(affecting, type)
-		//If a specific bodypart is targetted, check how that bodypart is protected and return the value.
-
-	//If you don't specify a bodypart, it checks ALL your bodyparts for protection, and averages out the values
-	else
-		for(var/X in limbs)
-			var/datum/limb/E = X
-			var/weight = GLOB.organ_rel_size[E.name]
-			armorval += getarmor_organ(E, type) * weight
-			total += weight
-			#ifdef DEBUG_HUMAN_EXPLOSIONS
-			to_chat(src, "DEBUG getarmor: total: [total], armorval: [armorval], weight: [weight], name: [E.name]")
-			#endif
-	return round(armorval / max(total, 1), 1)
-
 //this proc returns the Siemens coefficient of electrical resistivity for a particular external organ.
 /mob/living/carbon/human/proc/get_siemens_coefficient_organ(datum/limb/def_zone)
 	if (!def_zone)
@@ -96,11 +73,6 @@ Contains most of the procs that are called when a mob is attacked by something
 
 /mob/living/carbon/human/dummy/remove_limb_armor(obj/item/armor_item)
 	return
-
-
-///This proc returns the armour value for a particular external organ.
-/mob/living/carbon/human/proc/getarmor_organ(datum/limb/affected_limb, type)
-	return affected_limb.soft_armor.getRating(type)
 
 
 /mob/living/carbon/human/proc/check_head_coverage()
@@ -176,7 +148,7 @@ Contains most of the procs that are called when a mob is attacked by something
 			log_combat(user, src, "attacked", I, "(FAILED: shield blocked) (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(I.damtype)])")
 			return TRUE
 
-	var/armor = run_armor_check(affecting, "melee")
+	var/armor = get_soft_armor("melee", affecting)
 	var/attack_verb = LAZYLEN(I.attack_verb) ? pick(I.attack_verb) : "attacked"
 	var/armor_verb
 	switch(armor)
@@ -199,7 +171,7 @@ Contains most of the procs that are called when a mob is attacked by something
 
 	var/weapon_sharp = is_sharp(I)
 	var/weapon_edge = has_edge(I)
-	if((weapon_sharp || weapon_edge) && prob(getarmor(target_zone, "melee")))
+	if((weapon_sharp || weapon_edge) && prob(get_soft_armor("melee", target_zone)))
 		weapon_sharp = FALSE
 		weapon_edge = FALSE
 
@@ -330,7 +302,7 @@ Contains most of the procs that are called when a mob is attacked by something
 
 	thrown_item.set_throwing(FALSE) // Hit the limb.
 
-	var/armor = run_armor_check(affecting, "melee") //I guess "melee" is the best fit here
+	var/armor = get_soft_armor("melee", affecting) //I guess "melee" is the best fit here
 
 	if(armor >= 100)
 		visible_message(span_notice("\The [thrown_item] bounces on [src]'s armor!"), null, null, 5)

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -89,7 +89,7 @@
 		damage_mod += dam_bonus
 
 	if(!(signal_return & COMPONENT_BYPASS_ARMOR))
-		armor_block = run_armor_check(affecting, "melee")
+		armor_block = get_soft_armor("melee", affecting)
 
 	for(var/i in damage_mod)
 		damage += i

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -44,7 +44,7 @@
 			var/affecting = H.get_limb(ran_zone(null, 0))
 			if(!affecting) //Still nothing??
 				affecting = H.get_limb("chest") //Gotta have a torso?!
-			var/armor_block = H.run_armor_check(affecting, "melee")
+			var/armor_block = H.get_soft_armor("melee", affecting)
 			H.apply_damage(damage, BRUTE, affecting, armor_block) //Crap base damage after armour...
 			H.apply_damage(damage, STAMINA, updating_health = TRUE) //...But some sweet armour ignoring Stamina
 			H.Paralyze(5) //trip and go
@@ -426,7 +426,7 @@
 		var/affecting = slapped.get_limb(ran_zone(null, 0))
 		if(!affecting)
 			affecting = slapped.get_limb("chest")
-		var/armor_block = slapped.run_armor_check(affecting, "melee")
+		var/armor_block = slapped.get_soft_armor("melee", affecting)
 		slapped.apply_damage(damage, BRUTE, affecting, armor_block)
 		slapped.apply_damage(damage, STAMINA, updating_health = TRUE)
 		slapped.Paralyze(3)

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -483,9 +483,9 @@
 			L.remove_limb_flags(LIMB_SPLINTED)
 			to_chat(src, span_danger("The splint on your [L.display_name] comes apart!"))
 
-		L.take_damage_limb(damage, 0, FALSE, FALSE, run_armor_check(target_zone))
+		L.take_damage_limb(damage, 0, FALSE, FALSE, get_soft_armor(target_zone))
 	else
-		apply_damage(damage, BRUTE, target_zone, run_armor_check(target_zone))
+		apply_damage(damage, BRUTE, target_zone, get_soft_armor(target_zone))
 
 	if(push)
 		var/facing = get_dir(X, src)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -278,7 +278,8 @@
 
 		if(precrush > 0)
 			log_combat(charger, crushed_living, "xeno charged")
-			crushed_living.apply_damage(precrush, BRUTE, BODY_ZONE_CHEST, crushed_living.run_armor_check(BODY_ZONE_CHEST, "melee"), updating_health = TRUE) //There is a chance to do enough damage here to gib certain mobs. Better update immediately.
+			 //There is a chance to do enough damage here to gib certain mobs. Better update immediately.
+			crushed_living.apply_damage(precrush, BRUTE, BODY_ZONE_CHEST, crushed_living.get_soft_armor("melee", BODY_ZONE_CHEST), updating_health = TRUE)
 			if(QDELETED(crushed_living))
 				charger.visible_message(span_danger("[charger] anihilates [preserved_name]!"),
 				span_xenodanger("We anihilate [preserved_name]!"))

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -278,7 +278,7 @@
 
 		if(precrush > 0)
 			log_combat(charger, crushed_living, "xeno charged")
-			 //There is a chance to do enough damage here to gib certain mobs. Better update immediately.
+			//There is a chance to do enough damage here to gib certain mobs. Better update immediately.
 			crushed_living.apply_damage(precrush, BRUTE, BODY_ZONE_CHEST, crushed_living.get_soft_armor("melee", BODY_ZONE_CHEST), updating_health = TRUE)
 			if(QDELETED(crushed_living))
 				charger.visible_message(span_danger("[charger] anihilates [preserved_name]!"),

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -707,7 +707,7 @@
 
 	var/mob/living/victim = M
 	do_attack_animation(M)
-	var/armor_block = victim.run_armor_check(BODY_ZONE_CHEST, "bio")
+	var/armor_block = victim.get_soft_armor("bio", BODY_ZONE_CHEST)
 	victim.apply_damage(100, STAMINA, BODY_ZONE_CHEST, armor_block) //This should prevent sprinting
 	victim.apply_damage(1, BRUTE, sharp = TRUE) //Token brute for the injection
 	victim.reagents.add_reagent(/datum/reagent/toxin/xeno_neurotoxin, 10, no_overdose = TRUE)
@@ -774,7 +774,7 @@
 
 		target.adjust_stagger(3)
 		target.add_slowdown(15)
-		armor_block = target.run_armor_check(BODY_ZONE_CHEST, "bio")
+		armor_block = target.get_soft_armor("bio", BODY_ZONE_CHEST)
 		target.apply_damage(100, STAMINA, BODY_ZONE_CHEST, armor_block) //Small amount of stamina damage; meant to stop sprinting.
 
 	kill_hugger(0.5 SECONDS)
@@ -801,7 +801,7 @@
 	var/affecting = ran_zone(null, 0)
 	if(!affecting) //Still nothing??
 		affecting = BODY_ZONE_CHEST //Gotta have a torso?!
-	var/armor_block = victim.run_armor_check(affecting, "melee")
+	var/armor_block = victim.get_soft_armor("melee", affecting)
 	victim.apply_damage(CARRIER_SLASH_HUGGER_DAMAGE, BRUTE, affecting, armor_block) //Crap base damage after armour...
 	victim.visible_message(span_danger("[src] frantically claws at [victim]!"),span_danger("[src] frantically claws at you!"))
 	leaping = FALSE

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -550,7 +550,7 @@
 		GLOB.round_statistics.praetorian_spray_direct_hits++
 		SSblackbox.record_feedback("tally", "round_statistics", 1, "praetorian_spray_direct_hits")
 
-	var/armor_block = run_armor_check(BODY_ZONE_CHEST, "acid")
+	var/armor_block = get_soft_armor("acid", BODY_ZONE_CHEST)
 	var/damage = X.xeno_caste.acid_spray_damage_on_hit
 	INVOKE_ASYNC(src, .proc/apply_acid_spray_damage, damage, armor_block)
 	to_chat(src, span_xenodanger("\The [X] showers you in corrosive acid!"))

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -1,21 +1,3 @@
-
-/*
-	run_armor_check(a,b)
-	args
-	a:def_zone - What part is getting hit, if null will check entire body
-	b:attack_flag - What type of attack, bullet, laser, energy, melee
-
-	Returns
-	The armour percentage which is deducted om the damage.
-*/
-/mob/living/proc/run_armor_check(def_zone = null, attack_flag = "melee")
-	return getarmor(def_zone, attack_flag)
-
-
-//if null is passed for def_zone, then this should return something appropriate for all zones (e.g. area effect damage)
-/mob/living/proc/getarmor(def_zone, type)
-	return 0
-
 //Handles the effects of "stun" weapons
 /**
 	stun_effect_act(stun_amount, agony_amount, def_zone)
@@ -72,7 +54,7 @@
 			return
 
 		src.visible_message(span_warning(" [src] has been hit by [O]."), null, null, 5)
-		var/armor = run_armor_check(null, "melee")
+		var/armor = get_soft_armor("melee")
 
 		if(armor < 1)
 			apply_damage(max(0, throw_damage - (throw_damage * soft_armor.getRating("melee") * 0.01)), dtype, null, armor, is_sharp(O), has_edge(O), TRUE)

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -235,9 +235,9 @@
 /// This proc causes damage evenly on a human mob limbs, accounting individual limb armor, if used on livings will just call take_overall_damage().
 /mob/living/proc/take_overall_damage_armored(damage, damagetype, armortype, sharp = FALSE, edge = FALSE, updating_health = FALSE) //This proc is overrided on humans, otherwise it just applies some damage and checks armor on chest if not human.
 	if(damagetype == BRUTE)
-		return take_overall_damage(damage, 0, run_armor_check(BODY_ZONE_CHEST, armortype), sharp, edge, updating_health)
+		return take_overall_damage(damage, 0, get_soft_armor(armortype), sharp, edge, updating_health)
 	if(damagetype == BURN)
-		return take_overall_damage(0, damage, run_armor_check(BODY_ZONE_CHEST, armortype), sharp, edge, updating_health)
+		return take_overall_damage(0, damage, get_soft_armor(armortype), sharp, edge, updating_health)
 	return FALSE
 
 /mob/living/proc/restore_all_organs()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -276,7 +276,7 @@
 		visible_message(span_warning("[src] looks unharmed."))
 		return FALSE
 	else
-		apply_damage(damage, damagetype, null, getarmor(null, armorcheck))
+		apply_damage(damage, damagetype, blocked = get_soft_armor(armorcheck))
 		UPDATEHEALTH(src)
 		return TRUE
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -173,7 +173,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 			continue
 		victim.visible_message(span_danger("[victim] is hit by backlash from \a [proj.name]!"),
 			isxeno(victim) ? span_xenodanger("We are hit by backlash from \a </b>[proj.name]</b>!") : span_highdanger("You are hit by backlash from \a </b>[proj.name]</b>!"))
-		var/armor_block = victim.run_armor_check(null, proj.ammo.armor_type)
+		var/armor_block = victim.get_soft_armor(proj.ammo.armor_type)
 		victim.apply_damage(proj.damage * proj.airburst_multiplier, proj.ammo.damage_type, null, armor_block, updating_health = TRUE)
 
 ///handles the probability of a projectile hit to trigger fire_burst, based off actual damage done
@@ -183,7 +183,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	if(!istype(target, /mob/living))
 		return
 	var/mob/living/victim = target
-	var/armor_block = victim.run_armor_check(null, "fire") //checks fire armour across the victim's whole body
+	var/armor_block = victim.get_soft_armor("fire") //checks fire armour across the victim's whole body
 	var/deflagrate_chance = (proj.damage * deflagrate_multiplier * (100 + min(0, proj.penetration - armor_block)) / 100)
 	if(prob(deflagrate_chance))
 		playsound(target, 'sound/effects/incendiary_explode.ogg', 45, falloff = 5)
@@ -200,7 +200,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 			victim.visible_message(span_danger("[victim] is scorched by [target] as they burst into flames!"),
 				isxeno(victim) ? span_xenodanger("We are scorched by [target] as they burst into flames!") : span_highdanger("you are scorched by [target] as they burst into flames!"))
 		//Damages the victims, inflicts brief stagger+slow, and ignites
-		var/armor_block = victim.run_armor_check(null, "fire") //checks fire armour across the victim's whole body
+		var/armor_block = victim.get_soft_armor(null, "fire") //checks fire armour across the victim's whole body
 		victim.apply_damage(fire_burst_damage, BURN, null, armor_block, updating_health = TRUE) //Placeholder damage, will be a ammo var
 
 		staggerstun(victim, proj, stagger = 0.5, slowdown = 0.5)
@@ -2067,7 +2067,7 @@ datum/ammo/bullet/revolver/tp44
 	C.add_slowdown(slowdown_stacks) //slow em down
 
 	set_reagents()
-	var/armor_block = (1 - C.run_armor_check(BODY_ZONE_CHEST, armor_type) * 0.01) //Check the target's armor mod; default to chest
+	var/armor_block = (1 - C.get_soft_armor(armor_type, BODY_ZONE_CHEST) * 0.01) //Check the target's armor mod; default to chest
 	for(var/reagent_id in spit_reagents) //modify by armor
 		spit_reagents[reagent_id] *= armor_block
 
@@ -2387,7 +2387,7 @@ datum/ammo/bullet/revolver/tp44
 
 	var/mob/living/carbon/carbon_victim = victim
 	set_reagents()
-	var/armor_block = (1 - carbon_victim.run_armor_check(BODY_ZONE_CHEST, armor_type) * 0.01) //Check the target's armor mod; default to chest
+	var/armor_block = (1 - carbon_victim.get_soft_armor(armor_type, BODY_ZONE_CHEST) * 0.01) //Check the target's armor mod; default to chest
 	for(var/reagent_id in spit_reagents) //modify by armor
 		spit_reagents[reagent_id] *= armor_block
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -200,7 +200,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 			victim.visible_message(span_danger("[victim] is scorched by [target] as they burst into flames!"),
 				isxeno(victim) ? span_xenodanger("We are scorched by [target] as they burst into flames!") : span_highdanger("you are scorched by [target] as they burst into flames!"))
 		//Damages the victims, inflicts brief stagger+slow, and ignites
-		var/armor_block = victim.get_soft_armor(null, "fire") //checks fire armour across the victim's whole body
+		var/armor_block = victim.get_soft_armor("fire") //checks fire armour across the victim's whole body
 		victim.apply_damage(fire_burst_damage, BURN, null, armor_block, updating_health = TRUE) //Placeholder damage, will be a ammo var
 
 		staggerstun(victim, proj, stagger = 0.5, slowdown = 0.5)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1210,12 +1210,36 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	return ..()
 
 
+///Returns the soft armor for the given mob. If human and no limb is specified, it takes the weighted average of all available limbs.
 /mob/living/proc/get_soft_armor(armor_type, proj_def_zone, proj_dir)
 	return soft_armor.getRating(armor_type)
 
 /mob/living/carbon/human/get_soft_armor(armor_type, proj_def_zone, proj_dir)
-	var/datum/limb/affected_limb = get_limb(check_zone(proj_def_zone))
-	return affected_limb.soft_armor.getRating(armor_type)
+	if(proj_def_zone)
+		var/datum/limb/affected_limb
+
+		if(isorgan(proj_def_zone))
+			affected_limb = proj_def_zone
+		else
+			affected_limb = get_limb(proj_def_zone)
+
+		return affected_limb.soft_armor.getRating(armor_type)
+		//If a specific bodypart is targeted, check how that bodypart is protected and return the value.
+
+	//If you don't specify a bodypart, it checks ALL your available bodyparts for protection, and averages out the values
+	else
+		var/armor_val = 0
+		var/total_weight = 0
+
+		var/list/datum/limb/parts = get_damageable_limbs()
+
+		while(parts.len)
+			var/datum/limb/picked = pick_n_take(parts)
+			var/weight = GLOB.organ_rel_size[picked.name]
+			armor_val += picked.soft_armor.getRating(armor_type) * weight
+			total_weight += weight
+		//Note, in the case of limbs missing, this will increase average armor if remaining armor is higher than if fully limbed.
+		return armor_val / total_weight
 
 /mob/living/carbon/xenomorph/get_soft_armor(armor_type, proj_def_zone, proj_dir)
 	return ..() * get_sunder()

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -608,8 +608,8 @@ TUNNEL
 		return
 
 	stepper.next_move_slowdown += charges * 2 //Acid spray has slow down so this should too; scales with charges, Min 2 slowdown, Max 10
-	stepper.apply_damage(charges * 10, BURN, BODY_ZONE_PRECISE_L_FOOT, stepper.run_armor_check(BODY_ZONE_PRECISE_L_FOOT, "acid") * 0.66) //33% armor pen
-	stepper.apply_damage(charges * 10, BURN, BODY_ZONE_PRECISE_R_FOOT, stepper.run_armor_check(BODY_ZONE_PRECISE_R_FOOT, "acid") * 0.66) //33% armor pen
+	stepper.apply_damage(charges * 10, BURN, BODY_ZONE_PRECISE_L_FOOT, stepper.get_soft_armor("acid", BODY_ZONE_PRECISE_L_FOOT) * 0.66) //33% armor pen
+	stepper.apply_damage(charges * 10, BURN, BODY_ZONE_PRECISE_R_FOOT, stepper.get_soft_armor("acid", BODY_ZONE_PRECISE_R_FOOT) * 0.66) //33% armor pen
 	stepper.ExtinguishMob()
 	stepper.visible_message(span_danger("[stepper] is immersed in [src]'s acid!") , \
 	span_danger("We are immersed in [src]'s acid!") , null, 5)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

All armor checks now execute through proper soft armor checks instead of ancient CM armor checks.

How ancient you say?

![image](https://user-images.githubusercontent.com/29745705/168452708-913c4467-d455-4a92-bc11-9fc0ca9693b2.png)

--------

**Why this new PR? Because fuck Git. I broke the last PR trying to resolve a merge conflict. This now has all changes manually copied over. Line by line via the coder's favorite keyboard combination: Control - C Control - V.**

Pain.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

All armor interactions now execute through TGMC armor checks and returning TGMC values.

That means yes, Xeno armor now mean something.

Previously, xeno armor was infact returning 0 (as in no armor for anything) for numerous interactions. This was legacy code from Apop himself in the initial commit of open source CM.

Several ancient interactions such as acid rain were in fact doing 100% of damage to xenos regardless of armor due to this legacy code. Now, acid rain damage is mitigated according to xeno "acid" armor and, in the case of ancient crusher (and only ancient crusher), now made immune to acid rain.

WILL NEED TESTING. XENO ARMOR WILL NEED REBALANCING / REDUCING.

Note that all checks were replaced with soft armor pulls. THIS IS INTENDED. Previous legacy code checking armor ONLY CHECKED SOFT ARMOR ON TARGET LIMBS.

This is a refactor only, enabling intended gameplay. NO BALANCE CHANGES DONE except in the case where armor now is properly pulled.

## Changelog
:cl:
refactor: Armor checks now correctly request target armor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
