### PR TITLE
Fixes carriers not carrying huggers

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -130,7 +130,7 @@
 /obj/item/clothing/mask/facehugger/attack_hand(mob/living/user)
 	if(isxeno(user))
 		var/mob/living/carbon/xenomorph/X = user
-		if(X.xeno_caste.caste_flags & CASTE_CAN_HOLD_FACEHUGGERS)
+		if(X.xeno_caste.can_flags & CASTE_CAN_HOLD_FACEHUGGERS)
 			deltimer(jumptimer)
 			deltimer(activetimer)
 			remove_danger_overlay() //Remove the exclamation overlay as we pick it up


### PR DESCRIPTION
## About The Pull Request
Xeno flag revamp moved the relevant flag into a different var but forgot to update what the facehugger actually checked.

## Why It's Good For The Game
Bugfix

## Changelog
:cl:
fix: Carriers and other appropriate xenos can pick up facehuggers again
/:cl:
