### PR TITLE
Surgery single limb selection

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -118,11 +118,11 @@ proc/do_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool)
 	if(user.do_actions) //already doing an action
 		return TRUE
 
+	var/datum/limb/affected = user.client.prefs.toggles_gameplay & RADIAL_MEDICAL ? radial_medical(M, user) : M.get_limb(user.zone_selected)
 	for(var/datum/surgery_step/surgery_step AS in GLOB.surgery_steps)
 		//Check if tool is right or close enough, and the target mob valid, and if this step is possible
 		if(!surgery_step.tool_quality(tool) || !surgery_step.is_valid_target(M))
 			continue
-		var/datum/limb/affected = user.client.prefs.toggles_gameplay & RADIAL_MEDICAL ? radial_medical(M, user) : M.get_limb(user.zone_selected)
 		if(!affected)
 			return TRUE
 		if(affected.in_surgery_op) //two surgeons can't work on same limb at same time


### PR DESCRIPTION

## About The Pull Request
Radial limb selection only runs once when trying to do surgery instead of once for every possible surgery step available. Didn't test the last batch on radial oops.

## Why It's Good For The Game
bugfix

## Changelog
:cl:
fix: Radial medical will only need to choose limb once for surgery
/:cl: