### PR TITLE
Some fixes to equip procs

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -548,7 +548,7 @@
 				return TRUE
 			return FALSE
 		if(SLOT_IN_ACCESSORY)
-			if((H.w_uniform && istype(H.w_uniform.attachments_by_slot[ATTACHMENT_SLOT_UNIFORM], /obj/item/armor_module/storage/uniform/holster)))
+			if((H.w_uniform && istype(H.w_uniform.attachments_by_slot[ATTACHMENT_SLOT_UNIFORM], /obj/item/armor_module/storage/uniform)))
 				var/obj/item/armor_module/storage/U = H.w_uniform.attachments_by_slot[ATTACHMENT_SLOT_UNIFORM]
 				var/obj/item/storage/S = U.storage
 				if(S.can_be_inserted(src, warning))
@@ -602,7 +602,7 @@
 					return TRUE
 			return FALSE
 		if(SLOT_IN_S_HOLSTER)
-			if((H.s_store && istype(H.s_store, /obj/item/storage/holster)) ||(H.s_store && istype(H.s_store,/obj/item/storage/belt/gun)))
+			if((H.s_store && istype(H.s_store, /obj/item/storage/holster)) || (H.s_store && istype(H.s_store,/obj/item/storage/belt/gun)))
 				var/obj/item/storage/S = H.s_store
 				if(S.can_be_inserted(src, warning))
 					return TRUE
@@ -626,19 +626,41 @@
 			if(S.can_be_inserted(src, warning))
 				return TRUE
 		if(SLOT_IN_SUIT)
-			var/obj/item/clothing/suit/storage/S = H.wear_suit
-			if(!istype(S) || !S.pockets)
+			if(!H.wear_suit)
 				return FALSE
-			var/obj/item/storage/internal/T = S.pockets
-			if(T.can_be_inserted(src, warning))
-				return TRUE
+			if(istype(H.wear_suit, /obj/item/clothing/suit/modular))
+				var/obj/item/clothing/suit/modular/T = H.wear_suit
+				if(!T.attachments_by_slot[ATTACHMENT_SLOT_STORAGE])
+					return FALSE
+				var/obj/item/armor_module/storage/U = T.attachments_by_slot[ATTACHMENT_SLOT_STORAGE]
+				var/obj/item/storage/S = U.storage
+				if(S.can_be_inserted(src, warning))
+					return TRUE
+			if(istype(H.wear_suit, /obj/item/clothing/suit/storage)) //old suits use the pocket var instead of storage attachments
+				var/obj/item/clothing/suit/storage/T = H.wear_suit
+				if(!T.pockets)
+					return FALSE
+				var/obj/item/storage/internal/S = T.pockets
+				if(S.can_be_inserted(src, warning))
+					return TRUE
 		if(SLOT_IN_HEAD)
-			var/obj/item/clothing/head/helmet/marine/S = H.head
-			if(!istype(S) || !S.pockets)
+			if(!H.head)
 				return FALSE
-			var/obj/item/storage/internal/T = S.pockets
-			if(T.can_be_inserted(src, warning))
-				return TRUE
+			if(istype(H.head, /obj/item/clothing/head/modular))
+				var/obj/item/clothing/head/modular/T = H.head
+				if(!T.attachments_by_slot[ATTACHMENT_SLOT_STORAGE])
+					return FALSE
+				var/obj/item/armor_module/storage/U = T.attachments_by_slot[ATTACHMENT_SLOT_STORAGE]
+				var/obj/item/storage/S = U.storage
+				if(S.can_be_inserted(src, warning))
+					return TRUE
+			if(istype(H.head, /obj/item/clothing/head/helmet/marine)) //old hats use the pocket var instead of storage attachments
+				var/obj/item/clothing/head/helmet/marine/T = H.head
+				if(!T.pockets)
+					return FALSE
+				var/obj/item/storage/internal/S = T.pockets
+				if(S.can_be_inserted(src, warning))
+					return TRUE
 		if(SLOT_IN_BOOT)
 			var/obj/item/clothing/shoes/marine/S = H.shoes
 			if(!istype(S) || !S.pockets)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -375,18 +375,32 @@
 			var/obj/item/storage/S = back
 			S.handle_item_insertion(W, TRUE, src)
 		if(SLOT_IN_SUIT)
-			var/obj/item/clothing/suit/storage/S = wear_suit
-			var/obj/item/storage/internal/T = S.pockets
-			T.handle_item_insertion(W, FALSE, src)
-			T.close(src)
+			if(istype(wear_suit, /obj/item/clothing/suit/modular))
+				var/obj/item/clothing/suit/modular/T = wear_suit
+				var/obj/item/armor_module/storage/U = T.attachments_by_slot[ATTACHMENT_SLOT_STORAGE]
+				var/obj/item/storage/S = U.storage
+				S.handle_item_insertion(W, FALSE, src)
+				S.close(src)
+			if(istype(wear_suit, /obj/item/clothing/suit/storage)) //old suits use the pocket var instead of storage attachments
+				var/obj/item/clothing/suit/storage/T = wear_suit
+				var/obj/item/storage/internal/S = T.pockets
+				S.handle_item_insertion(W, FALSE, src)
+				S.close(src)
 		if(SLOT_IN_BELT)
 			var/obj/item/storage/belt/S = belt
 			S.handle_item_insertion(W, FALSE, src)
 		if(SLOT_IN_HEAD)
-			var/obj/item/clothing/head/helmet/marine/S = head
-			var/obj/item/storage/internal/T = S.pockets
-			T.handle_item_insertion(W, FALSE, src)
-			T.close(src)
+			if(istype(head, /obj/item/clothing/head/modular))
+				var/obj/item/clothing/head/modular/T = head
+				var/obj/item/armor_module/storage/U = T.attachments_by_slot[ATTACHMENT_SLOT_STORAGE]
+				var/obj/item/storage/S = U.storage
+				S.handle_item_insertion(W, FALSE, src)
+				S.close(src)
+			if(istype(head, /obj/item/clothing/head/helmet/marine)) //old hats use pocket var instead of storage attachments
+				var/obj/item/clothing/head/helmet/marine/T = head
+				var/obj/item/storage/internal/S = T.pockets
+				S.handle_item_insertion(W, FALSE, src)
+				S.close(src)
 		if(SLOT_IN_HOLSTER)
 			var/obj/item/storage/S = belt
 			S.handle_item_insertion(W, FALSE, src)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Over time the procs that are used to equip items to mobs (via stuff like quick equip etc) stopped working correctly due to refactors to how item storage worked for various things.

I fixed some of these for quick equip but didn't realise the issue was bigger than just effecting quick equip.

This should make the procs work for storing any ALL storage types regardless of slot now, so there may be some minor fixes for quick equip, but I mainly did this as a coder QOL as it makes fucking OUTFIT datums 200% easier to do, since postequip actually works, rather than having to make loaded storage items and all the pain that's involved with that.

If I've missed some storage items/types, please let me know.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix good
Outfits not being as suffering to make is gooder (also avoids bloat from loads of filled storage items in the code)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed some issues with storage procs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
