### PR TITLE
Maturity and evolution towers only work after shutters opening

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -16,10 +16,6 @@
 	var/list/list/xenos_by_upgrade = list()
 	var/list/dead_xenos = list() // xenos that are still assigned to this hive but are dead.
 	var/list/list/xenos_by_zlevel = list()
-	///list of evo towers
-	var/list/obj/structure/xeno/evotower/evotowers = list()
-	///list of upgrade towers
-	var/list/obj/structure/xeno/maturitytower/maturitytowers = list()
 	var/tier3_xeno_limit
 	var/tier2_xeno_limit
 	///Queue of all observer wanting to join xeno side
@@ -32,6 +28,10 @@
 	var/list/datum/hive_upgrade/upgrades_by_name = list()
 	///Its an int showing the count of living kings
 	var/king_present = 0
+	///Upgrade boost for all xenos
+	var/upgrade_boost = 0
+	///Evolution boost
+	var/evolution_boost = 0
 
 // ***************************************
 // *********** Init
@@ -193,19 +193,6 @@
 				continue
 			xenos += X
 	return xenos
-
-
-///fetches number of bonus evo points given to the hive
-/datum/hive_status/proc/get_evolution_boost()
-	. = 0
-	for(var/obj/structure/xeno/evotower/tower AS in evotowers)
-		. += tower.boost_amount
-
-///fetches number of bonus upgrade points given to the hive
-/datum/hive_status/proc/get_upgrade_boost()
-	. = 0
-	for(var/obj/structure/xeno/maturitytower/tower AS in maturitytowers)
-		. += tower.boost_amount
 
 // ***************************************
 // *********** Adding xenos

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -357,7 +357,7 @@
 	// Upgrade is increased based on marine to xeno population taking stored_larva as a modifier.
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
 	var/stored_larva = xeno_job.total_positions - xeno_job.current_positions
-	var/upgrade_points = 1 + (stored_larva/6) + hive.get_upgrade_boost()
+	var/upgrade_points = 1 + (stored_larva/6) + (SSmonitor.gamestate != SHUTTERS_CLOSED ? hive.upgrade_boost : 0)
 	upgrade_stored = min(upgrade_stored + upgrade_points, xeno_caste.upgrade_threshold)
 
 /mob/living/carbon/xenomorph/proc/update_evolving()
@@ -371,7 +371,7 @@
 	// Evolution is increased based on marine to xeno population taking stored_larva as a modifier.
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
 	var/stored_larva = xeno_job.total_positions - xeno_job.current_positions
-	var/evolution_points = 1 + (FLOOR(stored_larva / 3, 1)) + hive.get_evolution_boost()
+	var/evolution_points = 1 + (FLOOR(stored_larva / 3, 1)) + (SSmonitor.gamestate != SHUTTERS_CLOSED ? hive.evolution_boost : 0)
 	evolution_stored = min(evolution_stored + evolution_points, xeno_caste.evolution_threshold)
 
 	if(evolution_stored == xeno_caste.evolution_threshold)

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -1112,12 +1112,12 @@ TUNNEL
 
 /obj/structure/xeno/evotower/Initialize(mapload, hivenum)
 	. = ..()
-	GLOB.hive_datums[hivenum].evotowers += src
+	GLOB.hive_datums[hivenum].evolution_boost += boost_amount
 	hivenumber = hivenum
 	set_light(2, 2, LIGHT_COLOR_GREEN)
 
 /obj/structure/xeno/evotower/Destroy()
-	GLOB.hive_datums[hivenumber].evotowers -= src
+	GLOB.hive_datums[hivenumber].evolution_boost -= boost_amount
 	return ..()
 
 /obj/structure/xeno/evotower/ex_act(severity)
@@ -1146,12 +1146,12 @@ TUNNEL
 
 /obj/structure/xeno/maturitytower/Initialize(mapload, hivenum)
 	. = ..()
-	GLOB.hive_datums[hivenum].maturitytowers += src
+	GLOB.hive_datums[hivenum].upgrade_boost += boost_amount
 	hivenumber = hivenum
 	set_light(2, 2, LIGHT_COLOR_GREEN)
 
 /obj/structure/xeno/maturitytower/Destroy()
-	GLOB.hive_datums[hivenumber].maturitytowers -= src
+	GLOB.hive_datums[hivenumber].upgrade_boost -= boost_amount
 	return ..()
 
 /obj/structure/xeno/maturitytower/ex_act(severity)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tittle

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Will discourage fob hugging and xenos immediatly crushing marines. This is more in line with other xeno building, like silos which are not producing anything before the shutters open

This is made with nuclear war in mind, I hope this won't create too much trouble in distress

## Changelog
:cl:
balance: Maturity and evolution towers only work after shutters opening
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
