### PR TITLE
Resin doors now have the same armour values as resin walls

### DIFF
--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -21,6 +21,7 @@
 	var/hardness = 1
 	var/oreAmount = 7
 
+
 /obj/structure/mineral_door/Initialize()
 	. = ..()
 	icon_state = mineralType

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -21,7 +21,6 @@
 	var/hardness = 1
 	var/oreAmount = 7
 
-
 /obj/structure/mineral_door/Initialize()
 	. = ..()
 	icon_state = mineralType

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -144,6 +144,7 @@
 	smoothing_behavior = CARDINAL_SMOOTHING
 	smoothing_groups = SMOOTH_XENO_STRUCTURES
 	var/close_delay = 10 SECONDS
+	soft_armor = list("melee" = 0, "bullet" = 60, "laser" = 60, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/structure/mineral_door/resin/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives resin doors the same armour values as resin walls (60% bullet and laser resist)
They previously did not have any armor at all
Labeled as balance because im not sure if its a fix or not , and if it was intended for them to be this weak.

## Why It's Good For The Game
Even if they're meant to be weaker, the fact that they had less integrity than walls and no armour made it obvious why no xeno would use them, 4 P90 shots would take down a door, making them meaningless.
They're still far weaker compared to a wall, but now they can resist small arms fire way better in general(just like walls)
## Changelog
:cl:
balance: Resin doors now have the same armour as walls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
