### PR TITLE
Boiler glob's  a bit more worthwhile.

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2353,7 +2353,7 @@ datum/ammo/bullet/revolver/tp44
 	bullet_color = BOILER_LUMINOSITY_AMMO_NEUROTOXIN_COLOR
 	reagent_transfer_amount = 30
 	///On a direct hit, how long is the target paralyzed?
-	var/hit_paralyze_time = 1 SECONDS
+	var/hit_paralyze_time = 2.5 SECONDS
 	///On a direct hit, how much do the victim's eyes get blurred?
 	var/hit_eye_blur = 11
 	///On a direct hit, how much drowsyness gets added to the target?
@@ -2465,7 +2465,7 @@ datum/ammo/bullet/revolver/tp44
 	damage_type = BURN
 	penetration = 40
 	bullet_color = BOILER_LUMINOSITY_AMMO_CORROSIVE_COLOR
-	hit_paralyze_time = 1 SECONDS
+	hit_paralyze_time = 2 SECONDS
 	hit_eye_blur = 1
 	hit_drowsyness = 1
 	reagent_transfer_amount = 0


### PR DESCRIPTION
## About The Pull Request

Strengthens paralyze time for globs

## Why It's Good For The Game

Currently after several marine Pr's that have added beneficial things to them that make direct impact such as arrowhead or extra artillery, boiler has become less interesting and fun there is a higher risk to die while your impact on the battlefield has lessened. you can direct hit a marine twice with a acid glob and they can still walk off, heal up in less then 30 seconds and head back into combat.

This Pr aims to increase the paralyze time by 1.5+ for neuro and 1+ for neuro and acid glob respectively. boiler acid glob is currently the most used and you could siege a point for 20 minutes and feel like you do little effect to help change the tide. 

that being said this PR aims to make it more rewarding when you land a direct hit and nothing more. Neuro currently isn't used because its shit, a paralyze time of 2.5 will be more useful to the hive in a sense of a direct hit will properly put someone out of combat.

it currently takes 7+ globs to destroy a plasteel/metal cade including with acid ticks, I don't believe this is fair, especially with boiler being so easy to chase and kill. now that marines run Arrowhead i believe the extra paralyze time is fair.



## Changelog
:cl:
balance: Neuro glob paralyze time set to 2.5 seconds up from 1
balance: Acid glob paralyze time set to 2 seconds up from 1 second.
/:cl:


