### PR TITLE
Refactors Hive Upgrade Store Page To Separate Datum

### DIFF
--- a/code/datums/actions/observer_action.dm
+++ b/code/datums/actions/observer_action.dm
@@ -57,7 +57,7 @@
 			continue
 		if(isxeno(ssd_mob))
 			var/mob/living/carbon/xenomorph/potential_minion = ssd_mob
-			if((potential_minion.xeno_caste.caste_flags & CASTE_IS_A_MINION) && !potential_minion.hive.upgrades_by_name[GHOSTS_CAN_TAKE_MINIONS].times_bought)
+			if((potential_minion.xeno_caste.caste_flags & CASTE_IS_A_MINION) && !potential_minion.hive.upgrades.upgrades_by_name[GHOSTS_CAN_TAKE_MINIONS].times_bought)
 				continue
 		free_ssd_mobs += ssd_mob
 

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -103,7 +103,7 @@
 
 	for(var/hivenum in GLOB.hive_datums)
 		var/datum/hive_status/hive = GLOB.hive_datums[hivenum]
-		hive.setup_upgrades()
+		hive.upgrades.setup_upgrades()
 	return TRUE
 
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1285,7 +1285,5 @@
 
 /datum/action/xeno_action/blessing_menu/action_activate()
 	var/mob/living/carbon/xenomorph/X = owner
-	//X.hive.upgrades.interact(X)
-	//var/output = X.hive.upgrades == null ? "True" : "False"
-	log_admin("HELLO WORLD")
+	X.hive.upgrades.interact(X)
 	return succeed_activate()

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1272,17 +1272,20 @@
 	ADD_TRAIT(victim, TRAIT_STASIS, TRAIT_STASIS)
 	X.eject_victim(TRUE, starting_turf)
 
-/////////////////////////////////
-// blessing Menu
-/////////////////////////////////
+// ***************************************
+// Hive Store / Blessing Menu
+// ***************************************
 /datum/action/xeno_action/blessing_menu
 	name = "Mothers Blessings"
 	action_icon_state = "hivestore"
 	mechanics_text = "Ask the Queen Mother for blessings for your hive in exchange for psychic energy."
 	keybind_signal = COMSIG_XENOABILITY_BLESSINGSMENU
-	use_state_flags = XACT_USE_LYING|XACT_USE_CRESTED|XACT_USE_AGILITY
+	use_state_flags = XACT_USE_LYING
+	cooldown_timer = 10 SECONDS
 
 /datum/action/xeno_action/blessing_menu/action_activate()
 	var/mob/living/carbon/xenomorph/X = owner
-	X.hive.interact(X)
+	//X.hive.upgrades.interact(X)
+	//var/output = X.hive.upgrades == null ? "True" : "False"
+	log_admin("HELLO WORLD")
 	return succeed_activate()

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1281,7 +1281,6 @@
 	mechanics_text = "Ask the Queen Mother for blessings for your hive in exchange for psychic energy."
 	keybind_signal = COMSIG_XENOABILITY_BLESSINGSMENU
 	use_state_flags = XACT_USE_LYING
-	cooldown_timer = 10 SECONDS
 
 /datum/action/xeno_action/blessing_menu/action_activate()
 	var/mob/living/carbon/xenomorph/X = owner

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -28,7 +28,7 @@
 	var/king_present = 0
 
 	///Reference to upgrades available and purchased by this hive.
-	var/datum/hive_defcon/upgrades = new /datum/hive_defcon()
+	var/datum/hive_defcon/upgrades = new
 
 // ***************************************
 // *********** Init

--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -11,6 +11,72 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	XENO_TIER_FOUR = PRIMORDIAL_TIER_FOUR,
 ))
 
