### PR TITLE
Caustic upgraded cades can't be melted

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -506,7 +506,7 @@
 		return FALSE
 
 	if(metal_sheets.get_amount() < CADE_UPGRADE_REQUIRED_SHEETS)
-		to_chat(user, span_warning("You need at least [CADE_UPGRADE_REQUIRED_SHEETS] metal sheets to repair the base of [src]."))
+		to_chat(user, span_warning("You need at least [CADE_UPGRADE_REQUIRED_SHEETS] metal sheets to upgrade [src]."))
 		return FALSE
 
 	var/static/list/cade_types = list(CADE_TYPE_BOMB = image(icon = 'icons/Marine/barricades.dmi', icon_state = "explosive_obj"), CADE_TYPE_MELEE = image(icon = 'icons/Marine/barricades.dmi', icon_state = "brute_obj"), CADE_TYPE_ACID = image(icon = 'icons/Marine/barricades.dmi', icon_state = "burn_obj"))
@@ -533,8 +533,8 @@
 		if(CADE_TYPE_MELEE)
 			soft_armor = soft_armor.modifyRating(melee = 30, bullet = 30)
 		if(CADE_TYPE_ACID)
-			soft_armor = soft_armor.modifyRating(bio = 0, acid = 20)
-			resistance_flags = XENO_DAMAGEABLE|UNACIDABLE
+			soft_armor = soft_armor.modifyRating(acid = 20)
+			resistance_flags |= UNACIDABLE
 
 	barricade_upgrade_type = choice
 
@@ -769,7 +769,8 @@
 				if(CADE_TYPE_MELEE)
 					soft_armor = soft_armor.modifyRating(melee = -30, bullet = -30)
 				if(CADE_TYPE_ACID)
-					soft_armor = soft_armor.modifyRating(bio = 0, acid = -20)
+					soft_armor = soft_armor.modifyRating(acid = -20)
+					resistance_flags &= ~UNACIDABLE
 
 			new /obj/item/stack/sheet/metal(loc, CADE_UPGRADE_REQUIRED_SHEETS)
 			barricade_upgrade_type = null

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -534,6 +534,7 @@
 			soft_armor = soft_armor.modifyRating(melee = 30, bullet = 30)
 		if(CADE_TYPE_ACID)
 			soft_armor = soft_armor.modifyRating(bio = 0, acid = 20)
+			resistance_flags = XENO_DAMAGEABLE|UNACIDABLE
 
 	barricade_upgrade_type = choice
 


### PR DESCRIPTION
## About The Pull Request
Since MJP isn't finishing this.
Closes #10232 

## Why It's Good For The Game
Improves one cade upgrade, which are generally agreed upon as pretty not worth right now. Requires more dedication for marines than just making sandbags unmeltable.

## Changelog
:cl:
add: Metal cades upgraded with caustic armor can't have xeno acid applied.
/:cl: