### PR TITLE
Ravager ravage can no longer be triggered if there is no one to ravage.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -975,6 +975,35 @@
 		else
 			setDir(WEST)
 
+// This is face_atom, but instead of changing the dir it just returns the dir the original proc would
+// used for checking ravager's ability to ravage without actually forcing them to face the atom.
+/atom/movable/proc/get_facing_direction(atom/A)
+	if(!A || !x || !y || !A.x || !A.y)
+		return
+	var/dx = A.x - x
+	var/dy = A.y - y
+	if(!dx && !dy) // Wall items are graphically shifted but on the floor
+		if(A.pixel_y > 16)
+			return NORTH
+		else if(A.pixel_y < -16)
+			return SOUTH
+		else if(A.pixel_x > 16)
+			return EAST
+		else if(A.pixel_x < -16)
+			return WEST
+		return
+
+	if(abs(dx) < abs(dy))
+		if(dy > 0)
+			return NORTH
+		else
+			return SOUTH
+	else
+		if(dx > 0)
+			return EAST
+		else
+			return WEST
+
 /mob/face_atom(atom/A)
 	if(buckled || stat != CONSCIOUS)
 		return

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -101,14 +101,18 @@
 	if(!..())
 		return FALSE
 	var/mob/living/carbon/xenomorph/ravager/X = owner
+	var/facing_dir = X.get_facing_direction(A) // this prevents false-positives , since the actual ravage forces you to face the clicked atom(which can miss if you click behind you while having people infront)
 	var/sweep_range = 1
 	var/list/L = orange(sweep_range, X) // Not actually the fruit
 	var/target_facing
 	for(var/mob/living/carbon/human/H in L)
 		target_facing = get_dir(X, H)
-		if(target_facing != X.dir && target_facing != turn(X.dir,45) && target_facing != turn(X.dir,-45) ) //Have to be actually facing the target
-			return TRUE // just need ONE to be facing
-	to_chat(X, span_notice("There is nobody to ravage infront of you!"))
+		if(H.stat == DEAD || isnestedhost(H))
+			continue
+		if(target_facing != facing_dir && target_facing != turn(facing_dir,45) && target_facing != turn(facing_dir,-45) ) //Have to be actually facing the target
+			continue
+		return TRUE
+	X.balloon_alert(X, "There is nobody to ravage infront of you!")
 	return FALSE
 
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -97,6 +97,21 @@
 	playsound(owner, "sound/effects/xeno_newlarva.ogg", 50, 0, 1)
 	return ..()
 
+/datum/action/xeno_action/activable/ravage/can_use_ability(atom/A, silent, override_flags)
+	if(!..())
+		return FALSE
+	var/mob/living/carbon/xenomorph/ravager/X = owner
+	var/sweep_range = 1
+	var/list/L = orange(sweep_range, X) // Not actually the fruit
+	var/target_facing
+	for(var/mob/living/carbon/human/H in L)
+		target_facing = get_dir(X, H)
+		if(target_facing != X.dir && target_facing != turn(X.dir,45) && target_facing != turn(X.dir,-45) ) //Have to be actually facing the target
+			return TRUE // just need ONE to be facing
+	to_chat(X, span_notice("There is nobody to ravage infront of you!"))
+	return FALSE
+
+
 /datum/action/xeno_action/activable/ravage/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/ravager/X = owner
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -100,19 +100,18 @@
 /datum/action/xeno_action/activable/ravage/can_use_ability(atom/A, silent, override_flags)
 	if(!..())
 		return FALSE
-	var/mob/living/carbon/xenomorph/ravager/X = owner
-	var/facing_dir = X.get_facing_direction(A) // this prevents false-positives , since the actual ravage forces you to face the clicked atom(which can miss if you click behind you while having people infront)
+	var/facing_dir = owner.get_facing_direction(A) // this prevents false-positives , since the actual ravage forces you to face the clicked atom(which can miss if you click behind you while having people infront)
 	var/sweep_range = 1
-	var/list/L = orange(sweep_range, X) // Not actually the fruit
+	var/list/L = orange(sweep_range, owner) // Not actually the fruit
 	var/target_facing
 	for(var/mob/living/carbon/human/H in L)
-		target_facing = get_dir(X, H)
+		target_facing = get_dir(owner, H)
 		if(H.stat == DEAD || isnestedhost(H))
 			continue
 		if(target_facing != facing_dir && target_facing != turn(facing_dir,45) && target_facing != turn(facing_dir,-45) ) //Have to be actually facing the target
 			continue
 		return TRUE
-	X.balloon_alert(X, "There is nobody to ravage infront of you!")
+	owner.balloon_alert(owner, "There is nobody to ravage infront of you!")
 	return FALSE
 
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ravager's ravage ability now won't trigger if there is nobody to ravage infront


## Why It's Good For The Game
Considering ravage's high speed,along with shotgun knockback and other variables , this will increase their lethality in general and make playing ravager less of a pain for new players. Most xeno melle abilities cannot miss in general , so this should be no exception
(It also brings players more in line with the lethality of AI ravagers , which wreck because.. they cannot miss)

## Changelog
:cl:
qol: Ravager's ravage cannot be used if there is no one to ravage
code: Added the get_facing_direction proc for atoms , returns the DIR that would be set on the src if face_atom was called.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
