### PR TITLE
Lighting and bugfix

### DIFF
--- a/code/controllers/subsystem/modularmapping.dm
+++ b/code/controllers/subsystem/modularmapping.dm
@@ -8,4 +8,5 @@ SUBSYSTEM_DEF(modularmapping)
 	for(var/obj/effect/spawner/modularmap/map AS in markers)
 		map.load_modularmap()
 	markers = null
+	repopulate_sorted_areas() //adds all the modular map areas to the list
 	return ..()

--- a/code/datums/gamemodes/combat_patrol.dm
+++ b/code/datums/gamemodes/combat_patrol.dm
@@ -42,7 +42,7 @@
 			if(CEILING_UNDERGROUND to CEILING_UNDERGROUND_METAL)
 				area_to_lit.set_base_lighting(COLOR_WHITE, 75)
 			if(CEILING_DEEP_UNDERGROUND to CEILING_DEEP_UNDERGROUND_METAL)
-				area_to_lit.set_base_lighting(COLOR_WHITE, 25)
+				area_to_lit.set_base_lighting(COLOR_WHITE, 50)
 	GLOB.join_as_robot_allowed = FALSE
 
 /datum/game_mode/combat_patrol/scale_roles()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #10659  
Fixes light levels not being correctly assigned to modular map areas in Combat Patrol and Civil War.
Also fixes a few related bugs, such as these areas not being available to jump to for ghosts/admins, or for admin supply pods etc.

Modular map areas were being added to the game after a proc had run to add all areas in the world to a list of areas. Now that proc runs against after modular map inserts are loaded.

Maybe I should have had this as a separate PR, but I forgot to make a new PR when making the bug fix above, oh well.

Also increases the light levels of deep caves in Combat Patrol to 50 from 25. It'll still be dark, but it shouldn't be this aylmao squintfest.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Seeing is good.
Modular map areas being in the list of areas is very good.
Bugfixes doubleplus good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed lighting not updating in modular map areas during Combat Patrol
balance: Combat Patrol: Increased the light level of deep caves
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
