### PR TITLE
Disables SADAR from firing until wielded

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -601,7 +601,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	flags_equip_slot = NONE
 	w_class = WEIGHT_CLASS_HUGE
 	force = 15
-	wield_delay = 20
+	wield_delay = 12
 	wield_penalty = 1.6 SECONDS
 	aim_slowdown = 1.75
 	general_codex_key = "explosive weapons"

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -587,6 +587,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	desc = "The RL-152 is the primary anti-armor weapon of the TGMC. Used to take out light-tanks and enemy structures, the RL-152 rocket launcher is a dangerous weapon with a variety of combat uses. Uses a variety of 84mm rockets."
 	icon_state = "m5"
 	item_state = "m5"
+	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_WIELDED_STABLE_FIRING_ONLY
 	max_shells = 1 //codex
 	caliber = CALIBER_84MM //codex
 	load_method = SINGLE_CASING //codex
@@ -600,7 +601,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	flags_equip_slot = NONE
 	w_class = WEIGHT_CLASS_HUGE
 	force = 15
-	wield_delay = 12
+	wield_delay = 20
 	wield_penalty = 1.6 SECONDS
 	aim_slowdown = 1.75
 	general_codex_key = "explosive weapons"


### PR DESCRIPTION
## About The Pull Request
Per title. SADAR can no longer be fired until wielded.

## Why It's Good For The Game
People are insta PBing out of knockdown/stuns with SADAR AP. Yet another example of rocket tag gameplay with no viable or enjoyable response.

## Changelog
:cl: Lewdcifer
balance: SADAR is unable to fire until wielded.
/:cl: