### PR TITLE
Necrotic limbs applies organ damage over time

### DIFF
--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -163,7 +163,7 @@ REAGENT SCANNER
 	if(ishuman(patient))
 		var/mob/living/carbon/human/human_patient = patient
 		var/infection_message
-		var/infected
+		var/infected = 0
 		var/internal_bleeding
 
 		var/unknown_implants = 0
@@ -174,16 +174,12 @@ REAGENT SCANNER
 						continue
 					internal_bleeding = TRUE
 					break
-			if(!infected)
-				if(limb.germ_level >= INFECTION_LEVEL_THREE)
-					infection_message = "Subject's [limb.display_name] is in the last stage of infection. < 30u of antibiotics recommended."
-					infected = 2
-				if(limb.germ_level >= INFECTION_LEVEL_ONE && limb.germ_level < INFECTION_LEVEL_THREE)
-					infection_message = "Subject's [limb.display_name] has an infection. Antibiotics recommended."
-					infected = 1
-				if(limb.has_infected_wound())
-					infection_message = "Infected wound detected in subject's [limb.display_name]. Disinfection recommended."
-					infected = 1
+			if(infected < 2 && limb.limb_status & LIMB_NECROTIZED)
+				infection_message = "Subject's [limb.display_name] has necrotized. Surgery required."
+				infected = 2
+			if(infected < 1 && limb.germ_level > INFECTION_LEVEL_ONE)
+				infection_message = "Infection detected in subject's [limb.display_name]. Antibiotics recommended."
+				infected = 1
 
 			if(limb.hidden)
 				unknown_implants++

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -490,6 +490,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 			owner.adjustToxLoss(1)
 		if (prob(1))
 			to_chat(owner, span_notice("You have a high fever!"))
+//Not technically a germ effect, but derived from it
+	if(limb_status & LIMB_NECROTIZED)
+		for(var/datum/internal_organ/organ AS in internal_organs)
+			organ.take_damage(0.2, silent = TRUE) //1 point every 10 seconds, 100 seconds to bruise, five minutes to broken.
 
 
 ///Updating wounds. Handles natural damage healing from limb treatments and processes internal wounds

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -856,10 +856,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 /datum/limb/proc/get_damage()	//returns total damage
 	return brute_dam + burn_dam	//could use health?
 
-//Not meaningful any more, need to remove from health scanners
-/datum/limb/proc/has_infected_wound()
-	return FALSE
-
 ///True if the limb has any damage on it
 /datum/limb/proc/has_external_wound()
 	return brute_dam || burn_dam


### PR DESCRIPTION
## About The Pull Request
I was completely convinced this code already existed, which's why I opened #10394 . It's even part of the why section. But, uh, it didn't actually exist. Adds it.

## Why It's Good For The Game
Turns out germs were in fact the only way necrosis hurt organs. Oops. Without this, necrosis on head/chest/gut doesn't really do anything.
Also cleans some carryover medscanner stuff from wound removal.

## Changelog
:cl:
add: Necrosis causes organ damage over time. Accidentally removed this when I killed organ germs.
/:cl:
