### PR TITLE
DB juggling nerf -> Cannot fire DB unless stable wielding

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -212,7 +212,7 @@
 		/obj/item/attachable/scope/mini,
 	)
 
-	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY
+	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY|GUN_WIELDED_STABLE_FIRING_ONLY
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 17,"rail_x" = 15, "rail_y" = 19, "under_x" = 21, "under_y" = 13, "stock_x" = 13, "stock_y" = 16)
 
 	fire_delay = 5


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

DB cannot be shot unless the full wielding bar is completed. 

## Why It's Good For The Game

This prevents people from juggling 3 DBs in order to be able to shoot 6 slugs at a crazy firerate. Triple DBs are currently a concern and are in the rise since the T39 akimbo nerf. The issue is the same, a crazy firerate of slugs that staggers. 
This nerf keeps DB as a nice burst weapon that can quickly shoot out two shotgun ammo. The wield delay is 0.6 seconds, it's not that long but I believe it's enough to prevent juggling. I've been told this would impact single DBs greatly but I'm not sure of that since they rarely shoot at the same rate as jugglers that's why this PR should be testmerged for a few days if the maintainers are willing to try it.

**DO NOT MERGE THIS WITH #10668 THAT WOULD BE TOO MUCH OF A NERF**

## Changelog
:cl:
balance: Double Barrels now requires you to stable wield them to be able to shoot. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
