### PR TITLE
Wraith can't banish weeds

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -171,7 +171,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 /datum/action/xeno_action/activable/banish/can_use_ability(atom/A, silent = FALSE, override_flags)
 	. = ..()
 
-	if(!ismovableatom(A) || iseffect(A) || CHECK_BITFIELD(A.resistance_flags, INDESTRUCTIBLE) || CHECK_BITFIELD(A.resistance_flags, BANISH_IMMUNE)) //Cannot banish non-movables/things that are supposed to be invul; also we ignore effects
+	if(!ismovableatom(A) || iseffect(A) || istype(A, /obj/alien) || CHECK_BITFIELD(A.resistance_flags, INDESTRUCTIBLE) || CHECK_BITFIELD(A.resistance_flags, BANISH_IMMUNE)) //Cannot banish non-movables/things that are supposed to be invul; also we ignore effects
 		if(!silent)
 			to_chat(owner, span_xenowarning("We cannot banish this!"))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request
So for a while, wraith couldn't banish weeds/resin because the ability checked if something was an obj/effect to see if it was immune to banish. #10626 repathed a bunch of stuff out of obj/effect, which made weeds viable target. This fixes that with a check for /obj/alien.
Included in this are weeds+nodes, resin, eggs, and hivemind cores. 

## Why It's Good For The Game
Fixes burning your ability on the ground by accident.

## Changelog
:cl:
fix: Wraith can't banish weeds/resin
/:cl:
