### PR TITLE
Laser sniper rework (IFF mode seperated)

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1795,10 +1795,17 @@ datum/ammo/bullet/revolver/tp44
 	hud_state = "laser_sniper"
 	damage = 70
 	penetration = 30
-	flags_ammo_behavior = AMMO_ENERGY|AMMO_IFF|AMMO_SUNDERING|AMMO_HITSCAN|AMMO_SNIPER
+	flags_ammo_behavior = AMMO_ENERGY|AMMO_SUNDERING|AMMO_HITSCAN|AMMO_SNIPER
 	max_range = 40
 	damage_falloff = 0
 	hitscan_effect_icon = "beam_heavy"
+
+/datum/ammo/energy/lasgun/marine/sniper/iff
+	name = "sniper laser smartbolt"
+	hud_state = "laser_sniper"
+	damage = 50
+	penetration = 30
+	flags_ammo_behavior = AMMO_ENERGY|AMMO_SUNDERING|AMMO_IFF|AMMO_HITSCAN|AMMO_SNIPER
 
 /datum/ammo/energy/lasgun/marine/sniper_heat
 	name = "sniper heat bolt"

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -296,6 +296,8 @@
 	var/radial_icon = 'icons/mob/radial.dmi'
 	///The icon state the radial menu will use.
 	var/radial_icon_state = "laser"
+	///Windup delay modificatoin
+	var/windup_delay = 0
 
 /obj/item/weapon/gun/energy/lasgun/lasrifle/unique_action(mob/user)
 	if(!user)
@@ -319,6 +321,7 @@
 	burst_amount = initial(choice.burst_amount)
 	fire_sound = initial(choice.fire_sound)
 	rounds_per_shot = initial(choice.rounds_per_shot)
+	windup_delay = initial(choice.windup_delay)
 	SEND_SIGNAL(src, COMSIG_GUN_BURST_SHOTS_TO_FIRE_MODIFIED, burst_amount)
 	SEND_SIGNAL(src, COMSIG_GUN_AUTOFIREDELAY_MODIFIED, fire_delay)
 	SEND_SIGNAL(src, COMSIG_GUN_FIRE_MODE_TOGGLE, initial(choice.fire_mode), user.client)
@@ -612,7 +615,7 @@
 
 /obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_sniper
 	name = "\improper Terra Experimental laser sniper rifle"
-	desc = "The T-ES, a Terra Experimental standard issue laser sniper rifle, it has an integrated charge selector for normal and heat settings. Uses standard Terra Experimental (abbreviated as TE) power cells. As with all TE Laser weapons, they use a lightweight alloy combined without the need for bullets any longer decreases their weight and aiming speed quite some vs their ballistic counterparts."
+	desc = "The T-ES, a Terra Experimental standard issue laser sniper rifle, it has an integrated charge selector for normal, IFF via laserbending through a internal computer at the cost of reduced damage, and a microwave setting that sets foes on fire. Uses standard Terra Experimental (abbreviated as TE) power cells. As with all TE Laser weapons, they use a lightweight alloy combined without the need for bullets any longer decreases their weight and aiming speed quite some vs their ballistic counterparts."
 	reload_sound = 'sound/weapons/guns/interact/standard_laser_sniper_reload.ogg'
 	fire_sound = 'sound/weapons/guns/fire/Laser Sniper Standard.ogg'
 	icon_state = "tes"
@@ -625,6 +628,7 @@
 	damage_falloff_mult = 0
 	gun_firemode = GUN_FIREMODE_SEMIAUTO
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO)
+	windup_delay = 0
 
 	ammo_level_icon = "te"
 	icon_overlay_x_offset = -1
@@ -655,20 +659,28 @@
 	movement_acc_penalty_mult = 6
 	mode_list = list(
 		"Standard" = /datum/lasrifle/base/energy_sniper_mode/standard,
+		"Smart" = /datum/lasrifle/base/energy_sniper_mode/standard/IFF,
 		"Focused" = /datum/lasrifle/base/energy_sniper_mode/heat,
 	)
 
 /datum/lasrifle/base/energy_sniper_mode/standard
 	rounds_per_shot = 50
+	windup_delay = 0
 	fire_delay = 1 SECONDS
 	ammo_datum_type = /datum/ammo/energy/lasgun/marine/sniper
 	fire_sound = 'sound/weapons/guns/fire/Laser Sniper Standard.ogg'
-	message_to_user = "You set the sniper rifle's charge mode to IFF fire."
+	message_to_user = "You set the sniper rifle's charge mode to normal fire."
 	fire_mode = GUN_FIREMODE_SEMIAUTO
 	icon_state = "tes"
 
+/datum/lasrifle/base/energy_sniper_mode/standard/IFF
+	windup_delay = 0.5 SECONDS
+	ammo_datum_type = /datum/ammo/energy/lasgun/marine/sniper/iff
+	message_to_user = "You set the sniper rifle's charge mode to IFF fire."
+
 /datum/lasrifle/base/energy_sniper_mode/heat
 	rounds_per_shot = 150
+	windup_delay = 0
 	fire_delay = 1 SECONDS
 	ammo_datum_type = /datum/ammo/energy/lasgun/marine/sniper_heat
 	fire_sound = 'sound/weapons/guns/fire/laser3.ogg'


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Seperates IFF mode from normal mode, redoes description.

IFF MODE STATS
-
50/30 damage and 30 pen.
Short windup. (0.5)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes laser sniper not trash poopoo and gives it some level of gimmick.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Laser sniper IFF mode detangled from normal fire, it has a windup when firing, normal fire readded. IFF mode does lower damage, but is otherwise the same aside from damage and windup
spellcheck: Redid the description for laser sniper to be a bit more fluff due to the rework.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
