### PR TITLE
Boiler globs open resin doors

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -169,6 +169,10 @@
 		Open()
 		return TRUE
 
+/obj/structure/mineral_door/resin/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
+	if(!state && ispath(proj.ammo.type, /datum/ammo/xeno/boiler_gas))
+		Open()
+	return ..()
 
 /obj/structure/mineral_door/resin/attack_larva(mob/living/carbon/xenomorph/larva/M)
 	var/turf/cur_loc = M.loc


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

## Why It's Good For The Game

Reduces chances for builder castes to inadvertently troll boilers.
Makes approaching closed resin doors riskier.

## Changelog
:cl:
balance: Boiler globs now open resin doors in their way.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
