### PR TITLE
Adds code to enable preventing reagent container refills

### DIFF
--- a/code/game/objects/items/reagent_containers/reagent_container.dm
+++ b/code/game/objects/items/reagent_containers/reagent_container.dm
@@ -13,6 +13,8 @@
 	var/volume = 30
 	var/liquifier = FALSE //Can liquify/grind pills without needing fluid to dissolve.
 	var/list/list_reagents
+	///Whether we can restock this in a vendor without it having its starting reagents
+	var/free_refills = TRUE
 
 
 /obj/item/reagent_containers/Initialize()
@@ -68,3 +70,9 @@
 			. += "; [R.name]([R.volume]u)"
 	else
 		. = "No reagents"
+
+/obj/item/reagent_containers/proc/has_initial_reagents()
+	for(var/reagent_to_check in list_reagents)
+		if(reagents.get_reagent_amount(reagent_to_check) != list_reagents[reagent_to_check])
+			return FALSE
+	return TRUE

--- a/code/game/objects/items/reagent_containers/reagent_container.dm
+++ b/code/game/objects/items/reagent_containers/reagent_container.dm
@@ -71,6 +71,7 @@
 	else
 		. = "No reagents"
 
+///True if this object currently contains at least its starting reagents, false otherwise. Extra reagents are ignored.
 /obj/item/reagent_containers/proc/has_initial_reagents()
 	for(var/reagent_to_check in list_reagents)
 		if(reagents.get_reagent_amount(reagent_to_check) != list_reagents[reagent_to_check])

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -644,6 +644,11 @@
 			if(stack.amount != initial(stack.amount))
 				to_chat(user, span_warning("[stack] has been partially used. You must replace the missing amount before you can restock it."))
 				return
+		else if(istype(item_to_stock, /obj/item/reagent_containers))
+			var/obj/item/reagent_containers/reagent_container = item_to_stock
+			if(!reagent_container.free_refills && !reagent_container.has_initial_reagents())
+				to_chat(user, span_warning("\The [reagent_container] is missing some of its reagents. You must refill it before you can restock it."))
+				return
 
 		if(item_to_stock.loc == user) //Inside the mob's inventory
 			if(item_to_stock.flags_item & WIELDED)


### PR DESCRIPTION
## About The Pull Request
The frame from #7814 , but purely as an option. No gameplay changes, the var enabling it isn't active on anything.

## Why It's Good For The Game
Lets rarer chems be available in vendors in a limited amount, rather than forcing them to either be absent or infinite.

## Changelog
:cl:
code: Reagent containers can be set to not allow restocking after use.
/:cl: