### PR TITLE
Add name and area to planted supply beacon

### DIFF
--- a/code/game/objects/machinery/squad_supply/supply_beacon.dm
+++ b/code/game/objects/machinery/squad_supply/supply_beacon.dm
@@ -48,7 +48,7 @@
 	H.transferItemToLoc(src, H.loc)
 	beacon_cam = BC
 	message_admins("[ADMIN_TPMONTY(usr)] set up an orbital strike beacon.")
-	name = "transmitting orbital beacon"
+	name = "transmitting orbital beacon - [get_area(src)] - [H]"
 	activated = TRUE
 	anchored = TRUE
 	w_class = 10


### PR DESCRIPTION
## About The Pull Request
![image](https://user-images.githubusercontent.com/24830358/189546674-31db20e2-fd18-43de-a571-30b1c84230c5.png)

## Why It's Good For The Game
It makes it clearer for people to say which beacon they should send things to.

## Changelog
:cl:
qol: Added name & area to supply beacons
/:cl:

