### PR TITLE
Revert "Health kits chain apply (#9977)"

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -42,24 +42,19 @@
 			to_chat(user, span_warning("You can't apply [src] through [H.wear_suit]!"))
 			return TRUE
 
-	if(!can_affect_limb(affecting))
-		to_chat(user, span_warning("This isn't useful at all on [affecting.limb_status & LIMB_ROBOT ? "a robotic": "an organic"] limb."))
+	if(affecting.limb_status & LIMB_ROBOT)
+		to_chat(user, span_warning("This isn't useful at all on a robotic limb."))
 		return TRUE
 
 	H.UpdateDamageIcon()
 
 	if(user.skills.getRating("medical") < skill_level_needed)
-		if(user.do_actions || !do_mob(user, M, unskilled_delay, BUSY_ICON_UNSKILLED, BUSY_ICON_MEDICAL))
+		if(user.do_actions)
 			to_chat(user, span_warning("You're busy with something else right now!"))
+		if(!do_mob(user, M, unskilled_delay, BUSY_ICON_UNSKILLED, BUSY_ICON_MEDICAL))
 			return TRUE
 
 	return affecting
-
-///Checks for whether the limb is appropriately organic/robotic
-/obj/item/stack/medical/proc/can_affect_limb(datum/limb/affecting)
-	if(affecting.limb_status & LIMB_ROBOT)
-		return FALSE
-	return TRUE
 
 /obj/item/stack/medical/heal_pack
 	name = "platonic gauze"
@@ -85,33 +80,6 @@
 			to_chat(user, span_notice("\The [affecting.display_name] is cut open, you'll need more than a bandage!"))
 		return
 
-	var/unskilled_penalty = (user.skills.getRating("medical") < skill_level_needed) ? 0.5 : 1
-	var/affected = heal_limb(affecting, unskilled_penalty)
-
-	generate_treatment_messages(user, patient, affecting, affected)
-	if(!affected)
-		return
-	use(1)
-
-	//For fast use. If you're already treating and apply to another part, don't try to start cycling again
-	if(user.do_actions)
-		return
-
-	//After patching the first limb, start looping through the rest with a delay on each.
-	for(affecting AS in patient.limbs)
-		if(!can_affect_limb(affecting))
-			continue
-		//Always delay on the first try, otherwise only delay if you patched the last iterated limb.
-		if(affected && !do_mob(user, patient, SKILL_TASK_VERY_EASY / (unskilled_penalty ** 2), BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
-			to_chat(user, span_notice("You stop tending to [patient]'s wounds."))
-			return
-		affected = heal_limb(affecting, unskilled_penalty)
-		if(affected) //Limbs you don't treat just pass by silently
-			generate_treatment_messages(user, patient, affecting, affected)
-	to_chat(user, span_notice("You finish tending to [patient]'s wounds."))
-
-///Applies the heal_pack to a specified limb. Unskilled penalty is a multiplier between 0 and 1 on brute/burn healing effectiveness
-/obj/item/stack/medical/heal_pack/proc/heal_limb(datum/limb/affecting, unskilled_penalty)
 	var/affected = FALSE
 	if(heal_flags & BANDAGE)
 		affected |= affecting.bandage()
@@ -120,10 +88,11 @@
 	if(heal_flags & DISINFECT)
 		affected |= affecting.disinfect()
 
+	generate_treatment_messages(user, patient, affecting, affected)
 	if(affected)
-		affecting.heal_limb_damage(heal_brute * unskilled_penalty, heal_burn * unskilled_penalty, updating_health = TRUE)
-
-	return affected
+		var/untrained_healing_penalty = (user.skills.getRating("medical") < skill_level_needed) ? 0.5 : 1
+		affecting.heal_limb_damage(heal_brute * untrained_healing_penalty, heal_burn * untrained_healing_penalty, updating_health = TRUE)
+		use(1)
 
 ///Purely visual, generates the success/failure messages for using a health pack
 /obj/item/stack/medical/heal_pack/proc/generate_treatment_messages(mob/user, mob/patient, datum/limb/target_limb, success)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This reverts commit 80cd10017ea02765796f3d21e49aa66f1b4d99a0.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No clue how this got merged

#9977 makes it so that advanced kits can chain apply to all limbs, healing them without a need for input on the user's part. This *sounds* fine, except where it might waste kits on like, 3 damage limbs

except this PR made the chained applications *not consume kits*

one brute kit can heal up to 132 damage with a single kit, as long as you stay still!!

it's a needless corpsman buff. If you run out of kits, bring more. 
Btw this PR i'm reverting was an 'alternative' to one that literally just gave kits +3 healing
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Reverts PR#9977 (Chain medkit application PR)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
