### PR TITLE
Med Pouch Rebalance

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -142,6 +142,7 @@
 	name = "combat injector pouch"
 	desc = "Standard marine first-aid combat injector pouch. Specialized to store only autoinjectors."
 	icon_state = "firstaid_injector"
+	storage_slots = 10
 	can_hold = list(/obj/item/reagent_containers/hypospray/autoinjector)
 
 /obj/item/storage/pouch/firstaid/injectors/full
@@ -152,6 +153,11 @@
 	new /obj/item/reagent_containers/hypospray/autoinjector/combat (src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/combat (src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/combat (src)
+	new /obj/item/reagent_containers/hypospray/autoinjector/combat (src)
+	new /obj/item/reagent_containers/hypospray/autoinjector/tricordrazine (src)
+	new /obj/item/reagent_containers/hypospray/autoinjector/tricordrazine (src)
+	new /obj/item/reagent_containers/hypospray/autoinjector/alkysine (src)
+	new /obj/item/reagent_containers/hypospray/autoinjector/imidazoline (src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/oxycodone (src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/russian_red (src)
 
@@ -397,7 +403,6 @@
 	desc = "A pouch specifically for auto-injectors."
 	icon_state = "autoinjector"
 	storage_slots = 8
-	max_storage_space = 14
 	can_hold = list(
 		/obj/item/reagent_containers/hypospray/autoinjector,
 	)
@@ -431,8 +436,7 @@
 	name = "auto-injector pouch"
 	desc = "A pouch specifically for auto-injectors. This one comes pre-loaded with goodies!"
 	icon_state = "autoinjector"
-	storage_slots = 8
-	max_storage_space = 14
+	storage_slots = 10
 	can_hold = list(
 		/obj/item/reagent_containers/hypospray/autoinjector,
 	)
@@ -445,6 +449,8 @@
 	new /obj/item/reagent_containers/hypospray/autoinjector/isotonic(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/dexalinplus(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/synaptizine(src)
+	new /obj/item/reagent_containers/hypospray/autoinjector/russian_red(src)
+	new /obj/item/reagent_containers/hypospray/autoinjector/hypervene(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/quickclotplus(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/peridaxon_plus(src)
 
@@ -484,7 +490,7 @@
 	icon_state = "medkit"
 	w_class = WEIGHT_CLASS_BULKY //does not fit in backpack
 	max_w_class = 4
-	storage_slots = 7
+	storage_slots = 6
 	can_hold = list(
 		/obj/item/healthanalyzer,
 		/obj/item/reagent_containers/dropper,
@@ -502,9 +508,8 @@
 	. = ..()
 	new /obj/item/healthanalyzer(src)
 	new /obj/item/stack/medical/heal_pack/advanced/bruise_pack(src)
-	new /obj/item/stack/medical/heal_pack/advanced/bruise_pack(src)
 	new /obj/item/stack/medical/heal_pack/advanced/burn_pack(src)
-	new /obj/item/stack/medical/heal_pack/advanced/burn_pack(src)
+	new /obj/item/stack/medical/splint(src)
 	new /obj/item/stack/medical/splint(src)
 	new /obj/item/stack/medical/splint(src)
 

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -516,10 +516,9 @@
 /obj/item/storage/pouch/medkit/equippedcorpsman/Initialize()
 	. = ..()
 	new /obj/item/healthanalyzer(src)
-	new /obj/item/stack/medical/heal_pack/advanced/bruise_pack(src)
-	new /obj/item/stack/medical/heal_pack/advanced/burn_pack(src)
 	new /obj/item/storage/pill_bottle/bicaridine(src)
 	new /obj/item/storage/pill_bottle/kelotane(src)
+	new /obj/item/storage/pill_bottle/tricordrazine(src)
 	new /obj/item/storage/pill_bottle/tramadol(src)
 	new /obj/item/stack/medical/splint(src)
 


### PR DESCRIPTION
## About The Pull Request

Storage items with slots make injectors worse space-wise than pill bottles. This PR aims to make pills and injectors a little bit closer in terms of balance.

Injector pouches 6/8 -> 10 slots (equivalent to 5 slots weight-wise. 300u max total)
Medkit pouch 7 -> 6 slots (1440u max total) so it's a little bit less OP, and has same size as first-aid pouch.

## Why It's Good For The Game

Less meta, more freedom of choice.
Injector pouch having 6 slots for injectors and medkit having 7 for pill bottles is a joke.
Medkit is currently most space-effective pouch in the game, and every marine wants meds, so a lot of marines use it. To make it less a powercreep, same size as first-aid pouch.

## Changelog
:cl:
balance: Injector pouches are bigger
balance: Medkit pouch is a little smaller
/:cl:
