### PR TITLE
Make automated miners require open turfs on all 8 sides to sell ore (excluding map spawn turfs and xeno resin walls)

### DIFF
--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -265,18 +265,25 @@
 		return
 	if(add_tick >= required_ticks)
 		if(miner_upgrade_type == MINER_AUTOMATED)
-			for(var/direction in GLOB.cardinals)
-				if(!isopenturf(get_step(loc, direction))) //Must be open on one side to operate
-					continue
-				SSpoints.supply_points[faction] += mineral_value
-				do_sparks(5, TRUE, src)
-				playsound(loc,'sound/effects/phasein.ogg', 50, FALSE)
-				say("Ore shipment has been sold for [mineral_value] points.")
+			var/obstructions = list()
+			for(var/direction in GLOB.alldirs)
+				var/turf/selected_turf = get_step(loc, direction)
+				if(!isopenturf(selected_turf) && !istype(selected_turf, /turf/closed/wall/resin)) //Must be open on all sides to operate
+					obstructions += selected_turf.name
+
+			if(length(obstructions) > 0)
+				playsound(loc,'sound/machines/buzz-two.ogg', 35, FALSE)
+				say("Ore shipment export failed. Obstructed by: [jointext(obstructions, ", ")].")
 				add_tick = 0
 				return
-			playsound(loc,'sound/machines/buzz-two.ogg', 35, FALSE)
+
+			SSpoints.supply_points[faction] += mineral_value
+			do_sparks(5, TRUE, src)
+			playsound(loc,'sound/effects/phasein.ogg', 50, FALSE)
+			say("Ore shipment has been sold for [mineral_value] points.")
 			add_tick = 0
 			return
+
 		stored_mineral += 1
 		add_tick = 0
 	if(stored_mineral >= 8)	//Stores 8 boxes worth of minerals


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Guess who's back?
Can later be extended to include dense objects (like closed airlocks 😉)

This change is only a stop gap measure and will not prevent all wall cheese as in places where mapped in walls are you will be able to get away with leaving space around the rest and connecting to the existing closed turfs. I much prefer removing the upgrade altogether.

## Why It's Good For The Game
See mathematical explanation for why this is bad here: https://github.com/tgstation/TerraGov-Marine-Corps/pull/10375#issuecomment-1146151053
![image](https://user-images.githubusercontent.com/64715958/171784637-363832fd-dbc4-4b7e-bf04-e33a00aee43c.png)
![image](https://user-images.githubusercontent.com/64715958/171784692-89751cf6-a10c-4f56-aea2-cb3d23e25029.png)
![image](https://user-images.githubusercontent.com/64715958/171784785-43a5eb30-1d76-40a4-b580-e52b30b4f7d9.png)

## Changelog
:cl:
balance: Automated miners require open turfs on all 8 sides to sell ore with the exception of xeno resin walls and turfs present when the map loads.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
