### PR TITLE
Improve UV ammo logic & descriptions

### DIFF
--- a/code/modules/projectiles/magazines/unmanned_vehicle.dm
+++ b/code/modules/projectiles/magazines/unmanned_vehicle.dm
@@ -1,6 +1,6 @@
 /obj/item/ammo_magazine/box12x40mm
 	name = "box of 12x40mm"
-	desc = "A box containing 200 rounds of 12x40mm caseless.."
+	desc = "A box containing 200 rounds of 12x40mm caseless."
 	caliber = CALIBER_12X40
 	icon_state = "ltbcannon_4"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -11,7 +11,7 @@
 
 /obj/item/ammo_magazine/box11x35mm
 	name = "box of 11x35mm"
-	desc = "A box containing 200 rounds of 11x35mm caseless.."
+	desc = "A box containing 200 rounds of 11x35mm caseless."
 	caliber = CALIBER_11X35
 	icon_state = "ltbcannon_4"
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1437,17 +1437,17 @@ VEHICLES
 	containertype = /obj/structure/closet/crate/weapon
 
 /datum/supply_packs/vehicles/light_uv
-	name = "Light unmanned vehicle"
+	name = "Light unmanned vehicle - Iguana"
 	contains = list(/obj/vehicle/unmanned)
 	cost = 30
 
 /datum/supply_packs/vehicles/medium_uv
-	name = "Medium unmanned vehicle"
+	name = "Medium unmanned vehicle - Gecko"
 	contains = list(/obj/vehicle/unmanned/medium)
 	cost = 50
 
 /datum/supply_packs/vehicles/heavy_uv
-	name = "Heavy unmanned vehicle"
+	name = "Heavy unmanned vehicle - Komodo"
 	contains = list(/obj/vehicle/unmanned/heavy)
 	cost = 70
 
@@ -1464,13 +1464,13 @@ VEHICLES
 	containertype = /obj/structure/closet/crate/weapon
 
 /datum/supply_packs/vehicles/uv_light_ammo
-	name = "Light UV ammo"
+	name = "Light UV ammo - 11x35mm"
 	contains = list(/obj/item/ammo_magazine/box11x35mm)
 	cost = 3
 	containertype = /obj/structure/closet/crate/ammo
 
 /datum/supply_packs/vehicles/uv_heavy_ammo
-	name = "Heavy UV ammo"
+	name = "Heavy UV ammo - 12x40mm"
 	contains = list(/obj/item/ammo_magazine/box12x40mm)
 	cost = 3
 	containertype = /obj/structure/closet/crate/ammo

--- a/code/modules/vehicles/unmanned/unmanned_droid.dm
+++ b/code/modules/vehicles/unmanned/unmanned_droid.dm
@@ -1,6 +1,6 @@
 /obj/vehicle/unmanned/droid
 	name = "XN-43-H combat droid"
-	desc = "A prototype combat droid, first deployed as a prototype to fight the xeno menace in the frontier sytems. Uses 11x35mm ammo."
+	desc = "A prototype combat droid, first deployed as a prototype to fight the xeno menace in the frontier sytems."
 	icon_state = "droidcombat"
 	move_delay = 3
 	max_integrity = 150

--- a/code/modules/vehicles/unmanned/unmanned_droid.dm
+++ b/code/modules/vehicles/unmanned/unmanned_droid.dm
@@ -1,6 +1,6 @@
 /obj/vehicle/unmanned/droid
 	name = "XN-43-H combat droid"
-	desc = "A prototype combat droid, first deployed as a prototype to fight the xeno menace in the frontier sytems."
+	desc = "A prototype combat droid, first deployed as a prototype to fight the xeno menace in the frontier sytems. Uses 11x35mm ammo."
 	icon_state = "droidcombat"
 	move_delay = 3
 	max_integrity = 150

--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -100,7 +100,7 @@
 /obj/vehicle/unmanned/examine(mob/user, distance, infix, suffix)
 	. = ..()
 	if(current_rounds > 0)
-		. += "It has [current_rounds] ammo left."
+		. += "It has [current_rounds] shots left."
 	switch(turret_type)
 		if(TURRET_TYPE_LIGHT)
 			. += "It is equipped with a light weapon system. It uses [turret_path.magazine_type]"

--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -103,13 +103,13 @@
 		. += "It has [current_rounds] shots left."
 	switch(turret_type)
 		if(TURRET_TYPE_LIGHT)
-			. += "It is equipped with a light weapon system. It uses [turret_path.magazine_type]"
+			. += "It is equipped with a light weapon system. It uses 11x35mm ammo."
 		if(TURRET_TYPE_HEAVY)
-			. += "It is equipped with a heavy weapon system. It uses [turret_path.magazine_type]"
+			. += "It is equipped with a heavy weapon system. It uses 12x40mm ammo."
 		if(TURRET_TYPE_EXPLOSIVE)
-			. += "It is equipped with an explosive weapon system. It uses [turret_path.magazine_type]"
+			. += "It is equipped with an explosive weapon system. "
 		if(TURRET_TYPE_DROIDLASER)
-			. += "It is equipped with a droid weapon system. It uses [turret_path.magazine_type]"
+			. += "It is equipped with a droid weapon system. It uses 11x35mm ammo."
 
 /obj/vehicle/unmanned/attackby(obj/item/I, mob/user, params)
 	. = ..()

--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -99,8 +99,17 @@
 
 /obj/vehicle/unmanned/examine(mob/user, distance, infix, suffix)
 	. = ..()
-	if(ishuman(user))
+	if(current_rounds)
 		. += "It has [current_rounds] ammo left."
+	switch(turret_type)
+		if(TURRET_TYPE_LIGHT)
+			. += "It is equipped with a light weapon system. It uses [turret_path.magazine_type]"
+		if(TURRET_TYPE_HEAVY)
+			. += "It is equipped with a heavy weapon system. It uses [turret_path.magazine_type]"
+		if(TURRET_TYPE_EXPLOSIVE)
+			. += "It is equipped with an explosive weapon system. It uses [turret_path.magazine_type]"
+		if(TURRET_TYPE_DROIDLASER)
+			. += "It is equipped with a droid weapon system. It uses [turret_path.magazine_type]"
 
 /obj/vehicle/unmanned/attackby(obj/item/I, mob/user, params)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
This PR aims to make it clearer which ammo UV's use, how much they have left, and to make ordering easier.
It also changes the logic of the ammo system, so you can't try to reload a full UV anymore, or lose 149 bullets when you only reload 1. 
I also corrected 2 typos regarding the ammo magazines.
I also added some quick little descriptions about which ammo types the turrets use. It should make it easier for players to maintain things. I couldn't manage to make the system automatic, but it isn't likely to change anytime soon. 

## Why It's Good For The Game
Clarity = Good
Using roughly the same logic as any other ammo for UV's = good

## Changelog
:cl:
qol: Improved Droids and UV's examine to show more accurate ammo counts
qol: improved UV's crates names to make their names more useful
qol: Added caliber information to UV's, relative to their current weapon type. 
fix: Made UV ammo work closer to regular magazines. No more ammo wasting.
fix: Couple of typos related to UV ammo
/:cl:
