### PR TITLE
Nerfs the lasgun sniper

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1793,7 +1793,7 @@ datum/ammo/bullet/revolver/tp44
 /datum/ammo/energy/lasgun/marine/sniper
 	name = "sniper laser bolt"
 	hud_state = "laser_sniper"
-	damage = 70
+	damage = 50
 	penetration = 30
 	flags_ammo_behavior = AMMO_ENERGY|AMMO_IFF|AMMO_SUNDERING|AMMO_HITSCAN|AMMO_SNIPER
 	max_range = 40

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -645,7 +645,7 @@
 	starting_attachment_types = list(/obj/item/attachable/scope/unremovable/laser_sniper_scope)
 
 	iff_marine_damage_falloff = -0.10
-	aim_slowdown = 0.7
+	aim_slowdown = 2.0
 	wield_delay = 0.7 SECONDS
 	scatter = 0
 	scatter_unwielded = 10


### PR DESCRIPTION
## About The Pull Request
Per title. I am aware of the existence of another PR (#10353) but I disagree with its small changes.

## Why It's Good For The Game
Many sniper guns are forced to aim mode with considerable slowdown, yet you gave a sniper gun normal slowdown with in built IFF...
Damage reduced, since it's very quickly melting through xenos and can be stacked with ease.

## Changelog
:cl: Lewdcifer
balance: Lasgun sniper damage 70 > 50, wielded slowdown 0.7 > 2.0.
/:cl: