### PR TITLE
Vali Tweaks

### DIFF
--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -396,7 +396,7 @@
 		return
 
 	if((held_item.reagents.maximum_volume-held_item.reagents.total_volume) < volume)
-		wearer.balloon_alert(wearer, "Held beaker lacks required space for extraction.")
+		wearer.balloon_alert(wearer, "Held container lacks required space for extraction.")
 		return
 
 	wearer.balloon_alert(wearer, "You begin filling [held_item].")

--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -229,9 +229,9 @@
 ///Handles turning on/off the processing part of the component, along with the negative effects related to this
 /datum/component/chem_booster/proc/on_off(datum/source)
 	SIGNAL_HANDLER
-	wearer.clear_fullscreen("degeneration")
 	if(boost_on)
 		STOP_PROCESSING(SSobj, src)
+		wearer.clear_fullscreen("degeneration")
 		var/necrotized_counter = FLOOR(min(world.time-processing_start, 20 SECONDS)/200 + (world.time-processing_start-20 SECONDS)/100, 1)
 		if(necrotized_counter >= 1)
 			for(var/X in shuffle(wearer.limbs))

--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -245,17 +245,17 @@
 
 		UnregisterSignal(wearer, COMSIG_MOB_DEATH, .proc/on_off)
 		boost_on = FALSE
-		wearer.balloon_alert(wearer, "Halting green blood injection.")
+		wearer.balloon_alert(wearer, "Halting green blood injection")
 		COOLDOWN_START(src, chemboost_activation_cooldown, 10 SECONDS)
 		setup_bonus_effects()
 		return
 
 	if(!COOLDOWN_CHECK(src, chemboost_activation_cooldown))
-		wearer.balloon_alert(wearer, "You need to wait another [COOLDOWN_TIMELEFT(src, chemboost_activation_cooldown)/10] seconds.")
+		wearer.balloon_alert(wearer, "You need to wait another [COOLDOWN_TIMELEFT(src, chemboost_activation_cooldown)/10] seconds")
 		return
 
 	if(resource_storage_current < resource_drain_amount)
-		wearer.balloon_alert(wearer, "Insufficient green blood to begin operation.")
+		wearer.balloon_alert(wearer, "Insufficient green blood to begin operation")
 		return
 
 	boost_on = TRUE
@@ -272,7 +272,7 @@
 ///Updates the boost amount of the suit and effect_str of reagents if component is on. "amount" is the final level you want to set the boost to.
 /datum/component/chem_booster/proc/update_boost(amount)
 	boost_amount = amount
-	wearer?.balloon_alert(wearer, "Enhancement level set to [boost_amount].")
+	wearer?.balloon_alert(wearer, "Enhancement level set to [boost_amount]")
 	resource_drain_amount = boost_amount*(3 + boost_amount)
 
 ///Handles Vali stat boosts and any other potential buffs on activation/deactivation
@@ -316,33 +316,33 @@
 		return
 
 	if(wearer.do_actions)
-		wearer.balloon_alert(wearer, "You are already occupied with something.")
+		wearer.balloon_alert(wearer, "You're already occupied with something")
 		return
 
 	var/obj/item/held_item = wearer.get_held_item()
 	if(!held_item)
-		wearer.balloon_alert(wearer, "You need to be holding a harvester.")
+		wearer.balloon_alert(wearer, "You need to be holding a harvester")
 		return
 
 	if(!CHECK_BITFIELD(held_item.flags_item, DRAINS_XENO))
-		wearer.balloon_alert(wearer, "You need to be holding a harvester.")
+		wearer.balloon_alert(wearer, "You need to be holding a harvester")
 		return
 
 	wearer.add_movespeed_modifier(MOVESPEED_ID_CHEM_CONNECT, TRUE, 0, NONE, TRUE, 4)
-	wearer.balloon_alert(wearer, "You begin connecting [held_item].")
+	wearer.balloon_alert(wearer, "You begin connecting [held_item]")
 	if(!do_after(wearer, 1 SECONDS, TRUE, held_item, BUSY_ICON_FRIENDLY, null, PROGRESS_BRASS, ignore_turf_checks = TRUE))
 		wearer.remove_movespeed_modifier(MOVESPEED_ID_CHEM_CONNECT)
-		wearer.balloon_alert(wearer, "You were interrupted.")
+		wearer.balloon_alert(wearer, "You were interrupted")
 		return
 
-	wearer.balloon_alert(wearer, "Finished connecting [held_item].")
+	wearer.balloon_alert(wearer, "Finished connecting [held_item]")
 	wearer.remove_movespeed_modifier(MOVESPEED_ID_CHEM_CONNECT)
 	manage_weapon_connection(held_item)
 
 ///Handles the setting up and removal of signals and vars related to connecting an item to the suit
 /datum/component/chem_booster/proc/manage_weapon_connection(obj/item/weapon_to_connect)
 	if(connected_weapon)
-		wearer.balloon_alert(wearer, "Disconnected [connected_weapon].")
+		wearer.balloon_alert(wearer, "Disconnected [connected_weapon]")
 		DISABLE_BITFIELD(connected_weapon.flags_item, NODROP)
 		UnregisterSignal(connected_weapon, COMSIG_ITEM_ATTACK)
 		UnregisterSignal(connected_weapon, list(COMSIG_ITEM_EQUIPPED_NOT_IN_SLOT, COMSIG_ITEM_DROPPED))
@@ -383,23 +383,23 @@
 		return
 
 	if(resource_storage_current < volume)
-		wearer.balloon_alert(wearer, "Insufficient green blood for extraction.")
+		wearer.balloon_alert(wearer, "Insufficient green blood for extraction")
 		return
 
 	var/obj/item/held_item = wearer.get_held_item()
 	if(!held_item)
-		wearer.balloon_alert(wearer, "You need to be holding a glass reagent container.")
+		wearer.balloon_alert(wearer, "You must be holding a glass reagent container")
 		return
 
 	if(!istype(held_item, /obj/item/reagent_containers/glass))
-		wearer.balloon_alert(wearer, "You need to be holding a glass reagent container.")
+		wearer.balloon_alert(wearer, "You must be holding a glass reagent container")
 		return
 
 	if((held_item.reagents.maximum_volume-held_item.reagents.total_volume) < volume)
-		wearer.balloon_alert(wearer, "Held container lacks required space for extraction.")
+		wearer.balloon_alert(wearer, "Held container lacks required space for extraction")
 		return
 
-	wearer.balloon_alert(wearer, "You begin filling [held_item].")
+	wearer.balloon_alert(wearer, "You begin filling [held_item]")
 	if(!do_after(wearer, 1 SECONDS, TRUE, held_item, BUSY_ICON_FRIENDLY, null, PROGRESS_BRASS))
 		return
 
@@ -414,7 +414,7 @@
 
 	var/obj/item/held_item = wearer.get_held_item()
 	if((!istype(held_item, /obj/item/reagent_containers) && !meds_beaker.reagents.total_volume) || istype(held_item, /obj/item/reagent_containers/pill))
-		wearer.balloon_alert(wearer, "You need to be holding a glass reagent container.")
+		wearer.balloon_alert(wearer, "You must be holding a glass reagent container")
 		return
 
 	if(!istype(held_item, /obj/item/reagent_containers) && meds_beaker.reagents.total_volume)
@@ -423,12 +423,12 @@
 			automatic_meds_use = TRUE
 		else if(pick == "No")
 			automatic_meds_use = FALSE
-		wearer.balloon_alert(wearer, "The chemical system will [automatic_meds_use ? "" : "not"] inject loaded reagents on activation.")
+		wearer.balloon_alert(wearer, "The chemical system [automatic_meds_use ? "will" : "won't"] inject loaded reagents on activation")
 		return
 
 	var/obj/item/reagent_containers/held_beaker = held_item
 	if(!held_beaker.reagents.total_volume && !meds_beaker.reagents.total_volume)
-		wearer.balloon_alert(wearer, "Both the held reagent container and the system's reagent storage are empty.")
+		wearer.balloon_alert(wearer, "Both the held reagent container and the system's reagent storage are empty")
 		return
 
 	if(!held_beaker.reagents.total_volume && meds_beaker.reagents.total_volume)
@@ -441,14 +441,14 @@
 		return
 
 	if(meds_beaker.reagents.total_volume >= meds_beaker.volume)
-		wearer.balloon_alert(wearer, "The system's reagent storage is full.")
+		wearer.balloon_alert(wearer, "The system's reagent storage is full")
 		return
 
 	if(!do_after(wearer, 0.5 SECONDS, TRUE, held_item, BUSY_ICON_FRIENDLY, null, PROGRESS_BRASS, ignore_turf_checks = TRUE))
 		return
 
 	var/trans = held_beaker.reagents.trans_to(meds_beaker, held_beaker.amount_per_transfer_from_this)
-	wearer.balloon_alert(wearer, "Loaded [trans] units.")
+	wearer.balloon_alert(wearer, "Loaded [trans] units")
 	to_chat(wearer, get_meds_beaker_contents())
 
 ///Shows the loaded reagents to the person examining the parent/wearer


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the wording in multiple balloon messages, for example replacing "resource" with "green blood" since that's what the suit description says.

Oh, I also removed a redundant check for the volume amount since the checks happen on the same frame regardless of whether or not it's at the end of the checks or at the beginning. (Perhaps someone forgot to remove it?)

The pull request was, at first, aimed to fix a bug regarding the degeneration overlay, but somehow a person had fixed it in the time span of me discovering the bug a day earlier and then trying to fix it like, yesterday. So uh, yeah, the change I THOUGHT had fixed it has been reverted. (Tested in-game on dream daemon, bug was still gone even after moving it back.)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Having better wording on messages is good for obvious reasons and not having inconsistent mentions of "resource" and "green blood" clears up some things and makes vali easier to understand for people who didn't look at the wiki or ask others for help.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: removed useless vali messages
del: removed redundant check for volume amount
spellcheck: changed the exact wording on some of the vali balloon messages
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
