### PR TITLE
Turns long line of parse_zone else-if's into a switch

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -631,14 +631,6 @@ GLOBAL_REAL_VAR(list/stack_trace_storage)
 			return "left foot"
 		if ("r_foot")
 			return "right foot"
-		if ("l_hand")
-			return "left hand"
-		if ("r_hand")
-			return "right hand"
-		if ("l_foot")
-			return "left foot"
-		if ("r_foot")
-			return "right foot"
 		else
 			return zone
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -614,32 +614,33 @@ GLOBAL_REAL_VAR(list/stack_trace_storage)
 
 
 /proc/parse_zone(zone)
-	if(zone == "r_hand")
-		return "right hand"
-	else if (zone == "l_hand")
-		return "left hand"
-	else if (zone == "l_arm")
-		return "left arm"
-	else if (zone == "r_arm")
-		return "right arm"
-	else if (zone == "l_leg")
-		return "left leg"
-	else if (zone == "r_leg")
-		return "right leg"
-	else if (zone == "l_foot")
-		return "left foot"
-	else if (zone == "r_foot")
-		return "right foot"
-	else if (zone == "l_hand")
-		return "left hand"
-	else if (zone == "r_hand")
-		return "right hand"
-	else if (zone == "l_foot")
-		return "left foot"
-	else if (zone == "r_foot")
-		return "right foot"
-	else
-		return zone
+	switch(zone)
+		if("r_hand")
+			return "right hand"
+		if ("l_hand")
+			return "left hand"
+		if ("l_arm")
+			return "left arm"
+		if ("r_arm")
+			return "right arm"
+		if ("l_leg")
+			return "left leg"
+		if ("r_leg")
+			return "right leg"
+		if ("l_foot")
+			return "left foot"
+		if ("r_foot")
+			return "right foot"
+		if ("l_hand")
+			return "left hand"
+		if ("r_hand")
+			return "right hand"
+		if ("l_foot")
+			return "left foot"
+		if ("r_foot")
+			return "right foot"
+		else
+			return zone
 
 
 //Quick type checks for some tools


### PR DESCRIPTION
## About The Pull Request
turns THIS
![firefox_2022-06-10_11-36-46](https://user-images.githubusercontent.com/17747087/173039624-4f897f1a-d80f-4fa9-a089-b915da52f5b7.png)


into THIS
![bild](https://user-images.githubusercontent.com/17747087/173041345-b559a8e6-a20b-4c92-97aa-ef773c2d93e3.png)


removes 4 duplicate if's, removes a bunch of else-if's, turns this into a switch.

This PR has been fully tested on a local build with zero (0) runtimes or errors.
![dreamseeker_2022-06-10_11-42-22](https://user-images.githubusercontent.com/17747087/173039693-3fb963e1-b817-45e2-8b25-ae7b950a2010.gif)
## Why It's Good For The Game
This code is used fairly oftenly for someone seeing someone else get shot, also getting used for the stethoscope... So it probably would be better if this was turned into a switch since a long line of else-if's like this is not really efficient.

## Changelog
:cl: Vondiech
code: Turns long line of else-if's in parse_zone into a switch. Also removes 4 duplicate if's for the hands and feet
/:cl:
