### PR TITLE
Reenables modules on flak vest

### DIFF
--- a/code/modules/clothing/modular_armor/modular.dm
+++ b/code/modules/clothing/modular_armor/modular.dm
@@ -272,8 +272,6 @@
 	soft_armor = list("melee" = 40, "bullet" = 50, "laser" = 50, "energy" = 25, "bomb" = 30, "bio" = 5, "rad" = 5, "fire" = 25, "acid" = 30)
 	slowdown = 0.25
 
-	attachments_allowed = list()
-
 	allowed = list(
 		/obj/item/weapon/gun,
 		/obj/item/tank/emergency_oxygen,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows the flak vest to accept the modules Xenonauten armor has (IE, no jaeger amor pieces).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It had been disabled over a bugfix which had been mostly called a bug due to unintended behavior rather than breaking anything. During the time it had been enabled there wasn't any game breaking bugs and nor exploits of equal order since there's no reason to use flak over normal armors that can offer the same or more.

The bugfix however ended up as a crippling nerf to synth in terms of storage because they can't wear armor, therefore can't use said modules, other than what the flak vest used to be. This isn't about the armor values, as they can't even use the M3 harness that has literally no armor, although it can't accept modules either. The flak armor itself is a downgrade to other armors regardless, it's just that it's the only option it has.

Due to the unintended long testing of how it'd be without the "bugfix", and how little people seemed to complain about it and how vital it turned out to be for some loadouts, we could now call it an intentional change.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Flak vest can now accept modules. You still need a good reason to pick it over the other armors, though.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
