### PR TITLE
Delete healing portion of Doctor's Delight

### DIFF
--- a/code/modules/reagents/reagents/drink.dm
+++ b/code/modules/reagents/reagents/drink.dm
@@ -473,10 +473,6 @@
 	adj_dizzy = - 10
 
 /datum/reagent/consumable/drink/doctor_delight/on_mob_life(mob/living/L, metabolism)
-	L.adjustBruteLoss(-0.5, 0)
-	L.adjustFireLoss(-0.5, 0)
-	L.adjustToxLoss(-0.5, 0)
-	L.adjustOxyLoss(-0.5, 0)
 	L.AdjustConfused(-10 SECONDS)
 	return ..()
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You cannot heal from Doctor's Delight anymore.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The time of anti-powergamer PRs is now.

Doctor's delight is a superior tricord. You can't OD from doctor's delight, so your bloodstream can be filled with doctor's delight. I'm not even sure if this med counts against a marine if they get defiler purge.

It's true that doctor's delight makes you hungry, but you can just counter this by producing ironsugar or nutrition pills (yes, nutrition pills exist) and consume both doctor's delight and either the two pills mentioned above to not be hungry.

Lolipop is a good premed tool, but doctor's delight is superior.

This ends now.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: doctor's delight doesn't heal anymore
del: doctor's delight doesn't heal anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
