### PR TITLE
Operating tables apply a trait instead of using internals

### DIFF
--- a/code/game/objects/machinery/OpTable.dm
+++ b/code/game/objects/machinery/OpTable.dm
@@ -91,12 +91,17 @@
 	if(!buckling_human.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/medical(buckling_human), SLOT_WEAR_MASK))
 		to_chat(user, span_danger("You can't fit the gas mask over their face!"))
 		return FALSE
-	buckling_human.internal = anes_tank
 	buckling_human.visible_message("[span_notice("[user] fits the mask over [buckling_human]'s face and turns on the anesthetic.")]'")
 	to_chat(buckling_human, span_information("You begin to feel sleepy."))
+	addtimer(CALLBACK(src, .proc/knock_out_buckled, buckling_human), rand(20, 40))
 	buckling_human.setDir(SOUTH)
 	return ..()
 
+///Knocks out someone buckled to the op table a few seconds later
+/obj/machinery/optable/proc/knock_out_buckled(mob/living/buckled_mob)
+	if(!victim || victim != buckled_mob)
+		return
+	ADD_TRAIT(buckled_mob, TRAIT_KNOCKEDOUT, "op_table")
 
 /obj/machinery/optable/user_unbuckle_mob(mob/living/buckled_mob, mob/user, silent)
 	. = ..()
@@ -110,12 +115,14 @@
 	if(!ishuman(buckled_mob)) // sanity check
 		return
 	var/mob/living/carbon/human/buckled_human = buckled_mob
-	buckled_human.internal = null
 	var/obj/item/anesthetic_mask = buckled_human.wear_mask
 	buckled_human.dropItemToGround(anesthetic_mask)
 	qdel(anesthetic_mask)
+	addtimer(CALLBACK(src, .proc/remove_knockout, buckled_mob), rand(20, 40))
 	return ..()
 
+/obj/machinery/optable/proc/remove_knockout(mob/living/buckled_mob)
+	REMOVE_TRAIT(buckled_mob, TRAIT_KNOCKEDOUT, "op_table")
 
 /obj/machinery/optable/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()

--- a/code/game/objects/machinery/OpTable.dm
+++ b/code/game/objects/machinery/OpTable.dm
@@ -93,11 +93,11 @@
 		return FALSE
 	buckling_human.visible_message("[span_notice("[user] fits the mask over [buckling_human]'s face and turns on the anesthetic.")]'")
 	to_chat(buckling_human, span_information("You begin to feel sleepy."))
-	addtimer(CALLBACK(src, .proc/knock_out_buckled, buckling_human), rand(20, 40))
+	addtimer(CALLBACK(src, .proc/knock_out_buckled, buckling_human), rand(2 SECONDS, 4 SECONDS))
 	buckling_human.setDir(SOUTH)
 	return ..()
 
-///Knocks out someone buckled to the op table a few seconds later
+///Knocks out someone buckled to the op table a few seconds later. Won't knock out if they've been unbuckled since.
 /obj/machinery/optable/proc/knock_out_buckled(mob/living/buckled_mob)
 	if(!victim || victim != buckled_mob)
 		return
@@ -118,9 +118,10 @@
 	var/obj/item/anesthetic_mask = buckled_human.wear_mask
 	buckled_human.dropItemToGround(anesthetic_mask)
 	qdel(anesthetic_mask)
-	addtimer(CALLBACK(src, .proc/remove_knockout, buckled_mob), rand(20, 40))
+	addtimer(CALLBACK(src, .proc/remove_knockout, buckled_mob), rand(2 SECONDS, 4 SECONDS))
 	return ..()
 
+///Wakes the buckled mob back up after they're released
 /obj/machinery/optable/proc/remove_knockout(mob/living/buckled_mob)
 	REMOVE_TRAIT(buckled_mob, TRAIT_KNOCKEDOUT, "op_table")
 


### PR DESCRIPTION
## About The Pull Request
As title. You still need an anesthetic tank in the table, it just doesn't do anything. Instead the knocked out trait is applied to the mob after a delay, and removed after a delay following unbuckling. No behavior change gameside.

## Why It's Good For The Game
Supplement to #10313 , removing atmos remnants. 

## Changelog
:cl:
code: Operating tables don't use their anesthetic tank for internals any more. They still need one though.
/:cl: