### PR TITLE
Adds Capronine, A New Chemical

### DIFF
--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -314,7 +314,7 @@
 /obj/item/reagent_containers/hypospray/autoinjector/capronine
 	name = "capronine autoinjector"
 	desc = "An auto-injector loaded with 2 doses of capronine, a rapid wound healing chemical that often causes extreme burns when leaving the body."
-	icon_state = "autoinjector-3"
+	icon_state = "AngelLight"
 	amount_per_transfer_from_this = 15
 	list_reagents = list(/datum/reagent/medicine/capronine = 30)
 

--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -313,7 +313,7 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/capronine
 	name = "capronine autoinjector"
-	desc = "An auto-injector loaded with 2 doses of capronine, a rapid wound healing chemical that often causes extreme burns when leaving the body."
+	desc = "An auto-injector loaded with 2 doses of capronine, a rapid wound healing chemical that often causes extreme burns when leaving the body. Causes extreme toxin damage when overdosed, excercise caution."
 	icon_state = "AngelLight"
 	amount_per_transfer_from_this = 15
 	list_reagents = list(/datum/reagent/medicine/capronine = 30)

--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -311,6 +311,13 @@
 	volume = 1
 	list_reagents = list(/datum/reagent/medicine/research/medicalnanites = 1)
 
+/obj/item/reagent_containers/hypospray/autoinjector/capronine
+	name = "capronine autoinjector"
+	desc = "An auto-injector loaded with 2 doses of capronine, a rapid wound healing chemical that often causes extreme burns when leaving the body."
+	icon_state = "autoinjector-3"
+	amount_per_transfer_from_this = 15
+	list_reagents = list(/datum/reagent/medicine/capronine = 30)
+
 /obj/item/reagent_containers/hypospray/autoinjector/pain //made for debugging
 	name = "liquid pain autoinjector"
 	desc = "An auto-injector loaded with liquid pain. Ow."

--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -313,7 +313,7 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/capronine
 	name = "capronine autoinjector"
-	desc = "An auto-injector loaded with 2 doses of capronine, a rapid wound healing chemical that often causes extreme burns when leaving the body. Causes extreme toxin damage when overdosed, excercise caution."
+	desc = "An auto-injector loaded with 2 doses of capronine, a rapid wound healing chemical that often causes severe burns when leaving the body. Causes extreme toxin damage when overdosed, excercise caution."
 	icon_state = "AngelLight"
 	amount_per_transfer_from_this = 15
 	list_reagents = list(/datum/reagent/medicine/capronine = 30)

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -986,6 +986,7 @@
 			/obj/item/reagent_containers/hypospray/autoinjector/isotonic = 30,
 			/obj/item/reagent_containers/hypospray/autoinjector/quickclot = 10,
 			/obj/item/reagent_containers/hypospray/autoinjector/medicalnanites = 20,
+			/obj/item/reagent_containers/hypospray/autoinjector/capronine = 5,
 		),
 		"Heal Pack" = list(
 			/obj/item/stack/medical/heal_pack/gauze = -1,
@@ -1030,6 +1031,7 @@
 			/obj/item/reagent_containers/hypospray/autoinjector/isotonic = -1,
 			/obj/item/reagent_containers/hypospray/autoinjector/quickclot = -1,
 			/obj/item/reagent_containers/hypospray/autoinjector/medicalnanites = -1,
+			/obj/item/reagent_containers/hypospray/autoinjector/capronine = -1,
 		),
 		"Heal Pack" = list(
 			/obj/item/stack/medical/heal_pack/gauze = -1,

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -223,7 +223,7 @@
 	results = list(/datum/reagent/medicine/research/stimulon = 1)
 	required_reagents = list(/datum/reagent/medicine/synaptizine = 10, /datum/reagent/medicine/arithrazine = 20, /datum/reagent/consumable/nutriment = 20, /datum/reagent/medicine/lemoline = 20)
 
-/datum/chemical_reaction/curine
-	name = "Curine"
-	results = list(/datum/reagent/medicine/curine = 5)
-	required_reagents = list(/datum/reagent/medicine/kelotane = 1, /datum/reagent/medicine/bicaridine = 1, /datum/reagent/medicine/quickclot = 1, /datum/reagent/medicine/paracetamol = 2)
+/datum/chemical_reaction/capronine
+	name = "Capronine"
+	results = list(/datum/reagent/medicine/capronine = 5)
+	required_reagents = list(/datum/reagent/medicine/quickclot = 2, /datum/reagent/medicine/paracetamol = 2, /datum/reagent/medicine/lemoline = 1)

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -226,4 +226,4 @@
 /datum/chemical_reaction/curine
 	name = "Curine"
 	results = list(/datum/reagent/medicine/curine = 5)
-	required_reagents = list(/datum/reagent/medicine/dermaline = 2, /datum/reagent/medicine/bicaridine = 2, /datum/reagent/medicine/lemoline = 1)
+	required_reagents = list(/datum/reagent/medicine/kelotane = 1, /datum/reagent/medicine/bicaridine = 1, /datum/reagent/medicine/quickclot = 1, /datum/reagent/medicine/paracetamol = 2)

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -222,3 +222,8 @@
 	name = "Stimulum"
 	results = list(/datum/reagent/medicine/research/stimulon = 1)
 	required_reagents = list(/datum/reagent/medicine/synaptizine = 10, /datum/reagent/medicine/arithrazine = 20, /datum/reagent/consumable/nutriment = 20, /datum/reagent/medicine/lemoline = 20)
+
+/datum/chemical_reaction/curine
+	name = "Curine"
+	results = list(/datum/reagent/medicine/curine = 5)
+	required_reagents = list(/datum/reagent/medicine/dermaline = 2, /datum/reagent/medicine/bicaridine = 2, /datum/reagent/medicine/lemoline = 1)

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -226,4 +226,4 @@
 /datum/chemical_reaction/capronine
 	name = "Capronine"
 	results = list(/datum/reagent/medicine/capronine = 5)
-	required_reagents = list(/datum/reagent/medicine/quickclot = 2, /datum/reagent/medicine/paracetamol = 2, /datum/reagent/medicine/lemoline = 1)
+	required_reagents = list(/datum/reagent/medicine/quickclot = 1, /datum/reagent/medicine/paracetamol = 2, /datum/reagent/chlorine = 1, /datum/reagent/lithium = 1)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1345,7 +1345,7 @@
 	name = "Capronine"
 	description = "A chemical that rapidly consumes itself to heal wounds. Causes immense burning when leaving the body."
 	color = "#dada00"
-	custom_metabolism = REAGENTS_METABOLISM * 0.5
+	custom_metabolism = 0 //Handles metabolism on it's own since it's based off of the inefficiency variable. Actual metabolism is 0.2u/cycle times inefficiency.
 	scannable = TRUE
 	taste_description = "sweetness, with a metallic aftertaste"
 	overdose_threshold = REAGENTS_OVERDOSE * 0.5
@@ -1357,7 +1357,7 @@
 /datum/reagent/medicine/capronine/on_mob_life(mob/living/L, metabolism)
 	var/remaining_heal = min(volume*10, 20*effect_str)
 	var/amount = 0
-	var/inefficiency = min(1, damage_stored*0.02)
+	var/inefficiency = min(1, damage_stored*0.05)
 	if(L.getBruteLoss(TRUE) >= 1 && remaining_heal)
 		amount = min(remaining_heal, L.getBruteLoss())
 		damage_stored += amount
@@ -1371,8 +1371,8 @@
 		L.reagents.remove_reagent(/datum/reagent/medicine/capronine, amount*0.1*inefficiency)
 		L.heal_overall_damage(0, amount)
 		to_chat(L, span_notice("Your burns are disappearing!"))
-	if (volume)
-		return ..()
+	L.reagents.remove_reagent(/datum/reagent/medicine/capronine, REAGENTS_METABOLISM*0.5*inefficiency*effect_str)
+	return ..()
 
 /datum/reagent/medicine/capronine/on_mob_delete(mob/living/L, metabolism)
 	if (damage_stored)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1345,7 +1345,7 @@
 	name = "Capronine"
 	description = "A chemical that rapidly consumes itself to heal wounds. Causes immense burning when leaving the body."
 	color = "#dada00"
-	custom_metabolism = 0 //Handles metabolism on it's own since it's based off of the inefficiency variable. Actual metabolism is 0.2u/cycle times inefficiency.
+	custom_metabolism = REAGENTS_METABOLISM*0.5 //Changes constantly since it's based off of the inefficiency variable. Actual metabolism is 0.1u/cycle times inefficiency.
 	scannable = TRUE
 	taste_description = "sweetness, with a metallic aftertaste"
 	overdose_threshold = REAGENTS_OVERDOSE * 0.5
@@ -1372,7 +1372,7 @@
 		L.heal_overall_damage(0, amount)
 		to_chat(L, span_notice("Your burns are disappearing!"))
 	if (volume)
-		L.reagents.remove_reagent(/datum/reagent/medicine/capronine, REAGENTS_METABOLISM*0.5*inefficiency*effect_str)
+		custom_metabolism = REAGENTS_METABOLISM*0.5*inefficiency
 		return ..()
 
 /datum/reagent/medicine/capronine/on_mob_delete(mob/living/L, metabolism)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1379,9 +1379,9 @@
 	if (damage_stored)
 		var/message
 		switch(damage_stored)
-			if(0 to 2)
+			if(0 to 20)
 				message = span_danger("You feel something burning under your skin.")
-			if(2 to 5)
+			if(20 to 50)
 				message = span_userdanger("You feel intense burning all over your body!")
 			else
 				message = span_userdanger("Your entire body is burning up from the inside!")

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1345,7 +1345,7 @@
 	name = "Capronine"
 	description = "A chemical that rapidly consumes itself to heal wounds. Causes immense burning when leaving the body."
 	color = "#dada00"
-	custom_metabolism = 0 //Handles metabolism on it's own since it's based off of the inefficiency variable. Actual metabolism is 0.1u/cycle times inefficiency.
+	custom_metabolism = REAGENTS_METABOLISM * 0.5 //Changes constantly since it's based off of the inefficiency variable. Actual metabolism is 0.1u/cycle + extra times inefficiency.
 	scannable = TRUE
 	taste_description = "sweetness, with a metallic aftertaste"
 	overdose_threshold = REAGENTS_OVERDOSE * 0.5
@@ -1357,7 +1357,7 @@
 /datum/reagent/medicine/capronine/on_mob_life(mob/living/L, metabolism)
 	var/remaining_heal = min(volume*10, 20*effect_str)
 	var/amount = 0
-	var/inefficiency = min(1, damage_stored*0.05)
+	var/inefficiency = max(1, damage_stored*0.02)
 	var/to_remove = REAGENTS_METABOLISM * 0.5
 	if(L.getBruteLoss(TRUE) >= 1 && remaining_heal)
 		amount = min(remaining_heal, L.getBruteLoss())
@@ -1372,9 +1372,8 @@
 		to_remove += amount*0.1
 		L.heal_overall_damage(0, amount)
 		to_chat(L, span_notice("Your burns are disappearing!"))
-	L.reagents.remove_reagent(/datum/reagent/medicine/capronine, to_remove*inefficiency*L.metabolism_efficiency)
-	if (volume)
-		return ..()
+	custom_metabolism = to_remove*inefficiency
+	return ..()
 
 /datum/reagent/medicine/capronine/on_mob_delete(mob/living/L, metabolism)
 	if (damage_stored)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1351,7 +1351,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE * 0.4
 
 /datum/reagent/medicine/curine/on_mob_add(mob/living/L, metabolism)
-	to_chat(L, span_userdanger("Your wounds are rapidly disappearing!"))
+	to_chat(L, span_userdanger("Your wounds start to seemingly disappear!"))
 
 /datum/reagent/medicine/curine/on_mob_life(mob/living/L, metabolism)
 	var/remaining_heal = min(volume*10, 20*effect_str)
@@ -1362,7 +1362,7 @@
 		L.reagents.add_reagent(/datum/reagent/solidcurine, amount*0.1)
 		L.heal_overall_damage(amount, 0)
 		remaining_heal -= amount
-		to_chat(L, span_notice("Your cuts and bruises are getting filled in!"))
+		to_chat(L, span_notice("Your cuts and bruises are disappearing!"))
 	if(L.getFireLoss(TRUE) >= 1 && remaining_heal)
 		amount = min(remaining_heal, L.getFireLoss())
 		L.reagents.remove_reagent(/datum/reagent/medicine/curine, amount*0.1)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1353,14 +1353,14 @@
 /datum/reagent/medicine/curine/on_mob_life(mob/living/L, metabolism)
 	var/remaining_heal = min(volume*10, 20*effect_str)
 	var/amount = 0
-	if(L.getBruteLoss(TRUE) && remaining_heal)
+	if(L.getBruteLoss(TRUE) >= 1 && remaining_heal)
 		amount = min(remaining_heal, L.getBruteLoss())
 		L.reagents.remove_reagent(/datum/reagent/medicine/curine, amount*0.1)
 		L.reagents.add_reagent(/datum/reagent/solidcurine, amount*0.1)
 		L.heal_overall_damage(amount, 0)
 		remaining_heal -= amount
 		to_chat(L, span_notice("Your cuts and bruises fill in with elastic material!"))
-	if(L.getFireLoss(TRUE) && remaining_heal)
+	if(L.getFireLoss(TRUE) >= 1 && remaining_heal)
 		amount = min(remaining_heal, L.getFireLoss())
 		L.reagents.remove_reagent(/datum/reagent/medicine/curine, amount*0.1)
 		L.reagents.add_reagent(/datum/reagent/solidcurine, amount*0.1)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1378,11 +1378,11 @@
 		var/message
 		switch(amount)
 			if(0 to 2)
-				message = span_danger("The elastic material on your body melts away, revealing some burns.")
+				message = span_danger("A few burns appear on your skin.")
 			if(2 to 5)
-				message = span_userdanger("The elastic material on your body burns away painfully!")
+				message = span_userdanger("Small burns appear everywhere on your body!")
 			else
-				message = span_userdanger("The elastic material on your body combusts violently!")
+				message = span_userdanger("Your entire body burns in agony!")
 		to_chat(L, message)
 		var/mob/living/carbon/human/target = L
 		var/list/datum/limb/target_limbs = target.get_damageable_limbs()

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1345,7 +1345,7 @@
 	name = "Capronine"
 	description = "A chemical that rapidly consumes itself to heal wounds. Causes immense burning when leaving the body."
 	color = "#dada00"
-	custom_metabolism = REAGENTS_METABOLISM*0.5 //Changes constantly since it's based off of the inefficiency variable. Actual metabolism is 0.1u/cycle times inefficiency.
+	custom_metabolism = 0 //Handles metabolism on it's own since it's based off of the inefficiency variable. Actual metabolism is 0.1u/cycle times inefficiency.
 	scannable = TRUE
 	taste_description = "sweetness, with a metallic aftertaste"
 	overdose_threshold = REAGENTS_OVERDOSE * 0.5
@@ -1358,21 +1358,22 @@
 	var/remaining_heal = min(volume*10, 20*effect_str)
 	var/amount = 0
 	var/inefficiency = min(1, damage_stored*0.05)
+	var/to_remove = 0
 	if(L.getBruteLoss(TRUE) >= 1 && remaining_heal)
 		amount = min(remaining_heal, L.getBruteLoss())
 		damage_stored += amount
-		L.reagents.remove_reagent(/datum/reagent/medicine/capronine, amount*0.1*inefficiency)
+		to_remove += amount*0.1*inefficiency
 		L.heal_overall_damage(amount, 0)
 		remaining_heal -= amount
 		to_chat(L, span_notice("Your cuts and bruises are disappearing!"))
 	if(L.getFireLoss(TRUE) >= 1 && remaining_heal)
 		amount = min(remaining_heal, L.getFireLoss())
 		damage_stored += amount
-		L.reagents.remove_reagent(/datum/reagent/medicine/capronine, amount*0.1*inefficiency)
+		to_remove += amount*0.1*inefficiency
 		L.heal_overall_damage(0, amount)
 		to_chat(L, span_notice("Your burns are disappearing!"))
+	L.reagents.remove_reagent(/datum/reagent/medicine/capronine, REAGENTS_METABOLISM*0.5*inefficiency*L.metabolism_efficiency)
 	if (volume)
-		custom_metabolism = REAGENTS_METABOLISM*0.5*inefficiency
 		return ..()
 
 /datum/reagent/medicine/capronine/on_mob_delete(mob/living/L, metabolism)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1362,17 +1362,17 @@
 	if(L.getBruteLoss(TRUE) >= 1 && remaining_heal)
 		amount = min(remaining_heal, L.getBruteLoss())
 		damage_stored += amount
-		to_remove += amount*0.1*inefficiency
+		to_remove += amount*0.1
 		L.heal_overall_damage(amount, 0)
 		remaining_heal -= amount
 		to_chat(L, span_notice("Your cuts and bruises are disappearing!"))
 	if(L.getFireLoss(TRUE) >= 1 && remaining_heal)
 		amount = min(remaining_heal, L.getFireLoss())
 		damage_stored += amount
-		to_remove += amount*0.1*inefficiency
+		to_remove += amount*0.1
 		L.heal_overall_damage(0, amount)
 		to_chat(L, span_notice("Your burns are disappearing!"))
-	L.reagents.remove_reagent(/datum/reagent/medicine/capronine, to_remove*0.5*inefficiency*L.metabolism_efficiency)
+	L.reagents.remove_reagent(/datum/reagent/medicine/capronine, to_remove*inefficiency*L.metabolism_efficiency)
 	if (volume)
 		return ..()
 

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1371,8 +1371,9 @@
 		L.reagents.remove_reagent(/datum/reagent/medicine/capronine, amount*0.1*inefficiency)
 		L.heal_overall_damage(0, amount)
 		to_chat(L, span_notice("Your burns are disappearing!"))
-	L.reagents.remove_reagent(/datum/reagent/medicine/capronine, REAGENTS_METABOLISM*0.5*inefficiency*effect_str)
-	return ..()
+	if (volume)
+		L.reagents.remove_reagent(/datum/reagent/medicine/capronine, REAGENTS_METABOLISM*0.5*inefficiency*effect_str)
+		return ..()
 
 /datum/reagent/medicine/capronine/on_mob_delete(mob/living/L, metabolism)
 	if (damage_stored)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1350,6 +1350,9 @@
 	taste_description = "sweetness, with a metallic aftertaste"
 	overdose_threshold = REAGENTS_OVERDOSE * 0.4
 
+/datum/reagent/medicine/curine/on_mob_add(mob/living/L, metabolism)
+	to_chat(L, span_userdanger("Your wounds are rapidly disappearing!"))
+
 /datum/reagent/medicine/curine/on_mob_life(mob/living/L, metabolism)
 	var/remaining_heal = min(volume*10, 20*effect_str)
 	var/amount = 0
@@ -1359,13 +1362,13 @@
 		L.reagents.add_reagent(/datum/reagent/solidcurine, amount*0.1)
 		L.heal_overall_damage(amount, 0)
 		remaining_heal -= amount
-		to_chat(L, span_notice("Your cuts and bruises fill in with elastic material!"))
+		to_chat(L, span_notice("Your cuts and bruises are getting filled in!"))
 	if(L.getFireLoss(TRUE) >= 1 && remaining_heal)
 		amount = min(remaining_heal, L.getFireLoss())
 		L.reagents.remove_reagent(/datum/reagent/medicine/curine, amount*0.1)
 		L.reagents.add_reagent(/datum/reagent/solidcurine, amount*0.1)
 		L.heal_overall_damage(0, amount)
-		to_chat(L, span_notice("Your burns get covered up by an elastic layer!"))
+		to_chat(L, span_notice("Your burns are getting covered up!"))
 	if (volume)
 		return ..()
 

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1348,7 +1348,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	scannable = TRUE
 	taste_description = "sweetness, with a metallic aftertaste"
-	overdose_threshold = REAGENTS_OVERDOSE * 0.5
+	overdose_threshold = REAGENTS_OVERDOSE * 0.4
 
 /datum/reagent/medicine/curine/on_mob_life(mob/living/L, metabolism)
 	var/remaining_heal = min(volume*10, 20*effect_str)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1358,7 +1358,7 @@
 	var/remaining_heal = min(volume*10, 20*effect_str)
 	var/amount = 0
 	var/inefficiency = min(1, damage_stored*0.05)
-	var/to_remove = 0
+	var/to_remove = REAGENTS_METABOLISM * 0.5
 	if(L.getBruteLoss(TRUE) >= 1 && remaining_heal)
 		amount = min(remaining_heal, L.getBruteLoss())
 		damage_stored += amount
@@ -1372,7 +1372,7 @@
 		to_remove += amount*0.1*inefficiency
 		L.heal_overall_damage(0, amount)
 		to_chat(L, span_notice("Your burns are disappearing!"))
-	L.reagents.remove_reagent(/datum/reagent/medicine/capronine, REAGENTS_METABOLISM*0.5*inefficiency*L.metabolism_efficiency)
+	L.reagents.remove_reagent(/datum/reagent/medicine/capronine, to_remove*0.5*inefficiency*L.metabolism_efficiency)
 	if (volume)
 		return ..()
 

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1391,8 +1391,8 @@
 	L.adjustToxLoss(10*effect_str)
 
 /datum/reagent/solidcurine
-	name = "Solidified Curine"
-	description = "Solidified curine that remains highly elastic. Has restorative properties, but is highly volatile unless liquid curine is present."
+	name = "Solid Curine"
+	description = "A solid form of curine that remains highly elastic. Has restorative properties, but is highly volatile unless liquid curine is present."
 	reagent_state = SOLID
 	color = "#a00000"
 	custom_metabolism = 0


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Code improvements are appreciated, some things may be a little hacky such as the damage spreading.

Adds capronine, a new chemical to the game. It heals brute and burn damage by consuming itself and then causes an equal amount of burn damage when leaving the body.

The chemical consumes itself faster and faster the more total damage it has absorbed. This is to the point where absorbing over 100 damage becomes unreasonably difficult, dare I say impossible for any period of time over 15 seconds. The effect only increases if you try going past that. (It practically purges itself instantly at around 150 damage.)

This essentially stores damage for later. It avoids fractures and delimbs, however, it causes immense pain when the burn damage is dealt.

The chemical prioritizes healing brute damage and whatever remains of the total 20 healing per cycle is used on burn damage.

Capronine has a low OD of 15u that causes 10 toxin damage per cycle. (Infinite damage soaking wouldn't be very balanced.)

Capronine has a recipe of 1 part quick-clot, 2 parts paracetamol, 1 part chlorine and 1 part lithium in exchange for 5 parts capronine.

Capronine's main purpose is to be used as a more advanced option for easily running to get medical care/survive long enough to get medical care OR to use it before/in a fight to absorb incoming damage so you don't get advanced injuries.

Math references for nerds:
Inefficiency = max(1, damage_stored * 0.02)
Capronine Metabolization = (0.1 + Amount Healed / 10) * Inefficiency
Total Brute OR Burn Damage < 1 Is Ignored
Total Potential Heal Per Cycle = min(volume * 10, 20 * effect_str)
Which means that it's basically 20 damage stored per cycle with brute being prioritized first. If there's still some burn damage left and the remaining_heal value is above 0, it'll use the rest of it on that. This means that brute damage is healed first and burn damage is healed afterwards.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

We don't really have anything that can offset damage like this. (Unless you count painkillers, but that's different for a number of reasons.) Also, why are new chemicals good for the game? Because they're cool and fun to use. This is also specifically for brute and burn damage, not for overall pain. You can't offset organ damage, cloneloss, toxloss, oxyloss, fractures or anything else for that matter.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added capronine, a healing chemical
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
