### PR TITLE
Remove an useless argument in a mortar/binocs proc 

### DIFF
--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -230,7 +230,7 @@
 			targetturf = TU
 			to_chat(user, span_notice("COORDINATES TARGETED: LONGITUDE [targetturf.x]. LATITUDE [targetturf.y]."))
 			playsound(src, 'sound/effects/binoctarget.ogg', 35)
-			linked_mortar.recieve_target(TU,src,user)
+			linked_mortar.recieve_target(TU,user)
 			return
 		if(MODE_RAILGUN)
 			to_chat(user, span_notice("ACQUIRING TARGET. RAILGUN TRIANGULATING. DON'T MOVE."))

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -241,7 +241,7 @@
 	to_chat(user, "<span class='notice'>You disconnect the [binocs] from their linked mortar.")
 
 ///Proc called by tactical binoculars to send targeting information.
-/obj/machinery/deployable/mortar/proc/recieve_target(turf/T, binocs, mob/user)
+/obj/machinery/deployable/mortar/proc/recieve_target(turf/T, mob/user)
 	coords["targ_x"] = T.x
 	coords["targ_y"] = T.y
 	say("Remote targeting set by [user]. COORDINATES: X:[coords["targ_x"]] Y:[coords["targ_y"]] OFFSET: X:[coords["dial_x"]] Y:[coords["dial_y"]]")


### PR DESCRIPTION
## About The Pull Request
The binocs argument is used nowhere, so lets toss it.

Please merge this before #10834 or it will break it. 

## Why It's Good For The Game
No useless arguments = better codebase health

## Changelog
:cl:
code: removed an useless argument in mortar/binocs code
/:cl:
