### PR TITLE
Nerfs smartgunner minigun ammo count and magazine boxes

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -433,7 +433,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	icon_state = "minigun_sg"
 	item_state = "minigun_sg"
 	fire_animation = "minigun_sg_fire"
-	max_shells = 3000 //codex
+	max_shells = 1000 //codex
 	caliber = CALIBER_10x26_CASELESS //codex
 	allowed_ammo_types = list(/obj/item/ammo_magazine/minigun_powerpack/smartgun)
 	wield_delay = 1.5 SECONDS
@@ -444,7 +444,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	aim_slowdown = 1.5
 	actions_types = list()
 
-	fire_delay = 0.1 SECONDS
+	fire_delay = 0.15 SECONDS
 	windup_delay = 0.7 SECONDS
 	scatter = -5
 	recoil = 0

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -444,7 +444,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	aim_slowdown = 1.5
 	actions_types = list()
 
-	fire_delay = 0.15 SECONDS
+	fire_delay = 0.1 SECONDS
 	windup_delay = 0.7 SECONDS
 	scatter = -5
 	recoil = 0

--- a/code/modules/projectiles/magazines/misc.dm
+++ b/code/modules/projectiles/magazines/misc.dm
@@ -66,8 +66,8 @@
 	icon_state = "box_smartminigun"
 	default_ammo = /datum/ammo/bullet/smart_minigun
 	caliber = CALIBER_10x26_CASELESS
-	current_rounds = 1000
-	max_rounds = 1000
+	current_rounds = 500
+	max_rounds = 500
 	w_class = WEIGHT_CLASS_NORMAL
 
 // pistol packets

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -311,7 +311,7 @@
 	icon_state = "powerpacksg"
 	flags_magazine = MAGAZINE_WORN|MAGAZINE_REFILLABLE
 	default_ammo = /datum/ammo/bullet/smart_minigun
-	current_rounds = 3000
-	max_rounds = 3000
+	current_rounds = 1000
+	max_rounds = 1000
 	caliber = CALIBER_10x26_CASELESS
 	flags_item_map_variant = null


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR  brings back down the smart-minigun to a tolerable ammo count and ROF.
This was discussed in the balance channel on discord prior to making it. The numbers are chosen based on what a few people there said.
They keep the 1k magazines they get so it can be fully reloaded instead of having to use 3 magazines.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This makes it so the smartminigun isn't as oppressive as it currently is, alongside the sunder nerf it's getting in the other PR.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Smartminigun ammo count reduced to 1,000 and mag box down to 500.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
