### PR TITLE
Add CAS radio key to the tactical binocs crate.

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -60,7 +60,7 @@ OPERATIONS
 	name = "tactical binoculars crate"
 	contains = list(
 		/obj/item/binoculars/tactical,
-		/obj/item/encryptionkey/cas
+		/obj/item/encryptionkey/cas,
 	)
 	cost = 30
 	available_against_xeno_only = TRUE

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -58,7 +58,10 @@ OPERATIONS
 
 /datum/supply_packs/operations/binoculars_tatical
 	name = "tactical binoculars crate"
-	contains = list(/obj/item/binoculars/tactical)
+	contains = list(
+		/obj/item/binoculars/tactical,
+		/obj/item/encryptionkey/cas
+	)
 	cost = 30
 	available_against_xeno_only = TRUE
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When you order tactical binocs, you now get one key for CAS radio.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
There is pretty much no way for a regular marine to get access to fire support channels if they didn't grab the mortar crate at round start. This PR changes that. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added one CAS radio key to the tactical binoculars crate. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
