### PR TITLE
Accuracy tweaks

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -770,6 +770,14 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	user.sync_lighting_plane_alpha()
 	return TRUE
 
+/obj/item/attachable/scope/zoom(mob/living/user, tileoffset, viewsize)
+	. = ..()
+	//Makes the gun zoom align with the attachment, used for projectile procs
+	if(zoom)
+		master_gun.zoom = TRUE
+	else
+		master_gun.zoom = FALSE
+
 /obj/item/attachable/scope/optical/update_remote_sight(mob/living/user)
 	. = ..()
 	user.see_in_dark = 2

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1562,6 +1562,11 @@
 			iff_signal = sentry.iff_signal
 		projectile_to_fire.iff_signal = iff_signal
 	projectile_to_fire.damage_marine_falloff = iff_marine_damage_falloff
+	//no point blank bonus when akimbo
+	if(dual_wield == TRUE)
+		projectile_to_fire.point_blank_range = 0
+	else
+		projectile_to_fire.point_blank_range = projectile_to_fire.ammo.point_blank_range
 
 
 /obj/item/weapon/gun/proc/setup_bullet_accuracy(obj/projectile/projectile_to_fire, mob/user, bullets_fired = 1)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -104,6 +104,8 @@
 	var/proj_max_range = 30
 	///A damage multiplier applied when a mob from the same faction as the projectile firer is hit
 	var/friendly_fire_multiplier = 0.5
+	///The "point blank" range of the projectile. Inside this range the projectile gets a bonus to hit
+	var/point_blank_range = 0
 
 /obj/projectile/Initialize()
 	. = ..()
@@ -735,7 +737,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	hit_chance += proj.accuracy
 	BULLET_DEBUG("Base accuracy is <b>[hit_chance]; scatter:[proj.scatter]; distance:[proj.distance_travelled]</b>")
 	if(proj.distance_travelled <= proj.ammo.accurate_range) //If bullet stays within max accurate range.
-		if(proj.distance_travelled <= proj.ammo.point_blank_range) //If bullet within point blank range, big accuracy buff.
+		if(proj.distance_travelled <= proj.point_blank_range) //If bullet within point blank range, big accuracy buff.
 			BULLET_DEBUG("Point blank range (+30)")
 			hit_chance += 30
 		else if(proj.distance_travelled <= proj.ammo.accurate_range_min) //Snipers have accuracy falloff at closer range UNLESS in point blank range

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -736,8 +736,8 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	BULLET_DEBUG("Base accuracy is <b>[hit_chance]; scatter:[proj.scatter]; distance:[proj.distance_travelled]</b>")
 	if(proj.distance_travelled <= proj.ammo.accurate_range) //If bullet stays within max accurate range.
 		if(proj.distance_travelled <= proj.ammo.point_blank_range) //If bullet within point blank range, big accuracy buff.
-			BULLET_DEBUG("Point blank range (+50)")
-			hit_chance += 50
+			BULLET_DEBUG("Point blank range (+30)")
+			hit_chance += 30
 		else if(proj.distance_travelled <= proj.ammo.accurate_range_min) //Snipers have accuracy falloff at closer range UNLESS in point blank range
 			BULLET_DEBUG("Sniper ammo, too close (-[min(100, hit_chance) - (proj.ammo.accurate_range_min - proj.distance_travelled) * 10])")
 			hit_chance = min(100, hit_chance) //excess accuracy doesn't help within minimum accurate range
@@ -748,7 +748,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 
 	hit_chance = max(5, hit_chance) //default hit chance after range factors is at least 5%.
 
-	hit_chance += (mob_size - 1) * 25 //You're easy to hit when you're swoll, hard to hit when you're a manlet
+	hit_chance += (mob_size - 1) * 20 //You're easy to hit when you're swoll, hard to hit when you're a manlet
 
 	BULLET_DEBUG("Hit zone penalty (-[GLOB.base_miss_chance[proj.def_zone]]) ([proj.def_zone])")
 	hit_chance -= GLOB.base_miss_chance[proj.def_zone] //Reduce accuracy based on body part targeted.

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -772,7 +772,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 		if(shooter_living.faction == faction)
 			hit_chance = round(hit_chance*0.85) //You (presumably) aren't trying to shoot your friends
 		var/obj/item/shot_source = proj.shot_from
-		if(!line_of_sight(shooter_living, src, WORLD_VIEW_NUM) && (!istype(shot_source) || !shot_source.zoom)) //if you can't draw LOS, AND (shot didn't come from a item or it didn't come from something actively using zoom)... not sure why
+		if(!line_of_sight(shooter_living, src, 9) && (!istype(shot_source) || !shot_source.zoom)) //if you can't draw LOS within 9 tiles (to accomodate wide screen), AND the source was either not zoomed or not an item(like a xeno)
 			BULLET_DEBUG("Can't see target ([round(hit_chance*0.8)]).")
 			hit_chance = round(hit_chance*0.8) //Can't see the target (Opaque thing between shooter and target), or out of view range
 		if(ishuman(proj.firer))

--- a/config/config.txt
+++ b/config/config.txt
@@ -212,7 +212,7 @@ IS_AUTOMATIC_BALANCE_ON
 ##  15x15 would be the standard square view. 21x15 is what goonstation uses for widescreen.
 ##  Setting this to something different from DEFAULT_VIEW_SQUARE will enable widescreen toggles
 ##	Do note that changing this value will affect the title screen. The title screen will have to be updated manually if this is changed.
-DEFAULT_VIEW 19x15
+DEFAULT_VIEW 15x15
 
 ##Default view size, in tiles. Should *always* be square.
 ## The alternative square viewport size if you're using a widescreen view size

--- a/config/config.txt
+++ b/config/config.txt
@@ -212,7 +212,7 @@ IS_AUTOMATIC_BALANCE_ON
 ##  15x15 would be the standard square view. 21x15 is what goonstation uses for widescreen.
 ##  Setting this to something different from DEFAULT_VIEW_SQUARE will enable widescreen toggles
 ##	Do note that changing this value will affect the title screen. The title screen will have to be updated manually if this is changed.
-DEFAULT_VIEW 15x15
+DEFAULT_VIEW 19x15
 
 ##Default view size, in tiles. Should *always* be square.
 ## The alternative square viewport size if you're using a widescreen view size


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A few tweaks to the projectile accuracy system.

1. Slightly lower multiplier to hit chance for large mobs (20 instead of 25 for xeno, 40 instead of 50 for large xeno)
2. Lowered PB accuracy bonus from 50 to 30 (reminder PB range in projectile terms is normally 2 tiles)
3. Made the 'In view range" 9 tiles instead of 7 due to widescreen (currently you'd lose accuracy when shooting things at the edge of your screen horizontally but not vertically)
4. Akimbo now makes your PB range 0. This means you cannot get the PB accuracy bonus while akimbo, unless you're on top of a crit beno or something.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Improves accuracy system slightly, fixes a funny bug, makes akimbo less poo.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: accuracy bonus for large mob size reduced slightly
balance: accuracy bonus for PB range reduced slightly
balance: Akimbo makes PB range 0 instead of 2
fix: Fixed an accuracy malus triggering for a target being out of view when it was still in widescreen view.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
