### PR TITLE
C4 smoke reduction

### DIFF
--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -18,7 +18,7 @@
 	/// smoke type created when the c4 detonates
 	var/datum/effect_system/smoke_spread/smoketype = /datum/effect_system/smoke_spread/bad
 	/// radius this smoke will encompass
-	var/smokeradius = 2
+	var/smokeradius = 1
 
 /obj/item/explosive/plastique/Destroy()
 	plant_target = null
@@ -113,7 +113,7 @@
 		return
 	explosion(plant_target, 0, 0, 1, 0, 0, 1, 0, 1)
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
-	smoke.set_up(smokeradius, loc, 11)
+	smoke.set_up(smokeradius, loc, 2)
 	smoke.start()
 	plant_target.ex_act(EXPLODE_DEVASTATE)
 	qdel(src)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The previous supplier of C4 has been given the boot due to their excessively smokey explosions.

C4 now has a 1 tile smoke cloud on detonation, and only very a very short duration.

Currently it lasts for a very long time, making it impossible to use with any sort of aggression, as you'd have to push through the smoke blind or wait forever for it to clear.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes C4 a tiny bit more useful, mainly for HvH
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: C4 causes less smoke for a much shorter duration on detonation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
