### PR TITLE
Queen Hive Message Is Now Displayed and Animated

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -1,33 +1,4 @@
 // ***************************************
-// *********** Hive orders
-// ***************************************
-/mob/living/carbon/xenomorph/queen/proc/set_orders()
-	set category = "Alien"
-	set name = "Set Hive Orders (50)"
-	set desc = "Give some specific orders to the hive. They can see this on the status pane."
-
-	if(hivenumber == XENO_HIVE_CORRUPTED)
-		to_chat(src, span_warning("Only our masters can decide this!"))
-		return
-
-	if(!check_state())
-		return
-	if(!check_plasma(50))
-		return
-	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_ORDER))
-		return
-	plasma_stored -= 50
-	var/txt = stripped_input(src, "Set the hive's orders to what? Leave blank to clear it.", "Hive Orders")
-
-	if(txt)
-		xeno_message("<B>The Queen has given a new order. Check Game panel for details.</B>", "xenoannounce", 6,hivenumber)
-		hive.hive_orders = txt
-	else
-		hive.hive_orders = ""
-
-	TIMER_COOLDOWN_START(src, COOLDOWN_ORDER, 15 SECONDS)
-
-// ***************************************
 // *********** Hive message
 // ***************************************
 /datum/action/xeno_action/hive_message
@@ -39,10 +10,7 @@
 	use_state_flags = XACT_USE_LYING
 
 /datum/action/xeno_action/hive_message/action_activate()
-	var/mob/living/carbon/xenomorph/queen/xeno = owner
-	if(!xeno.check_concious_state())
-		to_chat(xeno, span_warning("We can't do that while unconcious."))
-		return
+	var/mob/living/carbon/xenomorph/queen/Q = owner
 
 	var/input = stripped_multiline_input(xeno, "This message will be broadcast throughout the hive.", "Hive Message", "")
 	if(!input)

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -6,44 +6,54 @@
 	action_icon_state = "queen_order"
 	mechanics_text = "Announces a message to the hive."
 	plasma_cost = 50
+	cooldown_timer = 10 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_QUEEN_HIVE_MESSAGE
 	use_state_flags = XACT_USE_LYING
+
+//Parameters used when displaying hive message to all xenos
+/obj/screen/text/screen_text/queen_order
+	maptext_height = 128 //Default 64 doubled in height
+	maptext_width = 456 //Default 480 shifted right by 12
+	maptext_x = 12 //Half of 24
+	maptext_y = -64 //Shifting expanded map text downwards to display below buttons.
+	screen_loc = "LEFT,TOP-3"
+
+	letters_per_update = 2
+	fade_out_delay = 5 SECONDS
+	style_open = "<span class='maptext' style=font-size:16pt;text-align:center valign='top'>"
+	style_close = "</span>"
 
 /datum/action/xeno_action/hive_message/action_activate()
 	var/mob/living/carbon/xenomorph/queen/Q = owner
 
-	var/input = stripped_multiline_input(xeno, "This message will be broadcast throughout the hive.", "Hive Message", "")
+	//Preferring the use of multiline input as the message box is larger and easier to quickly proofread before sending to hive.
+	var/input = stripped_multiline_input(Q, "Maximum message length: [MAX_BROADCAST_LEN]", "Hive Message", "", MAX_BROADCAST_LEN, TRUE)
+	//Newlines are of course stripped and replaced with a space.
+	input = capitalize(trim(replacetext(input, "\n", " ")))
 	if(!input)
 		return
-
 	if(CHAT_FILTER_CHECK(input))
-		to_chat(xeno, span_warning("That announcement contained a word prohibited in IC chat! Consider reviewing the server rules.\n<span replaceRegex='show_filtered_ic_chat'>\"[input]\"</span>"))
+		to_chat(Q, span_warning("That announcement contained a word prohibited in IC chat! Consider reviewing the server rules.\n<span replaceRegex='show_filtered_ic_chat'>\"[input]\"</span>"))
 		SSblackbox.record_feedback(FEEDBACK_TALLY, "ic_blocked_words", 1, lowertext(config.ic_filter_regex.match))
 		return FALSE
 	if(NON_ASCII_CHECK(input))
-		to_chat(usr, span_warning("That announcement contained characters prohibited in IC chat! Consider reviewing the server rules."))
+		to_chat(Q, span_warning("That announcement contained characters prohibited in IC chat! Consider reviewing the server rules."))
 		return FALSE
 
-	var/queensWord = "<br><h2 class='alert'>The words of the queen reverberate in your head...</h2>"
-	queensWord += "<br>[span_alert("[input]")]<br><br>"
+	log_game("[key_name(Q)] has messaged the hive with: \"[input]\"")
+	deadchat_broadcast(" has messaged the hive: \"[input]\"", Q, Q)
+	var/queens_word = "<span class='maptext' style=font-size:18pt;text-align:center valign='top'><u>HIVE MESSAGE:</u><br></span>" + input
 
-	INVOKE_ASYNC(xeno, /mob/living/carbon/xenomorph/queen/proc/do_hive_message, queensWord)
-
-/mob/living/carbon/xenomorph/queen/proc/do_hive_message(queensWord)
 	var/sound/queen_sound = sound(get_sfx("queen"), channel = CHANNEL_ANNOUNCEMENTS)
-	if(SSticker?.mode)
-		hive.xeno_message("[queensWord]")
-		for(var/i in hive.get_watchable_xenos())
-			var/mob/living/carbon/xenomorph/X = i
-			SEND_SOUND(X, queen_sound)
+	for(var/mob/living/carbon/xenomorph/X AS in Q.hive.get_all_xenos())
+		SEND_SOUND(X, queen_sound)
+		//Display the queen's hive message at the top of the game screen.
+		X.play_screen_text(queens_word, /obj/screen/text/screen_text/queen_order)
+		//In case in combat, couldn't read fast enough, or needs to copy paste into a translator. Here's the old hive message.
+		to_chat(X, span_xenoannounce("<h2 class='alert'>The words of the queen reverberate in your head...</h2><br>[span_alert(input)]<br><br>"))
 
-	for(var/i in GLOB.observer_list)
-		var/mob/dead/observer/G = i
-		SEND_SOUND(G, queen_sound)
-		to_chat(G, "[queensWord]")
-
-	log_game("[key_name(src)] has created a Hive Message: [queensWord]")
-	message_admins("[ADMIN_TPMONTY(src)] has created a Hive Message.")
+	succeed_activate()
+	add_cooldown()
 
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
@@ -23,7 +23,6 @@
 	var/breathing_counter = 0
 	var/mob/living/carbon/xenomorph/observed_xeno //the Xenomorph the queen is currently overwatching
 	inherent_verbs = list(
-		/mob/living/carbon/xenomorph/queen/proc/set_orders,
 		/mob/living/carbon/xenomorph/proc/hijack,
 	)
 

--- a/code/modules/screen_alert/_screen_alert.dm
+++ b/code/modules/screen_alert/_screen_alert.dm
@@ -70,7 +70,7 @@
 		else
 			tag_position = findtext(text_to_play, html_locate_regex, tag_position)
 			reading_tag = TRUE
-	for(var/letter = 2 to length(text_to_play) + 1 step letters_per_update)
+	for(var/letter = 2 to length(text_to_play) + letters_per_update step letters_per_update)
 		if(letter in lines_to_skip)
 			continue
 		maptext = "[style_open][copytext_char(text_to_play, 1, letter)][style_close]"
@@ -85,7 +85,7 @@
 	animate(src, alpha = 0, time = fade_out_time)
 	addtimer(CALLBACK(src, .proc/end_play, player), fade_out_time)
 
-///ends the play then deletes this screen object and plalys the next one in queue if it exists
+///ends the play then deletes this screen object and plays the next one in queue if it exists
 /obj/screen/text/screen_text/proc/end_play(client/player)
 	player.screen -= src
 	LAZYREMOVE(player.screen_texts, src)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Marine command orders have now been added to the Queen's hive message action.

Note, the current in-chat announcement of word of queen still occurs in order to allow xenos to reread what was announced in case they missed it or need to copy paste in a translator (for english playing on soviet servers or vice versa).

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Looks a lot more modern. Kinda. Trust me, this looks a lot better with less buttons taking up the padding space around the message but that's something only the queen suffers though.

![image](https://user-images.githubusercontent.com/29745705/169394418-95a7e39e-8862-4b13-b8cb-fb1560c2c6d5.png)

## Changelog
:cl:
add: Queen hive message now displays on game map.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
