### PR TITLE
Xenos are no longer cucked by a knee high railing

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -10,6 +10,7 @@
 	flags_atom = ON_BORDER
 	resistance_flags = XENO_DAMAGEABLE
 	climb_delay = 20 //Leaping a barricade is universally much faster than clumsily climbing on a table or rack
+	interaction_flags = INTERACT_CHECK_INCAPACITATED
 	max_integrity = 100
 	///The type of stack the barricade dropped when disassembled if any.
 	var/stack_type

--- a/code/game/objects/structures/platforms.dm
+++ b/code/game/objects/structures/platforms.dm
@@ -12,6 +12,7 @@
 	coverage = 10
 	layer = OBJ_LAYER
 	climb_delay = 20 //Leaping a barricade is universally much faster than clumsily climbing on a table or rack
+	interaction_flags = INTERACT_CHECK_INCAPACITATED //no dexterity flag so xenos can climb them
 	flags_atom = ON_BORDER
 	resistance_flags = XENO_DAMAGEABLE	//TEMP PATCH UNTIL XENO AI PATHFINDING IS BETTER, SET THIS TO INDESTRUCTIBLE ONCE IT IS - Tivi
 	obj_integrity = 1000	//Ditto


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the dexterity requirement to interact with all barricades and platforms.

Xenos do not have the dexterous flag, which means they can't interact with any object that requires dexterity. This is every item in the game by default, and climbing counts as interacting.

This doesn't let them open plasteel cades or anything, so there shouldn't be any issues. But please let me know if there is some kind of weird interaction this could let them do that they shouldn't be able to.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Getting stuck behind a knee high rail as a 3 meter tall alien is stinky.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Xenos have been sent to climbing school, and can now climb platforms and (unwired) barricades of all kinds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
