### PR TITLE
More volkite tweaks

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2190,11 +2190,12 @@ datum/ammo/bullet/revolver/tp44
 	shell_speed = 4
 	accuracy_var_low = 5
 	accuracy_var_high = 5
+	accuracy = 5
 	point_blank_range = 2
 	damage = 20
 	penetration = 10
 	sundering = 2
-	fire_burst_damage = 20
+	fire_burst_damage = 15
 
 	//inherited, could use some changes
 	ping = "ping_s"
@@ -2207,17 +2208,17 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/energy/volkite/medium
 	max_range = 25
-	accurate_range = 15
+	accurate_range = 12
 	damage = 30
 	accuracy_var_low = 3
 	accuracy_var_high = 3
-	fire_burst_damage = 25
+	fire_burst_damage = 20
 
 /datum/ammo/energy/volkite/heavy
 	max_range = 35
-	accurate_range = 18
+	accurate_range = 12
 	damage = 25
-	fire_burst_damage = 25
+	fire_burst_damage = 20
 
 /datum/ammo/energy/volkite/light
 	max_range = 25

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -844,7 +844,7 @@
 	wield_delay = 0.4 SECONDS
 	wield_penalty = 0.2 SECONDS
 
-	damage_falloff_mult = 0.25
+	damage_falloff_mult = 0.9
 	fire_delay = 0.2 SECONDS
 	mode_list = list()
 
@@ -869,7 +869,6 @@
 	accuracy_mult = 1.15
 	accuracy_mult_unwielded = 0.9
 	recoil_unwielded = 0
-	damage_falloff_mult = 0.5
 	movement_acc_penalty_mult = 2
 	aim_slowdown = 0.1
 
@@ -897,7 +896,6 @@
 	accuracy_mult_unwielded = 0.9
 	scatter_unwielded = 10
 	recoil_unwielded = 1
-	damage_falloff_mult = 0.9
 	movement_acc_penalty_mult = 4
 
 /obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/charger/magharness
@@ -919,7 +917,7 @@
 	item_state = "caliver"
 	ammo_level_icon = "caliver"
 	fire_sound = 'sound/weapons/guns/fire/volkite_3.ogg'
-	max_shots = 50
+	max_shots = 40
 	ammo_datum_type = /datum/ammo/energy/volkite/medium
 	rounds_per_shot = 36
 	default_ammo_type = /obj/item/cell/lasgun/volkite/highcap
@@ -943,6 +941,7 @@
 	attachable_offset = list("muzzle_x" = 38, "muzzle_y" = 13,"rail_x" = 6, "rail_y" = 20, "under_x" = 33, "under_y" = 10, "stock_x" = 22, "stock_y" = 12)
 	accuracy_mult = 1.1
 	aim_slowdown = 0.65
+	damage_falloff_mult = 0.6
 	wield_delay	= 0.7 SECONDS
 	fire_delay = 0.25 SECONDS
 
@@ -982,6 +981,7 @@
 	accuracy_mult_unwielded = 0.4
 	scatter_unwielded = 35
 	recoil_unwielded = 5
+	damage_falloff_mult = 0.5
 	movement_acc_penalty_mult = 6
 
 /obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/culverin/magharness

--- a/code/modules/projectiles/magazines/energy.dm
+++ b/code/modules/projectiles/magazines/energy.dm
@@ -85,7 +85,7 @@
 	desc = "An advanced, ultrahigh capacity battery used to power volkite weaponry."
 	icon = 'icons/obj/items/ammo.dmi'
 	icon_state = "volkite_big"
-	maxcharge = 1800
+	maxcharge = 1440
 	w_class = WEIGHT_CLASS_NORMAL
 	icon_state_mini = "mag_cell"
 	charge_overlay = "volkite_big"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Some further tweaks to volkite weaponry, mainly aimmed at making them a bit less oppressive at longer range.

- Volkite projectiles are less accurate (5 bonus accuracy instead of 15 like lasers)
- Volkite projectiles do less deflagrate damage (25% less for the charger, 20% less for the others)
- Increased the damage falloff on the Serpenta, Caliver and Culverin (as well as less damage at range, this also reduces the chance of deflagrate triggering).
- Reduced the caliver magazine capacity to 40 shots from 50 (backpack is unchanged)
- Reduced the accurate range of the Caliver and Culverin

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Slightly reduced the accuracy of volkite projectiles, and decreased the damage of deflagration
balance: Volkite weapons have higher damage falloff
balance: Reduced the accurate range of the VX-33 Caliver and VX-42 Culverin
balance: Reduced the magazine capacity of the VX-33 Caliver
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
