### PR TITLE
Assemblies now pulse wires they're attached to again

### DIFF
--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -178,6 +178,12 @@
 
 /datum/wires/proc/attach_assembly(color, obj/item/assembly/S)
 	if(istype(S) && S.attachable && !is_attached(color))
+		if(skill < SKILL_ENGINEER_ENGI)
+			user.visible_message(span_notice("[usr] fumbles around figuring out the wiring."),
+			span_notice("You fumble around figuring out the wiring."))
+			if(!do_after(user, 2 SECONDS * (SKILL_ENGINEER_ENGI - skill), TRUE, holder, BUSY_ICON_UNSKILLED) || is_cut(wire))
+				return
+
 		assemblies[color] = S
 		S.forceMove(holder)
 		S.connected = src
@@ -188,6 +194,13 @@
 	var/obj/item/assembly/S = get_attached(color)
 	if(!istype(S))
 		return
+
+	if(skill < SKILL_ENGINEER_ENGI)
+		user.visible_message(span_notice("[usr] fumbles around figuring out the wiring."),
+		span_notice("You fumble around figuring out the wiring."))
+		if(!do_after(user, 2 SECONDS * (SKILL_ENGINEER_ENGI - skill), TRUE, holder, BUSY_ICON_UNSKILLED) || is_cut(wire))
+			return
+
 	assemblies -= color
 	S.connected = null
 	S.forceMove(get_turf(S))

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -154,13 +154,13 @@
 /datum/wires/proc/pulse(wire, mob/user)
 	if(is_cut(wire))
 		return
-
-	var/skill = user.skills.getRating("engineer")
-	if(skill < SKILL_ENGINEER_ENGI)
-		user.visible_message(span_notice("[usr] fumbles around figuring out the wiring."),
-		span_notice("You fumble around figuring out the wiring."))
-		if(!do_after(user, 2 SECONDS * (SKILL_ENGINEER_ENGI - skill), TRUE, holder, BUSY_ICON_UNSKILLED) || is_cut(wire))
-			return
+	if(user) //Signalers skip pulse delay
+		var/skill = user.skills.getRating("engineer")
+		if(skill < SKILL_ENGINEER_ENGI)
+			user.visible_message(span_notice("[usr] fumbles around figuring out the wiring."),
+			span_notice("You fumble around figuring out the wiring."))
+			if(!do_after(user, 2 SECONDS * (SKILL_ENGINEER_ENGI - skill), TRUE, holder, BUSY_ICON_UNSKILLED) || is_cut(wire))
+				return
 
 	on_pulse(wire, user)
 

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -178,12 +178,6 @@
 
 /datum/wires/proc/attach_assembly(color, obj/item/assembly/S)
 	if(istype(S) && S.attachable && !is_attached(color))
-		if(skill < SKILL_ENGINEER_ENGI)
-			user.visible_message(span_notice("[usr] fumbles around figuring out the wiring."),
-			span_notice("You fumble around figuring out the wiring."))
-			if(!do_after(user, 2 SECONDS * (SKILL_ENGINEER_ENGI - skill), TRUE, holder, BUSY_ICON_UNSKILLED) || is_cut(wire))
-				return
-
 		assemblies[color] = S
 		S.forceMove(holder)
 		S.connected = src
@@ -194,12 +188,6 @@
 	var/obj/item/assembly/S = get_attached(color)
 	if(!istype(S))
 		return
-
-	if(skill < SKILL_ENGINEER_ENGI)
-		user.visible_message(span_notice("[usr] fumbles around figuring out the wiring."),
-		span_notice("You fumble around figuring out the wiring."))
-		if(!do_after(user, 2 SECONDS * (SKILL_ENGINEER_ENGI - skill), TRUE, holder, BUSY_ICON_UNSKILLED) || is_cut(wire))
-			return
 
 	assemblies -= color
 	S.connected = null


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Have you ever hacked a door, a vendor or even something weird like a radio and seen that little 'Attach' button in the wiring menu?
Yeah, putting stuff on it hasn't worked for about a year or two. I've been meaning to squash this bug for a while.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes good. This is a really really really cool feature.
Could create balance issues with possible traps, but if the door is powered enough for these assemblies to work, it'd take 5+ seconds for a xeno to slowwwly pry open when it's closed anyway. Shuttertraps are still far superior and AI can no longer close doors behind xenos groundside
 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Attaching stuff like signalers, voice sensors and the like to wires will now actually pulse them instead of runtiming
balance: Possible engi heaven
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
