### PR TITLE
Adds a buffer to delimbs (Alternate)

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -55,9 +55,6 @@
 	config_entry_value = 0
 	integer = FALSE
 
-/datum/config_entry/number/organ_health_multiplier
-	config_entry_value = 1
-
 /datum/config_entry/number/organ_regeneration_multiplier
 	config_entry_value = 1
 

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -269,7 +269,7 @@
 			owner.updatehealth()
 		return update_icon()
 	if(CONFIG_GET(flag/limbs_can_break) && brute_dam >= (max_damage - DELIMB_BUFFER) * CONFIG_GET(number/organ_health_multiplier))
-		droplimb() //Reached max damage threshold through brute damage, that limb is going bye bye
+		droplimb() //Reached limb severing threshold, that limb is going bye bye
 		if(!(owner.species && (owner.species.species_flags & NO_PAIN)))
 			owner.emote("scream")
 		return

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -1,3 +1,6 @@
+///This is the buffer between a limbs max_damage and severing threshold.
+#define DELIMB_BUFFER 25
+
 /****************************************************
 				EXTERNAL ORGANS
 ****************************************************/
@@ -13,7 +16,7 @@
 	var/brute_dam = 0
 	///burn damage this limb has taken as a part
 	var/burn_dam = 0
-	///Max damage the limb can take before being destroyed
+	///Max damage the limb can take, the limb sever threshold is this minus DELIMB_BUFFER
 	var/max_damage = 0
 	var/max_size = 0
 	var/last_dam = -1
@@ -83,6 +86,7 @@
 		RegisterSignal(owner, COMSIG_PARENT_QDELETING, .proc/clean_owner)
 	soft_armor = getArmor()
 	hard_armor = getArmor()
+	max_damage += DELIMB_BUFFER
 	return ..()
 
 /datum/limb/Destroy()
@@ -264,7 +268,7 @@
 		if(updating_health)
 			owner.updatehealth()
 		return update_icon()
-	if(CONFIG_GET(flag/limbs_can_break) && brute_dam >= max_damage * CONFIG_GET(number/organ_health_multiplier))
+	if(CONFIG_GET(flag/limbs_can_break) && brute_dam >= (max_damage - DELIMB_BUFFER) * CONFIG_GET(number/organ_health_multiplier))
 		droplimb() //Reached max damage threshold through brute damage, that limb is going bye bye
 		if(!(owner.species && (owner.species.species_flags & NO_PAIN)))
 			owner.emote("scream")

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -216,7 +216,7 @@
 	else
 		//If we can't inflict the full amount of damage, spread the damage in other ways
 		//How much damage can we actually cause?
-		var/can_inflict = max_damage * CONFIG_GET(number/organ_health_multiplier) - (brute_dam + burn_dam)
+		var/can_inflict = max_damage - (brute_dam + burn_dam)
 		var/remain_brute = brute
 		var/remain_burn = burn
 		if(can_inflict)
@@ -268,7 +268,7 @@
 		if(updating_health)
 			owner.updatehealth()
 		return update_icon()
-	if(CONFIG_GET(flag/limbs_can_break) && brute_dam >= (max_damage - DELIMB_BUFFER) * CONFIG_GET(number/organ_health_multiplier))
+	if(CONFIG_GET(flag/limbs_can_break) && brute_dam >= max_damage - DELIMB_BUFFER)
 		droplimb() //Reached limb severing threshold, that limb is going bye bye
 		if(!(owner.species && (owner.species.species_flags & NO_PAIN)))
 			owner.emote("scream")
@@ -384,7 +384,7 @@
 		update_wounds()
 
 	//Bone fractures
-	if(CONFIG_GET(flag/bones_can_break) && brute_dam > min_broken_damage * CONFIG_GET(number/organ_health_multiplier) && !(limb_status & LIMB_ROBOT))
+	if(CONFIG_GET(flag/bones_can_break) && brute_dam > min_broken_damage && !(limb_status & LIMB_ROBOT))
 		fracture()
 
 	//Infections

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -86,7 +86,6 @@
 		RegisterSignal(owner, COMSIG_PARENT_QDELETING, .proc/clean_owner)
 	soft_armor = getArmor()
 	hard_armor = getArmor()
-	max_damage += DELIMB_BUFFER
 	return ..()
 
 /datum/limb/Destroy()
@@ -1014,7 +1013,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "l_arm"
 	display_name = "left arm"
 	icon_name = "l_arm"
-	max_damage = 125
+	max_damage = 125 + DELIMB_BUFFER
 	min_broken_damage = 50
 	body_part = ARM_LEFT
 	cover_index = 7
@@ -1027,7 +1026,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "l_leg"
 	display_name = "left leg"
 	icon_name = "l_leg"
-	max_damage = 100
+	max_damage = 100 + DELIMB_BUFFER
 	min_broken_damage = 50
 	body_part = LEG_LEFT
 	cover_index = 14
@@ -1037,7 +1036,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "r_arm"
 	display_name = "right arm"
 	icon_name = "r_arm"
-	max_damage = 125
+	max_damage = 125 + DELIMB_BUFFER
 	min_broken_damage = 50
 	body_part = ARM_RIGHT
 	cover_index = 7
@@ -1050,7 +1049,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "r_leg"
 	display_name = "right leg"
 	icon_name = "r_leg"
-	max_damage = 100
+	max_damage = 100 + DELIMB_BUFFER
 	min_broken_damage = 50
 	body_part = LEG_RIGHT
 	cover_index = 14
@@ -1060,7 +1059,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "l_foot"
 	display_name = "left foot"
 	icon_name = "l_foot"
-	max_damage = 75
+	max_damage = 75 + DELIMB_BUFFER
 	min_broken_damage = 37
 	body_part = FOOT_LEFT
 	cover_index = 4
@@ -1070,7 +1069,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "r_foot"
 	display_name = "right foot"
 	icon_name = "r_foot"
-	max_damage = 75
+	max_damage = 75 + DELIMB_BUFFER
 	min_broken_damage = 37
 	body_part = FOOT_RIGHT
 	cover_index = 4
@@ -1080,7 +1079,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "r_hand"
 	display_name = "right hand"
 	icon_name = "r_hand"
-	max_damage = 75
+	max_damage = 75 + DELIMB_BUFFER
 	min_broken_damage = 37
 	body_part = HAND_RIGHT
 	cover_index = 2
@@ -1093,7 +1092,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "l_hand"
 	display_name = "left hand"
 	icon_name = "l_hand"
-	max_damage = 75
+	max_damage = 75 + DELIMB_BUFFER
 	min_broken_damage = 37
 	body_part = HAND_LEFT
 	cover_index = 2
@@ -1106,7 +1105,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "head"
 	icon_name = "head"
 	display_name = "head"
-	max_damage = 100
+	max_damage = 100 + DELIMB_BUFFER
 	min_broken_damage = 40
 	body_part = HEAD
 	vital = TRUE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Simply adds a flat 25 (Value may change.) to the max damage of a limb when it's created and then uses it when determining whether or not to sever the limb. The severing threshold is max damage minus the buffer.

Also removes the organ_health_multiplier config option. (Bravemole told me to, not my idea.)

This prevents burn damage from being abused to avoid delimbs, but uses a different method that isn't hardcoded into the max damage values themselves and is a flat value instead of a percentage so it doesn't cause any differences in the sever resistance of limbs, which the other PR does.

The amount can be changed later since it's not deeply hardcoded. (DELIMB_BUFFER in limbs.dm)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bug fix good? Is this a feature or a bugfix? Eh, whatever, not like it matters.

closes #10849

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added a threshold to delimbs
del: Removed the organ health multiplier config option
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
