### PR TITLE
Lemoline Crate Buff

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -926,12 +926,11 @@ MEDICAL
 
 /datum/supply_packs/medical/lemolime
 	name = "lemoline"
-	notes = "Contains 2 bottles of lemoline with 10 units each."
+	notes = "Contains 1 bottle of lemoline with 30 units each."
 	contains = list(
-		/obj/item/reagent_containers/glass/bottle/lemoline,
-		/obj/item/reagent_containers/glass/bottle/lemoline,
+		/obj/item/reagent_containers/glass/bottle/lemoline/doctor
 	)
-	cost = 5
+	cost = 8
 
 /datum/supply_packs/medical/advancedKits
 	name = "Advanced medical packs"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -929,7 +929,7 @@ MEDICAL
 	notes = "Contains 2 bottles of lemoline with 10 units each."
 	contains = list(
 		/obj/item/reagent_containers/glass/bottle/lemoline,
-		/obj/item/reagent_containers/glass/bottle/lemoline
+		/obj/item/reagent_containers/glass/bottle/lemoline,
 		)
 	cost = 5
 

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -930,7 +930,7 @@ MEDICAL
 	contains = list(
 		/obj/item/reagent_containers/glass/bottle/lemoline,
 		/obj/item/reagent_containers/glass/bottle/lemoline,
-		)
+	)
 	cost = 5
 
 /datum/supply_packs/medical/advancedKits

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -926,8 +926,11 @@ MEDICAL
 
 /datum/supply_packs/medical/lemolime
 	name = "lemoline"
-	notes = "Contains 1 bottle of lemoline with 10 units."
-	contains = list(/obj/item/reagent_containers/glass/bottle/lemoline)
+	notes = "Contains 2 bottles of lemoline with 10 units each."
+	contains = list(
+		/obj/item/reagent_containers/glass/bottle/lemoline,
+		/obj/item/reagent_containers/glass/bottle/lemoline
+		)
 	cost = 5
 
 /datum/supply_packs/medical/advancedKits

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -928,7 +928,7 @@ MEDICAL
 	name = "lemoline"
 	notes = "Contains 1 bottle of lemoline with 30 units each."
 	contains = list(
-		/obj/item/reagent_containers/glass/bottle/lemoline/doctor
+		/obj/item/reagent_containers/glass/bottle/lemoline/doctor,
 	)
 	cost = 8
 


### PR DESCRIPTION
## About The Pull Request
Increases the lemoline provided in the orderable crate, from 10u to 30u
Increased price of lemoline crate from 5 points to 8.

## Why It's Good For The Game

The ability to acquire larval jelly is largely dependent on the existence of carriers. From my experience playing xeno in the course of the past two months, it is not uncommon to play entire rounds, and not have a single carrier, at any point. Larval jelly is currently the only means of acquiring more reasonable amounts of lemoline. This aims to help alleviate that.

Now that a large number of chemicals are gatekept by lemoline, it should only be natural that the ability to acquire it should be less limited, and also less dependent on Xeno caste choices.

Also capture gameplay is dead.

I tried buffing carriers in a previous PR to fix this issue. I'm now doing a more direct approach.

## Changelog
:cl:

balance: Increased the amount of lemoline per crate from 10u to 30u
Balance: increased cost of lemoline crate from 5 points to 8 points

/:cl: