### PR TITLE
Resin silos can use pheros(for now crash only)

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -80,7 +80,8 @@
 /datum/game_mode/infestation/crash/post_setup()
 	. = ..()
 	for(var/i in GLOB.xeno_resin_silo_turfs)
-		new /obj/structure/xeno/silo(i)
+		var/obj/structure/xeno/silo/newsilo = new /obj/structure/xeno/silo(i)
+		newsilo.apply_pheros(RECOVERY)
 
 	for(var/obj/effect/landmark/corpsespawner/corpse AS in GLOB.corpse_landmarks_list)
 		corpse.create_mob(HEADBITE_DEATH)

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -532,6 +532,8 @@
 /datum/hive_status/proc/update_leader_pheromones() // helper function to easily trigger an update of leader pheromones
 	for(var/mob/living/carbon/xenomorph/leader AS in xeno_leader_list)
 		leader.handle_xeno_leader_pheromones(living_xeno_queen)
+	for(var/obj/structure/xeno/silo/ressilos AS in GLOB.xeno_resin_silos)
+		ressilos.handle_xeno_leader_pheromones(living_xeno_queen)
 
 // ***************************************
 // *********** Status changes

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -847,7 +847,8 @@ TUNNEL
 	//Regenerate if we're at less than max integrity
 	if(obj_integrity < max_integrity)
 		obj_integrity = min(obj_integrity + 25, max_integrity) //Regen 5 HP per sec
-	handle_aura_emiter()
+	if (current_aura)
+		handle_aura_emiter()
 
 /obj/structure/xeno/silo/proc/is_burrowed_larva_host(datum/source, list/mothers, list/silos)
 	SIGNAL_HANDLER

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -922,6 +922,14 @@ TUNNEL
 
 	hud_set_pheromone() //Visual feedback that the xeno has immediately started emitting pheromones
 
+/obj/structure/xeno/silo/proc/handle_xeno_leader_pheromones(mob/living/carbon/xenomorph/queen/Q)
+	if(QDELETED(Q) || !Q.current_aura || Q.loc.z != loc.z) //We are no longer a leader, or the Queen attached to us has dropped from her ovi, disabled her pheromones or even died
+		leader_aura_strength = 0
+		leader_current_aura = ""
+	else
+		leader_aura_strength = Q.xeno_caste.aura_strength
+		leader_current_aura = Q.current_aura
+
 /obj/structure/xeno/xeno_turret
 	icon = 'icons/Xeno/acidturret.dmi'
 	icon_state = XENO_TURRET_ACID_ICONSTATE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR aims to adds a way for silos to carry aura effects with them. For now just in context of crash.

The silo will carry its own very strong aura and be able to channel leaders aura

## Why It's Good For The Game

May be a neat feature that can be worked on in the future, but for the here and now this lets xenos recover some what quickly at silos. Which is great when a leader could not be spawned due to low pop. 

## Changelog
:cl:
add: Resin silos can now use phero's(currently only in crash)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
