### PR TITLE
You can no longer give orders to other factions

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_status_effects.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_status_effects.dm
@@ -24,12 +24,13 @@
 			command_aura_strength = skills.getRating("leadership") - 1
 			var/command_aura_range = round(4 + command_aura_strength * 1)
 			for(var/mob/living/carbon/human/H in range(command_aura_range, src))
-				if(command_aura == "move" && command_aura_strength > H.mobility_new)
-					H.mobility_new = command_aura_strength
-				if(command_aura == "hold" && command_aura_strength > H.protection_new)
-					H.protection_new = command_aura_strength
-				if(command_aura == "focus" && command_aura_strength > H.marksman_new)
-					H.marksman_new = command_aura_strength
+				if(H.faction == faction) //You can only give orders to people in your own faction
+					if(command_aura == "move" && command_aura_strength > H.mobility_new)
+						H.mobility_new = command_aura_strength
+					if(command_aura == "hold" && command_aura_strength > H.protection_new)
+						H.protection_new = command_aura_strength
+					if(command_aura == "focus" && command_aura_strength > H.marksman_new)
+						H.marksman_new = command_aura_strength
 
 	set_mobility_aura(mobility_new)
 	protection_aura = protection_new

--- a/code/modules/mob/living/carbon/human/life/handle_status_effects.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_status_effects.dm
@@ -24,13 +24,14 @@
 			command_aura_strength = skills.getRating("leadership") - 1
 			var/command_aura_range = round(4 + command_aura_strength * 1)
 			for(var/mob/living/carbon/human/H in range(command_aura_range, src))
-				if(H.faction == faction) //You can only give orders to people in your own faction
-					if(command_aura == "move" && command_aura_strength > H.mobility_new)
-						H.mobility_new = command_aura_strength
-					if(command_aura == "hold" && command_aura_strength > H.protection_new)
-						H.protection_new = command_aura_strength
-					if(command_aura == "focus" && command_aura_strength > H.marksman_new)
-						H.marksman_new = command_aura_strength
+				if(H.faction != faction) //You can only give orders to people in your own faction
+					continue
+				if(command_aura == "move" && command_aura_strength > H.mobility_new)
+					H.mobility_new = command_aura_strength
+				else if(command_aura == "hold" && command_aura_strength > H.protection_new)
+					H.protection_new = command_aura_strength
+				else if(command_aura == "focus" && command_aura_strength > H.marksman_new)
+					H.marksman_new = command_aura_strength
 
 	set_mobility_aura(mobility_new)
 	protection_aura = protection_new


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As QV pointed out, currently orders just apply to all humans in range... even hostile ones.
Makes it so that orders only apply to those within your own faction. So you won't buff SOM by accident, but also can't buff free lancers for example.

If people like being able to order friendly factions, maybe someone can code that in the future, but currently factions are only designated friendly/neutral/hostile, but this is fixed, and not relative to other specific factions.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
HvH will be a bit silly when you're buffing your enemies.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Orders no longer apply to humans in factions other than your own
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
