### PR TITLE
Repeater Nerf (lazy edition)

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -603,7 +603,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 1.25
 
 /datum/ammo/bullet/rifle/repeater/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, max_range = 3, slowdown = 2, stagger = 1, shake = 0.5)
+	staggerstun(M, P, max_range = 3, slowdown = 2, stagger = 1)
 
 /datum/ammo/bullet/rifle/incendiary
 	name = "incendiary rifle bullet"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -599,7 +599,7 @@ datum/ammo/bullet/revolver/tp44
 	name = "heavy impact rifle bullet"
 	hud_state = "revolver_heavy"
 	damage = 70
-	penetration = 20
+	penetration = 15
 	sundering = 1.25
 
 /datum/ammo/bullet/rifle/repeater/on_hit_mob(mob/M, obj/projectile/P)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -599,11 +599,11 @@ datum/ammo/bullet/revolver/tp44
 	name = "heavy impact rifle bullet"
 	hud_state = "revolver_heavy"
 	damage = 70
-	penetration = 15
+	penetration = 20
 	sundering = 1.25
 
 /datum/ammo/bullet/rifle/repeater/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, max_range = 3, slowdown = 2, stagger = 1)
+	staggerstun(M, P, max_range = 3, slowdown = 1 , stagger = 1)
 
 /datum/ammo/bullet/rifle/incendiary
 	name = "incendiary rifle bullet"

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -505,7 +505,7 @@
 	reload_sound = 'sound/weapons/guns/interact/mosin_reload.ogg'
 	caliber = CALIBER_4570 //codex
 	load_method = SINGLE_CASING //codex
-	max_chamber_items = 13 //codex
+	max_chamber_items = 9 //codex
 	default_ammo_type = /datum/ammo/bullet/rifle/repeater
 	gun_skill_category = GUN_SKILL_RIFLES
 	cocked_sound = 'sound/weapons/guns/interact/ak47_cocked.ogg'//good enough for now.


### PR DESCRIPTION
Ammo cap to 9 from 13.
Slowdown from 2 to 1.

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ammo cap to 9 from 13.
Slowdown from 2 to 1.
Screenshake removed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Remember that stuff I said about the repeater being a "self-defense gun" when I reworked it to using its own ammo? Yeah. I'm stupid like that. Anyway, it still procs staggerstun on mobs within a 3 tile range, you won't be chaining it on slower xenos through the slowdown though. I also felt like it had far too much ammo it had no business having. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Repeater screenshake (it did nothing)
balance: Repeater holds 9 (10) rounds from 13. 
balance: Repeater slowdown reduced to 1 from 2. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
