### PR TITLE
Adds a little Tox power to Sent neuro spit.

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2353,7 +2353,7 @@ datum/ammo/bullet/revolver/tp44
 	bullet_color = BOILER_LUMINOSITY_AMMO_NEUROTOXIN_COLOR
 	reagent_transfer_amount = 30
 	///On a direct hit, how long is the target paralyzed?
-	var/hit_paralyze_time = 1 SECONDS
+	var/hit_paralyze_time = 2.5 SECONDS
 	///On a direct hit, how much do the victim's eyes get blurred?
 	var/hit_eye_blur = 11
 	///On a direct hit, how much drowsyness gets added to the target?
@@ -2465,7 +2465,7 @@ datum/ammo/bullet/revolver/tp44
 	damage_type = BURN
 	penetration = 40
 	bullet_color = BOILER_LUMINOSITY_AMMO_CORROSIVE_COLOR
-	hit_paralyze_time = 1 SECONDS
+	hit_paralyze_time = 2 SECONDS
 	hit_eye_blur = 1
 	hit_drowsyness = 1
 	reagent_transfer_amount = 0

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -470,7 +470,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 2
 	overdose_threshold = 10000 //Overdosing for neuro is what happens when you run out of stamina to avoid its oxy and toxin damage
 	scannable = TRUE
-	toxpwr = 0
+	toxpwr = 0.3
 
 /datum/reagent/toxin/xeno_neurotoxin/on_mob_life(mob/living/L, metabolism)
 	var/power


### PR DESCRIPTION


## About The Pull Request

Makes sentinel neuro a bit better.

## Why It's Good For The Game

Currently Sentinel neuro spit is very very slow acting on marines, the only marines that die from neuro are either decapped with no way back or afk. its also very easy to purge, it also has no use against robots.

This gives Sentinel neuro spit some Tox power so the sentinel can be rewarded for good hits rather then feeling they do nothing. it is currently set at 0.3 for now to see how it affects gameplay.

Marines currently are having easy times killing xenos whilst xenos have no stopping power because of the new gear marines get, this aims to give xenos a bit more punch for their risk.

## Changelog
:cl:
balance: Neuro spit for sentinel = 0.3 Tox power.
/:cl:


