### PR TITLE
More hotkeys for CAS

### DIFF
--- a/tgui/packages/tgui/interfaces/MarineCasship.tsx
+++ b/tgui/packages/tgui/interfaces/MarineCasship.tsx
@@ -1,6 +1,6 @@
 import { useBackend } from '../backend';
 import { Box, Button, LabeledList, ProgressBar, NoticeBox, Section } from '../components';
-import { KEY_DOWN, KEY_ENTER, KEY_LEFT, KEY_RIGHT, KEY_SPACE, KEY_UP, KEY_W, KEY_D, KEY_S, KEY_A } from '../../common/keycodes';
+import { KEY_DOWN, KEY_ENTER, KEY_LEFT, KEY_RIGHT, KEY_SPACE, KEY_UP, KEY_W, KEY_D, KEY_S, KEY_A, KEY_1, KEY_2, KEY_3, KEY_4, KEY_5, KEY_6 } from '../../common/keycodes';
 import { Window } from '../layouts';
 
 type CasData = {
@@ -42,6 +42,24 @@ export const MarineCasship = (props, context) => {
           if (keyCode === KEY_SPACE) {
             act('launch');
           }
+          if (keyCode === KEY_1) {
+            act('change_weapon', { selection: 1 });
+          }
+          if (keyCode === KEY_2) {
+            act('change_weapon', { selection: 2 });
+          }
+          if (keyCode === KEY_3) {
+            act('change_weapon', { selection: 3 });
+          }
+          if (keyCode === KEY_4) {
+            act('change_weapon', { selection: 4 });
+          }
+          if (keyCode === KEY_5) {
+            act('change_weapon', { selection: 5 });
+          }
+          if (keyCode === KEY_6) {
+            act('deselect');
+          }
           if (data.plane_state !== 0) {
             let newdir = 0;
             switch (keyCode) {
@@ -49,12 +67,12 @@ export const MarineCasship = (props, context) => {
               case KEY_W:
                 newdir = 1;
                 break;
-              case KEY_RIGHT:
-              case KEY_D:
-                newdir = 2;
-                break;
               case KEY_DOWN:
               case KEY_S:
+                newdir = 2;
+                break;
+              case KEY_RIGHT:
+              case KEY_D:
                 newdir = 4;
                 break;
               case KEY_LEFT:


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Keys 1, 2, 3, 4, 5 select weapons
6 deselects weapon
South and East keybindings were the wrong way around, swaps them round to be correct
(so before down would = east, right would = south - that's swapped)

Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/10060 along with the lighting fix

You still need to focus on the window for keybindings (good), but firing a weapon un-focuses the weapon. I don't know how to fix that, so you'll still have to click on the window every time you fire a weapon. If there's a way to fix that please ping

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

More QoL good
Bugfixes good
This has been wanted for a while now

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: 123456 keybind weapon swapping for CAS
fix: Swaps south/east keybinds for CAS to where they should be
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
