### PR TITLE
Slightly reduce vox cooldown for the AI

### DIFF
--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -44,7 +44,7 @@
 ///Make sure that the code compiles with AI_VOX undefined
 #ifdef AI_VOX
 ///cooldown between vox announcements, divide by 10 to get the time in seconds
-#define VOX_DELAY 600
+#define VOX_DELAY 400
 /mob/living/silicon/ai/proc/announcement_help() //displays a list of available vox words for the user to make sentences with, players can click the words to hear a preview of how they sound
 
 	if(incapacitated())


### PR DESCRIPTION
## About The Pull Request
This PR changes the AI voice from a cooldown of 60 seconds to 40 seconds. (Assuming no lag)

## Why It's Good For The Game
The AI voice is nice, but it is not as good as announcement.
Making it slightly more frequent could help it to be leaned on more by AI players as a command tool.

## Changelog
:cl:
balance: Lowered vox cooldown from 60s to 40s
/:cl:

