### PR TITLE
Removes juggling

### DIFF
--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -95,3 +95,5 @@
 	var/has_unlimited_silicon_privilege = 0
 	///The faction this mob belongs to
 	var/faction = FACTION_NEUTRAL
+	/// The world.time of the moment we fired our last gun + the delay to the next shot of the gun we fired
+	var/last_gun_fire_delay

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1521,6 +1521,14 @@
 
 /obj/item/weapon/gun/proc/gun_on_cooldown(mob/user)
 	var/added_delay = fire_delay
+
+	for(var/obj/item/weapon/gun/G in user.contents)
+		if(!(world.time >= G.last_fired + G.fire_delay))
+			return TRUE
+	for(var/obj/item/weapon/gun/G in get_turf(user))
+		if(!(world.time >= G.last_fired + G.fire_delay))
+			return TRUE
+
 	if(user)
 		if(!user.skills.getRating("firearms")) //no training in any firearms
 			added_delay += 3 //untrained humans fire more slowly.
@@ -1532,6 +1540,7 @@
 				if(GUN_SKILL_SMARTGUN)
 					if(user.skills.getRating(gun_skill_category) < 0)
 						added_delay -= 2 * user.skills.getRating(gun_skill_category)
+
 	var/delay = last_fired + added_delay
 	if(gun_firemode == GUN_FIREMODE_BURSTFIRE)
 		delay += extra_delay

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -745,6 +745,8 @@
 		return
 
 	last_fired = world.time
+	if(!(flags_gun_features & GUN_IS_ATTACHMENT))
+		gun_user.last_gun_fire_delay = world.time + fire_delay
 	SEND_SIGNAL(src, COMSIG_MOB_GUN_FIRED, target, src)
 
 	if(!max_chamber_items)
@@ -1521,14 +1523,6 @@
 
 /obj/item/weapon/gun/proc/gun_on_cooldown(mob/user)
 	var/added_delay = fire_delay
-
-	for(var/obj/item/weapon/gun/G in user.contents)
-		if(!(world.time >= G.last_fired + G.fire_delay))
-			return TRUE
-	for(var/obj/item/weapon/gun/G in get_turf(user))
-		if(!(world.time >= G.last_fired + G.fire_delay))
-			return TRUE
-
 	if(user)
 		if(!user.skills.getRating("firearms")) //no training in any firearms
 			added_delay += 3 //untrained humans fire more slowly.
@@ -1540,12 +1534,11 @@
 				if(GUN_SKILL_SMARTGUN)
 					if(user.skills.getRating(gun_skill_category) < 0)
 						added_delay -= 2 * user.skills.getRating(gun_skill_category)
-
 	var/delay = last_fired + added_delay
 	if(gun_firemode == GUN_FIREMODE_BURSTFIRE)
 		delay += extra_delay
 
-	if(world.time >= delay)
+	if(world.time >= delay && world.time >= user.last_gun_fire_delay)
 		return FALSE
 
 	if(world.time % 3 && !user?.client?.prefs.mute_self_combat_messages)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -745,7 +745,7 @@
 		return
 
 	last_fired = world.time
-	if(!(flags_gun_features & GUN_IS_ATTACHMENT))
+	if(!(flags_gun_features & GUN_ATTACHMENT_FIRE_ONLY))
 		gun_user.last_gun_fire_delay = world.time + fire_delay
 	SEND_SIGNAL(src, COMSIG_MOB_GUN_FIRED, target, src)
 
@@ -1538,7 +1538,7 @@
 	if(gun_firemode == GUN_FIREMODE_BURSTFIRE)
 		delay += extra_delay
 
-	if(world.time >= delay && world.time >= user.last_gun_fire_delay)
+	if(world.time >= delay && ((flags_gun_features & GUN_ATTACHMENT_FIRE_ONLY) ? TRUE : world.time >= user.last_gun_fire_delay))
 		return FALSE
 
 	if(world.time % 3 && !user?.client?.prefs.mute_self_combat_messages)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -745,8 +745,7 @@
 		return
 
 	last_fired = world.time
-	if(!dual_wield)
-		gun_user.last_gun_fire_delay = world.time + fire_delay
+	gun_user.last_gun_fire_delay = world.time + fire_delay
 	SEND_SIGNAL(src, COMSIG_MOB_GUN_FIRED, target, src)
 
 	if(!max_chamber_items)
@@ -770,6 +769,7 @@
 		var/obj/item/weapon/gun/inactive_gun = gun_user.get_inactive_held_item()
 		if(inactive_gun.rounds && !(inactive_gun.flags_gun_features & GUN_WIELDED_FIRING_ONLY))
 			inactive_gun.last_fired = max(world.time - fire_delay * (1 - akimbo_additional_delay), inactive_gun.last_fired)
+			gun_user.last_gun_fire_delay = max(world.time - fire_delay * (1 - akimbo_additional_delay), inactive_gun.last_fired)
 			gun_user.swap_hand()
 	return TRUE
 

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -745,7 +745,7 @@
 		return
 
 	last_fired = world.time
-	if(!(flags_gun_features & GUN_ATTACHMENT_FIRE_ONLY))
+	if(!dual_wield)
 		gun_user.last_gun_fire_delay = world.time + fire_delay
 	SEND_SIGNAL(src, COMSIG_MOB_GUN_FIRED, target, src)
 
@@ -1538,7 +1538,7 @@
 	if(gun_firemode == GUN_FIREMODE_BURSTFIRE)
 		delay += extra_delay
 
-	if(world.time >= delay && ((flags_gun_features & GUN_ATTACHMENT_FIRE_ONLY) ? TRUE : world.time >= user.last_gun_fire_delay))
+	if(world.time >= delay && ((flags_gun_features & GUN_ATTACHMENT_FIRE_ONLY) || world.time >= user.last_gun_fire_delay))
 		return FALSE
 
 	if(world.time % 3 && !user?.client?.prefs.mute_self_combat_messages)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Removes juggling by using a var on the mob who fired which tracks when the next shot of the gun they fired should be possible (current world time + firing delay of the weapon). If the time isn't up we arent allowed to fire any new guns. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I should probably write a tirade about how terrible juggling is for the game, but I'll spare you. 

Basically being able to bypass the balancing of slugs (and shotguns in general) of a slow fire rate is not good.

https://user-images.githubusercontent.com/22431091/187104113-70a4b6f0-e539-4706-a436-3a79583272f9.mp4



<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Juggling weapons is no longer possible, see #10848 for details
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
