### PR TITLE
Refactor and fixes icon variants for armour attachments, adds this functionality to gun attachments

### DIFF
--- a/code/modules/clothing/modular_armor/attachments.dm
+++ b/code/modules/clothing/modular_armor/attachments.dm
@@ -69,11 +69,12 @@
 	parent.slowdown += slowdown
 	if(CHECK_BITFIELD(flags_attach_features, ATTACH_ACTIVATION))
 		RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, .proc/handle_actions)
-	if(!length(variants_by_parent_type) || !(parent.type in variants_by_parent_type))
-		base_icon = icon_state
-		return
-	icon_state = variants_by_parent_type[parent.type]
-	base_icon = variants_by_parent_type[parent.type]
+	if(length(variants_by_parent_type))
+		for(var/selection in variants_by_parent_type)
+			if(istype(parent, selection))
+				icon_state = variants_by_parent_type[selection]
+				base_icon = variants_by_parent_type[selection]
+
 	update_icon()
 
 /// Called when the module is removed from the armor.

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -131,6 +131,11 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	///Sound played on attach
 	var/attach_sound = 'sound/machines/click.ogg'
 
+	///Replacement for initial icon that allows for the code to work with multiple variants
+	var/base_icon
+	///Assoc list that uses the parents type as a key. type = "new_icon_state". This will change the icon state depending on what type the parent is. If the list is empty, or the parent type is not within, it will have no effect.
+	var/list/variants_by_parent_type = list()
+
 /obj/item/attachable/Initialize()
 	. = ..()
 	AddElement(/datum/element/attachment, slot, icon, .proc/on_attach, .proc/on_detach, .proc/activate, .proc/can_attach, pixel_shift_x, pixel_shift_y, flags_attach_features, attach_delay, detach_delay, attach_skill, attach_skill_upper_threshold, attach_sound)
@@ -194,6 +199,10 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 			if(master_gun == living_user.l_hand || master_gun == living_user.r_hand)
 				action_to_update.give_action(living_user)
 
+	//custom overlays for specific guns
+	if(length(variants_by_parent_type) && (master_gun.type in variants_by_parent_type))
+		icon_state = variants_by_parent_type[master_gun.type]
+
 	update_icon()
 
 ///Called when the attachment is detached from something. If the thing is a gun, it returns its stats to what they were before being attached.
@@ -253,6 +262,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 		break
 
 	master_gun = null
+	icon_state = initial(icon_state)
 	update_icon()
 
 
@@ -515,6 +525,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	accuracy_mod = 0.15
 	accuracy_unwielded_mod = 0.1
 	aim_mode_delay_mod = -0.5
+	variants_by_parent_type = list(/obj/item/weapon/gun/rifle/standard_assaultrifle = "reddot_test")
 
 /obj/item/attachable/m16sight
 	name = "M16 iron sights"

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -527,7 +527,6 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	accuracy_mod = 0.15
 	accuracy_unwielded_mod = 0.1
 	aim_mode_delay_mod = -0.5
-	variants_by_parent_type = list(/obj/item/weapon/gun/rifle/standard_assaultrifle = "reddot_test")
 
 /obj/item/attachable/m16sight
 	name = "M16 iron sights"

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -199,9 +199,11 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 			if(master_gun == living_user.l_hand || master_gun == living_user.r_hand)
 				action_to_update.give_action(living_user)
 
-	//custom overlays for specific guns
-	if(length(variants_by_parent_type) && (master_gun.type in variants_by_parent_type))
-		icon_state = variants_by_parent_type[master_gun.type]
+	//custom attachment icons for specific guns
+	if(length(variants_by_parent_type))
+		for(var/selection in variants_by_parent_type)
+			if(istype(master_gun, selection))
+				icon_state = variants_by_parent_type[selection]
 
 	update_icon()
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Armour attachments have different icons for jaeger and xenonauten, but the way it is currently coded means it checks for the exact type of the parent item when deciding on whether to use a different icon or not.
This means child items don't work unless every one is added to every list (for example, preset armour in the quick load vendors).

Refactored so it can properly istype, to fix this problem.

Also added this same functionality to gun attachments as there are quite a few use cases.
For example not all guns are in the same scale, so certain attachments can look funky on some guns, and some attachments just don't fit smoothly onto some guns due to their design.

Not actually used in this PR because I need to make mad coder sprites, but I will after Combat Patrol is merged as this issue is quite notable on some of the new SOM guns.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Refactor and bug fix good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Armour attachments will display the correct icons on armor types as expected
refactor: Refactored variant icons for armor attachments
add: Added variant icon support to gun attachments
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
