### PR TITLE
Nanites rework: a new no-brainer

### DIFF
--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -173,7 +173,6 @@
 			/obj/item/reagent_containers/glass/bottle/tramadol = 12,
 			/obj/item/reagent_containers/glass/bottle/oxycodone = 12,
 			/obj/item/reagent_containers/glass/bottle/polyhexanide = 12,
-			/obj/item/reagent_containers/glass/bottle/medicalnanites = 12,
 		),
 		"Pill Bottle" = list(
 			/obj/item/storage/pill_bottle/inaprovaline = 12,

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1281,11 +1281,11 @@
 			to_chat(L, span_warning("The pain rapidly subsides. Looks like they've adapted to you."))
 		if(152 to INFINITY)
 			if(volume < 30) //smol injection will self-replicate up to 30u using 240u of blood.
-				L.reagents.add_reagent(/datum/reagent/medicine/research/medicalnanites, 0.15)
+				L.reagents.add_reagent(/datum/reagent/medicine/research/medicalnanites, 0.10)
 				L.blood_volume -= 2
 
 			if(volume < 35) //allows 10 ticks of healing for 20 points of free heal to lower scratch damage bloodloss amounts.
-				L.reagents.add_reagent(/datum/reagent/medicine/research/medicalnanites, 0.1)
+				L.reagents.add_reagent(/datum/reagent/medicine/research/medicalnanites, 0.05)
 
 			if (volume >5 && L.getBruteLoss() && healing_stacks) //Unhealed IB wasting nanites is an INTENTIONAL feature.
 				L.heal_limb_damage(2*effect_str, 0)


### PR DESCRIPTION
## About The Pull Request

Nanites now heal only up to 8 health each time user receive damage(not instantly)
Nanites bottles removed from NanoMedPlus
Nanites replication rate reduced by 33%
Nanites replication rate above 30u reduced by 50%

In a nutshell - nanites will no longer heal people out of combat and will restore slower, effectively making them a reactive healing tool rather than passive. 
This is a draft as im not sure whether nanites need higher blood cost or just moved back to researcher. For now it seems to be a huge power creep.


## Why It's Good For The Game

Nanites are somewhat gimmicky chem that let players pick harder fight at the cost of having less fights overall. However, without (nano)blood they are difficult to manage as they tend to waste 100+ units of blood on wounds you would rather heal with pills, UNLESS you use vali to heal damage before it eats your blood. 
And then there are nanite bottles, defeating the purpose of chem that eats your blood to heal you. It doesn't make sense and it encourages people that have no respect for their time to make nanite pills and cheese the whole blood management thing.

Theory time
Every 1u of nanites heal 4 health(2/0.5)
Every 1u of nanites consumes 13u of blood(2/0.15)
Every tick you can regain up to 1.5u of blood by mixing nutriments(0.4), iron(0.8) and QC(0.2)
Therefore it takes about 9 ticks to compensate bloodloss from 1u of nanites(13/1.5)
Premed unga with nanites spends about 1u of nanites per 10 damage(half of that damage is healed by premed, another by nanites)
Therefore for every 10 damage taken unga have to stay out of combat for 9 ticks to regain blood. If i remember correctly 1 tick roughly equals to 1.7 seconds. So, 15 seconds for every 10 damage(15*1.7)
For every 40 damage it's a minute. 80 is two. 120 is three
Yes, waiting three minutes after being beaten to a pulp sounds fair, but compare to premed only(120/2.3 = 52) that takes about  1.5 minutes(52*1.7)

Caught a pair of stray bumps? half a minute of recovery. Got into acid cloud? another 30 seconds. caught fire? a full minute. Friendly fire? another minute. Oh, there is also shrapnel? Bleeding? Consider yourself gimped 
Don't forget that you just can't use nanites without DD though, as you will become obese too fast. 
So to nanites for it's highest potential, you need bktt, nutriment/iron pills, DD, QC and Inaprovaline. Don't even try playing without premed though you'll be fucked up. 
At this point even premedding with meraderm sounds reasonable.

To simply put, my problem with nanites is that they are not really viable for frontliners(except for vali users). It's a free health for engineers, medics, snipers, and civilians. everyone but those who actually take damage
## Changelog
:cl:
balance: Nanites now use healing stacks acquired by taking damage. Each time user is hurt his healing stacks are set to 4 and spent every tick nanites heal them. If stacks reach zero, healing stops. Each damage type consumes 1 healing stack per tick, for a total of 4 ticks of healing single type of damage, and 2 ticks of healing if both damage type present.
balance: Nanites replication amount per tick below 30u from 0.15 to 0.10(blood consumption is not adjusted so cost per nanite is increased)
balance: Nanites replication amount per tick below 35u from 0.10 to 0.05
delete: Nanites bottles removed from NanoMedPlus
/:cl:
