### PR TITLE
Laser MG buffed in normal shot, efficency reworked.

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1823,11 +1823,14 @@ datum/ammo/bullet/revolver/tp44
 	name = "machine laser bolt"
 	damage = 15
 	penetration = 15
+	sundering = 1.5
 
 /datum/ammo/energy/lasgun/marine/autolaser/efficiency
 	name = "efficient machine laser bolt"
-	damage = 8.5
+	damage = 5
+	penetration = 20
 	hitscan_effect_icon = "beam_particle"
+	sundering = 3.5
 
 /datum/ammo/energy/lasgun/marine/sniper
 	name = "sniper laser bolt"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Someone suggested this for the Laser MG to not straight up be complete trash, and so it might be interesting to try.
Normal shot has 1.5 sunder over 1 sunder.
Efficency reduced to 5 damage, upped to 20 pen so it actually still does SOME damage to things.
Efficency now has 3 sunder.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes efficent lasgun fire actually do something, and makes sense considering it'll have some level of gimmick now.
Laser MG is in a terrible spot, so this could be interesting to try.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Laser MG normal fire does .5 more sunder, efficency does 5 damage over 8.5, and 20 pen over 15. Does 3 sunder on hit over 1.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
