### PR TITLE
Remove girder in Big Red LZ1 and move crate in LV624

### DIFF
--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -13160,11 +13160,6 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/spaceport2)
-"mLK" = (
-/obj/structure/largecrate/random,
-/obj/effect/ai_node,
-/turf/open/floor,
-/area/lv624/lazarus/spaceport2)
 "mMU" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
@@ -37899,7 +37894,7 @@ tSf
 rOf
 fcJ
 vvX
-vvX
+mON
 mON
 mON
 vvX
@@ -38429,7 +38424,7 @@ kdu
 tSf
 rOf
 vvX
-mLK
+tFj
 vvX
 vvX
 lEg

--- a/_maps/modularmaps/big_red/bigredlzvar2.dmm
+++ b/_maps/modularmaps/big_red/bigredlzvar2.dmm
@@ -424,10 +424,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/space_port)
-"kG" = (
-/obj/structure/girder/displaced,
-/turf/open/floor/plating/dmg3,
-/area/bigredv2/outside/space_port)
 "kM" = (
 /obj/machinery/light{
 	dir = 4
@@ -3701,7 +3697,7 @@ UH
 UH
 UH
 UH
-kG
+Yc
 ii
 fe
 lh

--- a/_maps/modularmaps/big_red/bigredlzvar3.dmm
+++ b/_maps/modularmaps/big_red/bigredlzvar3.dmm
@@ -24,10 +24,6 @@
 	dir = 1
 	},
 /area/bigredv2/outside/space_port)
-"aF" = (
-/obj/structure/girder/displaced,
-/turf/open/floor/plating/dmg3,
-/area/bigredv2/outside/space_port)
 "aI" = (
 /obj/machinery/landinglight/ds1/delaytwo{
 	dir = 4
@@ -3808,7 +3804,7 @@ iu
 iu
 iu
 iu
-aF
+oJ
 im
 ut
 Dc

--- a/_maps/modularmaps/big_red/bigredlzvar8.dmm
+++ b/_maps/modularmaps/big_red/bigredlzvar8.dmm
@@ -131,10 +131,6 @@
 "ds" = (
 /turf/closed/mineral/smooth/bigred,
 /area/bigredv2/caves/rock)
-"dv" = (
-/obj/structure/girder/displaced,
-/turf/open/floor/plating/dmg3,
-/area/bigredv2/outside/space_port)
 "dz" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 1
@@ -3777,7 +3773,7 @@ gp
 ee
 Rc
 Rc
-dv
+bY
 Fk
 km
 Kh


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

https://user-images.githubusercontent.com/6610922/188245762-5a45593e-3935-4e26-9dc3-84e3c4e8ea38.mp4

https://user-images.githubusercontent.com/6610922/188245766-8caf2500-d4ff-4a95-892e-15a8cdce6ec0.mp4

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Anyone using the FOB drone can assure you that this single girder screws up with making FOB. I'm removing this single girder just to help with any marines.

Also, move a crate in LV624's LZ2 because said crate does the same thing.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: delete a girder in Big Red LZ1 and move crate in LV624 to let marines using FOB drone not suffer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
