### PR TITLE
Reagents rebalance

### DIFF
--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -37,8 +37,8 @@
 
 /datum/chemical_reaction/ryetalyn
 	name = "Ryetalyn"
-	results = list(/datum/reagent/medicine/ryetalyn = 2)
-	required_reagents = list(/datum/reagent/medicine/arithrazine = 1, /datum/reagent/carbon = 1, /datum/reagent/medicine/lemoline = 1)
+	results = list(/datum/reagent/medicine/ryetalyn = 4)
+	required_reagents = list(/datum/reagent/medicine/hyronalin = 3, /datum/reagent/medicine/lemoline = 1)
 
 /datum/chemical_reaction/cryoxadone
 	name = "Cryoxadone"
@@ -115,7 +115,7 @@
 
 /datum/chemical_reaction/synaptizine
 	name = "Synaptizine"
-	results = list(/datum/reagent/medicine/synaptizine = 3)
+	results = list(/datum/reagent/medicine/synaptizine = 2)
 	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/lithium = 1, /datum/reagent/water = 1, /datum/reagent/medicine/lemoline = 1)
 
 /datum/chemical_reaction/leporazine
@@ -126,13 +126,13 @@
 
 /datum/chemical_reaction/hyronalin
 	name = "Hyronalin"
-	results = list(/datum/reagent/medicine/hyronalin = 2)
+	results = list(/datum/reagent/medicine/hyronalin = 3)
 	required_reagents = list(/datum/reagent/radium = 1, /datum/reagent/medicine/dylovene = 1, /datum/reagent/medicine/lemoline = 1)
 
 /datum/chemical_reaction/arithrazine
 	name = "Arithrazine"
 	results = list(/datum/reagent/medicine/arithrazine = 2)
-	required_reagents = list(/datum/reagent/medicine/hyronalin = 1, /datum/reagent/hydrogen = 1)
+	required_reagents = list(/datum/reagent/medicine/dylovene = 1, /datum/reagent/hydrogen = 1)
 
 /datum/chemical_reaction/kelotane
 	name = "Kelotane"
@@ -142,7 +142,7 @@
 /datum/chemical_reaction/peridaxon_plus
 	name = "Peridaxon Plus"
 	results = list(/datum/reagent/medicine/peridaxon_plus = 1)
-	required_reagents = list(/datum/reagent/medicine/ryetalyn = 5, /datum/reagent/toxin/phoron = 5)
+	required_reagents = list(/datum/reagent/medicine/dylovene = 5, /datum/reagent/toxin/phoron = 5, /datum/reagent/medicine/lemoline = 2)
 
 /datum/chemical_reaction/quickclot
 	name = "Quick-Clot"
@@ -163,7 +163,7 @@
 /datum/chemical_reaction/neuraline
 	name = "Neuraline"
 	results = list(/datum/reagent/medicine/neuraline = 4, /datum/reagent/toxin/huskpowder = 1)
-	required_reagents = list(/datum/reagent/medicine/synaptizine = 1, /datum/reagent/medicine/arithrazine = 1, /datum/reagent/medicine/tricordrazine = 2, /datum/reagent/consumable/larvajellyprepared = 1)
+	required_reagents = list(/datum/reagent/medicine/dylovene = 1, /datum/reagent/medicine/arithrazine = 1, /datum/reagent/medicine/tricordrazine = 2, /datum/reagent/consumable/larvajellyprepared = 1)
 	required_catalysts = list(/datum/reagent/medicine/lemoline = 5)
 
 /datum/chemical_reaction/lemoline

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -271,7 +271,7 @@
 
 /datum/chemical_reaction/plasmalosssmoke
 	name = "Tanglefoot smoke"
-	required_reagents = list(/datum/reagent/toxin/sleeptoxin = 2, /datum/reagent/medicine/synaptizine = 1, /datum/reagent/sulfur = 1)
+	required_reagents = list(/datum/reagent/toxin/sleeptoxin = 2, /datum/reagent/potassium = 1, /datum/reagent/sulfur = 1)
 
 /datum/chemical_reaction/plasmalosssmoke/on_reaction(datum/reagents/holder, created_volume)
 	var/smoke_radius = round(sqrt(created_volume), 1)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -60,7 +60,7 @@
 	reagent_state = SOLID
 	color = "#C8A5DC" // rgb: 200, 165, 220
 	scannable = TRUE
-	custom_metabolism = REAGENTS_METABOLISM * 0.125
+	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	purge_list = list(/datum/reagent/toxin, /datum/reagent/zombium)
 	purge_rate = 5
 	overdose_threshold = REAGENTS_OVERDOSE
@@ -93,7 +93,7 @@
 
 /datum/reagent/medicine/paracetamol/on_mob_life(mob/living/L, metabolism)
 	L.reagent_pain_modifier += PAIN_REDUCTION_HEAVY
-	L.heal_limb_damage(0.2*effect_str, 0.2*effect_str)
+	L.heal_limb_damage(0.3*effect_str, 0.3*effect_str)
 	L.adjustToxLoss(-0.1*effect_str)
 	L.adjustStaminaLoss(-effect_str)
 	return ..()
@@ -220,8 +220,6 @@
 	description = "Kelotane is a drug used to treat burns."
 	color = "#D8C58C"
 	scannable = TRUE
-	purge_list = list(/datum/reagent/medicine/ryetalyn)
-	purge_rate = 1
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 
@@ -250,8 +248,6 @@
 	overdose_threshold = REAGENTS_OVERDOSE*0.5
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL*0.5
 	scannable = TRUE
-	purge_list = list(/datum/reagent/medicine/oxycodone)
-	purge_rate = 0.2
 
 /datum/reagent/medicine/dermaline/on_mob_life(mob/living/L, metabolism)
 	var/target_temp = L.get_standard_bodytemperature()
@@ -314,8 +310,6 @@
 	description = "Tricordrazine is a highly potent stimulant, originally derived from cordrazine. Can be used to treat a wide range of injuries."
 	color = "#B865CC"
 	scannable = TRUE
-	purge_list = list(/datum/reagent/medicine/ryetalyn)
-	purge_rate = 1
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "grossness"
@@ -424,6 +418,7 @@
 	if(TIMER_COOLDOWN_CHECK(L, name))
 		return
 	L.adjustStaminaLoss(-30*effect_str)
+	L.add_movespeed_modifier(type, TRUE, 0, NONE, TRUE, -0.3) //small but significant speed increase
 	to_chat(L, span_userdanger("You feel a burst of energy as the stimulants course through you! Time to go!"))
 
 /datum/reagent/medicine/synaptizine/on_mob_life(mob/living/L, metabolism)
@@ -432,8 +427,10 @@
 	L.AdjustUnconscious(-20)
 	L.AdjustStun(-20)
 	L.AdjustParalyzed(-20)
-	L.adjustToxLoss(effect_str)
 	L.hallucination = max(0, L.hallucination - 10)
+	L.adjustToxLoss(effect_str)
+	L.reagents.add_reagent(/datum/reagent/toxin, 2)
+
 	switch(current_cycle)
 		if(1 to 10)
 			L.adjustStaminaLoss(-7.5*effect_str)
@@ -450,6 +447,7 @@
 	L.apply_damages(effect_str, effect_str, effect_str)
 
 /datum/reagent/medicine/synaptizine/on_mob_delete(mob/living/L, metabolism)
+	L.remove_movespeed_modifier(type)
 	to_chat(L, span_userdanger("The room spins as you start to come down off your stimulants!"))
 	TIMER_COOLDOWN_START(L, name, 60 SECONDS)
 
@@ -457,7 +455,7 @@
 	name = "Neuraline"
 	description = "A chemical cocktail tailored to enhance or dampen specific neural processes."
 	color = "#C8A5DC" // rgb: 200, 165, 220
-	custom_metabolism = REAGENTS_METABOLISM * 2
+	custom_metabolism = REAGENTS_METABOLISM * 2.5
 	overdose_threshold = 5
 	overdose_crit_threshold = 6
 	scannable = FALSE
@@ -466,7 +464,7 @@
 	var/mob/living/carbon/human/H = L
 	if(TIMER_COOLDOWN_CHECK(L, name) || L.stat == DEAD)
 		return
-	if(L.health < H.health_threshold_crit && volume > 3) //If you are in crit, and someone injects at least 3u into you, you will heal 20% of your physical damage instantly.
+	if(L.health < H.health_threshold_crit && volume > 4) //If you are in crit, and someone injects at least 3u into you, you will heal 20% of your physical damage instantly.
 		to_chat(L, span_userdanger("You feel a rush of energy as stimulants course through your veins!"))
 		L.adjustBruteLoss(-L.getBruteLoss() * 0.20)
 		L.adjustFireLoss(-L.getFireLoss() * 0.20)
@@ -493,8 +491,8 @@
 	L.AdjustParalyzed(-20)
 	L.AdjustSleeping(-40)
 	L.adjustStaminaLoss(-30*effect_str)
-	L.heal_limb_damage(7.5*effect_str, 7.5*effect_str)
-	L.adjustToxLoss(3.75*effect_str)
+	L.heal_limb_damage(5*effect_str, 5*effect_str)
+	L.adjustToxLoss(2*effect_str)
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
 		C.setShock_Stage(min(C.shock_stage - volume*effect_str, 150)) //will pull a target out of deep paincrit instantly, if he's in it
@@ -510,13 +508,13 @@
 	name = "Hyronalin"
 	description = "Hyronalin is a medicinal drug used to counter the effect of toxin poisoning."
 	color = "#C8A5DC" // rgb: 200, 165, 220
-	custom_metabolism = REAGENTS_METABOLISM
+	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	scannable = TRUE
 
 /datum/reagent/medicine/hyronalin/on_mob_life(mob/living/L)
-	L.adjustToxLoss(-effect_str)
+	L.adjustToxLoss(-2*effect_str)
 	return ..()
 
 /datum/reagent/medicine/hyronalin/overdose_process(mob/living/L, metabolism)
@@ -527,19 +525,21 @@
 
 /datum/reagent/medicine/arithrazine
 	name = "Arithrazine"
-	description = "Arithrazine is a component medicine capable of healing very minor amounts of toxin poisoning."
+	description = "Arithrazine is a dangerous medicine capable of healing toxin damage, but with severe side effects of chemical burns and internal hematomas."
 	color = "#C8A5DC" // rgb: 200, 165, 220
-	custom_metabolism = REAGENTS_METABOLISM * 1.25
+	custom_metabolism = REAGENTS_METABOLISM * 5
 	overdose_threshold = REAGENTS_OVERDOSE/2
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/2
 	scannable = TRUE
 
 /datum/reagent/medicine/arithrazine/on_mob_life(mob/living/L)
-	L.adjustToxLoss(-0.2*effect_str)
+	L.adjustToxLoss(-effect_str)
+	L.take_limb_damage(2*effect_str, 2*effect_str)
 	return ..()
 
 /datum/reagent/medicine/arithrazine/overdose_process(mob/living/L, metabolism)
 	L.apply_damage(effect_str, TOX)
+	L.take_limb_damage(2*effect_str, 2*effect_str)
 
 /datum/reagent/arithrazine/overdose_crit_process(mob/living/L, metabolism)
 	L.apply_damages(effect_str, effect_str, 2*effect_str)
@@ -662,8 +662,6 @@
 	name = "Bicaridine"
 	description = "Bicaridine is an analgesic medication and can be used to treat blunt trauma."
 	color = "#E8756C"
-	purge_list = list(/datum/reagent/medicine/ryetalyn)
-	purge_rate = 1
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	scannable = TRUE
@@ -691,8 +689,6 @@
 	overdose_threshold = REAGENTS_OVERDOSE*0.5
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL*0.5
 	scannable = TRUE
-	purge_list = list(/datum/reagent/medicine/oxycodone)
-	purge_rate = 0.2
 
 /datum/reagent/medicine/meralyne/on_mob_life(mob/living/L, metabolism)
 	L.heal_limb_damage(2*effect_str, 0)
@@ -1245,7 +1241,7 @@
 			if(L.stat == UNCONSCIOUS)
 				L.heal_limb_damage(10*effect_str, 10*effect_str)
 				L.adjustCloneLoss(-0.2*effect_str-(0.02*(L.maxHealth - L.health)))
-				holder.remove_reagent(/datum/reagent/medicine/research/somolent, 0.6)
+				holder.remove_reagent(/datum/reagent/medicine/research/somolent, (1-custom_metabolism)) //1u per tick
 			if(prob(50) && L.stat != UNCONSCIOUS)
 				L.adjustStaminaLoss((current_cycle*0.75 - 14)*effect_str)
 	return ..()

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -458,6 +458,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 2.5
 	overdose_threshold = 6
 	overdose_crit_threshold = 7
+	scannable = TRUE
 
 /datum/reagent/medicine/neuraline/on_mob_add(mob/living/L, metabolism)
 	ADD_TRAIT(L, TRAIT_IGNORE_SUFFOCATION, REAGENT_TRAIT(src))
@@ -502,7 +503,9 @@
 		C.setShock_Stage(min(C.shock_stage - volume*effect_str, 150)) //will pull a target out of deep paincrit instantly, if he's in it
 		if(L.health < 0 && volume > 1) //Heals better in softcrit, no microdosing
 			heal_strength = 8
-	L.heal_limb_damage(heal_strength*effect_str, heal_strength*effect_str)
+
+	L.adjustBruteLoss(-heal_strength*effect_str)
+	L.adjustFireLoss(-heal_strength*effect_str)
 	return ..()
 
 /datum/reagent/medicine/neuraline/overdose_process(mob/living/L, metabolism)
@@ -577,7 +580,8 @@
 		TIMER_COOLDOWN_START(L, name, 300 SECONDS)
 
 /datum/reagent/medicine/russian_red/on_mob_life(mob/living/L, metabolism)
-	L.heal_limb_damage(10*effect_str, 10*effect_str)
+	L.adjustBruteLoss(-10*effect_str)
+	L.adjustFireLoss(-10*effect_str)
 	L.adjustToxLoss(-2.5*effect_str)
 	L.adjustCloneLoss(effect_str)
 	if(iscarbon(L))
@@ -1239,14 +1243,16 @@
 	switch(current_cycle)
 		if(1 to 24)
 			if(L.stat == UNCONSCIOUS)
-				L.heal_limb_damage(0.4*current_cycle*effect_str, 0.4*current_cycle*effect_str)
+				L.adjustBruteLoss(-0.4*current_cycle*effect_str)
+				L.adjustFireLoss(-0.4*current_cycle*effect_str)
 			if(prob(20) && L.stat != UNCONSCIOUS)
 				to_chat(L, span_notice("You feel as though you should be sleeping for the medicine to work."))
 		if(25)
 			to_chat(L, span_notice("You feel very sleepy all of a sudden."))
 		if(26 to INFINITY)
 			if(L.stat == UNCONSCIOUS)
-				L.heal_limb_damage(10*effect_str, 10*effect_str)
+				L.adjustBruteLoss(-10*effect_str)
+				L.adjustFireLoss(-10*effect_str)
 				L.adjustCloneLoss(-0.2*effect_str-(0.02*(L.maxHealth - L.health)))
 				holder.remove_reagent(/datum/reagent/medicine/research/somolent, (1-custom_metabolism)) //1u per tick
 			if(prob(50) && L.stat != UNCONSCIOUS)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -495,14 +495,14 @@
 	L.AdjustParalyzed(-20)
 	L.AdjustSleeping(-40)
 	L.adjustStaminaLoss(-30*effect_str)
-	L.heal_limb_damage(5*effect_str, 5*effect_str)
+	var/heal_strength = 5
 	L.adjustToxLoss(2*effect_str)
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
 		C.setShock_Stage(min(C.shock_stage - volume*effect_str, 150)) //will pull a target out of deep paincrit instantly, if he's in it
 		if(L.health < 0 && volume > 1) //Heals better in softcrit, no microdosing
-			L.heal_limb_damage(3*effect_str, 3*effect_str)
-			L.Losebreath
+			heal_strength = 8
+	L.heal_limb_damage(heal_strength*effect_str, heal_strength*effect_str)
 	return ..()
 
 /datum/reagent/medicine/neuraline/overdose_process(mob/living/L, metabolism)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -415,10 +415,10 @@
 	purge_rate = 5
 
 /datum/reagent/medicine/synaptizine/on_mob_add(mob/living/L, metabolism)
+	L.add_movespeed_modifier(type, TRUE, 0, NONE, TRUE, -0.3) //small but significant speed increase
 	if(TIMER_COOLDOWN_CHECK(L, name))
 		return
 	L.adjustStaminaLoss(-30*effect_str)
-	L.add_movespeed_modifier(type, TRUE, 0, NONE, TRUE, -0.3) //small but significant speed increase
 	to_chat(L, span_userdanger("You feel a burst of energy as the stimulants course through you! Time to go!"))
 
 /datum/reagent/medicine/synaptizine/on_mob_life(mob/living/L, metabolism)


### PR DESCRIPTION
## About The Pull Request

Lemoline reagents and some others are fixed and rebalanced. Previously part of #10558 

## Why It's Good For The Game

- Advanced reagents have more balanced effects and recipes.
- Other reagents have actual niche.
- Reagents with large healing properly update damage

## Fixes

Neuraline, RR and Somolent now use adjustXloss, so that you receive full healing from them.
**Now**, if you have both brute and burn, RR will heal both brute and burn 100% of time.
**Before**, if you have both brute and burn, RR picks a random limb, and heals up to 10 of each damage. This means that if you had chest with 50/40 damage and foot with 1/0 damage, there was a 50% chance to heal 20 damage, and 50% chance to heal 1 damage.

## Changes

**Ryetalin**
1 Lemoline -> 2 Rye
0.1 metab rate
Is NOT purged by BKTT anymore
Purge was there to counter premed.
_Now it's a Lemoline chem, so premeds are not a real problem.
Metab increased to be reasonable and not make rye OP._

**Synaptizine**
1 Lemoline -> 2 Syna
Adds 2 "Toxin" reagent per tick.
**Gives 0.3 speed.**
_Speed bonus is significant, but small.
Dangerous to use without rye._

**Hyronalin** 
1 Lemoline -> 3 Hyro
0.1 metab rate
Heals 2 TOX per tick

**Arithrazine**
Dylo + H -> 2 Ari
1 metab rate
Heals TOX 1 per tick
Gives BRUTE/BURN 2/2 per tick
_Arithrazine is a dangerous medicine capable of healing toxin damage, but with severe side effects.
Instead of powercreep, it now has a niche as emergency antitox chem - large TOX is hard to heal otherwise._

**Peridaxon+**
2 Lemoline -> 1 P+, same as QC+

**Paracetamol**
Increased BRUTE/BURN heal 0.2 -> 0.3
_Joke effects. Natural unga regen is about 0.2 per limb. 
Now that you can get it reliably (in injectors PR), it's probably best to make it non-garbage._

**Oxycodone**
Not purged by MeraDerm anymore.
_No idea why that was a thing. 
Oxy is similar power to Tramadol, but metabs x4 quicker and gives TOX.
Now ACA is less retarded._

**Neuraline**
No longer uses Syna in recipe.
Metab 0.5 per tick. Crit dose = 5u.
Heal per tick BRUTE/BURN 7.5 -> 5
Deal TOX per tick 3.75 -> 2
When in **negative health**, heals additional 3/3 per tick
Increases injector dosage.

**Somolent**
Increased a little bit metab rate when cloneloss heal stage kicks in.
Now its 1u per tick.

**Tanglefoot**
No longer uses Syna in recipe

## Changelog
:cl:
balance: Rebalanced reagents and their recipes
fix: RR, Neuraline and Somolent now heal damage properly
/:cl:
