### PR TITLE
The AI now has access Command Orders

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1,4 +1,4 @@
-#define MAX_COMMAND_MESSAGE_LEN 300
+#define MAX_COMMAND_MESSAGE_LGTH 300
 
 ///This elevator serves me alone. I have complete control over this entire level. With cameras as my eyes and nodes as my hands, I rule here, insect.
 /mob/living/silicon/ai
@@ -459,7 +459,7 @@
 /datum/action/innate/squad_message/action_activate()
 	if(!can_use_action())
 		return
-	var/text = stripped_input(owner, "Maximum message length [MAX_COMMAND_MESSAGE_LEN]", "Send message to squad", max_length = MAX_COMMAND_MESSAGE_LEN)
+	var/text = stripped_input(owner, "Maximum message length [MAX_COMMAND_MESSAGE_LGTH]", "Send message to squad", max_length = MAX_COMMAND_MESSAGE_LGTH)
 	if(!text)
 		return
 	if(CHAT_FILTER_CHECK(text))

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -441,7 +441,6 @@
 	owner.AddComponent(/datum/component/remote_control, vehicle, vehicle.turret_type, vehicle.can_interact)
 	SEND_SIGNAL(owner, COMSIG_REMOTECONTROL_TOGGLE, owner)
 
-//This is the exact same code as command_alert
 /datum/action/innate/squad_message
 	name = "Send Order"
 	action_icon_state = "screen_order_marine"
@@ -474,5 +473,4 @@
 	deadchat_broadcast(" has sent the command order \"[text]\"", owner, owner)
 	for(var/mob/living/carbon/human/human AS in GLOB.alive_human_list)
 		if(human.faction == owner.faction)
-		// to_chat(owner, span_warning("[GLOB.alive_human_list]"))
 			human.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>ORDERS UPDATED:</u></span><br>" + text, /obj/screen/text/screen_text/command_order)


### PR DESCRIPTION
## About The Pull Request
The AI can now use command orders like squad leaders or CIC staff.
It only reaches all marines, given they do not have an assigned squad.

I've had to copy all of the code, because it features a bunch of references to /living/human, and the Ai is not that sort of thing.

## Why It's Good For The Game
More communication good.

## Changelog
:cl:
expansion: Gave the AI similar command orders to CIC staff
/:cl:
