### PR TITLE
X fuel exploit fix

### DIFF
--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -31,10 +31,10 @@
 	if(istype(target, /obj/structure/reagent_dispensers/fueltank) && get_dist(user,target) <= 1)
 		if(default_ammo != /datum/ammo/flamethrower)
 			to_chat(user, span_warning("Not the right kind of fuel!"))
-			return..()
+			return ..()
 		if(current_rounds >= max_rounds)
 			to_chat(user, span_warning("[src] is already full."))
-			return..()
+			return ..()
 		var/obj/structure/reagent_dispensers/fueltank/FT = target
 		if(FT.reagents.total_volume == 0)
 			to_chat(user, span_warning("Out of fuel!"))

--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -32,6 +32,9 @@
 		if(default_ammo != /datum/ammo/flamethrower)
 			to_chat(user, span_warning("Not the right kind of fuel!"))
 			return..()
+		if(current_rounds >= max_rounds)
+			to_chat(user, span_warning("[src] is already full."))
+			return..()
 		var/obj/structure/reagent_dispensers/fueltank/FT = target
 		if(FT.reagents.total_volume == 0)
 			to_chat(user, span_warning("Out of fuel!"))

--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -29,6 +29,9 @@
 /obj/item/ammo_magazine/flamer_tank/afterattack(obj/target, mob/user , flag) //refuel at fueltanks when we run out of ammo.
 
 	if(istype(target, /obj/structure/reagent_dispensers/fueltank) && get_dist(user,target) <= 1)
+		if(default_ammo != /datum/ammo/flamethrower)
+			to_chat(user, span_warning("Not the right kind of fuel!"))
+			return..()
 		var/obj/structure/reagent_dispensers/fueltank/FT = target
 		if(FT.reagents.total_volume == 0)
 			to_chat(user, span_warning("Out of fuel!"))


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can no longer refill X fuel using regular fuel tanks, for infinite X fuel.
Also if you try fill a full tank, it now says it's full, instead of saying it was refilled and making the refuel sound, because that was annoying.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Exploit bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: X fuel tanks no longer convert ordinary fuel to X fuel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
