### PR TITLE
Akimbo nerfs

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -19,7 +19,6 @@
 	scatter_unwielded = 13
 	recoil_unwielded = 4
 	damage_falloff_mult = 0.5
-	akimbo_additional_delay = 0
 	upper_akimbo_accuracy = 5
 	lower_akimbo_accuracy = 3
 

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -27,6 +27,8 @@
 	recoil = 2
 	recoil_unwielded = 4
 	movement_acc_penalty_mult = 2
+	lower_akimbo_accuracy = 3
+	upper_akimbo_accuracy = 5
 
 	placed_overlay_iconstate = "shotgun"
 

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -117,6 +117,8 @@
 	scatter_unwielded = 8
 	aim_slowdown = 0.2
 	burst_amount = 0
+	upper_akimbo_accuracy = 4
+	lower_akimbo_accuracy = 2
 
 	placed_overlay_iconstate = "t90"
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Someone ded, plsnerf.

**shotguns**
For some reason shotguns had the default akimbo scatter values (so an extra 2-4 scatter for going akimbo).
Changed this to the rifle values of 3 and 5 (so between 6 and 10 extra scatter for akimbo), as it is presumably quite hard to akimbo two shotguns.

This should make akimbo combat shotguns still deadly at pb range, but medium/longer range slug spam will be considerably less reliable.

The only other shotgun you can actually do this with is the sawn off.

**Rifles**
Also changed rifles to have the standard akimbo firedelay debuff. It was removed when akimbo was made to actually effect autofire and I thought it was a bad idea at the time. Most notably it makes akimbo AR11 really gross at close range.

**SMG90**
Increased akimbo scatter for the SMG90 from the default 2-4 scatter to 4-8. This is still lower than the MP19/rifles, and as above should serve to make it less effective at longer ranges, while still being deadly at closer range.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Certain akimbo weapons are a bit too strong, outside of close range. This is bad because they have no slowdown, so can be a bit oppressive.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: shotguns and the SMG90 no longer have extremely low akimbo scatter penalties
balance: rifles no longer have zero akimbo firedelay penalties
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
