### PR TITLE
Optimize projectiles moving (by changing how lit turfs calculates with low light range)

### DIFF
--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -127,15 +127,16 @@
 /datum/component/overlay_lighting/proc/get_new_turfs()
 	if(!current_holder)
 		return
+	LAZYINITLIST(affected_turfs)
 	if(range <= 2)
 		//Range here is 1 because actual range of lighting mask is 1 tile even if it says that range is 2
 		for(var/turf/lit_turf in RANGE_TURFS(1, current_holder.loc))
 			lit_turf.dynamic_lumcount += lum_power
-			LAZYADD(affected_turfs, lit_turf)
+			affected_turfs += lit_turf
 	else
 		for(var/turf/lit_turf in view(lumcount_range, get_turf(current_holder)))
 			lit_turf.dynamic_lumcount += lum_power
-			LAZYADD(affected_turfs, lit_turf)
+			affected_turfs += lit_turf
 
 
 ///Clears the old affected turfs and populates the new ones.

--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -127,9 +127,15 @@
 /datum/component/overlay_lighting/proc/get_new_turfs()
 	if(!current_holder)
 		return
-	for(var/turf/lit_turf in view(lumcount_range, get_turf(current_holder)))
-		lit_turf.dynamic_lumcount += lum_power
-		LAZYADD(affected_turfs, lit_turf)
+	if(range <= 2)
+		//Range here is 1 because actual range of lighting mask is 1 tile even if it says that range is 2
+		for(var/turf/lit_turf in RANGE_TURFS(1, current_holder.loc))
+			lit_turf.dynamic_lumcount += lum_power
+			LAZYADD(affected_turfs, lit_turf)
+	else
+		for(var/turf/lit_turf in view(lumcount_range, get_turf(current_holder)))
+			lit_turf.dynamic_lumcount += lum_power
+			LAZYADD(affected_turfs, lit_turf)
 
 
 ///Clears the old affected turfs and populates the new ones.

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -716,7 +716,7 @@
 
 ///Wrapper proc to complete the whole firing process.
 /obj/item/weapon/gun/proc/Fire()
-	if(!target || (!gun_user && !istype(loc, /obj/machinery/deployable/mounted/sentry)) || (!CHECK_BITFIELD(flags_item, IS_DEPLOYED) && !able_to_fire(gun_user)) || windup_checked == WEAPON_WINDUP_CHECKING)
+	if(!target || !(gun_user || istype(loc, /obj/machinery/deployable/mounted/sentry)) || !(CHECK_BITFIELD(flags_item, IS_DEPLOYED) || able_to_fire(gun_user)) || windup_checked == WEAPON_WINDUP_CHECKING)
 		return
 	if(windup_delay && windup_checked == WEAPON_WINDUP_NOT_CHECKED)
 		windup_checked = WEAPON_WINDUP_CHECKING
@@ -755,7 +755,7 @@
 			QDEL_NULL(in_chamber)
 		else
 			in_chamber = null
-		if(!CHECK_BITFIELD(reciever_flags, AMMO_RECIEVER_REQUIRES_UNIQUE_ACTION) && !CHECK_BITFIELD(reciever_flags, AMMO_RECIEVER_CYCLE_ONLY_BEFORE_FIRE))
+		if(!(CHECK_BITFIELD(reciever_flags, AMMO_RECIEVER_REQUIRES_UNIQUE_ACTION) || CHECK_BITFIELD(reciever_flags, AMMO_RECIEVER_CYCLE_ONLY_BEFORE_FIRE)))
 			cycle(null)
 		if(length(chamber_items) && CHECK_BITFIELD(reciever_flags, AMMO_RECIEVER_AUTO_EJECT) && CHECK_BITFIELD(reciever_flags, AMMO_RECIEVER_MAGAZINES) && get_current_rounds(chamber_items[current_chamber_position]) < (!CHECK_BITFIELD(reciever_flags, AMMO_RECIEVER_REQUIRES_UNIQUE_ACTION) ? rounds_per_shot : 0))
 			playsound(src, empty_sound, 25, 1)
@@ -1571,7 +1571,7 @@
 	var/gun_scatter = scatter_unwielded
 	var/wielded_fire
 
-	if(flags_item & WIELDED && wielded_stable() || CHECK_BITFIELD(flags_item, IS_DEPLOYED) || (master_gun && CHECK_BITFIELD(master_gun.flags_item, WIELDED) && master_gun.wielded_stable()))
+	if(((flags_item & WIELDED) && wielded_stable()) || CHECK_BITFIELD(flags_item, IS_DEPLOYED) || (master_gun && CHECK_BITFIELD(master_gun.flags_item, WIELDED) && master_gun.wielded_stable()))
 		gun_accuracy_mult = accuracy_mult
 		gun_scatter = scatter
 		wielded_fire = TRUE


### PR DESCRIPTION
## About The Pull Request

Each projectile lights the turfs around it and while moving updates their luminosity in the range of 2 tiles. However, in fact, projectile lights turfs only in range of 1 tile because of the lighting mask sprite. Therefore, we can safely replace the expensive `view()` with a cheaper `block()` for calculating lit turfs for small lights.

Profling before changes
![image](https://user-images.githubusercontent.com/10997188/172352815-7a07aef0-ec71-4858-ac1d-e13aa17d2d17.png)
Profiling after
![image](https://user-images.githubusercontent.com/10997188/172352880-61a2e24e-87c9-4bcb-8ac5-fe9e6548cad4.png)

The `get_new_turfs()` function is about 20% of the load of `projectile_batch_move()`, so in overall we reduced the projectile movement load by about 10%

I also changed some logical operators to get performance increase in 0.00000001%, main logic hasn't been changed

## Why It's Good For The Game

Less lags - more bullets will fly


## Changelog
:cl:
refactor: refactored luminosity calculation for small movable lights therefore increased projectiles movement performance by ~10%
/:cl:
