### PR TITLE
Weeds Radial Menu Refactor and Slightly Compressed

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -7,7 +7,7 @@
 #define WEED "weed sac"
 #define STICKY_WEED "sticky weed sac"
 #define RESTING_WEED "resting weed sac"
-#define AUTOMATIC_WEEDING "toggle automatic weeding"
+#define AUTOMATIC_WEEDING "repeating"
 
 #define XENO_TURRET_ACID_ICONSTATE "acid_turret"
 #define XENO_TURRET_STICKY_ICONSTATE "resin_turret"
@@ -47,10 +47,11 @@ GLOBAL_LIST_INIT(weed_prob_list, list(
 		))
 
 //List of weed images
-GLOBAL_LIST_INIT(weed_images_list,  list(
+GLOBAL_LIST_INIT(weed_images_list, list(
 		WEED = image('icons/mob/actions.dmi', icon_state = WEED),
 		STICKY_WEED = image('icons/mob/actions.dmi', icon_state = STICKY_WEED),
 		RESTING_WEED = image('icons/mob/actions.dmi', icon_state = RESTING_WEED),
+		AUTOMATIC_WEEDING = image('icons/mob/actions.dmi', icon_state = AUTOMATIC_WEEDING)
 		))
 
 //List of Defiler toxin types

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -84,9 +84,7 @@
 
 ///Chose which weed will be planted by the xeno owner or toggle automatic weeding
 /datum/action/xeno_action/activable/plant_weeds/proc/choose_weed()
-	var/list/choices = GLOB.weed_images_list.Copy()
-	choices[AUTOMATIC_WEEDING] = image('icons/mob/actions.dmi', icon_state = "repeating")
-	var/weed_choice = show_radial_menu(owner, owner, choices, radius = 48)
+	var/weed_choice = show_radial_menu(owner, owner, GLOB.weed_images_list, radius = 35)
 	if(!weed_choice)
 		return
 	if(weed_choice == AUTOMATIC_WEEDING)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Just a small code relocation of the icon used in automatic weeding's radial menu selection.

From the current manual addition of the icon to the radial menu every time automatic weeding is selected to baked in at start time.

Weed radial menu is also a little bit tighter. From a radius of 48 to 35.

OLD:
![image](https://user-images.githubusercontent.com/29745705/169189434-2cb373af-5d3f-4139-9267-43271434269e.png)

NEW:
![image](https://user-images.githubusercontent.com/29745705/169189190-3ee8b9aa-a75d-45ad-81f3-48ce456dfcce.png)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Just more uniformity in the code logic.

## Changelog
:cl:
qol: Xeno weed type radial menu made smaller.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
