### PR TITLE
Make Tac/Rangefinder binoculars able to link to multiple mortars

### DIFF
--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -125,6 +125,7 @@
 	else
 		. += "binoculars_laser"
 
+/// Proc that when called checks if the selected mortar isnt out of list bounds and if it is, resets to 1
 /obj/item/binoculars/tactical/proc/check_mortar_index()
 	if(!linked_mortars)
 		return
@@ -248,7 +249,7 @@
 			targetturf = TU
 			to_chat(user, span_notice("COORDINATES TARGETED BY MORTAR [selected_mortar]: LONGITUDE [targetturf.x]. LATITUDE [targetturf.y]."))
 			playsound(src, 'sound/effects/binoctarget.ogg', 35)
-			var/obj/machinery/deployable/mortar/mortar = linked_mortars[selected_mortar] /// typecasted lists STILL dont help in the slightest
+			var/obj/machinery/deployable/mortar/mortar = linked_mortars[selected_mortar]
 			mortar.recieve_target(TU,user)
 			return
 		if(MODE_RAILGUN)

--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -125,13 +125,21 @@
 	else
 		. += "binoculars_laser"
 
+/obj/item/binoculars/tactical/proc/check_mortar_index()
+	if(!linked_mortars)
+		return
+	if(!linked_mortars.len)
+		selected_mortar = 1 // set back to default but it still wont fire because no mortars and thats good
+		return
+	if(selected_mortar > linked_mortars.len)
+		selected_mortar = 1
+
 /obj/item/binoculars/tactical/AltClick(mob/user)
 	. = ..()
 	if(!linked_mortars.len)
 		return
 	selected_mortar += 1
-	if(selected_mortar > linked_mortars.len)
-		selected_mortar = 1
+	check_mortar_index()
 	var/obj/mortar = linked_mortars[selected_mortar]
 	to_chat(user, span_notice("NOW SENDING COORDINATES TO MORTAR [selected_mortar] AT: LONGITUDE [mortar.x]. LATITUDE [mortar.y]."))
 
@@ -236,8 +244,7 @@
 			if(!linked_mortars.len)
 				to_chat(user, span_notice("No linked mortars found."))
 				return
-			if(linked_mortars.len < selected_mortar)
-				selected_mortar = 1 /// incase through some variable-edit or qdel tomfoolery something screws up
+			check_mortar_index() // incase varedit screws something up
 			targetturf = TU
 			to_chat(user, span_notice("COORDINATES TARGETED BY MORTAR [selected_mortar]: LONGITUDE [targetturf.x]. LATITUDE [targetturf.y]."))
 			playsound(src, 'sound/effects/binoctarget.ogg', 35)
@@ -317,6 +324,7 @@
 /obj/item/binoculars/tactical/proc/clean_refs(datum/source)
 	SIGNAL_HANDLER
 	linked_mortars -= source
+	check_mortar_index()
 	say("NOTICE: connection lost with linked mortar.")
 
 /obj/item/binoculars/tactical/scout


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tac/Rangefinder binoculars can now link to multiple mortars
Using binoculars on a mortar adds or removes them from the list
Using the binoculars to set target sets target on the selected linked mortar
Alt-click changes selected mortar, Unique Action now the only way to change modes, still has a verb for it i think
## Why It's Good For The Game
Its faster than getting a target, unlinking your mortar and then linking another target, then getting yet another mortar
Still needs teamwork or really,really quick hands to pull off firing the linked mortars in a speedy manner
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Rangefinder/Tactical Binoculars can now link to multiple mortars
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
