### PR TITLE
Disable more groundside stuff on hijack

### DIFF
--- a/code/game/objects/machinery/computer/intel_computer.dm
+++ b/code/game/objects/machinery/computer/intel_computer.dm
@@ -38,6 +38,7 @@
 /obj/machinery/computer/intel_computer/Initialize()
 	. = ..()
 	GLOB.intel_computers += src
+	RegisterSignal(SSdcs, COMSIG_GLOB_DROPSHIP_HIJACKED, .proc/disable_on_hijack)
 
 /obj/machinery/computer/intel_computer/process()
 	. = ..()
@@ -60,7 +61,7 @@
 
 /obj/machinery/computer/intel_computer/interact(mob/user)
 	if(!active)
-		to_chat(user, span_notice(" This terminal has nothing of use on it."))
+		to_chat(user, span_notice("This terminal has nothing of use on it."))
 		return
 	return ..()
 
@@ -97,3 +98,14 @@
 			faction = ui_user.faction
 			START_PROCESSING(SSmachines, src)
 	update_icon()
+
+/// Deactivates this intel computer, for use on hijack
+/obj/machinery/computer/intel_computer/proc/disable_on_hijack()
+	GLOB.intel_computers -= src // prevents the event running
+	if(!active)
+		return
+	SStgui.close_uis(src)
+	SSminimaps.remove_marker(src)
+	active = FALSE
+	if(printing)
+		STOP_PROCESSING(SSmachines, src)

--- a/code/game/objects/machinery/computer/nuke_disk_generator.dm
+++ b/code/game/objects/machinery/computer/nuke_disk_generator.dm
@@ -42,7 +42,7 @@
 		return INITIALIZE_HINT_QDEL
 
 	GLOB.nuke_disk_generators += src
-
+	RegisterSignal(SSdcs, COMSIG_GLOB_DROPSHIP_HIJACKED, .proc/set_broken)
 
 /obj/machinery/computer/nuke_disk_generator/Destroy()
 	GLOB.nuke_disk_generators -= src

--- a/code/game/objects/machinery/nuclearbomb.dm
+++ b/code/game/objects/machinery/nuclearbomb.dm
@@ -95,7 +95,7 @@
 
 /// Permanently disables this nuke, for use on hijack
 /obj/machinery/nuclearbomb/proc/disable_on_hijack()
-	desc += " Something seems to be wrong with it."
+	desc += " A strong interference renders this inoperable."
 	machine_stat |= BROKEN
 	anchored = FALSE
 	if(timer_enabled)

--- a/code/game/objects/machinery/nuclearbomb.dm
+++ b/code/game/objects/machinery/nuclearbomb.dm
@@ -39,6 +39,7 @@
 	countdown = new(src)
 	name = "[initial(name)] ([UNIQUEID])"
 	SSminimaps.add_marker(src, z, MINIMAP_FLAG_ALL, "nuke")
+	RegisterSignal(SSdcs, COMSIG_GLOB_DROPSHIP_HIJACKED, .proc/disable_on_hijack)
 
 
 /obj/machinery/nuclearbomb/Destroy()
@@ -92,6 +93,14 @@
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NUKE_EXPLODED, z)
 	return TRUE
 
+/// Permanently disables this nuke, for use on hijack
+/obj/machinery/nuclearbomb/proc/disable_on_hijack()
+	desc += " Something seems to be wrong with it."
+	machine_stat |= BROKEN
+	anchored = FALSE
+	if(timer_enabled)
+		timer_enabled = FALSE
+		stop_processing()
 
 /obj/machinery/nuclearbomb/attackby(obj/item/I, mob/user, params)
 	. = ..()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disables: Nuke disk gens, intel computers, and the nuke itself.

## Why It's Good For The Game

Fix good.

## Changelog
:cl:
fix: Fixed some groundside machinery not deactivating on hijack (like the nuke)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
