### PR TITLE
Fixes Ice Colony LZ1, adds APC to LZ2

### DIFF
--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -704,7 +704,6 @@
 	},
 /area/ice_colony/surface/engineering)
 "acY" = (
-/obj/effect/turf_underlay/icefloor,
 /turf/closed/ice/thin/corner{
 	dir = 1
 	},
@@ -14013,6 +14012,7 @@
 /obj/machinery/landinglight/ds1{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 4
 	},
@@ -14030,7 +14030,6 @@
 /turf/open/floor/tile/dark/yellow2,
 /area/ice_colony/surface/research/tech_storage)
 "aYs" = (
-/obj/effect/turf_underlay/icefloor,
 /turf/closed/ice/thin/end,
 /area/ice_colony/exterior/surface/landing_pad)
 "aYt" = (
@@ -14215,6 +14214,7 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/exterior/surface/taxiway)
 "aZg" = (
@@ -14283,7 +14283,6 @@
 	},
 /area/ice_colony/surface/hangar/beta)
 "aZr" = (
-/obj/effect/turf_underlay/icefloor,
 /turf/closed/ice/thin/end{
 	dir = 1
 	},
@@ -14918,7 +14917,6 @@
 	},
 /area/ice_colony/underground/responsehangar)
 "bbs" = (
-/obj/effect/turf_underlay/icefloor,
 /turf/closed/ice/thin/straight,
 /area/ice_colony/exterior/surface/landing_pad)
 "bbt" = (
@@ -14935,7 +14933,6 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/ice_colony/exterior/surface/valley/south)
 "bbx" = (
-/obj/effect/turf_underlay/icefloor,
 /turf/closed/ice/thin/junction,
 /area/ice_colony/exterior/surface/landing_pad)
 "bbz" = (
@@ -15065,7 +15062,6 @@
 	},
 /area/ice_colony/exterior/underground/caves/ice_se)
 "bca" = (
-/obj/effect/turf_underlay/icefloor,
 /turf/closed/ice/thin/corner,
 /area/ice_colony/exterior/surface/cliff)
 "bcb" = (
@@ -15469,7 +15465,6 @@
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/exterior/surface/landing_pad2)
 "bdA" = (
-/obj/effect/turf_underlay/icefloor,
 /turf/closed/ice/thin/junction{
 	dir = 1
 	},
@@ -17783,7 +17778,6 @@
 /turf/open/floor/wood,
 /area/ice_colony/underground/crew/library)
 "bmg" = (
-/obj/effect/turf_underlay/icefloor,
 /turf/closed/ice/thin/corner,
 /area/ice_colony/exterior/surface/landing_pad)
 "bmh" = (
@@ -19994,7 +19988,6 @@
 	},
 /area/ice_colony/underground/medical/hallway)
 "btJ" = (
-/obj/effect/turf_underlay/icefloor,
 /turf/closed/ice/thin/straight{
 	dir = 4
 	},
@@ -27566,7 +27559,6 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/ice_colony/exterior/surface/clearing/south)
 "bRF" = (
-/obj/effect/turf_underlay/icefloor,
 /obj/effect/ai_node,
 /turf/closed/ice/thin/corner{
 	dir = 8
@@ -27623,6 +27615,7 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor/plating/icefloor/warnplate,
 /area/ice_colony/exterior/surface/landing_pad)
 "bRS" = (
@@ -28297,6 +28290,7 @@
 /obj/machinery/landinglight/ds2/delayone{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 1
 	},
@@ -28983,6 +28977,7 @@
 /obj/machinery/landinglight/ds2/delaythree{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/icefloor/warnplate,
 /area/ice_colony/exterior/surface/landing_pad)
 "bWW" = (
@@ -29256,6 +29251,7 @@
 /obj/machinery/landinglight/ds2/delayone{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/icefloor/warnplate,
 /area/ice_colony/exterior/surface/landing_pad)
 "bXN" = (
@@ -29767,6 +29763,7 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 1
 	},
@@ -29794,6 +29791,7 @@
 	dir = 8
 	},
 /obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 1
 	},
@@ -29899,7 +29897,6 @@
 	},
 /area/ice_colony/exterior/surface/landing_pad)
 "bZL" = (
-/obj/effect/turf_underlay/icefloor,
 /turf/closed/ice/thin/corner{
 	dir = 8
 	},
@@ -29917,7 +29914,6 @@
 	},
 /area/ice_colony/surface/excavationbarracks)
 "bZO" = (
-/obj/effect/turf_underlay/icefloor,
 /turf/closed/ice/thin/corner{
 	dir = 4
 	},
@@ -29929,18 +29925,21 @@
 /obj/machinery/landinglight/ds2/delaythree{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/exterior/surface/landing_pad)
 "bZT" = (
 /obj/machinery/landinglight/ds2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/exterior/surface/landing_pad)
 "bZU" = (
 /obj/machinery/landinglight/ds2/delayone{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 4
 	},
@@ -29949,6 +29948,7 @@
 /obj/machinery/landinglight/ds2/delaytwo{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
 	},
@@ -29957,12 +29957,14 @@
 /obj/machinery/landinglight/ds2/delayone{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/exterior/surface/landing_pad)
 "bZX" = (
 /obj/machinery/landinglight/ds2/delaytwo{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 4
 	},
@@ -29971,6 +29973,7 @@
 /obj/machinery/landinglight/ds2/delaythree{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
 	},
@@ -30544,12 +30547,10 @@
 	},
 /area/ice_colony/exterior/surface/landing_pad2)
 "cVY" = (
-/obj/machinery/door/airlock/mainship/secure/locked/free_access{
-	name = "\improper Colony Requesitions Storage Pod"
+/turf/closed/ice/thin/end{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plating/icefloor,
-/area/ice_colony/exterior/surface/landing_pad2)
+/area/ice_colony/exterior/surface/cliff)
 "cXp" = (
 /turf/closed/ice/straight,
 /area/ice_colony/exterior/surface/landing_pad2)
@@ -30736,6 +30737,11 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/command)
+"dKq" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/obj/structure/cable,
+/turf/open/floor/plating/icefloor,
+/area/ice_colony/exterior/surface/landing_pad)
 "dPf" = (
 /turf/open/floor/tile/vault{
 	dir = 8
@@ -30840,6 +30846,13 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/ice,
 /area/ice_colony/exterior/underground/caves/open)
+"erM" = (
+/obj/machinery/landinglight/ds2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/icefloor,
+/area/ice_colony/exterior/surface/landing_pad)
 "esg" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -30931,6 +30944,13 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/command)
+"eOs" = (
+/obj/machinery/landinglight/ds2/delaytwo{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/icefloor,
+/area/ice_colony/exterior/surface/landing_pad)
 "ePo" = (
 /turf/open/floor/plating/ground/ice,
 /area/ice_colony/exterior/underground/caves/open)
@@ -31167,7 +31187,6 @@
 /turf/open/floor/plating,
 /area/ice_colony/underground/maintenance/central)
 "gkO" = (
-/obj/effect/turf_underlay/icefloor,
 /obj/structure/fence,
 /turf/closed/ice/thin/single,
 /area/ice_colony/exterior/surface/valley/southeast)
@@ -31297,6 +31316,11 @@
 	dir = 4
 	},
 /area/ice_colony/exterior/surface/cliff)
+"gHG" = (
+/turf/closed/ice/thin/end{
+	dir = 4
+	},
+/area/ice_colony/exterior/surface/landing_pad_external)
 "gIr" = (
 /obj/effect/turf_underlay/icefloor,
 /obj/effect/landmark/excavation_site_spawner,
@@ -31732,6 +31756,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/ice_colony/underground/maintenance/east)
+"iFb" = (
+/turf/closed/ice/thin/end{
+	dir = 8
+	},
+/area/ice_colony/exterior/surface/landing_pad)
 "iHq" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer2,
@@ -31828,6 +31857,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/hallway/north_west)
+"jcT" = (
+/obj/machinery/landinglight/ds2/delaythree{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/icefloor,
+/area/ice_colony/exterior/surface/landing_pad)
 "jev" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer2,
@@ -32057,6 +32093,13 @@
 	dir = 4
 	},
 /area/ice_colony/exterior/underground/caves/ice_w)
+"kla" = (
+/obj/machinery/landinglight/ds2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/icefloor,
+/area/ice_colony/exterior/surface/landing_pad)
 "klc" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark2,
@@ -32164,6 +32207,11 @@
 "kzj" = (
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/exterior/surface/taxiway)
+"kAC" = (
+/turf/closed/ice/thin/straight{
+	dir = 4
+	},
+/area/ice_colony/exterior/surface/cliff)
 "kCS" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating,
@@ -32426,6 +32474,11 @@
 	dir = 6
 	},
 /area/ice_colony/exterior/surface/taxiway)
+"mgF" = (
+/turf/closed/ice/thin/end{
+	dir = 4
+	},
+/area/ice_colony/exterior/surface/landing_pad)
 "mgR" = (
 /obj/structure/cable,
 /obj/structure/bed/chair/comfy/brown{
@@ -32674,6 +32727,13 @@
 	dir = 4
 	},
 /area/ice_colony/exterior/surface/cliff)
+"niU" = (
+/obj/machinery/landinglight/ds2/delaythree{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/icefloor,
+/area/ice_colony/exterior/surface/landing_pad)
 "nlt" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -32761,6 +32821,10 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/ice_colony/exterior/surface/valley/southwest)
+"nBJ" = (
+/obj/item/tool/shovel/snow,
+/turf/open/floor/plating/ground/ice,
+/area/ice_colony/exterior/surface/landing_pad)
 "nEc" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/blue2{
@@ -33047,6 +33111,9 @@
 	dir = 5
 	},
 /area/ice_colony/exterior/surface/cliff)
+"oAn" = (
+/turf/closed/ice/thin/single,
+/area/ice_colony/exterior/surface/landing_pad)
 "oBz" = (
 /turf/open/floor/plating,
 /area/ice_colony/underground/maintenance/east)
@@ -33088,6 +33155,11 @@
 /obj/effect/landmark/weed_node,
 /turf/closed/ice_rock/eastWall,
 /area/ice_colony/exterior/underground/caves)
+"oIz" = (
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/turf/open/floor/plating/icefloor,
+/area/ice_colony/exterior/surface/landing_pad)
 "oIU" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark2,
@@ -33130,6 +33202,13 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/corners,
 /area/ice_colony/exterior/surface/cliff)
+"oWg" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/icefloor,
+/area/ice_colony/exterior/surface/landing_pad)
+"oWx" = (
+/turf/closed/wall/r_wall,
+/area/ice_colony/exterior/surface/landing_pad)
 "oXx" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/ice,
@@ -33258,9 +33337,21 @@
 	dir = 4
 	},
 /area/ice_colony/exterior/surface/valley/southeast)
+"pyQ" = (
+/obj/machinery/landinglight/ds2/delayone{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/icefloor,
+/area/ice_colony/exterior/surface/landing_pad)
 "pBf" = (
 /turf/open/floor/plating/ground/ice,
 /area/ice_colony/exterior/underground/caves/ice_w)
+"pCi" = (
+/turf/closed/ice/thin/corner{
+	dir = 8
+	},
+/area/ice_colony/exterior/surface/cliff)
 "pCL" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/tile/green/whitegreen,
@@ -33687,6 +33778,10 @@
 	},
 /turf/open/floor/wood,
 /area/ice_colony/surface/bar/canteen)
+"rve" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/ground/ice,
+/area/ice_colony/exterior/surface/landing_pad)
 "rvr" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -33950,6 +34045,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/engineering)
+"sBA" = (
+/obj/structure/cable,
+/turf/open/floor/plating/ground/ice,
+/area/ice_colony/exterior/surface/landing_pad)
 "sCo" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice/straight,
@@ -34355,6 +34454,10 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/ice,
 /area/ice_colony/exterior/underground/caves/open)
+"uEc" = (
+/obj/structure/cable,
+/turf/open/floor/plating/icefloor,
+/area/ice_colony/exterior/surface/landing_pad)
 "uEl" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/ice_rock/corners{
@@ -34405,10 +34508,10 @@
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/substation/smes)
 "uOr" = (
-/obj/machinery/power/apc/drained,
-/obj/structure/cable,
-/turf/open/floor/plating/icefloor,
-/area/ice_colony/exterior/surface/landing_pad2)
+/turf/closed/ice/thin/end{
+	dir = 4
+	},
+/area/ice_colony/exterior/surface/cliff)
 "uOC" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/ice,
@@ -34435,12 +34538,24 @@
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/ice_colony/exterior/surface/clearing/north)
+"uSg" = (
+/turf/closed/ice/thin/straight{
+	dir = 4
+	},
+/area/ice_colony/exterior/surface/landing_pad_external)
 "uUO" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/ice_colony/exterior/surface/valley/southeast)
+"uUX" = (
+/obj/machinery/landinglight/ds2/delaytwo{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/icefloor,
+/area/ice_colony/exterior/surface/landing_pad)
 "uWx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
@@ -34463,6 +34578,13 @@
 	dir = 4
 	},
 /area/ice_colony/exterior/surface/landing_pad2)
+"vcb" = (
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/icefloor,
+/area/ice_colony/exterior/surface/landing_pad)
 "vcc" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating,
@@ -35031,6 +35153,13 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/hallway/north_west)
+"xGt" = (
+/obj/machinery/landinglight/ds2/delayone{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/icefloor,
+/area/ice_colony/exterior/surface/landing_pad)
 "xGZ" = (
 /turf/open/floor/tile/dark,
 /area/ice_colony/exterior/surface/landing_pad2)
@@ -41134,7 +41263,7 @@ xGZ
 adB
 xGZ
 gzL
-adJ
+xGZ
 ahB
 ajp
 ajW
@@ -41346,7 +41475,7 @@ adn
 aBi
 aji
 aBi
-cVY
+adn
 aBi
 aji
 aBi
@@ -41558,7 +41687,7 @@ qDA
 ajQ
 ajo
 aBi
-acl
+qDA
 ajQ
 ajo
 aBi
@@ -41770,7 +41899,7 @@ qDA
 qDA
 ajo
 aBi
-uOr
+qDA
 qDA
 ajo
 aBi
@@ -66889,7 +67018,7 @@ aOj
 cYG
 meD
 kzj
-kzj
+aYn
 kzj
 kzj
 kzj
@@ -67101,7 +67230,7 @@ aOj
 aOj
 jKJ
 kzj
-kzj
+aYn
 kzj
 kzj
 kzj
@@ -67313,7 +67442,7 @@ bwd
 aOj
 jKJ
 kzj
-kzj
+aYn
 kzj
 kzj
 kzj
@@ -67525,7 +67654,7 @@ ban
 baV
 jKJ
 kzj
-kzj
+aYn
 kzj
 kzj
 kzj
@@ -67737,7 +67866,7 @@ xYu
 baX
 kzj
 kzj
-kzj
+aYn
 kzj
 kzj
 kzj
@@ -67949,7 +68078,7 @@ xYu
 baX
 kzj
 kzj
-kzj
+aYn
 kzj
 kzj
 kzj
@@ -68161,7 +68290,7 @@ bap
 baX
 kzj
 kzj
-kzj
+aYn
 kzj
 kzj
 kzj
@@ -68373,7 +68502,7 @@ xYu
 baX
 kzj
 kzj
-kzj
+aYn
 kzj
 kzj
 kzj
@@ -68585,7 +68714,7 @@ xYu
 baX
 kzj
 kzj
-kzj
+aYn
 kzj
 kzj
 kzj
@@ -68797,7 +68926,7 @@ xYu
 baX
 kzj
 kzj
-kzj
+aYn
 bSt
 bBV
 kzj
@@ -69009,7 +69138,7 @@ baq
 baX
 kzj
 kzj
-kzj
+aYn
 kzj
 kzj
 kzj
@@ -69221,7 +69350,7 @@ xYu
 baX
 kzj
 kzj
-kzj
+aYn
 bgd
 kzj
 kzj
@@ -69433,7 +69562,7 @@ xYu
 baX
 kzj
 kzj
-kzj
+aYn
 kzj
 kzj
 kzj
@@ -69645,8 +69774,8 @@ baw
 bba
 lig
 kzj
-kzj
-kzj
+aYn
+aYn
 kzj
 kzj
 kzj
@@ -69858,7 +69987,7 @@ cKg
 lph
 hDJ
 hDJ
-hDJ
+dKq
 hDJ
 hDJ
 hDJ
@@ -70070,7 +70199,7 @@ aOj
 aYI
 aYO
 aYC
-aYC
+uEc
 aYC
 aYC
 aYC
@@ -70282,7 +70411,7 @@ iyH
 bZR
 oaD
 aYB
-aYC
+uEc
 bCm
 aYC
 aYC
@@ -70494,7 +70623,7 @@ bZR
 bZR
 bZR
 aYB
-aYC
+uEc
 aYC
 aYC
 aYC
@@ -70506,7 +70635,7 @@ bZR
 bZR
 bZR
 bZR
-abB
+iFb
 aaQ
 acm
 aac
@@ -70706,7 +70835,7 @@ bZR
 bZR
 bZR
 aYB
-aYC
+uEc
 aYC
 aYC
 aYC
@@ -70918,7 +71047,7 @@ bZR
 bZR
 bZR
 aYB
-aYC
+uEc
 bCC
 bbu
 pRM
@@ -71130,7 +71259,7 @@ bZR
 bZR
 bZR
 aYB
-aYC
+uEc
 aYB
 aYC
 aZR
@@ -71342,7 +71471,7 @@ bZR
 bZR
 bbf
 aYB
-aYC
+uEc
 aXR
 aYO
 aYH
@@ -71357,7 +71486,7 @@ acY
 bbs
 bbs
 bmg
-afO
+spj
 acm
 rMt
 eJg
@@ -71554,7 +71683,7 @@ aYs
 bZR
 oaD
 aYB
-aYC
+uEc
 aYC
 aYC
 aYC
@@ -71569,7 +71698,7 @@ bZR
 bZR
 bZR
 btJ
-afO
+spj
 acm
 rMt
 eJg
@@ -71766,7 +71895,7 @@ bZR
 bZR
 fYO
 aYB
-aYC
+uEc
 aYC
 aYC
 aYC
@@ -71781,7 +71910,7 @@ bZR
 bZR
 bZR
 btJ
-afO
+spj
 acm
 rMt
 ciw
@@ -71965,11 +72094,11 @@ wth
 wth
 wth
 wth
-awU
+aGf
 acp
 czW
 abg
-bhN
+cVY
 bZR
 bZR
 bZR
@@ -71978,7 +72107,7 @@ bZR
 oaD
 bZR
 aZh
-aYC
+uEc
 aYC
 aYC
 aYC
@@ -72181,7 +72310,7 @@ lem
 xBl
 aXz
 aaS
-aiS
+uOr
 bZR
 bZR
 oaD
@@ -72190,7 +72319,7 @@ bZR
 bZR
 aYQ
 aZi
-aZo
+vcb
 lHl
 aZA
 aZi
@@ -72205,7 +72334,7 @@ bZR
 bZR
 bZR
 bZR
-bcb
+kAC
 acj
 udt
 bSw
@@ -72402,22 +72531,22 @@ bLd
 bRA
 bRC
 bRK
-bLd
+niU
 bRQ
 bUA
-bRK
-bLd
-bRA
-bRC
-bRK
+uUX
+niU
+erM
+xGt
+uUX
 bWV
 bZw
-bRC
-bRK
-aYC
+xGt
+uUX
+uEc
 bzs
 bZR
-bcE
+uSg
 aaC
 vdz
 bSw
@@ -72629,7 +72758,7 @@ aYE
 bZS
 bZR
 bZR
-bcE
+uSg
 acm
 hKl
 bSw
@@ -72841,7 +72970,7 @@ aZR
 bZT
 bZR
 bZR
-bcE
+uSg
 acj
 udt
 bSw
@@ -73053,7 +73182,7 @@ aZR
 bZU
 bff
 bZR
-bcE
+uSg
 aaS
 vdz
 bSw
@@ -73265,7 +73394,7 @@ aZR
 bZV
 bfg
 bZR
-aWF
+gHG
 aaQ
 vdz
 bSw
@@ -74747,7 +74876,7 @@ aYO
 aYO
 aYH
 bZW
-abB
+iFb
 aaQ
 aaC
 acm
@@ -74949,16 +75078,16 @@ bRO
 bRx
 bUc
 bWU
-bRO
-bRx
-bRB
-bRJ
-bRO
+eOs
+pyQ
+kla
+jcT
+eOs
 bXM
 bZA
-bRJ
-bRO
-aYC
+jcT
+eOs
+uEc
 bRF
 abc
 aaC
@@ -75170,7 +75299,7 @@ bZR
 bZR
 oaD
 bZO
-baZ
+pCi
 aaC
 aaU
 aaG
@@ -75373,7 +75502,7 @@ bZR
 bZR
 bZR
 oaD
-bZR
+sBA
 bZR
 bZR
 bZR
@@ -75381,7 +75510,7 @@ oaD
 bZR
 bZO
 bbs
-baZ
+pCi
 rjH
 epB
 rBA
@@ -75576,7 +75705,7 @@ sGc
 xBl
 svd
 aaC
-abB
+iFb
 bZR
 bZR
 bZR
@@ -75585,14 +75714,14 @@ bZR
 bZR
 bZR
 bZR
-bZR
+sBA
 bZR
 bZR
 bZR
 bZR
 bZO
 bZL
-arS
+oAn
 aaS
 toc
 bSw
@@ -75788,23 +75917,23 @@ gkO
 aaU
 gtM
 aar
-acH
+mgF
 bZR
 bZR
 bZR
 aZr
 bbs
 bmg
+oWx
+oWg
+uEc
 bZR
-bZR
-bZR
-bZR
-bZR
-bZR
-bZR
+aYC
+aYC
+oWx
 btJ
-arS
-arS
+oAn
+oAn
 aaQ
 vdz
 bSw
@@ -76008,14 +76137,14 @@ aba
 abn
 bbx
 aYs
+oWx
+oIz
+aYC
+aYC
 bZR
-bZR
-bZR
-bZR
-bZR
-bZR
+oWx
 btJ
-arS
+oAn
 aaP
 aaZ
 vdz
@@ -76216,16 +76345,16 @@ aag
 aaU
 aaC
 bZK
-arS
-arS
-acH
+oAn
+oAn
+mgF
+oWx
 bZR
 bZR
-bZR
-bZR
-bZR
-bZR
-bZR
+aYC
+aYC
+nBJ
+oWx
 btJ
 aaP
 aaZ
@@ -76428,15 +76557,15 @@ aaC
 aYc
 aYc
 bZK
-arS
-arS
+oAn
+oAn
 aaS
-arS
-bZR
-bZR
-bZR
-bZR
-bZR
+oAn
+oWx
+aYC
+aYC
+aYC
+oWx
 aZr
 bdA
 aaQ
@@ -76640,17 +76769,17 @@ aaC
 aYc
 aaC
 bZK
-arS
-arS
+oAn
+oAn
 abj
 abb
-bZR
-bZR
-bZR
-bZR
-bZR
-bZR
-acH
+oWx
+aYC
+rve
+oWx
+oWx
+oWx
+mgF
 aaQ
 aaC
 aaC
@@ -76856,9 +76985,9 @@ aYS
 aba
 aaZ
 aaQ
-arS
-bZR
-bZR
+oAn
+oWx
+oWx
 bZO
 bbs
 aYs
@@ -77072,8 +77201,8 @@ aba
 abb
 aZr
 bZL
-arS
-arS
+oAn
+oAn
 aaQ
 aaC
 aaC
@@ -77284,7 +77413,7 @@ aaC
 aaR
 aba
 abb
-arS
+oAn
 aaP
 aaZ
 aaC

--- a/code/game/area/icecolony.dm
+++ b/code/game/area/icecolony.dm
@@ -23,11 +23,11 @@
 /area/ice_colony/exterior
 	name = "Ice Colony"
 	icon_state = "cliff_blocked"
-	requires_power = 1
-	always_unpowered = 1
-	power_light = 0
-	power_equip = 0
-	power_environ = 0
+	requires_power = TRUE
+	always_unpowered = TRUE
+	power_light = FALSE
+	power_equip = FALSE
+	power_environ = FALSE
 	ambience = list('sound/ambience/ambispace.ogg')
 	temperature = ICE_COLONY_TEMPERATURE
 	minimap_color = MINIMAP_AREA_COLONY
@@ -56,12 +56,14 @@
 	name = "Aerodrome Landing Pad"
 	icon_state = "landing_pad"
 	outside = FALSE
+	always_unpowered = FALSE
 
 //Landing Pad for the Vindi. THIS IS NOT THE SHUTTLE AREA
 /area/ice_colony/exterior/surface/landing_pad2
 	name = "Emergency Landing Pad"
 	icon_state = "landing_pad"
 	outside = FALSE
+	always_unpowered = FALSE
 
 //Everything around the physical landing pad
 /area/ice_colony/exterior/surface/landing_pad_external


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes Ice Colony LZ1 to not be perma unpowered, removes a duplicate APC, changes Ice Colony LZ2 to have an APC and be powerable.

Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/10508
## Why It's Good For The Game

People have been asking for this for a bit, I promised Zack that I would fix LZ1 today, and I have.

## Changelog
:cl:
balance: Ice Colony LZ2 now has an APC.
fix: Ice Colony LZ1 now can be powered like any other LZ.
fix: Removed a duplicate APC from Ice Colony LZ1.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
