### PR TITLE
Compasses can get target coordinates

### DIFF
--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -247,3 +247,12 @@
 	. = ..()
 	var/turf/location = get_turf(src)
 	to_chat(user, span_notice("After looking at the [src] you can tell your general coordinates.") + span_bold(" LONGITUDE [location.x]. LATITUDE [location.y]."))
+
+/obj/item/compass/afterattack(atom/target, mob/user, has_proximity, click_parameters)
+	. = ..()
+	if(user.do_actions)
+		return
+	var/turf/target_turf = isturf(target)? target : get_turf(target)
+	if(!do_after(user, 1 SECONDS))
+		return
+	to_chat(user, span_notice("Given your current position, target coordinates are:") + span_bold(" LONGITUDE [target_turf.x]. LATITUDE [target_turf.y]."))


### PR DESCRIPTION
## About The Pull Request
Click thing with compass, get coordinates. It does work through cameras, which isn't strictly intended, but that seems alright.

## Why It's Good For The Game
Saves basic math trying to get a location nearby. Potentially enables squad officer nonsense?

## Changelog
:cl:
add: Clicking on stuff when you're carrying a compass will tell you that stuff's coordinates.
/:cl: