### PR TITLE
Hunter Swap control simplification

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -470,7 +470,6 @@
 #define COMSIG_WARRIOR_USED_GRAPPLE_TOSS "warrior_used_grapple_toss"
 
 #define COMSIG_XENOABILITY_HUNTER_MARK "xenoability_hunter_mark"
-#define COMSIG_XENOABILITY_SWAP "xenoability_swap"
 #define COMSIG_XENOABILITY_PSYCHIC_TRACE "xenoability_psychic_trace"
 
 #define COMSIG_XENOMORPH_PLASMA_REGEN "xenomorph_plasma_regen"

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -359,12 +359,6 @@
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_TOGGLE_STEALTH
 
-/datum/keybinding/xeno/swap
-	name = "swap"
-	full_name = "Hunter: Swap"
-	description = ""
-	keybind_signal = COMSIG_XENOABILITY_SWAP
-
 /datum/keybinding/xeno/mirage
 	name = "mirage"
 	full_name = "Hunter: Mirage"

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -477,7 +477,7 @@
 	var/datum/action/xeno_action/mirage/mirage_action = X.actions_by_path[/datum/action/xeno_action/mirage]
 	if(!mirage_action?.illusions)
 		to_chat(X, span_xenowarning("We have no illusions to swap with!"))
-		return FALSE
+		return
 	var/turf/current_turf = get_turf(X)
 	X.forceMove(get_turf(mirage_action.illusions[1].loc))
 	mirage_action.illusions[1].forceMove(current_turf)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -466,7 +466,6 @@
 				illusions += new /mob/illusion/xeno(owner.loc, owner, null, illusion_life_time)
 	addtimer(CALLBACK(src, .proc/clean_illusions), illusion_life_time)
 
-
 /// Clean up the illusions list
 /datum/action/xeno_action/mirage/proc/clean_illusions()
 	illusions = list()

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
@@ -59,7 +59,6 @@
 		/datum/action/xeno_action/activable/hunter_mark,
 		/datum/action/xeno_action/psychic_trace,
 		/datum/action/xeno_action/mirage,
-		/datum/action/xeno_action/swap,
 	)
 
 	// *** Vent Crawl Parameters *** //
@@ -184,5 +183,4 @@
 		/datum/action/xeno_action/activable/hunter_mark,
 		/datum/action/xeno_action/psychic_trace,
 		/datum/action/xeno_action/mirage,
-		/datum/action/xeno_action/swap,
 	)


### PR DESCRIPTION
## About The Pull Request
Instead of Hunter Mirage and Swap being two different abilities, Swap is triggered by reactivating Mirage while illusions are active.

## Why It's Good For The Game
Simplifies the control scheme for this caste. Since the two abilities can only ever be used one after the other, they can be on the same hotkey instead of having two separate hotkeys.
## Changelog
:cl:
qol: Hunter's Swap is no longer activated with a separate ability, reactivate Mirage to trigger it.
/:cl: