### PR TITLE
Increases Damage to Organs

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_organs.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_organs.dm
@@ -45,7 +45,7 @@
 			if(E.is_broken() && E.internal_organs && prob(15))
 				var/datum/internal_organ/I = pick(E.internal_organs)
 				custom_pain("You feel broken bones moving in your [E.display_name]!", 1)
-				I.take_damage(rand(3,5))
+				I.take_damage(rand(4,6))
 
 			//Moving makes open wounds get infected much faster
 			if(!(E.limb_wound_status & LIMB_WOUND_DISINFECTED) && E.brute_dam >= 20)

--- a/code/modules/mob/living/carbon/human/life/handle_organs.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_organs.dm
@@ -45,7 +45,7 @@
 			if(E.is_broken() && E.internal_organs && prob(15))
 				var/datum/internal_organ/I = pick(E.internal_organs)
 				custom_pain("You feel broken bones moving in your [E.display_name]!", 1)
-				I.take_damage(rand(4,6))
+				I.take_damage(rand(3,5))
 
 			//Moving makes open wounds get infected much faster
 			if(!(E.limb_wound_status & LIMB_WOUND_DISINFECTED) && E.brute_dam >= 20)

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -174,8 +174,7 @@
 
 
 	//High brute damage or sharp objects may damage internal organs, as well as usual attacks after breakpoint
-	if(internal_organs && (((sharp && brute >= 10) || brute >= 20) && prob(5)
-	|| (((brute_dam + burn_dam) >= min_broken_damage) && prob(5))))
+	if(internal_organs && (((sharp && brute >= 10) || brute >= 20) && prob(5) || (((brute_dam + burn_dam) >= min_broken_damage) && prob(5))))
 		//Damage an internal organ
 		var/datum/internal_organ/I = pick(internal_organs)
 		I.take_damage(brute / 2)

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -173,8 +173,9 @@
 		burn *= 0.50
 
 
-	//High brute damage or sharp objects may damage internal organs
-	if(internal_organs && ((sharp && brute >= 10) || brute >= 20) && prob(10))
+	//High brute damage or sharp objects may damage internal organs, as well as usual attacks after breakpoint
+	if(internal_organs && (((sharp && brute >= 10) || brute >= 20) && prob(5)
+	|| (((brute_dam + burn_dam) >= min_broken_damage) && prob(5))))
 		//Damage an internal organ
 		var/datum/internal_organ/I = pick(internal_organs)
 		I.take_damage(brute / 2)

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -174,7 +174,7 @@
 
 
 	//High brute damage or sharp objects may damage internal organs
-	if(internal_organs && ((sharp && brute >= 10) || brute >= 20) && prob(5))
+	if(internal_organs && ((sharp && brute >= 10) || brute >= 20) && prob(10))
 		//Damage an internal organ
 		var/datum/internal_organ/I = pick(internal_organs)
 		I.take_damage(brute / 2)


### PR DESCRIPTION
## About The Pull Request

Recently effects of organ damage for heart, lungs were changed. Now instead of killing you over time, they give debuffs. This PR aims to restore long-term game balance.

When limb _is significantly damaged_, all brute attacks can cause organ damage with low chance.
Before, only strong attacks could do this. For example, in **light** armor, marine could get direct organ damage only if the attack had more than 33 raw damage. In **heavy+tyr**, 50 damage. Usual xeno attacks are 23 or 26, so not enough.

Overall, marines only got organ damage if they ran around with broken bones. Now beating them to a pulp actually does something.

## Why It's Good For The Game

Balance good. Before you could die from damage, now you don't.
We can appreciate the nerfs to organ damage if more organs are damaged.

_Note_: Yes, peri use was allowing you to ignore organ damage. But if I had a penny for every marine who used it, I wouldn't get enough money for a cup of coffee.

## Changelog
:cl:
balance: once limb can be broken, hitting them can damage organs.
/:cl:
