### PR TITLE
Adds new effects to kidneys, cleans up liver

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -288,7 +288,7 @@
 #define COMSIG_ITEM_HYDRO_CANNON_TOGGLED "hydro_cannon_toggled"
 
 #define COMSIG_NEW_REAGENT_ADD "new_reagent_add"					//from add_reagent(): (reagent_path, amount); it is sent when a reagent gets added for the first time to a holder
-#define COMSIG_REAGENT_DELETED "reagent_deleted"					//from /datum/reagents/del_reagent(): (reagent_path) When a reagent is entirely removed from its holder
+#define COMSIG_REAGENT_DELETING "reagent_deleting"					//from /datum/reagents/del_reagent(): (reagent_path) When a reagent is entirely removed from its holder
 
 #define COMSIG_CLOTHING_MECHANICS_INFO "clothing_mechanics_info"	//from base of /obj/item/clothing/get_mechanics_info()
 	#define COMPONENT_CLOTHING_MECHANICS_TINTED (1<<0)

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -287,7 +287,8 @@
 
 #define COMSIG_ITEM_HYDRO_CANNON_TOGGLED "hydro_cannon_toggled"
 
-#define COMSIG_NEW_REAGENT_ADD "new_reagent_add"					//from add_reagent(): (/datum/reagent, amount); it is sent when a reagent gets added for the first time to a holder
+#define COMSIG_NEW_REAGENT_ADD "new_reagent_add"					//from add_reagent(): (reagent_path, amount); it is sent when a reagent gets added for the first time to a holder
+#define COMSIG_REAGENT_DELETED "reagent_deleted"					//from /datum/reagents/del_reagent(): (reagent_path) When a reagent is entirely removed from its holder
 
 #define COMSIG_CLOTHING_MECHANICS_INFO "clothing_mechanics_info"	//from base of /obj/item/clothing/get_mechanics_info()
 	#define COMPONENT_CLOTHING_MECHANICS_TINTED (1<<0)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -6,14 +6,6 @@
 	if(!species)
 		set_species()
 
-	var/datum/reagents/R
-	if(species.species_flags & NO_CHEM_METABOLIZATION)
-		R = new /datum/reagents(0)
-	else
-		R = new /datum/reagents(1000)
-	reagents = R
-	R.my_atom = src
-
 	. = ..()
 
 	GLOB.human_mob_list += src
@@ -916,6 +908,14 @@
 	if(oldspecies)
 		//additional things to change when we're no longer that species
 		oldspecies.post_species_loss(src)
+
+	var/datum/reagents/R
+	if(species.species_flags & NO_CHEM_METABOLIZATION)
+		R = new /datum/reagents(0)
+	else
+		R = new /datum/reagents(1000)
+	reagents = R
+	R.my_atom = src
 
 	species.create_organs(src)
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -236,13 +236,6 @@
 			H.dropItemToGround(thing)
 	for(var/newtrait in inherent_traits)
 		ADD_TRAIT(H, newtrait, SPECIES_TRAIT)
-	var/datum/reagents/R
-	if(species_flags & NO_CHEM_METABOLIZATION)
-		R = new /datum/reagents(0)
-	else
-		R = new /datum/reagents(1000)
-	H.reagents = R
-	R.my_atom = H
 
 //special things to change after we're no longer that species
 /datum/species/proc/post_species_loss(mob/living/carbon/human/H)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -399,10 +399,10 @@
 		return U
 
 //////////////////CONFUSED
-/mob/living/proc/IsConfused() //If we're unconscious
+/mob/living/proc/IsConfused() //If we're confused
 	return has_status_effect(STATUS_EFFECT_CONFUSED)
 
-/mob/living/proc/AmountConfused() //How many deciseconds remain in our unconsciousness
+/mob/living/proc/AmountConfused() //How many deciseconds remain in our confusion. Also determines strength
 	var/datum/status_effect/confused/C = IsConfused()
 	if(C)
 		return C.duration - world.time
@@ -486,13 +486,6 @@
 					to_chat(src, span_boldwarning("[priority_absorb_key["self_message"]]"))
 			priority_absorb_key["stuns_absorbed"] += amount
 		return TRUE
-
-
-/mob/living/proc/adjust_drugginess(amount)
-	return
-
-/mob/living/proc/set_drugginess(amount)
-	return
 
 /mob/living/proc/jitter(amount)
 	jitteriness = clamp(jitteriness + amount,0, 1000)
@@ -579,7 +572,7 @@
 		ear_deaf = max((disabilities & DEAF|| ear_damage >= 100) ? 1 : 0, deaf)
 
 
-/mob/living/adjust_drugginess(amount)
+/mob/living/proc/adjust_drugginess(amount)
 	druggy = max(druggy + amount, 0)
 	if(druggy)
 		overlay_fullscreen("high", /obj/screen/fullscreen/high)
@@ -587,7 +580,7 @@
 		clear_fullscreen("high")
 
 
-/mob/living/set_drugginess(amount)
+/mob/living/proc/set_drugginess(amount)
 	druggy = max(amount, 0)
 	if(druggy)
 		overlay_fullscreen("high", /obj/screen/fullscreen/high)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -399,16 +399,19 @@
 		return U
 
 //////////////////CONFUSED
-/mob/living/proc/IsConfused() //If we're confused
+///Returns the current confuse status effect if any, else FALSE
+/mob/living/proc/IsConfused()
 	return has_status_effect(STATUS_EFFECT_CONFUSED)
 
-/mob/living/proc/AmountConfused() //How many deciseconds remain in our confusion. Also determines strength
+///Returns the remaining duration if a confuse effect exists, else 0
+/mob/living/proc/AmountConfused()
 	var/datum/status_effect/confused/C = IsConfused()
 	if(C)
 		return C.duration - world.time
 	return 0
 
-/mob/living/proc/Confused(amount, ignore_canstun = FALSE) //Can't go below remaining duration
+///Set confused effect duration to the provided value if not less than current duration
+/mob/living/proc/Confused(amount, ignore_canstun = FALSE)
 	if(status_flags & GODMODE)
 		return
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_CONFUSED, amount, ignore_canstun) & COMPONENT_NO_STUN)
@@ -421,6 +424,7 @@
 			C = apply_status_effect(STATUS_EFFECT_CONFUSED, amount)
 		return C
 
+///Set confused effect duration to the provided value
 /mob/living/proc/SetConfused(amount, ignore_canstun = FALSE) //Sets remaining duration
 	if(status_flags & GODMODE)
 		return
@@ -437,6 +441,7 @@
 			C = apply_status_effect(STATUS_EFFECT_CONFUSED, amount)
 		return C
 
+///Increases confused effect duration by the provided value.
 /mob/living/proc/AdjustConfused(amount, ignore_canstun = FALSE) //Adds to remaining duration
 	if(status_flags & GODMODE)
 		return
@@ -571,7 +576,7 @@
 	if(!isnull(deaf))
 		ear_deaf = max((disabilities & DEAF|| ear_damage >= 100) ? 1 : 0, deaf)
 
-
+///Modify mob's drugginess in either direction, minimum zero. Adds or removes druggy overlay as appropriate.
 /mob/living/proc/adjust_drugginess(amount)
 	druggy = max(druggy + amount, 0)
 	if(druggy)
@@ -579,7 +584,7 @@
 	else
 		clear_fullscreen("high")
 
-
+///Sets mob's drugginess to provided amount, minimum 0. Adds or removes druggy overlay as appropriate.
 /mob/living/proc/set_drugginess(amount)
 	druggy = max(amount, 0)
 	if(druggy)

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -254,10 +254,10 @@
 /datum/internal_organ/kidneys/New(mob/living/carbon/carbon_mob)
 	. = ..()
 	RegisterSignal(carbon_mob.reagents, COMSIG_NEW_REAGENT_ADD, .proc/owner_added_reagent)
-	RegisterSignal(carbon_mob.reagents, COMSIG_REAGENT_DELETED, .proc/owner_removed_reagent)
+	RegisterSignal(carbon_mob.reagents, COMSIG_REAGENT_DELETING, .proc/owner_removed_reagent)
 
 /datum/internal_organ/kidneys/clean_owner()
-	UnregisterSignal(owner.reagents, list(COMSIG_NEW_REAGENT_ADD, COMSIG_REAGENT_DELETED))
+	UnregisterSignal(owner.reagents, list(COMSIG_NEW_REAGENT_ADD, COMSIG_REAGENT_DELETING))
 	return ..()
 
 ///Signaled proc. Check if the added reagent was under reagent/medicine. If so, increment medicine counter and potentially notify owner.

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -191,8 +191,10 @@
 	removed_type = /obj/item/organ/liver
 	robotic_type = /obj/item/organ/liver/prosthetic
 	organ_id = ORGAN_LIVER
-	var/alcohol_tolerance = 0.005 //lower value, higher resistance.
-	var/filter_rate = 3 //How fast we clean out toxins/toxloss while healthy
+	///lower value, higher resistance.
+	var/alcohol_tolerance = 0.005
+	///How fast we clean out toxins/toxloss. Adjusts based on organ damage.
+	var/filter_rate = 3
 
 /datum/internal_organ/liver/process()
 	..()
@@ -205,8 +207,7 @@
 		//Damaged one shares the fun
 		else
 			var/datum/internal_organ/O = pick(owner.internal_organs)
-			if(O)
-				O.take_damage(0.2, TRUE)
+			O?.take_damage(0.2, TRUE)
 
 	// Heal a bit if needed and we're not busy. This allows recovery from low amounts of toxins.
 	if(!owner.drunkenness && owner.getToxLoss() <= 15 && organ_status == ORGAN_HEALTHY)
@@ -216,16 +217,16 @@
 			heal_organ_damage(0.04)
 
 	// Do some reagent filtering/processing.
-	for(var/datum/reagent/R in owner.reagents.reagent_list)
+	for(var/datum/reagent/potential_toxin AS in owner.reagents.reagent_list)
 		//Liver helps clear out any toxins but with drawbacks if damaged
-		if(istype(R, /datum/reagent/consumable/ethanol) || istype(R, /datum/reagent/toxin))
+		if(istype(potential_toxin, /datum/reagent/consumable/ethanol) || istype(potential_toxin, /datum/reagent/toxin))
 			if(organ_status != ORGAN_HEALTHY)
 				owner.adjustToxLoss(0.3 * organ_status)
-			owner.reagents.remove_reagent(R.type, R.custom_metabolism * filter_rate * 0.1)
+			owner.reagents.remove_reagent(potential_toxin.type, potential_toxin.custom_metabolism * filter_rate * 0.1)
 
 	//Heal toxin damage slowly if not damaged. If broken, increase it instead.
 	owner.adjustToxLoss((2 - filter_rate) * 0.1)
-	if(prob(organ_status))
+	if(prob(organ_status)) //Just under once every three minutes while bruised, twice as often while broken.
 		owner.vomit() //No stomach, so the liver can cause vomiting instead. Stagger and slowdown plus feedback that something's wrong.
 
 /datum/internal_organ/liver/set_organ_status()
@@ -245,31 +246,37 @@
 	removed_type = /obj/item/organ/kidneys
 	robotic_type = /obj/item/organ/kidneys/prosthetic
 	organ_id = ORGAN_KIDNEYS
-	var/current_medicine_count = 0 //Tracks the number of reagent/medicine datums we currently have
-	var/current_medicine_cap = 5 //How many drugs we can take before they overwhelm us. Decreases with damage
+	///Tracks the number of reagent/medicine datums we currently have
+	var/current_medicine_count = 0
+	///How many drugs we can take before they overwhelm us. Decreases with damage
+	var/current_medicine_cap = 5
 
 /datum/internal_organ/kidneys/New(mob/living/carbon/carbon_mob)
 	. = ..()
-	RegisterSignal(carbon_mob.reagents, COMSIG_NEW_REAGENT_ADD, .proc/increase_medicines)
-	RegisterSignal(carbon_mob.reagents, COMSIG_REAGENT_DELETED, .proc/decrease_medicines)
+	RegisterSignal(carbon_mob.reagents, COMSIG_NEW_REAGENT_ADD, .proc/owner_added_reagent)
+	RegisterSignal(carbon_mob.reagents, COMSIG_REAGENT_DELETED, .proc/owner_removed_reagent)
 
 /datum/internal_organ/kidneys/clean_owner()
 	UnregisterSignal(owner.reagents, list(COMSIG_NEW_REAGENT_ADD, COMSIG_REAGENT_DELETED))
 	return ..()
 
-/datum/internal_organ/kidneys/proc/increase_medicines(datum/source, reagent_type, amount)
+///Signaled proc. Check if the added reagent was under reagent/medicine. If so, increment medicine counter and potentially notify owner.
+/datum/internal_organ/kidneys/proc/owner_added_reagent(datum/source, reagent_type, amount)
 	SIGNAL_HANDLER
-	if(ispath(reagent_type, /datum/reagent/medicine))
-		current_medicine_count++
-		if(current_medicine_count == current_medicine_cap + 1)
-			to_chat(owner, span_warning("All the different drugs in you are starting to make you feel off..."))
+	if(!ispath(reagent_type, /datum/reagent/medicine))
+		return
+	current_medicine_count++
+	if(current_medicine_count == current_medicine_cap + 1)
+		to_chat(owner, span_warning("All the different drugs in you are starting to make you feel off..."))
 
-/datum/internal_organ/kidneys/proc/decrease_medicines(datum/source, reagent_type)
+///Signaled proc. Check if the removed reagent was under reagent/medicine. If so, decrement medicine counter and potentially notify owner.
+/datum/internal_organ/kidneys/proc/owner_removed_reagent(datum/source, reagent_type)
 	SIGNAL_HANDLER
-	if(ispath(reagent_type, /datum/reagent/medicine))
-		current_medicine_count--
-		if(current_medicine_count == current_medicine_cap)
-			to_chat(owner, span_notice("You don't feel as overwhelmed by all the drugs any more."))
+	if(!ispath(reagent_type, /datum/reagent/medicine))
+		return
+	current_medicine_count--
+	if(current_medicine_count == current_medicine_cap)
+		to_chat(owner, span_notice("You don't feel as overwhelmed by all the drugs any more."))
 
 /datum/internal_organ/kidneys/set_organ_status()
 	. = ..()
@@ -284,10 +291,11 @@
 		return //Hydration is good for your kidneys. Shame it purges medicines.
 
 	var/overflow = current_medicine_count - current_medicine_cap
-	if(overflow > 0)
-		owner.set_drugginess(3)
-		if(prob(overflow * (organ_status + 1) * 10))
-			owner.Confused(2 SECONDS * (organ_status + 1))
+	if(overflow < 1)
+		return
+	owner.set_drugginess(3)
+	if(prob(overflow * (organ_status + 1) * 10))
+		owner.Confused(2 SECONDS * (organ_status + 1))
 
 /datum/internal_organ/kidneys/prosthetic
 	robotic = ORGAN_ROBOT

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -200,7 +200,7 @@
 	..()
 
 	//High toxins levels are dangerous if you aren't actively treating them. 100 seconds to hit bruised from this alone
-	if(owner.getToxLoss() >= (80 - 20 * organ_status) && !owner.reagents.has_reagent(/datum/reagent/medicine/dylovene))
+	if(owner.getToxLoss() >= (80 - 20 * organ_status))
 		//Healthy liver suffers on its own
 		if (organ_status != ORGAN_BROKEN)
 			take_damage(0.2, TRUE)
@@ -211,10 +211,7 @@
 
 	// Heal a bit if needed and we're not busy. This allows recovery from low amounts of toxins.
 	if(!owner.drunkenness && owner.getToxLoss() <= 15 && organ_status == ORGAN_HEALTHY)
-		if(owner.reagents.has_reagent(/datum/reagent/medicine/dylovene)) // Detox effect
-			heal_organ_damage(0.2)
-		else
-			heal_organ_damage(0.04)
+		heal_organ_damage(0.04)
 
 	// Do some reagent filtering/processing.
 	for(var/datum/reagent/potential_toxin AS in owner.reagents.reagent_list)

--- a/code/modules/reagents/holder.dm
+++ b/code/modules/reagents/holder.dm
@@ -467,6 +467,7 @@
 /datum/reagents/proc/del_reagent(type_to_remove)
 	for(var/datum/reagent/test_reagent AS in reagent_list)
 		if (test_reagent.type == type_to_remove)
+			SEND_SIGNAL(src, COMSIG_REAGENT_DELETING, type_to_remove)
 			if(isliving(my_atom))
 				var/mob/living/L = my_atom
 				test_reagent.on_mob_delete(L, L.get_reagent_tags())
@@ -474,7 +475,6 @@
 			qdel(test_reagent)
 			update_total()
 			my_atom?.on_reagent_change(DEL_REAGENT)
-			SEND_SIGNAL(src, COMSIG_REAGENT_DELETED, type_to_remove)
 			return TRUE
 	return FALSE
 
@@ -597,6 +597,7 @@
 			return TRUE
 
 	//otherwise make a new one
+	SEND_SIGNAL(src, COMSIG_NEW_REAGENT_ADD, reagent, amount)
 	var/datum/reagent/R = new D.type(data)
 	cached_reagents += R
 	R.holder = src
@@ -613,7 +614,6 @@
 		my_atom.on_reagent_change(ADD_REAGENT)
 	if(!no_react)
 		handle_reactions()
-	SEND_SIGNAL(src, COMSIG_NEW_REAGENT_ADD, reagent, amount)
 	return TRUE
 
 /datum/reagents/proc/add_reagent_list(list/list_reagents, list/data=null) //// Like add_reagent but you can enter a list. Format it like this: list(/datum/reagent/toxin = 10, /datum/reagent/consumable/ethanol/beer = 15)

--- a/code/modules/reagents/holder.dm
+++ b/code/modules/reagents/holder.dm
@@ -465,19 +465,18 @@
 
 ///Remove a reagent datum with the type provided from this container. True if one is removed, false otherwise.
 /datum/reagents/proc/del_reagent(type_to_remove)
-	for(var/datum/reagent/test_reagent AS in reagent_list)
-		if (test_reagent.type == type_to_remove)
-			SEND_SIGNAL(src, COMSIG_REAGENT_DELETING, type_to_remove)
-			if(isliving(my_atom))
-				var/mob/living/L = my_atom
-				test_reagent.on_mob_delete(L, L.get_reagent_tags())
-			reagent_list -= test_reagent
-			qdel(test_reagent)
-			update_total()
-			my_atom?.on_reagent_change(DEL_REAGENT)
-			return TRUE
-	return FALSE
-
+	var/datum/reagent/reagent_to_remove = locate(type_to_remove) in reagent_list
+	if(!reagent_to_remove)
+		return FALSE
+	SEND_SIGNAL(src, COMSIG_REAGENT_DELETING, type_to_remove)
+	if(isliving(my_atom))
+		var/mob/living/L = my_atom
+		reagent_to_remove.on_mob_delete(L, L.get_reagent_tags())
+	reagent_list -= reagent_to_remove
+	qdel(reagent_to_remove)
+	update_total()
+	my_atom?.on_reagent_change(DEL_REAGENT)
+	return TRUE
 
 
 /datum/reagents/proc/update_total()
@@ -584,17 +583,16 @@
 	////
 
 	//add the reagent to the existing if it exists
-	for(var/A in cached_reagents)
-		var/datum/reagent/R = A
-		if (R.type == reagent)
-			R.volume += amount
-			update_total()
-			if(my_atom)
-				my_atom.on_reagent_change(ADD_REAGENT)
-			R.on_merge(data, amount)
-			if(!no_react)
-				handle_reactions()
-			return TRUE
+	var/datum/reagent/existing_reagent = locate(reagent) in cached_reagents
+	if(existing_reagent)
+		existing_reagent.volume += amount
+		update_total()
+		if(my_atom)
+			my_atom.on_reagent_change(ADD_REAGENT)
+		existing_reagent.on_merge(data, amount)
+		if(!no_react)
+			handle_reactions()
+		return TRUE
 
 	//otherwise make a new one
 	SEND_SIGNAL(src, COMSIG_NEW_REAGENT_ADD, reagent, amount)

--- a/code/modules/reagents/holder.dm
+++ b/code/modules/reagents/holder.dm
@@ -475,6 +475,7 @@
 			update_total()
 			if(my_atom)
 				my_atom.on_reagent_change(DEL_REAGENT)
+			SEND_SIGNAL(src, COMSIG_REAGENT_DELETED, reagent)
 	return 1
 
 

--- a/code/modules/reagents/holder.dm
+++ b/code/modules/reagents/holder.dm
@@ -462,21 +462,21 @@
 			del_reagent(R.type)
 			update_total()
 
-/datum/reagents/proc/del_reagent(reagent)
-	var/list/cached_reagents = reagent_list
-	for(var/_reagent in cached_reagents)
-		var/datum/reagent/R = _reagent
-		if (R.type == reagent)
-			if(my_atom && isliving(my_atom))
+
+///Remove a reagent datum with the type provided from this container. True if one is removed, false otherwise.
+/datum/reagents/proc/del_reagent(type_to_remove)
+	for(var/datum/reagent/test_reagent AS in reagent_list)
+		if (test_reagent.type == type_to_remove)
+			if(isliving(my_atom))
 				var/mob/living/L = my_atom
-				R.on_mob_delete(L, L.get_reagent_tags())
-			qdel(R)
-			reagent_list -= R
+				test_reagent.on_mob_delete(L, L.get_reagent_tags())
+			reagent_list -= test_reagent
+			qdel(test_reagent)
 			update_total()
-			if(my_atom)
-				my_atom.on_reagent_change(DEL_REAGENT)
-			SEND_SIGNAL(src, COMSIG_REAGENT_DELETED, reagent)
-	return 1
+			my_atom?.on_reagent_change(DEL_REAGENT)
+			SEND_SIGNAL(src, COMSIG_REAGENT_DELETED, type_to_remove)
+			return TRUE
+	return FALSE
 
 
 

--- a/code/modules/reagents/reagents/drink.dm
+++ b/code/modules/reagents/reagents/drink.dm
@@ -477,7 +477,6 @@
 	L.adjustFireLoss(-0.5, 0)
 	L.adjustToxLoss(-0.5, 0)
 	L.adjustOxyLoss(-0.5, 0)
-	L.AdjustConfused(-10 SECONDS)
 	return ..()
 
 /datum/reagent/consumable/drink/atomicbomb

--- a/html/changelogs/AutoChangeLog-pr-10326.yml
+++ b/html/changelogs/AutoChangeLog-pr-10326.yml
@@ -1,0 +1,4 @@
+author: "BraveMole"
+delete-after: True
+changes: 
+  - balance: "Internal organs damage are visible on the health analyzer"


### PR DESCRIPTION
## About The Pull Request
Kidneys now moderate the total number of medicines you can have in you at a time. 5 while healthy, decreasing while damaged. If you exceed this number you'll get an overlay and periodic confusion, the later scaling in frequency and strength with both organ damage and excess count.
Liver stuff is mostly cleaning up the current functionality. Only significant change is a chance to vomit if it's at least bruised.
Also fixes humans generating their reagent container twice, once in human/set_species and once in species/on_species_gain.

## Why It's Good For The Game
Provides a bit of reason not to just stuff yourself with one of every pill. Drawbacks are fairly minor without organ damage.
DD nerf is just there so having an extra healing chem in you doesn't make you able to run every single other chem with no drawbacks. It should probably be nerfed further.
Code cleanup for liver/easier for a patient to tell that something is wrong.

## Changelog
:cl:
add: Kidneys now apply downsides if you have too many drugs in you. Cap gets lowered with organ damage.
balance: DD doesn't heal confusion any more.
balance: Minor liver tweaks, more or less the same on the whole. Main addition is a very small chance to vomit.
/:cl:

