### PR TITLE
Fix getting out of the Condor in Reserved Z

### DIFF
--- a/code/modules/shuttle/cas_plane.dm
+++ b/code/modules/shuttle/cas_plane.dm
@@ -119,6 +119,9 @@
 ///Eject the user, use forced = TRUE to do so instantly
 /obj/structure/caspart/caschair/proc/eject_user(forced = FALSE)
 	if(!forced)
+		if(SSmapping.level_trait(z, ZTRAIT_RESERVED))
+			to_chat(occupant, span_notice("Getting out of the cockpit while flying seems like a bad idea to you."))
+			return
 		to_chat(occupant, span_notice("You start getting out of the cockpit."))
 		if(!do_after(occupant, 2 SECONDS, TRUE, src))
 			return


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You cannot resist out of the condor in Reserved Z Levels so you dont kill yourself
Setting forced to TRUE still ejects in reserved space
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #10729
Killing yourself and getting deleted in addition is bad, also a bug
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You can no longer get out of the condor while it is flying so you dont kill yourself
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
