### PR TITLE
Unifies Evolution Limit Calculation to Those Defined in Hive Datum

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -6,9 +6,6 @@
 //Such as evolves_to = list("Warrior", "Sentinel", "Runner", "Badass") etc
 // except use typepaths now so you dont have to have an entry for literally every evolve path
 
-#define TO_XENO_TIER_2_FORMULA(tierA, tierB, tierC) ( (tierB + tierC) > tierA ) )
-#define TO_XENO_TIER_3_FORMULA(tierA, tierB, tierC) ( (tierC * 3) > (tierA + tierB) )
-
 /mob/living/carbon/xenomorph/verb/Evolve()
 	set name = "Evolve"
 	set desc = "Evolve into a higher form."
@@ -151,11 +148,8 @@
 		return
 
 	// used below
-	var/tierzeros //Larva and burrowed larva if it's a certain kinda hive
-	var/tierones
-	var/tiertwos
-	var/tierthrees
-	var/tierfours
+	var/no_room_tier_two = length(hive.xenos_by_tier[XENO_TIER_TWO]) >= hive.tier2_xeno_limit
+	var/no_room_tier_three = length(hive.xenos_by_tier[XENO_TIER_THREE]) >= hive.tier3_xeno_limit
 
 	if(new_caste_type == /mob/living/carbon/xenomorph/queen) //Special case for dealing with queenae
 		if(is_banned_from(ckey, ROLE_XENO_QUEEN))
@@ -226,18 +220,12 @@
 	else
 		var/potential_queens = length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/larva]) + length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/drone])
 
-		tierzeros = hive.get_total_tier_zeros()
-		tierones = length(hive.xenos_by_tier[XENO_TIER_ONE])
-		tiertwos = length(hive.xenos_by_tier[XENO_TIER_TWO])
-		tierthrees = length(hive.xenos_by_tier[XENO_TIER_THREE])
-		tierfours = length(hive.xenos_by_tier[XENO_TIER_FOUR])
-
 		if(regression)
 			//Nothing, go on as normal.
-		else if((tier == XENO_TIER_ONE && TO_XENO_TIER_2_FORMULA(tierzeros + tierones + tierfours, tiertwos, tierthrees))
+		else if(tier == XENO_TIER_ONE && no_room_tier_two)
 			to_chat(src, span_warning("The hive cannot support another Tier 2, wait for either more aliens to be born or someone to die."))
 			return
-		else if(tier == XENO_TIER_TWO && TO_XENO_TIER_3_FORMULA(tierzeros + tierones, tiertwos + tierfours, tierthrees))
+		else if(tier == XENO_TIER_TWO && no_room_tier_three)
 			to_chat(src, span_warning("The hive cannot support another Tier 3, wait for either more aliens to be born or someone to die."))
 			return
 		else if(SSticker.mode?.flags_round_type & MODE_XENO_RULER && !hive.living_xeno_ruler && potential_queens == 1)
@@ -262,13 +250,6 @@
 
 	if(!regression && !do_after(src, 25, FALSE, null, BUSY_ICON_CLOCK))
 		to_chat(src, span_warning("We quiver, but nothing happens. We must hold still while evolving."))
-		return
-
-	tierzeros = hive.get_total_tier_zeros()
-	tierones = length(hive.xenos_by_tier[XENO_TIER_ONE])
-	tiertwos = length(hive.xenos_by_tier[XENO_TIER_TWO])
-	tierthrees = length(hive.xenos_by_tier[XENO_TIER_THREE])
-	tierfours = length(hive.xenos_by_tier[XENO_TIER_FOUR])
 
 	if(new_caste_type == /mob/living/carbon/xenomorph/queen)
 		if(hive.living_xeno_queen) //Do another check after the tick.
@@ -283,10 +264,10 @@
 			to_chat(src, span_warning("There cannot be two manifestations of the hivemind's will at once."))
 			return
 	else if(!regression) // these shouldnt be checked if trying to become a queen.
-		if((tier == XENO_TIER_ONE && TO_XENO_TIER_2_FORMULA(tierzeros + tierones + tierfours, tiertwos, tierthrees))
+		if(tier == XENO_TIER_ONE && no_room_tier_two)
 			to_chat(src, span_warning("Another sister evolved meanwhile. The hive cannot support another Tier 2."))
 			return
-		else if(tier == XENO_TIER_TWO && TO_XENO_TIER_3_FORMULA(tierzeros + tierones, tiertwos + tierfours, tierthrees))
+		else if(tier == XENO_TIER_TWO && no_room_tier_three)
 			to_chat(src, span_warning("Another sister evolved meanwhile. The hive cannot support another Tier 3."))
 			return
 
@@ -378,7 +359,3 @@
 	if(status_flags & INCORPOREAL)
 		return
 	return ..()
-
-
-#undef TO_XENO_TIER_2_FORMULA
-#undef TO_XENO_TIER_3_FORMULA

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -893,8 +893,14 @@ to_chat will check for valid clients itself already so no need to double check f
 
 ///updates and sets the t2 and t3 xeno limits
 /datum/hive_status/proc/update_tier_limits()
-	tier3_xeno_limit = max(length(xenos_by_tier[XENO_TIER_THREE]),FLOOR((length(xenos_by_tier[XENO_TIER_ZERO])+length(xenos_by_tier[XENO_TIER_ONE])+length(xenos_by_tier[XENO_TIER_TWO])+length(xenos_by_tier[XENO_TIER_FOUR]))/3+1,1))
-	tier2_xeno_limit = max(length(xenos_by_tier[XENO_TIER_TWO]),length(xenos_by_tier[XENO_TIER_ZERO]) + length(xenos_by_tier[XENO_TIER_ONE]) + length(xenos_by_tier[XENO_TIER_FOUR])+1 - length(xenos_by_tier[XENO_TIER_THREE]))
+	var/zeros = get_total_tier_zeros()
+	var/ones = length(xenos_by_tier[XENO_TIER_ONE])
+	var/twos = length(xenos_by_tier[XENO_TIER_TWO])
+	var/threes = length(xenos_by_tier[XENO_TIER_THREE])
+	var/fours = length(xenos_by_tier[XENO_TIER_FOUR])
+
+	tier3_xeno_limit = max(threes, FLOOR((zeros + ones + twos + fours) / 3 + 1, 1))
+	tier2_xeno_limit = max(twos, zeros + ones + fours + 1 - threes)
 
 // ***************************************
 // *********** Corrupted Xenos


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Hive status and actual evolution checks use two, possibly different, mathematical formulas to calculate the limit of xenos for tiers two and three.

One key difference is that hive status / datum did **NOT** take into account burrowed larvas counting towards tier zero counts whereas evolution checks **DID** take them into account. Which was why in rare occasions even if the slots were completely full in tier 2 according to the hive status page, tier one xenos could still evolve to tier two.

I have now removed the evolution check's limit calculation in favor of hive datum's **AND** changed hive datum's calculation to now take into account burrowed larva.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Hive status page no longer lies when it says no more slots when there really is. And future c*ders wanting to balance xeno caste population limits now just have to change one section of the code instead of two completely different mathematical formulas.

## Changelog
:cl:
refactor: Xeno evolution slots displayed in the hive status page now are the actual number of slots.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
