### PR TITLE
TAT APCR rebalance

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1525,9 +1525,9 @@ datum/ammo/bullet/revolver/tp44
 	hud_state = "shell_he"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING|AMMO_PASS_THROUGH_TURF|AMMO_PASS_THROUGH_MOVABLE
 	shell_speed = 4
-	damage = 200
+	damage = 100
 	penetration = 40
-	sundering = 65
+	sundering = 100
 
 /datum/ammo/rocket/atgun_shell/apcr/drop_nade(turf/T)
 	explosion(T, 0, 0, 0, 1)


### PR DESCRIPTION
## About The Pull Request
The TAT's APCR shell will receive the following tweaks:
- Damage reduced from 200 to 100.
- Sundering increased from 65 to 100.

## Why It's Good For The Game
TAT APCR is currently capable of very easily scoring offscreen kills. This is very much NOT fun to deal with, hence the rebalancing. I don't want to nerf it and kick it into the dirt, so I'm pushing it into the full sundering niche while reducing its damage.

## Changelog
:cl: Lewdcifer
balance: TAT damage reduced from 200 to 100, sundering increased from 65 to 100.
/:cl: