### PR TITLE
IB/QCP rebalances

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -510,7 +510,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			to_chat(owner, span_notice("You have a high fever!"))
 
 
-//Updating wounds. Handles wound natural I had some free spachealing, internal bleedings and infections
+///Updating wounds. Handles natural damage healing from limb treatments and processes internal wounds
 /datum/limb/proc/update_wounds()
 
 	if((limb_status & LIMB_ROBOT)) //Robotic limbs don't heal or get worse.
@@ -530,7 +530,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if (update_icon())
 		owner.UpdateDamageIcon(1)
 
-//Updates BLEEDING status.
+///Updates LIMB_BLEEDING limb flag
 /datum/limb/proc/update_bleeding()
 	if(limb_status & LIMB_ROBOT || owner.species.species_flags & NO_BLOOD)
 		return

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -60,7 +60,7 @@
 /** INTERNAL BLEEDING **/
 /datum/wound/internal_bleeding
 	desc = "damaged artery"
-	autoheal_cutoff = 5
+	autoheal_cutoff = 0
 
 /datum/wound/internal_bleeding/process()
 
@@ -68,12 +68,11 @@
 	var/inaprovaline = parent_limb.owner.reagents.get_reagent_amount(/datum/reagent/medicine/inaprovaline)
 	var/quickclot = parent_limb.owner.reagents.get_reagent_amount(/datum/reagent/medicine/quickclot)
 
-	if(!(can_autoheal() || (bicardose && inaprovaline) || quickclot))	//bicaridine and inaprovaline stop internal wounds from harming the parent limb over time, unless it is so small that it is already healing
+	if(!(bicardose && inaprovaline))	//bicaridine and inaprovaline stop internal wounds from harming the parent limb over time
 		parent_limb.createwound(CUT, 0.1)
-		damage += 0.1
 
 	if(!quickclot) //Quickclot stops bleeding, magic!
-		parent_limb.owner.blood_volume = max(0, parent_limb.owner.blood_volume - damage/40)
+		parent_limb.owner.blood_volume = max(0, parent_limb.owner.blood_volume - damage/30)
 		if(prob(1))
 			parent_limb.owner.custom_pain("You feel a stabbing pain in your [parent_limb.display_name]!", 1)
 

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -779,7 +779,7 @@
 	if(!ishuman(L))
 		return
 	var/mob/living/carbon/human/body = L
-	for(var/datum/limb/possible_limb in body.limbs)
+	for(var/datum/limb/possible_limb AS in body.limbs)
 		for(var/datum/wound/internal_bleeding/possible_IB in possible_limb.wounds)
 			target_IB = possible_IB
 			RegisterSignal(target_IB, COMSIG_PARENT_QDELETING, .proc/clear_wound)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -794,7 +794,7 @@
 	L.adjustStaminaLoss(15*effect_str)
 	if(!target_IB)
 		select_wound(L)
-		ticks_left-- //Keep it at the total ticks_to_cure, including the tick used to select a wound
+		ticks_left-- //Keep treatment time at the total ticks_to_cure if we select here, including the tick used to select a wound
 		return ..()
 	ticks_left--
 	if(!ticks_left)


### PR DESCRIPTION
## About The Pull Request
IB wounds don't get worse over time. Bloodloss is slightly scaled up to keep it consistent with old values.
Bic OD can't cure IB. Get QCP or use surgery or cryo.
Instead of healing IB's damage over time QCP now removes one wound entirely after every ~20s. The cloneloss gain is tied to this removal, as is a final chunk of brute damage to the parent limb.
QC/low damage no longer prevents IB from damaging the limb it's on. Bic+ina still does.

## Why It's Good For The Game
Puts to rest any issues with QCP seeming to not work.
Makes it easier to tell which limb specifically has internal bleeding, since you can pause the bleeding with QC but let the minor limb damage gain continue (0.1 per 2s, so any brute healing chem is more than enough to keep it from mattering if you want).
Makes it easier for corpsmen to tell when one IB wound is cured, since the patient will get hit with a bit of brute (this can't dismember or cause organ damage or another internal wound, but it could in theory push you past the threshold for a limb break. It probably won't unless you're specifically trying to.)


## Changelog
:cl:
balance: IB won't naturally get worse over time.
balance: Quickclot won't stop IB from slowly increasing bruteloss on the limb it's on. Bic+ina still will.
balance: Bic OD won't slowly cure IB.
fix: QCP will always remove internal bleeding so long as you have at least 5u injected and no purgatives. Every 5u injection will handle one instance of IB.
/:cl: