### PR TITLE
Engi/blood vendor changes

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -86,19 +86,13 @@
 		"Specialized" = list(
 			/obj/item/weapon/gun/grenade_launcher/multinade_launcher = -1,
 			/obj/item/weapon/gun/grenade_launcher/single_shot = -1,
-			/obj/item/weapon/gun/rifle/tx54 = 2,
-			/obj/item/ammo_magazine/rifle/tx54 = 10,
-			/obj/item/ammo_magazine/rifle/tx54/incendiary = 4,
 			/obj/item/weapon/gun/energy/lasgun/lasrifle/tesla = 2,
 			/obj/item/weapon/gun/rifle/pepperball = 4,
 			/obj/item/ammo_magazine/rifle/pepperball = 40,
-			/obj/item/storage/holster/backholster/rpg/full = 2,
 			/obj/item/weapon/gun/flamer/big_flamer/marinestandard = 4,
 			/obj/item/ammo_magazine/flamer_tank/backtank = 4,
 			/obj/item/ammo_magazine/flamer_tank/large = 20,
 			/obj/item/ammo_magazine/flamer_tank = 20,
-			/obj/item/tool/extinguisher = -1,
-			/obj/item/tool/extinguisher/mini = -1,
 			/obj/item/weapon/shield/riot/marine = 6,
 			/obj/item/jetpack_marine = 3,
 			/obj/item/weapon/powerfist = -1,
@@ -909,7 +903,7 @@
 	icon_state = "bloodvendor"
 	icon_deny = "bloodvendor-deny"
 	product_ads = "The best blood on the market!"
-	req_one_access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MEDPREP)
+	req_one_access = ALL_MARINE_ACCESS
 	products = list(
 		/obj/item/reagent_containers/blood/APlus = 5,
 		/obj/item/reagent_containers/blood/AMinus = 5,
@@ -921,7 +915,7 @@
 	)
 
 /obj/machinery/vending/MarineMed/Blood/rebel
-	req_one_access = list(ACCESS_MARINE_MEDBAY_REBEL, ACCESS_MARINE_CHEMISTRY_REBEL)
+	req_one_access = ALL_MARINE_ACCESS
 
 /obj/machinery/vending/MarineMed/Blood/build_inventory(list/productlist, category)
 	. = ..()
@@ -972,17 +966,21 @@
 	name = "\improper TerraGovTech Engineer System Vendor"
 	desc = "A marine engineering system vendor"
 	product_ads = "If it breaks, wrench it!;If it wrenches, weld it!;If it snips, snip it!"
-	req_access = list(ACCESS_MARINE_ENGPREP)
+	req_one_access = ALL_MARINE_ACCESS
 	icon_state = "engiprep"
 	icon_deny = "engiprep-deny"
 	wrenchable = FALSE
 
 	products = list(
+		/obj/item/ammo_magazine/sentry = 8,
 		/obj/structure/closet/crate/mortar_ammo/mortar_kit = 1,
 		/obj/structure/closet/crate/mortar_ammo/howitzer_kit = 1,
-		/obj/item/storage/box/sentry = 4,
-		/obj/item/storage/box/tl102 = 1,
 		/obj/structure/largecrate/supply/weapons/standard_atgun = 1,
+		/obj/item/storage/holster/backholster/rpg/full = 2,
+		/obj/item/storage/box/tl102 = 1,
+		/obj/item/weapon/gun/rifle/tx54 = 2,
+		/obj/item/ammo_magazine/rifle/tx54 = 10,
+		/obj/item/ammo_magazine/rifle/tx54/incendiary = 4,
 		/obj/item/weapon/gun/heavymachinegun = 1,
 		/obj/item/ammo_magazine/heavymachinegun = 10,
 	)
@@ -990,7 +988,7 @@
 	prices = list()
 
 /obj/machinery/vending/shared_vending/marine_engi/rebel
-	req_access = list(ACCESS_MARINE_ENGPREP_REBEL)
+	req_one_access = ALL_MARINE_ACCESS
 	products = list(
 		/obj/structure/closet/crate/mortar_ammo/mortar_kit = 1,
 		/obj/item/storage/box/sentry = 5,

--- a/code/modules/mining/remote_fob/remote_fob_computer.dm
+++ b/code/modules/mining/remote_fob/remote_fob_computer.dm
@@ -20,7 +20,7 @@
 	var/datum/action/innate/remote_fob/toggle_wiring/toggle_wiring //whether or not new barricades will be wired
 	var/do_wiring = FALSE
 	var/datum/action/innate/remote_fob/sentry/sentry
-	var/sentry_remaining = 0
+	var/sentry_remaining = 4
 	var/datum/action/innate/remote_fob/eject_metal_action/eject_metal_action
 	var/datum/action/innate/remote_fob/eject_plasteel_action/eject_plasteel_action
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Engi vendor no longer requires access. The majority of weapons which require req support have been moved here.
The blood vendor also no longer requires access.
Round start sentries have been moved onto the drone itself, their extra ammo can now be found in engi vendor.

## Why It's Good For The Game

Weapons such as the AT gun and the wheeled HMG have been moved to engi vend recently to prevent their usage on Crash (due to it having no requisition). Making the vendor all access and moving over other req reliant weaponry (RR, TX-54) continues this trend without forcing marines to wait for an engi to vend everything.

Putting the sentries in the Fob drone helps with the sentries being forgotten, whilst preventing them from being stolen.

## Changelog
:cl:
qol: TerraGovTech Engi Vend no longer requires access to vend items. (Blood vendor too).
balance: RR and TX-54 have been moved to Engi Vend
balance: Engi Vend's 4 sentries have been moved to the Fob drone itself, the extra ammo is still in Engi vend however.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
