### PR TITLE
Keybind for Move, Focus, Hold, Send, and Rally Order

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -749,6 +749,7 @@
 #define COMSIG_KB_HOLDORDER "keybind_holdorder"
 #define COMSIG_KB_FOCUSORDER "keybind_focusorder"
 #define COMSIG_KB_RALLYORDER "keybind_rallyorder"
+#define COMSIG_KB_SENDORDER "keybind_sendorder"
 
 // human modules signals for keybindings
 #define COMSIG_KB_VALI_CONFIGURE "keybinding_vali_configure"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -748,6 +748,7 @@
 #define COMSIG_KB_MOVEORDER "keybind_moveorder"
 #define COMSIG_KB_HOLDORDER "keybind_holdorder"
 #define COMSIG_KB_FOCUSORDER "keybind_focusorder"
+#define COMSIG_KB_RALLYORDER "keybind_rallyorder"
 
 // human modules signals for keybindings
 #define COMSIG_KB_VALI_CONFIGURE "keybinding_vali_configure"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -745,6 +745,9 @@
 #define COMSIG_KB_AIMMODE "keybinding_aimmode"
 #define COMSIG_KB_FIREMODE "keybind_firemode"
 #define COMSIG_KB_GIVE "keybind_give"
+#define COMSIG_KB_MOVEORDER "keybind_moveorder"
+#define COMSIG_KB_HOLDORDER "keybind_holdorder"
+#define COMSIG_KB_FOCUSORDER "keybind_focusorder"
 
 // human modules signals for keybindings
 #define COMSIG_KB_VALI_CONFIGURE "keybinding_vali_configure"

--- a/code/datums/actions/order_action.dm
+++ b/code/datums/actions/order_action.dm
@@ -119,6 +119,7 @@
 	var/skill_name = "leadership"
 	///What minimum level in that skill is needed to have that action
 	var/skill_min = SKILL_LEAD_EXPERT
+	keybind_signal = COMSIG_KB_RALLYORDER
 
 /datum/action/innate/order/rally_order/should_show()
 	return owner.skills.getRating(skill_name) >= skill_min

--- a/code/datums/actions/order_action.dm
+++ b/code/datums/actions/order_action.dm
@@ -116,10 +116,10 @@
 	verb_name = "rally to"
 	arrow_type = /obj/screen/arrow/rally_order_arrow
 	///What skill is needed to have this action
+	keybind_signal = COMSIG_KB_RALLYORDER
 	var/skill_name = "leadership"
 	///What minimum level in that skill is needed to have that action
 	var/skill_min = SKILL_LEAD_EXPERT
-	keybind_signal = COMSIG_KB_RALLYORDER
 
 /datum/action/innate/order/rally_order/should_show()
 	return owner.skills.getRating(skill_name) >= skill_min

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -115,3 +115,9 @@
 	full_name = "Send Rally Order"
 	description = "Order marines to rally"
 	keybind_signal = COMSIG_KB_RALLYORDER
+
+/datum/keybinding/human/send_order
+	name = "send_order"
+	full_name = "Send Order"
+	description = "Order marines a certain message"
+	keybind_signal = COMSIG_KB_SENDORDER

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -91,3 +91,21 @@
 	full_name = "Activate suit health analyzer"
 	description = ""
 	keybind_signal = COMSIG_KB_SUITANALYZER
+
+/datum/keybinding/human/move_order
+	name = "move_order"
+	full_name = "Issue Move Order"
+	description = "Order marines to move faster"
+	keybind_signal = COMSIG_KB_MOVEORDER
+
+/datum/keybinding/human/hold_order
+	name = "hold_order"
+	full_name = "Issue Hold Order"
+	description = "Order marines to hold ground"
+	keybind_signal = COMSIG_KB_HOLDORDER
+
+/datum/keybinding/human/focus_order
+	name = "focus_order"
+	full_name = "Issue Focus Order"
+	description = "Order marines to aim better"
+	keybind_signal = COMSIG_KB_FOCUSORDER

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -109,3 +109,9 @@
 	full_name = "Issue Focus Order"
 	description = "Order marines to aim better"
 	keybind_signal = COMSIG_KB_FOCUSORDER
+
+/datum/keybinding/human/rally_order
+	name = "rally_order"
+	full_name = "Send Rally Order"
+	description = "Order marines to rally"
+	keybind_signal = COMSIG_KB_RALLYORDER

--- a/code/game/objects/machinery/overwatch.dm
+++ b/code/game/objects/machinery/overwatch.dm
@@ -824,14 +824,17 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 /datum/action/skill/issue_order/move
 	name = "Issue Move Order"
 	order_type = "move"
+	keybind_signal = COMSIG_KB_MOVEORDER
 
 /datum/action/skill/issue_order/hold
 	name = "Issue Hold Order"
 	order_type = "hold"
+	keybind_signal = COMSIG_KB_HOLDORDER
 
 /datum/action/skill/issue_order/focus
 	name = "Issue Focus Order"
 	order_type = "focus"
+	keybind_signal = COMSIG_KB_FOCUSORDER
 
 
 

--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -15,11 +15,11 @@
 /datum/action/innate/message_squad
 	name = "Send Order"
 	action_icon_state = "screen_order_marine"
+	keybind_signal = COMSIG_KB_SENDORDER
 	///What skill is needed to have this action
 	var/skill_name = "leadership"
 	///What minimum level in that skill is needed to have that action
 	var/skill_min = SKILL_LEAD_EXPERT
-	keybind_signal = COMSIG_KB_SENDORDER
 
 /datum/action/innate/message_squad/should_show()
 	return owner.skills.getRating(skill_name) >= skill_min

--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -19,6 +19,7 @@
 	var/skill_name = "leadership"
 	///What minimum level in that skill is needed to have that action
 	var/skill_min = SKILL_LEAD_EXPERT
+	keybind_signal = COMSIG_KB_SENDORDER
 
 /datum/action/innate/message_squad/should_show()
 	return owner.skills.getRating(skill_name) >= skill_min


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. Pretty simple, and thank god we have quality code to add these things easily.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Just QoL stuff.

Some gamer leadership want to not click on action button on UI so that they can be a high speed leader buffing and rallying marines as fast as the speed of caffine induced mania that is TGMC. This continues the marine design philosophy of leaving mouse cursor for SHOOTING XENOMORPHS & getting stuff from inventory and keyboard for everything else.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Keybind for Move, Focus, Hold, Send, and Rally Order
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
