### PR TITLE
Removes mini scope from T-160 RR

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -696,7 +696,6 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	general_codex_key = "explosive weapons"
 	attachable_allowed = list(
 		/obj/item/attachable/magnetic_harness,
-		/obj/item/attachable/scope/mini,
 		/obj/item/attachable/buildasentry,
 		/obj/item/attachable/shoulder_mount,
 	)


### PR DESCRIPTION
## About The Pull Request
Per title.

## Why It's Good For The Game
Full sunder from offscreen is quite unfun.

## Changelog
:cl: Lewdcifer
balance: T-160 RR no longer accepts mini scopes.
/:cl: