### PR TITLE
Clonex and Cryox now heal organ damage.

### DIFF
--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -952,6 +952,7 @@
 		L.adjustOxyLoss(-effect_str)
 		L.heal_limb_damage(effect_str,effect_str)
 		L.adjustToxLoss(-effect_str)
+		L.heal_organ_damage(effect_str)
 	return ..()
 
 /datum/reagent/medicine/clonexadone
@@ -968,6 +969,7 @@
 		L.adjustOxyLoss(-3*effect_str)
 		L.heal_limb_damage(3*effect_str,3*effect_str)
 		L.adjustToxLoss(-3*effect_str)
+		L.heal_organ_damage(-3*effect_str)
 
 	return ..()
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cryo cells used to start with peri to heal organ damage, now that peri is gone, this is probably necessary.
Clonex heals organ damage faster than cryox
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes sense for cryo to keep fixing this.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: cryo cells heal organ damage once again
balance: Clonexadone heals organ damage faster than cryoX
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
