### PR TITLE
Floodlight Light Decay Changes

### DIFF
--- a/code/game/objects/machinery/floodlight.dm
+++ b/code/game/objects/machinery/floodlight.dm
@@ -6,9 +6,9 @@
 	density = TRUE
 	coverage = 25
 	light_system = HYBRID_LIGHT
-	light_power = 5
+	light_power = SQRTWO
 	///The brightness of the floodlight
-	var/brightness_on = 7
+	var/brightness_on = 8
 
 /obj/machinery/floodlight/Initialize()
 	. = ..()
@@ -44,7 +44,7 @@
 	desc = "A powerful light stationed near landing zones to provide better visibility."
 	icon_state = "flood01"
 	use_power = 0
-	brightness_on = 5
+	brightness_on = 6
 
 /obj/machinery/floodlight/landing/Initialize()
 	. = ..()
@@ -86,7 +86,7 @@
 	icon_state = "floodlightcombat_off"
 	anchored = FALSE
 	density = TRUE
-	light_power = 5
+	light_power = SQRTWO
 	light_system = STATIC_LIGHT
 	///the cell powering this floodlight
 	var/obj/item/cell/cell


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR modifies the lighting values of floodlights to produce more "circular" lighting rather than the current blocky lit tile appearance. 

However, this can be considered a balance change as it does kinda improve the range of colony floodlights, barely, and nerfs armored floodlights to be less laser beam from god.

* Requires #10302 for floodlights to function.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### OLD COLONY FLOODLIGHTS:
![image](https://user-images.githubusercontent.com/29745705/170656237-0220db25-9cd8-46e9-904a-e18d4fdb046e.png)

### NEW COLONY FLOODLIGHTS:
![image](https://user-images.githubusercontent.com/29745705/170656143-a16d529e-7616-4383-807a-b4f72b832a12.png)

### OLD LANDING ZONE FLOODLIGHTS:
![image](https://user-images.githubusercontent.com/29745705/170656790-291d0aa4-dbf0-4246-9d70-c8dbe3b39d37.png)

### NEW LANDING ZONE FLOODLIGHTS:
![image](https://user-images.githubusercontent.com/29745705/170656980-230527f0-1281-488a-8aa8-73bfca4ed402.png)

### OLD ARMORED FLOODLIGHTS:
![image](https://user-images.githubusercontent.com/29745705/170657664-0af587eb-e253-40fc-8bb4-1aef7fd20cb4.png)

### NEW ARMORED FLOODLIGHTS:
![image](https://user-images.githubusercontent.com/29745705/170657870-1296d32e-e40b-4038-a8d9-d2d4ce4e4d3e.png)


## Changelog
:cl:
balance: LZ, Colony, and Armored Floodlights have had their lighting power (inverse dropoff) reduced. This means less lighting around the edges of floodlights but will now appear more circular in lit area.
balance: LZ and Colony Floodlights have had their lighting range improved to compensate for increased dropoff in light.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
