### PR TITLE
All Xenos Now Have Overwatch Ability Through Chat

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -665,7 +665,6 @@
 #define COMSIG_XENOABILITY_MIRAGE "xenoability_mirage"
 
 #define COMSIG_XENOABILITY_SCREECH "xenoability_screech"
-#define COMSIG_XENOABILITY_WATCH_XENO "xenoability_watch_xeno"
 #define COMSIG_XENOABILITY_PSYCHIC_WHISPER "xenoability_psychic_whisper"
 #define COMSIG_XENOABILITY_TOGGLE_QUEEN_ZOOM "xenoability_toggle_queen_zoom"
 #define COMSIG_XENOABILITY_XENO_LEADERS "xenoability_xeno_leaders"

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -432,12 +432,6 @@
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_SCREECH
 
-/datum/keybinding/xeno/watch_xeno
-	name = "watch_xeno"
-	full_name = "Queen: Watch Xeno"
-	description = ""
-	keybind_signal = COMSIG_XENOABILITY_WATCH_XENO
-
 /datum/keybinding/xeno/toggle_queen_zoom
 	name = "toggle_queen_zoom"
 	full_name = "Queen: Toggle Zoom"

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -57,6 +57,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/place_acidwell,
 		/datum/action/xeno_action/activable/corrosive_acid/strong,
@@ -215,6 +216,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/place_acidwell,
 		/datum/action/xeno_action/activable/corrosive_acid/strong,

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
@@ -39,6 +39,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/ready_charge/bull_charge,
 		/datum/action/xeno_action/activable/bull_charge,

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
@@ -51,6 +51,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/cocoon,
 		/datum/action/xeno_action/activable/plant_weeds,
@@ -191,6 +192,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/cocoon,
 		/datum/action/xeno_action/activable/plant_weeds,

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -43,6 +43,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/stomp,
 		/datum/action/xeno_action/ready_charge,
@@ -175,6 +176,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/stomp,
 		/datum/action/xeno_action/ready_charge,

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
@@ -48,6 +48,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/toggle_crest_defense,
 		/datum/action/xeno_action/fortify,
@@ -176,6 +177,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/toggle_crest_defense,
 		/datum/action/xeno_action/fortify,

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
@@ -40,6 +40,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/cocoon,
 		/datum/action/xeno_action/activable/plant_weeds,
@@ -177,6 +178,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/cocoon,
 		/datum/action/xeno_action/activable/plant_weeds,

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -52,6 +52,7 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/cocoon,
 		/datum/action/xeno_action/activable/plant_weeds,
@@ -181,6 +182,7 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/cocoon,
 		/datum/action/xeno_action/activable/plant_weeds,

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
@@ -49,6 +49,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain/free,
 		/datum/action/xeno_action/activable/psychic_link,
 		/datum/action/xeno_action/activable/drain,
@@ -163,6 +164,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain/free,
 		/datum/action/xeno_action/activable/psychic_link,
 		/datum/action/xeno_action/activable/drain,

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
@@ -53,6 +53,7 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/cocoon,
 		/datum/action/xeno_action/activable/plant_weeds,
@@ -198,6 +199,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/cocoon,
 		/datum/action/xeno_action/activable/plant_weeds,

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
@@ -51,6 +51,7 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/pounce/hunter,
 		/datum/action/xeno_action/stealth,
@@ -175,6 +176,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/pounce/hunter,
 		/datum/action/xeno_action/stealth/disguise,

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -37,6 +37,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/cocoon,
 		/datum/action/xeno_action/activable/plant_weeds,

--- a/code/modules/mob/living/carbon/xenomorph/castes/larva/castedatum_larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/larva/castedatum_larva.dm
@@ -44,6 +44,7 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/xenohide,
 	)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -52,6 +52,7 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/place_acidwell,
 		/datum/action/xeno_action/activable/corrosive_acid,
@@ -203,6 +204,7 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/place_acidwell,
 		/datum/action/xeno_action/activable/corrosive_acid,

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -151,33 +151,32 @@
 	action_icon_state = "watch_xeno"
 	mechanics_text = "See from the target Xenomorphs vision. Click again the ability to stop observing"
 	plasma_cost = 0
-	keybind_signal = COMSIG_XENOABILITY_WATCH_XENO
-	var/overwatch_active = FALSE
 	use_state_flags = XACT_USE_LYING
-
+	var/overwatch_active = FALSE
 
 /datum/action/xeno_action/watch_xeno/give_action(mob/living/L)
 	. = ..()
 	RegisterSignal(L, COMSIG_MOB_DEATH, .proc/on_owner_death)
 	RegisterSignal(L, COMSIG_XENOMORPH_WATCHXENO, .proc/on_list_xeno_selection)
-	RegisterSignal(L, COMSIG_CLICK_CTRL_MIDDLE, .proc/on_ctrl_middle_click)
-
+	if(isxenoqueen(owner))
+		RegisterSignal(L, COMSIG_CLICK_CTRL_MIDDLE, .proc/on_ctrl_middle_click)
 
 /datum/action/xeno_action/watch_xeno/remove_action(mob/living/L)
 	if(overwatch_active)
 		stop_overwatch()
-	UnregisterSignal(L, list(COMSIG_MOB_DEATH, COMSIG_XENOMORPH_WATCHXENO, COMSIG_CLICK_CTRL_MIDDLE))
+	UnregisterSignal(L, list(COMSIG_MOB_DEATH, COMSIG_XENOMORPH_WATCHXENO))
+	if(isxenoqueen(owner))
+		UnregisterSignal(L, COMSIG_CLICK_CTRL_MIDDLE)
 	return ..()
-
 
 /datum/action/xeno_action/watch_xeno/action_activate()
 	if(overwatch_active)
 		stop_overwatch()
-		remove_selected_frame()
 		return
-	add_selected_frame()
 	select_xeno()
 
+/datum/action/xeno_action/watch_xeno/should_show()
+	return isxenoqueen(owner) //Only the queen should have the button for overwatch. All else uses chat (F).
 
 /datum/action/xeno_action/watch_xeno/proc/select_xeno(mob/living/carbon/xenomorph/selected_xeno)
 	var/mob/living/carbon/xenomorph/queen/X = owner
@@ -186,44 +185,42 @@
 
 	if(QDELETED(selected_xeno))
 		var/list/possible_xenos = X.hive.get_watchable_xenos()
-
 		selected_xeno = tgui_input_list(X, "Target", "Watch which xenomorph?", possible_xenos)
 		if(QDELETED(selected_xeno) || selected_xeno == X.observed_xeno || selected_xeno.stat == DEAD || is_centcom_level(selected_xeno.z))
 			if(!X.observed_xeno)
 				return
 			stop_overwatch()
 			return
-
 	start_overwatch(selected_xeno)
 
-
 /datum/action/xeno_action/watch_xeno/proc/start_overwatch(mob/living/carbon/xenomorph/target)
-	var/mob/living/carbon/xenomorph/queen/watcher = owner
+	var/mob/living/carbon/xenomorph/watcher = owner
 	var/mob/living/carbon/xenomorph/old_xeno = watcher.observed_xeno
 	if(old_xeno)
 		stop_overwatch(FALSE)
 	watcher.observed_xeno = target
-	target.hud_set_queen_overwatch()
+	if(isxenoqueen(watcher)) // Only queen needs the eye shown.
+		target.hud_set_queen_overwatch()
 	watcher.reset_perspective()
 	RegisterSignal(target, COMSIG_HIVE_XENO_DEATH, .proc/on_xeno_death)
 	RegisterSignal(target, list(COMSIG_XENOMORPH_EVOLVED, COMSIG_XENOMORPH_DEEVOLVED), .proc/on_xeno_evolution)
 	RegisterSignal(watcher, COMSIG_MOVABLE_MOVED, .proc/on_movement)
 	overwatch_active = TRUE
-	to_chat(owner, span_notice("Click again on overwatch ability button to stop overwatching"))
-
+	add_selected_frame()
 
 /datum/action/xeno_action/watch_xeno/proc/stop_overwatch(do_reset_perspective = TRUE)
-	var/mob/living/carbon/xenomorph/queen/watcher = owner
+	var/mob/living/carbon/xenomorph/watcher = owner
 	var/mob/living/carbon/xenomorph/observed = watcher.observed_xeno
 	watcher.observed_xeno = null
 	if(!QDELETED(observed))
 		UnregisterSignal(observed, list(COMSIG_HIVE_XENO_DEATH, COMSIG_XENOMORPH_EVOLVED, COMSIG_XENOMORPH_DEEVOLVED))
-		observed.hud_set_queen_overwatch()
+		if(isxenoqueen(watcher)) // Only queen has to reset the eye overlay.
+			observed.hud_set_queen_overwatch()
 	if(do_reset_perspective)
 		watcher.reset_perspective()
 	UnregisterSignal(watcher, COMSIG_MOVABLE_MOVED)
 	overwatch_active = FALSE
-
+	remove_selected_frame()
 
 /datum/action/xeno_action/watch_xeno/proc/on_list_xeno_selection(datum/source, mob/living/carbon/xenomorph/selected_xeno)
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -179,12 +179,12 @@
 	return isxenoqueen(owner) //Only the queen should have the button for overwatch. All else uses chat (F).
 
 /datum/action/xeno_action/watch_xeno/proc/select_xeno(mob/living/carbon/xenomorph/selected_xeno)
-	var/mob/living/carbon/xenomorph/queen/X = owner
-	if(!X.hive)
-		return
+	var/mob/living/carbon/xenomorph/X = owner
 
 	if(QDELETED(selected_xeno))
-		var/list/possible_xenos = X.hive.get_watchable_xenos()
+		if(!isxenoqueen(X))
+			return
+		var/list/possible_xenos = X.hive.get_watchable_xenos(X)
 		selected_xeno = tgui_input_list(X, "Target", "Watch which xenomorph?", possible_xenos)
 		if(QDELETED(selected_xeno) || selected_xeno == X.observed_xeno || selected_xeno.stat == DEAD || is_centcom_level(selected_xeno.z))
 			if(!X.observed_xeno)

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -48,6 +48,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/cocoon,
 		/datum/action/xeno_action/activable/plant_weeds,

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -48,7 +48,6 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
-		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/cocoon,
 		/datum/action/xeno_action/activable/plant_weeds,

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
@@ -21,7 +21,6 @@
 	upgrade = XENO_UPGRADE_ZERO
 
 	var/breathing_counter = 0
-	var/mob/living/carbon/xenomorph/observed_xeno //the Xenomorph the queen is currently overwatching
 	inherent_verbs = list(
 		/mob/living/carbon/xenomorph/queen/proc/set_orders,
 		/mob/living/carbon/xenomorph/proc/hijack,
@@ -125,7 +124,7 @@
 // ***************************************
 // *********** Overwatch (from hivemind chat)
 // ***************************************
-/mob/living/carbon/xenomorph/queen/Topic(href, href_list)
+/mob/living/carbon/xenomorph/Topic(href, href_list)
 	. = ..()
 	if(.)
 		return
@@ -134,8 +133,7 @@
 		if(!check_state())
 			return
 		var/xeno_name = href_list["watch_xeno_name"]
-		for(var/Y in hive.get_watchable_xenos())
-			var/mob/living/carbon/xenomorph/X = Y
+		for(var/mob/living/carbon/xenomorph/X AS in hive.get_watchable_xenos())
 			if(isnum(X.nicknumber))
 				if(num2text(X.nicknumber) != xeno_name)
 					continue

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
@@ -54,7 +54,7 @@
 		return TRUE
 	return FALSE
 
-/mob/living/carbon/xenomorph/queen/reset_perspective(atom/A)
+/mob/living/carbon/xenomorph/reset_perspective(atom/A)
 	if (!client)
 		return
 
@@ -120,25 +120,3 @@
 // ***************************************
 /datum/action/xeno_action/activable/psychic_cure/acidic_salve/queen
 	heal_range = HIVELORD_HEAL_RANGE
-
-// ***************************************
-// *********** Overwatch (from hivemind chat)
-// ***************************************
-/mob/living/carbon/xenomorph/Topic(href, href_list)
-	. = ..()
-	if(.)
-		return
-
-	if(href_list["watch_xeno_name"])
-		if(!check_state())
-			return
-		var/xeno_name = href_list["watch_xeno_name"]
-		for(var/mob/living/carbon/xenomorph/X AS in hive.get_watchable_xenos())
-			if(isnum(X.nicknumber))
-				if(num2text(X.nicknumber) != xeno_name)
-					continue
-			else
-				if(X.nicknumber != xeno_name)
-					continue
-			SEND_SIGNAL(src, COMSIG_XENOMORPH_WATCHXENO, X)
-			break

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
@@ -44,6 +44,7 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/charge,
 		/datum/action/xeno_action/activable/ravage,
@@ -164,6 +165,7 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/charge,
 		/datum/action/xeno_action/activable/ravage,

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -53,6 +53,7 @@
 	// *** Abilities *** ///
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/xenohide,
 		/datum/action/xeno_action/activable/pounce,
@@ -182,6 +183,7 @@
 	// *** Abilities *** ///
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/xenohide,
 		/datum/action/xeno_action/activable/pounce,

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
@@ -42,6 +42,7 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/corrosive_acid/drone,
 		/datum/action/xeno_action/activable/xeno_spit,
@@ -167,6 +168,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/corrosive_acid/drone,
 		/datum/action/xeno_action/activable/xeno_spit,

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -48,6 +48,7 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/cocoon,
 		/datum/action/xeno_action/activable/plant_weeds,
@@ -180,6 +181,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/cocoon,
 		/datum/action/xeno_action/activable/plant_weeds,

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -51,6 +51,7 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/corrosive_acid,
 		/datum/action/xeno_action/activable/xeno_spit,

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
@@ -43,6 +43,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/toggle_agility,
 		/datum/action/xeno_action/activable/lunge,
@@ -168,6 +169,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/toggle_agility,
 		/datum/action/xeno_action/activable/lunge,

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
@@ -43,6 +43,7 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/blink,
 		/datum/action/xeno_action/activable/banish,
@@ -152,6 +153,7 @@
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/blink,
 		/datum/action/xeno_action/activable/banish,

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -166,15 +166,12 @@
 		xenos += xenos_by_typepath[typepath]
 	return xenos
 
-// doing this by type means we get a pseudo sorted list
-/datum/hive_status/proc/get_watchable_xenos()
+///Returning all xenos including queen that are not at centcom and not self.
+/datum/hive_status/proc/get_watchable_xenos(mob/living/carbon/xenomorph/self)
 	var/list/xenos = list()
 	for(var/typepath in xenos_by_typepath)
-		if(typepath == /mob/living/carbon/xenomorph/queen) // hardcoded check for now
-			continue
-		for(var/i in xenos_by_typepath[typepath])
-			var/mob/living/carbon/xenomorph/X = i
-			if(is_centcom_level(X.z))
+		for(var/mob/living/carbon/xenomorph/X AS in xenos_by_typepath[typepath])
+			if(X == self || is_centcom_level(X.z))
 				continue
 			xenos += X
 	return xenos

--- a/code/modules/mob/living/carbon/xenomorph/say.dm
+++ b/code/modules/mob/living/carbon/xenomorph/say.dm
@@ -58,16 +58,9 @@
 
 	return TRUE
 
-
 /mob/living/carbon/xenomorph/proc/receive_hivemind_message(mob/living/carbon/xenomorph/X, message)
-	show_message("[X.hivemind_start()] [span_message("hisses, '[message]'")][X.hivemind_end()]", 2)
-
-
-/mob/living/carbon/xenomorph/queen/receive_hivemind_message(mob/living/carbon/xenomorph/X, message)
-	if(X != src)
-		show_message("(<a href='byond://?src=[REF(src)];watch_xeno_name=[X.nicknumber]'>F</a>) [X.hivemind_start()] [span_message("hisses, '[message]'")][X.hivemind_end()]", 2)
-	else
-		return ..()
+	var/follow_link = X != src ? "<a href='byond://?src=[REF(src)];watch_xeno_name=[X.nicknumber]'>(F)</a>" : ""
+	show_message("[follow_link] [X.hivemind_start()][span_message("hisses, '[message]'")][X.hivemind_end()]", 2)
 
 
 /mob/living/carbon/xenomorph/get_saymode(message, talk_key)

--- a/code/modules/mob/living/carbon/xenomorph/say.dm
+++ b/code/modules/mob/living/carbon/xenomorph/say.dm
@@ -59,8 +59,8 @@
 	return TRUE
 
 /mob/living/carbon/xenomorph/proc/receive_hivemind_message(mob/living/carbon/xenomorph/X, message)
-	var/follow_link = X != src ? "<a href='byond://?src=[REF(src)];watch_xeno_name=[X.nicknumber]'>(F)</a>" : ""
-	show_message("[follow_link] [X.hivemind_start()][span_message("hisses, '[message]'")][X.hivemind_end()]", 2)
+	var/follow_link = X != src ? "(<a href='byond://?src=[REF(src)];watch_xeno_name=[X.nicknumber]'>F</a>) " : ""
+	show_message("[follow_link][X.hivemind_start()][span_message(" hisses, '[message]'")][X.hivemind_end()]", 2)
 
 
 /mob/living/carbon/xenomorph/get_saymode(message, talk_key)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -335,6 +335,9 @@
 	var/warding_new = 0
 	var/recovery_new = 0
 
+	///The xenomorph player is currently overwatching
+	var/mob/living/carbon/xenomorph/observed_xeno
+
 	///Multiplicative melee damage modifier; referenced by attack_alien.dm, most notably attack_alien_harm
 	var/xeno_melee_damage_modifier = 1
 

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -335,7 +335,7 @@
 	var/warding_new = 0
 	var/recovery_new = 0
 
-	///The xenomorph player is currently overwatching
+	///The xenomorph that this source is currently overwatching
 	var/mob/living/carbon/xenomorph/observed_xeno
 
 	///Multiplicative melee damage modifier; referenced by attack_alien.dm, most notably attack_alien_harm

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -189,9 +189,9 @@
 		var/follow_name = href_list["watch_xeno_name"]
 		for(var/mob/living/carbon/xenomorph/X AS in hive.get_watchable_xenos(usr))
 			if(isnum(X.nicknumber) && num2text(X.nicknumber) != follow_name)
-					continue
+				continue
 			else if(X.nicknumber != follow_name)
-					continue
+				continue
 			SEND_SIGNAL(src, COMSIG_XENOMORPH_WATCHXENO, X)
 			break
 

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -188,11 +188,9 @@
 			return
 		var/follow_name = href_list["watch_xeno_name"]
 		for(var/mob/living/carbon/xenomorph/X AS in hive.get_watchable_xenos(usr))
-			if(isnum(X.nicknumber))
-				if(num2text(X.nicknumber) != follow_name)
+			if(isnum(X.nicknumber) && num2text(X.nicknumber) != follow_name)
 					continue
-			else
-				if(X.nicknumber != follow_name)
+			else if(X.nicknumber != follow_name)
 					continue
 			SEND_SIGNAL(src, COMSIG_XENOMORPH_WATCHXENO, X)
 			break

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -188,9 +188,7 @@
 			return
 		var/follow_name = href_list["watch_xeno_name"]
 		for(var/mob/living/carbon/xenomorph/X AS in hive.get_watchable_xenos(usr))
-			if(isnum(X.nicknumber) && num2text(X.nicknumber) != follow_name)
-				continue
-			else if(X.nicknumber != follow_name)
+			if((isnum(X.nicknumber) && num2text(X.nicknumber) != follow_name) || X.nicknumber != follow_name)
 				continue
 			SEND_SIGNAL(src, COMSIG_XENOMORPH_WATCHXENO, X)
 			break

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -183,6 +183,20 @@
 				to_chat(usr,span_notice(" You will now track [resin_silo.name]"))
 				break
 
+	if(href_list["watch_xeno_name"])
+		if(!check_state())
+			return
+		var/follow_name = href_list["watch_xeno_name"]
+		for(var/mob/living/carbon/xenomorph/X AS in hive.get_watchable_xenos(usr))
+			if(isnum(X.nicknumber))
+				if(num2text(X.nicknumber) != follow_name)
+					continue
+			else
+				if(X.nicknumber != follow_name)
+					continue
+			SEND_SIGNAL(src, COMSIG_XENOMORPH_WATCHXENO, X)
+			break
+
 ///Send a message to all xenos. Force forces the message whether or not the hivemind is intact. Target is an atom that is pointed out to the hive. Filter list is a list of xenos we don't message.
 /proc/xeno_message(message = null, span_class = "xenoannounce", size = 5, hivenumber = XENO_HIVE_NORMAL, force = FALSE, atom/target = null, sound = null, apply_preferences = FALSE, filter_list = null, arrow_type, arrow_color, report_distance = FALSE)
 	if(!message)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

All main caste xenos (not minions) and larva now have the ability to overwatch other xenos through chat (F) button.

However, only the queen is able to arbitrarily select a xeno from the hive to overwatch without seeing their voice in the chat (simply to prevent increasing the number of buttons).

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Now larva and young runners can rest inside the safety of the silo and grab popcorn to watch the rest of the hive get railed at the front line without having to actually risk their own lives to see how it is going.

![image](https://user-images.githubusercontent.com/29745705/169444624-f7951d0d-adcf-4557-af4a-a0cd759aa75d.png)

The drone is the player in this image and can now "overwatch" the queen via the (F) button in the chat. However, only the queen's overwatch will result in the eye appearing on the xeno HUD overlay.

Requires #10250 to be merged in order to function for all xenos other than the queen.

## Changelog
:cl:
add: All xenos now have the ability to overwatch other xenos through the chat (F) button.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
