### PR TITLE
More egg cleanup

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -19,10 +19,6 @@
 	. = ..()
 	if(!ignore_weed_destruction)
 		RegisterSignal(loc, COMSIG_TURF_WEED_REMOVED, .proc/weed_removed)
-	var/static/list/connections = list(
-		COMSIG_ATOM_ENTERED = .proc/on_cross,
-	)
-	AddElement(/datum/element/connect_loc, connections)
 
 /// Destroy the alien effect when the weed it was on is destroyed
 /obj/alien/proc/weed_removed()
@@ -37,12 +33,6 @@
 
 	if(obj_flags & CAN_BE_HIT)
 		return I.attack_obj(src, user)
-
-
-/obj/alien/proc/on_cross(datum/source, atom/movable/O, oldloc, oldlocs)
-	SIGNAL_HANDLER
-	if(istype(O, /obj/vehicle/multitile/hitbox/cm_armored))
-		tank_collision(O)
 
 /obj/alien/flamer_fire_act(burnlevel)
 	take_damage(burnlevel * 2, BURN, "fire")


### PR DESCRIPTION
## About The Pull Request
Cleans up a few parts of xeno eggs.
Removes all obj/alien registering to atom_entered, since it was only used by multitile tanks and didn't apply to most of the things that inherit from obj/alien anyway. Also it was runtiming when eggs set up detection.
Eggs more properly break in response to damage, exploding instead of just hatching.
Gas eggs break a lot easier.

## Why It's Good For The Game
fixes #10712 

## Changelog
:cl:
fix: Eggs work a little more the way they ought. Flaming them won't make the hugger hatch, for instance.
/:cl:
