### PR TITLE
Queen Leadership List Includes Info On Current Leaders and SSD

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -189,12 +189,8 @@
 				break // All xenos of same type share same caste flags. Skip entire typepath if can not be leader.
 			if (is_centcom_level(X.z))
 				continue
-			var/prefix = ""
-			var/suffix = ""
-			if (X.queen_chosen_lead)
-				prefix = "(L) "
-			if (!X.client)
-				suffix = " (SSD)"
+			var/prefix = X.queen_chosen_lead ? "(L) " : ""
+			var/suffix = !X.client ? " (SSD)" : ""
 			xenos += "[prefix][X.name][suffix]"
 	return xenos
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -183,15 +183,19 @@
 /datum/hive_status/proc/get_leaderable_xenos()
 	var/list/xenos = list()
 	for(var/typepath in xenos_by_typepath)
-		if(typepath == /mob/living/carbon/xenomorph/queen) // hardcoded check for now
-			continue
 		for(var/i in xenos_by_typepath[typepath])
 			var/mob/living/carbon/xenomorph/X = i
-			if(is_centcom_level(X.z))
+			if (!(X.xeno_caste.caste_flags & CASTE_CAN_BE_LEADER))
+				break // All xenos of same type share same caste flags. Skip entire typepath if can not be leader.
+			if (is_centcom_level(X.z))
 				continue
-			if(!(X.xeno_caste.caste_flags & CASTE_CAN_BE_LEADER))
-				continue
-			xenos += X
+			var/prefix = ""
+			var/suffix = ""
+			if (X.queen_chosen_lead)
+				prefix = "(L) "
+			if (!X.client)
+				suffix = " (SSD)"
+			xenos += "[prefix][X.name][suffix]"
 	return xenos
 
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR edits the queen leadership TGUI list to now include (L) prefix for current leaders and (SSD) suffix for disconnected players on the selection of the xeno.

![image](https://user-images.githubusercontent.com/29745705/169154488-c24b3a52-b1e9-46e2-9d30-78001354aa88.png)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

This makes selecting new leaders in a hive significantly easier. I personally select xeno leaders by tier with melee tier 3s having priority then ranged tier 3s then melee tier 2s and so on for good pheromone distribution. However, during the course of a game where leaders die and need to be replaced, I often select already promoted xenos and thus demote them. Requiring re-selection for re-promotion and then reopening the menu again and find a new leader.

This now allows queens to easily identify who is already promoted to leader within the same menu in selecting them.

This is however a bandaid solution. Ideally will be replaced by a unified TGUI of xeno hive status that includes selection / toggle of xeno leadership. Definitely on my to-do list but for now, hopefully this will suffice.

## Changelog
:cl:
qol: Queen leadership menu now identifies who is already leader and who is SSD.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
