### PR TITLE
Fix Hivemind Runtime Upon Evolution

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
@@ -47,6 +47,10 @@
 /mob/living/carbon/xenomorph/hivemind/upgrade_possible()
 	return FALSE
 
+/mob/living/carbon/xenomorph/hivemind/upgrade_xeno(newlevel, silent = FALSE)
+	newlevel = XENO_UPGRADE_BASETYPE
+	return ..()
+
 /mob/living/carbon/xenomorph/hivemind/updatehealth()
 	if(on_fire)
 		ExtinguishMob()
@@ -85,12 +89,10 @@
 		QDEL_NULL(core)
 	else
 		core = null
-	upgrade = XENO_UPGRADE_BASETYPE
 	return ..()
 
 
 /mob/living/carbon/xenomorph/hivemind/on_death()
-	upgrade = XENO_UPGRADE_BASETYPE
 	if(!QDELETED(core))
 		QDEL_NULL(core)
 	return ..()

--- a/code/modules/mob/living/carbon/xenomorph/xenoupgrade.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoupgrade.dm
@@ -1,7 +1,7 @@
 
 /mob/living/carbon/xenomorph/proc/upgrade_xeno(newlevel, silent = FALSE)
-	if(!(newlevel in (GLOB.xenoupgradetiers - XENO_UPGRADE_BASETYPE - XENO_UPGRADE_INVALID)))
-		return // smelly badmins
+	if(!(newlevel in (GLOB.xenoupgradetiers - XENO_UPGRADE_INVALID)))
+		return
 	hive.upgrade_xeno(src, upgrade, newlevel)
 	upgrade = newlevel
 	upgrade_stored = 0


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Due to the special case of hiveminds being purely base upgrade tier caste, setting the caste datum was crashing when trying to get a normal (e.g., young) upgrade since it does not exist.

This fixes that issue by forcing the upgrade to only look for base upgrade type since that is the only one that exists.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

One less runtime. Might prevent the MC from self destructing mid-game????

## Changelog
:cl:
fix: Fixed an error appearing when a drone evolves to hivemind.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
