### PR TITLE
Fix xeno hud perma fire stacks on dead

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -407,6 +407,9 @@
 	if(!holder)
 		return
 
+	if(stat == DEAD)
+		holder.icon_state = "firestack0"
+		return
 	switch(fire_stacks)
 		if(-INFINITY to 0)
 			holder.icon_state = "firestack0"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a stat DEAD check to the fire stacks hud code.

## Why It's Good For The Game

Fix.

## Changelog
:cl:
fix: Fixed xeno hud perma fire stacks on dead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
