### PR TITLE
Caustic upgrade cades cannot be melted.

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -534,6 +534,7 @@
 			soft_armor = soft_armor.modifyRating(melee = 30, bullet = 30)
 		if(CADE_TYPE_ACID)
 			soft_armor = soft_armor.modifyRating(bio = 0, acid = 20)
+			resistance_flags = XENO_DAMAGEABLE|UNACIDABLE
 
 	barricade_upgrade_type = choice
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![image](https://user-images.githubusercontent.com/46353991/168890111-be75d850-6c98-4d7d-9f32-6b0dd8eb6df2.png)
probably more balacned and enjoyable than #10227, but if people want 227 they can reopen it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More balanced then sandbags, overall. And I feel like foward FOBs could use this. You need quite a bit of metal to make this work.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Caustic armor cades are no longer meltable by vomit acid.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
