### PR TITLE
Combat Patrol sound tweaks

### DIFF
--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -31,7 +31,9 @@
 	var/max_loops
 	///(bool) If true plays directly to provided atoms instead of from them
 	var/direct = FALSE
-	var/extra_range = 0
+	///Range the sound will travel
+	var/range = 0
+	///The rate the volume falls off. Higher = volume drops slower
 	var/falloff
 
 	///(bool) Whether this datum is currently going through the subsystem on a loop
@@ -101,7 +103,7 @@
 		if(direct)
 			SEND_SOUND(thing, S)
 		else
-			playsound(thing, S, volume, vary, extra_range, falloff)
+			playsound(thing, S, volume, vary, range, falloff)
 
 /**
  * Picks and returns soundfile

--- a/code/datums/looping_sounds/machinery_sounds.dm
+++ b/code/datums/looping_sounds/machinery_sounds.dm
@@ -6,7 +6,6 @@
 	end_sound = 'sound/machines/generator/generator_end.ogg'
 	volume = 40
 
-
 /datum/looping_sound/grill
 	mid_sounds = list('sound/machines/grill/grillsizzle.ogg' = 1)
 	mid_length = 18
@@ -16,10 +15,11 @@
 	mid_sounds = list('sound/machines/sound_machines_FireAlarm2.ogg', 'sound/machines/sound_machines_FireAlarm4.ogg')
 	mid_length = 18
 	volume = 50
-	extra_range = 20
+	range = 20
 
 /datum/looping_sound/radio
 	mid_sounds = list('sound/effects/radio_chatter/radio1.ogg' = 1, 'sound/effects/radio_chatter/radio2.ogg' = 1, 'sound/effects/radio_chatter/radio3.ogg' = 1, 'sound/effects/radio_chatter/radio4.ogg' = 1, 'sound/effects/radio_chatter/radio5.ogg' = 1, 'sound/effects/radio_chatter/radio6.ogg' = 1, 'sound/effects/radio_chatter/radio7.ogg' = 1, 'sound/effects/radio_chatter/radio8.ogg' = 1)
 	mid_length = 35 SECONDS
-	volume = 75
-
+	volume = 24
+	range = 8
+	falloff = 1

--- a/code/game/objects/structures/patrol_points.dm
+++ b/code/game/objects/structures/patrol_points.dm
@@ -71,8 +71,8 @@
 
 /atom/movable/effect/rappel_rope/Initialize()
 	. = ..()
-	playsound(loc, 'sound/effects/rappel.ogg', 50, TRUE)
-	playsound(loc, 'sound/effects/tadpolehovering.ogg', 100, TRUE)
+	playsound(loc, 'sound/effects/rappel.ogg', 50, TRUE, falloff = 2)
+	playsound(loc, 'sound/effects/tadpolehovering.ogg', 100, TRUE, falloff = 2.5)
 	balloon_alert_to_viewers("You see a dropship fly overhead and begin dropping ropes!")
 	ropeanimation()
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces volume and/or increases falloff rate for combat base radio chatter, and rappel/hovering tad sounds.
They were really loud, with low falloff, so they stayed very loud even at a very high distance.

Also cleaned up/added autodoc to a couple of vars for looping sounds.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less ear damaging
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Made radio chatter and rappeling quieter in Combat Patrol
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
