### PR TITLE
SG Minigun balance part two

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1123,9 +1123,9 @@ datum/ammo/bullet/revolver/tp44
 	hud_state_empty = "smartgun_empty"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	accurate_range = 15
-	damage = 15
+	damage = 12.5
 	penetration = 15
-	sundering = 2
+	sundering = 2.5
 
 /datum/ammo/bullet/smartgun/lethal
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1123,28 +1123,9 @@ datum/ammo/bullet/revolver/tp44
 	hud_state_empty = "smartgun_empty"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	accurate_range = 15
-	damage = 15
+	damage = 13
 	penetration = 15
-	sundering = 2.5
-
-/datum/ammo/bullet/smartgun/lethal
-	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
-	icon_state 	= "bullet"
-	sundering = 1
-
-/datum/ammo/bullet/smartgun/dirty
-	name = "irradiated smartgun bullet"
-	hud_state = "smartgun_radioactive"
-	shrapnel_chance = 75
-
-/datum/ammo/bullet/smartgun/dirty/on_hit_mob(mob/living/victim, obj/projectile/proj)
-	victim.adjustToxLoss(10)//does tox damage now
-
-/datum/ammo/bullet/smartgun/dirty/lethal
-	flags_ammo_behavior = AMMO_BALLISTIC
-	icon_state 	= "bullet"
-	damage = 40
-	penetration = 30
+	sundering = 3
 
 /datum/ammo/bullet/turret
 	name = "autocannon bullet"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1123,7 +1123,7 @@ datum/ammo/bullet/revolver/tp44
 	hud_state_empty = "smartgun_empty"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	accurate_range = 15
-	damage = 14
+	damage = 15
 	penetration = 15
 	sundering = 2.5
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1123,9 +1123,9 @@ datum/ammo/bullet/revolver/tp44
 	hud_state_empty = "smartgun_empty"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	accurate_range = 15
-	damage = 12.5
+	damage = 15
 	penetration = 15
-	sundering = 2.5
+	sundering = 2
 
 /datum/ammo/bullet/smartgun/lethal
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1125,7 +1125,7 @@ datum/ammo/bullet/revolver/tp44
 	accurate_range = 15
 	damage = 15
 	penetration = 15
-	sundering = 2
+	sundering = 2.5
 
 /datum/ammo/bullet/smartgun/lethal
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1123,7 +1123,7 @@ datum/ammo/bullet/revolver/tp44
 	hud_state_empty = "smartgun_empty"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	accurate_range = 15
-	damage = 15
+	damage = 14
 	penetration = 15
 	sundering = 2.5
 

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -441,11 +441,11 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	actions_types = list()
 
 	fire_delay = 0.15 SECONDS
-	windup_delay = 0.4 SECONDS
+	windup_delay = 0.7 SECONDS
 	scatter = -5
 	recoil = 0
 	recoil_unwielded = 4
-	damage_falloff_mult = 0.7
+	damage_falloff_mult = 0.5
 
 // PEPPERBALL GUN
 

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -441,7 +441,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	actions_types = list()
 
 	fire_delay = 0.15 SECONDS
-	windup_delay = 0.7 SECONDS
+	windup_delay = 0.6 SECONDS
 	scatter = -5
 	recoil = 0
 	recoil_unwielded = 4

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -445,7 +445,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	scatter = -5
 	recoil = 0
 	recoil_unwielded = 4
-	damage_falloff_mult = 0.5
+	damage_falloff_mult = 0.7
 
 // PEPPERBALL GUN
 

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -441,7 +441,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	actions_types = list()
 
 	fire_delay = 0.15 SECONDS
-	windup_delay = 0.6 SECONDS
+	windup_delay = 0.7 SECONDS
 	scatter = -5
 	recoil = 0
 	recoil_unwielded = 4


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

SG minigun windup from .4 -> .7
SG minigun sunder from 2 -> 3
SG minigun damage from 15 -> 13

Removed some unused Smartgun bullet types

## Why It's Good For The Game

More tweaking, more support focused, ammo boxes coming soon.

## Changelog
:cl:
balance: SG minigun has slightly less damage, longer windup, and more sunder.
del: Unused smartgun bullet types
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
