### PR TITLE
Shield hard armor works, bullet pen applies

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -250,7 +250,7 @@
 		S.reagents?.reaction(src, TOUCH, S.fraction)
 	return protection
 
-/mob/living/proc/check_shields(attack_type, damage, damage_type = "melee", silent)
+/mob/living/proc/check_shields(attack_type, damage, damage_type = "melee", silent, penetration = 0)
 	if(!damage)
 		stack_trace("check_shields called without a damage value")
 		return 0
@@ -261,7 +261,7 @@
 		sortTim(affecting_shields, /proc/cmp_numeric_dsc, associative = TRUE)
 	for(var/shield in affecting_shields)
 		var/datum/callback/shield_check = shield
-		. = shield_check.Invoke(attack_type, ., damage_type, silent)
+		. = shield_check.Invoke(attack_type, ., damage_type, silent, penetration)
 		if(!.)
 			break
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -863,7 +863,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	if(!damage)
 		return
 
-	damage = check_shields(COMBAT_PROJ_ATTACK, damage, proj.ammo.armor_type)
+	damage = check_shields(COMBAT_PROJ_ATTACK, damage, proj.ammo.armor_type, FALSE, proj.penetration)
 	if(!damage)
 		proj.ammo.on_shield_block(src, proj)
 		bullet_ping(proj)


### PR DESCRIPTION
## About The Pull Request
Hard armor on shields had two issues: if it was more than the damage taken the shield didn't absorb anything at all, and if it wasn't then it still increased the damage the mob took.
Bullet pen didn't apply to shields at all. With this it'll increase the damage the shield itself takes (mob damage is unaffected) for absorption shields like riot and reduce block chance for binary shields like eswords. 

## Why It's Good For The Game
Bugfixes

## Changelog
:cl:
add: High-pen bullets deal more damage to shields
fix: Shield hard armor reduces damage instead of increasing it
/:cl:
