### PR TITLE
Makes resin structures cheaper faster to build, start weaker

### DIFF
--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -150,14 +150,14 @@
  * Regenerating walls that start with lower health, but grow to a much higher hp over time
  */
 /turf/closed/wall/resin/regenerating
-	max_integrity = 40
+	max_integrity = 150
 
 	/// Total health possible for a wall after regenerating at max health
 	var/max_upgradable_health = 300
 	/// How much the walls integrity heals per tick (5 seconds)
 	var/heal_per_tick = 25
 	/// How much the walls max_integrity increases per tick (5 seconds)
-	var/max_upgrade_per_tick = 6
+	var/max_upgrade_per_tick = 3
 	/// How long should the wall stop healing for when taking dmg
 	var/cooldown_on_taking_dmg = 30 SECONDS
 	///Whether we have a timer already to stop from clogging up the timer ss
@@ -200,4 +200,4 @@
 
 /* Hivelord walls, they start off stronger */
 /turf/closed/wall/resin/regenerating/thick
-	max_integrity = 100
+	max_integrity = 250

--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -150,14 +150,14 @@
  * Regenerating walls that start with lower health, but grow to a much higher hp over time
  */
 /turf/closed/wall/resin/regenerating
-	max_integrity = 150
+	max_integrity = 40
 
 	/// Total health possible for a wall after regenerating at max health
 	var/max_upgradable_health = 300
 	/// How much the walls integrity heals per tick (5 seconds)
 	var/heal_per_tick = 25
 	/// How much the walls max_integrity increases per tick (5 seconds)
-	var/max_upgrade_per_tick = 3
+	var/max_upgrade_per_tick = 6
 	/// How long should the wall stop healing for when taking dmg
 	var/cooldown_on_taking_dmg = 30 SECONDS
 	///Whether we have a timer already to stop from clogging up the timer ss
@@ -200,4 +200,4 @@
 
 /* Hivelord walls, they start off stronger */
 /turf/closed/wall/resin/regenerating/thick
-	max_integrity = 250
+	max_integrity = 100

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -166,10 +166,10 @@
 	action_icon_state = RESIN_WALL
 	mechanics_text = "Builds whatever resin you selected"
 	ability_name = "secrete resin"
-	plasma_cost = 75
+	plasma_cost = 60
 	keybind_signal = COMSIG_XENOABILITY_SECRETE_RESIN
 	///Minimum time to build a resin structure
-	var/base_wait = 1 SECONDS
+	var/base_wait = 0.5 SECONDS
 	///Multiplicator factor to add to the building time, depends on the health of the structure built
 	var/scaling_wait = 1 SECONDS
 	///List of buildable structures. Order corresponds with resin_images_list.
@@ -229,7 +229,7 @@
 		if(/obj/effect/alien/resin/sticky)
 			build_resin_modifier = 0.5
 		if(/obj/structure/mineral_door/resin)
-			build_resin_modifier = 2
+			build_resin_modifier = 1
 
 	return (base_wait + scaling_wait - max(0, (scaling_wait * X.health / X.maxHealth))) * build_resin_modifier
 
@@ -329,7 +329,7 @@
 		if(/obj/effect/alien/resin/sticky)
 			plasma_cost = initial(plasma_cost) / 3
 		if(/obj/structure/mineral_door/resin)
-			plasma_cost = initial(plasma_cost) * 3
+			plasma_cost = initial(plasma_cost)
 
 	if(new_resin)
 		add_cooldown(SSmonitor.gamestate == SHUTTERS_CLOSED ? get_cooldown()/2 : get_cooldown())


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes wall stats so that they start at a far lower health (40 from 150, 100 from 250 for HL). Resin door plasma and time cost equalized to wall (it was triple as expensive and twice as time consuming despite getting shot out in a single buckshot). Sticky and wall build time halved. Plasma cost down to 60 from 75, sticky to 20 from 25. Health upgrade per tick on walls increased from 3 to 6 so that they mature to max health at roughly the same time (bit faster due to rounding).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Making mazes is CBT, and with the recent flamer changes it's becoming more of a pain to maze given how easily it can be destroyed with the right tools. Even without said counters, to build a maze is an exercise in constant clicking, waiting, and labor that requires your constant focus. Inevitably as people get tired of building them (For example, a hivelord player that mazed half the map only to find out that the marines got fobsieged and massacred), they'll inevitably start building only the necessary. This can result in instances where only the fighting areas and the silo are mazed with hardly any other areas.

The issue becomes apparent in situations where xenos get one or two killed and the rest pushed back out of their frontline maze, only to find that marines will chase them through open ground due to the pain of building mazes that could've allowed for a safe retreat path. Castes that can build said maze would find it more fun and more impactful to just ignore that and head to the front to heal combat castes and so on, leading to said wipes.

This PR aims to make mazing a little less of a pain while still making sure to not cause an overboard frontline spam of quick walls by having them be weak at the moment of building them, so walling in a push of marines would not be feasible without a lot of teamwork. Ideally this'll allow sporadic building of walls with every break of combat or moment of inactivity without requiring so much time and focus. Due to the starting health being lowered that much, the maturity rate has been increased so as to make them mature fully at roughly the same time, so it's still feasibly to strengthen a maze close to the front, just not at a location where they're actively getting shot at.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Build time of resin structures halved. Resin door equalized in time and plasma cost to wall. Cost of walls and doors down to 60, sticky down to 20. Walls now start at 40 health, 100 for hivelord, but increase in max health faster so that they still fully mature at the same time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
