### PR TITLE
Fix large object transparency opacity issue

### DIFF
--- a/code/datums/components/largeobjecttransparency.dm
+++ b/code/datums/components/largeobjecttransparency.dm
@@ -108,4 +108,4 @@
 	var/atom/par_atom = parent
 	par_atom.alpha = initial_alpha
 	if(toggle_click)
-		par_atom.mouse_opacity = MOUSE_OPACITY_OPAQUE
+		par_atom.mouse_opacity = MOUSE_OPACITY_ICON


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Was wondering why my skinny street lamp was taking up 3 tiles worth of clicking space. Turns out when the transparency wears off, the mouse opacity becomes "opaque", which means any sprite will take up the entire tiles of space it occupies when you hover over the tiles with your cursor. Nothing in the game currently uses the large object transparency component except trees but this one line change will make trees and any future large objects work correctly.

## Why It's Good For The Game

Fixes large objects with transparency. If you had trouble with trees, not anymore.

## Changelog
:cl:
fix: Large object transparency no longer makes all tiles a multitile object occupies the only thing clickable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
