### PR TITLE
platform cover fix

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -678,6 +678,34 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 		return
 	bullet_act(proj)
 
+//platforms
+/obj/structure/platform/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
+	if(!density && !(obj_flags & PROJ_IGNORE_DENSITY)) //structure is passable
+		return FALSE
+	if(src == proj.original_target) //clicking on the structure itself hits the structure
+		return TRUE
+	if(!throwpass)
+		return TRUE
+	if(proj.distance_travelled <= proj.ammo.barricade_clear_distance)
+		return FALSE
+	. = coverage //Hitchance.
+	if(!(cardinal_move & dir)) //The bullet will only hit if the platform and its movement are facing the same direction, as platforms are on the 'lower' turf, so act in the opposite direction to barricades.
+		if(!uncrossing)
+			proj.uncross_scheduled += src
+		return FALSE
+	if (uncrossing)
+		return FALSE
+	if(proj.ammo.flags_ammo_behavior & AMMO_SNIPER || proj.iff_signal || proj.ammo.flags_ammo_behavior & AMMO_ROCKET) //sniper, rockets and IFF rounds are better at getting past cover
+		. *= 0.8
+	if(!anchored)
+		. *= 0.5 //Half the protection from unaffixed structures.
+	///50% better protection when shooting from outside accurate range.
+	if(proj.distance_travelled > proj.ammo.accurate_range)
+		. *= 1.5
+///Accuracy over 100 increases the chance of squeezing the bullet past the structure's uncovered areas.
+	. = min(. , . + 100 - proj.accuracy)
+	return prob(.)
+
 /obj/structure/window/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
 	if(proj.ammo.flags_ammo_behavior & AMMO_ENERGY && !opacity)
 		return FALSE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes platform bullet coverage behave correctly. They still have real low coverage though.

Platforms are the structures that split turfs into 'high' and 'low' ground. They stop movement like barricades, but for blocking bullets, the high ground is supposed to provide the advantage.
i.e. shooting at the low ground doesn't stop bullets, while the unga below you has a chance to hit the platform.

Unfortunately, platforms are actually on the 'low ground' turf for spriting reasons, so the code that barricades and other similar objects use needs to be reversed.

A little bit ugly to copy paste the base code with a minor change, but I thought this was better than adding an if check specifically for this one structure, and there isn't really a way to pull that direction hit code out and just call to parent, as there is a significant number of objects that use the relevant ON_BORDER flag.

Please let me know if I've been smooth brain and there is a neater way to do this, or if just adding the if check in the parent proc is actually preferrable.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Platforms block bullets in the correct direction.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Having the high ground now correctly gives you the advantage in a firefight.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
