### PR TITLE
Dead marines do not reduce number of xenos for crash

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -206,7 +206,7 @@
 	for(var/mob/living/carbon/human/H AS in GLOB.human_mob_list)
 		if(!H.job)
 			continue
-		if(!(H.z in z_levels) || isspaceturf(H.loc))
+		if(isspaceturf(H.loc))
 			continue
 		. += H.job.jobworth[/datum/job/xenomorph]
 

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -26,7 +26,7 @@
 	// Round start info
 	var/starting_squad = "Alpha"
 	///How long between two larva check
-	var/larva_check_interval = 2 MINUTES
+	var/larva_check_interval = 1 MINUTES
 	///Last time larva balance was checked
 	var/last_larva_check
 	bioscan_interval = 0

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -26,7 +26,7 @@
 	// Round start info
 	var/starting_squad = "Alpha"
 	///How long between two larva check
-	var/larva_check_interval = 1 MINUTES
+	var/larva_check_interval = 2 MINUTES
 	///Last time larva balance was checked
 	var/last_larva_check
 	bioscan_interval = 0

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -203,13 +203,10 @@
 /datum/game_mode/infestation/crash/get_total_joblarvaworth(list/z_levels, count_flags)
 	. = 0
 
-	for(var/i in GLOB.human_mob_list)
-		var/mob/living/carbon/human/H = i
+	for(var/mob/living/carbon/human/H AS in GLOB.human_mob_list)
 		if(!H.job)
 			continue
-		if(count_flags & COUNT_IGNORE_HUMAN_SSD && (H.stat != DEAD && !H.client))
-			continue
-		if(H.status_flags & XENO_HOST)
+		if(count_flags & COUNT_IGNORE_HUMAN_SSD && (H.stat != DEAD && H.client))
 			continue
 		if(!(H.z in z_levels) || isspaceturf(H.loc))
 			continue

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -206,7 +206,7 @@
 	for(var/mob/living/carbon/human/H AS in GLOB.human_mob_list)
 		if(!H.job)
 			continue
-		if(count_flags & COUNT_IGNORE_HUMAN_SSD && (H.stat != DEAD && H.client))
+		if(count_flags & COUNT_IGNORE_HUMAN_SSD && (H.stat != DEAD && !H.client))
 			continue
 		if(!(H.z in z_levels) || isspaceturf(H.loc))
 			continue

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -199,3 +199,19 @@
 		return //Things are balanced, no burrowed needed
 	xeno_job.add_job_positions(1)
 	xeno_hive.update_tier_limits()
+
+/datum/game_mode/infestation/crash/get_total_joblarvaworth(list/z_levels, count_flags)
+	. = 0
+
+	for(var/i in GLOB.human_mob_list)
+		var/mob/living/carbon/human/H = i
+		if(!H.job)
+			continue
+		if(count_flags & COUNT_IGNORE_HUMAN_SSD && !H.client)
+			continue
+		if(H.status_flags & XENO_HOST)
+			continue
+		if(!(H.z in z_levels) || isspaceturf(H.loc))
+			continue
+		. += H.job.jobworth[/datum/job/xenomorph]
+

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -206,8 +206,6 @@
 	for(var/mob/living/carbon/human/H AS in GLOB.human_mob_list)
 		if(!H.job)
 			continue
-		if(count_flags & COUNT_IGNORE_HUMAN_SSD && (H.stat != DEAD && !H.client))
-			continue
 		if(!(H.z in z_levels) || isspaceturf(H.loc))
 			continue
 		. += H.job.jobworth[/datum/job/xenomorph]

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -207,7 +207,7 @@
 		var/mob/living/carbon/human/H = i
 		if(!H.job)
 			continue
-		if(count_flags & COUNT_IGNORE_HUMAN_SSD && !H.client)
+		if(count_flags & COUNT_IGNORE_HUMAN_SSD && (H.state != DEAD && !H.client))
 			continue
 		if(H.status_flags & XENO_HOST)
 			continue

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -207,7 +207,7 @@
 		var/mob/living/carbon/human/H = i
 		if(!H.job)
 			continue
-		if(count_flags & COUNT_IGNORE_HUMAN_SSD && (H.state != DEAD && !H.client))
+		if(count_flags & COUNT_IGNORE_HUMAN_SSD && (H.stat != DEAD && !H.client))
 			continue
 		if(H.status_flags & XENO_HOST)
 			continue


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Overwrites the job larva worth proc so that dead marines will not reduce total number of xenos to spawn.

Also 1 minut interval between larval checks


Its tad difficult to test this properly, it does compile atleast. Could this be TM'ed atleast once to see if it works properly?

## Why It's Good For The Game

This avoids annoying situation on crash where a few marines die killing xenos, reducing the xeno pop to a point they cannot really fight them(1 of any cast cannot solo all the marines behind cades)

The latter change because same one pinged me about it

## Changelog
:cl:
balance: Dead marines will not cap the xeno pop for crash
balance: Xeno larva check will proc every 1 minut instead of 2 minuts for crash
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
