### PR TITLE
Refactors Hivemind Ability Checks to Not Use should_show()

### DIFF
--- a/code/datums/actions/xeno_action.dm
+++ b/code/datums/actions/xeno_action.dm
@@ -104,9 +104,6 @@
 			to_chat(owner, span_warning("We can't do this while in a solid object!"))
 		return FALSE
 
-	if(!should_show())
-		return FALSE
-
 	return TRUE
 
 /datum/action/xeno_action/fail_activate()
@@ -214,8 +211,6 @@
 	on_activation()
 
 /datum/action/xeno_action/activable/action_activate()
-	if(!should_show())
-		return
 	var/mob/living/carbon/xenomorph/X = owner
 	if(X.selected_ability == src)
 		deselect()

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -155,8 +155,10 @@
 		return FALSE
 	return ..()
 
-/datum/action/xeno_action/activable/plant_weeds/ranged/should_show()
-	return !(owner.status_flags & INCORPOREAL)
+/datum/action/xeno_action/activable/plant_weeds/ranged/can_use_action(silent = FALSE, override_flags, selecting = FALSE)
+	if (owner.status_flags & INCORPOREAL)
+		return FALSE
+	return ..()
 
 // Secrete Resin
 /datum/action/xeno_action/activable/secrete_resin

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
@@ -11,8 +11,10 @@
 	base_wait = 1 SECONDS
 	max_range = 4
 
-/datum/action/xeno_action/activable/secrete_resin/ranged/slow/should_show()
-	return !(owner.status_flags & INCORPOREAL)
+/datum/action/xeno_action/activable/secrete_resin/ranged/slow/can_use_action(silent = FALSE, override_flags, selecting = FALSE)
+	if (owner.status_flags & INCORPOREAL)
+		return FALSE
+	return ..()
 
 /datum/action/xeno_action/change_form
 	name = "Change form"
@@ -43,15 +45,21 @@
 	succeed_activate()
 	add_cooldown()
 
-/datum/action/xeno_action/activable/psychic_cure/hivemind/should_show()
-	return !(owner.status_flags & INCORPOREAL)
+/datum/action/xeno_action/activable/psychic_cure/hivemind/can_use_action(silent = FALSE, override_flags, selecting = FALSE)
+	if (owner.status_flags & INCORPOREAL)
+		return FALSE
+	return ..()
 
 /datum/action/xeno_action/activable/transfer_plasma/hivemind
 	plasma_transfer_amount = PLASMA_TRANSFER_AMOUNT * 2
 
-/datum/action/xeno_action/activable/transfer_plasma/hivemind/should_show()
-	return !(owner.status_flags & INCORPOREAL)
+/datum/action/xeno_action/activable/transfer_plasma/hivemind/can_use_action(silent = FALSE, override_flags, selecting = FALSE)
+	if (owner.status_flags & INCORPOREAL)
+		return FALSE
+	return ..()
 
-/datum/action/xeno_action/pheromones/hivemind/should_show()
-	return !(owner.status_flags & INCORPOREAL)
+/datum/action/xeno_action/pheromones/hivemind/can_use_action(silent = FALSE, override_flags, selecting = FALSE)
+	if (owner.status_flags & INCORPOREAL)
+		return FALSE
+	return ..()
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Due to a previous exploit with hiveminds, should show xeno action proc was used as a easy override check to ensure a hivemind that is not corporal could not use specific abilities.

This however broke hidden keybind only buttons I intended on implementing with my pheromone wheel of fortune #10240.

Instead, the could use check has been properly relocated to can_use_action.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Required fixes to allow for hidden keybind only buttons to be functional.

![image](https://user-images.githubusercontent.com/29745705/169364472-e71587f3-3446-4443-b6cc-87148a5ef24e.png)

## Changelog
:cl:
qol: The actions that hiveminds can use while manifested no longer disappear but instead are disabled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
