### PR TITLE
Adds balloon alerts to surgery actions

### DIFF
--- a/code/modules/surgery/amputation.dm
+++ b/code/modules/surgery/amputation.dm
@@ -26,18 +26,21 @@
 /datum/surgery_step/cut_limb/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] is beginning to cut off [target]'s [affected.display_name] with \the [tool].") , \
 	span_notice("You are beginning to cut off [target]'s [affected.display_name] with \the [tool]."))
+	target.balloon_alert_to_viewers("Sawing...")
 	target.custom_pain("Your [affected.display_name] is being ripped apart!", 1)
 	..()
 
 /datum/surgery_step/cut_limb/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] cuts off [target]'s [affected.display_name] with \the [tool]."), \
 	span_notice("You cut off [target]'s [affected.display_name] with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.droplimb(1)
 	target.updatehealth()
 
 /datum/surgery_step/generic/cut_limb/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, sawing through the bone in [target]'s [affected.display_name] with \the [tool]!"), \
 	span_warning("Your hand slips, sawing through the bone in [target]'s [affected.display_name] with \the [tool]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	affected.createwound(CUT, 30)
 	affected.fracture()
 	affected.update_wounds()

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -25,17 +25,20 @@
 /datum/surgery_step/bone/glue_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] starts applying medication to the damaged bones in [target]'s [affected.display_name] with \the [tool].") , \
 		span_notice("You start applying medication to the damaged bones in [target]'s [affected.display_name] with \the [tool]."))
+	target.balloon_alert_to_viewers("Applying gel...")
 	target.custom_pain("Something in your [affected.display_name] is causing you a lot of pain!", 1)
 	..()
 
 /datum/surgery_step/bone/glue_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] applies some [tool] to [target]'s bone in [affected.display_name]."), \
 	span_notice("You apply some [tool] to [target]'s bone in [affected.display_name] with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.bone_repair_stage = 1
 
 /datum/surgery_step/bone/glue_bone/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.display_name]!") , \
 	span_warning("Your hand slips, smearing [tool] in the incision in [target]'s [affected.display_name]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 
 
 /datum/surgery_step/bone/set_bone
@@ -57,6 +60,7 @@
 		user.visible_message(span_notice("[user] is beginning to set the bone in [target]'s [affected.display_name] in place with \the [tool].") , \
 		span_notice("You are beginning to set the bone in [target]'s [affected.display_name] in place with \the [tool]."))
 		target.custom_pain("The pain in your [affected.display_name] is going to make you pass out!", 1)
+	target.balloon_alert_to_viewers("Setting...")
 	..()
 
 /datum/surgery_step/bone/set_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
@@ -66,11 +70,13 @@
 	else
 		user.visible_message(span_notice("[user] sets the bone in [target]'s [affected.display_name] in place with \the [tool]."), \
 		span_notice("You set the bone in [target]'s [affected.display_name] in place with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.remove_limb_flags(LIMB_BROKEN | LIMB_SPLINTED | LIMB_STABILIZED)
 	affected.add_limb_flags(LIMB_REPAIRED)
 	affected.bone_repair_stage = 0
 
 /datum/surgery_step/bone/set_bone/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
+	target.balloon_alert_to_viewers("Slipped!")
 	if(affected.body_part == HEAD)
 		user.visible_message(span_warning("[user]'s hand slips, damaging [target]'s face with \the [tool]!")  , \
 		span_warning("Your hand slips, damaging [target]'s face with \the [tool]!"))

--- a/code/modules/surgery/brainrepair.dm
+++ b/code/modules/surgery/brainrepair.dm
@@ -30,11 +30,13 @@
 /datum/surgery_step/brain/bone_chips/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] starts taking bone chips out of [target]'s brain with \the [tool]."), \
 	span_notice("You start taking bone chips out of [target]'s brain with \the [tool]."))
+	target.balloon_alert_to_viewers("Clearing bone...")
 	..()
 
 /datum/surgery_step/brain/bone_chips/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] takes out all the bone chips in [target]'s brain with \the [tool]."),	\
 	span_notice("You take out all the bone chips in [target]'s brain with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	var/datum/internal_organ/brain/sponge = target.internal_organs_by_name["brain"]
 	if(sponge)
 		sponge.damage = 0
@@ -42,6 +44,7 @@
 /datum/surgery_step/brain/bone_chips/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, jabbing \the [tool] in [target]'s brain!"), \
 	span_warning("Your hand slips, jabbing \the [tool] in [target]'s brain!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	target.apply_damage(30, BRUTE, "head", 0, TRUE, updating_health = TRUE)
 
 
@@ -60,11 +63,13 @@
 /datum/surgery_step/brain/hematoma/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] starts mending hematoma in [target]'s brain with \the [tool]."), \
 	span_notice("You start mending hematoma in [target]'s brain with \the [tool]."))
+	target.balloon_alert_to_viewers("Mending...")
 	..()
 
 /datum/surgery_step/brain/hematoma/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] mends hematoma in [target]'s brain with \the [tool]."),	\
 	span_notice("You mend hematoma in [target]'s brain with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	var/datum/internal_organ/brain/sponge = target.internal_organs_by_name["brain"]
 	if(sponge)
 		sponge.damage = BONECHIPS_MAX_DAMAGE
@@ -72,4 +77,5 @@
 /datum/surgery_step/brain/hematoma/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, bruising [target]'s brain with \the [tool]!"), \
 	span_warning("Your hand slips, bruising [target]'s brain with \the [tool]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	target.apply_damage(20, BRUTE, "head", 0, TRUE, updating_health = TRUE)

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -26,17 +26,20 @@
 /datum/surgery_step/open_encased/saw/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] begins to cut through [target]'s [affected.encased] with \the [tool]."), \
 	span_notice("You begin to cut through [target]'s [affected.encased] with \the [tool]."))
+	target.balloon_alert_to_viewers("Sawing...")
 	target.custom_pain("Something hurts horribly in your [affected.display_name]!", 1)
 	..()
 
 /datum/surgery_step/open_encased/saw/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] has cut [target]'s [affected.encased] open with \the [tool]."),		\
 	span_notice("You have cut [target]'s [affected.encased] open with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.surgery_open_stage = 2.5
 
 /datum/surgery_step/open_encased/saw/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, cracking [target]'s [affected.encased] with \the [tool]!") , \
 	span_warning("Your hand slips, cracking [target]'s [affected.encased] with \the [tool]!") )
+	target.balloon_alert_to_viewers("Slipped!")
 
 	affected.createwound(CUT, 20)
 	affected.fracture()
@@ -56,12 +59,14 @@
 /datum/surgery_step/open_encased/retract/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] starts to force open the [affected.encased] in [target]'s [affected.display_name] with \the [tool]."), \
 	span_notice("You start to force open the [affected.encased] in [target]'s [affected.display_name] with \the [tool]."))
+	target.balloon_alert_to_viewers("Bending...")
 	target.custom_pain("Something hurts horribly in your [affected.display_name]!", 1)
 	..()
 
 /datum/surgery_step/open_encased/retract/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] forces open [target]'s [affected.encased] with \the [tool]."), \
 	span_notice("You force open [target]'s [affected.encased] with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.surgery_open_stage = 3
 
 	//Whoops!
@@ -71,6 +76,7 @@
 /datum/surgery_step/open_encased/retract/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, cracking [target]'s [affected.encased]!"), \
 	span_warning("Your hand slips, cracking [target]'s  [affected.encased]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 
 	affected.createwound(BRUISE, 20)
 	affected.fracture()
@@ -90,18 +96,20 @@
 /datum/surgery_step/open_encased/close/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] starts bending [target]'s [affected.encased] back into place with \the [tool]."), \
 	span_notice("You start bending [target]'s [affected.encased] back into place with \the [tool]."))
+	target.balloon_alert_to_viewers("Bending...")
 	target.custom_pain("Something hurts horribly in your [affected.display_name]!", 1)
 	..()
 
 /datum/surgery_step/open_encased/close/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] bends [target]'s [affected.encased] back into place with \the [tool]."), \
 	span_notice("You bend [target]'s [affected.encased] back into place with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.surgery_open_stage = 2.5
 
 /datum/surgery_step/open_encased/close/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, bending [target]'s [affected.encased] the wrong way!"), \
 	span_warning("Your hand slips, bending [target]'s [affected.encased] the wrong way!"))
-
+	target.balloon_alert_to_viewers("Slipped!")
 	affected.createwound(BRUISE, 20)
 	affected.fracture()
 	affected.update_wounds()

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -129,9 +129,11 @@
 	user.visible_message(span_notice("[user] starts applying \the [tool] to [target]'s [affected.encased]."), \
 	span_notice("You start applying \the [tool] to [target]'s [affected.encased]."))
 	target.custom_pain("Something hurts horribly in your [affected.display_name]!",1)
+	target.balloon_alert_to_viewers("Applying gel...")
 	..()
 
 /datum/surgery_step/open_encased/mend/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] applied \the [tool] to [target]'s [affected.encased]."), \
 	span_notice("You applied \the [tool] to [target]'s [affected.encased]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.surgery_open_stage = 2

--- a/code/modules/surgery/eye.dm
+++ b/code/modules/surgery/eye.dm
@@ -35,11 +35,13 @@
 /datum/surgery_step/eye/cut_open/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] starts to separate the cornea on [target]'s eyes with \the [tool]."), \
 	span_notice("You start to separate the cornea on [target]'s eyes with \the [tool]."))
+	target.balloon_alert_to_viewers("Separating...")
 	..()
 
 /datum/surgery_step/eye/cut_open/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] has separated the cornea on [target]'s eyes with \the [tool].") , \
 	span_notice("You have separated the cornea on [target]'s eyes with \the [tool]."),)
+	target.balloon_alert_to_viewers("Success")
 	var/datum/internal_organ/eyes/E = target.internal_organs_by_name["eyes"]
 	E.eye_surgery_stage = 1
 	target.disabilities |= NEARSIGHTED // code\#define\mobs.dm
@@ -48,6 +50,7 @@
 	var/datum/internal_organ/eyes/E = target.internal_organs_by_name["eyes"]
 	user.visible_message(span_warning("[user]'s hand slips, slicing [target]'s eyes with \the [tool]!") , \
 	span_warning("Your hand slips, slicing [target]'s eyes with \the [tool]!") )
+	target.balloon_alert_to_viewers("Slipped!")
 	affected.createwound(CUT, 10)
 	E.take_damage(5, 0)
 	target.updatehealth()
@@ -67,11 +70,13 @@
 /datum/surgery_step/eye/lift_eyes/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] starts lifting the cornea from [target]'s eyes with \the [tool]."), \
 	span_notice("You start lifting the cornea from [target]'s eyes with \the [tool]."))
+	target.balloon_alert_to_viewers("Lifting...")
 	..()
 
 /datum/surgery_step/eye/lift_eyes/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] has lifted the cornea from [target]'s eyes with \the [tool].") , \
 	span_notice("You have lifted the cornea from [target]'s eyes with \the [tool].") )
+	target.balloon_alert_to_viewers("Success")
 	var/datum/internal_organ/eyes/E = target.internal_organs_by_name["eyes"]
 	E.eye_surgery_stage = 2
 
@@ -79,6 +84,7 @@
 	var/datum/internal_organ/eyes/eyes = target.internal_organs_by_name["eyes"]
 	user.visible_message(span_warning("[user]'s hand slips, damaging [target]'s eyes with \the [tool]!"),
 	span_warning("Your hand slips, damaging [target]'s eyes with \the [tool]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	eyes.take_damage(5, 0)
 	target.apply_damage(10, BRUTE, affected, updating_health = TRUE)
 
@@ -96,11 +102,13 @@
 /datum/surgery_step/eye/mend_eyes/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] starts mending the nerves and lenses in [target]'s eyes with \the [tool]."), \
 	span_notice("You start mending the nerves and lenses in [target]'s eyes with the [tool]."))
+	target.balloon_alert_to_viewers("Mending...")
 	..()
 
 /datum/surgery_step/eye/mend_eyes/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] mends the nerves and lenses in [target]'s with \the [tool].") ,	\
 	span_notice("You mend the nerves and lenses in [target]'s with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	var/datum/internal_organ/eyes/E = target.internal_organs_by_name["eyes"]
 	E.eye_surgery_stage = 3
 
@@ -108,6 +116,7 @@
 	var/datum/internal_organ/eyes/E = target.internal_organs_by_name["eyes"]
 	user.visible_message(span_warning("[user]'s hand slips, stabbing \the [tool] into [target]'s eye!"),
 	span_warning("Your hand slips, stabbing \the [tool] into [target]'s eye!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	E.take_damage(5, 0)
 	target.apply_damage(10, BRUTE, affected, 0, TRUE, updating_health = TRUE)
 
@@ -127,10 +136,12 @@
 /datum/surgery_step/eye/cauterize/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] is beginning to cauterize the incision around [target]'s eyes with \the [tool].") , \
 	span_notice("You are beginning to cauterize the incision around [target]'s eyes with \the [tool]."))
+	target.balloon_alert_to_viewers("Cauterizing...")
 
 /datum/surgery_step/eye/cauterize/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] cauterizes the incision around [target]'s eyes with \the [tool]."), \
 	span_notice("You cauterize the incision around [target]'s eyes with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	target.disabilities &= ~NEARSIGHTED
 	target.disabilities &= ~BLIND
 	var/datum/internal_organ/eyes/E = target.internal_organs_by_name["eyes"]
@@ -142,5 +153,6 @@
 	var/datum/internal_organ/eyes/E = target.internal_organs_by_name["eyes"]
 	user.visible_message(span_warning("[user]'s hand slips, searing [target]'s eyes with \the [tool]!"),
 	span_warning("Your hand slips, searing [target]'s eyes with \the [tool]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	E.take_damage(5, 0)
 	target.apply_damage(5, BURN, affected, updating_health = TRUE)

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -32,16 +32,19 @@
 /datum/surgery_step/face/cut_face/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/head/affected)
 	user.visible_message(span_notice("[user] starts to cut open [target]'s face and neck with \the [tool]."), \
 	span_notice("You start to cut open [target]'s face and neck with \the [tool]."))
+	target.balloon_alert_to_viewers("Incising...")
 	..()
 
 /datum/surgery_step/face/cut_face/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/head/affected)
 	user.visible_message(span_notice("[user] has cut open [target]'s face and neck with \the [tool].") , \
 	span_notice("You have cut open [target]'s face and neck with \the [tool]."),)
+	target.balloon_alert_to_viewers("Success")
 	affected.face_surgery_stage = 1
 
 /datum/surgery_step/face/cut_face/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/head/affected)
 	user.visible_message(span_warning("[user]'s hand slips, slicing [target]'s throat wth \the [tool]!") , \
 	span_warning("Your hand slips, slicing [target]'s throat wth \the [tool]!") )
+	target.balloon_alert_to_viewers("Slipped!")
 	affected.createwound(CUT, 60)
 	target.Losebreath(10)
 	target.updatehealth()
@@ -62,16 +65,19 @@
 /datum/surgery_step/face/mend_vocal/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/head/affected)
 	user.visible_message(span_notice("[user] starts mending [target]'s vocal cords with \the [tool]."), \
 	span_notice("You start mending [target]'s vocal cords with \the [tool]."))
+	target.balloon_alert_to_viewers("Mending vocals...")
 	..()
 
 /datum/surgery_step/face/mend_vocal/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/head/affected)
 	user.visible_message(span_notice("[user] mends [target]'s vocal cords with \the [tool]."), \
 	span_notice("You mend [target]'s vocal cords with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.face_surgery_stage = 2
 
 /datum/surgery_step/face/mend_vocal/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/head/affected)
 	user.visible_message(span_warning("[user]'s hand slips, clamping [target]'s trachea shut for a moment with \the [tool]!"), \
 	span_warning("Your hand slips, clamping [user]'s trachea shut for a moment with \the [tool]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	target.Losebreath(10)
 	target.updatehealth()
 
@@ -90,16 +96,19 @@
 /datum/surgery_step/face/fix_face/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/head/affected)
 	user.visible_message(span_notice("[user] starts pulling the skin on [target]'s face back in place with \the [tool]."), \
 	span_notice("You start pulling the skin on [target]'s face back in place with \the [tool]."))
+	target.balloon_alert_to_viewers("Reshaping...")
 	..()
 
 /datum/surgery_step/face/fix_face/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/head/affected)
 	user.visible_message(span_notice("[user] pulls the skin on [target]'s face back in place with \the [tool]."),	\
 	span_notice("You pull the skin on [target]'s face back in place with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.face_surgery_stage = 3
 
 /datum/surgery_step/face/fix_face/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/head/affected)
 	user.visible_message(span_warning("[user]'s hand slips, tearing skin on [target]'s face with \the [tool]!"), \
 	span_warning("Your hand slips, tearing skin on [target]'s face with \the [tool]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	target.apply_damage(10, BRUTE, affected, 0, TRUE, updating_health = TRUE)
 
 
@@ -119,11 +128,13 @@
 /datum/surgery_step/face/cauterize/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/head/affected)
 	user.visible_message(span_notice("[user] is beginning to cauterize the incision on [target]'s face and neck with \the [tool].") , \
 	span_notice("You are beginning to cauterize the incision on [target]'s face and neck with \the [tool]."))
+	target.balloon_alert_to_viewers("Cauterizing...")
 	..()
 
 /datum/surgery_step/face/cauterize/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/head/affected)
 	user.visible_message(span_notice("[user] cauterizes the incision on [target]'s face and neck with \the [tool]."), \
 	span_notice("You cauterize the incision on [target]'s face and neck with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.remove_limb_flags(LIMB_BLEEDING)
 	affected.disfigured = 0
 	affected.owner.name = affected.owner.get_visible_name()
@@ -132,4 +143,5 @@
 /datum/surgery_step/face/cauterize/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/head/affected)
 	user.visible_message(span_warning("[user]'s hand slips, leaving a small burn on [target]'s face with \the [tool]!"), \
 	span_warning("Your hand slips, leaving a small burn on [target]'s face with \the [tool]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	target.apply_damage(4, BURN, affected, updating_health = TRUE)

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -34,12 +34,14 @@
 /datum/surgery_step/generic/incision_manager/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] starts to construct a prepared incision on and within [target]'s [affected.display_name] with \the [tool]."), \
 	span_notice("You start to construct a prepared incision on and within [target]'s [affected.display_name] with \the [tool]."))
+	target.balloon_alert_to_viewers("Incising...")
 	target.custom_pain("You feel a horrible, searing pain in your [affected.display_name] as it is pushed apart!",1)
 	..()
 
 /datum/surgery_step/generic/incision_manager/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] has constructed a prepared incision on and within [target]'s [affected.display_name] with \the [tool]."), \
 	span_notice("You have constructed a prepared incision on and within [target]'s [affected.display_name] with \the [tool]."),)
+	target.balloon_alert_to_viewers("Success")
 	affected.surgery_open_stage = 1
 
 	if(istype(target) && !(target.species.species_flags & NO_BLOOD))
@@ -53,6 +55,7 @@
 /datum/surgery_step/generic/incision_manager/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand jolts as the system sparks, ripping a gruesome hole in [target]'s [affected.display_name] with \the [tool]!"), \
 	span_warning("Your hand jolts as the system sparks, ripping a gruesome hole in [target]'s [affected.display_name] with \the [tool]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	affected.createwound(CUT, 20)
 	affected.createwound(BURN, 15)
 	affected.update_wounds()
@@ -76,11 +79,13 @@
 	user.visible_message(span_notice("[user] starts the bloodless incision on [target]'s [affected.display_name] with \the [tool]."), \
 	span_notice("You start the bloodless incision on [target]'s [affected.display_name] with \the [tool]."))
 	target.custom_pain("You feel a horrible, searing pain in your [affected.display_name]!", 1)
+	target.balloon_alert_to_viewers("Incising...")
 	..()
 
 /datum/surgery_step/generic/cut_with_laser/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] has made a bloodless incision on [target]'s [affected.display_name] with \the [tool]."), \
 	span_notice("You have made a bloodless incision on [target]'s [affected.display_name] with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	//Could be cleaner
 	affected.surgery_open_stage = 1
 
@@ -95,6 +100,7 @@
 /datum/surgery_step/generic/cut_with_laser/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips as the blade sputters, searing a long gash in [target]'s [affected.display_name] with \the [tool]!"), \
 	span_warning("Your hand slips as the blade sputters, searing a long gash in [target]'s [affected.display_name] with \the [tool]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	affected.createwound(CUT, 7.5)
 	affected.createwound(BURN, 12.5)
 	affected.update_wounds()
@@ -119,11 +125,13 @@
 	user.visible_message(span_notice("[user] starts the incision on [target]'s [affected.display_name] with \the [tool]."), \
 	span_notice("You start the incision on [target]'s [affected.display_name] with \the [tool]."))
 	target.custom_pain("You feel a horrible pain as if from a sharp knife in your [affected.display_name]!", 1)
+	target.balloon_alert_to_viewers("Incising...")
 	..()
 
 /datum/surgery_step/generic/cut_open/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] has made an incision on [target]'s [affected.display_name] with \the [tool]."), \
 	span_notice("You have made an incision on [target]'s [affected.display_name] with \the [tool]."),)
+	target.balloon_alert_to_viewers("Success")
 	affected.surgery_open_stage = 1
 
 	if(istype(target) && !(target.species.species_flags & NO_BLOOD))
@@ -135,6 +143,7 @@
 /datum/surgery_step/generic/cut_open/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, slicing open [target]'s [affected.display_name] in the wrong place with \the [tool]!"), \
 	span_warning("Your hand slips, slicing open [target]'s [affected.display_name] in the wrong place with \the [tool]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	affected.createwound(CUT, 10)
 	affected.update_wounds()
 
@@ -158,17 +167,20 @@
 	user.visible_message(span_notice("[user] starts clamping bleeders in [target]'s [affected.display_name] with \the [tool]."), \
 	span_notice("You start clamping bleeders in [target]'s [affected.display_name] with \the [tool]."))
 	target.custom_pain("The pain in your [affected.display_name] is maddening!", 1)
+	target.balloon_alert_to_viewers("Clamping...")
 	..()
 
 /datum/surgery_step/generic/clamp_bleeders/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] clamps bleeders in [target]'s [affected.display_name] with \the [tool]."),	\
 	span_notice("You clamp bleeders in [target]'s [affected.display_name] with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.clamp_bleeder()
 	spread_germs_to_organ(affected, user)
 
 /datum/surgery_step/generic/clamp_bleeders/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, tearing blood vessals and causing massive bleeding in [target]'s [affected.display_name] with \the [tool]!"),	\
 	span_warning("Your hand slips, tearing blood vessels and causing massive bleeding in [target]'s [affected.display_name] with \the [tool]!"),)
+	target.balloon_alert_to_viewers("Slipped!")
 	affected.createwound(CUT, 10)
 	affected.update_wounds()
 
@@ -193,6 +205,7 @@
 		user.visible_message(span_notice("[user] starts to pry open the incision on [target]'s [affected.display_name] with \the [tool]."), \
 		span_notice("You start to pry open the incision on [target]'s [affected.display_name] with \the [tool]."))
 	target.custom_pain("It feels like the skin on your [affected.display_name] is on fire!", 1)
+	target.balloon_alert_to_viewers("Incising...")
 	..()
 
 /datum/surgery_step/generic/retract_skin/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
@@ -205,6 +218,7 @@
 	else
 		user.visible_message(span_notice("[user] keeps the incision open on [target]'s [affected.display_name] with \the [tool]."), \
 		span_notice("You keep the incision open on [target]'s [affected.display_name] with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.surgery_open_stage = 2
 
 /datum/surgery_step/generic/retract_skin/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
@@ -217,6 +231,7 @@
 	else
 		user.visible_message(span_warning("[user]'s hand slips, tearing the edges of the incision on [target]'s [affected.display_name] with \the [tool]!"), \
 		span_warning("Your hand slips, tearing the edges of the incision on [target]'s [affected.display_name] with \the [tool]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	target.apply_damage(12, BRUTE, affected, 0, TRUE, updating_health = TRUE)
 	affected.update_wounds()
 
@@ -240,11 +255,13 @@
 	user.visible_message(span_notice("[user] is beginning to cauterize the incision on [target]'s [affected.display_name] with \the [tool].") , \
 	span_notice("You are beginning to cauterize the incision on [target]'s [affected.display_name] with \the [tool]."))
 	target.custom_pain("Your [affected.display_name] is being burned!", 1)
+	target.balloon_alert_to_viewers("Cauterizing...")
 	..()
 
 /datum/surgery_step/generic/cauterize/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] cauterizes the incision on [target]'s [affected.display_name] with \the [tool]."), \
 	span_notice("You cauterize the incision on [target]'s [affected.display_name] with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.surgery_open_stage = 0
 	affected.germ_level = 0
 	affected.remove_limb_flags(LIMB_BLEEDING)
@@ -253,6 +270,7 @@
 /datum/surgery_step/generic/cauterize/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, leaving a small burn on [target]'s [affected.display_name] with \the [tool]!"), \
 	span_warning("Your hand slips, leaving a small burn on [target]'s [affected.display_name] with \the [tool]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	target.apply_damage(3, BURN, affected, updating_health = TRUE)
 
 ///Sewing people closed. Not fast, but works on corpses.
@@ -279,11 +297,13 @@
 	user.visible_message(span_notice("[user] is beginning to suture the wounds on [target]'s [affected.display_name].")  , \
 	span_notice("You are beginning to suture the wounds on [target]'s [affected.display_name].") )
 	target.custom_pain("Your [affected.display_name] is getting stabbed!!", 1)
+	target.balloon_alert_to_viewers("Suturing...")
 	..()
 
 /datum/surgery_step/generic/repair/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] sews some of the wounds on [target]'s [affected.display_name] shut.") , \
 	span_notice("You finish suturing some of the wounds on [target]'s [affected.display_name].") )
+	target.balloon_alert_to_viewers("Success")
 	var/burn_heal = min(base_healing, affected.burn_dam)
 	var/brute_heal = max(base_healing - burn_heal, 0)
 	target.HealDamage(target_zone, brute_heal, burn_heal)
@@ -291,4 +311,5 @@
 /datum/surgery_step/generic/repair/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, tearing through [target]'s skin with \the [tool]!") , \
 	span_warning("Your hand slips, tearing \the [tool] through [target]'s skin!") )
+	target.balloon_alert_to_viewers("Slipped!")
 	affected.take_damage_limb(5, updating_health = TRUE)

--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -31,11 +31,13 @@
 /datum/surgery_step/head/peel/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] starts peeling back tattered flesh where [target]'s head used to be with \the [tool]."), \
 	span_notice("You start peeling back tattered flesh where [target]'s head used to be with \the [tool]."))
+	target.balloon_alert_to_viewers("Peeling...")
 	..()
 
 /datum/surgery_step/head/peel/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] peels back tattered flesh where [target]'s head used to be with \the [tool]."),	\
 	span_notice("You peel back tattered flesh where [target]'s head used to be with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.limb_replacement_stage = 1
 
 /datum/surgery_step/head/peel/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
@@ -43,6 +45,7 @@
 		affected = affected.parent
 		user.visible_message(span_warning("[user]'s hand slips, ripping [target]'s [affected.display_name] open!"), \
 		span_warning("Your hand slips,  ripping [target]'s [affected.display_name] open!"))
+		target.balloon_alert_to_viewers("Slipped!")
 		affected.createwound(CUT, 10)
 		affected.update_wounds()
 
@@ -61,11 +64,13 @@
 /datum/surgery_step/head/shape/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] is beginning to reshape [target]'s esophagal and vocal region with \the [tool]."), \
 	span_notice("You start to reshape [target]'s head esophagal and vocal region with \the [tool]."))
+	target.balloon_alert_to_viewers("Reshaping...")
 	..()
 
 /datum/surgery_step/head/shape/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] has finished repositioning flesh and tissue to something anatomically recognizable where [target]'s head used to be with \the [tool]."),	\
 	span_notice("You have finished repositioning flesh and tissue to something anatomically recognizable where [target]'s head used to be with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.limb_replacement_stage = 2
 
 /datum/surgery_step/head/shape/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
@@ -73,6 +78,7 @@
 		affected = affected.parent
 		user.visible_message(span_warning("[user]'s hand slips, further rending flesh on [target]'s neck!"), \
 		span_warning("Your hand slips, further rending flesh on [target]'s neck!"))
+		target.balloon_alert_to_viewers("Slipped!")
 		target.apply_damage(10, BRUTE, affected, updating_health = TRUE)
 
 
@@ -90,11 +96,13 @@
 /datum/surgery_step/head/suture/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] is stapling and suturing flesh into place in [target]'s esophagal and vocal region with \the [tool]."), \
 	span_notice("You start to staple and suture flesh into place in [target]'s esophagal and vocal region with \the [tool]."))
+	target.balloon_alert_to_viewers("Suturing...")
 	..()
 
 /datum/surgery_step/head/suture/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] has finished stapling [target]'s neck into place with \the [tool]."),	\
 	span_notice("You have finished stapling [target]'s neck into place with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.limb_replacement_stage = 3
 
 /datum/surgery_step/head/suture/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
@@ -102,6 +110,7 @@
 		affected = affected.parent
 		user.visible_message(span_warning("[user]'s hand slips, ripping apart flesh on [target]'s neck!"), \
 		span_warning("Your hand slips, ripping apart flesh on [target]'s neck!"))
+		target.balloon_alert_to_viewers("Slipped!")
 		target.apply_damage(10, BRUTE, affected, updating_health = TRUE)
 
 
@@ -120,11 +129,13 @@
 /datum/surgery_step/head/prepare/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] starts adjusting area around [target]'s neck with \the [tool]."), \
 	span_notice("You start adjusting area around [target]'s neck with \the [tool]."))
+	target.balloon_alert_to_viewers("Adjusting...")
 	..()
 
 /datum/surgery_step/head/prepare/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] has finished adjusting the area around [target]'s neck with \the [tool]."),	\
 	span_notice("You have finished adjusting the area around [target]'s neck with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.limb_replacement_stage = 0
 	affected.add_limb_flags(LIMB_AMPUTATED)
 	affected.setAmputatedTree()
@@ -134,6 +145,7 @@
 		affected = affected.parent
 		user.visible_message(span_warning("[user]'s hand slips, searing [target]'s neck!"), \
 		span_warning("Your hand slips, searing [target]'s [affected.display_name]!"))
+		target.balloon_alert_to_viewers("Slipped!")
 		target.apply_damage(10, BURN, affected, updating_health = TRUE)
 
 
@@ -152,11 +164,13 @@
 /datum/surgery_step/head/attach/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] starts attaching [tool] to [target]'s reshaped neck."), \
 	span_notice("You start attaching [tool] to [target]'s reshaped neck."))
+	target.balloon_alert_to_viewers("Attaching...")
 	..()
 
 /datum/surgery_step/head/attach/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] has attached [target]'s head to the body."),	\
 	span_notice("You have attached [target]'s head to the body."))
+	target.balloon_alert_to_viewers("Success")
 
 	//Update our dear victim to have a head again
 
@@ -179,4 +193,5 @@
 /datum/surgery_step/head/attach/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, damaging connectors on [target]'s neck!"), \
 	span_warning("Your hand slips, damaging connectors on [target]'s neck!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	target.apply_damage(10, BRUTE, affected, 0, TRUE, updating_health = TRUE)

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -156,6 +156,7 @@
 	user.visible_message(span_notice("[user] starts poking around inside the incision on [target]'s [affected.display_name] with \the [tool]."), \
 	span_notice("You start poking around inside the incision on [target]'s [affected.display_name] with \the [tool]."))
 	target.custom_pain("The pain in your chest is living hell!", 1)
+	target.balloon_alert_to_viewers("Checking...")
 	..()
 
 /datum/surgery_step/implant_removal/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
@@ -164,11 +165,13 @@
 		var/obj/item/implantfound = affected.implants[1]
 		user.visible_message(span_notice("[user] takes something out of incision on [target]'s [affected.display_name] with \the [tool]."), \
 		span_notice("You take [implantfound] out of incision on [target]'s [affected.display_name]s with \the [tool]."))
+		target.balloon_alert_to_viewers("Implant found")
 		implantfound.unembed_ourself()
 
 	else if(affected.hidden)
 		user.visible_message(span_notice("[user] takes something out of incision on [target]'s [affected.display_name] with \the [tool]."), \
 		span_notice(" You take something out of incision on [target]'s [affected.display_name]s with \the [tool]."))
+		target.balloon_alert_to_viewers("Shrapnel found")
 		affected.hidden.loc = get_turf(target)
 		affected.hidden.update_icon()
 		affected.hidden = null
@@ -176,10 +179,12 @@
 	else
 		user.visible_message(span_notice("[user] could not find anything inside [target]'s [affected.display_name], and pulls \the [tool] out."), \
 		span_notice("You could not find anything inside [target]'s [affected.display_name]."))
+		target.balloon_alert_to_viewers("Nothing found")
 
 /datum/surgery_step/implant_removal/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, scraping tissue inside [target]'s [affected.display_name] with \the [tool]!"), \
 	span_warning("Your hand slips, scraping tissue inside [target]'s [affected.display_name] with \the [tool]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	affected.createwound(CUT, 20)
 	if(affected.implants.len)
 		var/fail_prob = 10

--- a/code/modules/surgery/internal_bleeding.dm
+++ b/code/modules/surgery/internal_bleeding.dm
@@ -24,11 +24,13 @@
 	user.visible_message(span_notice("[user] starts patching the damaged vein in [target]'s [affected.display_name] with \the [tool].") , \
 	span_notice("You start patching the damaged vein in [target]'s [affected.display_name] with \the [tool]."))
 	target.custom_pain("The pain in [affected.display_name] is unbearable!",1)
+	target.balloon_alert_to_viewers("Fixing...")
 	..()
 
 /datum/surgery_step/fix_vein/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] has patched the damaged vein in [target]'s [affected.display_name] with \the [tool]."), \
 		span_notice("You have patched the damaged vein in [target]'s [affected.display_name] with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 
 	QDEL_LIST(affected.wounds)
 	if(ishuman(user) && prob(40))
@@ -37,5 +39,6 @@
 /datum/surgery_step/fix_vein/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.display_name]!") , \
 	span_warning("Your hand slips, smearing [tool] in the incision in [target]'s [affected.display_name]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	affected.take_damage_limb(5, 0)
 	target.updatehealth()

--- a/code/modules/surgery/necrosis.dm
+++ b/code/modules/surgery/necrosis.dm
@@ -29,17 +29,20 @@
 /datum/surgery_step/necro/fix_dead_tissue/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] starts cutting away necrotic tissue in [target]'s [affected.display_name] with \the [tool].") , \
 	span_notice("You start cutting away necrotic tissue in [target]'s [affected.display_name] with \the [tool]."))
+	target.balloon_alert_to_viewers("Cutting...")
 	target.custom_pain("The pain in [affected.display_name] is unbearable!", 1)
 	..()
 
 /datum/surgery_step/necro/fix_dead_tissue/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] has cut away necrotic tissue in [target]'s [affected.display_name] with \the [tool]."), \
 		span_notice("You have cut away necrotic tissue in [target]'s [affected.display_name] with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.necro_surgery_stage = 1
 
 /datum/surgery_step/necro/fix_dead_tissue/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, slicing an artery inside [target]'s [affected.display_name] with \the [tool]!"), \
 	span_warning("Your hand slips, slicing an artery inside [target]'s [affected.display_name] with \the [tool]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	affected.createwound(CUT, 20, 1)
 	affected.update_wounds()
 
@@ -61,6 +64,7 @@
 	user.visible_message(span_notice("[user] starts applying \the [tool] on the affected tissue in [target]'s [affected.display_name].") , \
 	span_notice("You start applying \the [tool] on the affected tissue in [target]'s [affected.display_name]."))
 	target.custom_pain("Something in your [affected.display_name] is causing you a lot of pain!", 1)
+	target.balloon_alert_to_viewers("Applying...")
 	..()
 
 /datum/surgery_step/necro/treat_necrosis/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
@@ -70,8 +74,10 @@
 
 	user.visible_message(span_notice("[user] applies \the [tool] on the affected tissue in [target]'s [affected.display_name]."), \
 	span_notice("You apply \the [tool] on the affected tissue in [target]'s [affected.display_name]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.necro_surgery_stage = 0
 
 /datum/surgery_step/treat_necrosis/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, applying \the [tool] to the wrong place in [target]'s [affected.display_name]!") , \
 	span_warning("Your hand slips, applying \the [tool] to the wrong place in [target]'s [affected.display_name]!"))
+	target.balloon_alert_to_viewers("Slipped!")

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -33,6 +33,7 @@
 /datum/surgery_step/internal/remove_embryo/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] starts to pull something out from [target]'s ribcage with \the [tool]."), \
 					span_notice("You start to pull something out from [target]'s ribcage with \the [tool]."))
+	target.balloon_alert_to_viewers("Pulling...")
 	target.custom_pain("Something hurts horribly in your chest!",1)
 	..()
 
@@ -41,6 +42,7 @@
 	if(A)
 		user.visible_message(span_warning("[user] rips a wriggling parasite out of [target]'s ribcage!"),
 							span_warning("You rip a wriggling parasite out of [target]'s ribcage!"))
+		target.balloon_alert_to_viewers("Success")
 		var/mob/living/carbon/xenomorph/larva/L = locate() in target //the larva was fully grown, ready to burst.
 		if(L)
 			L.forceMove(target.loc)
@@ -88,6 +90,7 @@
 		if(I && I.damage > 0 && I.robotic != ORGAN_ROBOT)
 			user.visible_message(span_notice("[user] starts treating damage to [target]'s [I.name] with [tool_name]."), \
 			span_notice("You start treating damage to [target]'s [I.name] with [tool_name].") )
+			target.balloon_alert_to_viewers("Fixing...")
 
 	target.custom_pain("The pain in your [affected.display_name] is living hell!", 1)
 	..()
@@ -104,10 +107,12 @@
 			user.visible_message(span_notice("[user] treats damage to [target]'s [I.name] with [tool_name]."), \
 			span_notice("You treat damage to [target]'s [I.name] with [tool_name].") )
 			I.damage = 0
+	target.balloon_alert_to_viewers("Success")
 
 /datum/surgery_step/internal/fix_organ/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, getting mess and tearing the inside of [target]'s [affected.display_name] with \the [tool]!"), \
 	span_warning("Your hand slips, getting mess and tearing the inside of [target]'s [affected.display_name] with \the [tool]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	var/dam_amt = 2
 
 	if(istype(tool, /obj/item/stack/medical/heal_pack/advanced/bruise_pack))
@@ -150,6 +155,7 @@
 			user.visible_message(span_notice("[user] starts mending the damage to [target]'s [I.name]'s mechanisms."), \
 			span_notice("You start mending the damage to [target]'s [I.name]'s mechanisms.") )
 
+	target.balloon_alert_to_viewers("Mending...")
 	target.custom_pain("The pain in your [affected.display_name] is living hell!", 1)
 	..()
 
@@ -159,10 +165,12 @@
 			user.visible_message(span_notice("[user] repairs [target]'s [I.name] with [tool]."), \
 			span_notice("You repair [target]'s [I.name] with [tool].") )
 			I.damage = 0
+	target.balloon_alert_to_viewers("Success")
 
 /datum/surgery_step/internal/fix_organ_robotic/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, gumming up the mechanisms inside of [target]'s [affected.display_name] with \the [tool]!"), \
 	span_warning("Your hand slips, gumming up the mechanisms inside of [target]'s [affected.display_name] with \the [tool]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 
 	target.adjustToxLoss(5)
 	affected.createwound(CUT, 5)
@@ -219,11 +227,13 @@
 	user.visible_message(span_notice("[user] starts to separate [target]'s [affected.surgery_organ] with \the [tool]."), \
 	span_notice("You start to separate [target]'s [affected.surgery_organ] with \the [tool].") )
 	target.custom_pain("The pain in your [affected.display_name] is living hell!", 1)
+	target.balloon_alert_to_viewers("Separating...")
 	..()
 
 /datum/surgery_step/internal/detach_organ/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] has separated [target]'s [affected.surgery_organ] with \the [tool].") , \
 	span_notice("You have separated [target]'s [affected.surgery_organ] with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 
 	var/datum/internal_organ/I = target.internal_organs_by_name[affected.surgery_organ]
 	I.cut_away = TRUE
@@ -232,6 +242,7 @@
 /datum/surgery_step/internal/detach_organ/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, slicing an artery inside [target]'s [affected.display_name] with \the [tool]!"), \
 	span_warning("Your hand slips, slicing an artery inside [target]'s [affected.display_name] with \the [tool]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	affected.createwound(CUT, rand(30, 50), 1)
 	affected.update_wounds()
 	affected.surgery_organ = null
@@ -283,11 +294,13 @@
 	user.visible_message(span_notice("[user] starts removing [target]'s [affected.surgery_organ] with \the [tool]."), \
 	span_notice("You start removing [target]'s [affected.surgery_organ] with \the [tool]."))
 	target.custom_pain("Someone's ripping out your [affected.surgery_organ]!", 1)
+	target.balloon_alert_to_viewers("Removing...")
 	..()
 
 /datum/surgery_step/internal/remove_organ/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] has removed [target]'s [affected.surgery_organ] with \the [tool]."), \
 	span_notice("You have removed [target]'s [affected.surgery_organ] with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 
 	//Extract the organ!
 	if(affected.surgery_organ)
@@ -319,6 +332,7 @@
 /datum/surgery_step/internal/remove_organ/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, damaging the flesh in [target]'s [affected.display_name] with \the [tool]!"), \
 	span_warning("Your hand slips, damaging the flesh in [target]'s [affected.display_name] with \the [tool]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	affected.createwound(BRUISE, 20)
 	affected.update_wounds()
 	affected.surgery_organ = null
@@ -376,11 +390,13 @@
 	user.visible_message(span_notice("[user] starts transplanting \the [tool] into [target]'s [affected.display_name]."), \
 	span_notice("You start transplanting \the [tool] into [target]'s [affected.display_name]."))
 	target.custom_pain("Someone's rooting around in your [affected.display_name]!", 1)
+	target.balloon_alert_to_viewers("Transplanting...")
 	..()
 
 /datum/surgery_step/internal/replace_organ/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] has transplanted \the [tool] into [target]'s [affected.display_name]."), \
 	span_notice("You have transplanted \the [tool] into [target]'s [affected.display_name]."))
+	target.balloon_alert_to_viewers("Success")
 	user.temporarilyRemoveItemFromInventory(tool)
 	var/obj/item/organ/O = tool
 
@@ -409,6 +425,7 @@
 /datum/surgery_step/internal/replace_organ/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, damaging \the [tool]!"), \
 	span_warning("Your hand slips, damaging \the [tool]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	var/obj/item/organ/I = tool
 	if(istype(I))
 		I.organ_data.take_damage(rand(3, 5), 0)
@@ -461,11 +478,13 @@
 	user.visible_message(span_notice("[user] begins reattaching [target]'s [affected.surgery_organ] with \the [tool]."), \
 	span_notice("You start reattaching [target]'s [affected.surgery_organ] with \the [tool]."))
 	target.custom_pain("Someone's digging needles into your [affected.surgery_organ]!", 1)
+	target.balloon_alert_to_viewers("Reattaching...")
 	..()
 
 /datum/surgery_step/internal/attach_organ/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] has reattached [target]'s [affected.surgery_organ] with \the [tool].") , \
 	span_notice("You have reattached [target]'s [affected.surgery_organ] with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 
 	var/datum/internal_organ/I = target.internal_organs_by_name[affected.surgery_organ]
 	I.cut_away = FALSE
@@ -474,6 +493,7 @@
 /datum/surgery_step/internal/attach_organ/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, damaging the flesh in [target]'s [affected.display_name] with \the [tool]!"), \
 	span_warning("Your hand slips, damaging the flesh in [target]'s [affected.display_name] with \the [tool]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	affected.createwound(BRUISE, 20)
 	affected.update_wounds()
 	affected.surgery_organ = null

--- a/code/modules/surgery/robolimbs.dm
+++ b/code/modules/surgery/robolimbs.dm
@@ -34,11 +34,13 @@
 /datum/surgery_step/limb/cut/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] starts cutting away flesh where [target]'s [affected.display_name] used to be with \the [tool]."), \
 	span_notice("You start cutting away flesh where [target]'s [affected.display_name] used to be with \the [tool]."))
+	target.balloon_alert_to_viewers("Cutting...")
 	..()
 
 /datum/surgery_step/limb/cut/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] cuts away flesh where [target]'s [affected.display_name] used to be with \the [tool]."),	\
 	span_notice("You cut away flesh where [target]'s [affected.display_name] used to be with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.limb_replacement_stage = 1
 
 /datum/surgery_step/limb/cut/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
@@ -46,6 +48,7 @@
 		affected = affected.parent
 		user.visible_message(span_warning("[user]'s hand slips, cutting [target]'s [affected.display_name] open!"), \
 		span_warning("Your hand slips, cutting [target]'s [affected.display_name] open!"))
+		target.balloon_alert_to_viewers("Slipped!")
 		affected.createwound(CUT, 10)
 		affected.update_wounds()
 
@@ -65,11 +68,13 @@
 /datum/surgery_step/limb/mend/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] is beginning to reposition flesh and nerve endings where where [target]'s [affected.display_name] used to be with [tool]."), \
 	span_notice("You start repositioning flesh and nerve endings where [target]'s [affected.display_name] used to be with [tool]."))
+	target.balloon_alert_to_viewers("Repositioning...")
 	..()
 
 /datum/surgery_step/limb/mend/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] has finished repositioning flesh and nerve endings where [target]'s [affected.display_name] used to be with [tool]."),	\
 	span_notice("You have finished repositioning flesh and nerve endings where [target]'s [affected.display_name] used to be with [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.limb_replacement_stage = 2
 
 /datum/surgery_step/limb/mend/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
@@ -77,6 +82,7 @@
 		affected = affected.parent
 		user.visible_message(span_warning("[user]'s hand slips, tearing flesh on [target]'s [affected.display_name]!"), \
 		span_warning("Your hand slips, tearing flesh on [target]'s [affected.display_name]!"))
+		target.balloon_alert_to_viewers("Slipped!")
 		target.apply_damage(10, BRUTE, affected, 0, TRUE, updating_health = TRUE)
 
 
@@ -95,11 +101,13 @@
 /datum/surgery_step/limb/prepare/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] starts adjusting the area around [target]'s [affected.display_name] with \the [tool]."), \
 	span_notice("You start adjusting the area around [target]'s [affected.display_name] with \the [tool]."))
+	target.balloon_alert_to_viewers("Adjusting...")
 	..()
 
 /datum/surgery_step/limb/prepare/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] has finished adjusting the area around [target]'s [affected.display_name] with \the [tool]."),	\
 	span_notice("You have finished adjusting the area around [target]'s [affected.display_name] with \the [tool]."))
+	target.balloon_alert_to_viewers("Success")
 	affected.add_limb_flags(LIMB_AMPUTATED)
 	affected.setAmputatedTree()
 	affected.limb_replacement_stage = 0
@@ -109,6 +117,7 @@
 		affected = affected.parent
 		user.visible_message(span_warning("[user]'s hand slips, searing [target]'s [affected.display_name]!"), \
 		span_warning("Your hand slips, searing [target]'s [affected.display_name]!"))
+		target.balloon_alert_to_viewers("Slipped!")
 		target.apply_damage(10, BURN, affected, updating_health = TRUE)
 
 
@@ -130,10 +139,12 @@
 /datum/surgery_step/limb/attach/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] starts attaching \the [tool] where [target]'s [affected.display_name] used to be."), \
 	span_notice("You start attaching \the [tool] where [target]'s [affected.display_name] used to be."))
+	target.balloon_alert_to_viewers("Attaching...")
 
 /datum/surgery_step/limb/attach/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] has attached \the [tool] where [target]'s [affected.display_name] used to be."),	\
 	span_notice("You have attached \the [tool] where [target]'s [affected.display_name] used to be."))
+	target.balloon_alert_to_viewers("Success")
 
 	//Update our dear victim to have a limb again
 	affected.robotize()
@@ -149,4 +160,5 @@
 /datum/surgery_step/limb/attach/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, damaging connectors on [target]'s [affected.display_name]!"), \
 	span_warning("Your hand slips, damaging connectors on [target]'s [affected.display_name]!"))
+	target.balloon_alert_to_viewers("Slipped!")
 	target.apply_damage(10, BRUTE, affected, 0, TRUE, updating_health = TRUE)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -120,7 +120,7 @@ proc/do_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool)
 	if(user.skills.getRating("surgery") < SKILL_SURGERY_PROFESSIONAL)
 		user.visible_message(span_notice("[user] fumbles around figuring out how to operate [M]."),
 		span_notice("You fumble around figuring out how to operate [M]."))
-		target.balloon_alert_to_viewers("Fumbling...")
+		M.balloon_alert_to_viewers("Fumbling...")
 		var/fumbling_time = max(0,SKILL_TASK_FORMIDABLE - ( 8 SECONDS * user.skills.getRating("surgery") )) // 20 secs non-trained, 12 amateur, 4 trained, 0 prof
 		if(fumbling_time && !do_after(user, fumbling_time, TRUE, M, BUSY_ICON_UNSKILLED))
 			return

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -120,6 +120,7 @@ proc/do_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool)
 	if(user.skills.getRating("surgery") < SKILL_SURGERY_PROFESSIONAL)
 		user.visible_message(span_notice("[user] fumbles around figuring out how to operate [M]."),
 		span_notice("You fumble around figuring out how to operate [M]."))
+		target.balloon_alert_to_viewers("Fumbling...")
 		var/fumbling_time = max(0,SKILL_TASK_FORMIDABLE - ( 8 SECONDS * user.skills.getRating("surgery") )) // 20 secs non-trained, 12 amateur, 4 trained, 0 prof
 		if(fumbling_time && !do_after(user, fumbling_time, TRUE, M, BUSY_ICON_UNSKILLED))
 			return

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -120,7 +120,6 @@ proc/do_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool)
 	if(user.skills.getRating("surgery") < SKILL_SURGERY_PROFESSIONAL)
 		user.visible_message(span_notice("[user] fumbles around figuring out how to operate [M]."),
 		span_notice("You fumble around figuring out how to operate [M]."))
-		M.balloon_alert_to_viewers("Fumbling...")
 		var/fumbling_time = max(0,SKILL_TASK_FORMIDABLE - ( 8 SECONDS * user.skills.getRating("surgery") )) // 20 secs non-trained, 12 amateur, 4 trained, 0 prof
 		if(fumbling_time && !do_after(user, fumbling_time, TRUE, M, BUSY_ICON_UNSKILLED))
 			return


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds balloon alerts to surgery steps.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes surgery much easier for new docs, prettier, and makes it easier to see if you failed a step among the flood in chatboxes.
I have wanted this every single time I've done groundside surgery as rsr

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Balloon alerts to surgery actions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
