### PR TITLE
Stun tweaks

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -51,7 +51,7 @@
 	bomb_delay = 32 SECONDS
 	ammo_multiplier = 1.5 SECONDS
 
-	acid_spray_duration = 10 SECONDS
+	acid_spray_duration = 20 SECONDS
 	acid_spray_damage = 16
 	acid_spray_damage_on_hit = 35
 	acid_spray_structure_damage = 45

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -96,7 +96,7 @@
 	///How far can we charge
 	var/range = 6
 	///How long is the windup before charging
-	var/windup_time = 0 SECONDS
+	var/windup_time = 0.5 SECONDS
 
 /datum/action/xeno_action/activable/forward_charge/proc/charge_complete()
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -90,7 +90,7 @@
 	mechanics_text = "Charge up to 6 tiles and knockdown any targets in our way."
 	ability_name = "charge"
 	cooldown_timer = 10 SECONDS
-	plasma_cost = 50
+	plasma_cost = 60
 	use_state_flags = XACT_USE_CRESTED|XACT_USE_FORTIFIED
 	keybind_signal = COMSIG_XENOABILITY_FORWARD_CHARGE
 	///How far can we charge

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -90,7 +90,7 @@
 	mechanics_text = "Charge up to 6 tiles and knockdown any targets in our way."
 	ability_name = "charge"
 	cooldown_timer = 10 SECONDS
-	plasma_cost = 80
+	plasma_cost = 50
 	use_state_flags = XACT_USE_CRESTED|XACT_USE_FORTIFIED
 	keybind_signal = COMSIG_XENOABILITY_FORWARD_CHARGE
 	///How far can we charge

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -87,16 +87,16 @@
 /datum/action/xeno_action/activable/forward_charge
 	name = "Forward Charge"
 	action_icon_state = "charge"
-	mechanics_text = "Charge up to 4 tiles and knockdown any targets in our way."
+	mechanics_text = "Charge up to 6 tiles and knockdown any targets in our way."
 	ability_name = "charge"
 	cooldown_timer = 10 SECONDS
 	plasma_cost = 80
 	use_state_flags = XACT_USE_CRESTED|XACT_USE_FORTIFIED
 	keybind_signal = COMSIG_XENOABILITY_FORWARD_CHARGE
 	///How far can we charge
-	var/range = 4
+	var/range = 6
 	///How long is the windup before charging
-	var/windup_time = 0.5 SECONDS
+	var/windup_time = 0 SECONDS
 
 /datum/action/xeno_action/activable/forward_charge/proc/charge_complete()
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -264,7 +264,7 @@
 	mechanics_text = "Plant yourself for a large defensive boost."
 	ability_name = "fortify"
 	use_state_flags = XACT_USE_FORTIFIED|XACT_USE_CRESTED // duh
-	cooldown_timer = 1 SECONDS
+	cooldown_timer = 0 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_FORTIFY
 	var/last_fortify_bonus = 0
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
@@ -58,8 +58,8 @@
 	var/target_turf = get_step_away(src, H, rand(1, 2)) //This is where we blast our target
 	target_turf = get_step_rand(target_turf) //Scatter
 	H.throw_at(get_turf(target_turf), 4, 70, H)
-	H.Paralyze(40)
-
+	H.Paralyze(5)
+	H.adjust_stagger(5)
 
 /mob/living/carbon/xenomorph/defender/lay_down()
 	if(fortify) // Ensure the defender isn't fortified while laid down

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
@@ -53,7 +53,7 @@
 	if(!ishuman(A))
 		return ..()
 	var/mob/living/carbon/human/H = A
-	var/extra_dmg = xeno_caste.melee_damage * xeno_melee_damage_modifier * 0.5 // 50% dmg reduction
+	var/extra_dmg = xeno_caste.melee_damage * xeno_melee_damage_modifier * 1
 	H.attack_alien_harm(src, extra_dmg, FALSE, TRUE, FALSE, TRUE) //Location is always random, cannot crit, harm only
 	var/target_turf = get_step_away(src, H, rand(1, 2)) //This is where we blast our target
 	target_turf = get_step_rand(target_turf) //Scatter

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
@@ -58,6 +58,8 @@
 	var/target_turf = get_step_away(src, H, rand(1, 2)) //This is where we blast our target
 	target_turf = get_step_rand(target_turf) //Scatter
 	H.throw_at(get_turf(target_turf), 4, 70, H)
+	playsound(src, 'sound/effects/bang.ogg', 25, 0)
+	H.emote("scream")
 	H.Paralyze(5)
 	H.adjust_stagger(5)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -191,6 +191,7 @@
 	span_danger("We strike [target] with [flavour] precision!"))
 	target.adjust_stagger(staggerslow_stacks)
 	target.add_slowdown(staggerslow_stacks)
+	target.Paralyze(5)
 	target.blind_eyes(3)
 	target.blur_eyes(6)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -191,7 +191,8 @@
 	span_danger("We strike [target] with [flavour] precision!"))
 	target.adjust_stagger(staggerslow_stacks)
 	target.add_slowdown(staggerslow_stacks)
-	target.ParalyzeNoChain(1 SECONDS)
+	target.blind_eyes(3)
+	target.blur_eyes(6)
 
 	cancel_stealth()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -36,7 +36,7 @@
 	spit_delay = 1.3 SECONDS
 	spit_types = list(/datum/ammo/xeno/toxin/heavy, /datum/ammo/xeno/acid/heavy)
 
-	acid_spray_duration = 10 SECONDS
+	acid_spray_duration = 20 SECONDS
 	acid_spray_range = 5
 	acid_spray_damage = 16
 	acid_spray_damage_on_hit = 35

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -55,8 +55,8 @@
 	name = "Psychic Fling"
 	action_icon_state = "fling"
 	mechanics_text = "Sends an enemy or an item flying. A close ranged ability."
-	cooldown_timer = 12 SECONDS
-	plasma_cost = 100
+	cooldown_timer = 6 SECONDS
+	plasma_cost = 50
 	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_FLING
 	target_flags = XABB_MOB_TARGET
 
@@ -113,7 +113,7 @@
 	succeed_activate()
 	add_cooldown()
 	if(ishuman(victim))
-		victim.apply_effects(1, 0.1) 	// The fling stuns you enough to remove your gun, otherwise the marine effectively isn't stunned for long.
+		victim.apply_effects(0.1, 0.1) 	// The fling stuns you enough to remove your gun, otherwise the marine effectively isn't stunned for long.
 		shake_camera(victim, 2, 1)
 
 	var/facing = get_dir(owner, victim)
@@ -136,8 +136,8 @@
 	name = "Unrelenting Force"
 	action_icon_state = "screech"
 	mechanics_text = "Unleashes our raw psychic power, pushing aside anyone who stands in our path."
-	cooldown_timer = 50 SECONDS
-	plasma_cost = 300
+	cooldown_timer = 25 SECONDS
+	plasma_cost = 150
 	keybind_flags = XACT_KEYBIND_USE_ABILITY | XACT_IGNORE_SELECTED_ABILITY
 	keybind_signal = COMSIG_XENOABILITY_UNRELENTING_FORCE
 	alternate_keybind_signal = COMSIG_XENOABILITY_UNRELENTING_FORCE_SELECT
@@ -183,7 +183,7 @@
 				var/mob/living/carbon/human/H = affected
 				if(H.stat == DEAD) //unless they are dead, then the blast mysteriously ignores them.
 					continue
-				H.apply_effects(1, 1) 	// Stun
+				H.apply_effects(0.1, 0.1) 	// Stun for just enough to drop the gun/held objects
 				shake_camera(H, 2, 1)
 			var/throwlocation = affected.loc //first we get the target's location
 			for(var/x in 1 to 6)

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -14,14 +14,14 @@
 	melee_damage = 20
 
 	// *** Speed *** //
-	speed = -0.3
+	speed = -0.7
 
 	// *** Plasma *** //
 	plasma_max = 750
 	plasma_gain = 30
 
 	// *** Health *** //
-	max_health = 325
+	max_health = 400
 
 	// *** Evolution *** //
 	evolution_threshold = 180
@@ -83,14 +83,14 @@
 	upgrade = XENO_UPGRADE_ONE
 
 	// *** Speed *** //
-	speed = -0.4
+	speed = -0.8
 
 	// *** Plasma *** //
 	plasma_max = 850
 	plasma_gain = 35
 
 	// *** Health *** //
-	max_health = 350
+	max_health = 440
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_TWO_MATURE_THRESHOLD
@@ -111,14 +111,14 @@
 	melee_damage = 23
 
 	// *** Speed *** //
-	speed = -0.5
+	speed = -0.9
 
 	// *** Plasma *** //
 	plasma_max = 900
 	plasma_gain = 40
 
 	// *** Health *** //
-	max_health = 375
+	max_health = 470
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_TWO_ELDER_THRESHOLD
@@ -139,14 +139,14 @@
 	melee_damage = 23
 
 	// *** Speed *** //
-	speed = -0.6
+	speed = -1
 
 	// *** Plasma *** //
 	plasma_max = 925
 	plasma_gain = 45
 
 	// *** Health *** //
-	max_health = 400
+	max_health = 500
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_TWO_ANCIENT_THRESHOLD
@@ -167,14 +167,14 @@
 	melee_damage = 23
 
 	// *** Speed *** //
-	speed = -0.6
+	speed = -1
 
 	// *** Plasma *** //
 	plasma_max = 925
 	plasma_gain = 45
 
 	// *** Health *** //
-	max_health = 400
+	max_health = 500
 	// *** Defense *** //
 	soft_armor = list("melee" = 45, "bullet" = 45, "laser" = 45, "energy" = 45, "bomb" = 20, "bio" = 23, "rad" = 23, "fire" = 45, "acid" = 20)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -174,7 +174,7 @@
 	plasma_gain = 45
 
 	// *** Health *** //
-	max_health = 500
+	max_health = 450
 	// *** Defense *** //
 	soft_armor = list("melee" = 45, "bullet" = 45, "laser" = 45, "energy" = 45, "bomb" = 20, "bio" = 23, "rad" = 23, "fire" = 45, "acid" = 20)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -21,7 +21,7 @@
 	plasma_gain = 30
 
 	// *** Health *** //
-	max_health = 400
+	max_health = 350
 
 	// *** Evolution *** //
 	evolution_threshold = 180
@@ -90,7 +90,7 @@
 	plasma_gain = 35
 
 	// *** Health *** //
-	max_health = 440
+	max_health = 390
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_TWO_MATURE_THRESHOLD
@@ -118,7 +118,7 @@
 	plasma_gain = 40
 
 	// *** Health *** //
-	max_health = 470
+	max_health = 420
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_TWO_ELDER_THRESHOLD
@@ -146,7 +146,7 @@
 	plasma_gain = 45
 
 	// *** Health *** //
-	max_health = 500
+	max_health = 450
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_TWO_ANCIENT_THRESHOLD

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -44,7 +44,7 @@
 	spit_delay = 0.8 SECONDS
 	spit_types = list(/datum/ammo/xeno/acid/medium) //Gotta give them their own version of heavy acid; kludgy but necessary as 100 plasma is way too costly.
 
-	acid_spray_duration = 10 SECONDS
+	acid_spray_duration = 20 SECONDS
 	acid_spray_damage_on_hit = 35
 	acid_spray_damage = 16
 	acid_spray_structure_damage = 45

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -357,7 +357,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	sundering = 2
 
 /datum/ammo/bullet/pistol/hollow/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, slowdown = 0.5, knockback = 1)
+	staggerstun(M, P, stagger = 1, slowdown = 0.5, knockback = 1)
 
 /datum/ammo/bullet/pistol/ap
 	name = "armor-piercing pistol bullet"
@@ -383,7 +383,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	sundering = 3.5
 
 /datum/ammo/bullet/pistol/superheavy/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, slowdown = 1, shake = 0)
+	staggerstun(M, P, stagger = 1, slowdown = 1, shake = 0)
 
 /datum/ammo/bullet/pistol/superheavy/derringer
 	handful_amount = 2
@@ -440,7 +440,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	sundering = 3
 
 /datum/ammo/bullet/revolver/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, slowdown = 0.5, knockback = 1)
