### PR TITLE
Peri+ clone loss scales with organ damage healed

### DIFF
--- a/code/modules/mob/living/carbon/carbon_helpers.dm
+++ b/code/modules/mob/living/carbon/carbon_helpers.dm
@@ -13,7 +13,15 @@
 /mob/living/carbon/get_reagent_tags()
 	return species?.reagent_tag
 
+///Return the most damaged internal_organ that isn't at 0, or null.
 /mob/living/carbon/proc/get_damaged_organ()
-	for(var/datum/internal_organ/our_organ AS in internal_organs)
-		if(our_organ.damage)
-			return our_organ
+	var/datum/internal_organ/chosen_organ
+	for(var/datum/internal_organ/test_organ AS in internal_organs)
+		if(!test_organ.damage)
+			continue
+		if(!chosen_organ)
+			chosen_organ = test_organ
+			continue
+		if(test_organ.damage > chosen_organ.damage)
+			chosen_organ = test_organ
+	return chosen_organ

--- a/code/modules/mob/living/carbon/carbon_helpers.dm
+++ b/code/modules/mob/living/carbon/carbon_helpers.dm
@@ -12,3 +12,8 @@
 
 /mob/living/carbon/get_reagent_tags()
 	return species?.reagent_tag
+
+/mob/living/carbon/proc/get_damaged_organ()
+	for(var/datum/internal_organ/our_organ AS in internal_organs)
+		if(our_organ.damage)
+			return our_organ

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -633,23 +633,17 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	scannable = TRUE
 
-/datum/reagent/medicine/peridaxon_plus/on_mob_add(mob/living/L, metabolism)
-	if(TIMER_COOLDOWN_CHECK(L, name))
-		return
-	L.adjustCloneLoss(5*effect_str)
-
-/datum/reagent/medicine/peridaxon_plus/on_mob_delete(mob/living/L, metabolism)
-	TIMER_COOLDOWN_START(L, name, 30 SECONDS)
-
 /datum/reagent/medicine/peridaxon_plus/on_mob_life(mob/living/L, metabolism)
 	L.reagents.add_reagent(/datum/reagent/toxin,5)
 	L.adjustStaminaLoss(10*effect_str)
 	if(!ishuman(L))
 		return ..()
 	var/mob/living/carbon/human/H = L
-	for(var/datum/internal_organ/I in H.internal_organs)
-		if(I.damage)
-			I.heal_organ_damage(2*effect_str)
+	var/datum/internal_organ/organ = H.get_damaged_organ()
+	if(!organ)
+		return ..()
+	organ.heal_organ_damage(3 * effect_str)
+	H.adjustCloneLoss(1 * effect_str)
 	return ..()
 
 /datum/reagent/medicine/peridaxon_plus/overdose_process(mob/living/L, metabolism)


### PR DESCRIPTION
## About The Pull Request
1 cloneloss per 3 organ damage. A bruised organ will be about as much as an old shot, a broken one will be more. Zero cloneloss if you don't have organ damage, of course.

## Why It's Good For The Game
On-field repair cost should scale with damage. Off field, you aren't using peri+.

## Changelog
:cl:
balance: Peridaxon Plus cloneloss scales with the organ damage it heals
/:cl: