### PR TITLE
Flamers are stronger against resin walls

### DIFF
--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -22,7 +22,7 @@
 
 
 /turf/closed/wall/resin/flamer_fire_act()
-	take_damage(25, BURN, "fire")
+	take_damage(50, BURN, "fire")
 
 
 /turf/closed/wall/resin/proc/thicken()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Revert flamer nerf from a while ago.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Engineers should not be the only pratical way for marines to clear out mazes. Mazes should not be as sturdy as they are especially in nuclear war

## Changelog
:cl:
balance: Resin walls take twice as much damage from flamer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
