### PR TITLE
Fix projectiles being able to bypass fog

### DIFF
--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -90,6 +90,7 @@
 	density = TRUE
 	icon_state = "blocker"
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	resistance_flags = RESIST_ALL
 
 /obj/effect/forcefield/Initialize()
 	. = ..()
@@ -144,6 +145,7 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "smoke"
 	density = FALSE
+	resistance_flags = RESIST_ALL|PROJECTILE_IMMUNE
 
 /obj/effect/forcefield/fog/passable_fog/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
What it says on the tin. Crash fog, forcefields (but not 'normal' decorative fog) can no longer be fired through.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed projectiles going through fog
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
