### PR TITLE
Add hud tablet to mortar and howitzer

### DIFF
--- a/code/game/objects/items/devices/tablets.dm
+++ b/code/game/objects/items/devices/tablets.dm
@@ -63,6 +63,10 @@
 				dat += " pilot's"
 				network = list("dropship1", "dropship2")
 				req_access = list(ACCESS_MARINE_PILOT, ACCESS_MARINE_DROPSHIP)
+			if(/datum/job/terragov/squad/engineer)
+				dat += " engineer's"
+				network = list("marinesl", "marine")
+				req_access = list(ACCESS_MARINE_ENGINEERING)
 		name = dat + " hud tablet"
 	// Convert networks to lowercase
 	for(var/i in network)
@@ -256,3 +260,11 @@
 	req_access = list(ACCESS_MARINE_PILOT, ACCESS_MARINE_DROPSHIP)
 	max_view_dist = WORLD_VIEW_NUM
 
+/obj/item/hud_tablet/mortar
+	name = "mortar's hub tablet"
+	network = list("marinesl", "marine")
+	req_access = list(ACCESS_MARINE_ENGINEERING)
+	max_view_dist = WORLD_VIEW_NUM
+
+/obj/item/hud_tablet/mortar/howitzer
+	name = "howitzer's hub tablet"

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -512,6 +512,7 @@
 	desc = "A crate containing a basic set of a mortar and some shells, to get an engineer started."
 
 /obj/structure/closet/crate/mortar_ammo/mortar_kit/PopulateContents()
+	new /obj/item/hud_tablet/mortar(src)
 	new /obj/item/mortar_kit(src)
 	new /obj/item/mortal_shell/he(src)
 	new /obj/item/mortal_shell/he(src)
@@ -551,6 +552,7 @@
 	desc = "A crate containing a basic, somehow compressed kit consisting of an entire howitzer and some shells, to get a artilleryman started."
 
 /obj/structure/closet/crate/mortar_ammo/howitzer_kit/PopulateContents()
+	new /obj/item/hud_tablet/mortar/howitzer(src)
 	new /obj/item/mortar_kit/howitzer(src)
 	new /obj/item/mortal_shell/howitzer/incendiary(src)
 	new /obj/item/mortal_shell/howitzer/incendiary(src)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Do you want to be a mortarman or howitzerman but can't see your beautiful work of FFing marines or gibbing xenomorphs since you are so far, far away?

NOW YOU CAN SEE THROUGH MARINE'S CAMERA LIKE A MADESHIFT SQUAD OFFICER!

https://user-images.githubusercontent.com/6610922/176825485-e63f7b2f-e31d-41a9-9056-3fe0f468f0f6.mp4

With just enough brain power, you can SEE where the frontline is, LOCATE where xenomorphs are, USE webmap for coordinates, LOAD that shell, BLAST that xenomorphs, and SEE your fine art.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The gameplay loop for mortar and howitzer is as following:

1) Move mortar / howitzer
2) load mortar / howitzer
3) look at minimap to see where marines are at
4) get coordinates for mortar / howitzer
5) fire
6) repeat starting from 1 or 2

It's easy to get coordinates since webmap exists and eyeball where to shoot since minimap ; however, mortarman and howitzerman only feedback is marines not saying anything about shelling OR marines yelling at mortarman and howitzerman for "dAnGeR cLoSe" and "fRiEnDlY fIrE" over the radio. All the mortarman and howitzerman can do is just look at minimap to see where marines move and choose another coordinates.

I propose that mortarman and howitzerman get hud tablet, which permits them to see through marine's camera.

1) It will let people go mortarman or howitzerman more since the hard part about being such role is that you can't see. This is a game, not real life where you have to HANG the shell, so it makes sense to improve what we got. That said, this will affect balance pretty fast, so no doubt we have to balance these baby out
2) Hud tablet is now a fundamental part for mortarman or howitzerman. The SL, captain, FC, and PO never use hud tablet, so this is a great way to use a tool that barely any leadership role will use.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: hud tablet to mortar and howitzer; ONLY people with engineering access can use mortar / howitzer hud tablet
expansion: hud tablet so that it cooperates with mortar and howitzer
balance: indirect fire from mortar and howitzer will be more precise and menacing to xenomorphs since big brain engineers can FINALLY have important data to work with when using mortar and howitzer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
