### PR TITLE
Fix xeno fire overlay not changing dir when the xeno is turning

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -85,19 +85,14 @@
 	apply_temp_overlay(X_SUIT_LAYER, 1.2 SECONDS)
 
 /mob/living/carbon/xenomorph/update_fire()
-	remove_overlay(X_FIRE_LAYER)
-	if(on_fire)
-		var/image/I
-		if(mob_size == MOB_SIZE_BIG)
-			if((!initial(pixel_y) || lying_angle) && !resting && !IsSleeping())
-				I = image("icon"='icons/Xeno/2x2_Xenos.dmi', "icon_state"="alien_fire", "layer"=-X_FIRE_LAYER)
-			else
-				I = image("icon"='icons/Xeno/2x2_Xenos.dmi', "icon_state"="alien_fire_lying", "layer"=-X_FIRE_LAYER)
-		else
-			I = image("icon"='icons/Xeno/Effects.dmi', "icon_state"="alien_fire", "layer"=-X_FIRE_LAYER)
-
-		overlays_standing[X_FIRE_LAYER] = I
-		apply_overlay(X_FIRE_LAYER)
+	if(!on_fire)
+		fire_overlay.icon_state = ""
+		return
+	fire_overlay.layer = layer + 0.4
+	if((!initial(pixel_y) || lying_angle) && !resting && !IsSleeping())
+		fire_overlay.icon_state = "alien_fire"
+	else
+		fire_overlay.icon_state = "alien_fire_lying"
 
 /mob/living/carbon/xenomorph/proc/apply_alpha_channel(image/I)
 	return I
@@ -154,3 +149,6 @@
 	SIGNAL_HANDLER
 	if(newdir != dir)
 		dir = newdir
+
+/atom/movable/vis_obj/xeno_wounds/fire_overlay
+	icon = 'icons/Xeno/2x2_Xenos.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -89,7 +89,7 @@
 		fire_overlay.icon_state = ""
 		return
 	fire_overlay.layer = layer + 0.4
-	if((!initial(pixel_y) || lying_angle) && !resting && !IsSleeping())
+	if(mob_size!= MOB_SIZE_BIG || ((!initial(pixel_y) || lying_angle) && !resting && !IsSleeping()))
 		fire_overlay.icon_state = "alien_fire"
 	else
 		fire_overlay.icon_state = "alien_fire_lying"
@@ -152,3 +152,6 @@
 
 /atom/movable/vis_obj/xeno_wounds/fire_overlay
 	icon = 'icons/Xeno/2x2_Xenos.dmi'
+
+/atom/movable/vis_obj/xeno_wounds/fire_overlay/small
+	icon = 'icons/Xeno/Effects.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -261,6 +261,7 @@
 
 	var/list/overlays_standing[X_TOTAL_LAYERS]
 	var/atom/movable/vis_obj/xeno_wounds/wound_overlay
+	var/atom/movable/vis_obj/xeno_wounds/fire_overlay/fire_overlay
 	var/datum/xeno_caste/xeno_caste
 	var/caste_base_type
 	var/language = "Xenomorph"

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -38,7 +38,7 @@
 	wound_overlay = new(null, src)
 	vis_contents += wound_overlay
 
-	fire_overlay = new(null, src)
+	fire_overlay = mob_size == MOB_SIZE_BIG ? new(null, src) : new /atom/movable/vis_obj/xeno_wounds/fire_overlay/small(null, src)
 	vis_contents += fire_overlay
 
 	set_initial_hivenumber()

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -38,6 +38,9 @@
 	wound_overlay = new(null, src)
 	vis_contents += wound_overlay
 
+	fire_overlay = new(null, src)
+	vis_contents += fire_overlay
+
 	set_initial_hivenumber()
 
 	generate_nicknumber()
@@ -245,7 +248,9 @@
 	hive_placeholder.update_tier_limits() //Update our tier limits.
 
 	vis_contents -= wound_overlay
+	vis_contents -= fire_overlay
 	QDEL_NULL(wound_overlay)
+	QDEL_NULL(fire_overlay)
 	return ..()
 
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

fix: https://github.com/tgstation/TerraGov-Marine-Corps/issues/9351

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fix xeno fire overlay not changing dir when the xeno is turning
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
