### PR TITLE
Splint break sound range limit

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -195,7 +195,7 @@
 		if(splint_health <= 0)
 			remove_limb_flags(LIMB_SPLINTED)
 			to_chat(owner, span_userdanger("The splint on your [display_name] comes apart!"))
-			playsound(owner, 'sound/items/splint_break.ogg', 100, falloff=5)
+			playsound(owner, 'sound/items/splint_break.ogg', 100, sound_range = 1, falloff = 5)
 		else
 			splint_health = max(splint_health - (brute + burn), 0)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Being able to hear your splint break is a super useful addition to the game, but currently the sound has a theoretical max range of 100 tiles, which effectively means you'll hear everyone's splints breaking which is uh, not ideal since you can't tell if it's yours or not.

Makes the sound effect have a range of 1, so you'll only hear other people's splints break if you're right next to them (So xenos still get to hear that juicy pop when they melee someone's splints off).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hearing everyones splints breaking across the map is funny but not useful.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Splint break sounds no longer carry over large distances
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
