### PR TITLE
Adds an argument to flamer_fire_act, buffs flamer against resin

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -417,8 +417,8 @@ directive is properly returned.
 	return //For handling the effects of explosions on contents that would not normally be effected
 
 
-//Generalized Fire Proc.
-/atom/proc/flamer_fire_act()
+///Generalized Fire Proc. Burn level is the base fire damage being received.
+/atom/proc/flamer_fire_act(burnlevel)
 	return
 
 

--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -87,7 +87,7 @@
 		ignite_fuel(I)
 		log_attack("[key_name(user)] ignites [src] in fuel in [AREACOORD(user)]")
 
-/obj/effect/decal/cleanable/liquid_fuel/flamer_fire_act()
+/obj/effect/decal/cleanable/liquid_fuel/flamer_fire_act(burnlevel)
 	. = ..()
 	ignite_fuel()
 

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -218,11 +218,11 @@
 		to_chat(bodybag_occupant, span_danger("You jolt out of [name] upon being hit!"))
 		open()
 
-/obj/structure/closet/bodybag/flamer_fire_act()
+/obj/structure/closet/bodybag/flamer_fire_act(burnlevel)
 	if(!opened && bodybag_occupant)
 		to_chat(bodybag_occupant, span_danger("The intense heat forces you out of [name]!"))
 		open()
-		bodybag_occupant.flamer_fire_act()
+		bodybag_occupant.flamer_fire_act(burnlevel)
 
 /obj/structure/closet/bodybag/ex_act(severity)
 	if(!opened && bodybag_occupant)

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -83,7 +83,7 @@
 	explosion(loc, light_impact_range = src.light_impact_range, small_animation = TRUE)
 	qdel(src)
 
-/obj/item/explosive/grenade/flamer_fire_act()
+/obj/item/explosive/grenade/flamer_fire_act(burnlevel)
 	activate()
 
 /obj/item/explosive/grenade/attack_hand(mob/living/user)

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -16,7 +16,7 @@
 	throw_range = initial(throw_range)
 
 
-/obj/item/explosive/grenade/training/flamer_fire_act()
+/obj/item/explosive/grenade/training/flamer_fire_act(burnlevel)
 	return
 
 
@@ -268,7 +268,7 @@
 	. = ..()
 	fuel = rand(lower_fuel_limit, upper_fuel_limit) // Sorry for changing this so much but I keep under-estimating how long X number of ticks last in seconds.
 
-/obj/item/explosive/grenade/flare/flamer_fire_act()
+/obj/item/explosive/grenade/flare/flamer_fire_act(burnlevel)
 	if(!fuel) //it's out of fuel, an empty shell.
 		return
 	if(!active)

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -52,7 +52,7 @@ Stepping directly on the mine will also blow it up
 	INVOKE_ASYNC(src, .proc/trigger_explosion)
 
 /// Flamer fire will cause mines to trigger their explosion
-/obj/item/explosive/mine/flamer_fire_act()
+/obj/item/explosive/mine/flamer_fire_act(burnlevel)
 	. = ..()
 	INVOKE_ASYNC(src, .proc/trigger_explosion)
 

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -16,8 +16,8 @@
 				qdel(src)
 
 
-/obj/structure/flora/flamer_fire_act()
-	take_damage(25, BURN, "fire")
+/obj/structure/flora/flamer_fire_act(burnlevel)
+	take_damage(burnlevel, BURN, "fire")
 
 /obj/structure/flora/fire_act()
 	take_damage(25, BURN, "fire")
@@ -85,8 +85,8 @@
 
 	qdel(src)
 
-/obj/structure/flora/tree/flamer_fire_act()
-	take_damage(5, BURN, "fire")
+/obj/structure/flora/tree/flamer_fire_act(burnlevel)
+	take_damage(burnlevel/6, BURN, "fire")
 
 
 /obj/structure/flora/tree/update_overlays()

--- a/code/game/objects/structures/plants.dm
+++ b/code/game/objects/structures/plants.dm
@@ -75,8 +75,8 @@
 		take_damage(damage)
 
 
-/obj/structure/bush/flamer_fire_act(heat)
-	take_damage(30, BURN, "fire")
+/obj/structure/bush/flamer_fire_act(burnlevel)
+	take_damage(burnlevel, BURN, "fire")
 
 //*******************************//
 // Strange, fruit-bearing plants //

--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -205,7 +205,7 @@
 	playsound(src, 'sound/effects/glob.ogg', 25, 1)
 
 
-/obj/structure/reagent_dispensers/fueltank/flamer_fire_act()
+/obj/structure/reagent_dispensers/fueltank/flamer_fire_act(burnlevel)
 	explode()
 
 /obj/structure/reagent_dispensers/water_cooler

--- a/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
@@ -133,8 +133,8 @@
 		. += image("icon_state" = "nest_overlay", "layer" = LYING_MOB_LAYER + 0.1)
 
 
-/obj/structure/bed/nest/flamer_fire_act()
-	take_damage(50, BURN, "fire")
+/obj/structure/bed/nest/flamer_fire_act(burnlevel)
+	take_damage(burnlevel * 2, BURN, "fire")
 
 /obj/structure/bed/nest/fire_act()
 	take_damage(50, BURN, "fire")

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -44,8 +44,8 @@
 	if(istype(O, /obj/vehicle/multitile/hitbox/cm_armored))
 		tank_collision(O)
 
-/obj/effect/alien/flamer_fire_act()
-	take_damage(50, BURN, "fire")
+/obj/effect/alien/flamer_fire_act(burnlevel)
+	take_damage(burnlevel * 2, BURN, "fire")
 
 /obj/effect/alien/ex_act(severity)
 	switch(severity)
@@ -192,8 +192,8 @@
 		src.balloon_alert(X, "Destroyed")
 		qdel(src)
 
-/obj/structure/mineral_door/resin/flamer_fire_act()
-	take_damage(50, BURN, "fire")
+/obj/structure/mineral_door/resin/flamer_fire_act(burnlevel)
+	take_damage(burnlevel * 2, BURN, "fire")
 
 /turf/closed/wall/resin/fire_act()
 	take_damage(50, BURN, "fire")

--- a/code/game/turfs/snow.dm
+++ b/code/game/turfs/snow.dm
@@ -165,7 +165,7 @@
 	return ..()
 
 //Fire act; fire now melts snow as it should; fire beats ice
-/turf/open/floor/plating/ground/snow/flamer_fire_act(burnlevel, firelevel)
+/turf/open/floor/plating/ground/snow/flamer_fire_act(burnlevel)
 
 	if(!slayer || !burnlevel) //Don't bother if there's no snow to melt or if there's no burn stacks
 		return

--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -21,8 +21,8 @@
 	return INITIALIZE_HINT_LATELOAD
 
 
-/turf/closed/wall/resin/flamer_fire_act()
-	take_damage(25, BURN, "fire")
+/turf/closed/wall/resin/flamer_fire_act(burnlevel)
+	take_damage(burnlevel * 1.5, BURN, "fire")
 
 
 /turf/closed/wall/resin/proc/thicken()

--- a/code/modules/hydroponics/vines.dm
+++ b/code/modules/hydroponics/vines.dm
@@ -245,7 +245,7 @@
 		return
 
 
-/obj/effect/plantsegment/flamer_fire_act()
+/obj/effect/plantsegment/flamer_fire_act(burnlevel)
 	qdel(src)
 
 /obj/effect/plant_controller

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
@@ -147,9 +147,9 @@
 
 
 
-/mob/living/carbon/xenomorph/hivemind/flamer_fire_act()
+/mob/living/carbon/xenomorph/hivemind/flamer_fire_act(burnlevel)
 	return_to_core()
-	to_chat(src, "<span class='xenonotice'>We were on top of fire, we got moved to our core.")
+	to_chat(src, span_xenonotice("We were on top of fire, we got moved to our core."))
 
 /mob/living/carbon/xenomorph/hivemind/proc/check_weeds(turf/T, strict_turf_check = FALSE)
 	SHOULD_BE_PURE(TRUE)

--- a/code/modules/mob/living/carbon/xenomorph/egg.dm
+++ b/code/modules/mob/living/carbon/xenomorph/egg.dm
@@ -60,7 +60,7 @@
 		return FALSE
 	return TRUE
 
-/obj/effect/alien/egg/flamer_fire_act()
+/obj/effect/alien/egg/flamer_fire_act(burnlevel)
 	burst(FALSE)
 
 /obj/effect/alien/egg/fire_act()

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -651,7 +651,7 @@
 	if(exposed_temperature > 300)
 		kill_hugger()
 
-/obj/item/clothing/mask/facehugger/flamer_fire_act()
+/obj/item/clothing/mask/facehugger/flamer_fire_act(burnlevel)
 	kill_hugger()
 
 /obj/item/clothing/mask/facehugger/dropped(mob/user)

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -207,7 +207,7 @@
 	default_ammo = source.default_ammo
 
 //~Art interjecting here for explosion when using flamer procs.
-/obj/item/ammo_magazine/flamer_fire_act()
+/obj/item/ammo_magazine/flamer_fire_act(burnlevel)
 	if(!current_rounds)
 		return
 	explosion(loc, 0, 0, 1, 2, throw_range = FALSE, small_animation = TRUE) //blow it up.
@@ -384,7 +384,7 @@ Turn() or Shift() as there is virtually no overhead. ~N
 				qdel(AM)
 
 //explosion when using flamer procs.
-/obj/item/big_ammo_box/flamer_fire_act()
+/obj/item/big_ammo_box/flamer_fire_act(burnlevel)
 	if(!bullet_amount)
 		return
 	explosion(loc, 0, 0, 1, 2, throw_range = FALSE, small_animation = TRUE) //blow it up.

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -323,6 +323,7 @@
 	pixel_shift_y = 18
 
 	mob_flame_damage_mod = 1
+	burn_level_mod = 0.6
 	flame_max_range = 4
 
 /obj/item/weapon/gun/flamer/mini_flamer/unremovable

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -267,7 +267,7 @@
 			var/mob/living/carbon/xenomorph/xeno_caught = mob_caught
 			if(CHECK_BITFIELD(xeno_caught.xeno_caste.caste_flags, CASTE_FIRE_IMMUNE))
 				continue
-		
+
 		else if(ishuman(mob_caught))
 			var/mob/living/carbon/human/human_caught = mob_caught
 			if(user)
@@ -570,7 +570,7 @@
 		qdel(src)
 		return
 
-	T.flamer_fire_act(burnlevel, firelevel)
+	T.flamer_fire_act(burnlevel)
 
 	var/j = 0
 	for(var/i in T)
@@ -579,13 +579,13 @@
 		var/atom/A = i
 		if(QDELETED(A)) //The destruction by fire of one atom may destroy others in the same turf.
 			continue
-		A.flamer_fire_act(burnlevel, firelevel)
+		A.flamer_fire_act(burnlevel)
 
 	firelevel -= 2 //reduce the intensity by 2 per tick
 
 
 // override this proc to give different idling-on-fire effects
-/mob/living/flamer_fire_act(burnlevel, firelevel)
+/mob/living/flamer_fire_act(burnlevel)
 	if(!burnlevel)
 		return
 	var/fire_mod = get_fire_resist()
@@ -604,16 +604,16 @@
 	to_chat(src, span_warning("You are burned!"))
 
 
-/mob/living/carbon/xenomorph/flamer_fire_act(burnlevel, firelevel)
+/mob/living/carbon/xenomorph/flamer_fire_act(burnlevel)
 	if(xeno_caste.caste_flags & CASTE_FIRE_IMMUNE)
 		return
 	. = ..()
 	updatehealth()
 
-/mob/living/carbon/xenomorph/queen/flamer_fire_act(burnlevel, firelevel)
+/mob/living/carbon/xenomorph/queen/flamer_fire_act(burnlevel)
 	to_chat(src, span_xenowarning("Our extra-thick exoskeleton protects us from the flames."))
 
-/mob/living/carbon/xenomorph/ravager/flamer_fire_act(burnlevel, firelevel)
+/mob/living/carbon/xenomorph/ravager/flamer_fire_act(burnlevel)
 	if(stat)
 		return
 	plasma_stored = xeno_caste.plasma_max

--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -274,8 +274,8 @@
 	playsound(src, pick('sound/effects/bang.ogg','sound/effects/metal_crash.ogg','sound/effects/meteorimpact.ogg'), 50, 1)
 	Shake(4, 4, 2 SECONDS)
 
-/obj/vehicle/unmanned/flamer_fire_act()
-	take_damage(20, BURN, "fire")
+/obj/vehicle/unmanned/flamer_fire_act(burnlevel)
+	take_damage(burnlevel / 2, BURN, "fire")
 
 /obj/vehicle/unmanned/fire_act()
 	take_damage(20, BURN, "fire")

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -31,8 +31,8 @@
 	balloon_alert(user, "You only scrape at it")
 	return TRUE
 
-/obj/structure/xeno/flamer_fire_act()
-	take_damage(10, BURN, "fire")
+/obj/structure/xeno/flamer_fire_act(burnlevel)
+	take_damage(burnlevel / 3, BURN, "fire")
 
 /obj/structure/xeno/fire_act()
 	take_damage(10, BURN, "fire")
@@ -137,7 +137,7 @@
 		else
 			. += "It's empty."
 
-/obj/structure/xeno/trap/flamer_fire_act()
+/obj/structure/xeno/trap/flamer_fire_act(burnlevel)
 	hugger?.kill_hugger()
 	trigger_trap()
 	set_trap_type(null)
@@ -510,7 +510,7 @@ TUNNEL
 		if(EXPLODE_LIGHT)
 			take_damage(70)
 
-/obj/structure/xeno/acidwell/flamer_fire_act() //Removes a charge of acid, but fire is extinguished
+/obj/structure/xeno/acidwell/flamer_fire_act(burnlevel) //Removes a charge of acid, but fire is extinguished
 	acid_well_fire_interaction()
 
 /obj/structure/xeno/acidwell/fire_act() //Removes a charge of acid, but fire is extinguished
@@ -921,8 +921,8 @@ TUNNEL
 		if(EXPLODE_LIGHT)
 			take_damage(300)
 
-/obj/structure/xeno/xeno_turret/flamer_fire_act()
-	take_damage(60, BURN, "fire")
+/obj/structure/xeno/xeno_turret/flamer_fire_act(burnlevel)
+	take_damage(burnlevel * 2, BURN, "fire")
 	ENABLE_BITFIELD(resistance_flags, ON_FIRE)
 
 /obj/structure/xeno/xeno_turret/fire_act()


### PR DESCRIPTION
## About The Pull Request
All of the flamer_fire_act calls already used this argument, it just was ignored by most of the proc defs. Also adds one missing span call.
Buffs flamers against resin walls. One flame duration will always destroy a resin wall, taking ~15 seconds to do so. Miniflamers are nerfed by roughly an equivalent amount, so they're the same against mazes and weaker against mobs. They won't take a fully matured wall down in one shot, but will kill fresh ones.
Alternative to #10311 

## Why It's Good For The Game
Lets different flamers/ammo more uniformly burn stuff at different rates.
Improves flamers at one of their dedicated roles, area clearing.
Nerfs miniflamers, which're apparently still overperforming.

## Changelog
:cl:
code: flamer_fire_act gets a new argument that, among other things, means x-fuel is better than default at burning non-mob stuff.
balance: Flamers chew through resin faster.
balance: Miniflamers are weaker against mobs, but the same as before against resin.
/:cl: