### PR TITLE
Make light masks visible again

### DIFF
--- a/code/modules/lighting/lighting_mask/lighting_mask.dm
+++ b/code/modules/lighting/lighting_mask/lighting_mask.dm
@@ -16,7 +16,6 @@
 	blend_mode = BLEND_ADD
 	appearance_flags = KEEP_TOGETHER|RESET_TRANSFORM
 	move_resist = INFINITY
-	vis_flags = VIS_HIDE
 
 	///The current angle the item is pointing at
 	var/current_angle = 0


### PR DESCRIPTION
## About The Pull Request
Light masks were made hidden because??? Now they are not hidden. Mortar flare shells and mech lights worked during testing. Wraith portal seems fine during testing as well.

## Why It's Good For The Game
So mortar flares can be useful again.

## Changelog
:cl:
fix: Make hybrid lights visible again
/:cl: