### PR TITLE
CIC markers now work as they used to (fix)

### DIFF
--- a/code/datums/actions/order_action.dm
+++ b/code/datums/actions/order_action.dm
@@ -101,10 +101,13 @@
 	arrow_type = /obj/screen/arrow/attack_order_arrow
 	visual_type = /obj/effect/temp_visual/order/attack_order
 
-/datum/action/innate/order/attack_order/should_show()
+//These 'personal' subtypes are the ones not used by overwatch; like what SL or FC gets
+/datum/action/innate/order/attack_order/personal
+
+/datum/action/innate/order/attack_order/personal/should_show()
 	return owner.skills.getRating(skill_name) >= skill_min
 
-/datum/action/innate/order/attack_order/action_activate()
+/datum/action/innate/order/attack_order/personal/action_activate()
 	var/mob/living/carbon/human/human = owner
 	if(send_order(human, human.assigned_squad, human.faction))
 		var/message = pick(";MARINES, FIGHT! SHOOT! KILL!!", ";BLAST THEM!", ";MAKE THEM EAT LEAD!", ";END THEM!", ";ATTACK HERE!", ";CHARGE!", ";RUN THEM OVER!")
@@ -117,10 +120,12 @@
 	arrow_type = /obj/screen/arrow/defend_order_arrow
 	visual_type = /obj/effect/temp_visual/order/defend_order
 
-/datum/action/innate/order/defend_order/should_show()
+/datum/action/innate/order/defend_order/personal
+
+/datum/action/innate/order/defend_order/personal/should_show()
 	return owner.skills.getRating(skill_name) >= skill_min
 
-/datum/action/innate/order/defend_order/action_activate()
+/datum/action/innate/order/defend_order/personal/action_activate()
 	var/mob/living/carbon/human/human = owner
 	if(send_order(human, human.assigned_squad, human.faction))
 		var/message = pick(";DUCK AND COVER!", ";HOLD THE LINE!", ";HOLD POSITION!", ";STAND YOUR GROUND!", ";STAND AND FIGHT!", ";TAKE COVER!", ";COVER THE AREA!", ";BRACE FOR COVER!", ";BRACE!", ";INCOMING!", ";DON'T PUSH! STAY HERE!")
@@ -132,10 +137,12 @@
 	verb_name = "retreat from"
 	visual_type = /obj/effect/temp_visual/order/retreat_order
 
-/datum/action/innate/order/retreat_order/should_show()
+/datum/action/innate/order/retreat_order/personal
+
+/datum/action/innate/order/retreat_order/personal/should_show()
 	return owner.skills.getRating(skill_name) >= skill_min
 
-/datum/action/innate/order/retreat_order/action_activate()
+/datum/action/innate/order/retreat_order/personal/action_activate()
 	var/mob/living/carbon/human/human = owner
 	if(send_order(human, human.assigned_squad, human.faction))
 		var/message = pick(";RETREAT! RETREAT!", ";GET OUT OF HERE!", ";DON'T DIE HERE! RUN!", ";RUN! RUN FOR YOUR LIFE!", ";DISENGAGE! I REPEAT, DISENGAGE!", ";GIVE UP GROUND! GIVE IT UP!")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -21,11 +21,11 @@
 	issue_order_hold.give_action(src)
 	var/datum/action/skill/issue_order/focus/issue_order_focus = new
 	issue_order_focus.give_action(src)
-	var/datum/action/innate/order/attack_order/send_attack_order = new
+	var/datum/action/innate/order/attack_order/personal/send_attack_order = new
 	send_attack_order.give_action(src)
-	var/datum/action/innate/order/defend_order/send_defend_order = new
+	var/datum/action/innate/order/defend_order/personal/send_defend_order = new
 	send_defend_order.give_action(src)
-	var/datum/action/innate/order/retreat_order/send_retreat_order = new
+	var/datum/action/innate/order/retreat_order/personal/send_retreat_order = new
 	send_retreat_order.give_action(src)
 	var/datum/action/innate/order/rally_order/send_rally_order = new
 	send_rally_order.give_action(src)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

https://github.com/tgstation/TerraGov-Marine-Corps/pull/10648 completely broke CIC markers. Going into overwatch just creates two sets of the personal marker abilities now. This separates the overwatch markers and personal markers so that CIC can actually use their overwatch markers (without removing the personal markers). Elsa is busy with real life stuff so I'm making this PR because grr let me use the epic MARKERS.

I think some other stuff might have broken in CIC markers, so please make an issue report for anything you notice, but for now making them actually functional is priority.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes good, this was completely unintentional & markers are actually pretty useful for CIC

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Overwatch markers now work again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
