### PR TITLE
Accuracy system tweaks

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1638,12 +1638,14 @@
 				var/datum/status_effect/stacking/gun_skill/debuff = living_user.has_status_effect(STATUS_EFFECT_GUN_SKILL_SCATTER_DEBUFF)
 				gun_scatter += debuff.stacks
 
+		if(ishuman(user))
+			var/mob/living/carbon/human/shooter_human = user
+			gun_accuracy_mod -= round(min(20, (shooter_human.shock_stage * 0.2))) //Accuracy declines with pain, being reduced by 0.2% per point of pain.
+			if(shooter_human.marksman_aura)
+				gun_accuracy_mod += 10 + max(5, shooter_human.marksman_aura * 5) //Accuracy bonus from active focus order
+
 	projectile_to_fire.accuracy = round((projectile_to_fire.accuracy * gun_accuracy_mult) + gun_accuracy_mod) // Apply gun accuracy multiplier to projectile accuracy
 	projectile_to_fire.scatter += gun_scatter					//Add gun scatter value to projectile's scatter value
-
-
-
-
 
 /obj/item/weapon/gun/proc/get_scatter(starting_scatter, mob/user)
 	. = starting_scatter //projectile_to_fire.scatter

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -654,8 +654,6 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 			return FALSE //you don't hit the cade from behind.
 	if(proj.ammo.flags_ammo_behavior & AMMO_SNIPER || proj.iff_signal || proj.ammo.flags_ammo_behavior & AMMO_ROCKET) //sniper, rockets and IFF rounds are better at getting past cover
 		hit_chance *= 0.8
-	if(!anchored)
-		hit_chance *= 0.5 //Half the protection from unaffixed structures.
 	///50% better protection when shooting from outside accurate range.
 	if(proj.distance_travelled > proj.ammo.accurate_range)
 		hit_chance *= 1.5
@@ -733,6 +731,20 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	//We want a temporary variable so accuracy doesn't change every time the bullet misses.
 	var/hit_chance = proj.accuracy
 	BULLET_DEBUG("Base accuracy is <b>[hit_chance]; scatter:[proj.scatter]; distance:[proj.distance_travelled]</b>")
+
+	hit_chance += (mob_size - 1) * 20 //You're easy to hit when you're swoll, hard to hit when you're a manlet
+
+	///Is the shooter a living mob. Defined before the check as used later as well
+	var/mob/living/shooter_living
+	if(isliving(proj.firer))
+		shooter_living = proj.firer
+		if(shooter_living.faction == faction)
+			hit_chance = round(hit_chance*0.85) //You (presumably) aren't trying to shoot your friends
+		var/obj/item/shot_source = proj.shot_from
+		if(!line_of_sight(shooter_living, src, 9) && (!istype(shot_source) || !shot_source.zoom)) //if you can't draw LOS within 9 tiles (to accomodate wide screen), AND the source was either not zoomed or not an item(like a xeno)
+			BULLET_DEBUG("Can't see target ([round(hit_chance*0.8)]).")
+			hit_chance = round(hit_chance*0.8) //Can't see the target (Opaque thing between shooter and target), or out of view range
+
 	if(proj.distance_travelled <= proj.ammo.accurate_range) //If bullet stays within max accurate range.
 		if(proj.distance_travelled <= proj.point_blank_range) //If bullet within point blank range, big accuracy buff.
 			BULLET_DEBUG("Point blank range (+30)")
@@ -744,10 +756,6 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	else
 		BULLET_DEBUG("Too far (+[((proj.distance_travelled - proj.ammo.accurate_range )* 5)])")
 		hit_chance -= ((proj.distance_travelled - proj.ammo.accurate_range )* 5) //Every tile travelled past accurate_range reduces accuracy
-
-	hit_chance = max(5, hit_chance) //default hit chance after range factors is at least 5%.
-
-	hit_chance += (mob_size - 1) * 20 //You're easy to hit when you're swoll, hard to hit when you're a manlet
 
 	BULLET_DEBUG("Hit zone penalty (-[GLOB.base_miss_chance[proj.def_zone]]) ([proj.def_zone])")
 	hit_chance -= GLOB.base_miss_chance[proj.def_zone] //Reduce accuracy based on body part targeted.
@@ -764,28 +772,9 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 		BULLET_DEBUG("Moving (*[evasion_bonus]).")
 		hit_chance = round(hit_chance * evasion_bonus)
 
-	///Is the shooter a living mob. Defined before the check as used later as well
-	var/mob/living/shooter_living
-	if(isliving(proj.firer))
-		shooter_living = proj.firer
-		if(shooter_living.faction == faction)
-			hit_chance = round(hit_chance*0.85) //You (presumably) aren't trying to shoot your friends
-		var/obj/item/shot_source = proj.shot_from
-		if(!line_of_sight(shooter_living, src, 9) && (!istype(shot_source) || !shot_source.zoom)) //if you can't draw LOS within 9 tiles (to accomodate wide screen), AND the source was either not zoomed or not an item(like a xeno)
-			BULLET_DEBUG("Can't see target ([round(hit_chance*0.8)]).")
-			hit_chance = round(hit_chance*0.8) //Can't see the target (Opaque thing between shooter and target), or out of view range
-		if(ishuman(proj.firer))
-			var/mob/living/carbon/human/shooter_human = proj.firer
-			BULLET_DEBUG("Traumatic shock (-[round(min(20, shooter_human.traumatic_shock * 0.2))]).")
-			hit_chance -= round(min(20, shooter_human.traumatic_shock * 0.2)) //Chance to hit declines with pain, being reduced by 0.3% per point of pain.
-			if(shooter_human.marksman_aura)
-				BULLET_DEBUG("marksman_aura (+[10 + max(5, shooter_human.marksman_aura * 5)]).")
-				hit_chance += 10 + max(5, shooter_human.marksman_aura * 5) //Accuracy bonus from active focus order
+	hit_chance = max(5, hit_chance) //It's never impossible to hit
 
 	BULLET_DEBUG("Final accuracy is <b>[hit_chance]</b>")
-
-	if(hit_chance <= 0) //If by now the sum is zero or negative, we won't be hitting at all.
-		return FALSE
 
 	var/hit_roll = rand(0, 99) //Our randomly generated roll
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Some minor tweaks to how accuracy and hits are calculated.

Moved the pain and focus order checks to when the bullet is fired instead of at hit. Because this was previously checked only when hitting mobs, this PR means pain and focus orders now actually impact your ability to shoot past cover.

Pain now correctly uses shock_stage instead of traumatic_shock.

Objects being unanchored no longer reduces their coverage by half.

Tweaked the order different affects are calculated when checking to hit. You're unlikely to notice much difference in game other than large xenos won't be so easily hit way off screen anymore.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Improve and clean up accuracy/hit code slightly, certain buffs and maluses working better is good.
bug fix good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Some tweaks to projectile accuracy and hit code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
