### PR TITLE
Dylovene doesn't affect stamina

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -78,6 +78,7 @@
 
 	set_armor_datum()
 	AddElement(/datum/element/gesture)
+	stamina_regen_modifiers = list()
 
 /mob/living/Destroy()
 	for(var/i in embedded_objects)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -43,8 +43,10 @@
 	var/max_stamina = 0
 	/// How much stamina can you regen
 	var/max_stamina_buffer = 0
-	/// How fast does a mob regen its stamina
+	/// How fast does a mob regen its stamina. Shouldn't go below 0.
 	var/stamina_regen_multiplier = 1
+	/// Maps modifiers by name to a value, applied additively to stamina_regen_multiplier
+	var/list/stamina_regen_modifiers
 	var/is_dizzy = FALSE
 	var/druggy = 0
 

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -120,6 +120,24 @@
 		relative_stamloss = round(((relative_stamloss * 7) / (maxHealth * 2)), 1)
 	hud_used.staminas.icon_state = "stamloss[relative_stamloss]"
 
+/// Adds an entry to our stamina_regen_modifiers and updates stamina_regen_multiplier
+/mob/living/proc/add_stamina_regen_modifier(mod_name, mod_value)
+	stamina_regen_modifiers[mod_name] = mod_value
+	recalc_stamina_regen_multiplier()
+
+/// Removes an entry from our stamina_regen_modifiers and updates stamina_regen_multiplier. Returns TRUE if an entry was removed
+/mob/living/proc/remove_stamina_regen_modifier(mod_name)
+	if(!stamina_regen_modifiers.Remove(mod_name))
+		return FALSE
+	recalc_stamina_regen_multiplier()
+	return TRUE
+
+/// Regenerates stamina_regen_multiplier from initial based on the current modifier list, minimum 0.
+/mob/living/proc/recalc_stamina_regen_multiplier()
+	stamina_regen_multiplier = initial(stamina_regen_multiplier)
+	for(var/mod_name in stamina_regen_modifiers)
+		stamina_regen_multiplier += stamina_regen_modifiers[mod_name]
+	stamina_regen_multiplier = max(stamina_regen_multiplier, 0)
 
 /mob/living/proc/getCloneLoss()
 	return cloneloss

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -171,12 +171,11 @@
 		owner.emote("me", 1, "gasps for air!")
 
 /datum/internal_organ/lungs/set_organ_status()
-	var/old_organ_status = organ_status
 	. = ..()
 	if(!.)
 		return
 	// For example, bruised lungs will reduce stamina regen by 40%, broken by 80%
-	owner.stamina_regen_multiplier += (old_organ_status - organ_status) * 0.40
+	owner.add_stamina_regen_modifier(name, organ_status * -0.40)
 	// Slowdown added when the heart is damaged
 	owner.add_movespeed_modifier(id = name, override = TRUE, multiplicative_slowdown = organ_status)
 

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -349,11 +349,17 @@
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "a roll of gauze"
 
+/datum/reagent/medicine/dylovene/on_mob_add(mob/living/L, metabolism)
+	L.add_stamina_regen_modifier(name, -0.5)
+	return ..()
+
+/datum/reagent/medicine/dylovene/on_mob_delete(mob/living/L, metabolism)
+	L.remove_stamina_regen_modifier(name)
+	return ..()
+
 /datum/reagent/medicine/dylovene/on_mob_life(mob/living/L,metabolism)
 	L.hallucination = max(0, L.hallucination -  2.5*effect_str)
 	L.adjustToxLoss(-effect_str)
-	if(volume > 10)
-		L.adjustStaminaLoss(0.5*effect_str)
 	return ..()
 
 /datum/reagent/medicine/dylovene/overdose_process(mob/living/L, metabolism)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -349,14 +349,6 @@
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "a roll of gauze"
 
-/datum/reagent/medicine/dylovene/on_mob_add(mob/living/L, metabolism)
-	L.add_stamina_regen_modifier(name, -0.5)
-	return ..()
-
-/datum/reagent/medicine/dylovene/on_mob_delete(mob/living/L, metabolism)
-	L.remove_stamina_regen_modifier(name)
-	return ..()
-
 /datum/reagent/medicine/dylovene/on_mob_life(mob/living/L,metabolism)
 	L.hallucination = max(0, L.hallucination -  2.5*effect_str)
 	L.adjustToxLoss(-effect_str)


### PR DESCRIPTION
## About The Pull Request
Alternative to #10538 
I made that one because I was annoyed at using supplies as provided being pretty strictly the wrong choice, but on rumination dylo's a core chem and probably doesn't strictly need a drawback. So, this. Keeps the stamina regen modifier stuff codeside because I'd like to use it in the future.

## Why It's Good For The Game
Basic supplies should be usable as is, and dylo might not need this drawback.

## Changelog
:cl:
balance: Dylovene doesn't impact stamina at all.
/:cl:
