### PR TITLE
Improving Combat Carrier Viability

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -39,7 +39,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 	mechanics_text = "Click on a non tile and non mob to bring a facehugger into your hand. Click at a target or tile to throw a facehugger."
 	ability_name = "throw facehugger"
 	keybind_signal = COMSIG_XENOABILITY_THROW_HUGGER
-	cooldown_timer = 3 SECONDS
+	cooldown_timer = 1 SECONDS
 
 /datum/action/xeno_action/activable/throw_hugger/get_cooldown()
 	var/mob/living/carbon/xenomorph/carrier/X = owner

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
@@ -130,7 +130,7 @@
 
 	// *** Carrier Abilities *** //
 	huggers_max = 6
-	hugger_delay = 2 SECONDS
+	hugger_delay = 1.5 SECONDS
 
 /datum/xeno_caste/carrier/ancient
 	upgrade_name = "Ancient"
@@ -191,7 +191,7 @@
 
 	// *** Carrier Abilities *** //
 	huggers_max = 7
-	hugger_delay = 1 SECONDS
+	hugger_delay = 0.8 SECONDS
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
@@ -98,7 +98,7 @@
 
 	// *** Carrier Abilities *** //
 	huggers_max = 5
-	hugger_delay = 2.5 SECONDS
+	hugger_delay = 2.0 SECONDS
 
 /datum/xeno_caste/carrier/elder
 	upgrade_name = "Elder"
@@ -162,7 +162,7 @@
 
 	// *** Carrier Abilities *** //
 	huggers_max = 7
-	hugger_delay = 1.5 SECONDS
+	hugger_delay = 1 SECONDS
 
 /datum/xeno_caste/carrier/primodial
 	upgrade_name = "Primordial"
@@ -191,7 +191,7 @@
 
 	// *** Carrier Abilities *** //
 	huggers_max = 7
-	hugger_delay = 1.5 SECONDS
+	hugger_delay = 1 SECONDS
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,


### PR DESCRIPTION
## The TL;DR

Decreases hugger delay (the road block to the speed at which you can chuck huggers) from elder to primordial

## Why It's Good For The Game

With the advent of the new smartminigun, on top of an entire arsenal of automatic weapons which are compatible with aim mode, this PR attempts to make it easier to flood the combat zone with your full stockpile of a whole seven huggers (at ancient.)

This PR will also:

1. increase the usefulness of the "take aim" order.
2. increase the usefulness of swat masks
3. somewhat add a downside to adhering to the shotgun meta
4. somewhat counter(?) melee marine builds.
5. Increase the prevalence of larval jelly for medical staff. (this means lots more lemoline, and advanced combat chems.)
6. Increased role Importance of the smartgunner class.

In summary: This will make carrier more useful in a combat support roll at the higher maturities, while encouraging use of more unused marine tools.

## Changelog
hugger delay at elder reduced from 2.5 to 1.5
hugger delay at ancient reduced from 1.5 to 1.0
hugger delay at primordial reduced from 1.5 to 0.8