### PR TITLE
AR-21 Skirmish rifle (AP buff)

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -587,8 +587,8 @@ datum/ammo/bullet/revolver/tp44
 	name = "heavy rifle bullet"
 	hud_state = "hivelo"
 	damage = 30
-	penetration = 10
-	sundering = 1.25
+	penetration = 15
+	sundering = 1.5
 
 /datum/ammo/bullet/rifle/repeater
 	name = "heavy impact rifle bullet"


### PR DESCRIPTION
## About The Pull Request

Changes the 10x25mm (heavy rifle bullet) penetration from 10 to 15 and the sunder from 1.25 to 1.5

## Why It's Good For The Game

makes the AR-21 a real "bigger than average round" rifle, always overshadowed by the BR-64

## Changelog
:cl:
balance: Buffed AR-21 AP and sunder
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
