### PR TITLE
Adds routing for robot heals in two human procs

### DIFF
--- a/code/datums/components/harvester.dm
+++ b/code/datums/components/harvester.dm
@@ -142,10 +142,10 @@
 	to_chat(user, span_rose("You prepare to stab <b>[target != user ? "[target]" : "yourself"]</b>!"))
 	new /obj/effect/temp_visual/telekinesis(get_turf(target))
 	if((target != user) && do_after(user, 2 SECONDS, TRUE, target, BUSY_ICON_DANGER))
-		target.heal_overall_damage(12.5, 0, TRUE)
+		target.heal_overall_damage(12.5, 0, updating_health = TRUE)
 	else
 		target.adjustStaminaLoss(-30)
-		target.heal_overall_damage(6, 0, TRUE)
+		target.heal_overall_damage(6, 0, updating_health = TRUE)
 
 ///Signal handler calling when user is filling the harvester
 /datum/component/harvester/proc/attackby(datum/source, obj/item/cont, mob/user)

--- a/code/game/objects/machinery/autodoc.dm
+++ b/code/game/objects/machinery/autodoc.dm
@@ -142,7 +142,7 @@
 			blood_transfer = 0
 			say("Blood transfer complete.")
 	if(heal_brute)
-		if(occupant.getexternalBruteLoss() > 0)
+		if(occupant.getBruteLoss() > 0)
 			occupant.heal_limb_damage(3, 0)
 			updating_health = TRUE
 			if(prob(10))

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -76,14 +76,14 @@
 	return brainloss
 
 //These procs fetch a cumulative total damage from all limbs
-/mob/living/carbon/human/getBruteLoss(organic_only=0)
+/mob/living/carbon/human/getBruteLoss(organic_only=FALSE)
 	var/amount = 0
 	for(var/datum/limb/O in limbs)
 		if(!(organic_only && O.limb_status & LIMB_ROBOT))
 			amount += O.brute_dam
 	return amount
 
-/mob/living/carbon/human/getFireLoss(organic_only=0)
+/mob/living/carbon/human/getFireLoss(organic_only=FALSE)
 	var/amount = 0
 	for(var/datum/limb/O in limbs)
 		if(!(organic_only && O.limb_status & LIMB_ROBOT))

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -111,17 +111,6 @@
 		heal_overall_damage(0, -amount, updating_health = updating_health)
 
 
-//These procs fetch a cumulative total damage from all limbs
-/mob/living/carbon/human/proc/getexternalBruteLoss(organic_only = TRUE)
-	. = 0
-	for(var/i in limbs)
-		var/datum/limb/bodypart = i
-		if(organic_only && bodypart.limb_status & LIMB_ROBOT)
-			continue
-		var/external_dam = bodypart.brute_dam
-		. += external_dam
-
-
 /mob/living/carbon/human/proc/adjustBruteLossByPart(amount, organ_name, obj/damage_source = null)
 	if(species && species.brute_mod && amount > 0)
 		amount = amount*species.brute_mod

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -98,7 +98,7 @@
 	if(amount > 0)
 		take_overall_damage(amount, updating_health = updating_health)
 	else
-		heal_overall_damage(-amount, 0, updating_health)
+		heal_overall_damage(-amount, 0, updating_health = updating_health)
 
 
 /mob/living/carbon/human/adjustFireLoss(amount, updating_health = FALSE)
@@ -108,7 +108,7 @@
 	if(amount > 0)
 		take_overall_damage(0, amount, updating_health = updating_health)
 	else
-		heal_overall_damage(0, -amount, updating_health)
+		heal_overall_damage(0, -amount, updating_health = updating_health)
 
 
 //These procs fetch a cumulative total damage from all limbs
@@ -221,9 +221,11 @@
 ////////////////////////////////////////////
 
 //Returns a list of damaged limbs
-/mob/living/carbon/human/proc/get_damaged_limbs(brute, burn)
+/mob/living/carbon/human/proc/get_damaged_limbs(brute, burn, include_robotics = FALSE)
 	var/list/datum/limb/parts = list()
 	for(var/datum/limb/O in limbs)
+		if(O.limb_status & LIMB_ROBOT && !include_robotics)
+			continue
 		if((brute && O.brute_dam) || (burn && O.burn_dam) || !(O.surgery_open_stage == 0))
 			parts += O
 	return parts
@@ -239,15 +241,13 @@
 //Heals ONE external organ, organ gets randomly selected from damaged ones.
 //It automatically updates damage overlays if necesary
 //It automatically updates health status
-/mob/living/carbon/human/heal_limb_damage(brute, burn, updating_health = FALSE)
-	var/list/datum/limb/parts = get_damaged_limbs(brute, burn)
+/mob/living/carbon/human/heal_limb_damage(brute, burn, robo_repair = FALSE, updating_health = FALSE)
+	var/list/datum/limb/parts = get_damaged_limbs(brute, burn, robo_repair)
 	if(!parts.len)
 		return
 	var/datum/limb/picked = pick(parts)
-	if(picked.heal_limb_damage(brute, burn, updating_health = updating_health))
+	if(picked.heal_limb_damage(brute, burn, robo_repair, updating_health))
 		UpdateDamageIcon()
-	if(updating_health)
-		updatehealth()
 
 /*
 In most cases it makes more sense to use apply_damage() instead! And make sure to check armour if applicable.
@@ -268,9 +268,9 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 	speech_problem_flag = 1
 
 
-//Heal MANY limbs, in random order
-/mob/living/carbon/human/heal_overall_damage(brute, burn, updating_health = FALSE)
-	var/list/datum/limb/parts = get_damaged_limbs(brute,burn)
+///Heal MANY limbs, in random order. If robo_repair is TRUE then both metal and flesh limbs will be healed, otherwise only flesh.
+/mob/living/carbon/human/heal_overall_damage(brute, burn, robo_repair = FALSE, updating_health = FALSE)
+	var/list/datum/limb/parts = get_damaged_limbs(brute, burn, robo_repair)
 
 	var/update = 0
 	while(parts.len && (brute>0 || burn>0) )
@@ -279,10 +279,10 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 		var/brute_was = picked.brute_dam
 		var/burn_was = picked.burn_dam
 
-		update |= picked.heal_limb_damage(brute, burn)
+		update |= picked.heal_limb_damage(brute, burn, robo_repair)
 
-		brute -= (brute_was-picked.brute_dam)
-		burn -= (burn_was-picked.burn_dam)
+		brute -= (brute_was - picked.brute_dam)
+		burn -= (burn_was - picked.burn_dam)
 
 		parts -= picked
 	if(updating_health)

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -362,7 +362,7 @@
 
 	X.do_jitter_animation(1000)
 	X.set_sunder(0)
-	X.heal_overall_damage(25, 25, TRUE)
+	X.heal_overall_damage(25, 25, updating_health = TRUE)
 	add_cooldown()
 	return succeed_activate()
 

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -182,7 +182,7 @@
 
 
 // heal ONE limb, organ gets randomly selected from damaged ones.
-/mob/living/proc/heal_limb_damage(brute, burn, updating_health = FALSE)
+/mob/living/proc/heal_limb_damage(brute, burn, robo_repair = FALSE, updating_health = FALSE)
 	adjustBruteLoss(-brute)
 	adjustFireLoss(-burn)
 	if(updating_health)
@@ -200,7 +200,7 @@
 
 
 // heal MANY limbs, in random order
-/mob/living/proc/heal_overall_damage(brute, burn, updating_health = FALSE)
+/mob/living/proc/heal_overall_damage(brute, burn, robo_repair = FALSE, updating_health = FALSE)
 	adjustBruteLoss(-brute)
 	adjustFireLoss(-burn)
 	if(updating_health)
@@ -296,7 +296,7 @@
 	set_blindness(0, TRUE)
 	set_blurriness(0, TRUE)
 	set_ear_damage(0, 0)
-	heal_overall_damage(getBruteLoss(), getFireLoss())
+	heal_overall_damage(getBruteLoss(), getFireLoss(), robo_repair = TRUE)
 
 	// fix all of our organs
 	restore_all_organs()

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -2,7 +2,7 @@
 //procs directly related to mob health
 
 
-/mob/living/proc/getBruteLoss()
+/mob/living/proc/getBruteLoss(organic_only = FALSE)
 	return bruteloss
 
 ///We straight up set bruteloss/brute damage to a desired amount unless godmode is enabled
@@ -19,7 +19,7 @@
 		updatehealth()
 
 
-/mob/living/proc/getFireLoss()
+/mob/living/proc/getFireLoss(organic_only = FALSE)
 	return fireloss
 
 ///We straight up set fireloss/burn damage to a desired amount unless godmode is enabled

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1284,14 +1284,14 @@
 			if(volume < 35) //allows 10 ticks of healing for 20 points of free heal to lower scratch damage bloodloss amounts.
 				L.reagents.add_reagent(/datum/reagent/medicine/research/medicalnanites, 0.1)
 
-			if (volume >5 && L.getBruteLoss()) //Unhealed IB wasting nanites is an INTENTIONAL feature.
+			if (volume >5 && L.getBruteLoss(organic_only = TRUE))
 				L.heal_limb_damage(2*effect_str, 0)
 				L.adjustToxLoss(0.1*effect_str)
 				holder.remove_reagent(/datum/reagent/medicine/research/medicalnanites, 0.5)
 				if(prob(40))
 					to_chat(L, span_notice("Your cuts and bruises begin to scab over rapidly!"))
 
-			if (volume > 5 && L.getFireLoss())
+			if (volume > 5 && L.getFireLoss(organic_only = TRUE))
 				L.heal_limb_damage(0, 2*effect_str)
 				L.adjustToxLoss(0.1*effect_str)
 				holder.remove_reagent(/datum/reagent/medicine/research/medicalnanites, 0.5)


### PR DESCRIPTION
## About The Pull Request
Adds a robo_repair arg to human's heal_limb_damage and heal_overall_damage to enable use of these procs to heal robot limbs.
Removes human's getexternalBruteLoss since internal brute damage got removed.

## Why It's Good For The Game
Fixes #10423 , enables options for future.

## Changelog
:cl:
code: Added routing to enable robot healing on two function calls.
/:cl:
