### PR TITLE
ZX-76 no longer takes masterkey

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -653,7 +653,6 @@
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/lasersight,
 		/obj/item/weapon/gun/flamer/mini_flamer,
-		/obj/item/weapon/gun/shotgun/combat/masterkey,
 		/obj/item/weapon/gun/grenade_launcher/underslung,
 	)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Xzibit would be disappointed.

## Why It's Good For The Game

When converted to a triple barrel it is capable of 1 tapping tier two xenos (or in a vacuum get 99% of the way there).

I think all other shotguns can't have this for a reason?

Please hold all comments along the lines of "it's a req weapon so walance does not matter" because when firing 3x volleys of free flech ammo the DPS rivals that of rockets at medium range.

## Changelog
:cl:
balance: ZX-76 no longer accepts the masterkey attachment.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
