### PR TITLE
Nerfs fire strength against resin walls

### DIFF
--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -22,7 +22,7 @@
 
 
 /turf/closed/wall/resin/flamer_fire_act(burnlevel)
-	take_damage(burnlevel * 1.5, BURN, "fire")
+	take_damage(burnlevel * 1.25, BURN, "fire")
 
 
 /turf/closed/wall/resin/proc/thicken()


### PR DESCRIPTION
## About The Pull Request
The strength of fire against resin walls specifically has been reduced from 1.5 to 1.25, as per Tivi's request.

## Why It's Good For The Game
Fire is too good at clearing walls. This should make it a tad bit more bearable.

## Changelog
:cl: Lewdcifer
balance: Fire strength against resin walls reduced from 1.5 to 1.25.
/:cl: