### PR TITLE
Remove miners near LZ

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -13927,8 +13927,8 @@
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "owS" = (
 /obj/machinery/miner/damaged,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/west)
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/nw)
 "oxg" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/marking/asteroidwarning{
@@ -17797,7 +17797,7 @@ tQg
 tQg
 jOB
 tQg
-owS
+tQg
 tQg
 tQg
 sNF
@@ -26905,7 +26905,7 @@ aaa
 aaa
 uUn
 mxa
-mxa
+owS
 mxa
 aMa
 aaa
@@ -28642,7 +28642,7 @@ aaa
 aaa
 aaa
 aMg
-sZl
+lKw
 aMc
 aaa
 aaa

--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -32050,10 +32050,6 @@
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/maintenance/engineering)
-"kgN" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/ice_colony/exterior/surface/clearing/south)
 "kkx" = (
 /obj/effect/turf_underlay/icefloor,
 /turf/closed/ice/thin/straight{
@@ -32206,10 +32202,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/ice_colony/exterior/surface/valley/south)
-"kQz" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/ice_colony/exterior/surface/valley/northwest)
 "kRm" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -47300,7 +47292,7 @@ mDM
 lSk
 mDM
 lSk
-kQz
+ggq
 ggq
 mqj
 mqj
@@ -62865,7 +62857,7 @@ vPZ
 aYz
 vPZ
 bbm
-kgN
+vPZ
 aYz
 vPZ
 aYz

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -26584,7 +26584,7 @@ jdc
 kBt
 miq
 vTe
-vqf
+xLz
 xLz
 lZZ
 wTy
@@ -27487,7 +27487,7 @@ uzl
 aRD
 mmx
 neU
-vqf
+xLz
 xLz
 qpS
 ubU

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -110,10 +110,11 @@
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/engineering)
 "adg" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder,
-/area/lv624/ground/jungle9)
+/obj/structure/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder/corner{
+	dir = 1
+	},
+/area/lv624/ground/jungle6)
 "adv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -2055,12 +2056,9 @@
 /turf/open/ground/river,
 /area/lv624/ground/river3)
 "aHI" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 1
-	},
-/area/lv624/ground/jungle9)
+/obj/machinery/miner/damaged,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
 "aHK" = (
 /turf/open/ground/coast{
 	dir = 8
@@ -7621,11 +7619,6 @@
 	dir = 5
 	},
 /area/lv624/lazarus/security)
-"fif" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder/corner,
-/area/lv624/ground/jungle9)
 "fij" = (
 /obj/structure/table,
 /obj/item/clothing/shoes/sandal,
@@ -18202,10 +18195,6 @@
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 8
 	},
-/area/lv624/ground/jungle6)
-"sfw" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle6)
 "sfH" = (
 /obj/structure/jungle/vines,
@@ -41989,9 +41978,9 @@ aJX
 mOs
 avd
 mOs
-avd
-avd
-avd
+uLT
+aWF
+iuG
 avd
 mOs
 mOs
@@ -42166,9 +42155,9 @@ avd
 mOs
 jxI
 mOs
-avd
-avd
-gWC
+xWM
+nny
+mhi
 avd
 mOs
 mOs
@@ -42342,10 +42331,10 @@ avd
 avd
 jxI
 auJ
-mOs
-uLT
-aWF
-iuG
+avd
+xWM
+kPD
+auH
 mOs
 mOs
 mOs
@@ -42371,9 +42360,9 @@ aES
 mOs
 mOs
 mOs
-fif
-pOJ
-xnf
+xRH
+aES
+aES
 aES
 mOs
 mOs
@@ -42516,12 +42505,12 @@ gMu
 brd
 ttA
 avd
-mOs
-mOs
+avd
 auJ
-mOs
+auJ
+avd
 dZO
-sfw
+nny
 auH
 mOs
 mOs
@@ -42548,9 +42537,9 @@ aES
 aET
 wEJ
 bjM
-adg
-miC
-hYO
+xRH
+aES
+aES
 aES
 mOs
 mOs
@@ -42693,9 +42682,9 @@ brd
 ttA
 avd
 avd
-mOs
-mOs
 avd
+auJ
+auJ
 auJ
 dZO
 kPD
@@ -42725,9 +42714,9 @@ pWs
 weB
 mOs
 mOs
-aHI
-tWO
-iiH
+xRH
+aET
+aET
 aES
 mOs
 mOs
@@ -42874,9 +42863,9 @@ mOs
 mOs
 avd
 auJ
-ejM
-sej
-weu
+dZO
+oXY
+ubO
 auJ
 mOs
 mOs
@@ -43051,9 +43040,9 @@ avd
 mOs
 mOs
 jxI
-jxI
-jxI
-jxI
+adg
+sej
+obX
 jxI
 auJ
 mOs
@@ -47127,7 +47116,7 @@ uYP
 uYP
 vkR
 hlt
-uYP
+aHI
 uYP
 uYP
 uCZ
@@ -49608,7 +49597,7 @@ gVO
 uYP
 uDS
 cIl
-miC
+cIl
 hYO
 aES
 xMs

--- a/_maps/modularmaps/big_red/bigredcargoareavar1.dmm
+++ b/_maps/modularmaps/big_red/bigredcargoareavar1.dmm
@@ -162,10 +162,6 @@
 	dir = 1
 	},
 /area/bigredv2/outside/nw)
-"mn" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating,
-/area/bigredv2/outside/nw)
 "mu" = (
 /obj/effect/decal/sandedge,
 /turf/open/floor/marking/asteroidwarning{
@@ -1498,7 +1494,7 @@ em
 em
 em
 em
-mn
+em
 em
 em
 em

--- a/_maps/modularmaps/big_red/bigredcargoareavar2.dmm
+++ b/_maps/modularmaps/big_red/bigredcargoareavar2.dmm
@@ -527,10 +527,6 @@
 	dir = 4
 	},
 /area/bigredv2/outside/nw)
-"Ta" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating,
-/area/bigredv2/outside/nw)
 "Tj" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -1612,7 +1608,7 @@ Zw
 iu
 Px
 gH
-Ta
+Px
 hX
 gH
 Mz

--- a/_maps/modularmaps/big_red/bigredcargoareavar3.dmm
+++ b/_maps/modularmaps/big_red/bigredcargoareavar3.dmm
@@ -141,7 +141,7 @@
 "jR" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
+	icon_state = "tube1"
 	},
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating,
@@ -282,10 +282,6 @@
 	dir = 5
 	},
 /area/bigredv2/outside/virology)
-"wl" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating,
-/area/bigredv2/outside/nw)
 "xc" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/nw)
@@ -333,7 +329,7 @@
 /area/bigredv2/outside/nw)
 "An" = (
 /turf/open/floor/plating/warning{
-	dir = 1;
+	dir = 1
 	},
 /area/bigredv2/outside/nw)
 "Av" = (
@@ -347,7 +343,7 @@
 /area/bigredv2/outside/nw)
 "AY" = (
 /turf/open/floor/plating/warning{
-	dir = 8;
+	dir = 8
 	},
 /area/bigredv2/outside/nw)
 "Bh" = (
@@ -359,7 +355,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/plating/warning{
-	dir = 1;
+	dir = 1
 	},
 /area/bigredv2/outside/nw)
 "Dx" = (
@@ -376,7 +372,7 @@
 "Ef" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
+	icon_state = "tube1"
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
@@ -599,7 +595,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating/warning{
-	dir = 8;
+	dir = 8
 	},
 /area/bigredv2/outside/nw)
 "XJ" = (
@@ -1608,7 +1604,7 @@ xc
 YT
 uM
 nd
-wl
+jE
 JJ
 jE
 TI

--- a/_maps/modularmaps/big_red/bigredcargoareavar4.dmm
+++ b/_maps/modularmaps/big_red/bigredcargoareavar4.dmm
@@ -591,10 +591,6 @@
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
-"OZ" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating,
-/area/bigredv2/outside/nw)
 "Pb" = (
 /obj/structure/cable,
 /turf/open/floor/plating/warning{
@@ -1828,7 +1824,7 @@ JU
 OL
 tS
 Hh
-OZ
+er
 bw
 er
 cJ

--- a/_maps/modularmaps/big_red/bigredcargoareavar5.dmm
+++ b/_maps/modularmaps/big_red/bigredcargoareavar5.dmm
@@ -486,10 +486,6 @@
 	dir = 5
 	},
 /area/bigredv2/outside/virology)
-"Ff" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating,
-/area/bigredv2/outside/nw)
 "Gb" = (
 /obj/machinery/light{
 	dir = 1;
@@ -1807,7 +1803,7 @@ Km
 ih
 rR
 zz
-Ff
+zF
 Nj
 zF
 QZ

--- a/_maps/modularmaps/big_red/bigredcargoareavar6.dmm
+++ b/_maps/modularmaps/big_red/bigredcargoareavar6.dmm
@@ -104,10 +104,6 @@
 	},
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/nw)
-"jJ" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating,
-/area/bigredv2/outside/nw)
 "km" = (
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/nw)
@@ -1733,7 +1729,7 @@ nS
 WI
 xh
 yH
-jJ
+WG
 EE
 WG
 Eg

--- a/_maps/modularmaps/big_red/bigredcargoareavar7.dmm
+++ b/_maps/modularmaps/big_red/bigredcargoareavar7.dmm
@@ -738,10 +738,6 @@
 "Wq" = (
 /turf/closed/wall,
 /area/bigredv2/outside/nw)
-"Wv" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating,
-/area/bigredv2/outside/nw)
 "Xm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -1771,7 +1767,7 @@ NJ
 jK
 JY
 Ly
-Wv
+JY
 LS
 Ly
 JY

--- a/_maps/modularmaps/big_red/bigredcargoareavar8.dmm
+++ b/_maps/modularmaps/big_red/bigredcargoareavar8.dmm
@@ -496,10 +496,6 @@
 	dir = 8
 	},
 /area/bigredv2/outside/nw)
-"GB" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating,
-/area/bigredv2/outside/nw)
 "Hb" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
@@ -1902,7 +1898,7 @@ PZ
 ll
 sY
 eM
-GB
+sY
 qg
 UJ
 sS


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's time to remove easy miners next to FOB.

Ice Colony has this issue for a long time. Both LZ literally have marines walking toward miners. Splinter once said that it was easy to just flank miners near FOB, but the autism fort from these miners can be extensive and continue to run the show.

![image](https://user-images.githubusercontent.com/6610922/172923269-d5af62e3-1478-4a42-b7ea-32eaa8394268.png)


Big Red has a miner next door to LZ1 that is practically protected by walls, though to be honest, if xenomorphs push here and marines are weak, they will lose miner. That said, if marines are strong, this places holds too well until marines drop the ball, which will take a long time.

![image](https://user-images.githubusercontent.com/6610922/172923026-f4a73726-8747-4ca9-8801-3809543d1dda.png)

LV-624 has a similar case. LZ2 has two miners next door to the point that one can snip from FOB to one of the miners. This makes LZ2 a meta pick for miner and engineers who just so happen to practically dictate what LZ marines will operate from.

![image](https://user-images.githubusercontent.com/6610922/172923097-c68a912c-59f4-41bf-a296-69b5d2814a11.png)
![image](https://user-images.githubusercontent.com/6610922/172923163-d8d4cf3d-9792-4785-87f0-e62ae9c49a50.png)


Also, triple miners next to LV-624 red disk. It's too cheese and too rewarding for marines to hold one disk and three miners. Maybe we should reward a miner when marines are holding a disk.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Remove miners that are near LZ in Ice Colony, Big Red, and LV-624
del: Remove the triple miners next to LV-624 red disk
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
