### PR TITLE
Fixes moving not canceling evolution

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -245,6 +245,7 @@
 
 	if(!regression && !do_after(src, 25, FALSE, null, BUSY_ICON_CLOCK))
 		to_chat(src, span_warning("We quiver, but nothing happens. We must hold still while evolving."))
+		return
 
 	if(new_caste_type == /mob/living/carbon/xenomorph/queen)
 		if(hive.living_xeno_queen) //Do another check after the tick.


### PR DESCRIPTION
## About The Pull Request
Just a missing return.

## Why It's Good For The Game
Fixes #10405 

## Changelog
:cl:
fix: Moving early cancels xeno evolution properly
/:cl: