### PR TITLE
Two Handing added to SH39

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -80,7 +80,7 @@
 	icon_state = "t39"
 	item_state = "t39"
 	fire_sound = 'sound/weapons/guns/fire/shotgun_automatic.ogg'
-	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
+	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY
 	default_ammo_type = /datum/ammo/bullet/shotgun/buckshot
 	attachable_allowed = list(
 		/obj/item/attachable/bayonet,


### PR DESCRIPTION
## About The Pull Request

This PR re-adds the requirement to start wielding the SH39 before being able to fire it.
It was removed as apart of [https://github.com/tgstation/TerraGov-Marine-Corps/pull/7142](7142)

## Why It's Good For The Game

Currently one handing the SH39 allows you to juggle up to three shotguns effectively. More so when combined with a shield.
This change is to mitigate some of the oppressiveness of three SH39 being rapid-fire on xenos.

## Changelog
:cl:
add: You are required to start wielding the SH39 before being able to fire it again.
/:cl:
