### PR TITLE
Nerfs Juggling

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -128,3 +128,10 @@
 
 	/// This is the cooldown on suffering additional effects for when shock gets high
 	COOLDOWN_DECLARE(last_shock_effect)
+
+///This shows when the human last fired a shotgun.
+	var/lastshotguntime
+///If the human fires a different shotgun before this amount of time has passed, it gets recoil damage. Saved for if the previously fired shotgun is gone.
+	var/lastshotgundelay
+///This is a reference to the last shotgun that the human fired.
+	var/lastshotgun

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -33,6 +33,16 @@
 	placed_overlay_iconstate = "shotgun"
 
 
+/obj/item/weapon/gun/shotgun/do_fire() //Handles recoil punishments for juggling.
+	. = ..()
+	var/mob/living/carbon/human/wielder = gun_user
+	if (wielder.lastshotgun != src && wielder.lastshotgun != wielder.get_inactive_held_item() && world.time < wielder.lastshotguntime + wielder.lastshotgundelay) //Does punishment for juggling in the form of recoil damage.
+		wielder.apply_damage(20, BRUTE, wielder.hand ? "l_arm" : "r_arm")
+		to_chat(wielder, span_userdanger("The recoil tears your arm!"))
+	wielder.lastshotguntime = world.time
+	wielder.lastshotgundelay = fire_delay
+	wielder.lastshotgun = src
+
 //-------------------------------------------------------
 //TACTICAL SHOTGUN
 

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -38,7 +38,7 @@
 	var/mob/living/carbon/human/wielder = gun_user
 	if (wielder.lastshotgun != src && wielder.lastshotgun != wielder.get_inactive_held_item() && world.time < wielder.lastshotguntime + wielder.lastshotgundelay) //Does punishment for juggling in the form of recoil damage.
 		wielder.apply_damage(20, BRUTE, wielder.hand ? "l_arm" : "r_arm")
-		to_chat(wielder, span_userdanger("The recoil tears your arm!"))
+		to_chat(wielder, span_userdanger("Your arm is torn by the recoil!"))
 	wielder.lastshotguntime = world.time
 	wielder.lastshotgundelay = fire_delay
 	wielder.lastshotgun = src

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -37,8 +37,12 @@
 	. = ..()
 	var/mob/living/carbon/human/wielder = gun_user
 	if (wielder.lastshotgun != src && wielder.lastshotgun != wielder.get_inactive_held_item() && world.time < wielder.lastshotguntime + wielder.lastshotgundelay) //Does punishment for juggling in the form of recoil damage.
-		wielder.apply_damage(20, BRUTE, wielder.hand ? "l_arm" : "r_arm")
+		var/zone = wielder.hand ? "l_arm" : "r_arm"
+		var/datum/limb/limb = wielder.get_limb(zone)
 		to_chat(wielder, span_userdanger("Your arm is torn by the recoil!"))
+		wielder.apply_damage(20, BRUTE, zone)
+		if (limb.get_damage() >= limb.max_damage)
+			limb.droplimb(0)
 	wielder.lastshotguntime = world.time
 	wielder.lastshotgundelay = fire_delay
 	wielder.lastshotgun = src


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Makes it so that firing a different shotgun before the firing delay of the shotgun you last fired has passed now causes 20 brute damage to the arm you're using alongside a warning message in chat. This ONLY affects juggling.

The message reads "Your arm is torn by the recoil!" in big, red text.

You can still get around 3 - 4 shots before a fracture and you'll either go critical or delimb if you go another 3 - 4 shots. This means that if you somehow manage to accidentally juggle a shot or two you won't just, idk, fucking explode?

This does take into account akimbo and has a check that prevents akimbo from being affected, don't worry about that.

Even if the limb has taken enough burn damage to avoid delimbing through ordinary means, this will forcefully delimb if it's at max damage when dealing damage. This prevents circumventing the punishment by using burn damage.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

This should be obvious. If a solo marine can kill a gorger with no issues in less than a second using juggling it should be pretty obvious why nerfing it/removing it is a good idea. In terms of balancing, 1 xeno is meant to be 3 marines and we're talking about the tankiest T3 xeno, so this just doesn't make any fucking sense and is annoying as all hell. (Primo crushers can also be reliably solo'd by this.)

So many people have complained about this that it's unreal. This is the first PR that tries to fix this issue that DOESN'T affect other aspects of the gun, such as having to wield it before firing. Things such as that significantly affect the weapon's CQC potential and may ruin it's viability while only partially mitigating the actual issue.

## Changelog
:cl:
balance: Juggling now has a 20 damage penalty to the arm you're using every time you do it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
