### PR TITLE
Resin Constructions Now Can Be Radial Selected

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -595,7 +595,6 @@
 #define COMSIG_XENOABILITY_DROP_PLANT "xenoability_drop_plant"
 #define COMSIG_XENOABILITY_CHOOSE_PLANT "xenoability_choose_plant"
 #define COMSIG_XENOABILITY_SECRETE_RESIN "xenoability_secrete_resin"
-#define COMSIG_XENOABILITY_SECRETE_RESIN_SILO "xenoability_secrete_resin_silo"
 #define COMSIG_XENOABILITY_EMIT_RECOVERY "xenoability_emit_recovery"
 #define COMSIG_XENOABILITY_EMIT_WARDING "xenoability_emit_warding"
 #define COMSIG_XENOABILITY_EMIT_FRENZY "xenoability_emit_frenzy"

--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -19,6 +19,11 @@
 #define STEALTH_PLANT "night shade"
 #define STEALTH_PLANT_PASSIVE_CAMOUFLAGE_ALPHA 64
 
+//Resin defines
+#define RESIN_WALL "resin wall"
+#define STICKY_RESIN "sticky resin"
+#define RESIN_DOOR "resin door"
+
 //Xeno reagents defines
 #define DEFILER_NEUROTOXIN "Neurotoxin"
 #define DEFILER_HEMODILE "Hemodile"
@@ -84,6 +89,14 @@ GLOBAL_LIST_INIT(plant_images_list, list(
 		PLASMA_PLANT = image('icons/Xeno/plants.dmi', icon_state = "plasma_fruit"),
 		STEALTH_PLANT = image('icons/Xeno/plants.dmi', icon_state = "stealth_plant")
 		))
+
+//List of resin structure images
+GLOBAL_LIST_INIT(resin_images_list, list(
+		RESIN_WALL = image('icons/mob/actions.dmi', icon_state = RESIN_WALL),
+		STICKY_RESIN = image('icons/mob/actions.dmi', icon_state = STICKY_RESIN),
+		RESIN_DOOR = image('icons/mob/actions.dmi', icon_state = RESIN_DOOR)
+		))
+
 //xeno upgrade flags
 ///Message the hive when we buy this upgrade
 #define UPGRADE_FLAG_MESSAGE_HIVE (1<<0)

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -40,12 +40,6 @@
 	description = "Builds whatever you’ve selected with (choose resin structure) on your tile."
 	keybind_signal = COMSIG_XENOABILITY_SECRETE_RESIN
 
-/datum/keybinding/xeno/secrete_resin_silo
-	name = "secrete_resin_silo"
-	full_name = "Secrete Resin Silo"
-	description = "Builds a resin silo."
-	keybind_signal = COMSIG_XENOABILITY_SECRETE_RESIN_SILO
-
 /datum/keybinding/xeno/emit_recovery
 	name = "emit_recovery"
 	full_name = "Emit Recovery Pheromones"

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -80,7 +80,7 @@
 
 
 /obj/effect/alien/resin/sticky
-	name = "sticky resin"
+	name = STICKY_RESIN
 	desc = "A layer of disgusting sticky slime."
 	icon_state = "sticky"
 	density = FALSE
@@ -145,7 +145,7 @@
 
 //Resin Doors
 /obj/structure/mineral_door/resin
-	name = "resin door"
+	name = RESIN_DOOR
 	mineralType = "resin"
 	icon = 'icons/Xeno/Effects.dmi'
 	hardness = 1.5
@@ -154,8 +154,6 @@
 	smoothing_behavior = CARDINAL_SMOOTHING
 	smoothing_groups = SMOOTH_XENO_STRUCTURES
 	var/close_delay = 10 SECONDS
-	
-
 
 /obj/structure/mineral_door/resin/Initialize()
 	. = ..()
@@ -276,7 +274,6 @@
 		qdel(src)
 
 /obj/structure/mineral_door/resin/thick
-	name = "thick resin door"
 	max_integrity = 160
 	hardness = 2.0
 

--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -4,7 +4,7 @@
  * Used mostly be xenomorphs
  */
 /turf/closed/wall/resin
-	name = "resin wall"
+	name = RESIN_WALL
 	desc = "Weird slime solidified into a wall."
 	icon = 'icons/Xeno/structures.dmi'
 	icon_state = "resin0"

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -187,6 +187,7 @@
 	return ..()
 
 /datum/action/xeno_action/activable/secrete_resin/action_activate()
+	//Left click on the secrete resin button opens up radial menu (new type of changing structures).
 	var/mob/living/carbon/xenomorph/X = owner
 	if(X.selected_ability != src)
 		return ..()
@@ -198,6 +199,19 @@
 	X.balloon_alert(X, initial(A.name))
 	update_button_icon()
 
+/datum/action/xeno_action/activable/secrete_resin/alternate_action_activate()
+	//Right click on secrete resin button cycles through to the next construction type (old method of changing structures).
+	var/mob/living/carbon/xenomorph/X = owner
+	if(X.selected_ability != src)
+		return ..()
+	var/i = buildable_structures.Find(X.selected_resin)
+	if(length(buildable_structures) == i)
+		X.selected_resin = buildable_structures[1]
+	else
+		X.selected_resin = buildable_structures[i+1]
+	var/atom/A = X.selected_resin
+	X.balloon_alert(X, initial(A.name))
+	update_button_icon()
 
 /datum/action/xeno_action/activable/secrete_resin/use_ability(atom/A)
 	build_resin(get_turf(owner))

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -163,7 +163,7 @@
 // Secrete Resin
 /datum/action/xeno_action/activable/secrete_resin
 	name = "Secrete Resin"
-	action_icon_state = "resin wall"
+	action_icon_state = RESIN_WALL
 	mechanics_text = "Builds whatever resin you selected"
 	ability_name = "secrete resin"
 	plasma_cost = 75
@@ -172,11 +172,11 @@
 	var/base_wait = 1 SECONDS
 	///Multiplicator factor to add to the building time, depends on the health of the structure built
 	var/scaling_wait = 1 SECONDS
-	///List of buildable structures
+	///List of buildable structures. Order corresponds with resin_images_list.
 	var/list/buildable_structures = list(
 		/turf/closed/wall/resin/regenerating,
 		/obj/effect/alien/resin/sticky,
-		/obj/structure/mineral_door/resin,
+		/obj/structure/mineral_door/resin
 		)
 
 /datum/action/xeno_action/activable/secrete_resin/update_button_icon()
@@ -187,18 +187,15 @@
 	return ..()
 
 /datum/action/xeno_action/activable/secrete_resin/action_activate()
-
 	var/mob/living/carbon/xenomorph/X = owner
 	if(X.selected_ability != src)
 		return ..()
 	. = ..()
-	var/i = buildable_structures.Find(X.selected_resin)
-	if(length(buildable_structures) == i)
-		X.selected_resin = buildable_structures[1]
-	else
-		X.selected_resin = buildable_structures[i+1]
+	var/resin_choice = show_radial_menu(owner, owner, GLOB.resin_images_list, radius = 35)
+	var/i = GLOB.resin_images_list.Find(resin_choice)
+	X.selected_resin = buildable_structures[i]
 	var/atom/A = X.selected_resin
-	to_chat(X, span_notice("We will now build <b>[initial(A.name)]\s</b> when secreting resin."))
+	X.balloon_alert(X, initial(A.name))
 	update_button_icon()
 
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -176,7 +176,7 @@
 	var/list/buildable_structures = list(
 		/turf/closed/wall/resin/regenerating,
 		/obj/effect/alien/resin/sticky,
-		/obj/structure/mineral_door/resin
+		/obj/structure/mineral_door/resin,
 		)
 
 /datum/action/xeno_action/activable/secrete_resin/update_button_icon()

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -11,7 +11,7 @@
 	buildable_structures = list(
 		/turf/closed/wall/resin/regenerating/thick,
 		/obj/effect/alien/resin/sticky,
-		/obj/structure/mineral_door/resin/thick
+		/obj/structure/mineral_door/resin/thick,
 	)
 	///the maximum range of the ability
 	var/max_range = 1

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -11,7 +11,7 @@
 	buildable_structures = list(
 		/turf/closed/wall/resin/regenerating/thick,
 		/obj/effect/alien/resin/sticky,
-		/obj/structure/mineral_door/resin/thick,
+		/obj/structure/mineral_door/resin/thick
 	)
 	///the maximum range of the ability
 	var/max_range = 1


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

In line with my previous PRs modernizing the xeno interface, resin construction selection for all xenos are now done through a radial menu.

![image](https://user-images.githubusercontent.com/29745705/169197036-faffd928-db6c-4980-8f0c-c09e2c2b111c.png)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Resin construction selection is in the odd position where it is the only action that is cycled through by clicking it multiple times.

While in its current state, it is quite simple to cycle through constructions by clicking the action icon the required amount of times (and a bit more if the player miss-clicked too many times), it is the only one to do so.

For uniformity, I believe changing the selection to radial menu and bringing it in line with weed selection, drone plant selection, and (proposed) pheromones selection will be easiest for everyone to understand.

Note, there are requests that I close this PR as they prefer the old click to cycle through. As compromise, left click can open this radial menu (new method) whereas right click on the button can cycle through the options (old method).

## Changelog
:cl:
qol: Xeno construction selection can now be done through radial menu. Left click now opens radial selection (new). Right click cycles through constructions (old).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
