### PR TITLE
Semi Stun Lock Slugs stagger set from 2 to 1

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -725,7 +725,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 15
 
 /datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, weaken = 1, stagger = 2, knockback = 1, slowdown = 2)
+	staggerstun(M, P, weaken = 1, stagger = 1, knockback = 1, slowdown = 2)
 
 
 /datum/ammo/bullet/shotgun/beanbag


### PR DESCRIPTION
## About The Pull Request

Slugs are pretty stronk and a bit unforgiving most times, the 2 stagger is set to 1 when trying to flee  a marine can often times deny that and semi stun lock you while his friends kill you.

## Why It's Good For The Game

less of a chance to semi stun lock

## Changelog
:cl:
balance: stagger set from 2 to 1
/:cl:

Adding videos.

Stagger set to 1 


https://user-images.githubusercontent.com/64131993/178089157-825013b4-90b6-45ae-a293-9d70f2238d83.mp4


Stagger at normal 2

https://user-images.githubusercontent.com/64131993/178089168-a380bc3f-84a5-48a0-99cf-d30edde02e6d.mp4



:Closing comment:

The difference is that the xeno can get up ever so slightly faster