### PR TITLE
Adds normal smoke grenades

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -112,6 +112,7 @@
 			/obj/item/explosive/grenade/m15 = 30,
 			/obj/item/explosive/grenade/sticky = 125,
 			/obj/item/explosive/grenade/incendiary = 50,
+			/obj/item/explosive/grenade/smokebomb = 25,
 			/obj/item/explosive/grenade/smokebomb/cloak = 25,
 			/obj/item/explosive/grenade/smokebomb/drain = 10,
 			/obj/item/explosive/grenade/mirage = 100,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This Pull request add normal smoke grenades that produces thick smoke that hides terrain, xenos and marines.

## Why It's Good For The Game

They definitely have some uses because they allow to hide objects such as other grenades, tarps, mines, dropped guns. 

## Changelog
:cl:
add: Adds back good old smoke grenades
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
