### PR TITLE
Adds explanatory comments to ammo flags

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -38,18 +38,18 @@
 
 //Ammo defines for gun/projectile related things.
 //flags_ammo_behavior
-#define AMMO_EXPLOSIVE (1<<0)
+#define AMMO_EXPLOSIVE (1<<0) //Ammo will impact a targeted open turf instead of continuing past it
 #define AMMO_XENO (1<<1)
 #define AMMO_XENO_TOX (1<<2) //Unused value.
-#define AMMO_ENERGY (1<<3)
-#define AMMO_ROCKET (1<<4)
-#define AMMO_SNIPER (1<<5)
-#define AMMO_INCENDIARY (1<<6)
+#define AMMO_ENERGY (1<<3) //Ammo will pass through windows and has damage reduced by smokes with SMOKE_NERF_BEAM
+#define AMMO_ROCKET (1<<4) //Ammo is more likely to continue past cover such as cades
+#define AMMO_SNIPER (1<<5) //Ammo is more likely to continue past cover such as cades
+#define AMMO_INCENDIARY (1<<6) //Ammo will attempt to add firestacks and ignite a hit mob if it deals any damage. Armor applies, regardless of AMMO_IGNORE_ARMOR
 #define AMMO_SKIPS_ALIENS (1<<7)
 #define AMMO_IS_SILENCED (1<<8) //Unused right now.
-#define AMMO_IGNORE_ARMOR (1<<9)
+#define AMMO_IGNORE_ARMOR (1<<9) //Projectile direct damage will ignore both hard and soft armor
 #define AMMO_IGNORE_RESIST (1<<10) //Unused.
-#define AMMO_BALLISTIC (1<<11)
+#define AMMO_BALLISTIC (1<<11) //Generates blood splatters on mob hit
 #define AMMO_SUNDERING (1<<12)
 #define SPECIAL_PROCESS (1<<13)
 #define AMMO_SENTRY (1<<14) //Used to identify ammo from sentry guns and other automated sources


### PR DESCRIPTION
## About The Pull Request
As title. No functional changes.

## Why It's Good For The Game
So people mucking with guns don't have to go code diving to figure out what each flag actually does.
Is this one of those cases where it's worse because it means changes need to be made in two places and probably one of them will be missed?

## Changelog
:cl:
code: Ammo flag comments expanded
/:cl: