### PR TITLE
Laser sniper changes (IFF mode)

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1810,22 +1810,20 @@ datum/ammo/bullet/revolver/tp44
 /datum/ammo/energy/lasgun/marine/sniper
 	name = "sniper laser bolt"
 	hud_state = "laser_sniper"
-	damage = 60
+	damage = 70
 	penetration = 30
-	sundering = 4
+	flags_ammo_behavior = AMMO_ENERGY|AMMO_IFF|AMMO_SUNDERING|AMMO_HITSCAN|AMMO_SNIPER
 	max_range = 40
 	damage_falloff = 0
 	hitscan_effect_icon = "beam_heavy"
 
 /datum/ammo/energy/lasgun/marine/sniper_heat
-	name = "sniper IFF bolt"
+	name = "sniper heat bolt"
 	icon_state = "microwavelaser"
 	hud_state = "laser_heat"
-	shell_speed = 2.5
 	damage = 40
 	penetration = 0
-	flags_ammo_behavior = AMMO_ENERGY|AMMO_SUNDERING|AMMO_HITSCAN|AMMO_IFF
-	sundering = 1
+	flags_ammo_behavior = AMMO_ENERGY|AMMO_INCENDIARY|AMMO_SUNDERING|AMMO_HITSCAN
 	hitscan_effect_icon = "u_laser_beam"
 
 /datum/ammo/energy/lasgun/marine/pistol

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1810,7 +1810,7 @@ datum/ammo/bullet/revolver/tp44
 /datum/ammo/energy/lasgun/marine/sniper
 	name = "sniper laser bolt"
 	hud_state = "laser_sniper"
-	damage = 85
+	damage = 70
 	penetration = 30
 	flags_ammo_behavior = AMMO_ENERGY|AMMO_IFF|AMMO_SUNDERING|AMMO_HITSCAN|AMMO_SNIPER
 	max_range = 40

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1818,13 +1818,13 @@ datum/ammo/bullet/revolver/tp44
 	hitscan_effect_icon = "beam_heavy"
 
 /datum/ammo/energy/lasgun/marine/sniper_heat
-	name = "sniper heat bolt"
+	name = "sniper IFF bolt"
 	icon_state = "microwavelaser"
 	hud_state = "laser_heat"
 	shell_speed = 2.5
 	damage = 40
 	penetration = 0
-	flags_ammo_behavior = AMMO_ENERGY|AMMO_INCENDIARY|AMMO_SUNDERING|AMMO_HITSCAN
+	flags_ammo_behavior = AMMO_ENERGY|AMMO_SUNDERING|AMMO_HITSCAN|AMMO_IFF
 	sundering = 1
 	hitscan_effect_icon = "u_laser_beam"
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1810,7 +1810,7 @@ datum/ammo/bullet/revolver/tp44
 /datum/ammo/energy/lasgun/marine/sniper
 	name = "sniper laser bolt"
 	hud_state = "laser_sniper"
-	damage = 70
+	damage = 85
 	penetration = 30
 	flags_ammo_behavior = AMMO_ENERGY|AMMO_IFF|AMMO_SUNDERING|AMMO_HITSCAN|AMMO_SNIPER
 	max_range = 40

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -656,7 +656,7 @@
 	accuracy_mult_unwielded = 0.5
 	mode_list = list(
 		"Standard" = /datum/lasrifle/base/energy_sniper_mode/standard,
-		"Heat" = /datum/lasrifle/base/energy_sniper_mode/heat,
+		"Focused" = /datum/lasrifle/base/energy_sniper_mode/heat,
 	)
 
 /datum/lasrifle/base/energy_sniper_mode/standard

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -644,6 +644,7 @@
 	attachable_offset = list("muzzle_x" = 41, "muzzle_y" = 18,"rail_x" = 19, "rail_y" = 19, "under_x" = 28, "under_y" = 8, "stock_x" = 22, "stock_y" = 12)
 	starting_attachment_types = list(/obj/item/attachable/scope/unremovable/laser_sniper_scope)
 
+	iff_marine_damage_falloff = -0.15
 	aim_slowdown = 0.7
 	wield_delay = 0.7 SECONDS
 	scatter = 0

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -644,7 +644,7 @@
 	attachable_offset = list("muzzle_x" = 41, "muzzle_y" = 18,"rail_x" = 19, "rail_y" = 19, "under_x" = 28, "under_y" = 8, "stock_x" = 22, "stock_y" = 12)
 	starting_attachment_types = list(/obj/item/attachable/scope/unremovable/laser_sniper_scope)
 
-	iff_marine_damage_falloff = -0.15
+	iff_marine_damage_falloff = -0.10
 	aim_slowdown = 0.7
 	wield_delay = 0.7 SECONDS
 	scatter = 0
@@ -658,7 +658,7 @@
 	)
 
 /datum/lasrifle/base/energy_sniper_mode/standard
-	rounds_per_shot = 100
+	rounds_per_shot = 50
 	fire_delay = 1 SECONDS
 	ammo_datum_type = /datum/ammo/energy/lasgun/marine/sniper
 	fire_sound = 'sound/weapons/guns/fire/Laser Sniper Standard.ogg'

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -633,14 +633,11 @@
 	attachable_allowed = list(
 		/obj/item/attachable/bayonet,
 		/obj/item/attachable/bayonetknife,
-		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/scope/unremovable/laser_sniper_scope,
-		/obj/item/weapon/gun/grenade_launcher/underslung,
-		/obj/item/weapon/gun/flamer/mini_flamer,
 		/obj/item/attachable/motiondetector,
 		/obj/item/attachable/buildasentry,
-		/obj/item/weapon/gun/rifle/pepperball/pepperball_mini,
 		/obj/item/attachable/shoulder_mount,
+		/obj/item/attachable/bipod,
 	)
 
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_ENERGY|GUN_AMMO_COUNTER|GUN_NO_PITCH_SHIFT_NEAR_EMPTY|GUN_AMMO_COUNT_BY_SHOTS_REMAINING
@@ -660,11 +657,11 @@
 	)
 
 /datum/lasrifle/base/energy_sniper_mode/standard
-	rounds_per_shot = 50
+	rounds_per_shot = 100
 	fire_delay = 1 SECONDS
 	ammo_datum_type = /datum/ammo/energy/lasgun/marine/sniper
 	fire_sound = 'sound/weapons/guns/fire/Laser Sniper Standard.ogg'
-	message_to_user = "You set the sniper rifle's charge mode to standard fire."
+	message_to_user = "You set the sniper rifle's charge mode to IFF fire."
 	fire_mode = GUN_FIREMODE_SEMIAUTO
 	icon_state = "tes"
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Before anyone says anything about Elsa's PR #10229
![image](https://user-images.githubusercontent.com/95723150/168690109-b96e3001-6629-4309-a1e9-be140a159cc7.png)
I've had this idea and been working on it for longer so this isn't some kneejerk reaction.

Changes the sniper rifles main fire mode to have the IFF tag (Does not affect heat shot)
This IFF mode loses damage logarithmically for each friendly target it passes through.
Changes its sunder to 4 -> 1 
Increases the damage from 60 -> 85

Laser sniper can no longer take magnetic harness (it has an unremovable scope so you shouldn't be able to put it on in the first place but oh well)
Laser sniper can no longer take under barrels
Laser sniper can now take the bipod 

##I would like to stress that none of these variables are permanent and are all open to discussion

## Why It's Good For The Game

Everyone knows that the laser sniper rifle is bad in its current form, it has quite honestly always been bad.
Compare the laser sniper rifle to the SR-127 often considered the quintessential round start sniper rifle:
![image](https://user-images.githubusercontent.com/95723150/168690912-9d423915-c93b-410a-a273-5fd4ce700da3.png)
SR-127 bullet:
![image](https://user-images.githubusercontent.com/95723150/168689503-b1039212-81ca-4a6d-8ff6-9a01aae3d468.png)

That's pretty good. Sure you're not gonna be deleting any xenos with it but you can provide support. In comparison the laser rifle is awful.

Now, the major issue with the laser sniper is the fact that is doesn't have aim mode and cannot actually snipe. However, given that the main contention with giving laser sniper aim mode is the heat mode (due to lasers being hitscan, and instant long ranged ignition application is frowned upon) why not give the laser sniper something unique without putting heat mode into an odd spot. 

In #10229 the heat mode is essentially soft removed (unless you have a handcrank or are sitting at fob with the battery recharger, both of which are reliant on Engineering). There is also the fact that even with the cost now being the entire magazine it will still be incredibly unfun if just infrequent (Nobody wants to be instantly set on fire from off screen, and there are plenty of ways for it to be spammed).

In comparison, by not giving the heat mode the ability to bypass marines it becomes a risk reward situation. Where the sniper must get closer and in front of their allies to get a heat shot, it also gives the sniper a closer range defensive tool in case of ambush opening up an interesting role for the laser sniper user.

Overall giving the laser sniper rifle an IFF mode gives it a unique gimmick whilst avoiding the unfun mechanic that hitscan aim mode heat instant burn heat shots would be.

TLDR: Laser sniper aim mode is a cool and unique gimmick, and having aim mode hitscan heat shots is unfun for Xenos no matter the ammo cost.


## Changelog
:cl:
balance: Laser sniper rifle now has an IFF mode that decreases in damage logarithmically for every marine it passes through (try to get a clear shot!)
fix: You can no longer force a mag harness unto the laser sniper rifle and bug out the scope sprite
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
