### PR TITLE
New healthscanner displays unknown chemicals

### DIFF
--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -144,9 +144,11 @@ REAGENT SCANNER
 
 		"hugged" = (locate(/obj/item/alien_embryo) in patient)
 	)
+	data["has_unknown_chemicals"] = FALSE
 	var/list/chemicals_lists = list()
 	for(var/datum/reagent/reagent AS in patient.reagents.reagent_list)
 		if(!reagent.scannable)
+			data["has_unknown_chemicals"] = TRUE
 			continue
 		chemicals_lists["[reagent.name]"] = list(
 			"name" = reagent.name,
@@ -154,7 +156,7 @@ REAGENT SCANNER
 			"od" = reagent.overdosed,
 			"dangerous" = reagent.overdosed || istype(reagent, /datum/reagent/toxin)
 		)
-	data["has_chemicals"] = length(chemicals_lists)
+	data["has_chemicals"] = length(patient.reagents.reagent_list)
 	data["chemicals_lists"] = chemicals_lists
 
 	var/list/limb_data_lists = list()

--- a/tgui/packages/tgui/interfaces/MedScanner.js
+++ b/tgui/packages/tgui/interfaces/MedScanner.js
@@ -16,6 +16,7 @@ export const MedScanner = (props, context) => {
 
     revivable,
     has_chemicals,
+    has_unknown_chemicals,
     chemicals_lists,
 
     limb_data_lists,
@@ -144,6 +145,11 @@ export const MedScanner = (props, context) => {
         </Section>
         {has_chemicals ? (
           <Section title="Chemical Contents">
+            {has_unknown_chemicals ? (
+              <NoticeBox warning>
+                Unknown reagents detected.
+              </NoticeBox>
+            ) : null}
             <LabeledList>
               {
                 chemicals.map(chemical => (


### PR DESCRIPTION
## About The Pull Request
As title. Only shows whether any exist, nothing about types/volume.

## Why It's Good For The Game
It was a feature on the old health scanner but didn't get carried over yet.

## Changelog
:cl:
add: New health scanner shows an alert if the patient has unscannable reagents in them.
/:cl: