### PR TITLE
Turns lengthy else-if chain in /mob/dead/observer/Topic(href, href_list) into a switch

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -145,97 +145,98 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	. = ..()
 	if(.)
 		return
-	if(href_list["reentercorpse"])
-		if(!isobserver(usr))
-			return
-		var/mob/dead/observer/A = usr
-		A.reenter_corpse()
+	switch(href_list[href])
+		if("reentercorpse")
+			if(!isobserver(usr))
+				return
+			var/mob/dead/observer/A = usr
+			A.reenter_corpse()
 
 
-	else if(href_list["track"])
-		var/mob/target = locate(href_list["track"]) in GLOB.mob_list
-		if(istype(target))
-			ManualFollow(target)
-			return
-		else
-			var/atom/movable/AM = locate(href_list["track"])
-			ManualFollow(AM)
-			return
-
-
-	else if(href_list["jump"])
-		var/x = text2num(href_list["x"])
-		var/y = text2num(href_list["y"])
-		var/z = text2num(href_list["z"])
-
-		if(x == 0 && y == 0 && z == 0)
-			return
-
-		var/turf/T = locate(x, y, z)
-		if(!T)
-			return
-
-		var/mob/dead/observer/A = usr
-		A.abstract_move(T)
-		return
-
-	else if(href_list["claim"])
-		var/mob/living/target = locate(href_list["claim"]) in GLOB.offered_mob_list
-		if(!istype(target))
-			to_chat(usr, span_warning("Invalid target."))
-			return
-
-		target.take_over(src)
-
-	else if(href_list["join_ert"])
-		if(!isobserver(usr))
-			return
-		var/mob/dead/observer/A = usr
-
-		A.JoinResponseTeam()
-		return
-
-	else if(href_list["join_larva"])
-		if(!isobserver(usr))
-			return
-		var/mob/dead/observer/ghost = usr
-
-		var/datum/hive_status/normal/HS = GLOB.hive_datums[XENO_HIVE_NORMAL]
-		if(LAZYFIND(HS.candidate, ghost))
-			to_chat(ghost, span_warning("You are already in the queue to become a Xenomorph."))
-			return
-
-		switch(tgui_alert(ghost, "What would you like to do?", "Burrowed larva source available", list("Join as Larva", "Cancel"), 0))
-			if("Join as Larva")
-				SSticker.mode.attempt_to_join_as_larva(ghost)
-		return
-
-	else if(href_list["preference"])
-		if(!client?.prefs)
-			return
-		stack_trace("This code path is no longer valid, migrate this to new TGUI prefs")
-		return
-
-	else if(href_list["track_xeno_name"])
-		var/xeno_name = href_list["track_xeno_name"]
-		for(var/Y in GLOB.hive_datums[XENO_HIVE_NORMAL].get_all_xenos())
-			var/mob/living/carbon/xenomorph/X = Y
-			if(isnum(X.nicknumber))
-				if(num2text(X.nicknumber) != xeno_name)
-					continue
+		if("track")
+			var/mob/target = locate(href_list["track"]) in GLOB.mob_list
+			if(istype(target))
+				ManualFollow(target)
+				return
 			else
-				if(X.nicknumber != xeno_name)
-					continue
-			ManualFollow(X)
-			break
+				var/atom/movable/AM = locate(href_list["track"])
+				ManualFollow(AM)
+				return
 
-	else if(href_list["track_silo_number"])
-		var/silo_number = href_list["track_silo_number"]
-		for(var/obj/structure/xeno/silo/resin_silo AS in GLOB.xeno_resin_silos)
-			if(resin_silo.associated_hive == GLOB.hive_datums[XENO_HIVE_NORMAL] && num2text(resin_silo.number_silo) == silo_number)
-				var/mob/dead/observer/ghost = usr
-				ghost.abstract_move(resin_silo.loc)
+
+		if("jump")
+			var/x = text2num(href_list["x"])
+			var/y = text2num(href_list["y"])
+			var/z = text2num(href_list["z"])
+
+			if(x == 0 && y == 0 && z == 0)
+				return
+
+			var/turf/T = locate(x, y, z)
+			if(!T)
+				return
+
+			var/mob/dead/observer/A = usr
+			A.abstract_move(T)
+			return
+
+		if("claim")
+			var/mob/living/target = locate(href_list["claim"]) in GLOB.offered_mob_list
+			if(!istype(target))
+				to_chat(usr, span_warning("Invalid target."))
+				return
+
+			target.take_over(src)
+
+		if("join_ert")
+			if(!isobserver(usr))
+				return
+			var/mob/dead/observer/A = usr
+
+			A.JoinResponseTeam()
+			return
+
+		if("join_larva")
+			if(!isobserver(usr))
+				return
+			var/mob/dead/observer/ghost = usr
+
+			var/datum/hive_status/normal/HS = GLOB.hive_datums[XENO_HIVE_NORMAL]
+			if(LAZYFIND(HS.candidate, ghost))
+				to_chat(ghost, span_warning("You are already in the queue to become a Xenomorph."))
+				return
+
+			switch(tgui_alert(ghost, "What would you like to do?", "Burrowed larva source available", list("Join as Larva", "Cancel"), 0))
+				if("Join as Larva")
+					SSticker.mode.attempt_to_join_as_larva(ghost)
+			return
+
+		if("preference")
+			if(!client?.prefs)
+				return
+			stack_trace("This code path is no longer valid, migrate this to new TGUI prefs")
+			return
+
+		if("track_xeno_name")
+			var/xeno_name = href_list["track_xeno_name"]
+			for(var/Y in GLOB.hive_datums[XENO_HIVE_NORMAL].get_all_xenos())
+				var/mob/living/carbon/xenomorph/X = Y
+				if(isnum(X.nicknumber))
+					if(num2text(X.nicknumber) != xeno_name)
+						continue
+				else
+					if(X.nicknumber != xeno_name)
+						continue
+				ManualFollow(X)
 				break
+
+		if("track_silo_number")
+			var/silo_number = href_list["track_silo_number"]
+			for(var/obj/structure/xeno/silo/resin_silo AS in GLOB.xeno_resin_silos)
+				if(resin_silo.associated_hive == GLOB.hive_datums[XENO_HIVE_NORMAL] && num2text(resin_silo.number_silo) == silo_number)
+					var/mob/dead/observer/ghost = usr
+					ghost.abstract_move(resin_silo.loc)
+					break
 
 /mob/proc/ghostize(can_reenter_corpse = TRUE, aghosting = FALSE)
 	if(!key || isaghost(src))


### PR DESCRIPTION
## About The Pull Request
found a long chain of else-if's that could be turned into a switch so i did that

heres part of the old code before i switch'd it up
![Code_2022-08-01_11-20-53](https://user-images.githubusercontent.com/17747087/182116941-3224abe9-a2cc-49ba-b032-f07b2ecebe4d.png)

and heres afterwards i switch'd it up
![bild](https://user-images.githubusercontent.com/17747087/182117147-f357bf62-9b66-430a-ac3e-832c8b201a85.png)

This PR has been fully tested on a local build with zero (0) runtimes or errors.
![dreamseeker_2022-08-01_11-27-17](https://user-images.githubusercontent.com/17747087/182118157-c7ee508c-0255-4987-ab03-97354b09e58a.gif)

## Why It's Good For The Game
Makes code look less weird and more efficient, helps if you have a bunch of ghosts using this in a long high-pop round.

## Changelog
:cl: Vondiech
code: turned long chain of else-if's in /mob/dead/observer/Topic(href, href_list) into a switch
/:cl:
