### PR TITLE
Add an auxiliary fuel tank for the condor

### DIFF
--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -49,6 +49,9 @@
 		return TRUE
 	if(installed_equipment || clamp.loaded != loaded_equipment)
 		return TRUE
+	if(loaded_equipment.attempt_attach(ship_tag))
+		to_chat(user, span_warning("Error, baby."))
+		return TRUE
 	to_chat(user, span_notice("You install [loaded_equipment] on [src]."))
 	loaded_equipment.forceMove(loc)
 	clamp.loaded = null
@@ -284,6 +287,10 @@
 /obj/structure/dropship_equipment/beforeShuttleMove(turf/newT, rotation, move_mode, obj/docking_port/mobile/moving_dock)
 	. = ..()
 	on_launch()
+
+//things to do when you try to attach the equipment
+/obj/structure/dropship_equipment/proc/attempt_attach()
+	return FALSE
 
 /obj/structure/dropship_equipment/proc/update_equipment()
 	return
@@ -1003,6 +1010,12 @@
 	icon_state = "table2-idle"
 	point_cost = 70
 	var/fuel_content = 0
+
+/obj/structure/dropship_equipment/fuel_tank/attempt_attach(tag)
+	if(tag == SHUTTLE_CAS_DOCK)
+		for(var/obj/docking_port/mobile/marine_dropship/casplane/S in SSshuttle.dropships)
+			if(/obj/structure/dropship_equipment/fuel_tank in S.equipments)
+				return TRUE
 
 /obj/structure/dropship_equipment/fuel_tank/update_equipment()
 	. = ..()

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -49,9 +49,6 @@
 		return TRUE
 	if(installed_equipment || clamp.loaded != loaded_equipment)
 		return TRUE
-	if(loaded_equipment.attempt_attach(ship_tag))
-		to_chat(user, span_warning("Error, baby."))
-		return TRUE
 	to_chat(user, span_notice("You install [loaded_equipment] on [src]."))
 	loaded_equipment.forceMove(loc)
 	clamp.loaded = null
@@ -287,10 +284,6 @@
 /obj/structure/dropship_equipment/beforeShuttleMove(turf/newT, rotation, move_mode, obj/docking_port/mobile/moving_dock)
 	. = ..()
 	on_launch()
-
-//things to do when you try to attach the equipment
-/obj/structure/dropship_equipment/proc/attempt_attach()
-	return FALSE
 
 /obj/structure/dropship_equipment/proc/update_equipment()
 	return
@@ -1010,12 +1003,6 @@
 	icon_state = "table2-idle"
 	point_cost = 70
 	var/fuel_content = 0
-
-/obj/structure/dropship_equipment/fuel_tank/attempt_attach(tag)
-	if(tag == SHUTTLE_CAS_DOCK)
-		for(var/obj/docking_port/mobile/marine_dropship/casplane/S in SSshuttle.dropships)
-			if(/obj/structure/dropship_equipment/fuel_tank in S.equipments)
-				return TRUE
 
 /obj/structure/dropship_equipment/fuel_tank/update_equipment()
 	. = ..()

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -1001,7 +1001,7 @@
 	equip_category = DROPSHIP_WEAPON
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "table2-idle"
-	point_cost = 100
+	point_cost = 70
 	var/fuel_content = 0
 
 /obj/structure/dropship_equipment/fuel_tank/update_equipment()

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -994,3 +994,30 @@
 	deployed_table.layer = ABOVE_OBJ_LAYER + 0.01 //make sure its directly ABOVE the layer
 	deployed_table.loc = loc
 	icon_state = "table2-idle"
+
+/obj/structure/dropship_equipment/fuel_tank
+	name = "Condor external tank"
+	desc = "A fuel tank. It roughly doubles the condor internal capacity. You need a powerloader to lift it."
+	equip_category = DROPSHIP_WEAPON
+	icon = 'icons/obj/surgery.dmi'
+	icon_state = "table2-idle"
+	point_cost = 100
+	var/fuel_content = 0
+
+/obj/structure/dropship_equipment/fuel_tank/update_equipment()
+	. = ..()
+
+	for(var/obj/docking_port/mobile/marine_dropship/casplane/S in SSshuttle.dropships)
+		if(S.id == SHUTTLE_CAS_DOCK)
+			if(!ship_base)
+				if(S.fuel_left > 40)
+					fuel_content = S.fuel_left - 40
+				S.fuel_left = 40
+				S.fuel_max = 40
+				break
+
+			S.fuel_max = 80
+			S.fuel_left = S.fuel_left + fuel_content
+			break
+
+	update_icon()


### PR DESCRIPTION
## About The Pull Request
This PR adds a fuel tank to the condor. It takes a weapon slot, but allows for a longer stay on target.

I didn't have a sprite for it.
![image](https://user-images.githubusercontent.com/24830358/186292439-3a77b615-d574-4a45-8999-a129d383e9b7.png)

Things to do : 
- [ ] Get yelled at for ugly code
- [ ] Get a semi decent sprite for it
- [x] Get feedback for the price
- [ ] Optional : Make it un-selectable in the condor screen

Actually, we don't care. If someone wants to have 4 extra fuel tanks and only the minigun, they are free to do that choice.~~- [ ] Make it so you can only have one fuel tank on the condor~~

## Why It's Good For The Game
A little more choice in your kit besides which flavor of xeno killing you like.

## Changelog
:cl:
add: Added an auxiliary fuel tank for the condor
/:cl:
