### PR TITLE
Moves some items away from reqs

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -577,7 +577,6 @@
 			/obj/item/ammo_magazine/rocket/sadar = 3,
 			/obj/item/ammo_magazine/minigun_powerpack = 2,
 			/obj/item/ammo_magazine/shotgun/mbx900 = 2,
-			/obj/item/bodybag/tarp = 2,
 			/obj/item/explosive/plastique = 5,
 			/obj/item/fulton_extraction_pack = 2,
 			/obj/item/clothing/suit/storage/marine/harness/boomvest = 20,

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -175,7 +175,6 @@
 			/obj/item/assembly/signaler = -1,
 			/obj/item/binoculars = -1,
 			/obj/item/compass = -1,
-			/obj/item/bodybag/tarp = 10,
 		),
 	)
 
@@ -577,6 +576,7 @@
 			/obj/item/ammo_magazine/rocket/sadar = 3,
 			/obj/item/ammo_magazine/minigun_powerpack = 2,
 			/obj/item/ammo_magazine/shotgun/mbx900 = 2,
+			/obj/item/bodybag/tarp = 10,
 			/obj/item/explosive/plastique = 5,
 			/obj/item/fulton_extraction_pack = 2,
 			/obj/item/clothing/suit/storage/marine/harness/boomvest = 20,

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -115,7 +115,7 @@
 			/obj/item/explosive/grenade/smokebomb/drain = 10,
 			/obj/item/explosive/grenade/mirage = 100,
 			/obj/item/storage/box/m94 = 200,
-			/obj/item/storage/box/m94/cas = 30,
+			/obj/item/storage/box/m94/cas = 50,
 		),
 		"Attachments" = list(
 			/obj/item/attachable/bayonet = -1,
@@ -175,6 +175,7 @@
 			/obj/item/assembly/signaler = -1,
 			/obj/item/binoculars = -1,
 			/obj/item/compass = -1,
+			/obj/item/bodybag/tarp = 10,
 		),
 	)
 

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -56,17 +56,6 @@ OPERATIONS
 	contains = list(/obj/item/minerupgrade/overclock)
 	cost = 5
 
-/datum/supply_packs/operations/cas_flares
-	name = "CAS flare pack"
-	contains = list(/obj/item/storage/box/m94/cas)
-	available_against_xeno_only = TRUE
-	cost = 5
-
-/datum/supply_packs/operations/binoculars_regular
-	name = "binoculars"
-	contains = list(/obj/item/binoculars)
-	cost = 15
-
 /datum/supply_packs/operations/binoculars_tatical
 	name = "tactical binoculars crate"
 	contains = list(/obj/item/binoculars/tactical)
@@ -77,17 +66,6 @@ OPERATIONS
 	name = "pool tracker crate"
 	contains = list(/obj/item/pinpointer)
 	cost = 20
-	available_against_xeno_only = TRUE
-
-/datum/supply_packs/operations/flares
-	name = "flare packs"
-	contains = list(/obj/item/storage/box/m94)
-	cost = 1
-
-/datum/supply_packs/operations/tarps
-	name = "V1 thermal-dampening tarp"
-	contains = list(/obj/item/bodybag/tarp)
-	cost = 6
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/operations/deployable_camera


### PR DESCRIPTION
## About The Pull Request
Some items have been moved away from reqs and its operational vendor. To compensate, some of these items have had their supply in normal vendors increased, or have been otherwise added to normal vendors.

List of changes:
- **CAS flares** can no longer be purchased from reqs. These were already available in the weapons vendor. To compensate, its supply has been increased from 30 to 50.
- **Normal binoculars** can no longer be purchased from reqs. Weapon vendors have these in infinite supply.
- **Normal flares** can no longer be purchased from reqs. Weapon vendors have 200 of these.
- **Tarps** can no longer be purchased from reqs. These were already in the reqs vendor. To compensate, its supply has been increased from 2 to 10.

## Why It's Good For The Game
Part of an effort to reduce content bloat in requisitions. With the later addition of lootboxes, and tweaks to some existing weapons, reqs should have much less bloat in the future.

## Changelog
:cl: Lewdcifer
del: CAS flares can no longer be obtained from reqs.
balance: CAS flare packs available in weapon vendors increased from 30 to 50.
del: Normal binoculars can no longer be obtained from reqs.
del: Normal flares can no longer be obtained from reqs.
del: Tarps can no longer be obtained from reqs.
balance: Number of tarps in reqs vendor increased from 2 to 10.
/:cl: