### PR TITLE
Beheading fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -7,64 +7,37 @@
 /proc/get_limb_icon_name(datum/species/S, gender, limb_name, ethnicity)
 	if(S.name == "Human" || S.name == "Synthetic")
 		switch(limb_name)
-			if ("torso")
+			if ("torso", "chest")
 				return "[ethnicity]_torso_[get_gender_name(gender)]"
 
-			if ("chest")
-				return "[ethnicity]_torso_[get_gender_name(gender)]"
-
-			if ("head")
-				return "[ethnicity]_[limb_name]_[get_gender_name(gender)]"
+			if ("head", "synthetic head")
+				return "[ethnicity]_head_[get_gender_name(gender)]"
 
 			if ("groin")
-				return "[ethnicity]_[limb_name]_[get_gender_name(gender)]"
+				return "[ethnicity]_groin_[get_gender_name(gender)]"
 
-			if ("r_arm")
+			if ("r_arm", "right arm")
 				return "[ethnicity]_right_arm"
 
-			if ("right arm")
-				return "[ethnicity]_right_arm"
-
-			if ("l_arm")
+			if ("l_arm", "left arm")
 				return "[ethnicity]_left_arm"
 
-			if ("left arm")
-				return "[ethnicity]_left_arm"
-
-			if ("r_leg")
+			if ("r_leg", "right leg")
 				return "[ethnicity]_right_leg"
 
-			if ("right leg")
-				return "[ethnicity]_right_leg"
-
-			if ("l_leg")
+			if ("l_leg", "left leg")
 				return "[ethnicity]_left_leg"
 
-			if ("left leg")
-				return "[ethnicity]_left_leg"
-
-			if ("r_hand")
+			if ("r_hand", "right hand")
 				return "[ethnicity]_right_hand"
 
-			if ("right hand")
-				return "[ethnicity]_right_hand"
-
-			if ("l_hand")
+			if ("l_hand", "left hand")
 				return "[ethnicity]_left_hand"
 
-			if ("left hand")
-				return "[ethnicity]_left_hand"
-
-			if ("r_foot")
+			if ("r_foot", "right foot")
 				return "[ethnicity]_right_foot"
 
-			if ("right foot")
-				return "[ethnicity]_right_foot"
-
-			if ("l_foot")
-				return "[ethnicity]_left_foot"
-
-			if ("left foot")
+			if ("l_foot", "left foot")
 				return "[ethnicity]_left_foot"
 
 			else
@@ -77,10 +50,7 @@
 			if ("chest")
 				return "[limb_name]_[get_gender_name(gender)]"
 
-			if ("head")
-				return "[limb_name]_[get_gender_name(gender)]"
-
-			if ("synthetic head")
+			if ("head", "synthetic head", "robotic head")
 				return "head_[get_gender_name(gender)]"
 
 			if ("groin")

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -10,7 +10,7 @@
 			if ("torso", "chest")
 				return "[ethnicity]_torso_[get_gender_name(gender)]"
 
-			if ("head", "synthetic head")
+			if ("head")
 				return "[ethnicity]_head_[get_gender_name(gender)]"
 
 			if ("groin")
@@ -50,7 +50,7 @@
 			if ("chest")
 				return "[limb_name]_[get_gender_name(gender)]"
 
-			if ("head", "synthetic head", "robotic head")
+			if ("head")
 				return "head_[get_gender_name(gender)]"
 
 			if ("groin")

--- a/code/modules/organs/limb_objects.dm
+++ b/code/modules/organs/limb_objects.dm
@@ -123,11 +123,9 @@
 
 //synthetic head, allowing brain mob inside to talk
 /obj/item/limb/head/synth
-	name = "synthetic head"
 	brain_item_type = null
 	braindeath_on_decap = 0
 
 /obj/item/limb/head/robotic
-	name = "robotic head"
 	brain_item_type = null
 	braindeath_on_decap = 0

--- a/code/modules/organs/limb_objects.dm
+++ b/code/modules/organs/limb_objects.dm
@@ -2,8 +2,8 @@
 /obj/item/limb
 	icon = 'icons/mob/human_races/r_human.dmi'
 
-/obj/item/limb/New(loc, mob/living/carbon/human/H)
-	..(loc)
+/obj/item/limb/Initialize(loc, mob/living/carbon/human/H)
+	. = ..()
 	if(!istype(H))
 		return
 	//Forming icon for the limb
@@ -77,7 +77,6 @@
 	if(!istype(H))
 		return
 
-	icon_state = H.gender == MALE? "head_m" : "head_f"
 	if(H.species.species_flags & HAS_NO_HAIR)
 		return
 	//Add (facial) hair.

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -691,12 +691,11 @@ Note that amputating the affected organ does in fact remove the infection from t
 	reset_limb_surgeries()
 
 	var/obj/organ	//Dropped limb object
-	var/mob/living/carbon/human/H
 	switch(body_part)
 		if(HEAD)
-			if(issynth(H)) //special head for synth to allow brainmob to talk without an MMI
+			if(issynth(owner)) //special head for synth to allow brainmob to talk without an MMI
 				organ = new /obj/item/limb/head/synth(owner.loc, owner)
-			else if(isrobot(H))
+			else if(isrobot(owner))
 				organ = new /obj/item/limb/head/robotic(owner.loc, owner)
 			else
 				organ = new /obj/item/limb/head(owner.loc, owner)


### PR DESCRIPTION
## About The Pull Request
Enables reattaching synth/robbit heads
Fixes heads turning invisible on removal

## Why It's Good For The Game
bugfix

## Changelog
:cl:
fix: Synth heads can be reattached
fix: Heads have their proper hair and name and aren't invisible sometimes
/:cl:
