### PR TITLE
Resizing bandannas (both kinds), heat absorbent coif/rebreather, and surgery cap

### DIFF
--- a/code/modules/clothing/head/head.dm
+++ b/code/modules/clothing/head/head.dm
@@ -23,6 +23,7 @@
 		slot_l_hand_str = 'icons/mob/items_lefthand_1.dmi',
 		slot_r_hand_str = 'icons/mob/items_righthand_1.dmi',)
 	icon_state = "band"
+	w_class = WEIGHT_CLASS_TINY
 	flags_inv_hide = NONE
 	flags_item_map_variant = (ITEM_JUNGLE_VARIANT|ITEM_ICE_VARIANT)
 

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -91,6 +91,7 @@
 	name = "surgical cap"
 	desc = "A cap surgeons wear during operations. Keeps their hair from tickling your internal organs."
 	icon_state = "surgcap_blue"
+	w_class = WEIGHT_CLASS_TINY
 	flags_inv_hide = HIDETOPHAIR
 
 /obj/item/clothing/head/surgery/purple

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -48,6 +48,7 @@
 	desc = "A close-fitting device that instantly heats or cools down air when you inhale so it doesn't damage your lungs."
 	icon_state = "rebreather"
 	item_state = "rebreather"
+	w_class = WEIGHT_CLASS_SMALL
 	flags_armor_protection = NONE
 	flags_inventory = COVERMOUTH|COVEREYES|ALLOWINTERNALS|BLOCKGASEFFECT |ALLOWREBREATH
 	flags_inv_hide = HIDELOWHAIR
@@ -71,6 +72,7 @@
 	desc = "A colored, resilient, and insulating cloth to cover your face from the elements. This one is Desert Tan"
 	icon_state = "bandanna"
 	item_state = "bandanna"
+	w_class = WEIGHT_CLASS_TINY
 	flags_armor_protection = NONE
 	flags_armor_protection = FACE
 	flags_inv_hide = HIDEFACE|HIDELOWHAIR


### PR DESCRIPTION
Makes rebreather and coif SMALL class like the gasmasks, makes bandannas (head and face) and surgical caps TINY class.

## About The Pull Request
An absolutely useless PR except for roleplayers and bandanna enthusiasts. Ever got frustrated when you wanted to keep a bandanna in your pack or webbing but it was too big? Not anymore! Ever have the same problem but with HAC (marine coif) or rebreather (no one cares about rebreather)? Those are fixed too! I could have kept surgery cap at SMALL class since it seems like a random change, but honestly its like, a wearable napkin, it didn't feel fair to keep it in the same weight class as a slouch hat or gasmask. _**I did NOT include headband however as it has (barely any) armor and decap protection.**_

I saw a good PR while putting this together that has good ideas for head bandannas, 

## Why It's Good For The Game
Well, it doesn't break anything. 
Jokes aside this is a PR for consistency in headgear sizes, basically has no effect on anything important while being more 'accurate'. Basically a spelling fix for 3 words on a 10 page essay.

## Changelog
:cl:
fix: fixed rebreathers and heat absorbent coif being larger than transparent and tactical gasmasks.
/:cl: