### PR TITLE
gives the BR-64 one (1) extra round per magazine

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -257,7 +257,7 @@
 	aim_slowdown = 0.55
 	wield_delay = 0.7 SECONDS
 	force = 20
-	max_shells = 35 //codex
+	max_shells = 36 //codex
 	default_ammo_type = /obj/item/ammo_magazine/rifle/standard_br
 	allowed_ammo_types = list(/obj/item/ammo_magazine/rifle/standard_br)
 	attachable_allowed = list(

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -97,7 +97,7 @@
 	icon_state = "t64"
 	w_class = WEIGHT_CLASS_NORMAL
 	default_ammo = /datum/ammo/bullet/rifle/standard_br
-	max_rounds = 35
+	max_rounds = 36
 	icon_state_mini = "mag_rifle_big"
 
 /obj/item/ammo_magazine/rifle/standard_br/incendiary
@@ -107,7 +107,7 @@
 	caliber = CALIBER_10x265_CASELESS
 	w_class = WEIGHT_CLASS_NORMAL
 	default_ammo = /datum/ammo/bullet/rifle/standard_br/incendiary
-	max_rounds = 35
+	max_rounds = 36
 	icon_state_mini = "mag_rifle_big_red"
 
 //-------------------------------------------------------


### PR DESCRIPTION
## About The Pull Request
gives the BR a 36 round mag instead of a 35 round one
## Why It's Good For The Game
magazine sizes that don't fit bursts give me minor, but stacking, aneurysms
## Changelog
:cl:
balance: the BR-64 battle rifle now has one extra round per magazine, raising it to 36 rounds instead of 35, with a new theoretical max of 36+1 rounds in the gun
/:cl:
