### PR TITLE
Pills and hypos call reaction_mob properly

### DIFF
--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -158,7 +158,7 @@
 	user.changeNext_move(3) // please don't break the game
 
 	playsound(loc, 'sound/items/hypospray.ogg', 50, 1)
-	reagents.reaction(A, INJECT)
+	reagents.reaction(A, INJECT, min(amount_per_transfer_from_this, reagents.total_volume) / reagents.total_volume)
 	var/trans = reagents.trans_to(A, amount_per_transfer_from_this)
 	to_chat(user, span_notice("[trans] units injected. [reagents.total_volume] units remaining in [src]. "))
 

--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -35,6 +35,7 @@
 		to_chat(M, span_notice("You swallow [src]."))
 		M.dropItemToGround(src) //icon update
 		if(reagents.total_volume)
+			reagents.reaction(M, INGEST)
 			reagents.trans_to(M, reagents.total_volume)
 
 		qdel(src)


### PR DESCRIPTION
## About The Pull Request
Pills weren't doing it at all, hypos were reacting with the proper amount.
Basically zero gameside changes, almost no reagents have reaction_mob implemented and any that do don't belong in pills.

## Why It's Good For The Game
Code cleanup. Might allow future differentiation between pills and injectors.

## Changelog
:cl:
code: Pills and hypos call a proc they were missing. No gameplay change.
/:cl:
