### PR TITLE
Keybinds for Attack, Defend, and Retreat orders

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -765,6 +765,10 @@
 #define COMSIG_KB_FOCUSORDER "keybind_focusorder"
 #define COMSIG_KB_RALLYORDER "keybind_rallyorder"
 #define COMSIG_KB_SENDORDER "keybind_sendorder"
+#define COMSIG_KB_ATTACKORDER "keybind_attackorder"
+#define COMSIG_KB_DEFENDORDER "keybind_defendorder"
+#define COMSIG_KB_RETREATORDER "keybind_retreatorder"
+
 
 // human modules signals for keybindings
 #define COMSIG_KB_VALI_CONFIGURE "keybinding_vali_configure"

--- a/code/datums/actions/order_action.dm
+++ b/code/datums/actions/order_action.dm
@@ -103,6 +103,7 @@
 
 //These 'personal' subtypes are the ones not used by overwatch; like what SL or FC gets
 /datum/action/innate/order/attack_order/personal
+	keybind_signal = COMSIG_KB_ATTACKORDER
 
 /datum/action/innate/order/attack_order/personal/should_show()
 	return owner.skills.getRating(skill_name) >= skill_min
@@ -121,6 +122,7 @@
 	visual_type = /obj/effect/temp_visual/order/defend_order
 
 /datum/action/innate/order/defend_order/personal
+	keybind_signal = COMSIG_KB_DEFENDORDER
 
 /datum/action/innate/order/defend_order/personal/should_show()
 	return owner.skills.getRating(skill_name) >= skill_min
@@ -138,6 +140,7 @@
 	visual_type = /obj/effect/temp_visual/order/retreat_order
 
 /datum/action/innate/order/retreat_order/personal
+	keybind_signal = COMSIG_KB_RETREATORDER
 
 /datum/action/innate/order/retreat_order/personal/should_show()
 	return owner.skills.getRating(skill_name) >= skill_min

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -121,3 +121,21 @@
 	full_name = "Send Order"
 	description = "Order marines a certain message"
 	keybind_signal = COMSIG_KB_SENDORDER
+
+/datum/keybinding/human/attack_order
+	name = "attack_order"
+	full_name = "Issue Attack Order"
+	description = "Order and rally marines to attack"
+	keybind_signal = COMSIG_KB_ATTACKORDER
+
+/datum/keybinding/human/defend_order
+	name = "defend_order"
+	full_name = "Issue Hold Order"
+	description = "Order and rally marines to defend"
+	keybind_signal = COMSIG_KB_DEFENDORDER
+
+/datum/keybinding/human/retreat_order
+	name = "hold_order"
+	full_name = "Issue Hold Order"
+	description = "Order and rally marines to retreat"
+	keybind_signal = COMSIG_KB_RETREATORDER

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -130,12 +130,12 @@
 
 /datum/keybinding/human/defend_order
 	name = "defend_order"
-	full_name = "Issue Hold Order"
+	full_name = "Issue Defend Order"
 	description = "Order and rally marines to defend"
 	keybind_signal = COMSIG_KB_DEFENDORDER
 
 /datum/keybinding/human/retreat_order
-	name = "hold_order"
-	full_name = "Issue Hold Order"
+	name = "retreat_order"
+	full_name = "Issue Retreat Order"
 	description = "Order and rally marines to retreat"
 	keybind_signal = COMSIG_KB_RETREATORDER


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Let the most robust SL or FC have keybinds to coordinate marines

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Keybinds for Attack, Defend, and Retreat orders
qol: easier to coordinate as FC or SL
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
