### PR TITLE
Fixes failing legs code

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_organs.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_organs.dm
@@ -22,7 +22,7 @@
 			if(overeatduration > 1)
 				overeatduration -= 2	//Doubled the unfat rate
 
-	var/leg_tally = 2
+	var/leg_tally = 0
 
 	last_dam = getBruteLoss() + getFireLoss() + getToxLoss()
 
@@ -31,6 +31,11 @@
 
 	for(var/i in limbs)
 		var/datum/limb/E = i
+
+		if((E.name in list("l_leg", "l_foot", "r_leg", "r_foot")) && !lying_angle) //Need to do this before checking need_process in order to catch missing limbs
+			if(!E.is_usable() || E.is_malfunctioning() || E.is_broken())
+				leg_tally++			//let it fail even if just foot&leg
+
 		if(!E.need_process())
 			continue
 
@@ -47,13 +52,10 @@
 				if(prob((E.brute_dam - (E.limb_wound_status & LIMB_WOUND_BANDAGED ? 50 : 0)) * 4))
 					E.germ_level++
 
-		if(E.name in list("l_leg", "l_foot", "r_leg", "r_foot") && !lying_angle)
-			if(!E.is_usable() || E.is_malfunctioning() || ( E.is_broken() && !(E.limb_status & LIMB_SPLINTED) && !(E.limb_status & LIMB_STABILIZED) ) )
-				leg_tally--			//let it fail even if just foot&leg
-
-	//standing is poor
-	if(leg_tally <= 0 && !IsUnconscious() && !lying_angle && prob(5))
+	//Hard to stay upright
+	if(leg_tally > 1 && prob(2.5 * leg_tally))
 		if(!(species.species_flags & NO_PAIN))
 			emote("pain")
-		emote("collapse")
-		SetUnconscious(20 SECONDS)
+		visible_message(span_warning("[src] collapses to the ground!"),	\
+			span_danger("Your legs give out from under you!"))
+		Knockdown(3 SECONDS)

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -667,7 +667,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		return FALSE
 
 	if(amputation)
-		set_limb_flags(LIMB_AMPUTATED & LIMB_DESTROYED)
+		set_limb_flags(LIMB_AMPUTATED|LIMB_DESTROYED)
 	else
 		set_limb_flags(LIMB_DESTROYED)
 

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -666,7 +666,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(body_part == CHEST)
 		return FALSE
 
-	set_limb_flags(LIMB_DESTROYED)
+	if(amputation)
+		set_limb_flags(LIMB_AMPUTATED & LIMB_DESTROYED)
+	else
+		set_limb_flags(LIMB_DESTROYED)
 
 	for(var/i in implants)
 		var/obj/item/embedded_thing = i


### PR DESCRIPTION
## About The Pull Request
Any two legs/feet that were missing or broken were supposed to cause an occasional knockout but this usually didn't happen because missing limbs don't process. Fixes that, and also reduces the knockout from a 20 second unconscious to a 3 second knockdown. It was a little overkill.
Also fixes amputated limbs not being amputated.

## Why It's Good For The Game
Bugfixes, and a random 20 second unconscious is not necessary.

## Changelog
:cl:
fix: When you have two broken or missing legs or feet, you'll now fall down once or twice a minute.
fix: Amputated limbs are amputated.
/:cl: