### PR TITLE
Prison Station Remap: Nuclear War Edition

### DIFF
--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -8,15 +8,14 @@
 /turf/open/space/sea,
 /area/space)
 "aac" = (
-/obj/machinery/computer/nuke_disk_generator/green,
 /turf/open/floor/prison/darkred{
 	dir = 1
 	},
 /area/prison/security/checkpoint/maxsec_highsec)
 "aad" = (
-/obj/effect/landmark/nuke_spawn,
-/turf/open/floor/plating/platebot,
-/area/prison/pirate)
+/obj/machinery/door/poddoor/four_tile_hor/secure,
+/turf/open/space/basic,
+/area/prison/research/secret/biolab)
 "aae" = (
 /turf/open/ground/river,
 /area/prison/maintenance/residential/access/north)
@@ -213,8 +212,8 @@
 /turf/open/space/sea,
 /area/space)
 "acE" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall/prison_unmeltable,
+/obj/machinery/door/airlock/mainship/generic,
+/turf/open/shuttle/dropship/three,
 /area/prison/research/secret/biolab)
 "acF" = (
 /turf/open/floor/plating,
@@ -229,8 +228,9 @@
 	},
 /area/prison/cellblock/highsec/north/north)
 "acH" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall/prison,
+/turf/open/shuttle/dropship{
+	icon_state = "floor8"
+	},
 /area/prison/research/secret/biolab)
 "acI" = (
 /obj/machinery/light/small{
@@ -239,10 +239,7 @@
 /turf/open/floor/plating,
 /area/prison/research/secret/biolab)
 "acJ" = (
-/obj/effect/landmark/corpsespawner/prisoner,
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plating,
+/turf/open/space/sea,
 /area/prison/research/secret/biolab)
 "acK" = (
 /turf/closed/wall/r_wall/prison_unmeltable,
@@ -317,15 +314,6 @@
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/cellblock/maxsec/north)
-"acU" = (
-/obj/structure/window/framed/prison/reinforced,
-/obj/machinery/door/poddoor/shutters/mainship/open{
-	dir = 2;
-	id = "biological_testing_1"
-	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating,
-/area/prison/research/secret/biolab)
 "acV" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -337,8 +325,6 @@
 	dir = 2;
 	id = "biological_testing_1"
 	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating,
 /area/prison/research/secret/biolab)
 "acW" = (
@@ -349,8 +335,9 @@
 	dir = 2;
 	id = "biological_testing_1"
 	},
-/obj/effect/landmark/xeno_resin_door,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/machinery/door/window{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/prison/research/secret/biolab)
 "acX" = (
@@ -446,14 +433,10 @@
 /turf/open/floor/prison/plate,
 /area/prison/research/secret/biolab)
 "adi" = (
-/obj/machinery/disposal,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/thin,
-/obj/structure/disposalpipe/up{
-	dir = 1
-	},
 /turf/open/floor/prison/plate,
 /area/prison/research/secret/biolab)
 "adj" = (
@@ -1139,10 +1122,9 @@
 /turf/open/floor/prison/cleanmarked,
 /area/prison/research/secret/biolab)
 "afk" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/vials,
-/turf/open/floor/prison/whitepurple/full,
-/area/prison/research/secret/bioengineering)
+/obj/machinery/door/poddoor/four_tile_hor/secure,
+/turf/open/space/sea,
+/area/prison/research/secret/biolab)
 "afl" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/beakers{
@@ -1297,17 +1279,10 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research/secret/biolab)
 "afH" = (
-/obj/item/storage/fancy/vials/prison,
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/prison/whitepurple/full,
-/area/prison/research/secret/bioengineering)
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating,
+/area/prison/research/secret/biolab)
 "afI" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
 /turf/open/floor/prison/whitepurple{
 	dir = 9
 	},
@@ -1504,6 +1479,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/item/weapon/gun/smg/m25/elite,
+/obj/item/ammo_casing,
 /turf/open/floor/prison/whitepurple{
 	dir = 4
 	},
@@ -1620,28 +1599,20 @@
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/north)
 "agG" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 6
+/turf/closed/shuttle/ert{
+	icon_state = "nt20"
 	},
-/obj/machinery/door/airlock/mainship/maint/free_access,
-/turf/open/floor/plating,
-/area/prison/research/secret/containment)
+/area/prison/research/secret/biolab)
 "agH" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/machinery/light/small{
-	dir = 1
+/turf/closed/shuttle/ert{
+	icon_state = "nt27"
 	},
-/turf/open/floor/plating,
-/area/prison/research/secret/containment)
+/area/prison/research/secret/biolab)
 "agI" = (
-/obj/structure/bed,
-/obj/machinery/light/small{
-	dir = 1
+/turf/closed/shuttle/ert{
+	icon_state = "nt25"
 	},
-/obj/effect/landmark/corpsespawner/prisoner,
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/prison,
-/area/prison/research/secret/containment)
+/area/prison/research/secret/biolab)
 "agJ" = (
 /turf/closed/wall/prison,
 /area/prison/research/secret/containment)
@@ -1650,6 +1621,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison,
 /area/prison/research/secret/containment)
 "agL" = (
@@ -1711,8 +1684,10 @@
 	},
 /area/prison/security/monitoring/maxsec/panopticon)
 "agW" = (
-/turf/open/floor/plating,
-/area/prison/research/secret/containment)
+/turf/closed/shuttle/ert{
+	icon_state = "nt22"
+	},
+/area/prison/research/secret/biolab)
 "agX" = (
 /obj/structure/toilet{
 	dir = 4
@@ -1768,9 +1743,8 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research/secret/bioengineering)
 "ahe" = (
-/obj/machinery/computer/nuke_disk_generator/blue,
-/turf/open/floor/prison/sterilewhite,
-/area/prison/research/secret/bioengineering)
+/turf/open/shuttle/dropship/floor,
+/area/prison/research/secret/biolab)
 "ahf" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/prison/sterilewhite,
@@ -1787,14 +1761,10 @@
 /turf/open/floor/prison,
 /area/prison/cellblock/maxsec/north)
 "ahi" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
+/turf/closed/shuttle/ert{
+	icon_state = "nt23"
 	},
-/obj/machinery/door/airlock/mainship/maint/free_access{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/prison/research/secret/containment)
+/area/prison/research/secret/biolab)
 "ahj" = (
 /obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 2;
@@ -1849,6 +1819,11 @@
 /area/prison/research/secret/bioengineering)
 "ahq" = (
 /obj/machinery/door/window/right,
+/obj/effect/landmark/corpsespawner/syndicatecommando,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/item/weapon/gun/rifle/mpi_km,
+/obj/item/ammo_casing,
+/obj/item/paper/syndicateraid,
 /turf/open/floor/prison/whitepurple{
 	dir = 4
 	},
@@ -1892,9 +1867,6 @@
 /turf/open/floor/prison,
 /area/prison/cellblock/maxsec/north)
 "ahw" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/north)
@@ -1987,6 +1959,8 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
+/obj/effect/landmark/corpsespawner/scientist,
+/obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research/secret/bioengineering)
 "ahI" = (
@@ -1995,11 +1969,9 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research/secret/bioengineering)
 "ahJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/landmark/corpsespawner/scientist,
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/prison/sterilewhite,
-/area/prison/research/secret/bioengineering)
+/obj/item/paper/pmc,
+/turf/open/shuttle/dropship/three,
+/area/prison/research/secret/biolab)
 "ahK" = (
 /obj/item/shard,
 /obj/item/stack/rods,
@@ -2672,6 +2644,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/prison/darkpurple/corner{
 	dir = 4
 	},
@@ -2739,13 +2713,11 @@
 /turf/open/floor/prison,
 /area/prison/cellblock/maxsec/north)
 "ajR" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/prison/darkpurple{
-	dir = 9
-	},
-/area/prison/research/secret/containment)
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/multitool,
+/turf/open/shuttle/dropship/floor,
+/area/prison/research/secret/biolab)
 "ajS" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -4009,8 +3981,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint/free_access{
-	name = "Research-Infirmary Maintenance"
+/obj/machinery/door/airlock/multi_tile/mainship/maint/free_access{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/south)
@@ -4146,8 +4118,9 @@
 /turf/open/floor/plating,
 /area/prison/security/checkpoint/maxsec)
 "anV" = (
-/turf/closed/wall/r_wall/prison,
-/area/prison/maintenance/research_medbay)
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating,
+/area/prison/research/secret/containment)
 "anW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison,
@@ -4446,8 +4419,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint/free_access{
-	name = "Research-Infirmary Maintenance"
+/obj/machinery/door/airlock/multi_tile/mainship/maint/free_access{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/research_medbay)
@@ -6573,10 +6546,11 @@
 /turf/open/floor/prison/whitegreen/full,
 /area/prison/medbay)
 "auV" = (
-/obj/structure/bed/chair/wheelchair,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/computer/nuke_disk_generator/green,
+/obj/structure/cable,
 /turf/open/floor/prison/whitegreen{
 	dir = 9
 	},
@@ -7153,15 +7127,10 @@
 /turf/open/floor/plating,
 /area/prison/hangar_storage/research)
 "awG" = (
-/obj/structure/bed/roller,
-/obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 8
+/turf/open/shuttle/dropship{
+	icon_state = "rasputin6"
 	},
-/turf/open/floor/prison/whitegreen{
-	dir = 4
-	},
-/area/prison/medbay)
+/area/prison/research/secret/biolab)
 "awH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -7634,6 +7603,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood,
+/obj/machinery/door/airlock/multi_tile/secure,
 /turf/open/floor/prison/red/corner{
 	dir = 8
 	},
@@ -8317,12 +8287,14 @@
 /obj/structure/bed/chair/office/light{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/medbay)
 "aAq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/medbay)
 "aAr" = (
@@ -11119,11 +11091,9 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/north)
 "aIA" = (
-/obj/effect/landmark/start/job/xenomorph,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/prison/bright_clean,
-/area/prison/yard)
+/obj/structure/girder/reinforced,
+/turf/open/floor/prison,
+/area/prison/research/secret/containment)
 "aIB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -12806,7 +12776,6 @@
 /area/prison/cellblock/lowsec/ne)
 "aNr" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/prison,
 /area/prison/cellblock/lowsec/ne)
 "aNs" = (
@@ -14331,7 +14300,6 @@
 /area/prison/security/checkpoint/highsec/n)
 "aSc" = (
 /obj/machinery/door/airlock/mainship/maint/free_access,
-/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/prison/cellblock/lowsec/nw)
 "aSd" = (
@@ -14367,7 +14335,6 @@
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "Low-Security"
 	},
-/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
 "aSk" = (
@@ -15298,7 +15265,6 @@
 /area/prison/security/monitoring/highsec)
 "aUU" = (
 /obj/machinery/door/airlock/mainship/maint/free_access,
-/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/prison/security/monitoring/lowsec/ne)
 "aUV" = (
@@ -18012,9 +17978,11 @@
 	},
 /area/prison/security/monitoring/maxsec/panopticon)
 "bdt" = (
-/obj/effect/landmark/start/job/xenomorph,
-/turf/open/floor/prison/bright_clean/two,
-/area/prison/yard)
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/prison/cellblock/maxsec/south)
 "bdu" = (
 /obj/structure/sink{
 	pixel_y = 15
@@ -18794,6 +18762,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/corpsespawner/prisoner,
 /turf/open/floor/prison/bright_clean,
 /area/prison/canteen)
 "bfE" = (
@@ -19331,6 +19300,7 @@
 	},
 /area/prison/hallway/central)
 "bha" = (
+/obj/item/ammo_casing,
 /turf/open/floor/prison,
 /area/prison/canteen)
 "bhb" = (
@@ -19604,6 +19574,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/ammo_magazine/rifle/mpi_km,
+/obj/item/ammo_casing,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/canteen)
 "bhQ" = (
@@ -19715,6 +19687,7 @@
 	dir = 2;
 	name = "Canteen"
 	},
+/obj/item/ammo_casing,
 /turf/open/floor/prison,
 /area/prison/canteen)
 "bih" = (
@@ -19728,6 +19701,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/ammo_casing,
 /turf/open/floor/prison/bright_clean,
 /area/prison/canteen)
 "bii" = (
@@ -19744,6 +19718,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison/bright_clean,
 /area/prison/canteen)
 "bij" = (
@@ -19909,6 +19885,8 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 2
 	},
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/kitchen)
 "bix" = (
@@ -20153,6 +20131,7 @@
 "bjm" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/ammo_magazine/rifle/m16,
+/obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/yard)
 "bjn" = (
@@ -20188,6 +20167,8 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison/bright_clean,
 /area/prison/canteen)
 "bjs" = (
@@ -20334,6 +20315,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/yard)
 "bjM" = (
@@ -20440,6 +20422,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
+/obj/item/ammo_magazine/rifle/mpi_km,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
 "bkb" = (
@@ -21467,12 +21450,14 @@
 /area/prison/security/monitoring/highsec)
 "bny" = (
 /obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/yard)
 "bnz" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean,
 /area/prison/yard)
 "bnB" = (
@@ -21902,7 +21887,6 @@
 	dir = 2;
 	name = "Low-Security"
 	},
-/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
 "boz" = (
@@ -22295,6 +22279,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/item/ammo_casing,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
 "bpN" = (
@@ -22329,7 +22314,6 @@
 /obj/structure/table/reinforced/flipped{
 	dir = 4
 	},
-/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean,
 /area/prison/yard)
 "bpT" = (
@@ -24735,7 +24719,6 @@
 /area/prison/yard)
 "bxZ" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/prison,
 /area/prison/cellblock/lowsec/se)
 "bya" = (
@@ -27336,7 +27319,6 @@
 /area/prison/cellblock/lowsec/se)
 "bGx" = (
 /obj/machinery/door/airlock/mainship/maint/free_access,
-/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/prison/cellblock/lowsec/se)
 "bGy" = (
@@ -28067,7 +28049,6 @@
 "bIQ" = (
 /obj/item/stack/rods,
 /obj/structure/window_frame/colony/reinforced,
-/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/prison/security/monitoring/lowsec/sw)
 "bIR" = (
@@ -28577,6 +28558,11 @@
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean,
 /area/prison/laundry)
+"bKH" = (
+/obj/structure/bed/chair,
+/obj/item/ammo_casing,
+/turf/open/floor/prison/bright_clean,
+/area/prison/canteen)
 "bKI" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 2;
@@ -28737,6 +28723,7 @@
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/hallway/central)
 "bLk" = (
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/prison/pirate)
 "bLl" = (
@@ -30692,6 +30679,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/computer/nuke_disk_generator/blue,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/engineering)
 "bRG" = (
@@ -34021,6 +34009,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/shuttle/blackfloor,
 /area/prison/pirate)
 "ccP" = (
@@ -35041,9 +35030,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/marking/delivery,
 /area/prison/execution)
 "cfF" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/marking/delivery,
 /area/prison/execution)
 "cfG" = (
@@ -35961,6 +35952,7 @@
 /obj/structure/closet/walllocker/emerglocker/full{
 	dir = 4
 	},
+/obj/item/paper/syndicateraid,
 /turf/open/shuttle/blackfloor,
 /area/prison/pirate)
 "ciN" = (
@@ -36396,9 +36388,6 @@
 /turf/open/floor/plating,
 /area/prison/pirate)
 "cko" = (
-/obj/structure/bed/chair/comfy{
-	dir = 4
-	},
 /obj/machinery/power/apc/drained{
 	dir = 4
 	},
@@ -36510,7 +36499,6 @@
 	dir = 4
 	},
 /obj/structure/closet/walllocker/emerglocker/full,
-/obj/item/weapon/gun/sentry/big_sentry/premade,
 /turf/open/shuttle/blackfloor,
 /area/prison/pirate)
 "ckG" = (
@@ -36985,9 +36973,11 @@
 /turf/open/floor/plating,
 /area/prison/disposal)
 "clQ" = (
-/obj/effect/landmark/corpsespawner/prisoner,
-/turf/open/floor/prison/bright_clean,
-/area/prison/canteen)
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/prison/maintenance/research_medbay)
 "clR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison,
@@ -37198,6 +37188,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean,
 /area/prison/execution)
 "cmC" = (
@@ -37230,6 +37221,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/shuttle/blackfloor,
 /area/prison/pirate)
 "cmG" = (
@@ -37272,6 +37264,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/shuttle,
 /area/prison/pirate)
 "cmN" = (
@@ -37577,9 +37570,8 @@
 /turf/open/floor/plating,
 /area/prison/pirate)
 "cnH" = (
-/obj/item/weapon/gun/sentry/big_sentry/premade,
-/turf/open/floor/plating,
-/area/prison/pirate)
+/turf/open/shuttle/dropship/seven,
+/area/prison/research/secret/biolab)
 "cnI" = (
 /obj/structure/table/reinforced/flipped{
 	dir = 1
@@ -37740,6 +37732,7 @@
 /obj/machinery/door/airlock/mainship/maint/free_access{
 	name = "Disposals"
 	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating,
 /area/prison/disposal)
 "coj" = (
@@ -37987,9 +37980,9 @@
 /turf/open/floor/plating/platebot,
 /area/prison/pirate)
 "cpb" = (
-/obj/item/weapon/gun/sentry/big_sentry/premade,
-/turf/open/floor/plating/platebot,
-/area/prison/pirate)
+/obj/structure/rack,
+/turf/open/shuttle/dropship/floor,
+/area/prison/research/secret/biolab)
 "cpc" = (
 /obj/item/ammo_magazine/rifle/mpi_km,
 /turf/open/floor/plating,
@@ -38132,6 +38125,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4
 	},
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean,
 /area/prison/execution)
 "cpA" = (
@@ -38152,6 +38146,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean,
 /area/prison/execution)
 "cpF" = (
@@ -38161,12 +38156,16 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean,
 /area/prison/execution)
 "cpG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/corpsespawner/prison_security,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean,
 /area/prison/execution)
 "cpH" = (
@@ -38174,6 +38173,7 @@
 	dir = 8;
 	on = 1
 	},
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean,
 /area/prison/execution)
 "cpI" = (
@@ -38232,6 +38232,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/pirate)
 "cpS" = (
@@ -38277,6 +38278,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Rocinante Storage/Medical"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/pirate)
 "cqb" = (
@@ -38342,6 +38344,7 @@
 /turf/open/floor/plating,
 /area/prison/disposal)
 "cqp" = (
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean,
 /area/prison/execution)
 "cqr" = (
@@ -38350,6 +38353,8 @@
 	},
 /obj/item/electropack,
 /obj/item/clothing/head/helmet,
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/prison,
 /area/prison/execution)
 "cqt" = (
@@ -38536,11 +38541,13 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean,
 /area/prison/execution)
 "crc" = (
 /obj/item/tool/wrench,
 /obj/item/tool/screwdriver,
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison,
 /area/prison/execution)
 "crf" = (
@@ -38548,6 +38555,7 @@
 	dir = 8;
 	id = "execution"
 	},
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean,
 /area/prison/execution)
 "crg" = (
@@ -38598,8 +38606,9 @@
 /turf/open/shuttle,
 /area/prison/pirate)
 "crn" = (
-/obj/machinery/computer/communications/bee,
 /obj/structure/table/reinforced,
+/obj/machinery/computer/nuke_disk_generator/red,
+/obj/structure/cable,
 /turf/open/shuttle,
 /area/prison/pirate)
 "cro" = (
@@ -38710,6 +38719,7 @@
 	code = 2;
 	frequency = 1449
 	},
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean,
 /area/prison/execution)
 "crJ" = (
@@ -38755,6 +38765,7 @@
 /area/prison/pirate)
 "crR" = (
 /obj/item/weapon/gun/shotgun/pump/cmb,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/prison/pirate)
 "crS" = (
@@ -38878,10 +38889,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/prison/pirate)
 "csr" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/prison/pirate)
 "css" = (
@@ -38896,6 +38909,7 @@
 	dir = 4;
 	on = 1
 	},
+/obj/structure/cable,
 /turf/open/shuttle,
 /area/prison/pirate)
 "csu" = (
@@ -38918,6 +38932,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/pirate)
 "csx" = (
@@ -39057,7 +39073,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/mainship/maint/free_access,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/south)
 "csZ" = (
@@ -39130,7 +39145,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/mainship/maint/free_access,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/south)
 "ctg" = (
@@ -39299,6 +39313,7 @@
 /area/prison/pirate)
 "ctE" = (
 /obj/item/ammo_magazine/rifle/mpi_km,
+/obj/structure/cable,
 /turf/open/shuttle/blackfloor,
 /area/prison/pirate)
 "ctF" = (
@@ -39353,6 +39368,7 @@
 /turf/open/floor/prison/yellow,
 /area/prison/cellblock/mediumsec/west)
 "ctP" = (
+/obj/effect/landmark/corpsespawner/syndicatecommando,
 /turf/open/floor/prison/yellow/corner{
 	dir = 8
 	},
@@ -39576,6 +39592,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/pirate)
 "cuF" = (
@@ -39767,6 +39784,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/pirate)
 "cvu" = (
@@ -39876,12 +39894,12 @@
 /area/prison/pirate)
 "cvM" = (
 /obj/machinery/sleep_console,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/pirate)
 "cvN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -39967,7 +39985,6 @@
 "cwb" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/pirate)
 "cwc" = (
@@ -40917,9 +40934,6 @@
 	},
 /area/prison/security/monitoring/medsec/south)
 "cAd" = (
-/obj/structure/bed/chair/comfy{
-	dir = 8
-	},
 /turf/open/floor/prison/darkred{
 	dir = 6
 	},
@@ -40929,21 +40943,17 @@
 /turf/open/floor/plating,
 /area/prison/security/monitoring/medsec/south)
 "cAf" = (
-/obj/structure/bed/chair/comfy{
-	dir = 1
-	},
+/obj/structure/closet/secure_closet/security,
 /turf/open/floor/prison/darkred{
 	dir = 10
 	},
 /area/prison/security/monitoring/medsec/south)
 "cAg" = (
-/obj/structure/bed/chair/comfy{
-	dir = 1
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
 	},
-/turf/open/floor/prison/darkred{
-	dir = 6
-	},
-/area/prison/security/monitoring/medsec/south)
+/turf/open/floor/plating,
+/area/prison/maintenance/research_medbay)
 "cCM" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -41034,9 +41044,10 @@
 /turf/closed/wall/r_wall/prison,
 /area/prison/maintenance/residential/sw)
 "cOL" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall/prison_unmeltable,
-/area/prison/cellblock/mediumsec/west)
+/turf/closed/shuttle/ert{
+	icon_state = "nt5"
+	},
+/area/prison/research/secret/biolab)
 "cON" = (
 /obj/structure/sink,
 /turf/open/floor/prison/plate,
@@ -41072,6 +41083,11 @@
 	dir = 1
 	},
 /area/prison/intake)
+"cRg" = (
+/obj/item/frame/table/reinforced,
+/obj/effect/landmark/start/job/xenomorph,
+/turf/open/floor/prison/bright_clean,
+/area/prison/yard)
 "cRI" = (
 /obj/effect/decal/woodsiding{
 	dir = 8
@@ -41256,11 +41272,15 @@
 	dir = 4
 	},
 /area/prison/cellblock/highsec/south/south)
+"dBf" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/landmark/start/job/xenomorph,
+/turf/open/floor/prison/bright_clean/two,
+/area/prison/yard)
 "dBh" = (
-/obj/structure/window/framed/prison/reinforced,
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/floor/plating,
-/area/prison/security/monitoring/lowsec/sw)
+/turf/open/shuttle/dropship/three,
+/area/prison/research/secret/biolab)
 "dCg" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean/two,
@@ -41307,7 +41327,6 @@
 /obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 2
 	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/west)
 "dQA" = (
@@ -41376,6 +41395,10 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/residential/south)
+"eao" = (
+/obj/item/ammo_magazine/rifle/mpi_km,
+/turf/open/floor/prison/bright_clean/two,
+/area/prison/canteen)
 "eaN" = (
 /obj/effect/decal/woodsiding,
 /obj/effect/decal/woodsiding{
@@ -41555,6 +41578,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/kitchen,
 /area/prison/kitchen)
+"ety" = (
+/obj/effect/landmark/corpsespawner/syndicatecommando,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
+/area/prison/pirate)
 "etG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -41663,6 +41691,11 @@
 	},
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/residential/south)
+"eHT" = (
+/obj/structure/bed/chair,
+/obj/effect/landmark/corpsespawner/prisoner,
+/turf/open/floor/prison/bright_clean,
+/area/prison/canteen)
 "eIO" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
@@ -41677,6 +41710,10 @@
 /obj/structure/cable,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/highsec/north/south)
+"eNp" = (
+/obj/item/ammo_casing,
+/turf/open/floor/prison/cleanmarked,
+/area/prison/canteen)
 "eOr" = (
 /turf/open/floor/prison/bright_clean,
 /area/prison/yard)
@@ -41758,6 +41795,10 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/highsec/north/south)
+"fea" = (
+/obj/structure/cable,
+/turf/open/floor/prison/whitegreen,
+/area/prison/medbay)
 "fej" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -41795,6 +41836,11 @@
 "fgf" = (
 /turf/open/ground/coast,
 /area/prison/cellblock/maxsec/south)
+"fgk" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/corpsespawner/prison_security,
+/turf/open/floor/prison/bright_clean,
+/area/prison/yard)
 "fgQ" = (
 /turf/open/floor/prison/darkred{
 	dir = 1
@@ -42003,6 +42049,13 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
+"fTb" = (
+/obj/structure/bed/roller,
+/obj/structure/cable,
+/turf/open/floor/prison/whitegreen{
+	dir = 4
+	},
+/area/prison/medbay)
 "fUu" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 2;
@@ -42022,6 +42075,13 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar/main)
+"fXW" = (
+/obj/effect/landmark/corpsespawner/syndicatecommando,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/item/weapon/gun/rifle/mpi_km,
+/obj/item/ammo_casing,
+/turf/open/floor/plating,
+/area/prison/research/secret/bioengineering)
 "fYc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -42036,6 +42096,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/prison/residential/north)
+"gaz" = (
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison/bright_clean/two,
+/area/prison/canteen)
 "gaZ" = (
 /turf/open/floor/prison,
 /area/prison/research/secret/dissection)
@@ -42044,12 +42109,10 @@
 /turf/open/ground/river,
 /area/prison/residential/central)
 "gcs" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/structure/disposaloutlet{
-	dir = 1
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 4
 	},
-/obj/structure/disposalpipe/up,
-/turf/open/floor/plating,
+/turf/open/shuttle/dropship/floor,
 /area/prison/research/secret/biolab)
 "gcC" = (
 /obj/effect/landmark/excavation_site_spawner,
@@ -42069,8 +42132,9 @@
 /turf/open/floor/prison,
 /area/prison/hangar/main)
 "gdU" = (
-/obj/effect/landmark/start/job/xenomorph,
-/turf/open/floor/plating,
+/turf/closed/shuttle/ert{
+	icon_state = "nt4"
+	},
 /area/prison/research/secret/biolab)
 "gfK" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -42183,6 +42247,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean,
 /area/prison/execution)
 "gxT" = (
@@ -42274,6 +42339,10 @@
 	dir = 8
 	},
 /area/prison/cellblock/highsec/north/south)
+"gIg" = (
+/obj/effect/landmark/start/job/xenomorph,
+/turf/open/floor/prison/bright_clean,
+/area/prison/yard)
 "gIl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -42293,9 +42362,11 @@
 /turf/open/floor/prison/yellow,
 /area/prison/cellblock/mediumsec/north)
 "gIY" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/prison,
-/area/prison/cellblock/mediumsec/west)
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 8
+	},
+/turf/open/shuttle/dropship/floor,
+/area/prison/research/secret/biolab)
 "gJR" = (
 /turf/template_noop,
 /area/prison/residential/south)
@@ -42325,9 +42396,10 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/east)
 "gMf" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating,
-/area/prison/cellblock/mediumsec/south)
+/obj/structure/rack,
+/obj/item/storage/firstaid/regular,
+/turf/open/shuttle/dropship/floor,
+/area/prison/research/secret/biolab)
 "gMU" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -42347,6 +42419,11 @@
 /obj/machinery/landinglight/ds1/delayone,
 /turf/open/floor/plating,
 /area/prison/hangar/main)
+"gOq" = (
+/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/research/secret/bioengineering)
 "gPc" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/plating,
@@ -42402,9 +42479,10 @@
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/lowsec/ne)
 "gWy" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/closed/wall/prison,
-/area/prison/cellblock/lowsec/ne)
+/turf/open/shuttle/dropship{
+	icon_state = "rasputin4"
+	},
+/area/prison/research/secret/biolab)
 "gZL" = (
 /obj/effect/decal/woodsiding{
 	dir = 4
@@ -42594,6 +42672,12 @@
 /obj/item/tool/kitchen/tray,
 /turf/open/floor/prison/kitchen,
 /area/prison/residential/north)
+"hGd" = (
+/obj/structure/cable,
+/turf/open/floor/prison/whitegreen{
+	dir = 8
+	},
+/area/prison/medbay)
 "hJL" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/green,
@@ -42702,6 +42786,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
 	},
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean,
 /area/prison/execution)
 "hYD" = (
@@ -42933,8 +43018,10 @@
 /turf/open/floor/prison,
 /area/prison/research/secret/dissection)
 "iFe" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating,
+/turf/closed/shuttle/ert{
+	icon_state = "leftengine_3";
+	opacity = 0
+	},
 /area/prison/research/secret/biolab)
 "iFC" = (
 /turf/open/ground/river,
@@ -42958,6 +43045,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
 	},
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean,
 /area/prison/execution)
 "iHW" = (
@@ -42971,6 +43059,10 @@
 	dir = 4
 	},
 /area/prison/cellblock/mediumsec/east)
+"iIg" = (
+/obj/item/ammo_casing,
+/turf/open/floor/prison/bright_clean,
+/area/prison/canteen)
 "iJd" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating,
@@ -43101,6 +43193,10 @@
 "iYA" = (
 /turf/open/floor/wood,
 /area/prison/residential/central)
+"iYX" = (
+/obj/item/ammo_casing,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/research/secret/bioengineering)
 "iZR" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/whitegreen,
@@ -43124,9 +43220,8 @@
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/monitoring/maxsec/panopticon)
 "jdI" = (
-/obj/machinery/computer/nuke_disk_generator/red,
-/turf/open/floor/prison,
-/area/prison/security/head)
+/turf/open/shuttle/dropship/eight,
+/area/prison/research/secret/biolab)
 "jej" = (
 /obj/structure/toilet{
 	dir = 4
@@ -43144,6 +43239,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood/broken,
 /area/prison/chapel)
+"jeR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/item/ammo_casing,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/canteen)
 "jfO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -43297,6 +43403,21 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/cellblock/lowsec/se)
+"jwK" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/start/job/xenomorph,
+/turf/open/floor/prison/bright_clean/two,
+/area/prison/yard)
+"jxl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/shuttle/blackfloor,
+/area/prison/pirate)
 "jyJ" = (
 /obj/structure/bed,
 /turf/open/floor/prison/cellstripe{
@@ -43375,6 +43496,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
+"jDW" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/r_wall/prison_unmeltable,
+/area/prison/execution)
 "jEE" = (
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research)
@@ -43397,6 +43522,10 @@
 	dir = 4
 	},
 /area/prison/cellblock/mediumsec/east)
+"jFJ" = (
+/obj/structure/cable,
+/turf/open/shuttle/blackfloor,
+/area/prison/pirate)
 "jFT" = (
 /obj/structure/window/reinforced,
 /obj/machinery/shower{
@@ -43425,6 +43554,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/yellow,
 /area/prison/cellblock/mediumsec/south)
+"jHQ" = (
+/obj/structure/cable,
+/turf/open/floor/prison/whitegreen{
+	dir = 1
+	},
+/area/prison/medbay)
 "jJJ" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/whitepurple{
@@ -43449,9 +43584,10 @@
 /turf/open/floor/prison,
 /area/prison/security/monitoring/medsec/south)
 "jNw" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/closed/wall/prison,
-/area/prison/cellblock/lowsec/nw)
+/turf/closed/shuttle/ert{
+	icon_state = "nt_leftengine"
+	},
+/area/prison/research/secret/biolab)
 "jNH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -43470,6 +43606,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"jQi" = (
+/obj/effect/landmark/excavation_site_spawner,
+/obj/effect/landmark/start/job/xenomorph,
+/turf/open/floor/prison/bright_clean,
+/area/prison/yard)
 "jRr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -43490,9 +43631,9 @@
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/holding/holding1)
 "jSF" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/prison,
-/area/prison/cellblock/mediumsec/east)
+/obj/effect/landmark/nuke_spawn,
+/turf/open/shuttle/dropship/three,
+/area/prison/research/secret/biolab)
 "jWH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -43570,6 +43711,10 @@
 	dir = 8
 	},
 /area/prison/cellblock/highsec/north/south)
+"key" = (
+/obj/effect/landmark/start/job/xenomorph,
+/turf/open/floor/prison,
+/area/prison/execution)
 "khD" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/prison/sterilewhite,
@@ -43594,7 +43739,6 @@
 /obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 2
 	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/east)
 "kla" = (
@@ -43685,15 +43829,16 @@
 /turf/open/floor/wood,
 /area/prison/parole/main)
 "kva" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/landmark/start/job/xenomorph,
-/turf/open/floor/plating,
+/turf/closed/shuttle/ert{
+	icon_state = "nt9"
+	},
 /area/prison/research/secret/biolab)
 "kxw" = (
-/obj/structure/window/framed/prison/reinforced,
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/floor/plating,
-/area/prison/security/monitoring/lowsec/ne)
+/turf/closed/shuttle/ert{
+	icon_state = "rightengine_3";
+	opacity = 0
+	},
+/area/prison/research/secret/biolab)
 "kxK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -43768,6 +43913,7 @@
 	dir = 8
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean,
 /area/prison/execution)
 "kIR" = (
@@ -43827,6 +43973,13 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/east)
+"kWN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/prison/pirate)
 "kXh" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
@@ -43844,6 +43997,11 @@
 /obj/machinery/power/apc/drained,
 /turf/open/floor/wood,
 /area/prison/parole/protective_custody)
+"kYx" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/start/job/xenomorph,
+/turf/open/floor/prison/bright_clean,
+/area/prison/yard)
 "kZy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -43902,6 +44060,10 @@
 "lnA" = (
 /turf/open/floor/prison,
 /area/prison/security/monitoring/highsec)
+"lpr" = (
+/obj/effect/landmark/start/job/xenomorph,
+/turf/open/floor/prison/bright_clean/two,
+/area/prison/yard)
 "lqu" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red{
@@ -43969,9 +44131,11 @@
 /turf/open/floor/prison/cleanmarked,
 /area/prison/canteen)
 "lAp" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/closed/wall/prison,
-/area/prison/cellblock/lowsec/sw)
+/turf/closed/shuttle/ert{
+	icon_state = "leftengine_2";
+	opacity = 0
+	},
+/area/prison/research/secret/biolab)
 "lAs" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -44002,6 +44166,10 @@
 	},
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/yard)
+"lDb" = (
+/obj/item/ammo_casing,
+/turf/open/floor/prison/bright_clean/two,
+/area/prison/canteen)
 "lEa" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating,
@@ -44159,6 +44327,7 @@
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/toilet/security)
 "mng" = (
+/obj/item/ammo_magazine/rifle/m16,
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean,
 /area/prison/yard)
@@ -44266,9 +44435,11 @@
 /turf/open/floor/prison/bright_clean,
 /area/prison/laundry)
 "myW" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/closed/wall/prison,
-/area/prison/cellblock/lowsec/se)
+/turf/closed/shuttle/ert{
+	icon_state = "rightengine_2";
+	opacity = 0
+	},
+/area/prison/research/secret/biolab)
 "mzx" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/carpet,
@@ -44290,9 +44461,11 @@
 /turf/open/floor/prison/red/full,
 /area/prison/cellblock/highsec/south/north)
 "mBf" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall/prison_unmeltable,
-/area/prison/cellblock/mediumsec/south)
+/turf/closed/shuttle/ert{
+	icon_state = "leftengine_1";
+	opacity = 0
+	},
+/area/prison/research/secret/biolab)
 "mBn" = (
 /turf/open/floor/prison,
 /area/prison/hangar_storage/main)
@@ -44506,6 +44679,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/engineering)
+"mZa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/medbay)
 "mZq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -44519,6 +44700,12 @@
 /obj/effect/landmark/fob_sentry_rebel,
 /turf/open/floor/carpet,
 /area/prison/command/quarters)
+"mZS" = (
+/obj/structure/cable,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 4
+	},
+/area/prison/medbay)
 "naL" = (
 /turf/open/floor/wood/broken,
 /area/prison/residential/south)
@@ -44668,11 +44855,20 @@
 	},
 /turf/open/floor/wood,
 /area/prison/residential/central)
+"nrc" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/r_wall/prison,
+/area/prison/disposal)
 "nry" = (
 /turf/open/floor/prison/yellow/corner{
 	dir = 8
 	},
 /area/prison/cellblock/mediumsec/south)
+"nud" = (
+/obj/structure/bed,
+/obj/effect/landmark/corpsespawner/prisoner,
+/turf/open/floor/prison/plate,
+/area/prison/cellblock/lowsec/ne)
 "nuk" = (
 /turf/open/ground/coast/corner{
 	dir = 1
@@ -44682,8 +44878,9 @@
 /turf/closed/wall/r_wall/prison,
 /area/prison/residential/north)
 "nwF" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plating,
+/turf/closed/shuttle/ert{
+	icon_state = "nt8"
+	},
 /area/prison/research/secret/biolab)
 "nzo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -44753,12 +44950,29 @@
 "nFz" = (
 /turf/open/floor/prison/red,
 /area/prison/cellblock/highsec/south/north)
+"nGt" = (
+/obj/machinery/power/apc/drained{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/prison/whitegreen{
+	dir = 4
+	},
+/area/prison/medbay)
 "nJI" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
+"nJW" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison/bright_clean,
+/area/prison/canteen)
 "nKr" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/yellow,
@@ -45150,11 +45364,9 @@
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
 "oAL" = (
-/obj/effect/landmark/corpsespawner/prisoner,
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/landmark/start/job/xenomorph,
-/turf/open/floor/plating,
+/turf/closed/shuttle/ert{
+	icon_state = "nt1"
+	},
 /area/prison/research/secret/biolab)
 "oAY" = (
 /turf/open/floor/prison/bright_clean,
@@ -45183,9 +45395,28 @@
 /obj/structure/sink,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/west)
+"oLw" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison/bright_clean,
+/area/prison/canteen)
 "oMZ" = (
 /turf/closed/wall/r_wall/prison,
 /area/prison/command/quarters)
+"oPf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/item/ammo_magazine/rifle/mpi_km,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/canteen)
 "oPA" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
@@ -45228,6 +45459,13 @@
 /obj/structure/table,
 /turf/open/floor/prison/kitchen,
 /area/prison/residential/north)
+"oXQ" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/landmark/corpsespawner/prisoner,
+/turf/open/floor/prison/bright_clean,
+/area/prison/canteen)
 "oYc" = (
 /obj/structure/table,
 /obj/item/clothing/suit/chef/classic,
@@ -45267,9 +45505,11 @@
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
 "peP" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/floor/prison/bright_clean,
-/area/prison/hallway/central)
+/obj/machinery/door/airlock/mainship/generic{
+	dir = 2
+	},
+/turf/open/shuttle/dropship/floor,
+/area/prison/research/secret/biolab)
 "pgl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -45330,8 +45570,6 @@
 	dir = 2;
 	id = "biological_testing_1"
 	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/prison/research/secret/biolab)
 "pmc" = (
@@ -45514,6 +45752,14 @@
 	dir = 1
 	},
 /area/prison/quarters/staff)
+"pMG" = (
+/obj/machinery/flasher{
+	id = "canteen"
+	},
+/obj/effect/landmark/weed_node,
+/obj/item/ammo_casing,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/canteen)
 "pMO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -45664,9 +45910,10 @@
 /turf/open/floor/wood,
 /area/prison/residential/north)
 "qcr" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall/prison_unmeltable,
-/area/prison/cellblock/mediumsec/east)
+/turf/closed/shuttle/ert{
+	icon_state = "nt2"
+	},
+/area/prison/research/secret/biolab)
 "qcw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -45735,6 +45982,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research/secret/bioengineering)
+"qld" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/prison,
+/area/prison/execution)
 "qls" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -45798,6 +46049,13 @@
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/sw)
+"qxv" = (
+/obj/structure/bed/chair,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/item/ammo_magazine/rifle/mpi_km,
+/turf/open/floor/prison/bright_clean,
+/area/prison/canteen)
 "qxy" = (
 /obj/structure/toilet{
 	dir = 4
@@ -45867,6 +46125,10 @@
 	dir = 4
 	},
 /area/prison/maintenance/residential/ne)
+"qGi" = (
+/obj/structure/cable,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/medbay)
 "qGW" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -45915,6 +46177,10 @@
 	dir = 8
 	},
 /area/prison/hallway/east)
+"qMo" = (
+/obj/item/ammo_magazine/rifle/mpi_km,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/canteen)
 "qNy" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -46027,8 +46293,9 @@
 /turf/open/floor/prison/bright_clean,
 /area/prison/laundry)
 "rcJ" = (
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/floor/plating,
+/turf/closed/shuttle/ert{
+	icon_state = "nt_rightengine"
+	},
 /area/prison/research/secret/biolab)
 "rdQ" = (
 /obj/effect/landmark/start/job/survivor,
@@ -46082,6 +46349,18 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/highsec/south/north)
+"rgF" = (
+/obj/structure/bed/chair,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison/bright_clean,
+/area/prison/canteen)
 "rhE" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/prison/plate,
@@ -46174,6 +46453,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean,
 /area/prison/execution)
 "rsn" = (
@@ -46412,7 +46692,6 @@
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/access/north)
 "rYj" = (
-/obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/prison/research/secret/biolab)
@@ -46448,9 +46727,8 @@
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
 "saw" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall/prison_unmeltable,
+/obj/structure/bed/chair/dropship/passenger,
+/turf/open/shuttle/dropship/floor,
 /area/prison/research/secret/biolab)
 "saN" = (
 /obj/effect/landmark/excavation_site_spawner,
@@ -46464,6 +46742,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/north)
+"sgx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/ammo_magazine/rifle/mpi_km,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/canteen)
 "shF" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge,
 /area/prison/hallway/central)
@@ -46502,6 +46787,12 @@
 	dir = 9
 	},
 /area/prison/cellblock/highsec/south/north)
+"slR" = (
+/obj/machinery/door/airlock/multi_tile/mainship/maint/free_access{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/prison/research/secret/containment)
 "soh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -46613,6 +46904,11 @@
 	},
 /turf/open/floor/prison/red,
 /area/prison/cellblock/highsec/north/north)
+"syg" = (
+/obj/effect/landmark/corpsespawner/scientist,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/research/secret/bioengineering)
 "syI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -46753,6 +47049,16 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/research/secret)
+"sPG" = (
+/obj/structure/bed/roller,
+/obj/structure/cable,
+/obj/machinery/power/apc/drained{
+	dir = 8
+	},
+/turf/open/floor/prison/whitegreen{
+	dir = 4
+	},
+/area/prison/medbay)
 "sQF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -46832,6 +47138,13 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"tcG" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/item/ammo_casing,
+/turf/open/floor/prison/bright_clean,
+/area/prison/canteen)
 "tdn" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -46859,6 +47172,12 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/access/south)
+"tii" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/turf/open/shuttle/blackfloor,
+/area/prison/pirate)
 "tjY" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/prison,
@@ -46960,6 +47279,12 @@
 	},
 /turf/open/ground/river,
 /area/prison/residential/central)
+"twm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/ammo_casing,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/canteen)
 "twI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -47091,6 +47416,23 @@
 	dir = 8
 	},
 /area/prison/cellblock/mediumsec/east)
+"tQj" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/ammo_casing,
+/turf/open/floor/prison/bright_clean,
+/area/prison/canteen)
 "tQo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -47117,6 +47459,12 @@
 	dir = 8
 	},
 /area/prison/monorail/west)
+"tTT" = (
+/obj/effect/landmark/corpsespawner/prison_security,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/landmark/start/job/xenomorph,
+/turf/open/floor/prison/bright_clean,
+/area/prison/execution)
 "tUs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -47129,6 +47477,10 @@
 	},
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/maxsec/north)
+"tUV" = (
+/obj/structure/cable,
+/turf/open/floor/prison/whitegreen/full,
+/area/prison/medbay)
 "tWb" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating,
@@ -47296,6 +47648,9 @@
 	},
 /turf/closed/wall/r_wall/prison,
 /area/prison/maintenance/residential/sw)
+"urb" = (
+/turf/open/floor/plating,
+/area/prison/research/secret/containment)
 "urN" = (
 /turf/open/floor/prison,
 /area/prison/hallway/entrance)
@@ -47419,6 +47774,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/excavation_site_spawner,
+/obj/structure/cable,
 /turf/open/shuttle/blackfloor,
 /area/prison/pirate)
 "uPA" = (
@@ -47494,6 +47850,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean,
 /area/prison/execution)
 "uZo" = (
@@ -47532,11 +47889,9 @@
 	},
 /area/prison/cellblock/highsec/south/south)
 "vdD" = (
-/obj/structure/disposaloutlet{
-	dir = 1
+/turf/closed/shuttle/ert{
+	icon_state = "nt3"
 	},
-/obj/structure/disposalpipe/up,
-/turf/open/floor/plating,
 /area/prison/research/secret/biolab)
 "vep" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -47633,6 +47988,12 @@
 	},
 /turf/open/floor/prison,
 /area/prison/hangar/main)
+"vrz" = (
+/obj/structure/bed/chair,
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison/bright_clean,
+/area/prison/canteen)
 "vrN" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
@@ -47677,6 +48038,14 @@
 "vue" = (
 /turf/open/floor/wood/broken,
 /area/prison/residential/central)
+"vuN" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/corpsespawner/prisoner,
+/turf/open/floor/prison/bright_clean,
+/area/prison/canteen)
 "vuV" = (
 /obj/effect/decal/woodsiding{
 	dir = 1
@@ -47762,9 +48131,11 @@
 	},
 /area/prison/hallway/staff)
 "vFP" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/closed/wall/prison,
-/area/prison/security/monitoring/lowsec/sw)
+/turf/closed/shuttle/ert{
+	icon_state = "rightengine_1";
+	opacity = 0
+	},
+/area/prison/research/secret/biolab)
 "vGa" = (
 /turf/closed/wall/r_wall/prison,
 /area/prison/yard)
@@ -47887,10 +48258,11 @@
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/hallway/central)
 "vSO" = (
-/obj/structure/window/framed/prison/reinforced,
-/obj/effect/landmark/lv624/fog_blocker,
+/obj/item/explosive/plastique{
+	pixel_y = 4
+	},
 /turf/open/floor/plating,
-/area/prison/hallway/central)
+/area/prison/research/secret/biolab)
 "vUd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -48030,7 +48402,6 @@
 /area/prison/hangar/civilian)
 "woW" = (
 /obj/machinery/door/airlock/mainship/maint/free_access,
-/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/prison/security/monitoring/lowsec/sw)
 "woY" = (
@@ -48047,6 +48418,10 @@
 "wpW" = (
 /turf/open/floor/prison/green/full,
 /area/prison/cellblock/lowsec/ne)
+"wsu" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/r_wall/prison,
+/area/prison/execution)
 "wtm" = (
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 9
@@ -48071,12 +48446,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/prison/visitation)
 "wuP" = (
-/obj/structure/window/framed/prison/reinforced,
-/obj/machinery/door/poddoor/shutters/mainship/open{
-	dir = 2;
-	id = "biological_testing_2"
-	},
-/obj/structure/disposalpipe/segment,
+/obj/item/ammo_casing,
 /turf/open/floor/plating,
 /area/prison/research/secret/biolab)
 "wvr" = (
@@ -48156,6 +48526,7 @@
 /area/prison/monorail/west)
 "wHm" = (
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean,
 /area/prison/execution)
 "wHN" = (
@@ -48250,6 +48621,16 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/prison/hangar/main)
+"wWZ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/r_wall/prison_unmeltable,
+/area/prison/disposal)
+"wXv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/ammo_magazine/rifle/mpi_km,
+/turf/open/floor/prison/bright_clean,
+/area/prison/canteen)
 "wXP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -48262,9 +48643,14 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research)
 "xar" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/prison,
-/area/prison/cellblock/mediumsec/south)
+/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/item/weapon/gun/smg/m25/elite,
+/obj/item/ammo_casing,
+/turf/open/floor/prison/whitepurple{
+	dir = 8
+	},
+/area/prison/research/secret/bioengineering)
 "xbg" = (
 /obj/effect/landmark/corpsespawner/prisoner,
 /turf/open/floor/prison/bright_clean/two,
@@ -48337,6 +48723,11 @@
 	dir = 8
 	},
 /area/prison/security/monitoring/maxsec/panopticon)
+"xom" = (
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison/cleanmarked,
+/area/prison/canteen)
 "xqe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -48379,6 +48770,7 @@
 "xvb" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/medbay)
 "xvg" = (
@@ -48442,12 +48834,10 @@
 /turf/open/floor/prison/whitepurple/full,
 /area/prison/research/secret/biolab)
 "xDs" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/floor/prison/bright_clean,
-/area/prison/hallway/central)
+/obj/item/ammo_casing,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/research/secret/bioengineering)
 "xDM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -48532,9 +48922,18 @@
 	},
 /area/prison/hallway/staff)
 "xYk" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/closed/wall/prison,
-/area/prison/security/monitoring/lowsec/ne)
+/obj/item/ammo_casing,
+/obj/item/ammo_casing,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/research/secret/bioengineering)
+"xYU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
+	},
+/obj/structure/cable,
+/turf/open/shuttle/blackfloor,
+/area/prison/pirate)
 "xZt" = (
 /obj/machinery/light,
 /obj/effect/ai_node,
@@ -48577,6 +48976,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/engineering)
+"ycO" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison/bright_clean,
+/area/prison/canteen)
 "ydk" = (
 /obj/effect/decal/woodsiding{
 	dir = 1
@@ -48591,6 +48998,20 @@
 	dir = 1
 	},
 /area/prison/maintenance/staff_research)
+"yei" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/ammo_casing,
+/turf/open/floor/prison/cleanmarked,
+/area/prison/canteen)
 "yeT" = (
 /obj/structure/bed/stool,
 /obj/effect/landmark/weed_node,
@@ -48653,6 +49074,10 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/prison/command/quarters)
+"yiV" = (
+/obj/item/ammo_casing,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/canteen)
 "yjo" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
@@ -70717,12 +71142,12 @@ cqz
 cio
 cgp
 cmF
-sHD
+jFJ
 ctE
-cuh
+xYU
 uOt
-swi
-sHD
+jxl
+jFJ
 cio
 cwp
 cio
@@ -70979,7 +71404,7 @@ ctF
 sHD
 sHD
 cvo
-crN
+tii
 ccO
 sHD
 cio
@@ -71223,7 +71648,7 @@ lZe
 lZe
 lED
 lED
-cnH
+lZe
 lED
 lED
 lZe
@@ -71237,7 +71662,7 @@ crO
 ctG
 crO
 ctG
-swi
+jxl
 sHD
 cio
 ccY
@@ -71996,7 +72421,7 @@ lED
 lED
 hKD
 lED
-cpb
+lED
 lZe
 cqC
 cro
@@ -72515,7 +72940,7 @@ lZe
 cqD
 cio
 crT
-csv
+kWN
 csV
 ctJ
 ckm
@@ -72766,16 +73191,16 @@ lZe
 lZe
 lZe
 lZe
-lZe
+ety
 cpc
 lZe
 cqE
 crp
 crU
 csw
-crU
-crU
-crU
+cwr
+cwr
+cwr
 cuD
 cvt
 cio
@@ -73023,7 +73448,7 @@ lED
 cmg
 cmS
 lED
-aad
+lED
 coq
 coq
 cfL
@@ -75871,7 +76296,7 @@ csB
 cqK
 cwG
 csB
-cOL
+cxL
 cyw
 cyw
 cyw
@@ -76128,7 +76553,7 @@ cvw
 bgQ
 cvw
 cyd
-gIY
+cqK
 fMj
 fMj
 bhC
@@ -76642,11 +77067,11 @@ csB
 cqK
 cwG
 csB
-gIY
+cqK
 fMj
 fMj
 fMj
-gMf
+fMj
 fMj
 fMj
 fMj
@@ -76899,7 +77324,7 @@ cvy
 cqK
 cuJ
 cvy
-gIY
+cqK
 fMj
 fMj
 mmI
@@ -77156,7 +77581,7 @@ crs
 cqK
 cuK
 crs
-gIY
+cqK
 fMj
 fMj
 fMj
@@ -77413,7 +77838,7 @@ cqJ
 cqK
 cqI
 cqJ
-gIY
+cqK
 fMj
 fMj
 bhC
@@ -77670,7 +78095,7 @@ cqK
 cqK
 cqK
 cqK
-gIY
+cqK
 fMj
 fMj
 fMj
@@ -77927,11 +78352,11 @@ ccB
 cun
 cuL
 ccB
-xar
-xar
-xar
-xar
-xar
+cun
+cun
+cun
+cun
+cun
 cyO
 cyT
 cez
@@ -78188,7 +78613,7 @@ cun
 viQ
 cvA
 cvA
-xar
+cun
 fMj
 fMj
 csp
@@ -78445,12 +78870,12 @@ cun
 quF
 cuN
 kzr
-xar
-xar
-xar
+cun
+cun
+cun
 csY
-xar
-mBf
+cun
+cyw
 cyw
 cyw
 cyw
@@ -80145,24 +80570,24 @@ vSz
 swF
 bRS
 vSz
-jNw
-jNw
-jNw
-jNw
+aNp
+aNp
+aNp
+aNp
 aSc
-jNw
-jNw
-jNw
-jNw
-jNw
-jNw
-jNw
-jNw
-jNw
-jNw
-jNw
-jNw
-jNw
+aNp
+aNp
+aNp
+aNp
+aNp
+aNp
+aNp
+aNp
+aNp
+aNp
+aNp
+aNp
+aNp
 vSz
 bRS
 avh
@@ -80175,24 +80600,24 @@ vSz
 aPu
 oPA
 vSz
-lAp
-lAp
-lAp
-lAp
-lAp
-lAp
-lAp
-lAp
-lAp
-lAp
-vFP
+bql
+bql
+bql
+bql
+bql
+bql
+bql
+bql
+bql
+bql
+bBh
 woW
-vFP
-dBh
-dBh
+bBh
+bFk
+bFk
 bIQ
-dBh
-dBh
+bFk
+bFk
 vSz
 bRS
 swF
@@ -80402,7 +80827,7 @@ aKQ
 swF
 bRS
 vSz
-jNw
+aNp
 aNR
 aNR
 aQQ
@@ -80419,7 +80844,7 @@ aZI
 aNp
 aNX
 aZI
-jNw
+aNp
 aIH
 bRS
 beB
@@ -80432,7 +80857,7 @@ pTN
 aMe
 bRS
 vSz
-lAp
+bql
 bsR
 bsG
 bql
@@ -80449,7 +80874,7 @@ bGr
 bHx
 bIR
 bJM
-dBh
+bFk
 vSz
 bnE
 swF
@@ -80659,7 +81084,7 @@ aIH
 swF
 bRS
 vSz
-jNw
+aNp
 aNS
 aPw
 aQR
@@ -80676,7 +81101,7 @@ aPC
 aNp
 bbk
 aPC
-jNw
+aNp
 vSz
 pFK
 bRS
@@ -80689,7 +81114,7 @@ bRS
 bRS
 bRS
 vSz
-lAp
+bql
 btM
 bsF
 bql
@@ -80706,7 +81131,7 @@ bAh
 bHy
 bIS
 bJN
-dBh
+bFk
 sXO
 bnE
 swF
@@ -80916,7 +81341,7 @@ vSz
 swF
 bnE
 vSz
-jNw
+aNp
 aNT
 aPx
 vLz
@@ -80933,7 +81358,7 @@ bce
 aNp
 bbl
 bce
-jNw
+aNp
 vSz
 bcq
 vSz
@@ -80946,7 +81371,7 @@ vSz
 vSz
 bcq
 vSz
-lAp
+bql
 btN
 buO
 bql
@@ -80963,7 +81388,7 @@ bGt
 bHz
 bSz
 bJO
-dBh
+bFk
 vSz
 bRS
 swF
@@ -81173,7 +81598,7 @@ vSz
 aFE
 alo
 vSz
-jNw
+aNp
 aKC
 aPx
 aBY
@@ -81190,20 +81615,20 @@ aSi
 aNp
 bbm
 aSi
-jNw
-jNw
-jNw
-jNw
-jNw
-vSO
-peP
+aNp
+aNp
+aNp
+aNp
+aNp
+aKT
+bRS
 boy
-vSO
-lAp
-lAp
-lAp
-lAp
-lAp
+aKT
+bql
+bql
+bql
+bql
+bql
 brP
 byq
 bql
@@ -81220,7 +81645,7 @@ bBh
 bHA
 bIU
 bJP
-dBh
+bFk
 vSz
 bRS
 swF
@@ -81430,7 +81855,7 @@ vSz
 swF
 bRS
 aMM
-jNw
+aNp
 aNT
 aPx
 aPC
@@ -81477,7 +81902,7 @@ bql
 bCa
 bCa
 bCa
-lAp
+bql
 aKQ
 bRS
 swF
@@ -81687,7 +82112,7 @@ vSz
 swF
 bRS
 vSz
-jNw
+aNp
 aNT
 aPy
 aPC
@@ -81734,7 +82159,7 @@ bJb
 bHC
 bxP
 bsG
-lAp
+bql
 aIH
 bRS
 swF
@@ -81944,7 +82369,7 @@ aKR
 aJZ
 aLv
 aMN
-jNw
+aNp
 aNU
 aPz
 aQS
@@ -81991,7 +82416,7 @@ brP
 bHD
 brg
 brR
-lAp
+bql
 bLj
 aLv
 bAB
@@ -82201,7 +82626,7 @@ vSz
 swF
 bRS
 vSz
-jNw
+aNp
 aNp
 aNp
 aQT
@@ -82248,7 +82673,7 @@ bql
 bql
 bql
 bql
-lAp
+bql
 vSz
 bRS
 aFE
@@ -82458,7 +82883,7 @@ oPA
 swF
 oPA
 vSz
-jNw
+aNp
 aNV
 aNp
 aNp
@@ -82505,7 +82930,7 @@ bJb
 bHC
 bxP
 bsG
-lAp
+bql
 vSz
 bRS
 aOE
@@ -82567,7 +82992,7 @@ cvA
 crr
 czn
 czx
-cSE
+czL
 cSE
 jLJ
 saN
@@ -82715,7 +83140,7 @@ aKS
 aKm
 alo
 vSz
-jNw
+aNp
 aNW
 aOd
 aQU
@@ -82762,7 +83187,7 @@ brP
 bHD
 brg
 brR
-lAp
+bql
 sXO
 bRS
 nmh
@@ -82828,7 +83253,7 @@ czL
 cSE
 cSE
 czY
-cAg
+cAd
 cAe
 aab
 aab
@@ -82972,7 +83397,7 @@ vSz
 swF
 bRS
 sXO
-jNw
+aNp
 aNp
 aNp
 aNp
@@ -83019,7 +83444,7 @@ bql
 bql
 bql
 bql
-lAp
+bql
 vSz
 bRS
 swF
@@ -83229,7 +83654,7 @@ vSz
 swF
 bRS
 vSz
-jNw
+aNp
 aNX
 aPA
 aQV
@@ -83276,7 +83701,7 @@ bJb
 bHC
 bxP
 bsG
-lAp
+bql
 vSz
 bRS
 swF
@@ -83486,7 +83911,7 @@ vSz
 swF
 bRS
 vSz
-jNw
+aNp
 aNY
 aPC
 aQA
@@ -83533,7 +83958,7 @@ brP
 bHD
 brg
 brR
-lAp
+bql
 vSz
 bRS
 swF
@@ -83743,7 +84168,7 @@ sXO
 swF
 bRS
 vSz
-jNw
+aNp
 aNp
 aNp
 aNp
@@ -83790,7 +84215,7 @@ bql
 bql
 bql
 bql
-lAp
+bql
 vSz
 bRS
 aFE
@@ -84000,7 +84425,7 @@ vSz
 swF
 bRS
 vSz
-jNw
+aNp
 aNX
 aPA
 aQV
@@ -84018,7 +84443,7 @@ hyt
 bfx
 bfx
 eOr
-mng
+eOr
 eOr
 eWj
 pMO
@@ -84047,7 +84472,7 @@ bJb
 bHC
 bxP
 bsG
-lAp
+bql
 vSz
 bRS
 swF
@@ -84177,15 +84602,15 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+bWl
+bWl
+bWl
+bWl
+bWl
+bWl
+bWl
+bWl
+bWl
 bWl
 bWl
 bWl
@@ -84257,7 +84682,7 @@ aKR
 aJZ
 aLv
 aMN
-jNw
+aNp
 aNY
 aPC
 aQA
@@ -84286,7 +84711,7 @@ bfw
 bfw
 lCB
 kAY
-bdt
+kAY
 kAY
 bft
 bfx
@@ -84304,7 +84729,7 @@ brP
 bHD
 brg
 brR
-lAp
+bql
 bLj
 aLv
 bAB
@@ -84432,15 +84857,15 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+bWl
+bWl
+bWl
+bWl
+bWl
+bWl
+bWl
+bWl
+bWl
 bWl
 bWl
 bWl
@@ -84461,17 +84886,17 @@ xAI
 xAI
 xAI
 agt
-agG
+agJ
+agJ
+agJ
+urb
+slR
 agt
 agt
 agt
 agt
 agt
-agt
-agt
-agt
-agt
-agt
+anV
 agt
 akK
 akY
@@ -84514,11 +84939,11 @@ aKT
 swF
 azE
 aKT
-jNw
-jNw
-jNw
-jNw
-jNw
+aNp
+aNp
+aNp
+aNp
+aNp
 aQu
 aUx
 aNp
@@ -84529,7 +84954,7 @@ bak
 hyt
 bfx
 bfx
-mng
+eOr
 phH
 bgR
 eOr
@@ -84542,7 +84967,7 @@ eOr
 eOr
 eOr
 bdE
-mng
+eOr
 eOr
 bgR
 bfu
@@ -84557,11 +84982,11 @@ bql
 bql
 bEb
 bFq
-lAp
-lAp
-lAp
-lAp
-lAp
+bql
+bql
+bql
+bql
+bql
 aKT
 bRS
 bKT
@@ -84689,25 +85114,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
 bWl
 bWl
 bWl
-saw
-acE
-acE
-acE
-acE
-saw
-acE
+rrt
+rrt
+rrt
+rrt
+rrt
+rrt
+rrt
+rrt
+rrt
+rrt
+rrt
+rrt
+rrt
+rrt
+rrt
+rrt
 xAI
 adw
 adF
@@ -84718,10 +85143,10 @@ afi
 fpI
 agb
 agt
-agH
-agW
-ahi
-ajR
+agL
+agX
+ahk
+ajq
 ahQ
 ahk
 agX
@@ -84775,7 +85200,7 @@ vSz
 vSz
 vSz
 vSz
-jNw
+aNp
 aPx
 aUv
 aTH
@@ -84814,7 +85239,7 @@ bBn
 bJb
 iGL
 bFm
-lAp
+bql
 vSz
 vSz
 vSz
@@ -84946,25 +85371,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
 bWl
 bWl
-acE
-acE
+rrt
+rrt
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
 acI
 acF
 acF
-nwF
-acJ
-acU
+acF
+acF
+pla
 adg
 adx
 svM
@@ -84975,9 +85400,9 @@ aea
 fpI
 agc
 agt
-agt
-agt
-agt
+agM
+agY
+ahj
 ahy
 ahR
 ahj
@@ -85032,7 +85457,7 @@ bRS
 bRS
 bRS
 xZt
-jNw
+aNp
 aSg
 aUA
 aSi
@@ -85042,7 +85467,7 @@ aPC
 bak
 hyt
 bfx
-mng
+eOr
 eOr
 bfu
 nzo
@@ -85051,8 +85476,8 @@ brS
 bjL
 kAY
 bmA
-mng
-bjj
+eOr
+fgk
 kAY
 kAY
 bpQ
@@ -85060,8 +85485,8 @@ brS
 bsH
 ttJ
 bfu
-mng
-sNa
+eOr
+aFz
 bfx
 hyt
 bqp
@@ -85071,7 +85496,7 @@ bBo
 brP
 bDS
 bFr
-lAp
+bql
 aKQ
 bRS
 ttr
@@ -85203,25 +85628,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
 bWl
 bWl
-acE
+rrt
 acF
-gdU
-gdU
-kva
 acF
-gdU
-acU
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+pla
 adh
 adx
 svM
@@ -85232,9 +85657,9 @@ aeb
 adF
 aea
 agt
-agI
-agX
-ahj
+agJ
+agJ
+agJ
 ahy
 oGc
 agJ
@@ -85289,7 +85714,7 @@ aLx
 aLz
 bRS
 vSz
-jNw
+aNp
 aNS
 aUC
 aNp
@@ -85328,7 +85753,7 @@ bql
 bql
 bDU
 bFs
-lAp
+bql
 vSz
 bRS
 gMU
@@ -85460,24 +85885,24 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
 bWl
 bWl
-acE
+rrt
 acF
-nwF
 acF
-gdU
 acF
-gcs
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
 pla
 adi
 adx
@@ -85489,9 +85914,9 @@ svM
 uKB
 aeX
 agt
-agJ
-agJ
-agJ
+agL
+agX
+ahk
 ahy
 ahR
 ahk
@@ -85509,7 +85934,7 @@ akV
 akV
 akV
 akV
-akV
+bdt
 icr
 akV
 akV
@@ -85546,7 +85971,7 @@ vSz
 aLB
 bRS
 sXO
-jNw
+aNp
 aTr
 aUB
 aVH
@@ -85559,16 +85984,16 @@ vGa
 eOr
 ekj
 bfw
-mng
+eOr
 bib
 aTR
-bku
-kAY
-eyF
-kAY
-eyF
-kAY
-eyF
+mng
+lpr
+jwK
+lpr
+jwK
+lpr
+jwK
 eOr
 kAY
 blk
@@ -85585,7 +86010,7 @@ bql
 bCy
 bDV
 aTr
-lAp
+bql
 vSz
 bRS
 swF
@@ -85717,24 +86142,24 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
 bWl
 bWl
-acE
-nwF
-oAL
+rrt
+afH
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
 rYj
 acF
-kva
-kva
+acF
+acF
 acV
 adj
 ady
@@ -85747,7 +86172,7 @@ aha
 aeX
 agt
 agK
-agX
+agY
 ahj
 ahy
 ahR
@@ -85762,11 +86187,11 @@ agL
 agt
 agt
 agt
+aIA
 agt
 agt
 agt
-agt
-akK
+akV
 anC
 akK
 akK
@@ -85803,7 +86228,7 @@ vSz
 aLB
 bRS
 bRS
-vSO
+aKT
 bRS
 mNz
 bRS
@@ -85819,14 +86244,14 @@ bfw
 eOr
 bib
 kAY
-bku
+mng
 kAY
 bmB
-blk
+cRg
 bmB
 eOr
 bqq
-mng
+eOr
 brS
 bsH
 eOr
@@ -85842,7 +86267,7 @@ eOr
 bRS
 bDW
 oPA
-vSO
+aKT
 bRS
 rFI
 swF
@@ -85976,21 +86401,21 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-bWl
-bWl
-bWl
+aad
+acF
+acF
+agG
+gdU
 acE
 gdU
-acF
+gdU
+gdU
+acE
+gdU
+jNw
 iFe
-nwF
-wcU
+lAp
+mBf
 acF
 acW
 adk
@@ -86023,7 +86448,7 @@ agL
 agL
 agL
 agt
-anP
+clQ
 fkw
 apt
 apH
@@ -86075,10 +86500,10 @@ qls
 bfx
 eOr
 eOr
-mng
 eOr
+gIg
 hwj
-bjj
+fgk
 bny
 yaF
 bpG
@@ -86233,23 +86658,23 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-bWl
-bWl
-bWl
-acE
-acF
-nwF
-gdU
-gdU
-nwF
 acJ
-acU
+acF
+agG
+agW
+ajR
+ahe
+gcs
+gcs
+gcs
+ahe
+gMf
+nwF
+gdU
+gdU
+oAL
+acF
+pla
 adl
 tBE
 adK
@@ -86317,7 +86742,7 @@ vSz
 aMd
 reT
 reT
-xDs
+reT
 reT
 riM
 aMj
@@ -86327,15 +86752,15 @@ nQR
 bam
 aIy
 bcl
-aIA
+nQR
 bdX
 bfx
 eOr
 bib
 bjj
-eOr
-kAY
-vPd
+gIg
+lpr
+jQi
 qRS
 rSZ
 eOr
@@ -86356,7 +86781,7 @@ byM
 reT
 aMh
 reT
-xDs
+reT
 reT
 reT
 brj
@@ -86490,23 +86915,23 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-bWl
-bWl
-bWl
-acE
-gdU
-gdU
+acJ
 acF
+agH
+ahe
+awG
+dBh
+dBh
+dBh
+dBh
+dBh
+gWy
+ahe
+ahe
+ahe
+peP
 acF
-gdU
-acF
-acU
+pla
 adh
 adx
 svM
@@ -86574,7 +86999,7 @@ vSz
 aLB
 bRS
 bRS
-vSO
+aKT
 bRS
 aUD
 bRS
@@ -86590,12 +87015,12 @@ bfw
 aXY
 bib
 qNF
-eOr
-bqq
-eOr
+gIg
+dBf
+gIg
 bnz
-eOr
-aFz
+gIg
+kYx
 bny
 bjj
 kAY
@@ -86613,7 +87038,7 @@ mWI
 bRS
 aUD
 bnE
-vSO
+aKT
 bnE
 bRS
 swF
@@ -86747,23 +87172,23 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-bWl
-bWl
-bWl
-acE
+acJ
 acF
-gdU
+agH
+ahe
+acH
+saw
+saw
+saw
+saw
+saw
+acH
+ahJ
+dBh
+dBh
+qcr
 acF
-acF
-gdU
-nwF
-acU
+pla
 adm
 adx
 svM
@@ -86831,7 +87256,7 @@ vSz
 aLB
 ttr
 vSz
-gWy
+aNq
 aTs
 aUF
 aVJ
@@ -86852,7 +87277,7 @@ aTR
 bjk
 kAY
 kAY
-bdt
+kAY
 kAY
 eOr
 kAY
@@ -86870,7 +87295,7 @@ bqs
 bCz
 bEh
 aTs
-myW
+bqs
 vSz
 bRS
 swF
@@ -86926,12 +87351,12 @@ cun
 mYk
 cvd
 vtF
-xar
-xar
-xar
+cun
+cun
+cun
 ctf
-xar
-mBf
+cun
+cyw
 cyw
 cyw
 cyw
@@ -87004,23 +87429,23 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-bWl
-bWl
-bWl
-bWl
+afk
+acF
+agH
+ahe
+acH
+saw
+saw
+saw
+saw
 saw
 acH
-acH
-acH
-acH
-acH
-acH
-acH
+jSF
+dBh
+dBh
+qcr
+acF
+xAI
 adn
 adx
 svM
@@ -87088,7 +87513,7 @@ aLx
 aMe
 bRS
 aAb
-gWy
+aNq
 wpW
 aUG
 aNq
@@ -87127,7 +87552,7 @@ bqs
 bqs
 bDX
 bFt
-myW
+bqs
 aIH
 bRS
 pDV
@@ -87183,7 +87608,7 @@ cun
 jgI
 cvA
 cvA
-xar
+cun
 fMj
 fMj
 cti
@@ -87261,21 +87686,21 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-bWl
-bWl
-bWl
-bWl
-rrt
+acJ
 acF
-acF
-acF
-acF
-acF
+agH
+ahe
+cnH
+dBh
+dBh
+dBh
+dBh
+dBh
+jdI
+ahe
+ahe
+ahe
+peP
 acF
 acX
 ado
@@ -87345,7 +87770,7 @@ bRS
 bRS
 bRS
 aMM
-gWy
+aNq
 aTu
 aUH
 aSk
@@ -87356,7 +87781,7 @@ ban
 hyt
 bfx
 eOr
-mng
+eOr
 bfu
 nzo
 bib
@@ -87384,7 +87809,7 @@ bBp
 brW
 bDY
 bFu
-myW
+bqs
 aKQ
 bRS
 bRS
@@ -87436,11 +87861,11 @@ ccA
 cun
 cxR
 ccA
-xar
-xar
-xar
-xar
-xar
+cun
+cun
+cun
+cun
+cun
 cyO
 cyT
 cyY
@@ -87518,21 +87943,21 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-bWl
-bWl
-rrt
+acJ
 acF
-acF
-wcU
-acF
-acF
+agI
+ahi
+cpb
+ahe
+gIY
+gIY
+gIY
+ahe
+cpb
+kva
+cOL
+cOL
+vdD
 acF
 acX
 adh
@@ -87602,7 +88027,7 @@ vSz
 vSz
 sXO
 vSz
-gWy
+aNq
 aTv
 oeD
 aTS
@@ -87623,7 +88048,7 @@ eOr
 bjn
 bjn
 eOr
-bjj
+fgk
 eOr
 bpS
 bjn
@@ -87641,7 +88066,7 @@ bBq
 bJC
 hYD
 bFv
-myW
+bqs
 sXO
 vSz
 vSz
@@ -87693,7 +88118,7 @@ cpU
 cpU
 cpU
 cpU
-jSF
+cpU
 fMj
 fMj
 fMj
@@ -87775,23 +88200,23 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-bWl
-bWl
-rrt
+acJ
 acF
+acF
+agI
+cOL
+acE
+cOL
+cOL
+cOL
+acE
+cOL
 rcJ
+kxw
+myW
+vFP
 acF
-acF
-acF
-vdD
-wuP
+acX
 adi
 adx
 adL
@@ -87855,11 +88280,11 @@ aKT
 swF
 azE
 aKT
-gWy
-gWy
-gWy
-gWy
-gWy
+aNq
+aNq
+aNq
+aNq
+aNq
 aQG
 aUJ
 aNq
@@ -87898,11 +88323,11 @@ bqs
 bqs
 bEl
 bFw
-myW
-myW
-myW
-myW
-myW
+bqs
+bqs
+bqs
+bqs
+bqs
 aKT
 bRS
 bKU
@@ -87950,7 +88375,7 @@ ccJ
 cpU
 cxS
 ccJ
-jSF
+cpU
 fMj
 bhC
 fMj
@@ -88030,18 +88455,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
 bWl
 bWl
 rrt
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
 acF
 acF
 acF
@@ -88094,12 +88519,12 @@ auB
 awM
 avu
 avu
-awM
+nGt
 aBo
 avw
 avw
-awG
 avw
+fTb
 aBo
 aDh
 apK
@@ -88112,7 +88537,7 @@ aKR
 aLq
 aLv
 aMN
-gWy
+aNq
 aNZ
 aPE
 aQW
@@ -88140,7 +88565,7 @@ bfx
 bfw
 bfw
 lCB
-bdt
+kAY
 kAY
 kAY
 bfz
@@ -88159,7 +88584,7 @@ brW
 bHF
 brl
 blQ
-myW
+bqs
 bLj
 aLv
 bAB
@@ -88207,11 +88632,11 @@ cxm
 cpU
 cqf
 cqO
-jSF
+cpU
 fMj
 fMj
 fMj
-gMf
+fMj
 fMj
 fMj
 fMj
@@ -88287,20 +88712,20 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
 bWl
 bWl
 rrt
 acF
 wcU
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
 acF
 acF
 wcU
@@ -88335,7 +88760,7 @@ agL
 vVg
 agL
 agL
-agt
+aIA
 anP
 aoJ
 apv
@@ -88356,7 +88781,7 @@ ayq
 apK
 apK
 apK
-avY
+tUV
 aBu
 apK
 apK
@@ -88416,7 +88841,7 @@ bJC
 bHG
 bIV
 bsK
-myW
+bqs
 vSz
 bRS
 aOE
@@ -88464,7 +88889,7 @@ cvH
 cpU
 cvf
 cvH
-jSF
+cpU
 fMj
 fMj
 fMj
@@ -88544,18 +88969,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
 bWl
 bWl
 rrt
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
 acF
 acF
 acF
@@ -88593,7 +89018,7 @@ alX
 agL
 agL
 agt
-anP
+cAg
 aoK
 apv
 apQ
@@ -88613,7 +89038,7 @@ wvr
 ayb
 apK
 azG
-aqv
+hGd
 aBv
 aDi
 apK
@@ -88626,7 +89051,7 @@ vSz
 swF
 bRS
 vSz
-gWy
+aNq
 aNq
 aNq
 aNq
@@ -88673,7 +89098,7 @@ bqs
 bqs
 bqs
 bqs
-myW
+bqs
 sXO
 bRS
 nmh
@@ -88721,7 +89146,7 @@ cqd
 cpU
 cuO
 cqd
-jSF
+cpU
 fMj
 fMj
 fMj
@@ -88801,18 +89226,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
 bWl
 bWl
 rrt
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
 acF
 acF
 acF
@@ -88850,7 +89275,7 @@ agt
 agt
 agt
 agt
-anV
+anP
 aoM
 apv
 apR
@@ -88883,7 +89308,7 @@ aKQ
 swF
 bRS
 vSz
-gWy
+aNq
 aNZ
 aPE
 aQW
@@ -88930,7 +89355,7 @@ brW
 bHF
 brl
 blQ
-myW
+bqs
 vSz
 bRS
 swF
@@ -89058,20 +89483,20 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
 bWl
 bWl
 rrt
 rrt
 acI
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
+acF
 acF
 acF
 acF
@@ -89083,8 +89508,8 @@ adM
 aek
 aeI
 aeY
-afj
-afj
+acF
+acF
 afj
 agt
 agM
@@ -89105,9 +89530,9 @@ ann
 ann
 gaZ
 gaZ
+ann
+ann
 gaZ
-ann
-ann
 mnG
 apv
 alu
@@ -89140,7 +89565,7 @@ vSz
 swF
 bRS
 vSz
-gWy
+aNq
 aOe
 aPF
 aRa
@@ -89187,7 +89612,7 @@ bJC
 bHG
 bIV
 bsK
-myW
+bqs
 vSz
 bRS
 swF
@@ -89235,7 +89660,7 @@ tqX
 iHZ
 iHZ
 cyi
-jSF
+cpU
 fMj
 bhC
 fMj
@@ -89315,18 +89740,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
 bWl
 bWl
 bWl
+rrt
+rrt
+rrt
+rrt
+rrt
+rrt
+rrt
+rrt
+rrt
 rrt
 rrt
 rrt
@@ -89340,8 +89765,8 @@ adN
 rrt
 rrt
 rrt
-xAI
-xAI
+vSO
+wuP
 xAI
 agt
 agL
@@ -89377,14 +89802,14 @@ apM
 atE
 apK
 auV
-avt
-gDz
-gDz
+mZS
+qGi
+qGi
 xvb
-aub
-avY
-apM
-awO
+fea
+tUV
+jHQ
+mZa
 aBz
 aDl
 apK
@@ -89397,7 +89822,7 @@ vSz
 swF
 alo
 vSz
-gWy
+aNq
 aNq
 aNq
 aNq
@@ -89444,7 +89869,7 @@ bqs
 bqs
 bqs
 bqs
-myW
+bqs
 jgG
 sMr
 ezb
@@ -89492,7 +89917,7 @@ cqd
 cpU
 cuO
 cqd
-qcr
+cqh
 cyw
 cyw
 cyw
@@ -89574,15 +89999,15 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+bWl
+bWl
+bWl
+bWl
+bWl
+bWl
+bWl
+bWl
+bWl
 bWl
 bWl
 bWl
@@ -89597,8 +90022,8 @@ aeJ
 adO
 adO
 aeZ
-afk
-afH
+afS
+afS
 agi
 agt
 agt
@@ -89634,7 +90059,7 @@ atG
 aud
 apK
 auW
-avw
+sPG
 awe
 awP
 awP
@@ -89654,7 +90079,7 @@ vSz
 swF
 oPA
 vSz
-gWy
+aNq
 aNZ
 aPE
 aQW
@@ -89666,7 +90091,7 @@ bkT
 aWV
 gVd
 aNq
-aOe
+nud
 aZh
 aNq
 aOe
@@ -89701,7 +90126,7 @@ brW
 bHF
 brl
 blQ
-myW
+bqs
 vSz
 bRS
 swF
@@ -89831,15 +90256,15 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+bWl
+bWl
+bWl
+bWl
+bWl
+bWl
+bWl
+bWl
+bWl
 bWl
 bWl
 bWl
@@ -89859,7 +90284,7 @@ afI
 agj
 agv
 agv
-agv
+xar
 agv
 ahG
 aib
@@ -89911,7 +90336,7 @@ vSz
 swF
 bRS
 vSz
-gWy
+aNq
 aOe
 aPF
 aRa
@@ -89958,7 +90383,7 @@ bJC
 bHG
 bIV
 bsK
-myW
+bqs
 bLj
 aLv
 bAB
@@ -90118,7 +90543,7 @@ agq
 dQA
 qlA
 agq
-agq
+gOq
 ung
 agq
 ait
@@ -90168,7 +90593,7 @@ aKR
 aJZ
 aLv
 aMN
-gWy
+aNq
 aNq
 aNq
 aNq
@@ -90215,7 +90640,7 @@ bqs
 bqs
 bqs
 bqs
-myW
+bqs
 vSz
 bRS
 swF
@@ -90373,11 +90798,11 @@ afK
 agl
 agw
 agR
-agp
+xDs
 agp
 agp
 aic
-agq
+iYX
 aiu
 afv
 aiI
@@ -90425,7 +90850,7 @@ bRS
 swF
 alo
 vSz
-gWy
+aNq
 aNZ
 aPE
 aQW
@@ -90472,7 +90897,7 @@ bFC
 bFC
 bFC
 bJR
-myW
+bqs
 tmF
 bRS
 aOE
@@ -90632,7 +91057,7 @@ afM
 afJ
 agq
 ahm
-agq
+syg
 aiV
 agq
 aiu
@@ -90682,7 +91107,7 @@ aKS
 vxU
 bRS
 vSz
-gWy
+aNq
 aOe
 aPF
 aRa
@@ -90729,7 +91154,7 @@ bGu
 bHH
 bCD
 bGv
-myW
+bqs
 aIH
 bRS
 bBg
@@ -90937,9 +91362,9 @@ aIc
 bsY
 vSz
 swF
-bzV
+bRS
 aMM
-gWy
+aNq
 aNq
 aNq
 aNq
@@ -90986,7 +91411,7 @@ bCE
 bCD
 jvl
 bGv
-myW
+bqs
 aKQ
 bRS
 swF
@@ -91144,7 +91569,7 @@ afp
 afp
 agx
 afJ
-ahe
+agq
 aho
 ahH
 aiV
@@ -91196,7 +91621,7 @@ vSz
 swF
 alo
 vSz
-kxw
+aNs
 aOr
 aPG
 aRb
@@ -91213,20 +91638,20 @@ aSk
 aNq
 aYp
 aSk
-gWy
-gWy
-gWy
-gWy
-gWy
-vSO
-peP
+aNq
+aNq
+aNq
+aNq
+aNq
+aKT
+bRS
 boy
-vSO
-myW
-myW
-myW
-myW
-myW
+aKT
+bqs
+bqs
+bqs
+bqs
+bqs
 brW
 bzs
 bqs
@@ -91243,7 +91668,7 @@ bCD
 bEx
 bCD
 bGv
-myW
+bqs
 vSz
 bRS
 swF
@@ -91453,7 +91878,7 @@ vSz
 aLr
 bRS
 vSz
-kxw
+aNs
 aOg
 aPH
 aRc
@@ -91470,7 +91895,7 @@ aZs
 aNq
 aYq
 aZs
-gWy
+aNq
 vSz
 aVR
 vSz
@@ -91483,7 +91908,7 @@ vSz
 vSz
 aVR
 vSz
-myW
+bqs
 btW
 buV
 bqs
@@ -91500,7 +91925,7 @@ bGv
 bqs
 bCE
 bGv
-myW
+bqs
 vSz
 oPA
 swF
@@ -91710,7 +92135,7 @@ aIH
 upB
 bRS
 vSz
-kxw
+aNs
 aOh
 aPI
 aRd
@@ -91727,7 +92152,7 @@ aYl
 aNq
 aYr
 aYl
-gWy
+aNq
 vSz
 pFK
 bRS
@@ -91740,7 +92165,7 @@ bRS
 oPA
 bRS
 vSz
-myW
+bqs
 btS
 brl
 bqs
@@ -91757,7 +92182,7 @@ bCD
 bFC
 bCD
 bGv
-myW
+bqs
 vSz
 bRS
 swF
@@ -91917,7 +92342,7 @@ qkA
 agp
 agp
 agp
-ahJ
+agp
 aie
 agq
 aiy
@@ -91967,7 +92392,7 @@ vSz
 swF
 bRS
 vSz
-kxw
+aNs
 aOi
 aPJ
 aRe
@@ -91984,7 +92409,7 @@ baR
 aNq
 aOe
 baR
-gWy
+aNq
 aIH
 alo
 iTP
@@ -91997,7 +92422,7 @@ aKO
 aCf
 bRS
 vSz
-myW
+bqs
 btk
 bsK
 bqs
@@ -92014,7 +92439,7 @@ bGw
 bEx
 bEx
 bEx
-myW
+bqs
 vSz
 bRS
 swF
@@ -92172,9 +92597,9 @@ afQ
 agq
 agq
 agq
+xYk
 agq
-agq
-agq
+iYX
 aif
 aip
 aiz
@@ -92224,24 +92649,24 @@ vSz
 swF
 bRS
 vSz
-kxw
-kxw
-kxw
-kxw
-kxw
-xYk
+aNs
+aNs
+aNs
+aNs
+aNs
+aSm
 aUU
-xYk
-gWy
-gWy
-gWy
-gWy
-gWy
-gWy
-gWy
-gWy
-gWy
-gWy
+aSm
+aNq
+aNq
+aNq
+aNq
+aNq
+aNq
+aNq
+aNq
+aNq
+aNq
 vSz
 bRS
 mvn
@@ -92254,24 +92679,24 @@ vSz
 aUD
 bRS
 xbg
-myW
-myW
-myW
-myW
-myW
-myW
+bqs
+bqs
+bqs
+bqs
+bqs
+bqs
 bxZ
-myW
-myW
-myW
-myW
-myW
-myW
+bqs
+bqs
+bqs
+bqs
+bqs
+bqs
 bGx
-myW
-myW
-myW
-myW
+bqs
+bqs
+bqs
+bqs
 vSz
 bRS
 swF
@@ -92943,7 +93368,7 @@ afS
 afv
 afS
 afv
-afS
+fXW
 afS
 afw
 afS
@@ -94039,10 +94464,10 @@ aVS
 hEC
 uLs
 aKa
-iFG
-iFG
+lDb
+lDb
 bhP
-iFG
+lDb
 aKa
 cPV
 cPV
@@ -94549,14 +94974,14 @@ iFG
 aYt
 iFG
 iFG
-iFG
+eao
 iFG
 bdi
 beb
-iFG
-xrI
+lDb
+iIg
 bih
-iFG
+lDb
 beb
 bdi
 iFG
@@ -94807,10 +95232,10 @@ aYu
 uoO
 aVT
 aXd
-aYu
+tcG
 bdj
 bec
-aXe
+wXv
 jHm
 bil
 aXe
@@ -95060,26 +95485,26 @@ aTF
 iFG
 aVT
 aXd
-aYu
-dbh
+nJW
+qMo
 aVT
 aXd
 aYu
-clQ
+xrI
 bed
-bed
+ycO
 bed
 bii
 bed
 bed
 xrI
-aVT
+bKH
 aXd
 aYu
-dbh
+yiV
 aVT
 aXd
-aYu
+nJW
 qFw
 aTF
 bjU
@@ -95321,7 +95746,7 @@ aYu
 dbh
 ppw
 aXd
-aYu
+nJW
 xrI
 aXd
 aXd
@@ -95330,9 +95755,9 @@ bij
 aXd
 aXd
 xrI
-aVT
+vrz
 aXd
-aYu
+oXQ
 dbh
 aVT
 bro
@@ -95572,7 +95997,7 @@ aRm
 aOs
 aTF
 iFG
-aWa
+rgF
 aXd
 aYu
 dbh
@@ -95582,18 +96007,18 @@ aYu
 aZv
 bef
 bef
-bef
+oLw
 bik
 bef
-bef
+oLw
 xAS
 aVT
 aXd
 aYu
 uoO
-aVT
+vrz
 aXd
-aYu
+nJW
 iFG
 aTF
 btL
@@ -95829,13 +96254,13 @@ aOt
 aOt
 aOt
 qFw
-aWa
+rgF
 aXd
 aYu
-gsH
+pMG
 aVT
 aXd
-aYu
+nJW
 xAS
 dbh
 hNW
@@ -95844,7 +96269,7 @@ bim
 dbh
 dbh
 xrI
-baq
+qxv
 aXd
 aYu
 aZu
@@ -96088,18 +96513,18 @@ aOt
 iFG
 aWa
 aXd
-aYv
+vuN
 dbh
-aVT
+vrz
 aXd
 aYu
 xrI
 bed
+ycO
+ycO
+tQj
 bed
-bed
-bii
-bed
-bed
+ycO
 xrI
 aVT
 aXd
@@ -96108,7 +96533,7 @@ dbh
 aVT
 aXd
 aYu
-iFG
+gaz
 bts
 dCg
 dtT
@@ -96361,7 +96786,7 @@ xrI
 aVT
 aXd
 aYu
-dbh
+yiV
 baq
 aXd
 aYu
@@ -96619,7 +97044,7 @@ aVT
 aXd
 ruI
 dbh
-aVT
+eHT
 aXd
 aYu
 iFG
@@ -96860,7 +97285,7 @@ aVc
 aVW
 uef
 uef
-uef
+twm
 uef
 uef
 uef
@@ -96872,7 +97297,7 @@ bir
 bjs
 bjs
 blt
-ueY
+sgx
 ueY
 ueY
 bka
@@ -97116,20 +97541,20 @@ aOt
 aVd
 lOX
 dbh
+yiV
 dbh
 dbh
-dbh
-dbh
+qMo
 dbh
 xrI
 beh
 beh
 oti
-bio
+yei
 beh
 beh
 tak
-dbh
+yiV
 dbh
 hNW
 bpM
@@ -97638,12 +98063,12 @@ aYu
 oti
 bei
 bei
-oti
+xom
 bio
 bei
 bei
 oti
-aVT
+vrz
 aXd
 aYu
 boN
@@ -97885,13 +98310,13 @@ aRo
 aSv
 aOt
 iFG
-aVT
+vrz
 aXd
 aYu
 dbh
-aVT
+vrz
 aXd
-aYu
+nJW
 oti
 bei
 bei
@@ -97903,7 +98328,7 @@ oti
 aVT
 aXd
 aYu
-boN
+oPf
 aVT
 aXd
 aYv
@@ -98142,7 +98567,7 @@ aRn
 aSw
 aOt
 qFw
-aVT
+vrz
 aXd
 aYu
 gsH
@@ -98157,7 +98582,7 @@ bip
 bei
 bej
 oti
-aVT
+vrz
 aXd
 aYu
 boR
@@ -98200,21 +98625,21 @@ cbW
 aXw
 cbW
 cfw
-cgI
-cgI
-cgI
-cgI
-cgI
-cgI
-cgI
-cgI
+nrc
+nrc
+nrc
+nrc
+nrc
+nrc
+nrc
+nrc
 coi
-cgI
-cgI
-cgI
-cgI
-cgI
-cpq
+nrc
+nrc
+nrc
+nrc
+nrc
+wWZ
 cpq
 aab
 aab
@@ -98403,10 +98828,10 @@ aVT
 aXd
 aYu
 dbh
-aVT
+bKH
 aXd
 aYu
-oti
+eNp
 aTF
 aTF
 bhd
@@ -98457,7 +98882,7 @@ cbX
 cdt
 cbW
 cfw
-cfD
+wsu
 chO
 chQ
 chQ
@@ -98656,13 +99081,13 @@ aRn
 aSw
 aOt
 iFG
-aVT
+vrz
 aXd
 aYu
 dbh
-aVT
+vrz
 aXd
-aYu
+nJW
 oti
 bdl
 bdu
@@ -98677,7 +99102,7 @@ aYu
 boN
 aVT
 aXd
-aYu
+nJW
 iFG
 btt
 bul
@@ -98714,7 +99139,7 @@ cbY
 cdl
 jeJ
 cbY
-cfD
+wsu
 mof
 chQ
 qJu
@@ -98726,7 +99151,7 @@ chQ
 coP
 cmB
 wHm
-cqp
+tTT
 crH
 crg
 aab
@@ -98917,7 +99342,7 @@ aVT
 aXd
 ubi
 dbh
-aVT
+vrz
 aXd
 aYu
 xAS
@@ -98928,13 +99353,13 @@ biw
 bfZ
 bdl
 aYG
-aVT
+vrz
 aXd
 aYu
-boN
+jeR
 aVT
 aXd
-aYu
+nJW
 iFG
 btt
 bul
@@ -98971,7 +99396,7 @@ cbZ
 cdm
 ceq
 cfB
-cfD
+wsu
 chP
 chQ
 cjS
@@ -99187,7 +99612,7 @@ bdl
 xAS
 aVT
 aXd
-aYu
+tcG
 qJG
 aVT
 aXd
@@ -99228,7 +99653,7 @@ cca
 cdn
 cer
 cfC
-cfD
+wsu
 bWv
 fQU
 chC
@@ -99236,10 +99661,10 @@ ckR
 ckR
 ckR
 ckR
-chQ
+qld
 coP
-chQ
-chQ
+key
+key
 crc
 gvs
 crg
@@ -99485,7 +99910,7 @@ bGC
 cdp
 hYR
 hYR
-cfD
+wsu
 cfD
 rES
 chC
@@ -99495,9 +99920,9 @@ ckR
 ckR
 chQ
 coP
-chQ
+key
 cqr
-chQ
+key
 gvs
 crg
 aab
@@ -99752,9 +100177,9 @@ ckR
 ckR
 chQ
 coP
-chQ
-chQ
-chQ
+key
+key
+key
 gvs
 crg
 aab
@@ -100256,7 +100681,7 @@ bEo
 bCI
 bCI
 hYR
-cfD
+wsu
 cfD
 chQ
 cjW
@@ -100513,7 +100938,7 @@ cbr
 cdC
 bMq
 bLv
-cfD
+wsu
 gQE
 chQ
 caK
@@ -100770,21 +101195,21 @@ ccc
 neV
 bMs
 cfG
-cfD
-cfD
-cfD
-cfD
-cfD
-cfD
-cfD
-cfD
-cfD
-cfD
-cfD
-cfD
-crg
-crg
-crg
+wsu
+wsu
+wsu
+wsu
+wsu
+wsu
+wsu
+wsu
+wsu
+wsu
+wsu
+wsu
+jDW
+jDW
+jDW
 aab
 aab
 aab
@@ -107959,7 +108384,7 @@ bSd
 bNm
 bNm
 bNm
-jdI
+bZz
 tkT
 caT
 bZx

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -515,3 +515,11 @@ then, for every time you included a field, increment fields. */
 /obj/item/paper/memorial
 	name = "Memorial Note"
 	info = {"May the souls of our fallen brothers be at rest; not that we may find solace in their passing, but that we should take our due initiative to press on in their memory."}
+
+/obj/item/paper/syndicateraid
+	name = "Operation Ash"
+	info = {"Retrieval of goods is priority. Contact Ash ASAP after retrieval. Everyone is expendable. Eliminate all witnesses."}
+
+/obj/item/paper/pmc
+	name = "Contain breach"
+	info = {"Ensure that the 'Beast' does not leak out. Intel suggests that enemy troops are set to capture the 'Beast'. Eliminate enemy at any cost. Use 'Big Bang' when OPSEC on the 'Beast' is compromised."}


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Green disk is now in medbay.

Blue disk is now in engineering.

Red disk is now in crashed ship.

Moved silos around for Crash.

Nuke is now in PMC ship, which is north of research.

Made lore relevant props on how xenomorphs got into Prison Station in the first place.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Prison station is due for a nuke disk relocation.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Green disk in Prison Station is now in medbay.
add: Blue disk in Prison Station  is now in engineering.
add: Red disk in Prison Station is now in crashed ship.
change: Moved silos in Prison Station around for Crash.
change: Nuke in Prison Station is now in PMC ship, which is north of research.
add: lore relevant props on how xenomorphs got into Prison Station in the first place.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
