### PR TITLE
Allow many non-combat essential objects to be slashed at all or faster by xenos

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -200,8 +200,10 @@
 		else
 			X.visible_message(span_danger("\The [X] smashes \the [src]!"), \
 			span_danger("We smash \the [src]!"), null, 5)
+			take_damage(damage_amount, damage_type, damage_flag, effects, null, armor_penetration)
 		SEND_SIGNAL(X, COMSIG_XENOMORPH_ATTACK_CLOSET)
 	else if(!opened)
+		X.changeNext_move(0) // opening an unlocked closet does not trigger attack cooldown
 		return attack_hand(X)
 
 /obj/structure/closet/attackby(obj/item/I, mob/user, params)

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -4,6 +4,7 @@
 	icon_state = "coffin"
 	icon_closed = "coffin"
 	icon_opened = "coffin_open"
+	max_integrity = 40
 	anchored = FALSE
 
 /obj/structure/closet/coffin/update_icon_state()

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -7,7 +7,7 @@
 	anchored = FALSE
 	var/dropmetal = TRUE
 	resistance_flags = XENO_DAMAGEABLE
-	max_integrity = 100
+	max_integrity = 40
 	hit_sound = 'sound/effects/woodhit.ogg'
 	var/spawn_type
 	var/spawn_amount

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -7,6 +7,8 @@
 	density = TRUE
 	drag_delay = 1
 	coverage = 20
+	resistance_flags = XENO_DAMAGEABLE
+	max_integrity = 100
 	//copypaste sorry
 	var/amount_per_transfer_from_this = 5 //shit I dunno, adding this so syringes stop runtime erroring. --NeoFite
 	var/obj/item/storage/bag/trash/mybag

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -204,6 +204,7 @@ obj/item/alienjar
 	anchored = TRUE
 	layer = MOB_LAYER
 	resistance_flags = XENO_DAMAGEABLE
+	max_integrity = 100
 
 /obj/structure/plasticflaps/CanAllowThrough(atom/A, turf/T)
 	. = ..()

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -57,6 +57,7 @@
 	icon_state = "mopbucket"
 	anchored = FALSE
 	resistance_flags = XENO_DAMAGEABLE
+	max_integrity = 40
 	var/amount_per_transfer_from_this = 5 //Shit I dunno, adding this so syringes stop runtime erroring. --NeoFite
 
 /obj/structure/mopbucket/Initialize()

--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -7,6 +7,8 @@
 	icon_state = "watertank"
 	density = TRUE
 	anchored = FALSE
+	resistance_flags = XENO_DAMAGEABLE
+	max_integrity = 100
 	///high chance to block bullets, offset by being unanchored
 	coverage = 80
 	///maximum tank capacity used to set reagents in initialize

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -10,6 +10,7 @@
 	coverage = 20
 	layer = BELOW_OBJ_LAYER
 	resistance_flags = XENO_DAMAGEABLE
+	max_integrity = 40
 
 	var/draw_warnings = 1 //Set to 0 to stop it from drawing the alert lights.
 

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -6,3 +6,4 @@
 	density = TRUE
 	anchored = FALSE
 	resistance_flags = XENO_DAMAGEABLE
+	max_integrity = 100

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -16,6 +16,8 @@
 	icon_state = "filingcabinet"
 	density = TRUE
 	anchored = TRUE
+	resistance_flags = XENO_DAMAGEABLE
+	max_integrity = 100
 
 
 /obj/structure/filingcabinet/chestdrawer

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -61,6 +61,8 @@ GLOBAL_LIST_EMPTY(tagger_locations)
 				to_chat(user, span_notice("It has a note attached which reads, \"[examtext]\""))
 		return
 
+/obj/structure/bigDelivery/attack_alien(mob/living/carbon/xenomorph/X, damage_amount, damage_type, damage_flag, effects, armor_penetration, isrightclick)
+	attack_hand(X)
 
 /obj/structure/bigDelivery/attackby(obj/item/I, mob/user, params)
 	. = ..()

--- a/code/modules/vehicles/train.dm
+++ b/code/modules/vehicles/train.dm
@@ -76,10 +76,6 @@
 // Latching/unlatching procs
 //-------------------------------------------
 
-//Xeno interaction with the Cargo Tug Train
-/obj/vehicle/train/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
-	attack_hand(X)
-
 //attempts to attach src as a follower of the train T
 /obj/vehicle/train/proc/attach_to(obj/vehicle/train/T, mob/user, silent=FALSE)
 	if(!istype(user))


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See changelog.

Part 1 of X.

## Why It's Good For The Game

Closets (including coffins and toggleable crates) probably should not be immune from slash destruction, and opening one should not trigger attack cooldown.
Wooden crates, barrels, cases, plastic flaps, beer kegs, ore boxes hydro trays etc.. take a long time to destroy especially with acid which is even slower than slashing which the majority of overlooked movement blocking objects lack the resistance flag for.

## Changelog
:cl:
balance: Reduced the max_integrity of: coffins, large crates (the kind that must be broken or opened with a crowbar), cases, barrels, ore boxes, plastic flaps, hydro trays, mop buckets, janitorial carts, filing cabinets, and reagent dispensers.
fix: Added the xeno damageable flag to: janitorial carts, filing cabinets and reagent dispensers (beer keg, boozeomat, etc..)
fix: Removed useless train vehicle attack_alien override preventing damage. 
fix: Fixed xenos not being able to open wrapped large parcels i.e. wrapped lockers.
fix: Opening gracefully, not smashing, closets does not put xeno attack on cooldown.
fix: Fixed closets not taking damage from slashes even though the animation played and informed the xeno they "smashed" the object.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
