### PR TITLE
Forward charge numbers change but i labelled it as a rework which means tivi was dissapointed when opening the pr to review it

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -87,16 +87,16 @@
 /datum/action/xeno_action/activable/forward_charge
 	name = "Forward Charge"
 	action_icon_state = "charge"
-	mechanics_text = "Charge up to 4 tiles and knockdown any targets in our way."
+	mechanics_text = "Charge up to 6 tiles and knockdown any targets in our way."
 	ability_name = "charge"
-	cooldown_timer = 10 SECONDS
+	cooldown_timer = 15 SECONDS
 	plasma_cost = 80
 	use_state_flags = XACT_USE_CRESTED|XACT_USE_FORTIFIED
 	keybind_signal = COMSIG_XENOABILITY_FORWARD_CHARGE
 	///How far can we charge
-	var/range = 4
+	var/range = 6
 	///How long is the windup before charging
-	var/windup_time = 0.5 SECONDS
+	var/windup_time = 0 SECONDS
 
 /datum/action/xeno_action/activable/forward_charge/proc/charge_complete()
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
@@ -58,7 +58,7 @@
 	var/target_turf = get_step_away(src, H, rand(1, 2)) //This is where we blast our target
 	target_turf = get_step_rand(target_turf) //Scatter
 	H.throw_at(get_turf(target_turf), 4, 70, H)
-	H.Paralyze(40)
+	H.Paralyze(5)
 
 
 /mob/living/carbon/xenomorph/defender/lay_down()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces Fordward Charge's stun duration to be equal to tail sweep's. Increases range to 6 (1 tile before edge of screen). Reduces windup to 0. Increases cooldown to 15.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As rewarding as hitting a 4 second long stun may be, stuns aren't fun to play against, and both sides should have fun fighting each other. Reworks the defender charge from a stun that is predominantly used midcombat into an initiation/escape tool. This'll let the defender close in a large gap into combat or be able to escape combat safely, given that it's a slow boy and its ability that grants more armor just makes it even slower resulting in the chase being either "Get killed quicker with less armor" or "Stay in the gunline for longer". Given the ability to escape combat, it shold allow defenders to play it a little bit riskier and remain in combat a bit longer, since even though 1v1 the stun did the same, marines tend to be in groups. Also lets it survive surprise freak scenarios of walking into marines already running towards its general direction from offscreen.

Cooldown is extended to 15 seconds so that it can't actually both initiate AND escape an engagement unless it's one that has dragged on for a while.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Defender's Forward Charge stun reduced on par with tail sweep's. Windup down to 0, range to 6 from 4, cooldown to 15 from 10.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
