### PR TITLE
Mimir Buff

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -140,7 +140,7 @@
 	desc = "Designed for mounting on modular armor. This older model provides minor resistance to acid, biological, and radiological attacks. Pairing this with a Mimir helmet module and mask will make the user impervious to xeno gas clouds. Will impact mobility."
 	icon_state = "mod_biohazard"
 	item_state = "mod_biohazard_a"
-	soft_armor = list("bio" = 15, "rad" = 10, "acid" = 15)
+	soft_armor = list("bio" = 15, "rad" = 10, "acid" = 20)
 	slowdown = 0.2
 
 /obj/item/armor_module/module/mimir_environment_protection/mimir_helmet
@@ -156,7 +156,7 @@
 /obj/item/armor_module/module/mimir_environment_protection/mimir_helmet/mark1 //gas protection
 	name = "Mark 1 Mimir Environmental Helmet System"
 	desc = "Designed for mounting on a modular helmet. This older model provides minor resistance to acid and biological attacks. Pairing this with a Mimir suit module and mask will make the user impervious to xeno gas clouds."
-	soft_armor = list("bio" = 15, "acid" = 15)
+	soft_armor = list("bio" = 15, "acid" = 20)
 
 //Explosive defense armor
 /obj/item/armor_module/module/hlin_explosive_armor


### PR DESCRIPTION
## About The Pull Request

Title. Mimir 1 has poor scaling, and is useless in all ways except having gas defense. Latter is not a problem as long as you can eat dylovene really.

Compare:
Mimir 1: gas resist, (+15 acid armor -> +20 acid armor)
Tyr 1: +10 every armor including acid
Mimir 2: gas resist, +30 acid armor

Note: having 70% vs 80% acid armor is still a big deal, so Mimir Mk2 is still viable.


## Why It's Good For The Game

More in-line defense of Mimir Mk1.
Xenos had their fire resist fix lately, so why not.

## Changelog
:cl:
balance: Mimir Mk1 has little more acid armor
/:cl:
