### PR TITLE
Eye damage reduces accuracy, imi suppresses

### DIFF
--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -160,7 +160,7 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/imidazoline
 	name = "imidazoline autoinjector"
-	desc = "An auto-injector loaded with 3 doses of imidazoline, medicine for fixing eyesight."
+	desc = "An auto-injector loaded with 3 doses of imidazoline, medicine for temporarily ignoring eye damage. Excessive use advised against."
 	icon_state = "autoinjector-5"
 	list_reagents = list(/datum/reagent/medicine/imidazoline = 30)
 

--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -193,7 +193,7 @@
 	pill_id = 14
 
 /obj/item/reagent_containers/pill/imidazoline
-	pill_desc = "An imidazoline pill. Heals eye damage."
+	pill_desc = "An imidazoline pill. Suppresses eye damage as long as it's in the patient, but slowly harms kidneys."
 	list_reagents = list(/datum/reagent/medicine/imidazoline = 10)
 	pill_id = 17
 

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -477,7 +477,7 @@
 
 /obj/item/storage/pill_bottle/imidazoline
 	name = "imidazoline pill bottle"
-	desc = "Contains pills that heal eye damage."
+	desc = "Contains pills that suppress eye damage. Long term use advised against."
 	greyscale_config = /datum/greyscale_config/pillbottleround
 	pill_type_to_fill = /obj/item/reagent_containers/pill/imidazoline
 	greyscale_colors = "#F7A151#ffffff" //orange like carrots

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -202,6 +202,12 @@
 		return FALSE
 	return TRUE
 
+/mob/living/carbon/human/get_mob_accuracy()
+	var/acc = ranged_accuracy_mod
+	var/datum/internal_organ/eyes/our_eyes = internal_organs_by_name["eyes"]
+	if(!reagents.has_reagent(/datum/reagent/medicine/imidazoline))
+		acc += our_eyes.get_accuracy_penalty()
+	return acc
 
 /mob/living/carbon/human/has_legs()
 	. = 0

--- a/code/modules/mob/living/living_helpers.dm
+++ b/code/modules/mob/living/living_helpers.dm
@@ -17,6 +17,10 @@
 		return FALSE
 	return has_eyes()
 
+///Fetches the mob's accuracy modifier. Mostly important for humans.
+/mob/living/proc/get_mob_accuracy()
+	return ranged_accuracy_mod
+
 /mob/living/proc/reagent_check(datum/reagent/R)
 	return TRUE
 

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -332,10 +332,16 @@
 
 /datum/internal_organ/eyes/process() //Eye damage replaces the old eye_stat var.
 	..()
+	if(owner.reagents.has_reagent(/datum/reagent/medicine/imidazoline))
+		return
 	if(organ_status == ORGAN_BRUISED)
-		owner.set_blurriness(20)
+		if(prob(5))
+			owner.adjust_blurriness(2) //As a reminder to the player that something's wrong
 	if(organ_status == ORGAN_BROKEN)
 		owner.set_blindness(20)
+
+/datum/internal_organ/eyes/proc/get_accuracy_penalty()
+	return organ_status * -50
 
 /datum/internal_organ/eyes/prosthetic
 	robotic = ORGAN_ROBOT

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1604,7 +1604,7 @@
 		projectile_to_fire.firer = user
 		if(isliving(user))
 			var/mob/living/living_user = user
-			gun_accuracy_mod += living_user.ranged_accuracy_mod
+			gun_accuracy_mod += living_user.get_mob_accuracy()
 			if(iscarbon(user))
 				var/mob/living/carbon/carbon_user = user
 				projectile_to_fire.def_zone = user.zone_selected

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -601,7 +601,8 @@
 
 /datum/reagent/medicine/imidazoline
 	name = "Imidazoline"
-	description = "Heals eye damage"
+	description = "Suppresses eye damage. Damages kidneys with continued use."
+	custom_metabolism = REAGENTS_METABOLISM * 0.5 //0.1 units per 2s, just over 3m per 10u pill
 	color = "#C8A5DC" // rgb: 200, 165, 220
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
@@ -611,11 +612,11 @@
 /datum/reagent/medicine/imidazoline/on_mob_life(mob/living/L, metabolism)
 	L.adjust_blurriness(-5)
 	L.adjust_blindness(-5)
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		var/datum/internal_organ/eyes/E = H.internal_organs_by_name["eyes"]
-		if(E)
-			E.heal_organ_damage(effect_str)
+	if(!ishuman(L))
+		return ..()
+	var/mob/living/carbon/human/human_owner = L
+	var/datum/internal_organ/kidneys/owner_kidneys = human_owner.internal_organs_by_name["kidneys"]
+	owner_kidneys.take_damage(0.01) //One point of damage per 10u volume.
 	return ..()
 
 /datum/reagent/medicine/imidazoline/overdose_process(mob/living/L, metabolism)


### PR DESCRIPTION
## About The Pull Request
Bruised eyes cause an accuracy reduction. I got no idea how much is reasonable, so the amount is a little random. You'll still get a bit of blur occasionally, but it's just there to remind you you got injured eyes. Broken eyes still blind you.
Imidazoline changed to suppress eye damage, similar to how QC works, as long as it's in the mob. Applies to both the accuracy penalty and the blur/blind. Causes 1 kidney damage per pill, each lasting just over 3 minutes.

## Why It's Good For The Game
Blur sucks and is annoying.
Making imi a suppressant keeps it useful as a temp fix rather than just being a situational peri+ without the cloneloss. Kidney damage is small, but means you can't just stay on imi all round. Bruise around half an hour, broken around triple that assuming no other damage. Metabolism is reduced from default but not tremendously, so you'll still chug through pills at a decent clip.

## Changelog
:cl:
balance: Eye damage reduces your accuracy with guns
balance: Imidazoline suppresses eye damage instead of curing it but metabolises slower.
/:cl: