### PR TITLE
Under barrels share last_fired with their master_gun

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -744,6 +744,12 @@
 		return
 
 	last_fired = world.time
+	if(master_gun)
+		master_gun.last_fired = world.time
+	if(attachments_by_slot[ATTACHMENT_SLOT_UNDER])
+		var/obj/item/weapon/gun/under = attachments_by_slot[ATTACHMENT_SLOT_UNDER]
+		under.last_fired = world.time
+
 	SEND_SIGNAL(src, COMSIG_MOB_GUN_FIRED, target, src)
 
 	if(!max_chamber_items)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Prevents UBs from being fired at the exact same time as their parent gun.

Closes #10442

## Why It's Good For The Game

Being able to shoot 2 different ammo types or an additional volley of the same type as is the case with the ZX in a single tick is pretty cheesy.

## Changelog
:cl:
balance: Under barrels share last_fired with their master_gun.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
