### PR TITLE
Marine and SOM armour rebalancing

### DIFF
--- a/code/modules/clothing/gloves/marine_gloves.dm
+++ b/code/modules/clothing/gloves/marine_gloves.dm
@@ -78,13 +78,11 @@
 	soft_armor = list("melee" = 40, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 30, "bio" = 20, "rad" = 20, "fire" = 20, "acid" = 25)
 	resistance_flags = UNACIDABLE
 
-
 /obj/item/clothing/gloves/marine/som
 	name = "\improper SoM gloves"
 	desc = "Gloves with origins dating back to the old mining colonies, they look pretty tough."
 	icon_state = "som"
 	item_state = "som"
-	soft_armor = list("melee" = 30, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 20, "bio" = 20, "rad" = 20, "fire" = 20, "acid" = 15)
 
 /obj/item/clothing/gloves/marine/som/insulated
 	name = "\improper Insulated SoM gloves"
@@ -96,7 +94,7 @@
 	desc = "Gloves with origins dating back to the old mining colonies. These ones seem tougher than normal."
 	icon_state = "som_veteran"
 	item_state = "som_veteran"
-	soft_armor = list("melee" = 35, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 20, "bio" = 20, "rad" = 20, "fire" = 20, "acid" = 25)
+	soft_armor = list("melee" = 30, "bullet" = 20, "laser" = 15, "energy" = 20, "bomb" = 15, "bio" = 5, "rad" = 5, "fire" = 15, "acid" = 15)
 
 /obj/item/clothing/gloves/marine/commissar
 	name = "\improper commissar gloves"

--- a/code/modules/clothing/modular_armor/modular.dm
+++ b/code/modules/clothing/modular_armor/modular.dm
@@ -581,7 +581,7 @@
 	name = "Jaeger Pattern Infantry Helmet"
 	desc = "Usually paired with the Jaeger Combat Exoskeleton. Can mount utility functions on the helmet hard points. Has Infantry markings."
 	icon_state = "infantry_helmet"
-	soft_armor = list("melee" = 50, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 50, "bio" = 50, "rad" = 50, "fire" = 50, "acid" = 50)
+	soft_armor = list("melee" = 50, "bullet" = 70, "laser" = 70, "energy" = 60, "bomb" = 50, "bio" = 50, "rad" = 50, "fire" = 50, "acid" = 60)
 	accuracy_mod = 0
 	greyscale_config = /datum/greyscale_config/modularhelmet
 	attachments_allowed = list(
@@ -821,14 +821,14 @@
 /obj/item/clothing/head/modular/marine/m10x/leader
 	name = "\improper M11X pattern leader helmet"
 	desc = "A slightly fancier helmet for marine leaders. This one has cushioning to project your fragile brain."
-	soft_armor = list("melee" = 75, "bullet" = 65, "laser" = 55, "energy" = 55, "bomb" = 50, "bio" = 50, "rad" = 50, "fire" = 50, "acid" = 50)
+	soft_armor = list("melee" = 75, "bullet" = 75, "laser" = 75, "energy" = 65, "bomb" = 55, "bio" = 50, "rad" = 50, "fire" = 50, "acid" = 60)
 
 //SOM modular armour
 
 /obj/item/clothing/suit/modular/som
 	name = "\improper SOM light battle armor"
 	desc = "The M-21 battle armor is typically used by SOM light infantry, or other specialists that require more mobility at the cost of some protection. Provides good protection without minor impairment to the users mobility. Alt-Click to remove attached items. Use it to toggle the built-in flashlight."
-	soft_armor = list("melee" = 45, "bullet" = 70, "laser" = 60, "energy" = 60, "bomb" = 50, "bio" = 50, "rad" = 50, "fire" = 50, "acid" = 45)
+	soft_armor = list("melee" = 45, "bullet" = 70, "laser" = 60, "energy" = 60, "bomb" = 50, "bio" = 50, "rad" = 50, "fire" = 50, "acid" = 50)
 	icon_state = "som_medium"
 	item_state = "som_medium"
 	slowdown = 0.5
@@ -880,7 +880,7 @@
 /obj/item/clothing/suit/modular/som/heavy
 	name = "\improper SOM heavy battle armor"
 	desc = "A standard suit of M-31 heavy duty combat armor worn by SOM shock troops. Provides excellent protection however it does reduce mobility somewhat. Alt-Click to remove attached items. Use it to toggle the built-in flashlight."
-	soft_armor = list("melee" = 50, "bullet" = 75, "laser" = 65, "energy" = 65, "bomb" = 55, "bio" = 50, "rad" = 65, "fire" = 60, "acid" = 50)
+	soft_armor = list("melee" = 50, "bullet" = 75, "laser" = 65, "energy" = 65, "bomb" = 50, "bio" = 50, "rad" = 65, "fire" = 60, "acid" = 55)
 	icon_state = "som_heavy"
 	item_state = "som_heavy"
 	slowdown = 0.7
@@ -888,7 +888,7 @@
 /obj/item/clothing/suit/modular/som/heavy/leader
 	name = "\improper SOM Gorgon pattern assault armor"
 	desc = "A bulky suit of heavy combat armor, the M-35 'Gorgon' armour provides the user with superior protection without severely impacting mobility. Typically seen on SOM leaders or their most elite combat units due to the significant construction and maintenance requirements. You'll need serious firepower to punch through this. Alt-Click to remove attached items. Use it to toggle the built-in flashlight."
-	soft_armor = list("melee" = 60, "bullet" = 80, "laser" = 70, "energy" = 70, "bomb" = 65, "bio" = 55, "rad" = 70, "fire" = 70, "acid" = 55)
+	soft_armor = list("melee" = 60, "bullet" = 80, "laser" = 70, "energy" = 70, "bomb" = 60, "bio" = 55, "rad" = 70, "fire" = 65, "acid" = 55)
 	icon_state = "som_leader"
 	item_state = "som_leader"
 
@@ -914,7 +914,7 @@
 		slot_r_hand_str = 'icons/mob/items_righthand_1.dmi',)
 	icon_state = "som_helmet"
 	item_state = "som_helmet"
-	soft_armor = list("melee" = 45, "bullet" = 70, "laser" = 60, "energy" = 60, "bomb" = 50, "bio" = 50, "rad" = 50, "fire" = 50, "acid" = 45)
+	soft_armor = list("melee" = 45, "bullet" = 70, "laser" = 60, "energy" = 60, "bomb" = 50, "bio" = 50, "rad" = 50, "fire" = 50, "acid" = 50)
 	accuracy_mod = 0
 	greyscale_config = null
 	greyscale_colors = null
@@ -957,4 +957,4 @@
 		slot_r_hand_str = 'icons/mob/items_righthand_1.dmi',)
 	icon_state = "som_helmet"
 	item_state = "som_helmet"
-	soft_armor = list("melee" = 50, "bullet" = 75, "laser" = 65, "energy" = 65, "bomb" = 55, "bio" = 50, "rad" = 65, "fire" = 70, "acid" = 50)
+	soft_armor = list("melee" = 50, "bullet" = 75, "laser" = 65, "energy" = 65, "bomb" = 50, "bio" = 50, "rad" = 65, "fire" = 60, "acid" = 55)

--- a/code/modules/clothing/shoes/marine_shoes.dm
+++ b/code/modules/clothing/shoes/marine_shoes.dm
@@ -144,7 +144,6 @@
 	desc = "Shoes with origins dating back to the old mining colonies. These were made for more than just walking."
 	icon_state = "som"
 	item_state = "som"
-	soft_armor = list("melee" = 30, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 20, "bio" = 20, "rad" = 20, "fire" = 20, "acid" = 25)
 
 /obj/item/clothing/shoes/marine/som/knife
 	pockets = /obj/item/storage/internal/shoes/boot_knife/full


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Some number tweaks to make things more consistant.

**Marines**
Marine helmets now have the same armour values as heavy armour across the board. Previously they have notably lower bullet, laser, energy and acid armour.
MX11 helmets are now just 5 more armour across the board (except for melee which was already higher).

**SOM**
SOM shoes and gloves now have the same armour as marine versions, except veteran gloves which have 5 higher on bullet, laser and energy.

Some consistancy changes for SOM armour:
5 higher acid armour on medium and heavy armour (still lower than marine versions however).
5 lower bomb armour on heavy and Gorgon armour
5 lower fire armour on Gorgon armour

SOM helmets adjusted so that the standard helmet is equal armour values to **medium** armour and veteran helmets are the same as **heavy** armour.

**What does this mean for unga?**
In HvX, the asshole aiming head will do less damage, basically, and xenos spitting head will do very slightly less.

In HvH, aiming head will be far less effective than before, and against light and medium armoured TGMC, is actually worse than aiming for the torso, while SOM SL's specifically are best shot in the head.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistancy good
Better  balance in HvH
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Marine helmets now consistantly provide the same armour as heavy armour, with MX11 helmets a little better against projectiles
balance: SOM armour tweaked slightly to be more consistant, with shoes and gloves now having the same armour as marine versions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
