### PR TITLE
Xenos keep health percent through balance buff

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -226,7 +226,7 @@
 	else //Upgrade process finished or impossible
 		stat("Upgrade Progress:", "(FINISHED)")
 
-	stat("Health:", "[overheal ? "[overheal] + ": ""][health]/[xeno_caste.max_health]")
+	stat("Health:", "[overheal ? "[overheal] + ": ""][health]/[maxHealth]") //Changes with balance scalar, can't just use the caste
 
 	if(xeno_caste.plasma_max > 0)
 		stat("Plasma:", "[plasma_stored]/[xeno_caste.plasma_max]")


### PR DESCRIPTION
## About The Pull Request
As title. Right now, if a xeno is at low health while at high balance buff and then the buff drops a ways, it can just die immediately. Which's funny and usually won't happen since that requires a fairly drastic shift, but still. With this, if you're at 50% health before adjustment, you'll be at 50% after too.

## Why It's Good For The Game
Smooths out strong scalar adjustments.
Also fixes modified max health not showing up in the game status window.

## Changelog
:cl:
balance: Xenos keep current percent health when a balance scalar is applied.
fix: Game status window properly shows current max health when a balance scalar is active.
/:cl:
