### PR TITLE
Add yet another set of railing to the ASRS Elevator to prevent crate spacing

### DIFF
--- a/_maps/shuttles/supply.dmm
+++ b/_maps/shuttles/supply.dmm
@@ -9,39 +9,108 @@
 /obj/docking_port/mobile/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/shuttle/supply)
+"f" = (
+/obj/machinery/door/poddoor/railing{
+	id = "supply_elevator_railing"
+	},
+/obj/machinery/door/poddoor/railing{
+	dir = 2;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/shuttle/supply)
+"l" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/shuttle/supply)
+"C" = (
+/obj/machinery/door/poddoor/railing{
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/shuttle/supply)
+"E" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 2;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/shuttle/supply)
+"I" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/shuttle/supply)
+"K" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/shuttle/supply)
+"M" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "supply_elevator_railing"
+	},
+/obj/machinery/door/poddoor/railing{
+	dir = 2;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/shuttle/supply)
+"Q" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/obj/machinery/door/poddoor/railing{
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/shuttle/supply)
 
 (1,1,1) = {"
-a
-a
-a
-a
-a
+I
+l
+l
+l
+M
 "}
 (2,1,1) = {"
-a
+K
 b
 a
 b
-a
+E
 "}
 (3,1,1) = {"
-a
+K
 a
 c
 a
-a
+E
 "}
 (4,1,1) = {"
-a
+K
 b
 a
 b
-a
+E
 "}
 (5,1,1) = {"
-a
-a
-a
-a
-a
+Q
+C
+C
+C
+f
 "}


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds retractable railing to the Elevator to prevent crates getting spaced in transit
![2022-08-19 18_34_53-Window](https://user-images.githubusercontent.com/70376633/185666377-7c6d4508-f8ce-48a3-a481-f4d344125376.png)
![2022-08-19 18_35_41-Window](https://user-images.githubusercontent.com/70376633/185666402-7f7fc837-46e8-4ad4-b563-c74492dd0e82.png)

## Why It's Good For The Game

Crates getting spaced is very bad for the RO and whoever wants contents of said crates

## Changelog
:cl:
add: Added another set of railing to the ASRS so crates dont get spaced
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
