### PR TITLE
Rockets use bullet armor for direct impact damage

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1554,7 +1554,7 @@ datum/ammo/bullet/revolver/tp44
 	ping = null //no bounce off.
 	sound_bounce	= "rocket_bounce"
 	flags_ammo_behavior = AMMO_EXPLOSIVE|AMMO_ROCKET|AMMO_SUNDERING
-	armor_type = "bomb"
+	armor_type = BULLET
 	damage_falloff = 0
 	shell_speed = 2
 	accuracy = 40
@@ -1680,7 +1680,6 @@ datum/ammo/bullet/revolver/tp44
 	hud_state = "shell_he"
 	hud_state_empty = "shell_empty"
 	flags_ammo_behavior = AMMO_EXPLOSIVE|AMMO_ROCKET|AMMO_SUNDERING
-	armor_type = "bomb"
 	damage_falloff = 0
 	shell_speed = 2
 	accurate_range = 20


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
What it says on the tin.
Currently, all rockets (except thermobaric) use bomb armor when calculating the damage done from the actual impact. This means they are doing far more damage than they should, since almost everything has lower bomb armour than bullet armour.

Many rockets already have high pen, up to 100, so no change will be seen in game, but for rockets that have lower pen like RR and some TAT shells, they'll do less damage to most xenos (and to marines you manage to hit in the back of the head).

Note: This is a bug fix for TAT, this was always supposed to use bullet armor.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Non explosion damage uses non explosion armor
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: All rocket type ammo now uses bullet armor when calculating direct impact damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
