### PR TITLE
Minigun pre barrel spinning

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -78,6 +78,7 @@
 #define GUN_AMMO_COUNT_BY_SHOTS_REMAINING (1<<12)
 #define GUN_NO_PITCH_SHIFT_NEAR_EMPTY (1<<13)
 #define GUN_SHOWS_AMMO_REMAINING (1<<14)
+#define GUN_HAS_ALT_FIRE (1<<15)
 
 //reciever_flags. Used to determin how the gun cycles, what kind of ammo it uses, etc.
 #define AMMO_RECIEVER_REQUIRES_UNIQUE_ACTION (1<<0)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This code is pretty wack and it's not any final, i doubt this will be finished either, drafting so i can show code to maintainers and see if we can find solutions.

I think most of the code of course is organizable and doable, BUT there's an annoying bug which i believe is related to #6864
meaning it's a byond issue and sucks, once you start spinning up(right click) the mouse apparently "locks" into that place for byond, meaning that if you click the button to fire(M1)  apparently will click there instead of wherever your mouse is, mousedragging still sets target and all but when your mouse is still it tries to fire where you first aimed when spun your minigun :(
Only way i find to actually fix that is by making it a toggle, since it gives you slowdown having that woulnd't be a problem i guess but it wont face where youre spinning to or whatever, maybe that'd be fine for unique action.



https://user-images.githubusercontent.com/29824735/173480595-2eecd64b-5d54-4624-b0d9-75bc03bbb8b7.mp4

maybe we could talk to lummox about this ?


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