+	staggerstun(M, P, stagger = 1, slowdown = 0.5, knockback = 1)
 
 datum/ammo/bullet/revolver/tp44
 	name = "standard revolver bullet"
@@ -485,7 +485,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 3
 
 /datum/ammo/bullet/revolver/highimpact/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, weaken = 1, slowdown = 1, knockback = 1, shake = 0.5)
+	staggerstun(M, P, weaken = 1, stagger = 1, slowdown = 1, knockback = 1, shake = 0.5)
 
 /datum/ammo/bullet/revolver/ricochet
 	bonus_projectiles_type = /datum/ammo/bullet/revolver/small
@@ -603,7 +603,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 1.25
 
 /datum/ammo/bullet/rifle/repeater/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, max_range = 3, slowdown = 2, shake = 0.5)
+	staggerstun(M, P, max_range = 3, slowdown = 2, stagger = 1, shake = 0.5)
 
 /datum/ammo/bullet/rifle/incendiary
 	name = "incendiary rifle bullet"
@@ -725,7 +725,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 15
 
 /datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, weaken = 1, knockback = 1, slowdown = 2)
+	staggerstun(M, P, weaken = 1, stagger = 2, knockback = 1, slowdown = 2)
 
 
 /datum/ammo/bullet/shotgun/beanbag
@@ -809,7 +809,7 @@ datum/ammo/bullet/revolver/tp44
 
 
 /datum/ammo/bullet/shotgun/buckshot/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, weaken = 1, knockback = 2, slowdown = 0.5, max_range = 3)
+	staggerstun(M, P, weaken = 1, stagger = 1, knockback = 2, slowdown = 0.5, max_range = 3)
 
 /datum/ammo/bullet/shotgun/spread
 	name = "additional buckshot"
@@ -1054,7 +1054,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 10
 
 /datum/ammo/bullet/sniper/martini/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, weaken = 1, knockback = 2, slowdown = 0.5, max_range = 5)
+	staggerstun(M, P, weaken = 1, stagger = 1, knockback = 2, slowdown = 0.5, max_range = 5)
 
 /datum/ammo/bullet/sniper/elite
 	name = "supersonic sniper bullet"
@@ -1084,7 +1084,7 @@ datum/ammo/bullet/revolver/tp44
 	damage_falloff = 0.25
 
 /datum/ammo/bullet/sniper/pfc/flak/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, knockback = 4, slowdown = 1.5, max_range = 17)
+	staggerstun(M, P, knockback = 4, slowdown = 1.5, stagger = 1, max_range = 17)
 
 
 /datum/ammo/bullet/sniper/auto
@@ -1188,7 +1188,7 @@ datum/ammo/bullet/revolver/tp44
 	on_pierce_multiplier = 0.85
 
 /datum/ammo/bullet/railgun/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, weaken = 1, slowdown = 2, knockback = 2, shake = 0)
+	staggerstun(M, P, weaken = 1, stagger = 3, slowdown = 2, knockback = 2, shake = 0)
 
 /datum/ammo/bullet/railgun/hvap
 	name = "high velocity railgun slug"
@@ -1199,7 +1199,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 100
 
 /datum/ammo/bullet/railgun/hvap/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, knockback = 3, shake = 0)
+	staggerstun(M, P, stagger = 2, knockback = 3, shake = 0)
 
 /datum/ammo/bullet/railgun/smart
 	name = "smart armor piercing railgun slug"
@@ -1209,7 +1209,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 50
 
 /datum/ammo/bullet/railgun/smart/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, slowdown = 3, shake = 0)
+	staggerstun(M, P, stagger = 3, slowdown = 3, shake = 0)
 
 
 /datum/ammo/tx54

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -357,7 +357,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	sundering = 2
 
 /datum/ammo/bullet/pistol/hollow/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, stagger = 1, slowdown = 0.5, knockback = 1)
+	staggerstun(M, P, slowdown = 0.5, knockback = 1)
 
 /datum/ammo/bullet/pistol/ap
 	name = "armor-piercing pistol bullet"
@@ -383,7 +383,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	sundering = 3.5
 
 /datum/ammo/bullet/pistol/superheavy/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, stagger = 1, slowdown = 1, shake = 0)
+	staggerstun(M, P, slowdown = 1, shake = 0)
 
 /datum/ammo/bullet/pistol/superheavy/derringer
 	handful_amount = 2
@@ -440,7 +440,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	sundering = 3
 
 /datum/ammo/bullet/revolver/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, stagger = 1, slowdown = 0.5, knockback = 1)
+	staggerstun(M, P, slowdown = 0.5, knockback = 1)
 
 datum/ammo/bullet/revolver/tp44
 	name = "standard revolver bullet"
@@ -485,7 +485,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 3
 
 /datum/ammo/bullet/revolver/highimpact/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, weaken = 1, stagger = 1, slowdown = 1, knockback = 1, shake = 0.5)
+	staggerstun(M, P, weaken = 1, slowdown = 1, knockback = 1, shake = 0.5)
 
 /datum/ammo/bullet/revolver/ricochet
 	bonus_projectiles_type = /datum/ammo/bullet/revolver/small
@@ -603,7 +603,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 1.25
 
 /datum/ammo/bullet/rifle/repeater/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, max_range = 3, slowdown = 2, stagger = 1, shake = 0.5)
+	staggerstun(M, P, max_range = 3, slowdown = 2, shake = 0.5)
 
 /datum/ammo/bullet/rifle/incendiary
 	name = "incendiary rifle bullet"
@@ -725,7 +725,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 15
 
 /datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, weaken = 1, stagger = 2, knockback = 1, slowdown = 2)
+	staggerstun(M, P, weaken = 1, knockback = 1, slowdown = 2)
 
 
 /datum/ammo/bullet/shotgun/beanbag
@@ -809,7 +809,7 @@ datum/ammo/bullet/revolver/tp44
 
 
 /datum/ammo/bullet/shotgun/buckshot/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, weaken = 1, stagger = 1, knockback = 2, slowdown = 0.5, max_range = 3)
+	staggerstun(M, P, weaken = 1, knockback = 2, slowdown = 0.5, max_range = 3)
 
 /datum/ammo/bullet/shotgun/spread
 	name = "additional buckshot"
@@ -1054,7 +1054,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 10
 
 /datum/ammo/bullet/sniper/martini/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, weaken = 1, stagger = 1, knockback = 2, slowdown = 0.5, max_range = 5)
+	staggerstun(M, P, weaken = 1, knockback = 2, slowdown = 0.5, max_range = 5)
 
 /datum/ammo/bullet/sniper/elite
 	name = "supersonic sniper bullet"
@@ -1084,7 +1084,7 @@ datum/ammo/bullet/revolver/tp44
 	damage_falloff = 0.25
 
 /datum/ammo/bullet/sniper/pfc/flak/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, knockback = 4, slowdown = 1.5, stagger = 1, max_range = 17)
+	staggerstun(M, P, knockback = 4, slowdown = 1.5, max_range = 17)
 
 
 /datum/ammo/bullet/sniper/auto
@@ -1188,7 +1188,7 @@ datum/ammo/bullet/revolver/tp44
 	on_pierce_multiplier = 0.85
 
 /datum/ammo/bullet/railgun/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, weaken = 1, stagger = 3, slowdown = 2, knockback = 2, shake = 0)
+	staggerstun(M, P, weaken = 1, slowdown = 2, knockback = 2, shake = 0)
 
 /datum/ammo/bullet/railgun/hvap
 	name = "high velocity railgun slug"
@@ -1199,7 +1199,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 100
 
 /datum/ammo/bullet/railgun/hvap/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, stagger = 2, knockback = 3, shake = 0)
+	staggerstun(M, P, knockback = 3, shake = 0)
 
 /datum/ammo/bullet/railgun/smart
 	name = "smart armor piercing railgun slug"
@@ -1209,7 +1209,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 50
 
 /datum/ammo/bullet/railgun/smart/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, stagger = 3, slowdown = 3, shake = 0)
+	staggerstun(M, P, slowdown = 3, shake = 0)
 
 
 /datum/ammo/tx54

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -99,7 +99,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 				to_chat(target, span_highdanger("The blast knocks you off your feet!"))
 		step_away(victim, proj)
 
-/datum/ammo/proc/staggerstun(mob/victim, obj/projectile/proj, max_range = 5, stun = 0, weaken = 0, slowdown = 0, knockback = 0, shake = 1, soft_size_threshold = 3, hard_size_threshold = 2)
+/datum/ammo/proc/staggerstun(mob/victim, obj/projectile/proj, max_range = 5, stun = 0, weaken = 0, stagger = 0, slowdown = 0, knockback = 0, shake = 1, soft_size_threshold = 3, hard_size_threshold = 2)
 	if(!victim)
 		CRASH("staggerstun called without a mob target")
 	if(!isliving(victim))
@@ -449,7 +449,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 1.5
 
 /datum/ammo/bullet/revolver/tp44/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, slowdown = 0.5, knockback = 1, shake = 0)
+	staggerstun(M, P, stagger = 0, slowdown = 0.5, knockback = 1, shake = 0)
 
 /datum/ammo/bullet/revolver/small
 	name = "small revolver bullet"
@@ -1241,7 +1241,7 @@ datum/ammo/bullet/revolver/tp44
 	projectile_greyscale_colors = "#3ab0c9"
 
 /datum/ammo/tx54/on_hit_mob(mob/M, obj/projectile/proj)
-	staggerstun(M, proj, slowdown = 0.5, knockback = 1, shake = 0)
+	staggerstun(M, proj, stagger = 0, slowdown = 0.5, knockback = 1, shake = 0)
 	bonus_projectiles_amount = 7
 	playsound(proj, sound(get_sfx("explosion_small")), 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, 4, 3, Get_Angle(proj.firer, M) )

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -99,7 +99,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 				to_chat(target, span_highdanger("The blast knocks you off your feet!"))
 		step_away(victim, proj)
 
-/datum/ammo/proc/staggerstun(mob/victim, obj/projectile/proj, max_range = 5, stun = 0, weaken = 0, stagger = 0, slowdown = 0, knockback = 0, shake = 1, soft_size_threshold = 3, hard_size_threshold = 2)
+/datum/ammo/proc/staggerstun(mob/victim, obj/projectile/proj, max_range = 5, stun = 0, weaken = 0, slowdown = 0, knockback = 0, shake = 1, soft_size_threshold = 3, hard_size_threshold = 2)
 	if(!victim)
 		CRASH("staggerstun called without a mob target")
 	if(!isliving(victim))
@@ -449,7 +449,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 1.5
 
 /datum/ammo/bullet/revolver/tp44/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, stagger = 0, slowdown = 0.5, knockback = 1, shake = 0)
+	staggerstun(M, P, slowdown = 0.5, knockback = 1, shake = 0)
 
 /datum/ammo/bullet/revolver/small
 	name = "small revolver bullet"
@@ -1241,7 +1241,7 @@ datum/ammo/bullet/revolver/tp44
 	projectile_greyscale_colors = "#3ab0c9"
 
 /datum/ammo/tx54/on_hit_mob(mob/M, obj/projectile/proj)
-	staggerstun(M, proj, stagger = 0, slowdown = 0.5, knockback = 1, shake = 0)
+	staggerstun(M, proj, slowdown = 0.5, knockback = 1, shake = 0)
 	bonus_projectiles_amount = 7
 	playsound(proj, sound(get_sfx("explosion_small")), 30, falloff = 5)
 	fire_directionalburst(proj, proj.firer, proj.shot_from, 4, 3, Get_Angle(proj.firer, M) )


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Disclaimer: Values up to change as testing is done so that equivalent buffs are applied where stun removal acts as a harsh nerf. This is meant to distance gameplay away from chaining stuns, not net nerf or buff to xeno compositions.

Rebalances some xenos to be competitive while toning down their stuns in exchange for buffs in other areas, or other xeno aspects as a whole. Draft while working it out.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The game oughta be fun for both sides, to play as and to play against. Stuns lead to a bit of fun on the one using them, while the ones on the receiving end end up in stunlock city. However, due to stuns playing a large role in the power of a caste, they end up weak in other areas that turn into a mess when they're no longer in a situation they can use their stuns, extreme example being ungaballs of 20+ marines if they're not rushing the 1x1 chokes so that they're fighting only a few at a time.

A smaller scale PR had been TM'd for the shrike and after talking with some people, it seems that even though initially it was tedious and difficult to get used to the new gameplay, they found it not only fun to play the new shrike, but also fun to play against as well. This PR would be the next step in toning down stuns for xenos as a whole but also giving them something in return while thinking of them as a team rather than castes in a vacuum.

This does NOT aim to remove ALL stuns from xenos.

Changes:

Shrike:
HP increased ~~by 25%~~ to 350/390/420/450 Young/Mature/Elder/Ancient (Health was initially put there before speed was considered, both together ended up a bit overboard), speed equalized to ravager. Stun effectively removes from fling and unrelenting force, knockdown remains. Cooldown and cost of abilities reduced by half.

Boiler, Spitter, Praetorian:
Acid spray turf duration increased by 2x. Buffs them as an area denial tool since inevitably fewer stuns means xenos won't be able to keep marines from just bumrushing forward even harder.

Defender:
Forward charge stun equalized to tail sweep. Gives around 5s of stagger (for marines, it means around a 50% damage debuff), increased the bonus damage from 0.5x to 1x, in practice meaning if you hit a marine you're effectively landing 2 slashes. Range increased to 6. Plasma cost reduced to 60 from 80, even on ancient a defender would've only been able to use it twice; it's considerably weaker, so the old high cost is no longer justified. Purpose is making it less of a midcombat stun and more of a mobility ability that'll still tank your plasma, be it as initiation or retreat tool, while still retaining a benefit for using it against a target.

Fortify reduced to no cooldown so as to increase its midcombat viability. Ideally, a high skill xeno that totally won't be pit boss 99% of the time will be able to use it to tank low firerate high damage shots. So far fortify is mostly used to sit in front of boilers or slash cades, so hopefully this adds uses.

~~Guns:~~
~~Removed stagger from most of them. Even though staggered marines had a 50% damage debuff, staggered xenos were locked out of their abilities altogether, a good few of them needing said abilities for their own survival rather than horizontaling spessmen faster. Same way marines shold have fun playing vs xenos, xenos should also have fun playing vs marines, and getting locked out of your abilities by marines is just as unfun as getting stunlocked by xenos. Note, this only affects stagger; that is to say, slugs and buckshot still knockdown and punch xenos a few tiles, so does martini, and so on. Only the "xeno can't use any abilities" part is changed.~~ Will probably be put up in another PR so as to keep this one strictly xeno-only.

Hunter: Reduced stealth's stun with a brief knockdown, adds a blind + blur. A competent hunter can chain the stun with a pounce for a double stun with no cooldown that can bring someone down to almost crit from full health unless they're a chonky boi with heavy tyr2. Ideally this also gives a reason to use it outside of soloing marines, since a blinded marine is more prone to shooting randomly and potentially causing FF. Not the most fun thing to be around with, but hopefully is a better alternative. Originally removed the stun entirely, no knockdown, but realized that a marine with a weapon like a wielded T60 had no business still magdumping the hunter during a stealth attack. My bad.

Will be real here for the hunter, I don't have the coding knowledge to buff it in ways I wanted to. Can't even get the code to look at its own melee damage on maturity to double it for stealth, and that was an idea that came due to numerous others being infinitely more complex to code for my current limits. If anyone got anything to offer with the code to back it up, I'll vouch for it, either adding it or setting it up as its own PR should this pass. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Shrike: HP up to 350/390/420/450 Young/Mature/Elder/Ancient. Speed equalized to rav. Unrelenting Force and Fling stun durations reduced to 0.1 (essentially only knockdown), cost and cooldown reduced by 50%.
balance: Boiler, Spitter, Praetorian: Acid spray turf duration doubled.
balance: Defender: Forward Charge stun down to tail sweep duration. Plasma cost down to 60. Range increased to 6. Added 5s of stagger on hit (Staggered marines do only 50% damage). Damage on landing increased from 1.5x slash to 2x. Fortify to 0 cooldown.
balance: Hunter: Stun on stealthed normal attack reduced to knowckdown, added blind + blur.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
