### PR TITLE
Removes Largely Unused Overwatch Keybind (Ctrl-Middle Click) and OW Changes

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -108,7 +108,7 @@
 #define COMSIG_CLICK_CTRL "ctrl_click"							//from base of atom/CtrlClickOn(): (/mob)
 #define COMSIG_CLICK_ALT "alt_click"							//from base of atom/AltClick(): (/mob)
 #define COMSIG_CLICK_CTRL_SHIFT "ctrl_shift_click"				//from base of atom/CtrlShiftClick(/mob)
-#define COMSIG_CLICK_CTRL_MIDDLE "ctrl_middle_click"
+#define COMSIG_CLICK_CTRL_MIDDLE "ctrl_middle_click"			//from base of atom/CtrlMiddleClick(): (/mob)
 #define COMSIG_CLICK_RIGHT "right_click"						//from base of atom/RightClick(): (/mob)
 #define COMSIG_CLICK_SHIFT_RIGHT "shift_right_click"						//from base of atom/ShiftRightClick(): (/mob)
 #define COMSIG_CLICK_ALT_RIGHT "alt_right_click"							//from base of atom/AltRightClick(): (/mob)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -73,9 +73,6 @@
 	if(modifiers["shift"] && modifiers["ctrl"])
 		CtrlShiftClickOn(A)
 		return
-	if(modifiers["ctrl"] && modifiers["middle"])
-		CtrlMiddleClickOn(A)
-		return
 	if(modifiers["middle"] && MiddleClickOn(A))
 		return
 	if(modifiers["shift"] && modifiers["right"])
@@ -497,13 +494,6 @@ if(selected_ability.target_flags & flagname && !istype(A, typepath)){\
 
 /atom/proc/CtrlShiftClick(mob/user)
 	SEND_SIGNAL(src, COMSIG_CLICK_CTRL_SHIFT)
-
-
-/*
-	Ctrl+Middle click
-*/
-/atom/proc/CtrlMiddleClickOn(atom/A)
-	SEND_SIGNAL(src, COMSIG_CLICK_CTRL_MIDDLE, A)
 
 
 /obj/screen/proc/scale_to(x1,y1)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -73,6 +73,9 @@
 	if(modifiers["shift"] && modifiers["ctrl"])
 		CtrlShiftClickOn(A)
 		return
+	if(modifiers["ctrl"] && modifiers["middle"])
+		CtrlMiddleClickOn(A)
+		return
 	if(modifiers["middle"] && MiddleClickOn(A))
 		return
 	if(modifiers["shift"] && modifiers["right"])
@@ -494,6 +497,13 @@ if(selected_ability.target_flags & flagname && !istype(A, typepath)){\
 
 /atom/proc/CtrlShiftClick(mob/user)
 	SEND_SIGNAL(src, COMSIG_CLICK_CTRL_SHIFT)
+
+
+/*
+	Ctrl+Middle click
+*/
+/atom/proc/CtrlMiddleClickOn(atom/A)
+	SEND_SIGNAL(src, COMSIG_CLICK_CTRL_MIDDLE, A)
 
 
 /obj/screen/proc/scale_to(x1,y1)

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -136,15 +136,11 @@
 	. = ..()
 	RegisterSignal(L, COMSIG_MOB_DEATH, .proc/on_owner_death)
 	RegisterSignal(L, COMSIG_XENOMORPH_WATCHXENO, .proc/on_list_xeno_selection)
-	if(isxenoqueen(owner))
-		RegisterSignal(L, COMSIG_CLICK_CTRL_MIDDLE, .proc/on_ctrl_middle_click)
 
 /datum/action/xeno_action/watch_xeno/remove_action(mob/living/L)
 	if(overwatch_active)
 		stop_overwatch()
 	UnregisterSignal(L, list(COMSIG_MOB_DEATH, COMSIG_XENOMORPH_WATCHXENO))
-	if(isxenoqueen(owner))
-		UnregisterSignal(L, COMSIG_CLICK_CTRL_MIDDLE)
 	return ..()
 
 /datum/action/xeno_action/watch_xeno/action_activate()
@@ -183,6 +179,7 @@
 	RegisterSignal(target, COMSIG_HIVE_XENO_DEATH, .proc/on_xeno_death)
 	RegisterSignal(target, list(COMSIG_XENOMORPH_EVOLVED, COMSIG_XENOMORPH_DEEVOLVED), .proc/on_xeno_evolution)
 	RegisterSignal(watcher, COMSIG_MOVABLE_MOVED, .proc/on_movement)
+	RegisterSignal(watcher, COMSIG_XENOMORPH_TAKING_DAMAGE, .proc/on_damage_taken)
 	overwatch_active = TRUE
 	add_selected_frame()
 
@@ -197,6 +194,7 @@
 	if(do_reset_perspective)
 		watcher.reset_perspective()
 	UnregisterSignal(watcher, COMSIG_MOVABLE_MOVED)
+	UnregisterSignal(watcher, COMSIG_XENOMORPH_TAKING_DAMAGE)
 	overwatch_active = FALSE
 	remove_selected_frame()
 
@@ -223,20 +221,10 @@
 	if(overwatch_active)
 		stop_overwatch()
 
-/datum/action/xeno_action/watch_xeno/proc/on_ctrl_middle_click(datum/source, atom/A)
+/datum/action/xeno_action/watch_xeno/proc/on_damage_taken(datum/source, damage)
 	SIGNAL_HANDLER
-	var/mob/living/carbon/xenomorph/queen/watcher = owner
-	if(!watcher.check_state())
-		return
-	if(!isxeno(A))
-		return
-	var/mob/living/carbon/xenomorph/observation_candidate = A
-	if(observation_candidate.stat == DEAD)
-		return
-	if(observation_candidate == watcher.observed_xeno)
+	if(overwatch_active)
 		stop_overwatch()
-		return
-	start_overwatch(observation_candidate)
 
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -168,6 +168,9 @@
 	start_overwatch(selected_xeno)
 
 /datum/action/xeno_action/watch_xeno/proc/start_overwatch(mob/living/carbon/xenomorph/target)
+	if(!can_use_action()) // Check for action now done here as action_activate pipeline has been bypassed with signal activation.
+		return
+
 	var/mob/living/carbon/xenomorph/watcher = owner
 	var/mob/living/carbon/xenomorph/old_xeno = watcher.observed_xeno
 	if(old_xeno)

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -193,8 +193,7 @@
 			observed.hud_set_queen_overwatch()
 	if(do_reset_perspective)
 		watcher.reset_perspective()
-	UnregisterSignal(watcher, COMSIG_MOVABLE_MOVED)
-	UnregisterSignal(watcher, COMSIG_XENOMORPH_TAKING_DAMAGE)
+	UnregisterSignal(watcher, list(COMSIG_MOVABLE_MOVED, COMSIG_XENOMORPH_TAKING_DAMAGE))
 	overwatch_active = FALSE
 	remove_selected_frame()
 

--- a/code/modules/mob/living/carbon/xenomorph/say.dm
+++ b/code/modules/mob/living/carbon/xenomorph/say.dm
@@ -59,7 +59,7 @@
 	return TRUE
 
 /mob/living/carbon/xenomorph/proc/receive_hivemind_message(mob/living/carbon/xenomorph/X, message)
-	var/follow_link = X != src ? "<a href='byond://?src=[REF(src)];watch_xeno_name=[X.nicknumber]'>(F)</a> " : ""
+	var/follow_link = X != src ? "<a href='byond://?src=[REF(src)];watch_xeno_name=[REF(X)]'>(F)</a> " : ""
 	show_message("[follow_link][X.hivemind_start()][span_message(" hisses, '[message]'")][X.hivemind_end()]", 2)
 
 

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -187,7 +187,7 @@
 		if(!check_state())
 			return
 		var/target = locate(href_list["watch_xeno_name"])
-		if(!QDELETED(target) && isxeno(target))
+		if(target && isxeno(target))
 			// Checks for can use done in overwatch action.
 			SEND_SIGNAL(src, COMSIG_XENOMORPH_WATCHXENO, target)
 

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -187,7 +187,7 @@
 		if(!check_state())
 			return
 		var/target = locate(href_list["watch_xeno_name"])
-		if(target && isxeno(target))
+		if(isxeno(target))
 			// Checks for can use done in overwatch action.
 			SEND_SIGNAL(src, COMSIG_XENOMORPH_WATCHXENO, target)
 

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -186,12 +186,10 @@
 	if(href_list["watch_xeno_name"])
 		if(!check_state())
 			return
-		var/follow_name = href_list["watch_xeno_name"]
-		for(var/mob/living/carbon/xenomorph/X AS in hive.get_watchable_xenos(usr))
-			if((isnum(X.nicknumber) && num2text(X.nicknumber) != follow_name) || X.nicknumber != follow_name)
-				continue
-			SEND_SIGNAL(src, COMSIG_XENOMORPH_WATCHXENO, X)
-			break
+		var/target = locate(href_list["watch_xeno_name"])
+		if(!QDELETED(target) && isxeno(target))
+			// Checks for can use done in overwatch action.
+			SEND_SIGNAL(src, COMSIG_XENOMORPH_WATCHXENO, target)
 
 ///Send a message to all xenos. Force forces the message whether or not the hivemind is intact. Target is an atom that is pointed out to the hive. Filter list is a list of xenos we don't message.
 /proc/xeno_message(message = null, span_class = "xenoannounce", size = 5, hivenumber = XENO_HIVE_NORMAL, force = FALSE, atom/target = null, sound = null, apply_preferences = FALSE, filter_list = null, arrow_type, arrow_color, report_distance = FALSE)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Deletes control middle click overwatch selection for overwatch.

Overwatch now cancels if the watcher is damaged.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Removes code bloat. Also prevents xenos from being surprise killed when they're watching someone else.

## Changelog
:cl:
add: Overwatch is now canceled if the watcher is damaged.
refactor: Overwatch from chat now uses target reference instead of trying to match nicknames. This should mean it should no longer fail to work if xeno names are identical.
del: Queen can no longer select xenos to overwatch using control middle click.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
