### PR TITLE
Shifts projectile flamer to deal damage on hit

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -59,6 +59,8 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	var/deflagrate_multiplier = 1
 	///Flat damage caused if fire_burst is triggered by deflagrate
 	var/fire_burst_damage = 10
+	///Base fire stacks added on hit if the projectile has AMMO_INCENDIARY
+	var/incendiary_strength = 10
 
 /datum/ammo/proc/do_at_max_range(obj/projectile/proj)
 	return
@@ -2545,19 +2547,21 @@ datum/ammo/bullet/revolver/tp44
 	hud_state = "flame"
 	hud_state_empty = "flame_empty"
 	damage_type = BURN
-	flags_ammo_behavior = AMMO_INCENDIARY|AMMO_IGNORE_ARMOR|AMMO_FLAME|AMMO_EXPLOSIVE
+	flags_ammo_behavior = AMMO_INCENDIARY|AMMO_FLAME|AMMO_EXPLOSIVE
 	armor_type = "fire"
 	max_range = 7
-	damage = 0
+	damage = 31
+	damage_falloff = 0
+	incendiary_strength = 30 //Firestacks cap at 20, but that's after armor.
 	bullet_color = LIGHT_COLOR_FIRE
 	var/fire_color = "red"
-	var/burnlevel = 31
 	var/burntime = 17
+	var/burnlevel = 31
 
 /datum/ammo/flamethrower/drop_flame(turf/T)
 	if(!istype(T))
 		return
-	T.ignite(burntime, burnlevel, fire_color, burnlevel)
+	T.ignite(burntime, burnlevel, fire_color)
 
 /datum/ammo/flamethrower/on_hit_mob(mob/M,obj/projectile/P)
 	drop_flame(get_turf(M))
@@ -2581,8 +2585,8 @@ datum/ammo/bullet/revolver/tp44
 	hud_state = "flame_blue"
 	max_range = 7
 	fire_color = "blue"
-	burnlevel = 46
 	burntime = 40
+	burnlevel = 46
 	bullet_color = COLOR_NAVY
 
 /datum/ammo/water

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -246,16 +246,6 @@
 /obj/item/weapon/gun/flamer/proc/flame_turf(turf/turf_to_ignite, mob/living/user, burn_time, burn_level, fire_color = "red")
 	turf_to_ignite.ignite(burn_time, burn_level, fire_color)
 
-	// Melt a single layer of snow
-	if(istype(turf_to_ignite, /turf/open/floor/plating/ground/snow))
-		var/turf/open/floor/plating/ground/snow/snow_turf = turf_to_ignite
-		if(snow_turf.slayer > 0)
-			snow_turf.slayer -= 1
-			snow_turf.update_icon(1, 0)
-
-	for(var/obj/structure/jungle/vines/vines in turf_to_ignite)
-		QDEL_NULL(vines)
-
 	var/fire_mod
 	for(var/mob/living/mob_caught in turf_to_ignite) //Deal bonus damage if someone's caught directly in initial stream
 		if(mob_caught.stat == DEAD)
@@ -447,6 +437,15 @@
 
 	new /obj/flamer_fire(src, fire_lvl, burn_lvl, f_color, fire_stacks, fire_damage)
 
+	for(var/obj/structure/jungle/vines/vines in src)
+		QDEL_NULL(vines)
+
+/turf/open/floor/plating/ground/snow/ignite(fire_lvl, burn_lvl, f_color, fire_stacks = 0, fire_damage = 0)
+	if(slayer > 0)
+		slayer -= 1
+		update_icon(1, 0)
+	return ..()
+
 //////////////////////////////////////////////////////////////////////////////////////////////////
 //Time to redo part of abby's code.
 //Create a flame sprite object. Doesn't work like regular fire, ie. does not affect atmos or heat
@@ -493,6 +492,7 @@
 		COMSIG_ATOM_ENTERED = .proc/on_cross,
 	)
 	AddElement(/datum/element/connect_loc, connections)
+
 
 /obj/flamer_fire/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -923,7 +923,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 		var/fire_mod = get_fire_resist()
 		var/fire_hard_armor = get_hard_armor("fire", BODY_ZONE_CHEST)
 		if(fire_mod > 0 && fire_hard_armor < 100) //If the modifier is not bigger than zero or the hard armor is 100 then the armor fully absorbs this effect.
-			adjust_fire_stacks(CEILING(10 * fire_mod * ((100- fire_hard_armor) * 0.01), 1)) //We could add an ammo fire strength in time, as a variable.
+			adjust_fire_stacks(CEILING(proj.ammo.incendiary_strength * fire_mod * ((100- fire_hard_armor) * 0.01), 1)) //We could add an ammo fire strength in time, as a variable.
 			IgniteMob()
 			feedback_flags |= (BULLET_FEEDBACK_FIRE|BULLET_FEEDBACK_SCREAM)
 


### PR DESCRIPTION
## About The Pull Request
Previously all of the damage was dealt through igniting the mob's turf, which led to certain weirdness like not actually damaging moving mobs and AMMO_INCENDIARY code not triggering. This shouldn't change the effective damage in any way, just clean out niche bugs.
Adds an incendiary_strength var to ammo datums to adjust how hard AMMO_INCENDIARY actually ignites stuff.
Also fixes projectile flamer not being able to clear out vines or snow.

## Why It's Good For The Game
Bugfixes

## Changelog
:cl:
balance: Flamer's extended nozzle can remove vines and snow, along with other sources of ground fire.
fix: Flamer projectiles should more reliably ignite on hit.
/:cl: