### PR TITLE
Reduce plasma cutter to be closer to other melee

### DIFF
--- a/code/game/objects/items/tools/mining_tools.dm
+++ b/code/game/objects/items/tools/mining_tools.dm
@@ -86,7 +86,7 @@
 	item_state = "plasmacutter"
 	w_class = WEIGHT_CLASS_BULKY
 	flags_equip_slot = ITEM_SLOT_BELT|ITEM_SLOT_BACK
-	force = 100.0
+	force = 70.0
 	damtype = BURN
 	digspeed = 20 //Can slice though normal walls, all girders, or be used in reinforced wall deconstruction
 	desc = "A tool that cuts with deadly hot plasma. You could use it to cut limbs off of xenos! Or, you know, cut apart walls or mine through stone. Eye protection strongly recommended."
@@ -237,7 +237,7 @@
 	else
 		icon_state = "plasma_cutter_on"
 		powered = TRUE
-		force = 100
+		force = 70
 		damtype = BURN
 		heat = 3800
 		set_light_on(TRUE)


### PR DESCRIPTION
## About The Pull Request
This PR reduces the damage from a whooping 100 to 75

## Why It's Good For The Game
Plasma cutters are a tool, and a very useful one at that. Their ability to deal with maze, walls and other structures is very useful and why they are carried by most people who can take one.

When used against xenomorphs, it also drains 1/5th of the target plasma per hit.

Why it has more damage than **any** other melee weapon in the game, outside of the energy axe, is byond me. 
Bringing the damage closer to the machete and spears seems more reasonable to me. Still absolutely capable of killing, but less of an outlier. 

## Changelog
:cl:
balance: Lowered Plasma cutter damage
/:cl:

