### PR TITLE
Adds a buffer between a limb's max damage and the brute required to sever

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -1,3 +1,5 @@
+#define LIMB_MAX_DAMAGE_SEVER_RATIO 0.8
+
 /****************************************************
 				EXTERNAL ORGANS
 ****************************************************/
@@ -13,7 +15,7 @@
 	var/brute_dam = 0
 	///burn damage this limb has taken as a part
 	var/burn_dam = 0
-	///Max damage the limb can take before being destroyed
+	///Max damage the limb can take. Extremities sever when they have at least LIMB_MAX_DAMAGE_SEVER_RATIO as a fraction of this in brute damage.
 	var/max_damage = 0
 	var/max_size = 0
 	var/last_dam = -1
@@ -264,7 +266,7 @@
 		if(updating_health)
 			owner.updatehealth()
 		return update_icon()
-	if(CONFIG_GET(flag/limbs_can_break) && brute && brute_dam + burn_dam >= max_damage * CONFIG_GET(number/organ_health_multiplier))
+	if(CONFIG_GET(flag/limbs_can_break) && brute_dam >= max_damage * LIMB_MAX_DAMAGE_SEVER_RATIO && CONFIG_GET(number/organ_health_multiplier))
 		droplimb() //If the limb's at its max damage and takes any brute, it severs
 		if(!(owner.species && (owner.species.species_flags & NO_PAIN)))
 			owner.emote("scream")
@@ -1010,7 +1012,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "l_arm"
 	display_name = "left arm"
 	icon_name = "l_arm"
-	max_damage = 125
+	max_damage = 150
 	min_broken_damage = 50
 	body_part = ARM_LEFT
 	cover_index = 7
@@ -1023,7 +1025,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "l_leg"
 	display_name = "left leg"
 	icon_name = "l_leg"
-	max_damage = 100
+	max_damage = 125
 	min_broken_damage = 50
 	body_part = LEG_LEFT
 	cover_index = 14
@@ -1033,7 +1035,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "r_arm"
 	display_name = "right arm"
 	icon_name = "r_arm"
-	max_damage = 125
+	max_damage = 150
 	min_broken_damage = 50
 	body_part = ARM_RIGHT
 	cover_index = 7
@@ -1046,7 +1048,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "r_leg"
 	display_name = "right leg"
 	icon_name = "r_leg"
-	max_damage = 100
+	max_damage = 125
 	min_broken_damage = 50
 	body_part = LEG_RIGHT
 	cover_index = 14
@@ -1056,7 +1058,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "l_foot"
 	display_name = "left foot"
 	icon_name = "l_foot"
-	max_damage = 75
+	max_damage = 100
 	min_broken_damage = 37
 	body_part = FOOT_LEFT
 	cover_index = 4
@@ -1066,7 +1068,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "r_foot"
 	display_name = "right foot"
 	icon_name = "r_foot"
-	max_damage = 75
+	max_damage = 100
 	min_broken_damage = 37
 	body_part = FOOT_RIGHT
 	cover_index = 4
@@ -1076,7 +1078,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "r_hand"
 	display_name = "right hand"
 	icon_name = "r_hand"
-	max_damage = 75
+	max_damage = 100
 	min_broken_damage = 37
 	body_part = HAND_RIGHT
 	cover_index = 2
@@ -1089,7 +1091,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "l_hand"
 	display_name = "left hand"
 	icon_name = "l_hand"
-	max_damage = 75
+	max_damage = 100
 	min_broken_damage = 37
 	body_part = HAND_LEFT
 	cover_index = 2
@@ -1102,7 +1104,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "head"
 	icon_name = "head"
 	display_name = "head"
-	max_damage = 100
+	max_damage = 125
 	min_broken_damage = 40
 	body_part = HEAD
 	vital = TRUE

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -264,7 +264,7 @@
 		if(updating_health)
 			owner.updatehealth()
 		return update_icon()
-	if(CONFIG_GET(flag/limbs_can_break) && brute_dam >= max_damage * CONFIG_GET(number/organ_health_multiplier))
+	if(CONFIG_GET(flag/limbs_can_break) && brute_dam + burn_dam >= max_damage * CONFIG_GET(number/organ_health_multiplier))
 		droplimb() //Reached max damage threshold through brute damage, that limb is going bye bye
 		if(!(owner.species && (owner.species.species_flags & NO_PAIN)))
 			owner.emote("scream")

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -267,7 +267,7 @@
 			owner.updatehealth()
 		return update_icon()
 	if(CONFIG_GET(flag/limbs_can_break) && brute_dam >= max_damage * LIMB_MAX_DAMAGE_SEVER_RATIO * CONFIG_GET(number/organ_health_multiplier))
-		droplimb() //If the limb's at its max damage and takes any brute, it severs
+		droplimb()
 		if(!(owner.species && (owner.species.species_flags & NO_PAIN)))
 			owner.emote("scream")
 		return

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -266,7 +266,7 @@
 		if(updating_health)
 			owner.updatehealth()
 		return update_icon()
-	if(CONFIG_GET(flag/limbs_can_break) && brute_dam >= max_damage * LIMB_MAX_DAMAGE_SEVER_RATIO && CONFIG_GET(number/organ_health_multiplier))
+	if(CONFIG_GET(flag/limbs_can_break) && brute_dam >= max_damage * LIMB_MAX_DAMAGE_SEVER_RATIO * CONFIG_GET(number/organ_health_multiplier))
 		droplimb() //If the limb's at its max damage and takes any brute, it severs
 		if(!(owner.species && (owner.species.species_flags & NO_PAIN)))
 			owner.emote("scream")

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -264,8 +264,8 @@
 		if(updating_health)
 			owner.updatehealth()
 		return update_icon()
-	if(CONFIG_GET(flag/limbs_can_break) && brute_dam + burn_dam >= max_damage * CONFIG_GET(number/organ_health_multiplier))
-		droplimb() //Reached max damage threshold through brute damage, that limb is going bye bye
+	if(CONFIG_GET(flag/limbs_can_break) && brute && brute_dam + burn_dam >= max_damage * CONFIG_GET(number/organ_health_multiplier))
+		droplimb() //If the limb's at its max damage and takes any brute, it severs
 		if(!(owner.species && (owner.species.species_flags & NO_PAIN)))
 			owner.emote("scream")
 		return


### PR DESCRIPTION
## About The Pull Request
Just about the same brute damage as before on all limbs, but limbs can hold more damage than before so you need 20-30 burn damage to become immune to amputations instead of any at all.

## Why It's Good For The Game
Solves tactical 1 burn damage with minimal potential for increasing burn damage potency on the whole.

## Changelog
:cl:
balance: You need 20-30 burn damage on a limb in order for it to be immune to getting chopped off, instead of any at all.
/:cl:
