### PR TITLE
Remove untangle's 10 slowdown

### DIFF
--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -138,7 +138,6 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list( //Those networks can only be 
 #define RAZORWIRE_ENTANGLE_DELAY 5 SECONDS
 #define RAZORWIRE_SOAK 5
 #define RAZORWIRE_MAX_HEALTH 100
-#define RAZORWIRE_SLOWDOWN 10
 #define RAZORWIRE_MIN_DAMAGE_MULT_LOW 0.4 //attacking
 #define RAZORWIRE_MAX_DAMAGE_MULT_LOW 0.6
 #define RAZORWIRE_MIN_DAMAGE_MULT_MED 0.8 //climbing into, disentangling or crusher charging it

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -109,7 +109,6 @@
 	SIGNAL_HANDLER
 	if((entangled.flags_pass & PASSSMALLSTRUCT) || entangled.status_flags & INCORPOREAL)
 		return
-	entangled.next_move_slowdown += RAZORWIRE_SLOWDOWN //big slowdown
 	do_razorwire_untangle(entangled)
 	visible_message(span_danger("[entangled] disentangles from [src]!"))
 	playsound(src, 'sound/effects/barbed_wire_movement.ogg', 25, TRUE)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Untangle via resist no longer applies a "big slowdown" making pixel hunt slashing the wire only better for destroying the wire faster and not a requirement for survival.

## Why It's Good For The Game

Crusher Time To Kill has been on a steady decline ever since razorburn got buffed to be full health and with each new sunder hose (mini-SG) and accuracy change (no miss on big mobs) introduced.

## Changelog
:cl:
balance: Untangle from razorwire via resist no longer applies a slowdown.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
