### PR TITLE
Fix off-set of spitter sprites

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/spitter.dm
@@ -7,8 +7,8 @@
 	health = 180
 	maxHealth = 180
 	plasma_stored = 150
-	pixel_x = -12
-	old_x = -12
+	pixel_x = -16
+	old_x = -16
 	tier = XENO_TIER_TWO
 	upgrade = XENO_UPGRADE_ZERO
 	inherent_verbs = list(


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/6610922/181608251-fdfa653f-3bb0-4c11-ab53-ec0096295c7d.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Code was adjusted for when spitter had 48x48 sprites, not 2x2 sprites. This changes that.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fix off-set of spitter sprites
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
