### PR TITLE
LV-624 changes: Remove chokepoint in cave, add crowbars in LZ, and make Sand Temple underground

### DIFF
--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -12517,6 +12517,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle8)
+"lfr" = (
+/obj/item/tool/crowbar,
+/turf/open/floor/marking/warning{
+	dir = 10
+	},
+/area/lv624/lazarus/spaceport)
 "lfE" = (
 /obj/effect/spawner/random/toolbox,
 /turf/open/ground/grass,
@@ -17805,6 +17811,10 @@
 	dir = 8
 	},
 /area/lv624/ground/jungle10)
+"rJe" = (
+/obj/item/tool/crowbar,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
 "rJh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -33079,7 +33089,7 @@ aym
 bfR
 bfR
 bfR
-aWe
+bfR
 bfR
 bfR
 bfR
@@ -33251,13 +33261,13 @@ abc
 abc
 abc
 aTS
-aWe
+bfR
 bfR
 bfR
 bpA
 bfR
 bfR
-aWe
+bfR
 bfR
 bfR
 bfR
@@ -33605,13 +33615,13 @@ abc
 abc
 abc
 aTS
-aWe
+bfR
 bfR
 bpA
 bfR
 bpA
 bfR
-aWe
+bfR
 bfR
 bfR
 eud
@@ -33787,7 +33797,7 @@ aym
 bfR
 bfR
 bfR
-aWe
+bfR
 bfR
 bfR
 bfR
@@ -33963,8 +33973,8 @@ xLJ
 xLJ
 aym
 bfR
-aWe
-aWe
+bfR
+bfR
 bfR
 eud
 bfR
@@ -34144,7 +34154,7 @@ aIm
 aIm
 aWe
 aWe
-aWe
+bfR
 aIm
 aIm
 aWe
@@ -38470,7 +38480,7 @@ kdu
 tSf
 eDX
 vvX
-vvX
+rJe
 mON
 vvX
 wEr
@@ -55993,7 +56003,7 @@ sPW
 qnx
 gif
 hVV
-iOa
+lfr
 tMe
 iPZ
 ens

--- a/code/game/area/lv624.dm
+++ b/code/game/area/lv624.dm
@@ -385,6 +385,7 @@
 	name = "\improper Mysterious Temple"
 	icon_state = "sandtemple"
 	always_unpowered = TRUE
+	ceiling = CEILING_DEEP_UNDERGROUND
 
 /area/lv624/lazarus/sandtemple/sideroom //needed to allow nuke generator within temple to function
 	name = "\improper Mysterious Temple"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/6610922/171753605-8e618105-cb33-42ef-8396-1a62212041db.png)

![image](https://user-images.githubusercontent.com/6610922/171753810-4df3282f-1cb0-4f42-acc0-9a4da4dcc7af.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This chokepoint is the bane of marines and xenomorphs. Marines can't push else they get screw over by stun castes and xenomorphs can't push else they eat lead. Fundamentally, this chokepoint is the hallmark of a map design that mappers must keep in mind: avoid 1-tile entry in large traffic else you create chokepoints.

In Distress, it is pain.

In Nuclear War, it is less pain unless marines choose to push silo.

Also, add crowbar just to let anyone with incentive to break open boxes and connect plasteel.

Also, saw RipGrayson saying to make sand temple underground, so one line add.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: A memorable chokepoint in LV-624 cave
add: sand temple in LV-624 is now underground
add: crowbar in LV-624 LZ
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
