### PR TITLE
Combat shotgun akimbo tweak - again

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -110,6 +110,7 @@
 	recoil = 0 //It has a stock on the sprite.
 	recoil_unwielded = 2
 	wield_delay = 1 SECONDS
+	akimbo_additional_delay = 0.9
 
 /obj/item/weapon/gun/shotgun/combat/masterkey
 	name = "masterkey shotgun"

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -110,7 +110,6 @@
 	recoil = 0 //It has a stock on the sprite.
 	recoil_unwielded = 2
 	wield_delay = 1 SECONDS
-	akimbo_additional_delay = 0.9
 
 /obj/item/weapon/gun/shotgun/combat/masterkey
 	name = "masterkey shotgun"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I almost ded, pls nerf.

Previous nerf to akimbo scatter for the combat shotgun isn't sufficient, due to the rate of fire allowing for almost perma slow to be applied. Increases akimbo additional delay to 0.9 from 0.5. In practice this may not actually make enough of a difference, but I don't want to sledgehammer it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Akimbo shotgun is gross, previous minor nerf was insufficient.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: SH39 akimbo additional delay changed to 0.9 from 0.5.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
