### PR TITLE
Nerfs SG minigun sunder

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1120,7 +1120,7 @@ datum/ammo/bullet/revolver/tp44
 	accurate_range = 12
 	damage = 10
 	penetration = 15
-	sundering = 2
+	sundering = 1
 
 /datum/ammo/bullet/turret
 	name = "autocannon bullet"


### PR DESCRIPTION
## About The Pull Request
Per title. Sundering value reduced from 2 > 1.

## Why It's Good For The Game
SG Miniguns are sundering really quickly, faster than Hivelords can treat entire hives worth of sunder.

## Changelog
:cl: Lewdcifer
balance: SG minigun sunder 2 > 1.
/:cl: