### PR TITLE
Increases the survivability of certain objects and structures

### DIFF
--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -8,6 +8,7 @@
 	var/dropmetal = TRUE
 	resistance_flags = XENO_DAMAGEABLE
 	max_integrity = 40
+	soft_armor = list("melee" = 0, "bullet" = 60, "laser" = 60, "energy" = 60, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	hit_sound = 'sound/effects/woodhit.ogg'
 	var/spawn_type
 	var/spawn_amount

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -8,7 +8,7 @@
 	var/dropmetal = TRUE
 	resistance_flags = XENO_DAMAGEABLE
 	max_integrity = 40
-	soft_armor = list("melee" = 0, "bullet" = 60, "laser" = 60, "energy" = 60, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	soft_armor = list("melee" = 0, "bullet" = 80, "laser" = 80, "energy" = 80, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	hit_sound = 'sound/effects/woodhit.ogg'
 	var/spawn_type
 	var/spawn_amount

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -8,7 +8,7 @@
 	var/dropmetal = TRUE
 	resistance_flags = XENO_DAMAGEABLE
 	max_integrity = 40
-	soft_armor = list("melee" = 0, "bullet" = 80, "laser" = 80, "energy" = 80, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	soft_armor = list(MELEE = 0, BULLET = 80, LASER = 80, ENERGY = 80, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 	hit_sound = 'sound/effects/woodhit.ogg'
 	var/spawn_type
 	var/spawn_amount

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -11,7 +11,7 @@
 	layer = BELOW_OBJ_LAYER
 	resistance_flags = XENO_DAMAGEABLE
 	max_integrity = 40
-	soft_armor = list("melee" = 0, "bullet" = 80, "laser" = 80, "energy" = 80, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	soft_armor = list(MELEE = 0, BULLET = 80, LASER = 80, ENERGY = 80, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 
 	var/draw_warnings = 1 //Set to 0 to stop it from drawing the alert lights.
 

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -11,7 +11,7 @@
 	layer = BELOW_OBJ_LAYER
 	resistance_flags = XENO_DAMAGEABLE
 	max_integrity = 40
-	soft_armor = list("melee" = 0, "bullet" = 60, "laser" = 60, "energy" = 60, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	soft_armor = list("melee" = 0, "bullet" = 80, "laser" = 80, "energy" = 80, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 	var/draw_warnings = 1 //Set to 0 to stop it from drawing the alert lights.
 

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -7,10 +7,11 @@
 	density = TRUE
 	anchored = TRUE
 	volume = 100
-	coverage = 20
+	coverage = 40
 	layer = BELOW_OBJ_LAYER
 	resistance_flags = XENO_DAMAGEABLE
 	max_integrity = 40
+	soft_armor = list("melee" = 0, "bullet" = 60, "laser" = 60, "energy" = 60, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 	var/draw_warnings = 1 //Set to 0 to stop it from drawing the alert lights.
 

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -7,4 +7,4 @@
 	anchored = FALSE
 	resistance_flags = XENO_DAMAGEABLE
 	max_integrity = 100
-	soft_armor = list("melee" = 0, "bullet" = 60, "laser" = 60, "energy" = 60, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	soft_armor = list(MELEE = 0, BULLET = 60, LASER = 60, ENERGY = 60, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -7,3 +7,4 @@
 	anchored = FALSE
 	resistance_flags = XENO_DAMAGEABLE
 	max_integrity = 100
+	soft_armor = list("melee" = 0, "bullet" = 60, "laser" = 60, "energy" = 60, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -18,6 +18,7 @@
 	anchored = TRUE
 	resistance_flags = XENO_DAMAGEABLE
 	max_integrity = 100
+	soft_armor = list("melee" = 0, "bullet" = 60, "laser" = 60, "energy" = 60, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 
 /obj/structure/filingcabinet/chestdrawer

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -18,7 +18,7 @@
 	anchored = TRUE
 	resistance_flags = XENO_DAMAGEABLE
 	max_integrity = 100
-	soft_armor = list("melee" = 0, "bullet" = 60, "laser" = 60, "energy" = 60, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	soft_armor = list(MELEE = 0, BULLET = 60, LASER = 60, ENERGY = 60, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 
 
 /obj/structure/filingcabinet/chestdrawer


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds soft armour for bullet, laser and energy to certain objects and structures.

A previous PR heavily reduced the HP of these objects and structures, to make it easier for xenos to clear junk out.
This was a sensible QOL change, but in HvH guns simply output far more dps, so these structures are functionally useless for cover, which isn't ideal.

This PR means they are still easily destroyed by melee or acid, but are a bit more survivable when shot by guns
Also slightly increases the coverage for hydrotrays, since I made them lower back when they had a load of HP.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cover not disintegrating after 2 bullets is good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Increased the durability of some map objects and structures against guns
balance: Hydro trays provide slightly better cover
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
