### PR TITLE
Volkite powerpack fix

### DIFF
--- a/code/modules/projectiles/magazines/energy.dm
+++ b/code/modules/projectiles/magazines/energy.dm
@@ -123,15 +123,16 @@
 		gun.reload(src, user)
 		return
 
-	if(istype(I, /obj/item/cell))
-		if(I != user.r_hand && I != user.l_hand)
-			to_chat(user, span_warning("[I] must be in your hand to do that."))
-			return
-		var/obj/item/cell/D = I
-		var/charge_difference = D.maxcharge - D.charge
-		if(charge_difference) //If the cell has less than max charge, recharge it.
-			var/charge_used = use_charge(user, charge_difference) //consume an appropriate amount of charge
-			D.charge += charge_used //Recharge the cell battery with the lower of the difference between its present and max cap, or the remaining charge
-			D.update_icon()
-		else
-			to_chat(user, span_warning("This cell is already at maximum charge!"))
+	if(!istype(I, /obj/item/cell))
+		return
+	if(I != user.r_hand && I != user.l_hand)
+		to_chat(user, span_warning("[I] must be in your hand to do that."))
+		return
+	var/obj/item/cell/D = I
+	var/charge_difference = D.maxcharge - D.charge
+	if(charge_difference) //If the cell has less than max charge, recharge it.
+		var/charge_used = use_charge(user, charge_difference) //consume an appropriate amount of charge
+		D.charge += charge_used //Recharge the cell battery with the lower of the difference between its present and max cap, or the remaining charge
+		D.update_icon()
+	else
+		to_chat(user, span_warning("This cell is already at maximum charge!"))

--- a/code/modules/projectiles/magazines/energy.dm
+++ b/code/modules/projectiles/magazines/energy.dm
@@ -114,20 +114,24 @@
 		to_chat(user, span_notice("[warning]<b>Charge Remaining: [charge]/[maxcharge]</b>"))
 	update_icon()
 
-/obj/item/cell/lasgun/volkite/powerpack/MouseDrop_T(obj/item/W, mob/living/user) //Dragging the power cell onto the backpack will trigger its special functionality.
+/obj/item/cell/lasgun/volkite/powerpack/attackby(obj/item/I, mob/user, params)
 	. = ..()
-	if(!istype(W, /obj/item/cell))
+	if(istype(I, /obj/item/weapon/gun) && loc == user)
+		var/obj/item/weapon/gun/gun = I
+		if(!CHECK_BITFIELD(gun.reciever_flags, AMMO_RECIEVER_MAGAZINES))
+			return
+		gun.reload(src, user)
 		return
 
-	if(W != user.r_hand && W != user.l_hand)
-		to_chat(user, span_warning("[W] must be in your hand to do that."))
-		return
-
-	var/obj/item/cell/D = W
-	var/charge_difference = D.maxcharge - D.charge
-	if(charge_difference) //If the cell has less than max charge, recharge it.
-		var/charge_used = use_charge(user, charge_difference) //consume an appropriate amount of charge
-		D.charge += charge_used //Recharge the cell battery with the lower of the difference between its present and max cap, or the remaining charge
-		D.update_icon()
-	else
-		to_chat(user, span_warning("This cell is already at maximum charge!"))
+	if(istype(I, /obj/item/cell))
+		if(I != user.r_hand && I != user.l_hand)
+			to_chat(user, span_warning("[I] must be in your hand to do that."))
+			return
+		var/obj/item/cell/D = I
+		var/charge_difference = D.maxcharge - D.charge
+		if(charge_difference) //If the cell has less than max charge, recharge it.
+			var/charge_used = use_charge(user, charge_difference) //consume an appropriate amount of charge
+			D.charge += charge_used //Recharge the cell battery with the lower of the difference between its present and max cap, or the remaining charge
+			D.update_icon()
+		else
+			to_chat(user, span_warning("This cell is already at maximum charge!"))


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently you can only tactical reload a culverin by dragging the powerpack to the gun (which is kinda funny since if you get brain damage now, you can no longer operate it).

The same also applies to the caliver if used with a powerpack of course.

Added attackby code to the culverin so you can now normal reload it (click on the powerpack with the gun).
I also moved cell charging from click drag to power pack to just clicking the powerpack with the cell.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Braindamaged ungas should be able to use their guns
bugfix good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Volkite culverins and calivers can now be normally reloaded by clicking the powerpack with the gun, instead of only being tac reloadable
add: Volkite powerpacks now recharge cells by clicking the powerpack with the cell instead of click dragging
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
