### PR TITLE
Removes the automatic miner upgrade

### DIFF
--- a/code/game/objects/items/misc.dm
+++ b/code/game/objects/items/misc.dm
@@ -155,9 +155,3 @@
 /obj/item/dropship_points_voucher/examine(mob/user)
 	. = ..()
 	. += "It contains [extra_points] points."
-
-/obj/item/minerupgrade/automatic
-	name = "mining computer"
-	desc = "A small computer that can automate mining wells, reducing the need for oversight."
-	icon_state = "mining_drill_automaticdisplay"
-	uptype = "mining computer"

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -6,7 +6,6 @@
 #define MINER_LIGHT_SDAMAGE 4
 #define MINER_LIGHT_MDAMAGE 2
 #define MINER_LIGHT_DESTROYED 0
-#define MINER_AUTOMATED "mining computer"
 #define MINER_RESISTANT "reinforced components"
 #define MINER_OVERCLOCKED "high-efficiency drill"
 
@@ -93,14 +92,6 @@
 			miner_integrity = 300
 		if(MINER_OVERCLOCKED)
 			required_ticks = 60
-		if(MINER_AUTOMATED)
-			if(stored_mineral)
-				SSpoints.supply_points[faction] += mineral_value * stored_mineral
-				do_sparks(5, TRUE, src)
-				playsound(loc,'sound/effects/phasein.ogg', 50, FALSE)
-				say("Ore shipment has been sold for [mineral_value * stored_mineral] points.")
-				stored_mineral = 0
-				start_processing()
 	miner_upgrade_type = upgrade.uptype
 	user.visible_message(span_notice("[user] attaches the [miner_upgrade_type] to the [src]!"))
 	qdel(upgrade)
@@ -141,9 +132,6 @@
 			if(MINER_OVERCLOCKED)
 				upgrade = new /obj/item/minerupgrade/overclock
 				required_ticks = initial(required_ticks)
-			if(MINER_AUTOMATED)
-				upgrade = new /obj/item/minerupgrade/automatic
-				stop_processing()
 		upgrade.forceMove(user.loc)
 		miner_upgrade_type = null
 		update_icon()
@@ -243,9 +231,6 @@
 	if(miner_status != MINER_RUNNING)
 		to_chat(user, span_warning("[src] is damaged!"))
 		return
-	if(miner_upgrade_type == MINER_AUTOMATED)
-		to_chat(user, span_warning("[src] is automated!"))
-		return
 	if(!stored_mineral)
 		to_chat(user, span_warning("[src] is not ready to produce a shipment yet!"))
 		return
@@ -264,19 +249,6 @@
 		SSminimaps.add_marker(src, z, hud_flags = MINIMAP_FLAG_ALL, iconstate = "miner_[mineral_value >= PLATINUM_CRATE_SELL_AMOUNT ? "platinum" : "phoron"]_off")
 		return
 	if(add_tick >= required_ticks)
-		if(miner_upgrade_type == MINER_AUTOMATED)
-			for(var/direction in GLOB.cardinals)
-				if(!isopenturf(get_step(loc, direction))) //Must be open on one side to operate
-					continue
-				SSpoints.supply_points[faction] += mineral_value
-				do_sparks(5, TRUE, src)
-				playsound(loc,'sound/effects/phasein.ogg', 50, FALSE)
-				say("Ore shipment has been sold for [mineral_value] points.")
-				add_tick = 0
-				return
-			playsound(loc,'sound/machines/buzz-two.ogg', 35, FALSE)
-			add_tick = 0
-			return
 		stored_mineral += 1
 		add_tick = 0
 	if(stored_mineral >= 8)	//Stores 8 boxes worth of minerals

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -278,12 +278,10 @@
 	switch(health_percent)
 		if(-INFINITY to 0)
 			miner_status = MINER_DESTROYED
-			stored_mineral = 0
+			stored_mineral = round(stored_mineral / 2)
 		if(1 to 50)
-			stored_mineral = 0
 			miner_status = MINER_MEDIUM_DAMAGE
 		if(51 to 99)
-			stored_mineral = 0
 			miner_status = MINER_SMALL_DAMAGE
 		if(100 to INFINITY)
 			start_processing()

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -584,7 +584,6 @@
 			/obj/item/radio/headset/mainship/marine/delta = -1,
 		),
 		"Mining Equipment" = list(
-			/obj/item/minerupgrade/automatic = 1,
 			/obj/item/minerupgrade/reinforcement = 1,
 			/obj/item/minerupgrade/overclock = 1,
 		),
@@ -637,7 +636,6 @@
 		"Surplus Special Equipment" = list(
 			/obj/item/bodybag/tarp = 2,
 			/obj/item/explosive/plastique = 5,
-			/obj/item/minerupgrade/automatic = 3,
 			/obj/item/radio/headset/mainship/marine/alpha = -1,
 			/obj/item/radio/headset/mainship/marine/bravo = -1,
 			/obj/item/radio/headset/mainship/marine/charlie = -1,

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -41,11 +41,6 @@ OPERATIONS
 	contains = list(/obj/item/fulton_extraction_pack)
 	cost = 10
 
-/datum/supply_packs/operations/autominer
-	name = "Autominer upgrade"
-	contains = list(/obj/item/minerupgrade/automatic)
-	cost = 5
-
 /datum/supply_packs/operations/miningwelloverclock
 	name = "Mining well reinforcement upgrade"
 	contains = list(/obj/item/minerupgrade/reinforcement)
@@ -150,11 +145,6 @@ OPERATIONS
 	cost = 40
 	containertype = null
 	available_against_xeno_only = TRUE
-
-/datum/supply_packs/operations/autominer
-	name = "Autominer upgrade"
-	contains = list(/obj/item/minerupgrade/automatic)
-	cost = 15
 
 /*******************************************************************************
 WEAPONS


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See changelog.
Closes: #10375

If acceptable I will seek to improve overclock after auto is gone.

## Why It's Good For The Game

Prevents fully walled in, and never visited again, far away automatic miner cheese. See #10375 for images.

Automated miners are strictly the best configuration for a miner as it stands, so why even have others or default. Please don't leave comments that the upgrade costs points when they are clearly worth the investment every single time if just a single export happens from it.

No longer needed. Since 10 months ago it has been possible to just walk up to a miner with 1 to 8 stored ore shipments and click it to sell them on the spot for points without any use time. Nobody seems to have noticed including myself because of the ubiquity of the automatic upgrade.

I don't think marines are hurting at all for points between: phoron miners, xeno/minion corpse export, research, intel computers, and potentially in the near future selling other marine's corpses.

Engi mains can have fun walling up miners, but will need to venture back at some point to make a hole and collect those juicy points by standing there and sending the shipments giving opportunity for emergent objective based gameplay on both sides.

## Changelog
:cl:
del: Removed the automatic miner upgrade.
balance: Miners keep half their stored ore shipments when fully destroyed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
