### PR TITLE
Kidneys catch microdoses, confuse fix

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -49,7 +49,7 @@
 
 #define STATUS_EFFECT_ADMINSLEEP /datum/status_effect/incapacitating/adminsleep //the affected is admin slept
 
-#define STATUS_EFFECT_CONFUSED /datum/status_effect/confused // random direction chosen when trying to move
+#define STATUS_EFFECT_CONFUSED /datum/status_effect/incapacitating/confused // random direction chosen when trying to move
 
 #define STATUS_EFFECT_GUN_SKILL_ACCURACY_DEBUFF /datum/status_effect/stacking/gun_skill/accuracy/debuff // Decreases the accuracy of the mob
 

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -179,7 +179,7 @@
 	icon_state = "asleep"
 
 //CONFUSED
-/datum/status_effect/confused
+/datum/status_effect/incapacitating/confused
 	id = "confused"
 	alert_type = /obj/screen/alert/status_effect/confused
 

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -405,7 +405,7 @@
 
 ///Returns the remaining duration if a confuse effect exists, else 0
 /mob/living/proc/AmountConfused()
-	var/datum/status_effect/confused/C = IsConfused()
+	var/datum/status_effect/incapacitating/confused/C = IsConfused()
 	if(C)
 		return C.duration - world.time
 	return 0
@@ -417,7 +417,7 @@
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_CONFUSED, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(((status_flags & CANCONFUSE) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE))  || ignore_canstun)
-		var/datum/status_effect/confused/C = IsConfused()
+		var/datum/status_effect/incapacitating/confused/C = IsConfused()
 		if(C)
 			C.duration = max(world.time + amount, C.duration)
 		else if(amount > 0)
@@ -431,7 +431,7 @@
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_CONFUSED, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(((status_flags & CANCONFUSE) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		var/datum/status_effect/confused/C = IsConfused()
+		var/datum/status_effect/incapacitating/confused/C = IsConfused()
 		if(amount <= 0)
 			if(C)
 				qdel(C)
@@ -448,7 +448,7 @@
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_CONFUSED, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(((status_flags & CANCONFUSE) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		var/datum/status_effect/confused/C = IsConfused()
+		var/datum/status_effect/incapacitating/confused/C = IsConfused()
 		if(C)
 			C.duration += amount
 		else if(amount > 0)

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -251,6 +251,10 @@
 	var/current_medicine_cap = 5
 	///Whether we were over cap the last time we checked.
 	var/old_overflow = FALSE
+	///Total medicines added since last tick
+	var/new_medicines = 0
+	///Total medicines removed since last tick
+	var/removed_medicines = 0
 
 /datum/internal_organ/kidneys/New(mob/living/carbon/carbon_mob)
 	. = ..()
@@ -266,14 +270,14 @@
 	SIGNAL_HANDLER
 	if(!ispath(reagent_type, /datum/reagent/medicine))
 		return
-	current_medicine_count++
+	new_medicines++
 
 ///Signaled proc. Check if the removed reagent was under reagent/medicine. If so, decrement medicine counter and potentially notify owner.
 /datum/internal_organ/kidneys/proc/owner_removed_reagent(datum/source, reagent_type)
 	SIGNAL_HANDLER
 	if(!ispath(reagent_type, /datum/reagent/medicine))
 		return
-	current_medicine_count--
+	removed_medicines++
 
 /datum/internal_organ/kidneys/set_organ_status()
 	. = ..()
@@ -284,15 +288,19 @@
 /datum/internal_organ/kidneys/process()
 	..()
 
-	if(owner.reagents.has_reagent(/datum/reagent/water))
-		return //Hydration is good for your kidneys. Shame it purges medicines.
+	var/bypass = FALSE
 
-	if(owner.bodytemperature <= 170) //No sense worrying about a chem cap if we're in cryo anyway.
-		return
+	if(owner.bodytemperature <= 170) //No sense worrying about a chem cap if we're in cryo anyway. Still need to clear tick counts.
+		bypass = TRUE
 
-	var/overflow = current_medicine_count - current_medicine_cap
+	current_medicine_count += new_medicines //We want to include medicines that were individually both added and removed this tick
+	var/overflow = current_medicine_count - current_medicine_cap //This catches any case where a reagent was added with volume below its metabolism
+	current_medicine_count -= removed_medicines //Otherwise, you can microdose infinite chems without kidneys complaining
 
-	if(overflow < 1)
+	new_medicines = 0
+	removed_medicines = 0
+
+	if(overflow < 1 || bypass)
 		if(old_overflow)
 			to_chat(owner, span_notice("You don't feel as overwhelmed by all the drugs any more."))
 			old_overflow = FALSE


### PR DESCRIPTION
## About The Pull Request
Kidneys are a little more aggressive in counting: they'll include any medicines that got added since the last life tick, but not any that've been removed.
This catches any chems that were added with a volume below their metabolism rate, since otherwise you can microdose infinite chems without care.
Also fixes an issue where confuse status effects weren't properly being created with a duration, leaving them to do nothing forever.

## Why It's Good For The Game
Bugfix, remove a way to ignore organ drawbacks.

## Changelog
:cl:
fix: Kidneys count microdosed chems against their limit
fix: Confuse effects won't be created with infinite duration and zero function.
/:cl: