### PR TITLE
Expand Pillar of Spring's AI core slightly

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -3164,8 +3164,6 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "iX" = (
-/obj/structure/window/reinforced/extratoughened,
-/obj/machinery/camera/autoname/mainship,
 /obj/vehicle/unmanned/droid,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
@@ -4413,7 +4411,7 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
 "mJ" = (
 /obj/effect/decal/warning_stripes/thin,
@@ -6550,7 +6548,8 @@
 /area/mainship/shipboard/weapon_room)
 "tj" = (
 /obj/structure/cable,
-/turf/closed/wall/mainship,
+/obj/machinery/light/mainship,
+/turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
 "tk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -7298,8 +7297,10 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
 "vw" = (
-/obj/machinery/door/airlock/mainship/ai/glass,
-/turf/open/floor/mainship/mono,
+/obj/structure/window/reinforced/extratoughened{
+	dir = 4
+	},
+/turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
 "vx" = (
 /obj/structure/bed/chair/comfy/black{
@@ -7399,7 +7400,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "vO" = (
-/obj/machinery/holopad,
+/obj/machinery/door/airlock/mainship/ai/glass,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/airoom)
 "vP" = (
@@ -9706,6 +9707,9 @@
 /obj/machinery/alarm{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/airoom)
 "Ct" = (
@@ -10747,6 +10751,7 @@
 /obj/machinery/light/mainship{
 	dir = 8
 	},
+/obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/airoom)
 "Fp" = (
@@ -11646,17 +11651,15 @@
 /area/mainship/hallways/port_umbilical)
 "HL" = (
 /obj/structure/cable,
-/obj/machinery/light/mainship,
-/turf/open/floor/mainship/tcomms,
-/area/mainship/command/airoom)
-"HM" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/mainship/hardened{
-	dir = 8
+	dir = 1
 	},
 /obj/structure/window/reinforced/extratoughened{
 	dir = 1
 	},
+/turf/open/floor/mainship/tcomms,
+/area/mainship/command/airoom)
+"HM" = (
 /obj/vehicle/unmanned/droid/scout,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
@@ -11807,7 +11810,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "If" = (
-/obj/effect/landmark/start/job/ai,
+/obj/structure/window/reinforced/extratoughened{
+	dir = 8
+	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
 "Ih" = (
@@ -12110,9 +12115,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "IW" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
+/obj/structure/window/reinforced/extratoughened,
+/obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
 "IX" = (
@@ -13890,10 +13894,7 @@
 /area/mainship/medical/medical_science)
 "NH" = (
 /obj/structure/cable,
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
+/turf/closed/wall/mainship,
 /area/mainship/command/airoom)
 "NI" = (
 /obj/structure/table/mainship/nometal,
@@ -17149,9 +17150,7 @@
 /turf/open/floor/mainship/empty,
 /area/mainship/squads/req)
 "WT" = (
-/obj/structure/window/reinforced/extratoughened{
-	dir = 4
-	},
+/obj/effect/landmark/start/job/ai,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
 "WU" = (
@@ -49980,7 +49979,7 @@ GA
 GA
 Cr
 xD
-mI
+OE
 vO
 NH
 OE
@@ -50237,7 +50236,7 @@ Em
 GA
 tY
 xD
-OE
+mI
 vw
 tj
 OE


### PR DESCRIPTION
## About The Pull Request
![image](https://user-images.githubusercontent.com/24830358/189427813-f45c883f-1998-413b-a55c-54589fd0a979.png)


## Why It's Good For The Game
The AI core on POS is very small, and being against the wall to the right weakens in a lot. 
This makes the AI not look as shoved into a storage closet, and it makes the core decently stronger. 

## Changelog
:cl:
add: Expanded the AI core on Pillar of Spring
/:cl:

