### PR TITLE
Adds Radio Pack to Clothing Vendor

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -116,7 +116,7 @@ GLOBAL_LIST_INIT(leader_gear_listed_products, list(
 		/obj/item/explosive/grenade/chem_grenade/razorburn_smol = list(CAT_LEDSUP, "Razorburn grenade", 6, "black"),
 		/obj/item/weapon/gun/flamer/big_flamer/marinestandard = list(CAT_LEDSUP, "FL-84 flamethrower", 12, "black"),
 		/obj/item/ammo_magazine/flamer_tank = list(CAT_LEDSUP, "Flamethrower tank", 4, "black"),
-		/obj/item/storage/backpack/marine/radiopack = list(CAT_LEDSUP, "Radio Pack", 15, "black"),
+		/obj/item/storage/backpack/marine/radiopack = list(CAT_LEDSUP, "Radio Pack", 10, "black"),
 		/obj/item/storage/firstaid/adv = list(CAT_LEDSUP, "Advanced firstaid kit", 10, "orange"),
 		/obj/item/reagent_containers/hypospray/autoinjector/synaptizine = list(CAT_LEDSUP, "Injector (Synaptizine)", 10, "black"),
 		/obj/item/reagent_containers/hypospray/autoinjector/combat_advanced = list(CAT_LEDSUP, "Injector (Advanced)", 15, "orange"),

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -339,7 +339,7 @@
 
 /obj/item/storage/backpack/marine/tech
 	name = "\improper TGMC technician backpack"
-	desc = "The standard-issue backpack worn by TGMC technicians. Specially equipped to hold sentry gun and M56D emplacement parts."
+	desc = "The standard-issue backpack worn by TGMC technicians. Specially equipped to hold sentry gun and HSG-102 emplacement parts."
 	icon_state = "marinepackt"
 	bypass_w_limit = list(
 		/obj/item/weapon/gun/sentry/big_sentry,

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1293,6 +1293,7 @@
 			/obj/item/storage/backpack/marine/standard = -1,
 			/obj/item/storage/backpack/marine/satchel = -1,
 			/obj/item/tool/weldpack/marinestandard = -1,
+			/obj/item/storage/backpack/marine/radiopack = 4,
 		),
 		"Instruments" = list(
 			/obj/item/instrument/violin = -1,

--- a/code/modules/reqs/supply.dm
+++ b/code/modules/reqs/supply.dm
@@ -628,6 +628,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	name = "\improper TGMC radio operator backpack"
 	desc = "A backpack that resembles the ones old-age radio operator soldiers would use."
 	icon_state = "radiopack"
+	max_storage_space = 15
 	///Var for the window pop-up
 	var/datum/supply_ui/requests/supply_interface
 	/// Reference to the datum used by the supply drop console


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a limited amount of radio packs (4 to be precise) to the clothing vedor usable by everyone, but in particular PFCs at which this change was aimed. To trade off the increased availability and avoid "thing, but better", the capacity was nerfed to be a satchel's while keeping the backpack's delay on retrieving items. Price cost in SL vendor was reduced 15 -> 10 since its not a better backpack anymore. Also fixed mention of old CM M6D in engie backpack.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
With approval from bravemole, I thought that increasing the availability was good for a number of reasons. The radio pack ets never chosen, not by engies which get better choices like the welder pack or their unique backpack which fits engie stuff, and SLs which have to pay a whopping 15 points to get it. The 5 point cost in req is fine, but it gets overlooked in favour of thermal imagers for the same price. Then theres the fact its a niche item: sure you get storage benefits, but its literally just an antenna, which is infinite and free and only takes a helmet module slot (for which only two other choices exist), compared to a backslot for the radio pack. Only benefit is to make your req orders yourself, but considering they still need approval and delivery by an RO, its not much different from just asking the RO for things.
So, now PFCs can larp as radio operators without nagging req or engies, hopefully we get better logistics if some marines pick the radio pack and act as requisition beacons for the unga ball. It was sidegraded not to be a "+" option, in addition to sacrificing a back slot for a gun or melee weapon.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: added 4 radio packs to the marine clothing vendor
balance: rebalanced SL vendor cost of radio pack 15 -> 10
balance: adjusted storage capacity of radio pack to take into account increased availability.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
