### PR TITLE
Remove using wrench to undeploy mortar

### DIFF
--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -241,7 +241,9 @@
 	qdel(mortar_shell)
 	firing = FALSE
 
-/obj/machinery/deployable/mortar/wrench_act(mob/living/user, obj/item/I)
+/obj/machinery/deployable/mortar/attack_hand_alternate(mob/living/user)
+	if(!Adjacent(user) || user.lying_angle || user.incapacitated() || !ishuman(user))
+		return
 
 	if(busy)
 		to_chat(user, span_warning("Someone else is currently using [src]."))
@@ -256,12 +258,12 @@
 //The portable mortar item
 /obj/item/mortar_kit
 	name = "\improper TA-50S mortar"
-	desc = "A manual, crew-operated mortar system intended to rain down 80mm goodness on anything it's aimed at. Needs to be set down first to fire. Use Ctrl-Click to deploy."
+	desc = "A manual, crew-operated mortar system intended to rain down 80mm goodness on anything it's aimed at. Needs to be set down first to fire. Ctrl-Click on a tile to deploy."
 	icon = 'icons/Marine/mortar.dmi'
 	icon_state = "mortar"
 
 	max_integrity = 200
-	flags_item = IS_DEPLOYABLE|DEPLOYED_WRENCH_DISASSEMBLE
+	flags_item = IS_DEPLOYABLE|DEPLOY_ON_INITIALIZE
 	/// What item is this going to deploy when we put down the mortar?
 	var/deployable_item = /obj/machinery/deployable/mortar
 

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -263,7 +263,7 @@
 	icon_state = "mortar"
 
 	max_integrity = 200
-	flags_item = IS_DEPLOYABLE|DEPLOY_ON_INITIALIZE
+	flags_item = IS_DEPLOYABLE
 	/// What item is this going to deploy when we put down the mortar?
 	var/deployable_item = /obj/machinery/deployable/mortar
 

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -258,7 +258,7 @@
 //The portable mortar item
 /obj/item/mortar_kit
 	name = "\improper TA-50S mortar"
-	desc = "A manual, crew-operated mortar system intended to rain down 80mm goodness on anything it's aimed at. Needs to be set down first to fire. Ctrl-Click on a tile to deploy."
+	desc = "A manual, crew-operated mortar system intended to rain down 80mm goodness on anything it's aimed at. Needs to be set down first to fire. Ctrl+Click on a tile to deploy, drag the mortar's sprites to mob's sprite to undeploy."
 	icon = 'icons/Marine/mortar.dmi'
 	icon_state = "mortar"
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As of right now, you need to use wrench to move mortar. Relic of CM.

This PR removes that. Just drag the mortar's sprite your mob's sprites like other deployable objects, and you're good.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Deployable weapons are easy to move with the sheer and weird exception of mortar. 11C Indirect Fire Infantryman in the Army or 0341 Mortarman in the Marine Corps don't need to use a wrench to move mortar. My hypothesis is that no one has updated mortar to the new deployable code, therefore I'm doing the favor for all indirect fire marines.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Mortar's description now tells players how to deploy and undeploy
qol: Remove wrench from moving mortar; drag the mortar's sprite your mob's sprites like other deployable objects
balance: Makes it easier for mortar marines for tactical and superior position with mortar
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
