### PR TITLE
Give energy sniper rifle aim mode, increase fire delay, & balance its heat mode

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -646,6 +646,7 @@
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_ENERGY|GUN_AMMO_COUNTER|GUN_NO_PITCH_SHIFT_NEAR_EMPTY|GUN_AMMO_COUNT_BY_SHOTS_REMAINING
 	attachable_offset = list("muzzle_x" = 41, "muzzle_y" = 18,"rail_x" = 19, "rail_y" = 19, "under_x" = 28, "under_y" = 8, "stock_x" = 22, "stock_y" = 12)
 	starting_attachment_types = list(/obj/item/attachable/scope/unremovable/laser_sniper_scope)
+	actions_types = list(/datum/action/item_action/aim_mode)
 
 	aim_slowdown = 0.7
 	wield_delay = 0.7 SECONDS
@@ -669,7 +670,7 @@
 	icon_state = "tes"
 
 /datum/lasrifle/base/energy_sniper_mode/heat
-	rounds_per_shot = 150
+	rounds_per_shot = 600
 	fire_delay = 1 SECONDS
 	ammo_datum_type = /datum/ammo/energy/lasgun/marine/sniper_heat
 	fire_sound = 'sound/weapons/guns/fire/laser3.ogg'

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -652,7 +652,7 @@
 	wield_delay = 0.7 SECONDS
 	scatter = 0
 	scatter_unwielded = 10
-	fire_delay = 1 SECONDS
+	fire_delay = 2 SECONDS
 	accuracy_mult = 1.35
 	accuracy_mult_unwielded = 0.5
 	mode_list = list(
@@ -662,7 +662,7 @@
 
 /datum/lasrifle/base/energy_sniper_mode/standard
 	rounds_per_shot = 50
-	fire_delay = 1 SECONDS
+	fire_delay = 2 SECONDS
 	ammo_datum_type = /datum/ammo/energy/lasgun/marine/sniper
 	fire_sound = 'sound/weapons/guns/fire/Laser Sniper Standard.ogg'
 	message_to_user = "You set the sniper rifle's charge mode to standard fire."


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

https://cdn.discordapp.com/attachments/504094319075131402/975634899266580500/2022-05-15_22-43-55.mp4

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Barely anyone use energy sniper rifle. You have to frontline with it, which defeats the purpose, or you are content with accidently FFing marines (with the latter more plausable).

Many people agree that the energy sniper rifle needs more, but they fear that a hitscan sniper will wreck balance. In an attempt to calm such doubts, I ensure that in heat mode it shall take all the energy of the energy sniper rifle, meaning that any gamers that want to lit xenomorphs up from afar shall have to reload every time they use head mode energy sniper rifle.

I also put an additional second fire delay on standard ammo. Pray that I don't increase fire delay.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: aim mode on energy sniper rifle
balance: aim mode on energy sniper rifle
balance: increase fire delay to 2 seconds on energy sniper rifle
balance: heat mode, which lit xenomorphs on fire, on energy sniper rifle uses all of 600 energy in mag, therefore one needs a fresh mag for every heat mode shot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
