### PR TITLE
Fixes orbital spotlights (+range buff)

### DIFF
--- a/code/game/objects/machinery/overwatch.dm
+++ b/code/game/objects/machinery/overwatch.dm
@@ -701,7 +701,7 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 
 	var/power_amount = myAPC?.terminal?.powernet?.avail
 
-	if(power_amount >= 10000)
+	if(power_amount <= 10000)
 		return
 
 	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_ORBITAL_SPOTLIGHT))
@@ -728,11 +728,12 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 	resistance_flags = RESIST_ALL
 	light_system = STATIC_LIGHT
 	light_color = COLOR_TESLA_BLUE
-	light_power = 11	//This is a HUGE light.
+	light_range = 15	//This is a HUGE light.
+	light_power = SQRTWO
 
 /obj/effect/overwatch_light/Initialize()
 	. = ..()
-	set_light(light_power)
+	set_light(light_range, light_power)
 	playsound(src,'sound/mecha/heavylightswitch.ogg', 25, 1, 20)
 	visible_message(span_warning("You see a twinkle in the sky before your surroundings are hit with a beam of light!"))
 	QDEL_IN(src, SPOTLIGHT_DURATION)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

-Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/9784
Previously spotlights only worked if the grid had under 10k power (not happening)
-Ups spotlight range from 11 --> 15, light power to SQRTWO (same as floodlight)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes good. This makes shipside CIC more useful and gives engines more reason to exist.
If light seems too much feel free to change, but this is only a few tiles extra & it looks prettier

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: CIC orbital spotlights now work again.
balance: Spotlight range 11 --> 15, about the same light level as combat floodlights
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
