### PR TITLE
Added Balloon Alerts and Fixes For Resin Jelly

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -617,7 +617,9 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 
 //Drone defines
 #define DRONE_HEAL_RANGE 1
-#define AUTO_WEEDING_MIN_DIST 4 // How far the xeno must be from the last spot to auto weed
+#define AUTO_WEEDING_MIN_DIST 4 //How far the xeno must be from the last spot to auto weed
+#define RESIN_SELF_TIME 2 SECONDS //Time it takes to apply resin jelly on themselves
+#define RESIN_OTHER_TIME 1 SECONDS //Time it takes to apply resin jelly to other xenos
 
 //Boiler defines
 #define BOILER_LUMINOSITY_BASE 0
@@ -627,7 +629,6 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define BOILER_LUMINOSITY_AMMO_CORROSIVE_COLOR LIGHT_COLOR_GREEN
 
 //Hivelord defines
-
 #define HIVELORD_TUNNEL_DISMANTLE_TIME 3 SECONDS
 #define HIVELORD_TUNNEL_MIN_TRAVEL_TIME 2 SECONDS
 #define HIVELORD_TUNNEL_SMALL_MAX_TRAVEL_TIME 4 SECONDS

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -75,7 +75,7 @@
 
 
 /obj/effect/alien/resin/attack_hand(mob/living/user)
-	to_chat(usr, span_warning("You scrape ineffectively at \the [src]."))
+	balloon_alert(user, "You only scrape at it")
 	return TRUE
 
 
@@ -186,12 +186,10 @@
 		TryToSwitchState(X)
 		return TRUE
 
-	X.visible_message(span_warning("\The [X] digs into \the [src] and begins ripping it down."), \
-	span_warning("We dig into \the [src] and begin ripping it down."), null, 5)
+	src.balloon_alert(X, "Destroying...")
 	playsound(src, "alien_resin_break", 25)
 	if(do_after(X, 4 SECONDS, FALSE, src, BUSY_ICON_HOSTILE))
-		X.visible_message(span_danger("[X] rips down \the [src]!"), \
-		span_danger("We rip down \the [src]!"), null, 5)
+		src.balloon_alert(X, "Destroyed")
 		qdel(src)
 
 /obj/structure/mineral_door/resin/flamer_fire_act()
@@ -270,7 +268,7 @@
 			. = TRUE
 			break
 	if(!.)
-		visible_message("<span class = 'notice'>[src] collapses from the lack of support.</span>")
+		src.balloon_alert_to_viewers("Collapsed")
 		qdel(src)
 
 /obj/structure/mineral_door/resin/thick
@@ -284,6 +282,8 @@
 	icon_state = "biomass"
 	soft_armor = list("fire" = 200)
 	var/immune_time = 15 SECONDS
+	///Holder to ensure only one user per resin jelly.
+	var/current_user
 
 /obj/item/resin_jelly/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
 	if(X.status_flags & INCORPOREAL)
@@ -291,34 +291,45 @@
 
 	if(X.xeno_caste.caste_flags & CASTE_CAN_HOLD_JELLY)
 		return attack_hand(X)
-	if(X.do_actions)
+	if(X.do_actions || !isnull(current_user))
 		return
-	X.visible_message(span_notice("[X] starts to cover themselves in a foul substance..."), span_xenonotice("We begin to cover ourselves in a foul substance..."))
-	if(!do_after(X, 2 SECONDS, TRUE, X, BUSY_ICON_MEDICAL))
+	current_user = X
+	X.balloon_alert(X, "Applying...")
+	if(!do_after(X, RESIN_SELF_TIME, TRUE, X, BUSY_ICON_MEDICAL))
+		current_user = null
 		return
 	activate_jelly(X)
 
 /obj/item/resin_jelly/attack_self(mob/living/carbon/xenomorph/user)
+	//Activates if the item itself is clicked in hand.
 	if(!isxeno(user))
 		return
-	if(user.do_actions)
+	if(user.do_actions || !isnull(current_user))
 		return
-	user.visible_message(span_notice("[user] starts to cover themselves in a foul substance..."), span_xenonotice("We begin to cover ourselves in a foul substance..."))
-	if(!do_after(user, 2 SECONDS, TRUE, user, BUSY_ICON_MEDICAL))
+	current_user = user
+	user.balloon_alert(user, "Applying...")
+	if(!do_after(user, RESIN_SELF_TIME, TRUE, user, BUSY_ICON_MEDICAL))
+		current_user = null
 		return
 	activate_jelly(user)
 
 /obj/item/resin_jelly/attack(mob/living/carbon/xenomorph/M, mob/living/user)
+	//Activates if active hand and clicked on mob in game.
+	//Can target self so we need to check for that.
 	if(!isxeno(user))
 		return TRUE
 	if(!isxeno(M))
-		to_chat(user, span_xenonotice("We cannot apply the [src] to this creature."))
+		M.balloon_alert(user, "Cannot apply")
 		return FALSE
-	if(user.do_actions)
+	if(user.do_actions || !isnull(current_user))
 		return FALSE
-	if(!do_after(user, 1 SECONDS, TRUE, M, BUSY_ICON_MEDICAL))
+	current_user = M
+	M.balloon_alert(user, "Applying...")
+	if(M != user)
+		user.balloon_alert(M, "Applying jelly...") //Notify recipient to not move.
+	if(!do_after(user, (M == user ? RESIN_SELF_TIME : RESIN_OTHER_TIME), TRUE, M, BUSY_ICON_MEDICAL))
+		current_user = null
 		return FALSE
-	user.visible_message(span_notice("[user] smears a viscous substance on [M]."),span_xenonotice("We carefully smear [src] onto [user]."))
 	activate_jelly(M)
 	user.temporarilyRemoveItemFromInventory(src)
 	return FALSE
@@ -340,7 +351,7 @@
 	if(!isxeno(hit_atom))
 		return
 	var/mob/living/carbon/xenomorph/X = hit_atom
-	if(X.fire_resist_modifier <= -20)
+	if(X.fire_resist_modifier <= -20 || X.xeno_caste.caste_flags & CASTE_FIRE_IMMUNE)
 		return
 	X.visible_message(span_notice("[X] is splattered with jelly!"))
 	INVOKE_ASYNC(src, .proc/activate_jelly, X)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -241,7 +241,6 @@
 /datum/action/xeno_action/create_jelly/action_activate()
 	var/obj/item/resin_jelly/jelly = new(owner.loc)
 	owner.put_in_hands(jelly)
-	owner.balloon_alert(owner, "Resin jelly created")
 	to_chat(owner, span_xenonotice("We create a globule of resin from our ovipostor.")) // Ewww...
 	add_cooldown()
 	succeed_activate()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Added balloon alerts to resin interaction and resin jelly application.

Also fixed multiple people using the same resin jelly and halved application time if resin jelly was in hand.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Balloon alerts and fixes good.

## Changelog
:cl:
qol: Resin jelly now has balloon alerts for application.
fix: Resin jelly can no longer be used by multiple xenos at once.
fix: Resin jelly is no longer applied twice as fast to self while in hand.
fix: Resin jelly can no longer be applied to fireproof xenos.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
