### PR TITLE
Allows the AI to grab coordinates with ctrl click

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -164,6 +164,8 @@
 		alarm()
 
 
+/* Turf */
+
 //
 // Override TurfAdjacent for AltClicking
 //
@@ -187,3 +189,8 @@
 
 	else if(down)
 		TD.move_camera_by_click()
+
+/turf/AICtrlClick(mob/living/silicon/ai/user)
+	var/turf/T = get_turf(src)
+	to_chat(user, span_notice("Coordinates of selected turf at [T.loc]. COORDINATES: X:[T.x] Y:[T.y]"))
+	

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -191,5 +191,5 @@
 		TD.move_camera_by_click()
 
 /turf/AICtrlClick(mob/living/silicon/ai/user)
-	to_chat(user, span_notice("Coordinates of selected turf at [src.loc]. COORDINATES: X:[src.x] Y:[src.y]"))
+	to_chat(user, span_notice("Coordinates of selected turf at [loc]. COORDINATES: X:[x] Y:[y]"))
 	

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -191,6 +191,5 @@
 		TD.move_camera_by_click()
 
 /turf/AICtrlClick(mob/living/silicon/ai/user)
-	var/turf/T = get_turf(src)
-	to_chat(user, span_notice("Coordinates of selected turf at [T.loc]. COORDINATES: X:[T.x] Y:[T.y]"))
+	to_chat(user, span_notice("Coordinates of selected turf at [src.loc]. COORDINATES: X:[src.x] Y:[src.y]"))
 	


### PR DESCRIPTION
## About The Pull Request
Clicking Ctrl click on a turf you can see will now print the coordinates in your chat. 
I'd have liked to have it copy into your clipboard, but I'm not sure byond can do that. 

## Why It's Good For The Game
This would allow the AI to more easily provide drop pod coordinates, and targeting information for artillery pieces. 
I think this is a buff for the role, but nothing you couldn't do with a (working) webmap before. 

## Changelog
:cl:
add: Gave the AI the ability to Ctrl-click turfs to get their coordinates. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
