### PR TITLE
Vending restock changes

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -153,6 +153,10 @@
 
 #define isgun(A) (istype(A, /obj/item/weapon/gun))
 
+#define isammomagazine(A) (istype(A, /obj/item/ammo_magazine))
+
+#define isgrenade(A) (istype(A, /obj/item/explosive/grenade))
+
 #define isstorage(A) (istype(A, /obj/item/storage))
 
 #define isitemstack(A) (istype(A, /obj/item/stack))
@@ -190,6 +194,8 @@
 #define ismultitool(I) (istype(I, /obj/item/multitool))
 
 #define iscrowbar(I) (istype(I, /obj/item/tool/crowbar))
+
+#define iscell(I) (istype(I, /obj/item/cell))
 
 #define isfactorypart(I) (istype(I, /obj/item/factory_part))
 

--- a/code/__DEFINES/vending.dm
+++ b/code/__DEFINES/vending.dm
@@ -1,0 +1,4 @@
+// Vending machine flags
+
+///Vendor is capable of recharging cells when restocking.
+#define VENDING_RECHARGER (1<<0)

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -685,6 +685,7 @@
 	icon_state = "lascharger"
 	icon_vend = "lascharger-vend"
 	icon_deny = "lascharger-denied"
+	vending_flags = VENDING_RECHARGER
 	wrenchable = TRUE
 	drag_delay = FALSE
 	anchored = FALSE
@@ -708,78 +709,16 @@
 /obj/machinery/vending/lasgun/update_icon()
 	if(machine_max_charge)
 		switch(machine_current_charge / max(1,machine_max_charge))
-			if(0)
-				icon_state = "lascharger-off"
-			if(1 to 0.76)
+			if(0.7 to 1)
 				icon_state = "lascharger"
-			if(0.75 to 0.51)
+			if(0.51 to 0.75)
 				icon_state = "lascharger_75"
-			if(0.50 to 0.26)
+			if(0.26 to 0.50)
 				icon_state = "lascharger_50"
-			if(0.25 to 0.01)
+			if(0.01 to 0.25)
 				icon_state = "lascharger_25"
-
-/obj/machinery/vending/lasgun/examine(mob/user)
-	. = ..()
-	. += "<b>It has [machine_current_charge] of [machine_max_charge] charge remaining.</b>"
-
-
-/obj/machinery/vending/lasgun/MouseDrop_T(atom/movable/A, mob/user)
-	if(machine_stat & (BROKEN|NOPOWER))
-		return
-
-	if(user.stat || user.restrained() || user.lying_angle)
-		return
-
-	if(get_dist(user, src) > 1 || get_dist(src, A) > 1)
-		return
-
-	var/obj/item/I = A
-	if(istype(I, /obj/item/cell/lasgun))
-		stock(I, user, TRUE)
-	else
-		stock(I, user)
-
-/obj/machinery/vending/lasgun/stock(obj/item/item_to_stock, mob/user, recharge = FALSE)
-	//More accurate comparison between absolute paths.
-	for(var/datum/vending_product/R AS in (product_records + coin_records ))
-		if(item_to_stock.type == R.product_path && !istype(item_to_stock,/obj/item/storage)) //Nice try, specialists/engis
-			if(istype(item_to_stock, /obj/item/cell/lasgun) && recharge)
-				if(!recharge_lasguncell(item_to_stock, user))
-					return //Can't recharge so cancel out
-
-			if(item_to_stock.loc == user) //Inside the mob's inventory
-				if(item_to_stock.flags_item & WIELDED)
-					item_to_stock.unwield(user)
-				user.temporarilyRemoveItemFromInventory(item_to_stock)
-
-			if(istype(item_to_stock.loc, /obj/item/storage)) //inside a storage item
-				var/obj/item/storage/S = item_to_stock.loc
-				S.remove_from_storage(item_to_stock, user.loc, user)
-
-			qdel(item_to_stock)
-			if(!recharge)
-				user.visible_message(span_notice("[user] stocks [src] with \a [R.product_name]."),
-				span_notice("You stock [src] with \a [R.product_name]."))
-			R.amount++
-			updateUsrDialog()
-			break //We found our item, no reason to go on.
-
-/obj/machinery/vending/lasgun/proc/recharge_lasguncell(obj/item/cell/lasgun/A, mob/user)
-	var/recharge_cost = (A.maxcharge - A.charge)
-	if(recharge_cost > machine_current_charge)
-		to_chat(user, span_warning("[A] cannot be recharged; [src] has inadequate charge remaining: [machine_current_charge] of [machine_max_charge]."))
-		return FALSE
-	else
-		to_chat(user, span_warning("You insert [A] into [src] to be recharged."))
-		if(icon_vend)
-			flick(icon_vend,src)
-		playsound(loc, 'sound/machines/hydraulics_1.ogg', 25, 0, 1)
-		machine_current_charge -= min(machine_current_charge, recharge_cost)
-		to_chat(user, span_notice("This dispenser has [machine_current_charge] of [machine_max_charge] remaining."))
-		update_icon()
-		return TRUE
-
+			if(0)
+				icon_state = "lascharger_0"
 
 /obj/machinery/vending/marineFood
 	name = "\improper Marine Food and Drinks Vendor"

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -656,18 +656,6 @@
 		display_message_and_visuals(user, show_feedback, "Can't restock containers!", VENDING_RESTOCK_DENY)
 		return FALSE
 
-	if(isgun(item_to_stock))
-		var/obj/item/weapon/gun/G = item_to_stock
-
-		if(G.rounds) //We are not barbarians and stock loaded weapons. TerraGov has standards!
-			display_message_and_visuals(user, show_feedback, "Gun is still loaded!", VENDING_RESTOCK_DENY)
-			return FALSE
-
-		for(var/obj/item/attachable/A in G.contents) //Search for attachments on the gun. This is the easier method
-			if((A.flags_attach_features & ATTACH_REMOVABLE) && !(is_type_in_list(A, G.starting_attachment_types))) //There are attachments that are default and others that can't be removed
-				display_message_and_visuals(user, show_feedback, "Gun has non-standard attachments equipped!", VENDING_RESTOCK_DENY)
-				return FALSE
-
 	else if(isgrenade(item_to_stock))
 		var/obj/item/explosive/grenade/grenade = item_to_stock
 		if(grenade.active) //Machine ain't gonna save you from your dumb decisions now

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -168,6 +168,8 @@
 
 	///Faction of the vendor. Can be null
 	var/faction
+	///Timerid for the automatic mass restock of excess items.
+	var/restock_timer
 
 
 /obj/machinery/vending/Initialize(mapload, ...)
@@ -601,7 +603,7 @@
 		else
 			return
 	SSblackbox.record_feedback("tally", "vendored", 1, R.product_name)
-	addtimer(CALLBACK(src, .proc/stock_vacuum), 2.5 MINUTES, TIMER_UNIQUE | TIMER_OVERRIDE) // We clean up some time after the last item has been vended.
+	restock_timer = addtimer(CALLBACK(src, .proc/stock_vacuum), 2.5 MINUTES, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_STOPPABLE) // We clean up some time after the last item has been vended.
 	if(vending_sound)
 		playsound(src, vending_sound, 25, 0)
 	else
@@ -739,6 +741,7 @@
 		stocked = stock(I, null, FALSE) ? TRUE : stocked
 
 	stocked ? display_message_and_visuals(user, TRUE, "Automatically restocked all items from outlet.", VENDING_RESTOCK_ACCEPT) : null
+	restock_timer ? deltimer(restock_timer) : null
 
 	update_icon()
 

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -2,6 +2,12 @@
 #define CAT_HIDDEN 1
 #define CAT_COIN 2
 
+#define VENDING_RESTOCK_IDLE 0
+#define VENDING_RESTOCK_DENY 1
+#define VENDING_RESTOCK_RECHARGE 2
+#define VENDING_RESTOCK_ACCEPT 3
+#define VENDING_RESTOCK_ACCEPT_RECHARGE 4
+
 #define MAKE_VENDING_RECORD_DATA(record) list(\
 		"product_name" = record.product_name,\
 		"product_color" = record.display_color,\
@@ -69,6 +75,8 @@
 	var/vend_ready = TRUE
 	///How long it takes to vend an item, vend_ready is false during that.
 	var/vend_delay = 10
+	///Vending flags to determine the behaviour of the machine
+	var/vending_flags = null
 	/// A /datum/vending_product instance of what we're paying for right now.
 	var/datum/vending_product/currently_vending = null
 	///If this vendor uses a global list for items.
@@ -192,6 +200,11 @@
 /obj/machinery/vending/LateInitialize()
 	. = ..()
 	power_change()
+
+/obj/machinery/vending/examine(mob/user)
+	. = ..()
+	if(vending_flags & VENDING_RECHARGER)
+		. += "Internal battery charge: <b>[machine_current_charge]</b>/<b>[machine_max_charge]</b>"
 
 
 /obj/machinery/vending/Destroy()
@@ -361,8 +374,7 @@
 			var/turf/current_turf = get_turf(src)
 			if(current_turf && density)
 				current_turf.flags_atom &= ~AI_BLOCKED
-
-	else if(istype(I, /obj/item))
+	else if(isitem(I))
 		var/obj/item/to_stock = I
 		stock(to_stock, user)
 
@@ -521,6 +533,10 @@
 				currently_vending = R
 			. = TRUE
 
+		if("vacuum")
+			stock_vacuum(usr)
+			. = TRUE
+
 		if("cancel_buying")
 			currently_vending = null
 			. = TRUE
@@ -610,63 +626,159 @@
 		var/obj/item/I = A
 		stock(I, user)
 
-/obj/machinery/vending/proc/stock(obj/item/item_to_stock, mob/user, recharge = FALSE)
-	if(!powered(power_channel) && machine_current_charge < active_power_usage)
-		return
-	if(icon_vend)
-		flick(icon_vend, src) //Show the vending animation if needed
-	//More accurate comparison between absolute paths.
-	for(var/datum/vending_product/R AS in product_records + hidden_records + coin_records)
-		if(item_to_stock.type != R.product_path || istype(item_to_stock, /obj/item/storage)) //Nice try, specialists/engis
-			continue
-		if(istype(item_to_stock, /obj/item/weapon/gun))
-			var/obj/item/weapon/gun/G = item_to_stock
-			if(G.rounds)
-				to_chat(user, span_warning("[G] is still loaded. Unload it before you can restock it."))
-				return
-			for(var/obj/item/attachable/A in G.contents) //Search for attachments on the gun. This is the easier method
-				if((A.flags_attach_features & ATTACH_REMOVABLE) && !(is_type_in_list(A, G.starting_attachment_types))) //There are attachments that are default and others that can't be removed
-					to_chat(user, span_warning("[G] has non-standard attachments equipped. Detach them before you can restock it."))
-					return
+/**
+ * Tries to restock "item_to_stock" into the vending machine again after some checks.
+ * show_feedback states whether or not to display any messages to the player, display the vending flicker animation as well as sound effects when recharging a cell.
+ * Returns TRUE if item has been restocked, FALSE otherwise..
+ */
+/obj/machinery/vending/proc/stock(obj/item/item_to_stock, mob/user, show_feedback = TRUE)
+	/// The found record matching the item_to_stock in the vending_records lists
+	var/datum/vending_product/record = FALSE
+	/// In case of a cell, the amount of charge required to fully charge said cell
+	var/recharge_amount = 0
 
-		else if(istype(item_to_stock, /obj/item/ammo_magazine))
+	if(!powered(power_channel) && machine_current_charge < active_power_usage)
+		display_message_and_visuals(user, show_feedback, "Vendor is unresponsive!", VENDING_RESTOCK_IDLE)
+		return FALSE
+
+	for(var/datum/vending_product/R AS in product_records + hidden_records + coin_records)
+		if(item_to_stock.type != R.product_path)
+			continue
+		record = R
+
+	if(!record) //Item isn't listed in the vending records.
+		display_message_and_visuals(user, show_feedback, "[item_to_stock] doesn't belong here!", VENDING_RESTOCK_DENY)
+		return FALSE
+
+	//More accurate comparison between absolute paths.
+	if(isstorage(item_to_stock)) //Nice try, specialists/engis
+		display_message_and_visuals(user, show_feedback, "Can't restock containers!", VENDING_RESTOCK_DENY)
+		return FALSE
+
+	if(isgun(item_to_stock))
+		var/obj/item/weapon/gun/G = item_to_stock
+
+		if(G.rounds) //We are not barbarians and stock loaded weapons. TerraGov has standards!
+			display_message_and_visuals(user, show_feedback, "Gun is still loaded!", VENDING_RESTOCK_DENY)
+			return FALSE
+
+		for(var/obj/item/attachable/A in G.contents) //Search for attachments on the gun. This is the easier method
+			if((A.flags_attach_features & ATTACH_REMOVABLE) && !(is_type_in_list(A, G.starting_attachment_types))) //There are attachments that are default and others that can't be removed
+				display_message_and_visuals(user, show_feedback, "Gun has non-standard attachments equipped!", VENDING_RESTOCK_DENY)
+				return FALSE
+
+	else if(record.amount >= 0) //Item is finite so we are more strict on it's condition
+
+		if(isammomagazine(item_to_stock))
 			var/obj/item/ammo_magazine/A = item_to_stock
 			if(A.current_rounds < A.max_rounds)
-				to_chat(user, span_warning("[A] isn't full. Fill it before you can restock it."))
-				return
-		else if(istype(item_to_stock, /obj/item/cell))
+				display_message_and_visuals(user, show_feedback, "Magazine isn't full!", VENDING_RESTOCK_DENY)
+				return FALSE
+
+		if(iscell(item_to_stock))
 			var/obj/item/cell/cell = item_to_stock
+
 			if(cell.charge < cell.maxcharge)
-				to_chat(user, span_warning("\The [cell] isn't full. You must recharge it before you can restock it."))
-				return
-		else if(isitemstack(item_to_stock))
+
+				if(vending_flags & VENDING_RECHARGER) // Item is finite and not full. Time to try to recharge
+					recharge_amount = cell.maxcharge - cell.charge
+
+					if(machine_current_charge == 0)
+						display_message_and_visuals(user, show_feedback, "No power!", VENDING_RESTOCK_DENY)
+						return FALSE
+
+					else if(machine_current_charge < recharge_amount) // Not enough but some charge remaining so partially recharge cell and move on
+						cell.give(machine_current_charge)
+						machine_current_charge = 0
+						cell.update_icon()
+						display_message_and_visuals(user, show_feedback, "Cell charged partially! [round(cell.percent())]%.", VENDING_RESTOCK_RECHARGE)
+						playsound(loc, 'sound/machines/hydraulics_1.ogg', 25, 0, 1)
+						return FALSE
+
+				else
+					display_message_and_visuals(user, show_feedback, "Cell isn't at full charge!", VENDING_RESTOCK_DENY)
+					return FALSE
+
+		if(isitemstack(item_to_stock))
 			var/obj/item/stack/stack = item_to_stock
 			if(stack.amount != initial(stack.amount))
-				to_chat(user, span_warning("[stack] has been partially used. You must replace the missing amount before you can restock it."))
-				return
-		else if(istype(item_to_stock, /obj/item/reagent_containers))
+				display_message_and_visuals(user, show_feedback, "[stack] has been partially used. Refill it!", VENDING_RESTOCK_DENY)
+				return FALSE
+
+		if(isreagentcontainer(item_to_stock))
 			var/obj/item/reagent_containers/reagent_container = item_to_stock
 			if(!reagent_container.free_refills && !reagent_container.has_initial_reagents())
-				to_chat(user, span_warning("\The [reagent_container] is missing some of its reagents. You must refill it before you can restock it."))
-				return
+				display_message_and_visuals(user, show_feedback, "\The [reagent_container] is missing some of its reagents!", VENDING_RESTOCK_DENY)
+				return FALSE
 
-		if(item_to_stock.loc == user) //Inside the mob's inventory
-			if(item_to_stock.flags_item & WIELDED)
-				item_to_stock.unwield(user)
-			user.transferItemToLoc(item_to_stock, src)
+		if(isgrenade(item_to_stock))
+			var/obj/item/explosive/grenade/grenade = item_to_stock
+			if(grenade.active) //Machine ain't gonna save you from your dumb decisions now
+				display_message_and_visuals(user, show_feedback, "You panic and erratically fumble around!", VENDING_RESTOCK_DENY)
+				return FALSE
 
-		if(istype(item_to_stock.loc, /obj/item/storage)) //inside a storage item
-			var/obj/item/storage/S = item_to_stock.loc
-			S.remove_from_storage(item_to_stock, user.loc, user)
+	// At this point the item is guaranteed to be accepted into the vending machine
 
-		qdel(item_to_stock)
-		if(!recharge)
-			user.visible_message(span_notice("[user] stocks [src] with \a [R.product_name]."),
-			span_notice("You stock [src] with \a [R.product_name]."))
-		if(R.amount >= 0) //R negative means infinite item, no need to restock
-			R.amount++
-		updateUsrDialog()
-		return //We found our item, no reason to go on.
+	if(item_to_stock.loc == user) //Inside the mob's inventory
+		if(item_to_stock.flags_item & WIELDED)
+			item_to_stock.unwield(user)
+		user.transferItemToLoc(item_to_stock, src)
+
+	if(istype(item_to_stock.loc, /obj/item/storage)) //inside a storage item
+		var/obj/item/storage/S = item_to_stock.loc
+		S.remove_from_storage(item_to_stock, user.loc, user)
+
+	if(vending_flags & VENDING_RECHARGER && recharge_amount)
+		machine_current_charge -= recharge_amount
+		display_message_and_visuals(user, show_feedback, "Restocked and recharged", VENDING_RESTOCK_ACCEPT_RECHARGE)
+	else
+		display_message_and_visuals(user, show_feedback, "Restocked", VENDING_RESTOCK_ACCEPT)
+
+	qdel(item_to_stock)
+
+	if(record.amount >= 0) //R negative means infinite item, no need to restock
+		record.amount++
+
+	updateUsrDialog()
+	return TRUE //Item restocked, no reason to go on.
+
+/// Vending machine tries to restock all of the loose item on it's location onto itself.
+/obj/machinery/vending/proc/stock_vacuum(mob/user)
+	var/stocked = FALSE
+
+	for(var/obj/item/I in loc)
+		stocked = stock(I, null, FALSE) ? TRUE : stocked
+
+	stocked ? display_message_and_visuals(user, TRUE, "Automatically restocked all items from outlet.", VENDING_RESTOCK_ACCEPT) : null
+
+	update_icon()
+
+/**
+ * Displays a balloon alert to the user if enable is true
+ * state determines what the vending machine will do other than display a simple balloon message
+ */
+/obj/machinery/vending/proc/display_message_and_visuals(mob/user, enable = TRUE, message, state = VENDING_RESTOCK_ACCEPT)
+	if(!enable || !user)
+		return
+	message ? balloon_alert(user, message) : null
+	switch(state)
+		if(VENDING_RESTOCK_DENY)
+			update_icon()
+			if(icon_deny)
+				flick(icon_deny, src)
+		if(VENDING_RESTOCK_RECHARGE)
+			update_icon()
+			playsound(loc, 'sound/machines/hydraulics_1.ogg', 25, 0, 1)
+		if(VENDING_RESTOCK_ACCEPT)
+			update_icon()
+			if(icon_vend)
+				flick(icon_vend, src)
+		if(VENDING_RESTOCK_ACCEPT_RECHARGE)
+			update_icon()
+			if(icon_vend)
+				flick(icon_vend, src)
+			playsound(loc, 'sound/machines/hydraulics_1.ogg', 25, 0, 1)
+
 
 /obj/machinery/vending/process()
 	if(machine_stat & (BROKEN|NOPOWER))
@@ -750,3 +862,15 @@
 	if(density && dam >= knockdown_threshold)
 		tip_over()
 	return ..()
+
+#undef CAT_NORMAL
+#undef CAT_HIDDEN
+#undef CAT_COIN
+
+#undef VENDING_RESTOCK_IDLE
+#undef VENDING_RESTOCK_DENY
+#undef VENDING_RESTOCK_RECHARGE
+#undef VENDING_RESTOCK_ACCEPT
+#undef VENDING_RESTOCK_ACCEPT_RECHARGE
+
+#undef MAKE_VENDING_RECORD_DATA

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -76,7 +76,7 @@
 	///How long it takes to vend an item, vend_ready is false during that.
 	var/vend_delay = 10
 	///Vending flags to determine the behaviour of the machine
-	var/vending_flags = null
+	var/vending_flags = NONE
 	/// A /datum/vending_product instance of what we're paying for right now.
 	var/datum/vending_product/currently_vending = null
 	///If this vendor uses a global list for items.
@@ -673,7 +673,7 @@
 			display_message_and_visuals(user, show_feedback, "You panic and erratically fumble around!", VENDING_RESTOCK_DENY)
 			return FALSE
 
-	else if(record.amount >= 0) //Item is finite so we are more strict on it's condition
+	else if(record.amount >= 0) //Item is finite so we are more strict on its condition
 
 		if(isammomagazine(item_to_stock))
 			var/obj/item/ammo_magazine/A = item_to_stock

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -168,10 +168,6 @@
 
 	///Faction of the vendor. Can be null
 	var/faction
-	///If the machine clean itself up after being idle.
-	var/self_cleaned = TRUE
-	///Timer for the self_cleanup to trigger automatically upon being idle.
-	COOLDOWN_DECLARE(self_clean_cooldown)
 
 
 /obj/machinery/vending/Initialize(mapload, ...)
@@ -605,8 +601,7 @@
 		else
 			return
 	SSblackbox.record_feedback("tally", "vendored", 1, R.product_name)
-	self_cleaned = FALSE
-	COOLDOWN_START(src, self_clean_cooldown, 2.5 MINUTES)
+	addtimer(CALLBACK(src, .proc/stock_vacuum), 2.5 MINUTES, TIMER_UNIQUE | TIMER_OVERRIDE) // We clean up some time after the last item has been vended.
 	if(vending_sound)
 		playsound(src, vending_sound, 25, 0)
 	else
@@ -758,7 +753,6 @@
 	stocked ? display_message_and_visuals(user, TRUE, "Automatically restocked all items from outlet.", VENDING_RESTOCK_ACCEPT) : null
 
 	update_icon()
-	self_cleaned = TRUE
 
 /**
  * Displays a balloon alert to the user if enable is true
@@ -805,9 +799,6 @@
 
 	if(shoot_inventory && prob(2) && !hacking_safety)
 		throw_item()
-
-	if(COOLDOWN_CHECK(src, self_clean_cooldown) && !self_cleaned) // It's been a while since somoene vended something
-		stock_vacuum()
 
 /obj/machinery/vending/proc/speak(message)
 	if(machine_stat & NOPOWER)

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -168,10 +168,6 @@
 
 	///Faction of the vendor. Can be null
 	var/faction
-	///If the machine cleaned itself up after being idle long enough.
-	var/self_cleaned = TRUE
-	///Timer for the self_cleanup to trigger automatically upon being idle.
-	COOLDOWN_DECLARE(self_clean_cooldown)
 
 
 /obj/machinery/vending/Initialize(mapload, ...)
@@ -605,8 +601,7 @@
 		else
 			return
 	SSblackbox.record_feedback("tally", "vendored", 1, R.product_name)
-	self_cleaned = FALSE
-	COOLDOWN_START(src, self_clean_cooldown, 2.5 MINUTES) // We clean up some time after the last item has been vended.
+	addtimer(CALLBACK(src, .proc/stock_vacuum), 2.5 MINUTES, TIMER_UNIQUE | TIMER_OVERRIDE) // We clean up some time after the last item has been vended.
 	if(vending_sound)
 		playsound(src, vending_sound, 25, 0)
 	else
@@ -746,7 +741,6 @@
 	stocked ? display_message_and_visuals(user, TRUE, "Automatically restocked all items from outlet.", VENDING_RESTOCK_ACCEPT) : null
 
 	update_icon()
-	self_cleaned = TRUE
 
 /**
  * Displays a balloon alert to the user if enable is true
@@ -793,9 +787,6 @@
 
 	if(shoot_inventory && prob(2) && !hacking_safety)
 		throw_item()
-
-	if(COOLDOWN_CHECK(src, self_clean_cooldown) && !self_cleaned)
-		stock_vacuum()
 
 /obj/machinery/vending/proc/speak(message)
 	if(machine_stat & NOPOWER)

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -168,6 +168,10 @@
 
 	///Faction of the vendor. Can be null
 	var/faction
+	///If the machine cleaned itself up after being idle long enough.
+	var/self_cleaned = TRUE
+	///Timer for the self_cleanup to trigger automatically upon being idle.
+	COOLDOWN_DECLARE(self_clean_cooldown)
 
 
 /obj/machinery/vending/Initialize(mapload, ...)
@@ -601,7 +605,8 @@
 		else
 			return
 	SSblackbox.record_feedback("tally", "vendored", 1, R.product_name)
-	addtimer(CALLBACK(src, .proc/stock_vacuum), 2.5 MINUTES, TIMER_UNIQUE | TIMER_OVERRIDE) // We clean up some time after the last item has been vended.
+	self_cleaned = FALSE
+	COOLDOWN_START(src, self_clean_cooldown, 2.5 MINUTES) // We clean up some time after the last item has been vended.
 	if(vending_sound)
 		playsound(src, vending_sound, 25, 0)
 	else
@@ -741,6 +746,7 @@
 	stocked ? display_message_and_visuals(user, TRUE, "Automatically restocked all items from outlet.", VENDING_RESTOCK_ACCEPT) : null
 
 	update_icon()
+	self_cleaned = TRUE
 
 /**
  * Displays a balloon alert to the user if enable is true
@@ -787,6 +793,9 @@
 
 	if(shoot_inventory && prob(2) && !hacking_safety)
 		throw_item()
+
+	if(COOLDOWN_CHECK(src, self_clean_cooldown) && !self_cleaned)
+		stock_vacuum()
 
 /obj/machinery/vending/proc/speak(message)
 	if(machine_stat & NOPOWER)

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -711,11 +711,11 @@
 				display_message_and_visuals(user, show_feedback, "\The [reagent_container] is missing some of its reagents!", VENDING_RESTOCK_DENY)
 				return FALSE
 
-		if(isgrenade(item_to_stock))
-			var/obj/item/explosive/grenade/grenade = item_to_stock
-			if(grenade.active) //Machine ain't gonna save you from your dumb decisions now
-				display_message_and_visuals(user, show_feedback, "You panic and erratically fumble around!", VENDING_RESTOCK_DENY)
-				return FALSE
+	if(isgrenade(item_to_stock))
+		var/obj/item/explosive/grenade/grenade = item_to_stock
+		if(grenade.active) //Machine ain't gonna save you from your dumb decisions now
+			display_message_and_visuals(user, show_feedback, "You panic and erratically fumble around!", VENDING_RESTOCK_DENY)
+			return FALSE
 
 	// At this point the item is guaranteed to be accepted into the vending machine
 

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -667,6 +667,12 @@
 				display_message_and_visuals(user, show_feedback, "Gun has non-standard attachments equipped!", VENDING_RESTOCK_DENY)
 				return FALSE
 
+	else if(isgrenade(item_to_stock))
+		var/obj/item/explosive/grenade/grenade = item_to_stock
+		if(grenade.active) //Machine ain't gonna save you from your dumb decisions now
+			display_message_and_visuals(user, show_feedback, "You panic and erratically fumble around!", VENDING_RESTOCK_DENY)
+			return FALSE
+
 	else if(record.amount >= 0) //Item is finite so we are more strict on it's condition
 
 		if(isammomagazine(item_to_stock))
@@ -710,12 +716,6 @@
 			if(!reagent_container.free_refills && !reagent_container.has_initial_reagents())
 				display_message_and_visuals(user, show_feedback, "\The [reagent_container] is missing some of its reagents!", VENDING_RESTOCK_DENY)
 				return FALSE
-
-	if(isgrenade(item_to_stock))
-		var/obj/item/explosive/grenade/grenade = item_to_stock
-		if(grenade.active) //Machine ain't gonna save you from your dumb decisions now
-			display_message_and_visuals(user, show_feedback, "You panic and erratically fumble around!", VENDING_RESTOCK_DENY)
-			return FALSE
 
 	// At this point the item is guaranteed to be accepted into the vending machine
 

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -168,8 +168,6 @@
 
 	///Faction of the vendor. Can be null
 	var/faction
-	///Timerid for the automatic mass restock of excess items.
-	var/restock_timer
 
 
 /obj/machinery/vending/Initialize(mapload, ...)
@@ -603,7 +601,7 @@
 		else
 			return
 	SSblackbox.record_feedback("tally", "vendored", 1, R.product_name)
-	restock_timer = addtimer(CALLBACK(src, .proc/stock_vacuum), 2.5 MINUTES, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_STOPPABLE) // We clean up some time after the last item has been vended.
+	addtimer(CALLBACK(src, .proc/stock_vacuum), 2.5 MINUTES, TIMER_UNIQUE | TIMER_OVERRIDE) // We clean up some time after the last item has been vended.
 	if(vending_sound)
 		playsound(src, vending_sound, 25, 0)
 	else
@@ -741,7 +739,6 @@
 		stocked = stock(I, null, FALSE) ? TRUE : stocked
 
 	stocked ? display_message_and_visuals(user, TRUE, "Automatically restocked all items from outlet.", VENDING_RESTOCK_ACCEPT) : null
-	restock_timer ? deltimer(restock_timer) : null
 
 	update_icon()
 

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -107,6 +107,7 @@
 #include "code\__DEFINES\turf_flags.dm"
 #include "code\__DEFINES\typeids.dm"
 #include "code\__DEFINES\vehicles.dm"
+#include "code\__DEFINES\vending.dm"
 #include "code\__DEFINES\vv.dm"
 #include "code\__DEFINES\wires.dm"
 #include "code\__DEFINES\xeno.dm"

--- a/tgui/packages/tgui/interfaces/Vending.tsx
+++ b/tgui/packages/tgui/interfaces/Vending.tsx
@@ -29,7 +29,7 @@ type VendingRecord = {
 }
 
 export const Vending = (props, context) => {
-  const { data } = useBackend<VendingData>(context);
+  const { act, data } = useBackend<VendingData>(context);
 
   const {
     vendor_name,
@@ -79,12 +79,19 @@ export const Vending = (props, context) => {
         <Section
           title="Select an item"
           buttons={
-            <Button
-              icon="power-off"
-              selected={showEmpty}
-              onClick={() => setShowEmpty(!showEmpty)}>
-              Show sold-out items
-            </Button>
+            <>
+              <Button
+                icon="power-off"
+                selected={showEmpty}
+                onClick={() => setShowEmpty(!showEmpty)}>
+                Show sold-out items
+              </Button>
+              <Button
+                icon="truck-loading"
+                color="good"
+                tooltip="Stock all loose items in the outlet back into the vending machine"
+                onClick={() => act('vacuum')} />
+            </>
           }>
           {(tabs.length > 0 && (
             <Section


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR changes the restocking behavior of the vending machines somewhat.

Firstly, added a button that sucks up all items on the same tile as the vending machine back into the vendor:
![grafik](https://user-images.githubusercontent.com/41807890/179960586-f0e1b496-9237-4bb8-8738-e561131a9d1b.png)
I intend this to be for people who want to clean up after themselves when filling ammo boxes. Latejoins no longer have to pixelhunt/ alt-click around the 30 stacked mags left on the vendor so they can make their own ammo boxes in peace now.
Vending machine cleans itself up 2.5 minutes after the last vended item.

Secondly, replaced the reject messages as to why you can't restock an item with shorter balloon alerts.

Thirdly, loosened up some of the restrictions on restocking things, especially in correlation with infinite items.
You no longer need to refill a magazine, charge a cell or refill reagent bottles to restock it if it's infinitely available anyways.
Lasgun field recharger now uses up its internal machine charge when having cells recharged and restocked.
(Field charger has enough charge to recharge about 80 cells roundstart and charges enough energy to fill a new cell every 2 seconds if it's anchored. Haven't changed the charge rate and capacity)

Fourth, grenades no longer get accepted into the vending machine if it's primed. I dare you to try.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

A cleaner prep room makes a cleaner op
Also less restock spam/ emptying vendor tiles 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Added a new button to restock all loose items ontop of a vending machine's turf.
fix: Lasgun field charger now updates their charge meter icon state properly.
fix: Vending machines no longer save you from active grenades
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
