### PR TITLE
Underbarrel weapon rebalance

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1704,7 +1704,6 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	if(!istype(attached_to, /obj/item/weapon/gun))
 		return
 	master_gun = attached_to
-	master_gun.aim_slowdown					+= aim_speed_mod
 	master_gun.wield_delay					+= wield_delay_mod
 	if(gun_user)
 		UnregisterSignal(gun_user, list(COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEUP, COMSIG_ITEM_ZOOM, COMSIG_ITEM_UNZOOM, COMSIG_MOB_MOUSEDRAG, COMSIG_KB_RAILATTACHMENT, COMSIG_KB_UNDERRAILATTACHMENT, COMSIG_KB_UNLOADGUN, COMSIG_KB_FIREMODE, COMSIG_KB_GUN_SAFETY, COMSIG_KB_UNIQUEACTION, COMSIG_PARENT_QDELETING,  COMSIG_MOB_CLICK_RIGHT))

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1704,6 +1704,8 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	if(!istype(attached_to, /obj/item/weapon/gun))
 		return
 	master_gun = attached_to
+	master_gun.aim_slowdown					+= aim_speed_mod
+	master_gun.wield_delay					+= wield_delay_mod
 	if(gun_user)
 		UnregisterSignal(gun_user, list(COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEUP, COMSIG_ITEM_ZOOM, COMSIG_ITEM_UNZOOM, COMSIG_MOB_MOUSEDRAG, COMSIG_KB_RAILATTACHMENT, COMSIG_KB_UNDERRAILATTACHMENT, COMSIG_KB_UNLOADGUN, COMSIG_KB_FIREMODE, COMSIG_KB_GUN_SAFETY, COMSIG_KB_UNIQUEACTION, COMSIG_PARENT_QDELETING,  COMSIG_MOB_CLICK_RIGHT))
 	var/datum/action/new_action = new /datum/action/item_action/toggle(src, master_gun)
@@ -1729,6 +1731,8 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	overlays -= image('icons/Marine/marine-weapons.dmi', src, "active")
 	if(master_gun.active_attachable == src)
 		master_gun.active_attachable = null
+	master_gun.aim_slowdown					-= aim_speed_mod
+	master_gun.wield_delay					-= wield_delay_mod
 	master_gun = null
 	attached_to:gunattachment = null
 	update_icon(user)

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1731,7 +1731,6 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	overlays -= image('icons/Marine/marine-weapons.dmi', src, "active")
 	if(master_gun.active_attachable == src)
 		master_gun.active_attachable = null
-	master_gun.aim_slowdown					-= aim_speed_mod
 	master_gun.wield_delay					-= wield_delay_mod
 	master_gun = null
 	attached_to:gunattachment = null

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -303,6 +303,10 @@
 	var/attach_delay = 0 SECONDS
 	///Time it takes to detach src to a master gun.
 	var/detach_delay = 0 SECONDS
+	///Changes the slowdown amount when wielding a weapon by this value.
+	var/aim_speed_mod	= 0
+	///How long ADS takes (time before firing)
+	var/wield_delay_mod	= 0
 
 
 /*

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -303,8 +303,6 @@
 	var/attach_delay = 0 SECONDS
 	///Time it takes to detach src to a master gun.
 	var/detach_delay = 0 SECONDS
-	///Changes the slowdown amount when wielding a weapon by this value.
-	var/aim_speed_mod	= 0
 	///How long ADS takes (time before firing)
 	var/wield_delay_mod	= 0
 

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -327,8 +327,7 @@
 	mob_flame_damage_mod = 1
 	flame_max_range = 4
 
-	aim_speed_mod	= 0.1
-	wield_delay_mod	= 0.1 SECONDS
+	wield_delay_mod	= 0.2 SECONDS
 
 /obj/item/weapon/gun/flamer/mini_flamer/unremovable
 	flags_attach_features = NONE

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -327,6 +327,9 @@
 	mob_flame_damage_mod = 1
 	flame_max_range = 4
 
+	aim_speed_mod	= 0.1
+	wield_delay_mod	= 0.1 SECONDS
+
 /obj/item/weapon/gun/flamer/mini_flamer/unremovable
 	flags_attach_features = NONE
 

--- a/code/modules/projectiles/guns/grenade_launchers.dm
+++ b/code/modules/projectiles/guns/grenade_launchers.dm
@@ -152,6 +152,9 @@ The Grenade Launchers
 		/obj/item/explosive/grenade/sticky,
 	)
 
+	aim_speed_mod	= 0.1
+	wield_delay_mod	= 0.1 SECONDS
+
 /obj/item/weapon/gun/grenade_launcher/underslung/invisible
 	flags_attach_features = NONE
 

--- a/code/modules/projectiles/guns/grenade_launchers.dm
+++ b/code/modules/projectiles/guns/grenade_launchers.dm
@@ -152,8 +152,7 @@ The Grenade Launchers
 		/obj/item/explosive/grenade/sticky,
 	)
 
-	aim_speed_mod	= 0.1
-	wield_delay_mod	= 0.1 SECONDS
+	wield_delay_mod	= 0.2 SECONDS
 
 /obj/item/weapon/gun/grenade_launcher/underslung/invisible
 	flags_attach_features = NONE

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -112,6 +112,9 @@
 	pixel_shift_x = 10
 	pixel_shift_y = 19
 
+	aim_speed_mod	= 0.2
+	wield_delay_mod	= 0.1 SECONDS
+
 	placed_overlay_iconstate = "tx7"
 
 /obj/item/weapon/gun/pistol/plasma_pistol/can_attach(obj/item/attaching_to, mob/attacher)

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -112,7 +112,7 @@
 	pixel_shift_x = 10
 	pixel_shift_y = 19
 
-	aim_speed_mod	= 0.2
+	aim_speed_mod	= 0.1
 	wield_delay_mod	= 0.1 SECONDS
 
 	placed_overlay_iconstate = "tx7"

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -112,8 +112,7 @@
 	pixel_shift_x = 10
 	pixel_shift_y = 19
 
-	aim_speed_mod	= 0.1
-	wield_delay_mod	= 0.1 SECONDS
+	wield_delay_mod	= 0.2 SECONDS
 
 	placed_overlay_iconstate = "tx7"
 

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -131,6 +131,9 @@
 	pixel_shift_x = 14
 	pixel_shift_y = 18
 
+	aim_speed_mod	= 0.1
+	wield_delay_mod	= 0.1 SECONDS
+
 //-------------------------------------------------------
 //DOUBLE SHOTTY
 

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -131,8 +131,7 @@
 	pixel_shift_x = 14
 	pixel_shift_y = 18
 
-	aim_speed_mod	= 0.1
-	wield_delay_mod	= 0.1 SECONDS
+	wield_delay_mod	= 0.2 SECONDS
 
 //-------------------------------------------------------
 //DOUBLE SHOTTY

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -508,8 +508,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	pixel_shift_x = 18
 	pixel_shift_y = 16
 
-	aim_speed_mod	= 0.1
-	wield_delay_mod	= 0.1 SECONDS
+	wield_delay_mod	= 0.2 SECONDS
 
 //-------------------------------------------------------
 //M5 RPG

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -508,6 +508,9 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	pixel_shift_x = 18
 	pixel_shift_y = 16
 
+	aim_speed_mod	= 0.1
+	wield_delay_mod	= 0.1 SECONDS
+
 //-------------------------------------------------------
 //M5 RPG
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds wield time and wielded movement speed maluses to underbarrel weapon attachments.

Underbarrel weapons provide marines huge damage and/or utility buffs with literally zero downside.
This is in comparison with most other attachments that have some sort of downsides for the benefits they provide.

The changes are pretty mild. All 5 underbarrels now add 0.2 second of wield time.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Make underbarrel weapons slightly more reasonable
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Underbarrel weapons now slightly impact wield times for their parent guns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
