### PR TITLE
Fixes detpacks

### DIFF
--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -132,7 +132,8 @@
 	if(!signal || !on)
 		return
 
-	if(!(signal.source.loc.z == z || signal.source.z == z))
+	var/turf/location = get_turf(signal.source)
+	if(location.z != z)
 		return
 
 	if(signal.data["code"] != code)

--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -132,7 +132,7 @@
 	if(!signal || !on)
 		return
 
-	if(signal.source.z != z)
+	if(!(signal.source.loc.z == z || signal.source.z == z))
 		return
 
 	if(signal.data["code"] != code)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Detpacks now check for the Z level of whoever's hand they're in, instead of only their own Z level. This broke detpacks because, when an object is on a person or inside of a storage unit, the object's z level is always set to 0. This caused issues with https://github.com/tgstation/TerraGov-Marine-Corps/pull/10703

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes good, I like using my funny detpacks :)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Detpacks now work when a signaler is in your hand again, instead of only working on the floor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
