### PR TITLE
Adjacency check for external magazines on turrets

### DIFF
--- a/code/modules/projectiles/sentries.dm
+++ b/code/modules/projectiles/sentries.dm
@@ -332,6 +332,7 @@
 
 
 /obj/machinery/deployable/mounted/sentry/process()
+	. = ..()
 	update_icon()
 	if(!scan())
 		var/obj/item/weapon/gun/gun = internal_item


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

How it works: when a deployable's reload() is called, or on Initialize(), it looks for if the magazine is external (WORN). Then it starts process() which checks if the magazine is adjacent to the deployable. If you walk off with the magazine, it disconnects from the turret.

## Why It's Good For The Game

Was told flamethrower turrets can use external magazines which lead to teleportation of flamer fuel to wherever the turret is if you walk away with the backpack. This fixes that and any future deployables with external magazines.

## Changelog
:cl:
fix: Worn magazines disconnect from turrets if you walk away with it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
