### PR TITLE
Makes doctoring instruments of medicine fit on labcoat

### DIFF
--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -8,6 +8,16 @@
 	pockets = /obj/item/storage/internal/modular/medical
 	permeability_coefficient = 0.6
 	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 50, "rad" = 0, "fire" = 0, "acid" = 0)
+	allowed = list(
+		/obj/item/stack/medical,
+		/obj/item/reagent_containers/dropper,
+		/obj/item/reagent_containers/hypospray,
+		/obj/item/reagent_containers/syringe,
+		/obj/item/healthanalyzer,
+		/obj/item/flashlight,
+		/obj/item/radio,
+		/obj/item/tank/emergency_oxygen,
+	)
 
 	verb/toggle()
 		set name = "Toggle Labcoat Buttons"


### PR DESCRIPTION
Put medical stuff on your labcoat! (most importantly, a med scanner for quick equipping)

## About The Pull Request
I used to always gun for the labcoat as a doctor, either by asking CMO for one out of their locker (if they weren't anywhere else on the ship map) or by ACCIDENTALLY stumbling into their window with a machete, repeatedly, then ACCIDENTALLY hitting their locker until it disappeared (if they weren't anywhere else on the ship map). Why? because DRIP! no not really, its because the only equipment storage items that have quick equip are pouches, belts, back storage, _**and the place where you put your gun when playing marine.**_ Surgical aprons didn't allow you to put medscanner on your quick equip suit slot, but labcoats did. 

And they don't anymore. Why? well, they got updated to have 5 slot medical-storage-module internal storage instead of unique 2 slot labcoat internal storage. I guess whoever did that thought it'd be more balanced or whatever to get rid of the quick equip suit thing due to improved internal storage. Or it was a mistake. Either way, I redid it. (by the way one extra slot shouldn't murder balance, especially since this is for an outfit for a non-combat job)
This is what the allowed item list for outer suit storage looks like now:
    allowed = list(
        /obj/item/stack/medical,
        /obj/item/reagent_containers/dropper,
        /obj/item/reagent_containers/hypospray,
        /obj/item/reagent_containers/syringe,
        /obj/item/healthanalyzer,
        /obj/item/flashlight,
        /obj/item/radio,
        /obj/item/tank/emergency_oxygen, (every suit can equip o2, so this is to keep it in-line with everything else)
    )

## Why It's Good For The Game
TOO LONG DON'T WANT TO READ: Makes it easier to sort out doctoring equipment for people like me who are used to having something really really important on their suit which is instantly accessible by pressing E.

Medical storage belts and medkit pouches have incredibly important stuff in them, meaning that if you put a medscanner in the 'last' slot for quick equip, it will very quickly get replaced by a half-used autoinjector, defibrillator, roller bed, or heal pack. Adding in the ability to put something like a health analyzer or hypospray onto the suit quickdraw, separate from everything else, allows a reliable quick draw of your favorite doctoring item. 

## Changelog
:cl:
qol: Adds suit outer storage back to labcoats
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
