### PR TITLE
Unifies Xeno TGUI Windows to Xeno Theme

### DIFF
--- a/tgui/packages/tgui/interfaces/BlessingMenu.tsx
+++ b/tgui/packages/tgui/interfaces/BlessingMenu.tsx
@@ -42,11 +42,11 @@ export const BlessingMenu = (props, context) => {
   return (
     <Window
       theme="xeno"
-      title={"Queen Mothers blessings"}
+      title={"Queen Mothers Blessings"}
       width={500}
       height={600}>
       <Window.Content scrollable>
-        <Section title={"Psychic points: " + (psypoints ? psypoints : 0) + ". What does your hive need, daughter?"}>
+        <Section title={"Psychic points: " + (psypoints ? psypoints : 0)}>
           {(categories.length > 0 && (
             <Section
               lineHeight={1.75}
@@ -99,7 +99,7 @@ const Upgrades = (props, context) => {
     <Section>
       <LabeledList>
         {upgrades.length === 0 ? (
-          <Box color="red">No upgrades available!</Box>
+          <Box color="bad">No upgrades available!</Box>
         ) : (
           upgrades
             .filter(record => record.category === selectedCategory)
@@ -140,9 +140,11 @@ const UpgradeEntry = (props: UpgradeEntryProps, context) => {
 
   return (
     <Collapsible
-      title={`${upgrade_name} (click for details)`}
+      ml={1}
+      title={upgrade_name}
       buttons={(
         <Button
+          mr={1}
           tooltip={upgrade_cost + " points"}
           onClick={() => act('buy', { buyname: upgrade_name })}>
           Claim Blessing
@@ -168,6 +170,11 @@ type UpgradeViewEntryProps = {
 }
 
 const UpgradeView = (props: UpgradeViewEntryProps, context) => {
+  const { data } = useBackend<BlessingData>(context);
+  const {
+    psypoints,
+  } = data;
+
   const {
     name,
     desc,
@@ -178,22 +185,24 @@ const UpgradeView = (props: UpgradeViewEntryProps, context) => {
 
   return (
     <Flex align="center">
-      <Flex.Item grow={1} basis={0}>
-        <Box bold fontSize={1.25}>
-          {name}
+      <Flex.Item grow={1} basis={0} ml={1}>
+        <Box className="Section__title">
+          <Box as="span" className="Section__titleText">
+            {name}
+          </Box>
         </Box>
         <Box
           className={classes(['blessingmenu32x32', iconstate])}
           ml={3}
-          mt={2}
+          mt={3}
           style={{
             'transform': 'scale(2) translate(0px, 10%)',
           }}
         />
-        <Box bold mt={3}>
+        <Box bold mt={5} color={psypoints > cost ? "good" : "bad"}>
           {"Cost: " + cost}
         </Box>
-        <Box bold>
+        <Box bold my={0.5} color={timesbought >= 1 ? "good" : ""}>
           {timesbought + " Bought"}
         </Box>
       </Flex.Item>

--- a/tgui/packages/tgui/interfaces/BlessingMenu.tsx
+++ b/tgui/packages/tgui/interfaces/BlessingMenu.tsx
@@ -86,6 +86,7 @@ const Upgrades = (props, context) => {
   const { data } = useBackend<BlessingData>(context);
 
   const {
+    psypoints,
     upgrades,
     categories,
   } = data;
@@ -105,6 +106,7 @@ const Upgrades = (props, context) => {
             .filter(record => record.category === selectedCategory)
             .map(upgrade => (
               <UpgradeEntry
+                psy_points={psypoints}
                 upgrade_name={upgrade.name}
                 key={upgrade.name}
                 upgrade_desc={upgrade.desc}
@@ -120,6 +122,7 @@ const Upgrades = (props, context) => {
 
 
 type UpgradeEntryProps = {
+  psy_points: number,
   upgrade_name: string,
   upgrade_desc: string,
   upgrade_cost: number,
@@ -131,6 +134,7 @@ const UpgradeEntry = (props: UpgradeEntryProps, context) => {
   const { act } = useBackend<UpgradeData>(context);
 
   const {
+    psy_points,
     upgrade_name,
     upgrade_desc,
     upgrade_cost,
@@ -146,6 +150,7 @@ const UpgradeEntry = (props: UpgradeEntryProps, context) => {
         <Button
           mr={1}
           tooltip={upgrade_cost + " points"}
+          disabled={upgrade_cost > psy_points}
           onClick={() => act('buy', { buyname: upgrade_name })}>
           Claim Blessing
         </Button>

--- a/tgui/packages/tgui/interfaces/HiveEvolveScreen.js
+++ b/tgui/packages/tgui/interfaces/HiveEvolveScreen.js
@@ -60,6 +60,7 @@ export const HiveEvolveScreen = (props, context) => {
 
   return (
     <Window
+      theme="xeno"
       title="Xenomorph Evolution"
       width={400}
       height={750}>


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

I **strongly disagree** with the design choices in the xeno theme but I have atomized the improvements to blessings menu and conversion of evo screen to xeno theme into a separate PR.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

![image](https://cdn.discordapp.com/attachments/500801682058379265/979108725061206066/unknown.png)

## Changelog
:cl:
qol: Xeno Evolution UI now has the same theme as Hive Blessings.
qol: Minor improvements to spacing and color in the Hive Blessings UI.
qol: Hive upgrade button is now disabled if the hive has insufficient number of points to purchase it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
