### PR TITLE
plasma pistol does less direct damage when attached

### DIFF
--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -122,10 +122,12 @@
 
 /obj/item/weapon/gun/pistol/plasma_pistol/on_attach(obj/item/attached_to, mob/user)
 	flags_gun_features |= GUN_WIELDED_STABLE_FIRING_ONLY|GUN_WIELDED_FIRING_ONLY
+	damage_mult = 0.1
 	return ..()
 
 /obj/item/weapon/gun/pistol/plasma_pistol/on_detach(obj/item/attached_to, mob/user)
 	flags_gun_features &= ~GUN_WIELDED_STABLE_FIRING_ONLY|GUN_WIELDED_FIRING_ONLY
+	damage_mult = 1
 	return ..()
 
 


### PR DESCRIPTION
## About The Pull Request
see title

i tested this a few times, looks like the damage mod changes both attached and attached+removed work fine
## Why It's Good For The Game
miniflamer got its direct damage sent to brazil before, this is just that but plasma pistol

also for some reason the projectile doesnt transfer fire stacks at 0 damage mod, so i had to settle for 0.1 damage mod

also also plasma pistol is kinda bugged and you can't fire it outside of PBs after you remove it from a gun

## Changelog
:cl:
balance: plasma pistol attachment direct damage reduced to almost nothing
/:cl:
