### PR TITLE
AI vox reaches all Z levels & all humans

### DIFF
--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -133,11 +133,10 @@
 	///If there is no single listener, broadcast to everyone in the same z level
 		if(!only_listener)
 			///Play voice for all mobs in the z level
-			for(var/mob/M in GLOB.player_list)
+			var/list/receivers = (GLOB.alive_human_list + GLOB.ai_list + GLOB.observer_list)
+			for(var/mob/M in receivers)
 				if(!isdeaf(M))
-					var/turf/T = get_turf(M)
-					if(T.z == z_level)
-						SEND_SOUND(M, voice)
+					SEND_SOUND(M, voice)
 		else
 			SEND_SOUND(only_listener, voice)
 		return TRUE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I took a look at the Bioscan code and orders code under advice, and copied it for the AI.
It now sends the VOX voice to all living humans, observers, and synths.

I tested it by putting a synth on the ground and on the ship. It heard the message. I tried it with a bean, didn't hear anything.

## Why It's Good For The Game
Currently, Vox only works ship side, which is not obvious. This basically makes it only useful at the start, and if the xenos board the ship. Now, it can be used to give advice to ground side teams. 


## Changelog
:cl:
expansion: Extend AI vox to all Z levels
fix: Prevent xenos from hearing Vox on shipside
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
