### PR TITLE
Defender charge rebalance

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -96,7 +96,7 @@
 	///How far can we charge
 	var/range = 5
 	///How long is the windup before charging
-	var/windup_time = 0.5 SECONDS
+	var/windup_time = 0.3 SECONDS
 
 /datum/action/xeno_action/activable/forward_charge/proc/charge_complete()
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -140,9 +140,6 @@
 	var/mob/living/carbon/xenomorph/defender/defender = X
 	if(defender.fortify)
 		var/datum/action/xeno_action/fortify/fortify_action = X.actions_by_path[/datum/action/xeno_action/fortify]
-		if(fortify_action.cooldown_id)
-			to_chat(X, span_xenowarning("We cannot yet untuck ourselves from our fortified stance!"))
-			return fail_activate()
 
 		fortify_action.set_fortify(FALSE, TRUE)
 		fortify_action.add_cooldown()

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -96,7 +96,7 @@
 	///How far can we charge
 	var/range = 5
 	///How long is the windup before charging
-	var/windup_time = 0.3 SECONDS
+	var/windup_time = 0.5 SECONDS
 
 /datum/action/xeno_action/activable/forward_charge/proc/charge_complete()
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -96,7 +96,7 @@
 	///How far can we charge
 	var/range = 5
 	///How long is the windup before charging
-	var/windup_time = 0.5 SECONDS
+	var/windup_time = 0 SECONDS
 
 /datum/action/xeno_action/activable/forward_charge/proc/charge_complete()
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -89,7 +89,7 @@
 	action_icon_state = "charge"
 	mechanics_text = "Charge up to 4 tiles and knockdown any targets in our way."
 	ability_name = "charge"
-	cooldown_timer = 8 SECONDS
+	cooldown_timer = 7 SECONDS
 	plasma_cost = 50
 	use_state_flags = XACT_USE_CRESTED|XACT_USE_FORTIFIED
 	keybind_signal = COMSIG_XENOABILITY_FORWARD_CHARGE

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -96,7 +96,7 @@
 	///How far can we charge
 	var/range = 5
 	///How long is the windup before charging
-	var/windup_time = 0 SECONDS
+	var/windup_time = 0.5 SECONDS
 
 /datum/action/xeno_action/activable/forward_charge/proc/charge_complete()
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -89,8 +89,8 @@
 	action_icon_state = "charge"
 	mechanics_text = "Charge up to 4 tiles and knockdown any targets in our way."
 	ability_name = "charge"
-	cooldown_timer = 10 SECONDS
-	plasma_cost = 60
+	cooldown_timer = 8 SECONDS
+	plasma_cost = 50
 	use_state_flags = XACT_USE_CRESTED|XACT_USE_FORTIFIED
 	keybind_signal = COMSIG_XENOABILITY_FORWARD_CHARGE
 	///How far can we charge

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -90,11 +90,11 @@
 	mechanics_text = "Charge up to 4 tiles and knockdown any targets in our way."
 	ability_name = "charge"
 	cooldown_timer = 10 SECONDS
-	plasma_cost = 80
+	plasma_cost = 60
 	use_state_flags = XACT_USE_CRESTED|XACT_USE_FORTIFIED
 	keybind_signal = COMSIG_XENOABILITY_FORWARD_CHARGE
 	///How far can we charge
-	var/range = 4
+	var/range = 5
 	///How long is the windup before charging
 	var/windup_time = 0.5 SECONDS
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
@@ -58,7 +58,7 @@
 	var/target_turf = get_step_away(src, H, rand(1, 2)) //This is where we blast our target
 	target_turf = get_step_rand(target_turf) //Scatter
 	H.throw_at(get_turf(target_turf), 4, 70, H)
-	H.Paralyze(40)
+	H.Paralyze(2 SECONDS)
 
 
 /mob/living/carbon/xenomorph/defender/lay_down()


### PR DESCRIPTION
## About The Pull Request

A non-retarded version of #10489 . I want people to have options.

Stun decreased 4 -> 2 (only half of original time now!)
Plasma cost decreased 80 -> 50
CD decreased 10 -> 7
Range increased 4 -> 5 (in comment below I call it useless - it is useless without stun, with stun _maybe_ better)
Fortify cooldown no longer prevents you from using charge.

I would like to buff defender's health as well - 320 of anc def vs 300 anc sent. Def has more armor, obviously, but current meta makes armor less effective - nades, sunder and high AP weaponry (AR11). I'd give it at least +10%. If maints agree, let me know.

You are welcome to discuss this - here or on Discord. Ping me (qwerty4429).


## Why It's Good For The Game

Giving people other options is good.
4 sec stun was meh. That's true. Overall stun time decreased from 24 to 17 per minute.
Decreased stun while keeping the ability overall same purpose and use.
Removing stun is bad because stun is main kill option for robust marines, and ability to make marine drop his weapon is still there. Low CD allows better control of marines inside mazes, which is precisely the purpose of Defender.

**IMPORTANT:**
Please do not forget how xeno gameplay looks like.
You get up, press skills, do few attacks and come back.
Therefore, CD and plasma are likely to not affect how defender plays, and only allows it to be a little better in some cases like when marine goes solo into maze.
Overall it's still a strong nerf to stun. But I feel that stun itself is broken.
Defender needs to be buffed in other PRs to compensate, but I don't know what to do yet (because maints will say no to direct HP increase)

![image](https://user-images.githubusercontent.com/42085626/175807414-63540108-aee3-4c93-910e-7fde59ba32c2.png)

## Changelog
:cl:
balance: Defender charge stun decreased 4 -> 2
balance: Defender charge CD and cost decreased, range increased, fortify CD doesn't interfere.
/:cl:
