### PR TITLE
Support for bigger worn and inhand icons and change some images to mutable appearances

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1146,3 +1146,39 @@ GLOBAL_LIST_EMPTY(transformation_animation_objects)
 	GLOB.transformation_animation_objects -= src
 	if(filters && length(filters) >= filter_index)
 		filters -= filters[filter_index]
+
+/**
+ * Center's an image.
+ * Requires:
+ * The Image
+ * The x dimension of the icon file used in the image
+ * The y dimension of the icon file used in the image
+ * eg: center_image(image_to_center, 32,32)
+ * eg2: center_image(image_to_center, 96,96)
+**/
+/proc/center_image(image/image_to_center, x_dimension = 0, y_dimension = 0)
+	if(!image_to_center)
+		return
+
+	if(!x_dimension || !y_dimension)
+		return
+
+	if((x_dimension == world.icon_size) && (y_dimension == world.icon_size))
+		return image_to_center
+
+	//Offset the image so that it's bottom left corner is shifted this many pixels
+	//This makes it infinitely easier to draw larger inhands/images larger than world.iconsize
+	//but still use them in game
+	var/x_offset = -((x_dimension / world.icon_size) - 1) * (world.icon_size * 0.5)
+	var/y_offset = -((y_dimension / world.icon_size) - 1) * (world.icon_size * 0.5)
+
+	//Correct values under world.icon_size
+	if(x_dimension < world.icon_size)
+		x_offset *= -1
+	if(y_dimension < world.icon_size)
+		y_offset *= -1
+
+	image_to_center.pixel_x = x_offset
+	image_to_center.pixel_y = y_offset
+
+	return image_to_center

--- a/code/datums/components/attachment_handler.dm
+++ b/code/datums/components/attachment_handler.dm
@@ -328,7 +328,7 @@
 		parent_item.overlays += overlay
 
 ///Updates the mob sprite of the attachment.
-/datum/component/attachment_handler/proc/apply_custom(datum/source, image/standing)
+/datum/component/attachment_handler/proc/apply_custom(datum/source, mutable_appearance/standing)
 	SIGNAL_HANDLER
 	var/obj/item/parent_item = parent
 	if(!ismob(parent_item.loc))
@@ -355,7 +355,7 @@
 			else
 				icon = attachment_data[OVERLAY_ICON]
 				suffix = attachment.icon == icon ? "_a" : ""
-		var/image/new_overlay = image(icon, wearer, icon_state + suffix, -attachment_data[ATTACHMENT_LAYER])
+		var/mutable_appearance/new_overlay = mutable_appearance(icon, icon_state + suffix, -attachment_data[ATTACHMENT_LAYER])
 		if(CHECK_BITFIELD(attachment_data[FLAGS_ATTACH_FEATURES], ATTACH_SAME_ICON))
 			new_overlay.overlays += attachment.overlays
 		if(attachment_data[MOB_PIXEL_SHIFT_X])

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1155,21 +1155,21 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 ///Generates worn icon for sprites on-mob.
 /obj/item/proc/make_worn_icon(species_type, slot_name, inhands, default_icon, default_layer)
 	//Get the required information about the base icon
-	var/icon2use = get_worn_icon_file(species_type = species_type, slot_name = slot_name, default_icon = default_icon, inhands = inhands)
+	var/iconfile2use = get_worn_icon_file(species_type = species_type, slot_name = slot_name, default_icon = default_icon, inhands = inhands)
 	var/state2use = get_worn_icon_state(slot_name = slot_name, inhands = inhands)
 	var/layer2use = !inhands && worn_layer ? -worn_layer : -default_layer
 
 	//Snowflakey inhand icons in a specific slot
-	if(inhands && icon2use == icon_override)
+	if(inhands && iconfile2use == icon_override)
 		switch(slot_name)
 			if(slot_r_hand_str)
 				state2use += "_r"
 			if(slot_l_hand_str)
 				state2use += "_l"
 
-	//testing("[src] (\ref[src]) - Slot: [slot_name], Inhands: [inhands], Worn Icon:[icon2use], Worn State:[state2use], Worn Layer:[layer2use]")
+	//testing("[src] (\ref[src]) - Slot: [slot_name], Inhands: [inhands], Worn Icon:[iconfile2use], Worn State:[state2use], Worn Layer:[layer2use]")
 
-	var/mutable_appearance/standing = mutable_appearance(icon2use, state2use, layer2use)
+	var/mutable_appearance/standing = mutable_appearance(iconfile2use, state2use, layer2use)
 
 	//Apply any special features
 	if(!inhands)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -92,14 +92,28 @@
 	var/list/item_state_slots
 	///>LazyList< Used to specify the icon file to be used when the item is worn in a certain slot. icon_override or sprite_sheets are set they will take precendence over this, assuming they apply to the slot in question.
 	var/list/item_icons
-	///icon equivalent but for on-mob icon.
-	var/icon/default_worn_icon
 	///specific layer for on-mob icon.
 	var/worn_layer
 	///tells if the item shall use item_state for non-inhands, needed due to some items using item_state only for inhands and not worn.
 	var/item_state_worn = FALSE
-
-	var/icon_override = null  //Used to override hardcoded ON-MOB clothing dmis in human clothing proc (i.e. not the icon_state sprites).
+	///overrides the icon file which the item will be used to render on mob, if its in hands it will add _l or _r to the state depending if its on left or right hand.
+	var/icon_override = null
+	///Dimensions of the icon file used when this item is worn, eg: hats.dmi (32x32 sprite, 64x64 sprite, etc.). Allows inhands/worn sprites to be of any size, but still centered on a mob properly
+	var/worn_x_dimension = 32
+	///Dimensions of the icon file used when this item is worn, eg: hats.dmi (32x32 sprite, 64x64 sprite, etc.). Allows inhands/worn sprites to be of any size, but still centered on a mob properly
+	var/worn_y_dimension = 32
+	///Same as for [worn_x_dimension][/obj/item/var/worn_x_dimension] but for inhands.
+	var/inhand_x_dimension = 32
+	///Same as for [worn_y_dimension][/obj/item/var/worn_y_dimension] but for inhands.
+	var/inhand_y_dimension = 32
+	/// Worn overlay will be shifted by this along x axis
+	var/worn_x_offset = 0
+	/// Worn overlay will be shifted by this along y axis
+	var/worn_y_offset = 0
+	///Worn nhand overlay will be shifted by this along x axis
+	var/inhand_x_offset = 0
+	///Worn inhand overlay will be shifted by this along y axis
+	var/inhand_y_offset = 0
 
 	var/flags_item_map_variant = NONE
 
@@ -1141,7 +1155,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 ///Generates worn icon for sprites on-mob.
 /obj/item/proc/make_worn_icon(species_type, slot_name, inhands, default_icon, default_layer)
 	//Get the required information about the base icon
-	var/icon/icon2use = get_worn_icon_file(species_type = species_type, slot_name = slot_name, default_icon = default_icon, inhands = inhands)
+	var/icon2use = get_worn_icon_file(species_type = species_type, slot_name = slot_name, default_icon = default_icon, inhands = inhands)
 	var/state2use = get_worn_icon_state(slot_name = slot_name, inhands = inhands)
 	var/layer2use = !inhands && worn_layer ? -worn_layer : -default_layer
 
@@ -1155,16 +1169,20 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 	//testing("[src] (\ref[src]) - Slot: [slot_name], Inhands: [inhands], Worn Icon:[icon2use], Worn State:[state2use], Worn Layer:[layer2use]")
 
-	var/image/standing = image(icon2use, icon_state = state2use)
-	standing.alpha = alpha
-	standing.color = color
-	standing.layer = layer2use
+	var/mutable_appearance/standing = mutable_appearance(icon2use, state2use, layer2use)
 
 	//Apply any special features
 	if(!inhands)
 		apply_custom(standing)		//image overrideable proc to customize the onmob icon.
 		apply_blood(standing)			//Some items show blood when bloodied.
 		apply_accessories(standing)		//Some items sport accessories like webbings or ties.
+
+	standing = center_image(standing, inhands ? inhand_x_dimension : worn_x_dimension, inhands ? inhand_y_dimension : worn_y_dimension)
+
+	standing.pixel_x += inhands ? inhand_x_offset : worn_x_offset
+	standing.pixel_y += inhands ? inhand_y_offset : worn_y_offset
+	standing.alpha = alpha
+	standing.color = color
 
 	//Return our icon
 	return standing
@@ -1185,10 +1203,6 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	. = LAZYACCESS(item_icons, slot_name)
 	if(.)
 		return
-
-	//4: item's default icon
-	if(default_worn_icon)
-		return default_worn_icon
 
 	//5: provided default_icon
 	if(default_icon)
@@ -1215,15 +1229,15 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 		return icon_state
 
 ///applies any custom thing to the sprite, caled by make_worn_icon().
-/obj/item/proc/apply_custom(image/standing)
+/obj/item/proc/apply_custom(mutable_appearance/standing)
 	SHOULD_CALL_PARENT(TRUE)
 	SEND_SIGNAL(src, COMSIG_ITEM_APPLY_CUSTOM_OVERLAY, standing)
 	return standing
 
 ///applies blood on the item, called by make_worn_icon().
-/obj/item/proc/apply_blood(image/standing)
+/obj/item/proc/apply_blood(mutable_appearance/standing)
 	return standing
 
 ///applies any accessory the item may have, called by make_worn_icon().
-/obj/item/proc/apply_accessories(image/standing)
+/obj/item/proc/apply_accessories(mutable_appearance/standing)
 	return standing

--- a/code/game/objects/items/jetpack.dm
+++ b/code/game/objects/items/jetpack.dm
@@ -141,10 +141,10 @@
 		else
 			. += image('icons/obj/items/jetpack.dmi', src, "+jetpackempty")
 
-/obj/item/jetpack_marine/apply_custom(image/standing)
+/obj/item/jetpack_marine/apply_custom(mutable_appearance/standing)
 	. = ..()
 	if(lit)
-		standing.overlays += image('icons/mob/back.dmi',src,"+jetpack_lit")
+		standing.overlays += mutable_appearance('icons/mob/back.dmi',"+jetpack_lit")
 
 ///Manage the fuel indicator overlay
 /obj/item/jetpack_marine/proc/change_fuel_indicator()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -59,16 +59,16 @@
 /obj/item/clothing/proc/update_clothing_icon()
 	return
 
-/obj/item/clothing/apply_blood(image/standing)
+/obj/item/clothing/apply_blood(mutable_appearance/standing)
 	if(blood_overlay && blood_sprite_state)
-		var/image/bloodsies	= image(icon = 'icons/effects/blood.dmi', icon_state = blood_sprite_state)
+		var/image/bloodsies	= mutable_appearance('icons/effects/blood.dmi', blood_sprite_state)
 		bloodsies.color	= blood_color
 		standing.add_overlay(bloodsies)
 
-/obj/item/clothing/suit/apply_blood(image/standing)
+/obj/item/clothing/suit/apply_blood(mutable_appearance/standing)
 	if(blood_overlay && blood_sprite_state)
 		blood_sprite_state = "[blood_overlay_type]blood"
-		var/image/bloodsies	= image(icon = 'icons/effects/blood.dmi', icon_state = blood_sprite_state)
+		var/image/bloodsies	= mutable_appearance('icons/effects/blood.dmi', blood_sprite_state)
 		bloodsies.color = blood_color
 		standing.add_overlay(bloodsies)
 

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -285,7 +285,7 @@
 		var/mob/M = loc
 		M.update_inv_head()
 
-/obj/item/clothing/head/helmet/marine/apply_custom(image/standing)
+/obj/item/clothing/head/helmet/marine/apply_custom(mutable_appearance/standing)
 	. = ..()
 	var/mutable_appearance/M
 	for(var/i in helmet_overlays)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -287,12 +287,12 @@
 
 /obj/item/clothing/head/helmet/marine/apply_custom(image/standing)
 	. = ..()
-	var/image/I
+	var/mutable_appearance/M
 	for(var/i in helmet_overlays)
-		I = helmet_overlays[i]
-		if(I)
-			I = image('icons/mob/modular/modular_helmet_storage.dmi',src,I.icon_state)
-			standing.overlays += I
+		M = helmet_overlays[i]
+		if(M)
+			M = mutable_appearance('icons/mob/modular/modular_helmet_storage.dmi',M.icon_state)
+			standing.overlays += M
 
 
 /obj/item/clothing/head/helmet/marine/proc/add_hugger_damage() //This is called in XenoFacehuggers.dm to first add the overlay and set the var.

--- a/code/modules/clothing/modular_armor/modular.dm
+++ b/code/modules/clothing/modular_armor/modular.dm
@@ -129,7 +129,7 @@
 	. = ..()
 	update_icon()
 
-/obj/item/clothing/suit/modular/apply_custom(image/standing)
+/obj/item/clothing/suit/modular/apply_custom(mutable_appearance/standing)
 	. = ..()
 	if(!attachments_by_slot[ATTACHMENT_SLOT_STORAGE] || !istype(attachments_by_slot[ATTACHMENT_SLOT_STORAGE], /obj/item/armor_module/storage))
 		return standing
@@ -137,7 +137,7 @@
 	if(!storage_module.show_storage)
 		return standing
 	for(var/obj/item/stored AS in storage_module.storage.contents)
-		standing.overlays += image(storage_module.show_storage_icon, icon_state = initial(stored.icon_state))
+		standing.overlays += mutable_appearance(storage_module.show_storage_icon, icon_state = initial(stored.icon_state))
 	return standing
 
 /obj/item/clothing/suit/modular/mob_can_equip(mob/user, slot, warning)
@@ -540,13 +540,13 @@
 	if(armor_storage.storage.handle_mousedrop(usr, over_object))
 		return ..()
 
-/obj/item/clothing/head/modular/apply_custom(image/standing)
+/obj/item/clothing/head/modular/apply_custom(mutable_appearance/standing)
 	. = ..()
 	if(attachments_by_slot[ATTACHMENT_SLOT_STORAGE] && istype(attachments_by_slot[ATTACHMENT_SLOT_STORAGE], /obj/item/armor_module/storage))
 		var/obj/item/armor_module/storage/storage_module = attachments_by_slot[ATTACHMENT_SLOT_STORAGE]
 		if(storage_module.show_storage)
 			for(var/obj/item/stored AS in storage_module.storage.contents)
-				standing.overlays += image(storage_module.show_storage_icon, icon_state = initial(stored.icon_state))
+				standing.overlays += mutable_appearance(storage_module.show_storage_icon, icon_state = initial(stored.icon_state))
 	if(attachments_by_slot[ATTACHMENT_SLOT_VISOR])
 		return standing
 	standing.pixel_x = visorless_offset_x

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -71,14 +71,14 @@
 		armor_overlays["lamp"] = null
 	user?.update_inv_wear_suit()
 
-/obj/item/clothing/suit/storage/marine/apply_custom(image/standing)
+/obj/item/clothing/suit/storage/marine/apply_custom(mutable_appearance/standing)
 	. = ..()
-	var/image/I
+	var/image/M
 	for(var/i in armor_overlays)
-		I = armor_overlays[i]
-		if(I)
-			I = image('icons/mob/suit_1.dmi',src,I.icon_state)
-			standing.overlays += I
+		M = armor_overlays[i]
+		if(M)
+			M = mutable_appearance('icons/mob/suit_1.dmi',M.icon_state)
+			standing.overlays += M
 
 
 /obj/item/clothing/suit/storage/marine/Destroy()

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -77,7 +77,7 @@
 	for(var/i in armor_overlays)
 		new_overlay = armor_overlays[i]
 		if(new_overlay)
-			overlay = mutable_appearance('icons/mob/suit_1.dmi', new_overlay.icon_state)
+			new_overlay = mutable_appearance('icons/mob/suit_1.dmi', new_overlay.icon_state)
 			standing.overlays += new_overlay
 
 

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -73,12 +73,12 @@
 
 /obj/item/clothing/suit/storage/marine/apply_custom(mutable_appearance/standing)
 	. = ..()
-	var/image/M
+	var/mutable_appearance/new_overlay
 	for(var/i in armor_overlays)
-		M = armor_overlays[i]
-		if(M)
-			M = mutable_appearance('icons/mob/suit_1.dmi',M.icon_state)
-			standing.overlays += M
+		new_overlay = armor_overlays[i]
+		if(new_overlay)
+			overlay = mutable_appearance('icons/mob/suit_1.dmi', new_overlay.icon_state)
+			standing.overlays += new_overlay
 
 
 /obj/item/clothing/suit/storage/marine/Destroy()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -349,7 +349,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 
 			face_standing.Blend(hair_s, ICON_OVERLAY)
 
-	overlays_standing[HAIR_LAYER]	= image("icon"= face_standing, "layer" =-HAIR_LAYER)
+	overlays_standing[HAIR_LAYER] = mutable_appearance(face_standing, layer =-HAIR_LAYER)
 
 	apply_overlay(HAIR_LAYER)
 
@@ -442,15 +442,15 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		return
 	var/datum/limb/left_hand = get_limb("l_hand")
 	var/datum/limb/right_hand = get_limb("r_hand")
-	var/image/bloodsies
+	var/mutable_appearance/bloodsies
 	if(left_hand.limb_status & LIMB_DESTROYED)
 		if(right_hand.limb_status & LIMB_DESTROYED)
 			return //No hands.
-		bloodsies = image("icon" = 'icons/effects/blood.dmi', "icon_state" = "bloodyhand_right") //Only right hand.
+		bloodsies = mutable_appearance(icon = 'icons/effects/blood.dmi', icon_state = "bloodyhand_right") //Only right hand.
 	else if(right_hand.limb_status & LIMB_DESTROYED)
-		bloodsies = image("icon" = 'icons/effects/blood.dmi', "icon_state" = "bloodyhand_left") //Only left hand.
+		bloodsies = mutable_appearance(icon = 'icons/effects/blood.dmi', icon_state = "bloodyhand_left") //Only left hand.
 	else
-		bloodsies = image("icon" = 'icons/effects/blood.dmi', "icon_state" = "bloodyhands") //Both hands.
+		bloodsies = mutable_appearance(icon = 'icons/effects/blood.dmi', icon_state = "bloodyhands") //Both hands.
 
 	bloodsies.color = blood_color
 	overlays_standing[GLOVES_LAYER]	= bloodsies
@@ -499,7 +499,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	if(shoes)
 		overlays_standing[SHOES_LAYER] = shoes.make_worn_icon(species_type = species.name, slot_name = slot_shoes_str, default_icon = 'icons/mob/feet.dmi', default_layer = SHOES_LAYER)
 	else if(feet_blood_color)
-		var/image/bloodsies = image("icon" = 'icons/effects/blood.dmi', "icon_state" = "shoeblood")
+		var/mutable_appearance/bloodsies = mutable_appearance(icon = 'icons/effects/blood.dmi', icon_state = "shoeblood")
 		bloodsies.color = feet_blood_color
 		overlays_standing[SHOES_LAYER] = bloodsies
 
@@ -673,20 +673,20 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 
 /mob/living/carbon/human/update_burst()
 	remove_overlay(BURST_LAYER)
-	var/image/standing
+	var/mutable_appearance/standing
 	if(chestburst == 1)
-		standing = image("icon" = 'icons/Xeno/Effects.dmi',"icon_state" = "burst_stand", "layer" =-BURST_LAYER)
+		standing = mutable_appearance('icons/Xeno/Effects.dmi', "burst_stand", -BURST_LAYER)
 	else if(chestburst == 2)
-		standing = image("icon" = 'icons/Xeno/Effects.dmi',"icon_state" = "bursted_stand", "layer" =-BURST_LAYER)
+		standing = mutable_appearance('icons/Xeno/Effects.dmi', "bursted_stand", -BURST_LAYER)
 
 	overlays_standing[BURST_LAYER]	= standing
 	apply_overlay(BURST_LAYER)
 
 /mob/living/carbon/human/update_headbite()
 	remove_overlay(HEADBITE_LAYER)
-	var/image/standing
+	var/mutable_appearance/standing
 	if(headbitten)
-		standing = image("icon" = 'icons/Xeno/Effects.dmi',"icon_state" = "headbite_stand", "layer" =-HEADBITE_LAYER)
+		standing = mutable_appearance('icons/Xeno/Effects.dmi', "headbite_stand", -HEADBITE_LAYER)
 
 	overlays_standing[HEADBITE_LAYER]	= standing
 	apply_overlay(HEADBITE_LAYER)
@@ -695,7 +695,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	remove_overlay(FIRE_LAYER)
 	if(on_fire)
 		switch(fire_stacks)
-			if(1 to 14)	overlays_standing[FIRE_LAYER] = image("icon"='icons/mob/OnFire.dmi', "icon_state"="Standing_weak", "layer"=-FIRE_LAYER)
-			if(15 to 20) overlays_standing[FIRE_LAYER] = image("icon"='icons/mob/OnFire.dmi', "icon_state"="Standing_medium", "layer"=-FIRE_LAYER)
+			if(1 to 14)	overlays_standing[FIRE_LAYER] = mutable_appearance('icons/mob/OnFire.dmi', "Standing_weak", -FIRE_LAYER)
+			if(15 to 20) overlays_standing[FIRE_LAYER] = mutable_appearance('icons/mob/OnFire.dmi', "Standing_medium", -FIRE_LAYER)
 
 		apply_overlay(FIRE_LAYER)


### PR DESCRIPTION

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This adds the possibility of using bigger icons for any worn or inhand item without them being limited to the leftmost pixel of the tile and autocenters, also adds a offset that can be applied on both worn and inhand icons for stuff that doens't need to be bigger but needs to be more distant from the mob sprite.
Example:
![image](https://user-images.githubusercontent.com/29824735/172980165-63829c88-981f-4767-8fdc-499e43bb91f8.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We can have bigger stuff now!!!11!1!!!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: changed human item rendering code so it can support bigger icons with centralization.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
