### PR TITLE
Hunter stealth plasma fixes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -203,7 +203,7 @@
 
 /datum/action/xeno_action/stealth/proc/plasma_regen(datum/source, list/plasma_mod)
 	SIGNAL_HANDLER
-	if(owner.last_move_intent > world.time - 20) //Stealth halves the rate of plasma recovery on weeds, and eliminates it entirely while moving
+	if(owner.last_move_intent < world.time - 20) //Stealth halves the rate of plasma recovery on weeds, and eliminates it entirely while moving
 		plasma_mod[1] *= 0.5
 	else
 		plasma_mod[1] = 0
@@ -250,7 +250,8 @@
 	//Retaining old rendering layer to prevent rendering under objects.
 	xenoowner.layer = old_layer
 	xenoowner.underlays.Cut()
-	xenoowner.use_plasma(owner.m_intent == MOVE_INTENT_WALK ? HUNTER_STEALTH_WALK_PLASMADRAIN : HUNTER_STEALTH_RUN_PLASMADRAIN)
+	if(owner.last_move_intent >= world.time - HUNTER_STEALTH_STEALTH_DELAY)
+		xenoowner.use_plasma(owner.m_intent == MOVE_INTENT_WALK ? HUNTER_STEALTH_WALK_PLASMADRAIN : HUNTER_STEALTH_RUN_PLASMADRAIN)
 	//If we have 0 plasma after expending stealth's upkeep plasma, end stealth.
 	if(!xenoowner.plasma_stored)
 		to_chat(xenoowner, span_xenodanger("We lack sufficient plasma to remain disguised."))


### PR DESCRIPTION
## About The Pull Request
Fixes disguise using plasma while standing still
Fixes hunter not regening plasma on weeds while standing still.

## Why It's Good For The Game
Fixes #10578 

## Changelog
:cl:
fix: If you stand still as a disguised hunter, you won't use any plasma.
fix: Hunters with stealth active get half plasma regen while still and zero while moving, instead of the opposite.
/:cl:
