### PR TITLE
V-21 tweak

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -419,7 +419,7 @@
 	aim_slowdown = 0.15
 	wield_delay = 0.4 SECONDS
 
-	accuracy_mult = 1.2
+	accuracy_mult = 1.05
 	accuracy_mult_unwielded = 0.9
 
 	recoil = 0
@@ -433,7 +433,7 @@
 	extra_delay = 0.1 SECONDS
 	autoburst_delay = 0.1 SECONDS //this makes it fuller auto
 	burst_accuracy_mult = 0.7
-	burst_scatter_mult = 9
+	burst_scatter_mult = 15
 
 	akimbo_additional_delay = 0.7
 	upper_akimbo_accuracy = 5


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases burst scatter (so only effects the higher rate of fire mode), and decreases wielded accuracy.

The V-21 has worse accuracy and scatter on fuller auto, but it was still a bit too effective, especially at longer range. It will still be extremely effective, you just won't be able to stand near the edge of the screen and still land almost everything.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Balance the bullet hose
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: V-21 wielded accuracy reduced slightly, and fuller auto scatter increased
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