+/datum/hive_defcon //Defcon is back baby. What do you mean this is the wrong game.
+	///Flat list of upgrades we can buy
+	var/list/buyable_upgrades = list()
+	///Assocative list name = upgraderef
+	var/list/datum/hive_upgrade/upgrades_by_name = list()
+
+// ***************************************
+// *********** UI for hive store/blessing menu
+// ***************************************
+
+///Initializing hive status with all relevant to be purchased upgrades.
+/datum/hive_defcon/proc/setup_upgrades()
+	for(var/type in subtypesof(/datum/hive_upgrade))
+		var/datum/hive_upgrade/upgrade = new type
+		if(upgrade.name == "Error upgrade") //defaultname just skip it its probably organisation
+			continue
+		if(!(SSticker.mode.flags_xeno_abilities & upgrade.flags_gamemode))
+			continue
+		buyable_upgrades += upgrade
+		upgrades_by_name[upgrade.name] = upgrade
+
+/datum/hive_defcon/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "BlessingMenu", "Queen Mothers Blessings")
+		ui.open()
+
+/datum/hive_defcon/ui_state(mob/user)
+	return GLOB.conscious_state
+
+/datum/hive_defcon/ui_assets(mob/user)
+	. = ..()
+	. += get_asset_datum(/datum/asset/spritesheet/blessingmenu)
+
+/datum/hive_defcon/ui_data(mob/user)
+	. = ..()
+
+	var/mob/living/carbon/xenomorph/X = user
+	var/datum/hive_status/hive = X.hive
+
+	.["upgrades"] = list()
+	for(var/datum/hive_upgrade/upgrade AS in buyable_upgrades)
+		.["upgrades"] += list(list("name" = upgrade.name, "desc" = upgrade.desc, "category" = upgrade.category,\
+		"cost" = upgrade.psypoint_cost, "times_bought" = upgrade.times_bought, "iconstate" = upgrade.icon))
+	.["psypoints"] = SSpoints.xeno_points_by_hive[hive.hivenumber]
+
+/datum/hive_defcon/ui_static_data(mob/user)
+	. = ..()
+	.["categories"] = GLOB.upgrade_categories
+
+/datum/hive_defcon/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	switch(action)
+		if("buy")
+			var/buying = params["buyname"]
+			var/datum/hive_upgrade/upgrade = upgrades_by_name[buying]
+			var/mob/living/carbon/xenomorph/user = usr
+			var/datum/hive_status/hive = user.hive
+			if(!upgrade.can_buy(user, FALSE))
+				return
+			if(!upgrade.on_buy(user))
+				return
+			log_game("[key_name(user)] has purchased \a [upgrade] Blessing for [upgrade.psypoint_cost] psypoints for the [hive.hivenumber] hive")
+			if(upgrade.flags_upgrade & UPGRADE_FLAG_MESSAGE_HIVE)
+				xeno_message("[user] has purchased \a [upgrade] Blessing", "xenoannounce", 5, user.hivenumber)
+
 /datum/hive_upgrade
 	///name of the upgrade, string, used in ui
 	var/name = "Error upgrade"

--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -12,6 +12,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 ))
 
 /datum/hive_defcon //Defcon is back baby. What do you mean this is the wrong game.
+	interaction_flags = INTERACT_UI_INTERACT
 	///Flat list of upgrades we can buy
 	var/list/buyable_upgrades = list()
 	///Assocative list name = upgraderef

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -197,7 +197,7 @@
 ///returns TRUE if we are permitted to evo to the next case FALSE otherwise
 /mob/living/carbon/xenomorph/proc/upgrade_possible()
 	if(upgrade == XENO_UPGRADE_THREE)
-		return hive.upgrades_by_name[GLOB.tier_to_primo_upgrade[xeno_caste.tier]].times_bought
+		return hive.upgrades.upgrades_by_name[GLOB.tier_to_primo_upgrade[xeno_caste.tier]].times_bought
 	return (upgrade != XENO_UPGRADE_INVALID && upgrade != XENO_UPGRADE_FOUR)
 
 //Adds stuff to your "Status" pane -- Specific castes can have their own, like carrier hugger count


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Some refactoring / relocation of hive upgrades properties to now be located in their own datum.

All lists related to upgrades shifted to this new datum and the TGUI display for the storefront has also been migrated.

Yes, TGUI hive status will be coming in chunks. Each with their own PR.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Frees up the TGUI interaction procs for incoming port of CM's hive status page.

## Changelog

No in game effects. Just backend type additions. Players dont need to know this.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
