### PR TITLE
Tweak xeno hive chat follow link, less click accuracy needed

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/say.dm
+++ b/code/modules/mob/living/carbon/xenomorph/say.dm
@@ -59,7 +59,7 @@
 	return TRUE
 
 /mob/living/carbon/xenomorph/proc/receive_hivemind_message(mob/living/carbon/xenomorph/X, message)
-	var/follow_link = X != src ? "(<a href='byond://?src=[REF(src)];watch_xeno_name=[X.nicknumber]'>F</a>) " : ""
+	var/follow_link = X != src ? "<a href='byond://?src=[REF(src)];watch_xeno_name=[X.nicknumber]'>(F)</a> " : ""
 	show_message("[follow_link][X.hivemind_start()][span_message(" hisses, '[message]'")][X.hivemind_end()]", 2)
 
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the parenthesis part of the clickable text.

## Why It's Good For The Game

Arguably looks better in both light and dark mode.
Is consistent with how the `FOLLOW_LINK` macro renders them.

## Changelog
:cl:
qol: Xeno hivemind chat follow links are easier to click.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
