### PR TITLE
Halves Flare Min/Max Fuel

### DIFF
--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -279,8 +279,8 @@
 	light_range = 6
 	light_color = LIGHT_COLOR_FLARE
 	var/fuel = 0
-	var/lower_fuel_limit = 300
-	var/upper_fuel_limit = 360
+	var/lower_fuel_limit = 400
+	var/upper_fuel_limit = 460
 
 /obj/item/explosive/grenade/flare/Initialize()
 	. = ..()

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -279,8 +279,8 @@
 	light_range = 6
 	light_color = LIGHT_COLOR_FLARE
 	var/fuel = 0
-	var/lower_fuel_limit = 800
-	var/upper_fuel_limit = 1000
+	var/lower_fuel_limit = 300
+	var/upper_fuel_limit = 360
 
 /obj/item/explosive/grenade/flare/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Flare fuel decreased to 400:460 (~13 to 15 minutes) from 800:1000 (~27 to 33 minutes)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Light is essential for marines in order to even get off a shot or appropriately react to the approach of a xeno. Flares burning out sooner just means that Marines won't have as much control over an area for a long period of time. Xenos also won't be _as_ pressed to melt every flare they see and can afford to be more selective in that process.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Flares now run out of fuel within 13 to 15 minutes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
