### PR TITLE
Fix Combat Patrol groundmap votes

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -255,10 +255,6 @@ SUBSYSTEM_DEF(vote)
 				if(!lower_admin && SSmapping.groundmap_voted)
 					to_chat(usr, span_warning("The next ground map has already been selected."))
 					return FALSE
-				var/datum/game_mode/next_gamemode = config.pick_mode(GLOB.master_mode)
-				if(next_gamemode.flags_round_type & MODE_SPECIFIC_SHIP_MAP)
-					to_chat(usr, span_warning("No other valid maps for [next_gamemode.name]."))
-					return FALSE
 				var/list/maps = list()
 				if(!config.maplist)
 					return
@@ -280,6 +276,10 @@ SUBSYSTEM_DEF(vote)
 				multiple_vote = TRUE
 				if(!lower_admin && SSmapping.shipmap_voted)
 					to_chat(usr, span_warning("The next ship map has already been selected."))
+					return FALSE
+				var/datum/game_mode/next_gamemode = config.pick_mode(GLOB.master_mode)
+				if(next_gamemode.flags_round_type & MODE_SPECIFIC_SHIP_MAP)
+					to_chat(usr, span_warning("No other valid maps for [next_gamemode.name]."))
 					return FALSE
 				var/list/maps = list()
 				if(!config.maplist)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I have no idea how this wasn't picked up, I think some shitcode meant this issue wasn't always actually triggering...
Fixed voting so you can't vote shipmap if the upcoming round is combat patrol.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fucking vote codesdfshdfisdhf
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Voting a different shipmap during Combat Patrol is correctly disabled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
