### PR TITLE
Fixes some minor issues with chigusa

### DIFF
--- a/_maps/map_files/desertdam/desertdam.dmm
+++ b/_maps/map_files/desertdam/desertdam.dmm
@@ -1526,10 +1526,6 @@
 	dir = 4
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
-"ajR" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/tile/white,
-/area/desert_dam/building/medical/chemistry)
 "ajV" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -4833,6 +4829,12 @@
 	dir = 10
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_RND)
+"azn" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/twoside,
+/area/desert_dam/exterior/valley/valley_mining)
 "azo" = (
 /turf/open/floor/prison/blue,
 /area/desert_dam/interior/lab_northeast/east_lab_RND)
@@ -6007,6 +6009,15 @@
 /obj/structure/flora/desert/grass/ten,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"aHT" = (
+/obj/structure/desertdam/decals/road{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "aHV" = (
 /obj/structure/table,
 /obj/item/tool/pickaxe/hammer,
@@ -6400,19 +6411,6 @@
 "aLm" = (
 /turf/open/floor/plating/asteroidplating,
 /area/desert_dam/exterior/valley/valley_crashsite)
-"aLr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/whitegreen{
-	dir = 1
-	},
-/area/desert_dam/building/medical/north_wing_hallway)
 "aLv" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge{
@@ -7994,6 +7992,12 @@
 	},
 /turf/open/floor/wood,
 /area/desert_dam/building/administration/office)
+"aWW" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen{
+	dir = 1
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
 "aWY" = (
 /turf/closed/wall/r_wall,
 /area/desert_dam/building/administration/hallway)
@@ -12448,6 +12452,12 @@
 	dir = 8
 	},
 /area/desert_dam/building/security/staffroom)
+"bwF" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/landing/landing_pad_two_external)
 "bwH" = (
 /turf/open/floor/tile/dark,
 /area/desert_dam/building/security/observation)
@@ -15348,10 +15358,6 @@
 	dir = 4
 	},
 /area/desert_dam/building/security/armory)
-"bNV" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt/twoside,
-/area/desert_dam/exterior/valley/valley_medical)
 "bNY" = (
 /turf/closed/wall/r_wall/chigusa,
 /area/desert_dam/interior/dam_interior/workshop)
@@ -16422,16 +16428,6 @@
 	dir = 4
 	},
 /area/desert_dam/interior/dam_interior/west_tunnel)
-"bUs" = (
-/obj/structure/platform{
-	dir = 4
-	},
-/obj/structure/platform,
-/obj/structure/platform_decoration{
-	dir = 6
-	},
-/turf/open/ground/river/desertdam/clean/deep_water_clean,
-/area/desert_dam/exterior/river/riverside_south)
 "bUt" = (
 /obj/structure/flora/desert/grass/heavy/four,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -19367,10 +19363,6 @@
 	},
 /turf/open/floor/tile/white,
 /area/desert_dam/building/medical/chemistry)
-"ckK" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/desertdam/asphalt/tile,
-/area/desert_dam/exterior/valley/valley_medical)
 "ckM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -19840,6 +19832,14 @@
 	},
 /turf/open/floor/carpet,
 /area/desert_dam/building/warehouse/breakroom)
+"cnF" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 4
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
 "cnG" = (
 /turf/open/floor/tile/purple/whitepurple,
 /area/desert_dam/building/medical/chemistry)
@@ -20268,6 +20268,10 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
+"cpW" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/desert_dam/exterior/valley/valley_medical)
 "cpZ" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 9
@@ -24081,10 +24085,6 @@
 "cLG" = (
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/warehouse/warehouse)
-"cLJ" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/valley_medical)
 "cLL" = (
 /obj/machinery/landinglight/ds2{
 	dir = 8
@@ -26827,16 +26827,6 @@
 	dir = 1
 	},
 /area/desert_dam/building/warehouse/warehouse)
-"dhp" = (
-/obj/structure/desertdam/decals/road{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_civilian)
 "dhs" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -28518,10 +28508,6 @@
 /obj/item/reagent_containers/food/snacks/cookie,
 /turf/open/floor/prison/kitchen,
 /area/desert_dam/building/cafeteria/cafeteria)
-"dAi" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison/whitegreen,
-/area/desert_dam/building/medical/north_wing_hallway)
 "dAk" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/bun,
@@ -29001,6 +28987,9 @@
 /obj/structure/platform{
 	dir = 8
 	},
+/obj/structure/platform_decoration{
+	dir = 5
+	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/riverside_south)
 "dEr" = (
@@ -29067,6 +29056,9 @@
 	},
 /obj/structure/platform{
 	dir = 1
+	},
+/obj/structure/platform_decoration{
+	dir = 9
 	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/riverside_south)
@@ -29140,12 +29132,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/green/whitegreen,
 /area/desert_dam/building/lab_northwest/west_lab_xenoflora)
-"dFO" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_civilian)
 "dFP" = (
 /obj/structure/platform,
 /obj/structure/platform{
@@ -29224,6 +29210,9 @@
 /obj/structure/platform,
 /obj/structure/platform{
 	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 10
 	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/riverside_south)
@@ -29334,6 +29323,9 @@
 	dir = 4
 	},
 /obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 6
+	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/riverside_south)
 "dHB" = (
@@ -29933,10 +29925,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/freezer,
 /area/desert_dam/building/security/prison)
-"dPi" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison,
-/area/desert_dam/building/substation/northeast)
 "dPj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
@@ -30021,6 +30009,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/dam_interior/hangar_storage)
+"dRW" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "dSz" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -30079,12 +30073,6 @@
 /obj/structure/desertdam/decals/road,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/river/riverside_south)
-"dTI" = (
-/obj/machinery/sleep_console,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison/whitegreen,
-/area/desert_dam/building/medical/emergency_room)
 "dTK" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/edge{
 	dir = 10
@@ -30181,15 +30169,6 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/prison/whitegreen/full,
 /area/desert_dam/building/dorms/pool)
-"dWr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/whitegreen{
-	dir = 8
-	},
-/area/desert_dam/building/medical/east_wing_hallway)
 "dWy" = (
 /obj/structure/rack,
 /turf/open/floor/prison/whitegreen/full,
@@ -30943,6 +30922,13 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"ehh" = (
+/obj/structure/cable,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen{
+	dir = 1
+	},
+/area/desert_dam/building/medical/north_wing_hallway)
 "ehx" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -31063,17 +31049,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/asteroidplating,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"ekP" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/twoside,
+/area/desert_dam/exterior/valley/valley_medical)
 "ekQ" = (
 /obj/structure/desertdam/decals/road,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/south_tunnel)
-"ekU" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt/twoside,
-/area/desert_dam/exterior/valley/valley_medical)
 "ekW" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -31446,10 +31430,6 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"exd" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_mining)
 "exn" = (
 /obj/structure/flora/desert/grass/eleven,
 /obj/effect/ai_node,
@@ -31485,12 +31465,6 @@
 	},
 /turf/open/floor/prison/kitchen,
 /area/desert_dam/building/cafeteria/cafeteria)
-"eyh" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison/whitegreen{
-	dir = 4
-	},
-/area/desert_dam/building/medical/east_wing_hallway)
 "eyi" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -31507,11 +31481,6 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_south)
-"eyW" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/whitegreen,
-/area/desert_dam/building/medical/east_wing_hallway)
 "ezm" = (
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 4
@@ -31964,6 +31933,10 @@
 	},
 /turf/open/floor/prison/whitegreen/full,
 /area/desert_dam/interior/east_engineering)
+"eNF" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_medical)
 "eNR" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -31972,11 +31945,10 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"eOh" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/desertdam/asphalt/tile,
-/area/desert_dam/exterior/valley/valley_medical)
+"eNY" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/sterilewhite,
+/area/desert_dam/building/medical/emergency_room)
 "eOn" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -32269,11 +32241,6 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
-"eUI" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/tile/white,
-/area/desert_dam/building/medical/chemistry)
 "eUP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -32378,10 +32345,13 @@
 	},
 /turf/open/floor/prison/plate,
 /area/desert_dam/exterior/valley/valley_northwest)
-"eXS" = (
+"eXX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/sterilewhite,
-/area/desert_dam/building/medical/emergency_room)
+/turf/open/floor/prison/whitegreen{
+	dir = 4
+	},
+/area/desert_dam/building/medical/virology_isolation)
 "eYf" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -32489,12 +32459,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_mining)
-"fbY" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/whitegreen{
-	dir = 4
-	},
-/area/desert_dam/building/medical/virology_wing)
 "fcj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -32988,18 +32952,6 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/security/staffroom)
-"fqE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/whitegreen{
-	dir = 1
-	},
-/area/desert_dam/building/medical/north_wing_hallway)
 "fqF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/gloves/latex,
@@ -33411,6 +33363,10 @@
 	},
 /turf/open/floor/freezer,
 /area/desert_dam/building/cafeteria/cold_room)
+"fCx" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/wall,
+/area/desert_dam/building/dorms/pool)
 "fCB" = (
 /obj/structure/desertdam/decals/road/edge/long{
 	dir = 4
@@ -33632,6 +33588,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/interior/lab_northeast/east_lab_maintenence)
+"fID" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 1
+	},
+/area/desert_dam/building/medical/west_wing_hallway)
 "fIK" = (
 /obj/structure/platform{
 	dir = 4
@@ -33867,12 +33829,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/bar/bar_restroom)
-"fPJ" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/landing/landing_pad_two_external)
 "fPM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/bright_clean,
@@ -33990,6 +33946,16 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_wilderness)
+"fSb" = (
+/obj/structure/desertdam/decals/road{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "fSc" = (
 /obj/structure/flora/desert/grass/twelve,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -34845,14 +34811,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/west_tunnel)
-"goB" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 1
-	},
-/area/desert_dam/exterior/valley/valley_civilian)
 "goN" = (
 /obj/effect/landmark/start/job/xenomorph,
 /obj/structure/cable,
@@ -35325,11 +35283,6 @@
 	dir = 9
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
-"gGS" = (
-/obj/effect/decal/medical_decals/triage/bottom,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison/sterilewhite,
-/area/desert_dam/building/medical/lobby)
 "gHa" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -35575,6 +35528,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/freezer,
 /area/desert_dam/interior/dam_interior/break_room)
+"gPD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison,
+/area/desert_dam/building/medical/break_room)
 "gQg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -35775,6 +35734,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/west_tunnel)
+"gWP" = (
+/obj/structure/cable,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 4
+	},
+/area/desert_dam/building/medical/treatment_room)
 "gXe" = (
 /obj/structure/desertdam/decals/road{
 	dir = 4
@@ -36060,6 +36026,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/interior/caves/east_caves)
+"hfi" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/desert_dam/exterior/valley/valley_medical)
 "hfu" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -36200,16 +36171,6 @@
 	dir = 4
 	},
 /area/desert_dam/interior/dam_interior/break_room)
-"hiL" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison/whitegreen{
-	dir = 1
-	},
-/area/desert_dam/building/medical/north_wing_hallway)
 "hiN" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/cavetodirt{
@@ -36646,6 +36607,10 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
+"hvS" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_medical)
 "hvV" = (
 /obj/structure/bed/chair/office/light,
 /turf/open/floor/prison,
@@ -36661,13 +36626,6 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
-"hwP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/whitegreen{
-	dir = 4
-	},
-/area/desert_dam/building/medical/virology_isolation)
 "hwW" = (
 /obj/structure/filingcabinet,
 /obj/machinery/light{
@@ -36693,13 +36651,6 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/interior/lab_northeast/east_lab_security_armory)
-"hxK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/whitegreen{
-	dir = 1
-	},
-/area/desert_dam/building/medical/treatment_room)
 "hxM" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -36916,11 +36867,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_wilderness)
-"hCs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/sterilewhite,
-/area/desert_dam/building/medical/lobby)
 "hCB" = (
 /obj/structure/desertdam/decals/road{
 	dir = 4
@@ -36936,10 +36882,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_cargo)
-"hCN" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison/whitegreen/corner,
-/area/desert_dam/building/medical/north_wing_hallway)
 "hDc" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner,
 /area/desert_dam/exterior/river/riverside_south)
@@ -36988,10 +36930,6 @@
 	dir = 4
 	},
 /area/desert_dam/interior/dam_interior/disposals)
-"hDJ" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/closed/wall,
-/area/desert_dam/building/dorms/restroom)
 "hDM" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/xeno_resin_wall,
@@ -37262,14 +37200,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/freezer,
 /area/desert_dam/building/water_treatment_one/breakroom)
-"hLc" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/whitegreen{
-	dir = 4
-	},
-/area/desert_dam/building/medical/east_wing_hallway)
 "hLl" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/chips,
@@ -37417,10 +37347,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_cargo)
-"hOW" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison/whitegreen,
-/area/desert_dam/building/medical/treatment_room)
 "hPi" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating/ground/desertdam/asphalt/twoside,
@@ -37615,6 +37541,10 @@
 "hUX" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner,
 /area/desert_dam/exterior/river/riverside_central_south)
+"hVa" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen,
+/area/desert_dam/building/medical/north_wing_hallway)
 "hVo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge{
@@ -37990,15 +37920,6 @@
 	dir = 1
 	},
 /area/desert_dam/building/administration/hallway)
-"ifF" = (
-/obj/structure/desertdam/decals/road{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/landing/landing_pad_two_external)
 "ifM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/lv624/fog_blocker,
@@ -38355,6 +38276,11 @@
 	dir = 10
 	},
 /area/desert_dam/exterior/valley/valley_mining)
+"isa" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/tile/white,
+/area/desert_dam/building/medical/chemistry)
 "isk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38416,15 +38342,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/warehouse/breakroom)
-"itq" = (
-/obj/structure/desertdam/decals/road{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_civilian)
 "its" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/decal/medical_decals/doc/four,
@@ -38479,12 +38396,18 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
-"ivi" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison/whitegreen/corner{
+"ivp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
 	dir = 1
 	},
-/area/desert_dam/building/medical/west_wing_hallway)
+/area/desert_dam/exterior/valley/valley_medical)
 "ivu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -38506,6 +38429,12 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"iwp" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/landing/landing_pad_two_external)
 "iwv" = (
 /obj/machinery/landinglight/ds2/delaythree{
 	dir = 8
@@ -38515,11 +38444,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
-"iwz" = (
-/obj/machinery/light,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison/whitegreen,
-/area/desert_dam/building/medical/north_wing_hallway)
 "iwE" = (
 /obj/structure/desertdam/decals/road/edge/long{
 	dir = 4
@@ -38592,13 +38516,6 @@
 	dir = 6
 	},
 /area/desert_dam/exterior/valley/tradeship)
-"iyp" = (
-/obj/machinery/floodlight/colony,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_civilian)
 "iyD" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -38620,6 +38537,17 @@
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/cafeteria/cafeteria)
+"iyQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/sterilewhite,
+/area/desert_dam/building/medical/primary_storage)
 "iyR" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge{
@@ -38652,12 +38580,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean/two,
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
-"izy" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt/twoside,
-/area/desert_dam/exterior/valley/valley_mining)
 "izM" = (
 /obj/structure/window/framed/colony,
 /obj/structure/cable,
@@ -39067,14 +38989,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/west_tunnel)
-"iLI" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge{
-	dir = 8
-	},
-/area/desert_dam/exterior/valley/valley_civilian)
 "iLK" = (
 /obj/structure/desertdam/decals/road{
 	dir = 1
@@ -40044,6 +39958,15 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"jpn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 8
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
 "jpH" = (
 /obj/structure/bed/alien,
 /obj/item/bedsheet/brown,
@@ -40133,6 +40056,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"jrN" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/sterilewhite,
+/area/desert_dam/building/medical/lobby)
 "jsf" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -40854,6 +40782,10 @@
 	dir = 5
 	},
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"jKO" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/prison/whitegreen/full,
+/area/desert_dam/building/dorms/pool)
 "jLd" = (
 /obj/machinery/light{
 	dir = 8
@@ -41398,6 +41330,18 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/primary_storage)
+"jZY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 1
+	},
+/area/desert_dam/building/medical/north_wing_hallway)
 "jZZ" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_telecoms)
@@ -41408,6 +41352,12 @@
 	dir = 1
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
+"kaA" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "kaE" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/xeno_resin_wall,
@@ -41727,14 +41677,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_mining)
-"kjP" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 4
-	},
-/area/desert_dam/exterior/valley/valley_civilian)
 "kjQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
@@ -41770,6 +41712,13 @@
 /obj/item/trash/cheesie,
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_westwing)
+"kkP" = (
+/obj/machinery/floodlight/colony,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_civilian)
 "kkX" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/kitchen,
@@ -42158,6 +42107,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/freezer,
 /area/desert_dam/building/hydroponics/hydroponics_breakroom)
+"kvQ" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen,
+/area/desert_dam/building/medical/east_wing_hallway)
 "kvS" = (
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 9
@@ -42292,10 +42246,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_telecoms)
-"kAc" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt/edge,
-/area/desert_dam/exterior/valley/valley_medical)
 "kAh" = (
 /obj/structure/platform,
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner{
@@ -42383,6 +42333,22 @@
 	dir = 4
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
+"kCR" = (
+/obj/structure/cable,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 1
+	},
+/area/desert_dam/building/medical/north_wing_hallway)
+"kDf" = (
+/obj/structure/desertdam/decals/road{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/landing/landing_pad_two_external)
 "kDh" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -42478,10 +42444,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/whitegreen,
 /area/desert_dam/building/medical/emergency_room)
-"kHq" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/sterilewhite,
-/area/desert_dam/building/medical/lobby)
 "kHr" = (
 /obj/structure/largecrate/random,
 /obj/effect/decal/cleanable/dirt,
@@ -42509,17 +42471,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/workshop)
-"kHQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/sterilewhite,
-/area/desert_dam/building/medical/primary_storage)
 "kHR" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -42725,6 +42676,19 @@
 	dir = 10
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
+"kME" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 1
+	},
+/area/desert_dam/building/medical/north_wing_hallway)
 "kMH" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/edge{
 	dir = 9
@@ -42803,6 +42767,13 @@
 	dir = 10
 	},
 /area/desert_dam/interior/dam_interior/west_tunnel)
+"kOx" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 4
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
 "kOL" = (
 /obj/structure/flora/rock/alt3{
 	name = "rock"
@@ -43358,6 +43329,13 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
+"ldN" = (
+/obj/structure/desertdam/decals/road,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "ldU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43789,10 +43767,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/cafeteria/loading)
-"lrS" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating,
-/area/desert_dam/building/medical/east_wing_hallway)
 "lrV" = (
 /obj/item/shard,
 /obj/effect/decal/cleanable/blood/six,
@@ -44248,22 +44222,9 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/central_tunnel)
-"lFt" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/prison,
-/area/desert_dam/building/dorms/hallway_northwing)
 "lFE" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/desert_dam/interior/east_engineering)
-"lFG" = (
-/obj/structure/cable,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison/whitegreen/corner{
-	dir = 1
-	},
-/area/desert_dam/building/medical/north_wing_hallway)
 "lFQ" = (
 /obj/effect/ai_node,
 /turf/open/ground/river/desertdam/clean/shallow_edge{
@@ -44779,6 +44740,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/tile/white,
 /area/desert_dam/interior/lab_northeast/east_lab_lobby)
+"lWX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen/full,
+/area/desert_dam/building/medical/emergency_room)
 "lXF" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/toolbox,
@@ -44921,6 +44887,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/white,
 /area/desert_dam/interior/dam_interior/lobby)
+"mba" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "mbd" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/twoside,
@@ -44982,6 +44956,10 @@
 /obj/structure/desertdam/decals/road/edge/long,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"mer" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/desert_dam/exterior/valley/valley_mining)
 "mfa" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/edge{
 	dir = 10
@@ -45280,6 +45258,12 @@
 /obj/structure/cable,
 /turf/open/floor/prison/whitegreen/full,
 /area/desert_dam/building/water_treatment_two/floodgate_control)
+"mnY" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 4
+	},
+/area/desert_dam/building/medical/virology_wing)
 "moG" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean/two,
@@ -45730,6 +45714,13 @@
 	dir = 8
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_biology)
+"mAS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 1
+	},
+/area/desert_dam/building/medical/treatment_room)
 "mAU" = (
 /obj/structure/desertdam/decals/road{
 	dir = 4
@@ -46148,16 +46139,19 @@
 "mNk" = (
 /turf/closed/wall/r_wall,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"mNt" = (
+/obj/effect/landmark/weed_node,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "mNA" = (
 /obj/machinery/landinglight/ds1/delaythree{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
-"mNO" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating,
-/area/desert_dam/building/medical/garage)
 "mNP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
@@ -46519,14 +46513,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/dorms/restroom)
-"mYc" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 9
-	},
-/area/desert_dam/exterior/valley/valley_civilian)
 "mYf" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison,
@@ -46764,6 +46750,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean/two,
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
+"nfg" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/sterilewhite,
+/area/desert_dam/building/medical/lobby)
 "nfj" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -46955,6 +46945,12 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
+"nkT" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 8
+	},
+/area/desert_dam/building/medical/west_wing_hallway)
 "nkZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge{
@@ -46982,6 +46978,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/cafeteria/cafeteria)
+"nlD" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/desert_dam/exterior/valley/valley_medical)
 "nlM" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -47501,6 +47501,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/cafeteria/cafeteria)
+"nDx" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "nDH" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/tool,
@@ -47742,6 +47750,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/tradeship)
+"nMC" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "nMM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -48393,6 +48409,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
+"obR" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/tile/white,
+/area/desert_dam/building/medical/chemistry)
 "obX" = (
 /obj/structure/flora/desert/grass/heavy/three,
 /obj/effect/landmark/weed_node,
@@ -48647,6 +48667,18 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/warehouse/warehouse)
+"ojb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen,
+/area/desert_dam/building/medical/east_wing_hallway)
 "ojA" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/twoside{
@@ -48813,10 +48845,6 @@
 	},
 /turf/open/floor/freezer,
 /area/desert_dam/building/water_treatment_two/equipment)
-"opA" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/closed/wall,
-/area/desert_dam/building/dorms/pool)
 "opC" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -49262,13 +49290,6 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
-"oEq" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/whitegreen{
-	dir = 4
-	},
-/area/desert_dam/building/medical/east_wing_hallway)
 "oEr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50134,11 +50155,6 @@
 	dir = 6
 	},
 /area/desert_dam/building/church)
-"oZV" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/sterilewhite,
-/area/desert_dam/building/medical/east_wing_hallway)
 "paa" = (
 /obj/structure/cable,
 /turf/closed/wall{
@@ -50379,6 +50395,14 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean/two,
 /area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
+"pfn" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "pfs" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkyellow{
@@ -50916,14 +50940,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/cult,
 /area/desert_dam/building/bar/bar)
-"ptm" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge{
-	dir = 4
-	},
-/area/desert_dam/exterior/valley/valley_civilian)
 "ptA" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -51208,25 +51224,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
-"pBO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/whitegreen,
-/area/desert_dam/building/medical/east_wing_hallway)
-"pBY" = (
-/obj/effect/landmark/weed_node,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_civilian)
 "pCq" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
@@ -51274,6 +51271,12 @@
 	dir = 8
 	},
 /area/desert_dam/interior/dam_interior/south_tunnel)
+"pDx" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen{
+	dir = 1
+	},
+/area/desert_dam/building/medical/emergency_room)
 "pDI" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -51305,6 +51308,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/cult,
 /area/desert_dam/building/church)
+"pED" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/mineral/smooth,
+/area/desert_dam/exterior/rock)
 "pEI" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -51445,10 +51454,6 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/dam_interior/CE_office)
-"pHL" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt/tile,
-/area/desert_dam/exterior/valley/valley_medical)
 "pHY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -51902,11 +51907,21 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark2,
 /area/desert_dam/building/security/prison)
+"pSq" = (
+/obj/machinery/sleep_console,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen,
+/area/desert_dam/building/medical/emergency_room)
 "pSr" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
+"pSB" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen,
+/area/desert_dam/building/medical/treatment_room)
 "pSK" = (
 /obj/structure/desertdam/decals/road/edge{
 	dir = 4
@@ -51942,10 +51957,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean/two,
 /area/desert_dam/building/medical/surgery_observation)
-"pTo" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_medical)
 "pTz" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
@@ -51959,6 +51970,10 @@
 "pTU" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/edge,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"pUi" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/wall,
+/area/desert_dam/building/dorms/restroom)
 "pUl" = (
 /obj/structure/flora/desert/grass/two,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -52146,6 +52161,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
+"pZF" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison,
+/area/desert_dam/building/substation/northeast)
 "pZJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkyellow/corner,
@@ -52176,6 +52195,10 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/interior/caves/temple)
+"qaz" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_medical)
 "qaA" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
@@ -53084,6 +53107,10 @@
 	dir = 8
 	},
 /area/desert_dam/building/medical/virology_wing)
+"qzS" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating,
+/area/desert_dam/building/medical/east_wing_hallway)
 "qAm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/prop/mainship/brokengen,
@@ -53320,6 +53347,14 @@
 "qJA" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/interior/dam_interior/western_dam_cave)
+"qJD" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 4
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "qJQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -53586,6 +53621,10 @@
 	dir = 8
 	},
 /area/desert_dam/building/security/southern_hallway)
+"qRj" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/prison/green,
+/area/desert_dam/building/dorms/hallway_northwing)
 "qRR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -53617,18 +53656,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/bright_clean/two,
 /area/desert_dam/building/administration/control_room)
-"qSk" = (
-/obj/structure/platform{
-	dir = 1
-	},
-/obj/structure/platform{
-	dir = 8
-	},
-/obj/structure/platform_decoration{
-	dir = 5
-	},
-/turf/open/ground/river/desertdam/clean/deep_water_clean,
-/area/desert_dam/exterior/river/riverside_south)
 "qSH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -54320,12 +54347,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
-"rkJ" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 4
-	},
-/area/desert_dam/exterior/valley/valley_medical)
 "rkL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -55009,6 +55030,10 @@
 	dir = 9
 	},
 /area/desert_dam/exterior/valley/valley_medical)
+"rIw" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen/corner,
+/area/desert_dam/building/medical/east_wing_hallway)
 "rIA" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/whitepurple/corner{
@@ -55188,12 +55213,6 @@
 	dir = 9
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
-"rNr" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison/whitegreen/corner{
-	dir = 8
-	},
-/area/desert_dam/building/medical/west_wing_hallway)
 "rNt" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall/prison,
@@ -55291,6 +55310,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
+"rPX" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge,
+/area/desert_dam/exterior/valley/valley_medical)
 "rQk" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/xeno_resin_door,
@@ -55659,18 +55682,18 @@
 	dir = 9
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
+"rXG" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 1
+	},
+/area/desert_dam/building/medical/virology_wing)
 "rXI" = (
 /obj/structure/desertdam/decals/road/edge{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
-"rXT" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison/whitegreen{
-	dir = 4
-	},
-/area/desert_dam/building/medical/lobby)
 "rXX" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -55727,6 +55750,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"rZh" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/twoside,
+/area/desert_dam/exterior/valley/valley_medical)
 "rZl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -55776,12 +55805,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_hydro)
-"sas" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison,
-/area/desert_dam/building/medical/break_room)
 "say" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -56622,12 +56645,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/staffroom)
-"sxq" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/closed/mineral/smooth,
-/area/desert_dam/exterior/rock)
 "sxu" = (
 /obj/effect/ai_node,
 /obj/structure/prop/templedoor,
@@ -56959,11 +56976,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_cargo)
-"sIi" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/wood,
-/area/desert_dam/building/medical/break_room)
 "sIv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -56987,6 +56999,12 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/building/water_treatment_one/hallway)
+"sII" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen{
+	dir = 4
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
 "sIL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -57327,6 +57345,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/bar/bar_restroom)
+"sXq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/sterilewhite,
+/area/desert_dam/building/medical/lobby)
 "sXr" = (
 /obj/structure/desertdam/decals/road,
 /obj/structure/desertdam/decals/road/line{
@@ -57402,13 +57425,6 @@
 	dir = 8
 	},
 /area/desert_dam/interior/dam_interior/hanger)
-"sZv" = (
-/obj/structure/desertdam/decals/road,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/valley/valley_civilian)
 "sZB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
@@ -57837,12 +57853,6 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/river_mouth/southern)
-"tjO" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison/whitegreen{
-	dir = 1
-	},
-/area/desert_dam/building/medical/east_wing_hallway)
 "tjR" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner2{
 	dir = 4
@@ -57916,6 +57926,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison/bright_clean/two,
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
+"tmA" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_mining)
 "tmE" = (
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
@@ -58587,12 +58601,6 @@
 	},
 /turf/open/floor/bcircuit,
 /area/desert_dam/interior/dam_interior/smes_main)
-"tGp" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/whitegreen{
-	dir = 1
-	},
-/area/desert_dam/building/medical/virology_wing)
 "tGC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58650,10 +58658,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_cargo)
-"tHQ" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/wood,
-/area/desert_dam/building/medical/break_room)
 "tIn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/whitegreen{
@@ -59139,6 +59143,12 @@
 	dir = 6
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
+"tWm" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen{
+	dir = 4
+	},
+/area/desert_dam/building/medical/lobby)
 "tWo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -59594,6 +59604,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/dam_interior/control_room)
+"uhM" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "uhN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -59740,6 +59756,10 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"una" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/wood,
+/area/desert_dam/building/medical/break_room)
 "und" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkyellow{
@@ -59908,12 +59928,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/dam_interior/engine_west_wing)
-"usi" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_civilian)
 "usl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -60368,15 +60382,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/twoside/regular,
 /area/desert_dam/interior/dam_interior/south_tunnel)
-"uEU" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/whitegreen{
-	dir = 4
-	},
-/area/desert_dam/building/medical/virology_wing)
 "uFz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -61146,10 +61151,6 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
-"vaU" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/valley/valley_medical)
 "vbj" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
@@ -61317,6 +61318,11 @@
 	dir = 8
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
+"vfY" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/wood,
+/area/desert_dam/building/medical/break_room)
 "vgh" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
@@ -61369,12 +61375,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/southern_hallway)
-"vhQ" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison/whitegreen{
-	dir = 1
-	},
-/area/desert_dam/building/medical/emergency_room)
 "vih" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge{
 	dir = 4
@@ -61410,9 +61410,14 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
-"viE" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison/whitegreen,
+"viA" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 4
+	},
 /area/desert_dam/building/medical/virology_wing)
 "viH" = (
 /obj/effect/landmark/excavation_site_spawner,
@@ -61645,10 +61650,6 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
-"voG" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/prison/green,
-/area/desert_dam/building/dorms/hallway_northwing)
 "voI" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner2{
 	dir = 1
@@ -61669,10 +61670,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/desert_dam/building/warehouse/warehouse)
-"vpC" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt/tile,
-/area/desert_dam/exterior/valley/valley_mining)
 "vpK" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -61788,11 +61785,6 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_east)
-"vuh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison/whitegreen,
-/area/desert_dam/building/medical/north_wing_hallway)
 "vul" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/valley/valley_cargo)
@@ -62014,18 +62006,6 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/valley/valley_labs)
-"vAa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/desertdam/asphalt/edge{
-	dir = 1
-	},
-/area/desert_dam/exterior/valley/valley_medical)
 "vAf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -62151,6 +62131,11 @@
 	dir = 9
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"vDj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen,
+/area/desert_dam/building/medical/north_wing_hallway)
 "vDG" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -62317,6 +62302,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_wilderness)
+"vJl" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/sterilewhite,
+/area/desert_dam/building/medical/east_wing_hallway)
 "vJI" = (
 /obj/effect/landmark/weed_node,
 /obj/structure/cable,
@@ -62455,11 +62445,6 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/cult,
 /area/desert_dam/building/church)
-"vLK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/whitegreen/full,
-/area/desert_dam/building/medical/emergency_room)
 "vLM" = (
 /obj/item/weapon/gun/pistol/holdout,
 /obj/structure/toilet,
@@ -62614,6 +62599,16 @@
 	dir = 9
 	},
 /area/desert_dam/exterior/valley/valley_mining)
+"vQx" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen{
+	dir = 1
+	},
+/area/desert_dam/building/medical/north_wing_hallway)
 "vQL" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -62698,13 +62693,6 @@
 	dir = 5
 	},
 /area/desert_dam/building/security/prison)
-"vTS" = (
-/obj/structure/cable,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison/whitegreen{
-	dir = 1
-	},
-/area/desert_dam/building/medical/north_wing_hallway)
 "vUc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62917,6 +62905,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/green/whitegreen,
 /area/desert_dam/building/lab_northwest/west_lab_xenoflora)
+"vZO" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 1
+	},
+/area/desert_dam/building/medical/virology_isolation)
 "vZV" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 6
@@ -63022,10 +63016,6 @@
 	dir = 1
 	},
 /area/desert_dam/interior/dam_interior/western_dam_cave)
-"wbL" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/prison/whitegreen/full,
-/area/desert_dam/building/dorms/pool)
 "wbM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -63258,12 +63248,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/dam_interior/smes_main)
-"wgW" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/valley_civilian)
 "whf" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -63787,12 +63771,6 @@
 	},
 /turf/open/floor/prison/marked,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
-"wxe" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/whitegreen{
-	dir = 1
-	},
-/area/desert_dam/building/medical/virology_isolation)
 "wxq" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -63816,18 +63794,17 @@
 /obj/machinery/light,
 /turf/open/floor/tile/whiteyellow,
 /area/desert_dam/interior/dam_interior/break_room)
+"wyt" = (
+/obj/machinery/light,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen,
+/area/desert_dam/building/medical/north_wing_hallway)
 "wyz" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 8
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
-"wyH" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 5
-	},
-/area/desert_dam/exterior/valley/valley_medical)
 "wyJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -64034,6 +64011,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/freezer,
 /area/desert_dam/building/hydroponics/hydroponics_breakroom)
+"wEN" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen,
+/area/desert_dam/building/medical/virology_wing)
 "wEO" = (
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/plating/ground/desertdam/asphalt,
@@ -64287,12 +64268,6 @@
 /obj/structure/platform,
 /turf/open/floor/plating/ground/desertdam/grate/alternate,
 /area/desert_dam/exterior/river/riverside_east)
-"wMD" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/landing/landing_pad_two_external)
 "wMF" = (
 /turf/closed/wall/mainship,
 /area/desert_dam/exterior/valley/tradeship)
@@ -65163,6 +65138,12 @@
 /obj/structure/cable,
 /turf/open/floor/prison/whitegreen/full,
 /area/desert_dam/building/water_treatment_one/floodgate_control)
+"xlL" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 8
+	},
+/area/desert_dam/building/medical/north_wing_hallway)
 "xlN" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -65254,6 +65235,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/desert_dam/interior/dam_interior/south_tunnel)
+"xnw" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_civilian)
 "xnC" = (
 /obj/machinery/light{
 	dir = 8
@@ -65663,6 +65650,12 @@
 /obj/structure/window_frame/colony/reinforced,
 /turf/open/floor/plating,
 /area/desert_dam/building/administration/overseer_office)
+"xAc" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/prison,
+/area/desert_dam/building/dorms/hallway_northwing)
 "xAs" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -65873,6 +65866,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/yellow2/corner,
 /area/desert_dam/building/security/prison)
+"xFz" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen/corner,
+/area/desert_dam/building/medical/north_wing_hallway)
 "xFD" = (
 /obj/structure/bed/chair/wood/wings{
 	dir = 1
@@ -65900,12 +65897,6 @@
 	dir = 4
 	},
 /area/desert_dam/building/medical/west_wing_hallway)
-"xFY" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison/whitegreen/corner{
-	dir = 8
-	},
-/area/desert_dam/building/medical/north_wing_hallway)
 "xGi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -66077,13 +66068,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_wilderness)
-"xLg" = (
-/obj/structure/cable,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison/whitegreen/corner{
-	dir = 4
-	},
-/area/desert_dam/building/medical/treatment_room)
 "xLh" = (
 /obj/effect/decal/cleanable/blood/six,
 /turf/open/floor/prison/bright_clean/two,
@@ -66262,6 +66246,11 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/plating,
 /area/desert_dam/building/warehouse/warehouse)
+"xPY" = (
+/obj/effect/decal/medical_decals/triage/bottom,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/sterilewhite,
+/area/desert_dam/building/medical/lobby)
 "xPZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -66336,6 +66325,10 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/building/hydroponics/hydroponics_storage)
+"xSK" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating,
+/area/desert_dam/building/medical/garage)
 "xSZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -66566,11 +66559,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/workshop)
-"xYR" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison/sterilewhite,
-/area/desert_dam/building/medical/lobby)
 "xZe" = (
 /obj/structure/desertdam/decals/road{
 	dir = 1
@@ -67034,16 +67022,18 @@
 	dir = 1
 	},
 /area/desert_dam/building/medical/treatment_room)
-"ykV" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/prison/whitegreen/corner,
-/area/desert_dam/building/medical/east_wing_hallway)
 "ylf" = (
 /obj/structure/desertdam/decals/road/edge{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"ylj" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "yll" = (
 /obj/structure/platform{
 	dir = 1
@@ -92273,7 +92263,7 @@ pMR
 diQ
 dTH
 rdd
-qSk
+dEo
 mFz
 chm
 dvB
@@ -94138,7 +94128,7 @@ cpv
 lYE
 dGA
 dGA
-bUs
+dHA
 pYp
 dfc
 dgF
@@ -99310,7 +99300,7 @@ okO
 cEh
 chM
 cDf
-mNO
+xSK
 dnP
 mtl
 jXq
@@ -100227,7 +100217,7 @@ ckB
 coN
 ciR
 crA
-hCs
+sXq
 vYQ
 crA
 cvM
@@ -100235,7 +100225,7 @@ crA
 crA
 cvM
 crA
-kHq
+nfg
 vYQ
 crA
 cCf
@@ -100940,7 +100930,7 @@ hnn
 jxa
 gro
 uyc
-eXS
+eNY
 cCi
 nuV
 xCZ
@@ -101162,18 +101152,18 @@ cnH
 coQ
 cpC
 cjV
-xYR
-kHq
+jrN
+nfg
 qoX
 oJW
-rXT
-rXT
-rXT
+tWm
+tWm
+tWm
 gVq
 kLZ
 djf
-hCs
-gGS
+sXq
+xPY
 cCg
 dQY
 tIn
@@ -101643,7 +101633,7 @@ sHL
 hxS
 ctS
 cCg
-vhQ
+pDx
 cEp
 uus
 osI
@@ -101858,8 +101848,8 @@ ciR
 cjr
 cjq
 xqF
-ajR
-eUI
+obR
+isa
 ymh
 coR
 cpD
@@ -101882,7 +101872,7 @@ gbr
 xBi
 bKa
 cgP
-dTI
+pSq
 cCf
 rCV
 rCV
@@ -102330,7 +102320,7 @@ aSb
 vKT
 cnK
 cjX
-rNr
+nkT
 cqt
 rRU
 myA
@@ -102347,7 +102337,7 @@ fQw
 cCj
 cDp
 fiZ
-vLK
+lWX
 pSf
 xDU
 iqt
@@ -102398,7 +102388,7 @@ bcc
 diQ
 dTH
 rdd
-qSk
+dEo
 dEn
 dEn
 dEn
@@ -103032,7 +103022,7 @@ vGw
 ckN
 ckN
 uXz
-ivi
+fID
 cqw
 uHP
 kTu
@@ -103267,7 +103257,7 @@ cka
 cka
 cka
 cpH
-aLr
+kME
 crL
 cpH
 ctW
@@ -103275,7 +103265,7 @@ ctX
 ctX
 ctX
 ctX
-kHQ
+iyQ
 cyW
 ctX
 ctX
@@ -103503,7 +103493,7 @@ cka
 cpI
 jVC
 lFU
-dAi
+hVa
 ctX
 cuY
 cvT
@@ -103520,7 +103510,7 @@ cEy
 oyT
 cGg
 oaD
-hOW
+pSB
 cEG
 cJC
 cKu
@@ -103737,7 +103727,7 @@ cka
 cpI
 qPy
 rKM
-dAi
+hVa
 ctX
 cuZ
 jZX
@@ -103971,7 +103961,7 @@ cka
 cpJ
 oDZ
 lFU
-dAi
+hVa
 ctX
 cva
 iZW
@@ -104205,7 +104195,7 @@ coT
 aaQ
 oob
 vFD
-iwz
+wyt
 ctW
 ctW
 ctW
@@ -104439,7 +104429,7 @@ cka
 cpL
 obg
 uZc
-xFY
+xlL
 ctY
 cvb
 cvb
@@ -104456,7 +104446,7 @@ lJv
 cFp
 qQz
 gQZ
-hOW
+pSB
 cEG
 cJF
 sAK
@@ -104924,7 +104914,7 @@ sfs
 cFq
 nnh
 cHc
-hOW
+pSB
 cIH
 cJG
 cKx
@@ -105138,10 +105128,10 @@ ckg
 ckg
 ckg
 cka
-vTS
+ehh
 cqA
 lFU
-hCN
+xFz
 ctY
 gOd
 cvW
@@ -105372,7 +105362,7 @@ cjy
 cjy
 cjy
 cjy
-hiL
+vQx
 cqA
 uZc
 wiU
@@ -105606,10 +105596,10 @@ vFv
 cmB
 vGI
 cjy
-vTS
-fqE
+ehh
+jZY
 jXN
-vuh
+vDj
 ctY
 gOd
 cvW
@@ -105631,7 +105621,7 @@ cIJ
 cJG
 iIq
 tCs
-hwP
+eXX
 cLY
 fkJ
 uam
@@ -105856,11 +105846,11 @@ cAt
 miO
 cCu
 cDu
-xLg
+gWP
 jfe
 rHt
 cHc
-hOW
+pSB
 cIH
 cJG
 cKx
@@ -106094,7 +106084,7 @@ cED
 xId
 raS
 cHf
-hOW
+pSB
 cHL
 cHL
 cHL
@@ -106308,7 +106298,7 @@ cjy
 cjy
 cjy
 cjy
-vTS
+ehh
 fSC
 uZc
 crM
@@ -106325,7 +106315,7 @@ cBt
 cCw
 cDu
 fGe
-hxK
+mAS
 sKY
 cHg
 eeh
@@ -106559,7 +106549,7 @@ cyp
 cyp
 cyp
 cEG
-hxK
+mAS
 eEW
 cEG
 cHL
@@ -107008,7 +106998,7 @@ qyf
 tdo
 hUR
 oKU
-sas
+gPD
 kSk
 qhj
 nbC
@@ -107026,7 +107016,7 @@ tPv
 nZu
 nZu
 nZu
-dWr
+jpn
 sDZ
 xxp
 cHi
@@ -107248,8 +107238,8 @@ lov
 wDK
 sjB
 csV
-oEq
-hLc
+kOx
+cnF
 qsI
 dGG
 pgB
@@ -107265,10 +107255,10 @@ gZj
 cGq
 cxH
 cHL
-lrS
-lrS
+qzS
+qzS
 cKC
-lrS
+qzS
 cHL
 cMZ
 cNH
@@ -107478,7 +107468,7 @@ ffv
 qmn
 ckk
 coU
-lFG
+kCR
 iTe
 pBn
 csT
@@ -107486,14 +107476,14 @@ cub
 qCS
 cwd
 cwV
-ykV
-eyh
+rIw
+sII
 cze
 qCS
-eyh
-eyh
+sII
+sII
 qCS
-eyh
+sII
 cwd
 tyj
 aHL
@@ -107505,7 +107495,7 @@ cHL
 cHL
 cHL
 cNa
-wxe
+vZO
 jzi
 lYq
 cJG
@@ -107710,9 +107700,9 @@ tTs
 hZn
 tTR
 noh
-tHQ
+una
 cjy
-vTS
+ehh
 iTe
 pBn
 crM
@@ -107946,7 +107936,7 @@ wef
 tTR
 cnQ
 cjy
-hiL
+vQx
 iTe
 mEm
 csR
@@ -108178,9 +108168,9 @@ tUy
 xmk
 wdR
 uZW
-sIi
+vfY
 coU
-vTS
+ehh
 iTe
 pBn
 crM
@@ -108412,9 +108402,9 @@ tUy
 fYM
 yhy
 cmF
-tHQ
+una
 coU
-vTS
+ehh
 iTe
 iyZ
 lFU
@@ -108430,7 +108420,7 @@ dre
 cBx
 cBx
 dyW
-oZV
+vJl
 cEM
 dPD
 nVv
@@ -108646,9 +108636,9 @@ tUy
 dCw
 scl
 gNX
-tHQ
+una
 coU
-vTS
+ehh
 eLs
 mEm
 lFU
@@ -108675,7 +108665,7 @@ cKE
 cLp
 cHN
 cHO
-tGp
+rXG
 rxq
 cHO
 cHN
@@ -108880,7 +108870,7 @@ fpC
 ckZ
 ubw
 cjG
-tHQ
+una
 coU
 yiG
 xwW
@@ -108898,7 +108888,7 @@ cBy
 cBy
 cCy
 czf
-tjO
+aWW
 jre
 lKI
 cHj
@@ -108911,7 +108901,7 @@ cHN
 wTF
 cIP
 ipq
-viE
+wEN
 cPP
 cLu
 cAe
@@ -109113,7 +109103,7 @@ smf
 xpp
 hvk
 xpp
-tHQ
+una
 nlW
 cjy
 cpM
@@ -109366,7 +109356,7 @@ cAB
 cAB
 cAB
 cAB
-tjO
+aWW
 uis
 oYY
 uJs
@@ -109579,7 +109569,7 @@ iMk
 cjT
 cjT
 cjT
-bNV
+ekP
 cjT
 mbd
 cjT
@@ -109604,7 +109594,7 @@ kug
 pAz
 tTo
 flo
-uEU
+viA
 cHQ
 cHQ
 cKH
@@ -109813,7 +109803,7 @@ cdw
 cdw
 cdw
 hgO
-vaU
+eNF
 cdw
 cdw
 cdw
@@ -109846,7 +109836,7 @@ cJM
 ppA
 nzH
 cJM
-fbY
+mnY
 dTp
 cPS
 gNh
@@ -110536,7 +110526,7 @@ cAG
 cAG
 cAG
 cAG
-tjO
+aWW
 tyj
 cGt
 vMx
@@ -110770,7 +110760,7 @@ cpz
 nSN
 nSN
 cDA
-tjO
+aWW
 jre
 jXv
 snM
@@ -110987,11 +110977,11 @@ aMz
 vfH
 mrv
 aNh
-dPi
+pZF
 ceX
 acN
 jiY
-ckK
+nlD
 rCV
 rCV
 rCV
@@ -111222,10 +111212,10 @@ sqC
 aNh
 aNh
 aMz
-ckK
-vAa
-kAc
-eOh
+nlD
+ivp
+rPX
+hfi
 aOG
 rCV
 rCV
@@ -111460,7 +111450,7 @@ aMz
 iEU
 jXq
 aYE
-wyH
+dRW
 rCV
 rCV
 rCV
@@ -111694,9 +111684,9 @@ aNC
 cbD
 jXq
 caH
-pTo
+qaz
 aOG
-cLJ
+hvS
 rCV
 rCV
 rCV
@@ -111706,10 +111696,10 @@ iHA
 iHA
 rJm
 cAG
-tjO
-tjO
-pBO
-eyW
+aWW
+aWW
+ojb
+kvQ
 cub
 cIX
 cJN
@@ -111930,8 +111920,8 @@ jXq
 caH
 jEa
 cdv
-cLJ
-cLJ
+hvS
+hvS
 rCV
 rCV
 rCV
@@ -112166,7 +112156,7 @@ cdw
 cdw
 cdv
 utM
-cLJ
+hvS
 rCV
 rCV
 rCV
@@ -112400,8 +112390,8 @@ cdw
 owP
 cdw
 xaO
-wyH
-cLJ
+dRW
+hvS
 rCV
 rCV
 rCV
@@ -112636,9 +112626,9 @@ cdw
 coI
 cdw
 oHC
-rkJ
-rkJ
-rkJ
+uhM
+uhM
+uhM
 rCV
 nXY
 cDF
@@ -112856,11 +112846,11 @@ aYE
 caH
 lDe
 caH
-pHL
+cpW
 aYE
 caH
 caH
-pHL
+cpW
 cbD
 jXq
 lDe
@@ -112869,7 +112859,7 @@ caH
 caH
 caH
 caH
-pHL
+cpW
 caH
 fPP
 caH
@@ -113090,11 +113080,11 @@ cjT
 him
 him
 mbd
-bNV
+ekP
 cjT
 cjT
 mbd
-bNV
+ekP
 sgm
 cbG
 cbH
@@ -113103,7 +113093,7 @@ cbH
 cbH
 dgl
 cbH
-ekU
+rZh
 cbH
 brz
 brz
@@ -113114,7 +113104,7 @@ brz
 brz
 wSU
 brz
-izy
+azn
 brz
 brz
 bWD
@@ -113348,7 +113338,7 @@ ohd
 iaj
 yhu
 ohd
-vpC
+mer
 bnA
 bnA
 ltO
@@ -113578,11 +113568,11 @@ aUU
 lsJ
 aUU
 aUU
-exd
-exd
+tmA
+tmA
 bCK
-exd
-exd
+tmA
+tmA
 bKI
 bnA
 bFF
@@ -114809,33 +114799,33 @@ cXw
 dbQ
 duD
 del
-lFt
+xAc
 mcz
-lFt
+xAc
 lby
-voG
-hDJ
+qRj
+pUi
 dCg
-hDJ
+pUi
 dCg
-hDJ
+pUi
 dCg
-hDJ
+pUi
 dCg
-hDJ
+pUi
 dCg
-opA
+fCx
 dyt
 wNu
 dWp
-wbL
-wbL
+jKO
+jKO
 dCV
-wbL
-opA
+jKO
+fCx
 uaV
 uaV
-sxq
+pED
 rCV
 acu
 "}
@@ -115039,7 +115029,7 @@ pRI
 jqE
 ras
 cto
-sZv
+ldN
 cUc
 cko
 cko
@@ -115069,7 +115059,7 @@ dIk
 dIk
 rCV
 rCV
-sxq
+pED
 rCV
 acu
 "}
@@ -115303,7 +115293,7 @@ rCV
 rCV
 rCV
 rCV
-sxq
+pED
 rCV
 acu
 "}
@@ -115507,7 +115497,7 @@ dpJ
 veQ
 hji
 hqD
-iLI
+nMC
 mEf
 cok
 hXU
@@ -115537,7 +115527,7 @@ rCV
 rCV
 rCV
 rCV
-sxq
+pED
 rCV
 acu
 "}
@@ -115741,7 +115731,7 @@ wFp
 mDV
 crX
 cmN
-ptm
+qJD
 cod
 cod
 mmS
@@ -115771,7 +115761,7 @@ rCV
 rCV
 rCV
 rCV
-sxq
+pED
 rCV
 acu
 "}
@@ -115975,7 +115965,7 @@ dpL
 cto
 crW
 rVj
-mYc
+nDx
 csi
 rCV
 fYm
@@ -116005,7 +115995,7 @@ rCV
 rCV
 rCV
 rCV
-sxq
+pED
 rCV
 acu
 "}
@@ -116209,7 +116199,7 @@ dpI
 cto
 crW
 cmN
-goB
+pfn
 rCV
 rCV
 fYm
@@ -116239,7 +116229,7 @@ wsw
 rCV
 rCV
 rCV
-sxq
+pED
 rCV
 acu
 "}
@@ -116443,7 +116433,7 @@ pRI
 jqE
 crW
 cmN
-sxq
+pED
 rCV
 rCV
 fYm
@@ -116473,7 +116463,7 @@ wsw
 wsw
 rCV
 rCV
-sxq
+pED
 rCV
 acu
 "}
@@ -116677,7 +116667,7 @@ dpI
 cto
 crW
 cmN
-sxq
+pED
 rCV
 rCV
 fYm
@@ -116707,7 +116697,7 @@ pcA
 rCV
 rCV
 rCV
-sxq
+pED
 rCV
 acu
 "}
@@ -116911,7 +116901,7 @@ dpI
 cto
 crW
 rVj
-sxq
+pED
 rCV
 rCV
 fYm
@@ -116941,7 +116931,7 @@ iBL
 rCV
 rCV
 rCV
-sxq
+pED
 rCV
 acu
 "}
@@ -117145,7 +117135,7 @@ qdp
 jqE
 crW
 cvw
-sxq
+pED
 rCV
 rCV
 fYm
@@ -117175,7 +117165,7 @@ rCV
 rCV
 rCV
 rCV
-sxq
+pED
 rCV
 acu
 "}
@@ -117379,7 +117369,7 @@ dpI
 cto
 crW
 ctm
-sxq
+pED
 rCV
 rCV
 fYm
@@ -117409,7 +117399,7 @@ xLK
 lZG
 rCV
 rCV
-sxq
+pED
 rCV
 acu
 "}
@@ -117613,7 +117603,7 @@ dpI
 cto
 crW
 ctm
-sxq
+pED
 rCV
 rCV
 fYm
@@ -117643,7 +117633,7 @@ xLK
 lUB
 wsw
 rCV
-sxq
+pED
 rCV
 acu
 "}
@@ -117847,7 +117837,7 @@ pRI
 jqE
 pom
 ctm
-sxq
+pED
 rCV
 rCV
 rCV
@@ -117877,7 +117867,7 @@ xLK
 xLK
 lUB
 rCV
-sxq
+pED
 rCV
 acu
 "}
@@ -118081,7 +118071,7 @@ dpI
 cto
 crW
 ctm
-sxq
+pED
 rCV
 rCV
 rCV
@@ -118111,7 +118101,7 @@ xLK
 xLK
 xLK
 rCV
-sxq
+pED
 rCV
 acu
 "}
@@ -118315,7 +118305,7 @@ dpI
 cto
 crW
 ctm
-wgW
+ylj
 rCV
 rCV
 iBL
@@ -118345,7 +118335,7 @@ xLK
 xLK
 xLK
 rCV
-sxq
+pED
 rCV
 acu
 "}
@@ -118549,7 +118539,7 @@ pRI
 jqE
 crW
 fgI
-sxq
+pED
 rCV
 sHc
 nYf
@@ -118579,7 +118569,7 @@ fJE
 pVD
 xLK
 lZG
-sxq
+pED
 rCV
 acu
 "}
@@ -118783,7 +118773,7 @@ gOn
 cto
 crW
 ctm
-sxq
+pED
 rCV
 fEE
 nFr
@@ -118813,7 +118803,7 @@ nFr
 jIb
 xLK
 lZG
-wMD
+bwF
 rCV
 acu
 "}
@@ -119017,7 +119007,7 @@ dpI
 cto
 crW
 pfV
-kjP
+mba
 rCV
 rCV
 jpO
@@ -119047,7 +119037,7 @@ hXz
 uop
 xLK
 lZG
-wMD
+bwF
 rCV
 acu
 "}
@@ -119251,7 +119241,7 @@ pRI
 jqE
 crW
 aKm
-usi
+xnw
 rCV
 rCV
 mqF
@@ -119281,7 +119271,7 @@ oVQ
 uop
 xLK
 lUB
-sxq
+pED
 rCV
 acu
 "}
@@ -119485,7 +119475,7 @@ dpI
 cto
 pom
 cvw
-usi
+xnw
 rCV
 rCV
 tbc
@@ -119515,7 +119505,7 @@ hZm
 uop
 xLK
 xLK
-sxq
+pED
 rCV
 acu
 "}
@@ -119719,7 +119709,7 @@ dpI
 cto
 crW
 cvw
-usi
+xnw
 pfV
 jwg
 eYW
@@ -119749,7 +119739,7 @@ ijn
 uop
 xLK
 hgC
-sxq
+pED
 rCV
 acu
 "}
@@ -119953,7 +119943,7 @@ wUy
 jqE
 crW
 dzG
-usi
+xnw
 xAV
 jwg
 aVA
@@ -119983,7 +119973,7 @@ yhL
 uop
 xLK
 vrY
-wMD
+bwF
 rCV
 acu
 "}
@@ -120187,7 +120177,7 @@ cUb
 cto
 crW
 cvw
-usi
+xnw
 cpZ
 cwu
 mqF
@@ -120217,7 +120207,7 @@ oVQ
 uop
 xLK
 lZG
-sxq
+pED
 rCV
 acu
 "}
@@ -120421,7 +120411,7 @@ cto
 cto
 crW
 cvw
-usi
+xnw
 fgI
 cwu
 tbc
@@ -120451,7 +120441,7 @@ hZm
 uop
 xLK
 lZG
-sxq
+pED
 rCV
 acu
 "}
@@ -120655,7 +120645,7 @@ wEO
 jqE
 crW
 cvw
-usi
+xnw
 mrx
 cwu
 eYW
@@ -120685,7 +120675,7 @@ ijn
 uop
 xLK
 lZG
-wMD
+bwF
 rCV
 acu
 "}
@@ -120889,7 +120879,7 @@ cto
 cto
 crW
 dzG
-usi
+xnw
 ctm
 cwu
 aVA
@@ -120919,7 +120909,7 @@ yhL
 uop
 xLK
 lUB
-sxq
+pED
 rCV
 acu
 "}
@@ -121123,7 +121113,7 @@ qqa
 cto
 crW
 cvw
-usi
+xnw
 ctm
 cwu
 ndY
@@ -121153,7 +121143,7 @@ oVQ
 uop
 xLK
 xLK
-sxq
+pED
 rCV
 acu
 "}
@@ -121357,7 +121347,7 @@ wEO
 jqE
 crW
 dzG
-iyp
+kkP
 lPn
 rCV
 tbc
@@ -121387,7 +121377,7 @@ jKI
 fAg
 xLK
 rCV
-sxq
+pED
 rCV
 acu
 "}
@@ -121591,7 +121581,7 @@ cto
 cto
 crW
 cvw
-usi
+xnw
 rCV
 rCV
 nFr
@@ -121621,7 +121611,7 @@ nFr
 jIb
 hgC
 rCV
-sxq
+pED
 rCV
 acu
 "}
@@ -121825,7 +121815,7 @@ cto
 cto
 crW
 cvw
-sxq
+pED
 rCV
 rCV
 bmQ
@@ -121855,7 +121845,7 @@ fJE
 ttd
 jYe
 rCV
-sxq
+pED
 rCV
 acu
 "}
@@ -122059,7 +122049,7 @@ xHh
 jqE
 crY
 daT
-itq
+aHT
 daT
 ycz
 ycz
@@ -122089,7 +122079,7 @@ ycz
 ycz
 ycz
 ycz
-ifF
+kDf
 vKS
 acu
 "}
@@ -122293,7 +122283,7 @@ cto
 cto
 cto
 kYD
-pBY
+mNt
 cto
 qeH
 dXU
@@ -122323,7 +122313,7 @@ qeH
 dXU
 dXU
 qeH
-fPJ
+iwp
 dXU
 acu
 "}
@@ -122527,7 +122517,7 @@ qqa
 cto
 cto
 dvb
-dFO
+kaA
 cto
 xVv
 etF
@@ -122557,7 +122547,7 @@ xVv
 etF
 dXU
 xVv
-fPJ
+iwp
 dXU
 acu
 "}
@@ -122761,7 +122751,7 @@ cmb
 cmb
 sxN
 cmb
-dhp
+fSb
 cmb
 gXe
 aVd
@@ -122995,7 +122985,7 @@ rCV
 rCV
 rCV
 rCV
-sxq
+pED
 rCV
 ebs
 ebs
@@ -123025,7 +123015,7 @@ xLK
 gbX
 tZQ
 rCV
-sxq
+pED
 rCV
 acu
 "}
@@ -123229,7 +123219,7 @@ rCV
 rCV
 rCV
 rCV
-sxq
+pED
 rCV
 rCV
 rCV
@@ -123259,7 +123249,7 @@ oud
 rCV
 rCV
 rCV
-sxq
+pED
 rCV
 acu
 "}
@@ -123463,7 +123453,7 @@ rCV
 rCV
 rCV
 rCV
-sxq
+pED
 uaV
 uaV
 uaV
@@ -123493,7 +123483,7 @@ uaV
 uaV
 uaV
 uaV
-sxq
+pED
 rCV
 acu
 "}

--- a/_maps/map_files/desertdam/desertdam.dmm
+++ b/_maps/map_files/desertdam/desertdam.dmm
@@ -147,6 +147,9 @@
 /obj/structure/platform{
 	dir = 4
 	},
+/obj/structure/platform_decoration{
+	dir = 6
+	},
 /turf/open/floor/plating/ground/dirt{
 	dir = 8
 	},
@@ -996,6 +999,9 @@
 /obj/structure/platform{
 	dir = 8
 	},
+/obj/structure/platform_decoration{
+	dir = 10
+	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/riverside_east)
 "agK" = (
@@ -1325,6 +1331,9 @@
 /obj/structure/platform{
 	dir = 1
 	},
+/obj/structure/platform_decoration{
+	dir = 9
+	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/riverside_central_north)
 "aiH" = (
@@ -1517,6 +1526,10 @@
 	dir = 4
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
+"ajR" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/tile/white,
+/area/desert_dam/building/medical/chemistry)
 "ajV" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -1721,7 +1734,7 @@
 	dir = 8
 	},
 /obj/structure/platform_decoration{
-	dir = 1
+	dir = 10
 	},
 /turf/open/floor/plating/ground/dirt{
 	dir = 8
@@ -1747,6 +1760,9 @@
 	},
 /obj/structure/platform{
 	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 5
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_crashsite)
@@ -2022,6 +2038,9 @@
 	dir = 8
 	},
 /obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 10
+	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_labs)
 "amg" = (
@@ -2068,6 +2087,9 @@
 	dir = 8
 	},
 /obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 10
+	},
 /turf/open/floor/plating/ground/dirt{
 	dir = 8
 	},
@@ -2833,6 +2855,9 @@
 /obj/structure/platform{
 	dir = 8
 	},
+/obj/structure/platform_decoration{
+	dir = 5
+	},
 /turf/open/floor/plating/ground/dirt{
 	dir = 8
 	},
@@ -3292,6 +3317,9 @@
 /obj/structure/platform{
 	dir = 8
 	},
+/obj/structure/platform_decoration{
+	dir = 10
+	},
 /turf/open/ground/coast{
 	dir = 1
 	},
@@ -3471,6 +3499,9 @@
 /obj/structure/platform{
 	dir = 4
 	},
+/obj/structure/platform_decoration{
+	dir = 9
+	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/riverside_east)
 "ata" = (
@@ -3598,6 +3629,9 @@
 /obj/structure/platform{
 	dir = 8
 	},
+/obj/structure/platform_decoration{
+	dir = 5
+	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/valley/valley_mining)
 "atE" = (
@@ -3679,6 +3713,9 @@
 /obj/structure/platform,
 /obj/structure/platform{
 	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 6
 	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/riverside_east)
@@ -4880,6 +4917,9 @@
 /obj/structure/platform{
 	dir = 4
 	},
+/obj/structure/platform_decoration{
+	dir = 9
+	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "azM" = (
@@ -4999,6 +5039,9 @@
 	},
 /obj/structure/platform{
 	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 5
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_labs)
@@ -5293,9 +5336,7 @@
 /area/desert_dam/exterior/valley/valley_wilderness)
 "aCO" = (
 /obj/machinery/vending/nanomed{
-	name = "Emergency NanoMed";
-	pixel_x = 30;
-	req_access = null
+	name = "Emergency NanoMed"
 	},
 /turf/open/floor/wood,
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
@@ -5502,6 +5543,9 @@
 /obj/structure/platform{
 	dir = 8
 	},
+/obj/structure/platform_decoration{
+	dir = 10
+	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aEa" = (
@@ -5548,6 +5592,9 @@
 /obj/structure/platform,
 /obj/structure/platform{
 	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 6
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_crashsite)
@@ -6101,6 +6148,9 @@
 /obj/structure/platform{
 	dir = 4
 	},
+/obj/structure/platform_decoration{
+	dir = 9
+	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_telecoms)
 "aIW" = (
@@ -6350,6 +6400,19 @@
 "aLm" = (
 /turf/open/floor/plating/asteroidplating,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"aLr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 1
+	},
+/area/desert_dam/building/medical/north_wing_hallway)
 "aLv" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge{
@@ -6674,6 +6737,7 @@
 	name = "\improper Mining Substation"
 	},
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison,
 /area/desert_dam/building/substation/northeast)
 "aNJ" = (
@@ -6792,6 +6856,7 @@
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/tech_storage)
 "aOG" = (
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 1
 	},
@@ -6971,6 +7036,9 @@
 	},
 /obj/structure/platform{
 	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 5
 	},
 /turf/open/ground/coast/corner,
 /area/desert_dam/exterior/river/riverside_central_south)
@@ -7617,21 +7685,13 @@
 	},
 /area/desert_dam/building/water_treatment_two/hallway)
 "aUY" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 10
-	},
-/area/desert_dam/exterior/landing/landing_pad_two_external)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/mineral/smooth,
+/area/desert_dam/building/administration/control_room)
 "aVa" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 6
-	},
-/area/desert_dam/exterior/landing/landing_pad_two_external)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/mineral/smooth,
+/area/desert_dam/building/administration/office)
 "aVd" = (
 /obj/structure/desertdam/decals/road{
 	dir = 4
@@ -7811,6 +7871,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/prison/plate,
 /area/desert_dam/exterior/valley/valley_northwest)
 "aWj" = (
@@ -7853,6 +7914,9 @@
 	},
 /obj/structure/platform{
 	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 5
 	},
 /turf/open/ground/coast,
 /area/desert_dam/exterior/valley/south_valley_dam)
@@ -8341,6 +8405,9 @@
 	dir = 8
 	},
 /obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 10
+	},
 /turf/open/floor/plating/ground/dirt{
 	dir = 8
 	},
@@ -9106,7 +9173,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/computer/nuke_disk_generator/blue,
+/obj/machinery/computer/intel_computer,
 /turf/open/floor/wood,
 /area/desert_dam/building/administration/meetingrooom)
 "bdp" = (
@@ -9743,13 +9810,9 @@
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_east_hallway)
 "bhe" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/twoside{
-	dir = 4
-	},
-/area/desert_dam/exterior/landing/landing_pad_one_external)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/mineral/smooth,
+/area/desert_dam/building/administration/lobby)
 "bhi" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/north_valley_dam)
@@ -9810,6 +9873,9 @@
 	dir = 2;
 	id = "hangar_dam_1";
 	name = "\improper Hangar Blast Doors"
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
 	},
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/dam_interior/hanger)
@@ -9922,6 +9988,9 @@
 /obj/structure/platform,
 /obj/structure/platform{
 	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 6
 	},
 /turf/open/floor/plating/ground/dirt{
 	dir = 8
@@ -10187,6 +10256,9 @@
 /obj/structure/platform{
 	dir = 4
 	},
+/obj/structure/platform_decoration{
+	dir = 9
+	},
 /turf/open/floor/plating/ground/dirt{
 	dir = 1
 	},
@@ -10407,6 +10479,9 @@
 	dir = 4
 	},
 /obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 6
+	},
 /turf/open/floor/plating/ground/dirt{
 	dir = 1
 	},
@@ -11360,13 +11435,9 @@
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_mining)
 "bqs" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 1
-	},
-/area/desert_dam/exterior/landing/landing_pad_two_external)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/mineral/smooth,
+/area/desert_dam/building/administration/hallway)
 "bqy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -12216,6 +12287,12 @@
 /area/desert_dam/building/security/staffroom)
 "bvU" = (
 /obj/structure/platform,
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 6
+	},
 /turf/open/floor/plating/ground/desertdam/asphalt/tile,
 /area/desert_dam/exterior/valley/valley_mining)
 "bvV" = (
@@ -12414,12 +12491,9 @@
 	},
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "bwV" = (
-/obj/structure/platform{
-	dir = 8;
-	layer = 2.7
-	},
-/turf/open/ground/river/desertdam/clean/deep_water_clean,
-/area/desert_dam/exterior/river/riverside_east)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/mineral/smooth,
+/area/desert_dam/building/administration/overseer_office)
 "bwW" = (
 /turf/open/floor/prison/darkyellow{
 	dir = 8
@@ -13029,7 +13103,6 @@
 /turf/open/floor/prison/darkyellow,
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "bAF" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/wall/r_wall/chigusa{
 	name = "reinforced metal wall"
 	},
@@ -13340,11 +13413,13 @@
 "bCK" = (
 /obj/structure/flora/desert/grass/heavy/four,
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_mining)
 "bCL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
@@ -13855,6 +13930,9 @@
 	},
 /obj/structure/platform{
 	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 5
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
@@ -15270,6 +15348,10 @@
 	dir = 4
 	},
 /area/desert_dam/building/security/armory)
+"bNV" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/twoside,
+/area/desert_dam/exterior/valley/valley_medical)
 "bNY" = (
 /turf/closed/wall/r_wall/chigusa,
 /area/desert_dam/interior/dam_interior/workshop)
@@ -15292,6 +15374,9 @@
 /obj/structure/platform,
 /obj/machinery/light,
 /obj/machinery/light,
+/obj/structure/platform_decoration{
+	dir = 10
+	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "bOh" = (
@@ -15308,6 +15393,9 @@
 /obj/structure/platform,
 /obj/structure/platform{
 	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 6
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
@@ -16334,6 +16422,16 @@
 	dir = 4
 	},
 /area/desert_dam/interior/dam_interior/west_tunnel)
+"bUs" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 6
+	},
+/turf/open/ground/river/desertdam/clean/deep_water_clean,
+/area/desert_dam/exterior/river/riverside_south)
 "bUt" = (
 /obj/structure/flora/desert/grass/heavy/four,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -16537,6 +16635,9 @@
 	},
 /obj/structure/platform{
 	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 5
 	},
 /turf/open/floor/plating/ground/dirt{
 	dir = 8
@@ -16894,6 +16995,9 @@
 /obj/structure/platform{
 	dir = 8
 	},
+/obj/structure/platform_decoration{
+	dir = 5
+	},
 /turf/open/ground/river/desertdam/clean/shallow_edge{
 	dir = 8
 	},
@@ -16929,6 +17033,9 @@
 /obj/structure/platform,
 /obj/structure/platform{
 	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 10
 	},
 /turf/open/ground/coast{
 	dir = 4
@@ -17098,6 +17205,9 @@
 /obj/structure/platform{
 	dir = 8
 	},
+/obj/structure/platform_decoration{
+	dir = 5
+	},
 /turf/open/ground/river/desertdam/clean/shallow_edge{
 	dir = 8
 	},
@@ -17215,6 +17325,9 @@
 	},
 /obj/structure/platform{
 	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 5
 	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/riverside_central_north)
@@ -17372,6 +17485,9 @@
 	},
 /obj/structure/platform{
 	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 9
 	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/riverside_central_north)
@@ -17599,6 +17715,9 @@
 /obj/structure/platform{
 	dir = 4
 	},
+/obj/structure/platform_decoration{
+	dir = 9
+	},
 /turf/open/ground/river/desertdam/clean/shallow_edge{
 	dir = 4
 	},
@@ -17730,6 +17849,9 @@
 	dir = 8
 	},
 /obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 10
+	},
 /turf/open/ground/river/desertdam/clean/shallow_edge{
 	dir = 8
 	},
@@ -17829,6 +17951,9 @@
 	dir = 8
 	},
 /obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 10
+	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/riverside_central_north)
 "cci" = (
@@ -17836,6 +17961,9 @@
 	dir = 4
 	},
 /obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 6
+	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/riverside_central_north)
 "ccj" = (
@@ -17843,6 +17971,9 @@
 	dir = 4
 	},
 /obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 6
+	},
 /turf/open/ground/river/desertdam/clean/shallow_edge{
 	dir = 4
 	},
@@ -18373,6 +18504,9 @@
 	id = "hangar_dam_1";
 	name = "\improper Hangar Blast Doors"
 	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/prison/plate,
 /area/desert_dam/interior/dam_interior/hanger)
 "cfw" = (
@@ -18466,6 +18600,9 @@
 	dir = 8
 	},
 /obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 10
+	},
 /turf/open/ground/coast{
 	dir = 4
 	},
@@ -18673,6 +18810,9 @@
 /obj/structure/platform{
 	dir = 8
 	},
+/obj/structure/platform_decoration{
+	dir = 5
+	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/riverside_central_south)
 "chA" = (
@@ -18695,6 +18835,9 @@
 	dir = 4
 	},
 /obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 6
+	},
 /turf/open/floor/plating/ground/desertdam/asphalt/tile,
 /area/desert_dam/exterior/valley/valley_telecoms)
 "chM" = (
@@ -18768,6 +18911,9 @@
 	dir = 8
 	},
 /obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 10
+	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/riverside_central_south)
 "cif" = (
@@ -18922,6 +19068,9 @@
 	dir = 8
 	},
 /obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 10
+	},
 /turf/open/ground/river/desertdam/clean/shallow,
 /area/desert_dam/exterior/river/riverside_south)
 "cjm" = (
@@ -18955,6 +19104,7 @@
 	},
 /area/desert_dam/building/medical/chemistry)
 "cjq" = (
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 1
 	},
@@ -18973,6 +19123,7 @@
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	name = "\improper Medical"
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen{
 	dir = 8
 	},
@@ -19074,6 +19225,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 1
 	},
@@ -19096,6 +19248,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 4
 	},
@@ -19132,6 +19285,7 @@
 /turf/open/floor/prison,
 /area/desert_dam/building/medical/break_room)
 "ckk" = (
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/darkbrown{
 	dir = 4
 	},
@@ -19213,6 +19367,10 @@
 	},
 /turf/open/floor/tile/white,
 /area/desert_dam/building/medical/chemistry)
+"ckK" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/desert_dam/exterior/valley/valley_medical)
 "ckM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -19310,6 +19468,9 @@
 /obj/structure/platform{
 	dir = 8
 	},
+/obj/structure/platform_decoration{
+	dir = 5
+	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/filtration_a)
 "clq" = (
@@ -19358,6 +19519,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/chemistry)
 "clH" = (
@@ -19380,6 +19542,7 @@
 	dir = 2;
 	name = "\improper Medical Chemistry"
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/tile/white,
 /area/desert_dam/building/medical/chemistry)
 "clM" = (
@@ -19514,6 +19677,7 @@
 "cmE" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison,
 /area/desert_dam/building/medical/break_room)
 "cmF" = (
@@ -19526,8 +19690,11 @@
 /turf/open/floor/carpet,
 /area/desert_dam/building/warehouse/breakroom)
 "cmH" = (
-/turf/open/floor/plating/ground/dirt,
-/area/desert_dam/exterior/valley/valley_civilian)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 1
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "cmI" = (
 /obj/structure/flora/bush,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -19571,6 +19738,9 @@
 	},
 /obj/structure/platform{
 	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 9
 	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/filtration_a)
@@ -19701,12 +19871,14 @@
 	},
 /area/desert_dam/building/medical/break_room)
 "cnP" = (
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/darkbrown/corner{
 	dir = 8
 	},
 /area/desert_dam/building/medical/break_room)
 "cnQ" = (
 /obj/machinery/light,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/wood,
 /area/desert_dam/building/medical/break_room)
 "cnS" = (
@@ -19873,6 +20045,7 @@
 /area/desert_dam/building/medical/chemistry)
 "coR" = (
 /obj/structure/bed/stool,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/tile/purple/whitepurplecorner,
 /area/desert_dam/building/medical/chemistry)
 "coS" = (
@@ -19889,6 +20062,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/bright_clean/two,
 /area/desert_dam/building/medical/morgue)
 "coU" = (
@@ -20019,6 +20193,7 @@
 /obj/structure/disposalpipe/junction/flipped{
 	dir = 1
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen{
 	dir = 4
 	},
@@ -20073,9 +20248,10 @@
 /turf/open/floor/prison,
 /area/desert_dam/building/telecommunication)
 "cpT" = (
-/obj/structure/flora/desert/grass/six,
-/turf/open/floor/plating/ground/dirt,
-/area/desert_dam/exterior/valley/valley_civilian)
+/obj/structure/cable,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge,
+/area/desert_dam/exterior/valley/valley_northwest)
 "cpU" = (
 /obj/structure/platform{
 	dir = 4
@@ -20338,6 +20514,7 @@
 	dir = 1;
 	name = "\improper Medical Hallway"
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen,
 /area/desert_dam/building/medical/north_wing_hallway)
 "crM" = (
@@ -20608,6 +20785,9 @@
 /obj/structure/platform{
 	dir = 4
 	},
+/obj/structure/platform_decoration{
+	dir = 9
+	},
 /turf/open/floor/plating/ground/desertdam/asphalt/tile,
 /area/desert_dam/exterior/valley/valley_telecoms)
 "ctA" = (
@@ -20656,6 +20836,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen,
 /area/desert_dam/building/medical/lobby)
 "ctV" = (
@@ -20686,10 +20867,12 @@
 	name = "\improper Observation"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/surgery_observation)
 "cua" = (
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/surgery_observation)
 "cub" = (
@@ -20701,6 +20884,7 @@
 	name = "\improper Medical Hallway"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen{
 	dir = 8
 	},
@@ -20810,6 +20994,9 @@
 /obj/structure/platform{
 	dir = 4
 	},
+/obj/structure/platform_decoration{
+	dir = 9
+	},
 /turf/open/ground/coast/corner{
 	dir = 1
 	},
@@ -20859,6 +21046,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 8
 	},
@@ -21013,6 +21201,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/surgery_observation)
 "cwd" = (
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
 	},
@@ -21152,6 +21341,7 @@
 /area/desert_dam/building/medical/lobby)
 "cwL" = (
 /obj/machinery/door/airlock/mainship/generic,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/bright_clean/two,
 /area/desert_dam/building/medical/lobby)
 "cwM" = (
@@ -21196,6 +21386,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/east_wing_hallway)
 "cwW" = (
@@ -21284,6 +21475,9 @@
 /obj/structure/platform{
 	dir = 8
 	},
+/obj/structure/platform_decoration{
+	dir = 5
+	},
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/valley/valley_cargo)
 "cxr" = (
@@ -21369,6 +21563,9 @@
 /obj/structure/platform{
 	dir = 8
 	},
+/obj/structure/platform_decoration{
+	dir = 5
+	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_cargo)
 "cxQ" = (
@@ -21404,6 +21601,9 @@
 	dir = 8
 	},
 /obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 10
+	},
 /turf/open/ground/coast{
 	dir = 4
 	},
@@ -21593,6 +21793,7 @@
 	dir = 2;
 	name = "\improper Medical Storage"
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/primary_storage)
 "cyX" = (
@@ -21634,6 +21835,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 4
 	},
@@ -21748,9 +21950,11 @@
 	},
 /area/desert_dam/building/substation/central)
 "czQ" = (
-/obj/structure/flora/desert/cactus/eight,
-/turf/open/floor/plating/ground/dirt,
-/area/desert_dam/exterior/valley/valley_civilian)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/wall/r_wall/chigusa{
+	name = "reinforced metal wall"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "czR" = (
 /obj/structure/desertdam/decals/road{
 	dir = 1
@@ -21769,6 +21973,9 @@
 /obj/structure/platform{
 	dir = 4
 	},
+/obj/structure/platform_decoration{
+	dir = 9
+	},
 /turf/open/floor/plating/ground/dirt{
 	dir = 4
 	},
@@ -21779,6 +21986,9 @@
 	},
 /obj/structure/platform{
 	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 5
 	},
 /turf/open/ground/coast,
 /area/desert_dam/exterior/river/riverside_east)
@@ -22186,6 +22396,7 @@
 	name = "\improper Garage"
 	},
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating,
 /area/desert_dam/building/medical/garage)
 "cCf" = (
@@ -22419,6 +22630,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
@@ -22435,6 +22647,7 @@
 	},
 /area/desert_dam/building/medical/emergency_room)
 "cDp" = (
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
@@ -22465,6 +22678,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/surgery_room_one)
 "cDu" = (
@@ -22479,6 +22693,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/surgery_room_two)
 "cDy" = (
@@ -22492,6 +22707,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/office1)
 "cDA" = (
@@ -22505,6 +22721,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/office2)
 "cDC" = (
@@ -22649,6 +22866,7 @@
 	},
 /area/desert_dam/building/medical/emergency_room)
 "cEr" = (
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 9
 	},
@@ -22670,6 +22888,7 @@
 	start_charge = 0
 	},
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 9
 	},
@@ -22688,6 +22907,7 @@
 "cED" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/treatment_room)
 "cEF" = (
@@ -22695,6 +22915,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 1
 	},
@@ -22704,6 +22925,7 @@
 /turf/open/floor/plating,
 /area/desert_dam/building/medical/treatment_room)
 "cEJ" = (
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
@@ -22795,6 +23017,7 @@
 /turf/open/floor/plating,
 /area/desert_dam/building/medical/emergency_room)
 "cFp" = (
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen{
 	dir = 9
 	},
@@ -22877,6 +23100,7 @@
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
 "cFV" = (
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/tile/white,
 /area/desert_dam/building/medical/emergency_room)
 "cFX" = (
@@ -22903,6 +23127,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen{
 	dir = 1
 	},
@@ -23031,6 +23256,7 @@
 	name = "\improper Emergency Room"
 	},
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/tile/white,
 /area/desert_dam/building/medical/emergency_room)
 "cGY" = (
@@ -23050,6 +23276,7 @@
 	name = "\improper Surgery"
 	},
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen,
 /area/desert_dam/building/medical/emergency_room)
 "cHc" = (
@@ -23065,6 +23292,7 @@
 	},
 /area/desert_dam/building/medical/treatment_room)
 "cHg" = (
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/corner,
 /area/desert_dam/building/medical/treatment_room)
 "cHi" = (
@@ -23130,6 +23358,7 @@
 /turf/open/floor/prison/whitegreen,
 /area/desert_dam/building/medical/emergency_room)
 "cHA" = (
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 8
 	},
@@ -23143,6 +23372,7 @@
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_telecoms)
 "cHI" = (
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 8
 	},
@@ -23153,6 +23383,7 @@
 /area/desert_dam/building/medical/treatment_room)
 "cHK" = (
 /obj/machinery/light,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen,
 /area/desert_dam/building/medical/treatment_room)
 "cHL" = (
@@ -23165,6 +23396,7 @@
 	req_one_access = null
 	},
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating,
 /area/desert_dam/building/medical/east_wing_hallway)
 "cHN" = (
@@ -23176,6 +23408,7 @@
 /area/desert_dam/building/medical/virology_wing)
 "cHP" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen{
 	dir = 8
 	},
@@ -23194,6 +23427,7 @@
 	name = "\improper Patient Room 1"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/east_wing_hallway)
 "cHS" = (
@@ -23202,6 +23436,7 @@
 	name = "\improper Patient Room 2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/east_wing_hallway)
 "cHT" = (
@@ -23216,6 +23451,7 @@
 	name = "\improper Patient Room 3"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/east_wing_hallway)
 "cIa" = (
@@ -23325,6 +23561,7 @@
 /area/desert_dam/building/medical/emergency_room)
 "cIE" = (
 /obj/machinery/light,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 10
 	},
@@ -23335,6 +23572,7 @@
 	name = "\improper Medical Office"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/treatment_room)
 "cIG" = (
@@ -23343,15 +23581,18 @@
 "cIH" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/full,
 /area/desert_dam/building/medical/treatment_room)
 "cII" = (
 /obj/machinery/iv_drip,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/full,
 /area/desert_dam/building/medical/treatment_room)
 "cIJ" = (
 /obj/machinery/iv_drip,
 /obj/machinery/light,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/full,
 /area/desert_dam/building/medical/treatment_room)
 "cIK" = (
@@ -23398,6 +23639,7 @@
 	},
 /area/desert_dam/building/medical/virology_wing)
 "cIU" = (
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 5
 	},
@@ -23502,6 +23744,7 @@
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "\improper Garage"
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating,
 /area/desert_dam/building/medical/garage)
 "cJA" = (
@@ -23574,6 +23817,7 @@
 	},
 /area/desert_dam/building/medical/virology_wing)
 "cJM" = (
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 4
 	},
@@ -23686,6 +23930,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating,
 /area/desert_dam/building/medical/east_wing_hallway)
 "cKD" = (
@@ -23712,6 +23957,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/virology_wing)
 "cKH" = (
@@ -23732,6 +23978,7 @@
 	start_charge = 0
 	},
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 4
 	},
@@ -23834,6 +24081,10 @@
 "cLG" = (
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/warehouse/warehouse)
+"cLJ" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_medical)
 "cLL" = (
 /obj/machinery/landinglight/ds2{
 	dir = 8
@@ -23882,6 +24133,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/freezer,
 /area/desert_dam/building/medical/virology_wing)
 "cMi" = (
@@ -24044,6 +24296,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/virology_isolation)
 "cMZ" = (
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
 	},
@@ -24148,6 +24401,9 @@
 	},
 /obj/structure/platform{
 	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 9
 	},
 /turf/open/floor/plating/ground/dirt{
 	dir = 8
@@ -24476,6 +24732,7 @@
 	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison,
 /area/desert_dam/building/medical/virology_isolation)
 "cPO" = (
@@ -24483,6 +24740,7 @@
 	dir = 2;
 	req_one_access = null
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating,
 /area/desert_dam/building/medical/virology_wing)
 "cPP" = (
@@ -24496,12 +24754,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/full,
 /area/desert_dam/building/medical/virology_wing)
 "cPR" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/full,
 /area/desert_dam/building/medical/virology_wing)
 "cPS" = (
@@ -25448,11 +25708,17 @@
 /obj/structure/desertdam/decals/road,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_civilian)
 "cXx" = (
 /obj/structure/desertdam/decals/road/edge/long{
 	dir = 4
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_civilian)
@@ -25933,6 +26199,7 @@
 "dbQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge{
 	dir = 1
 	},
@@ -26238,6 +26505,7 @@
 "del" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge{
 	dir = 6
 	},
@@ -26512,6 +26780,9 @@
 /obj/structure/platform{
 	dir = 4
 	},
+/obj/structure/platform_decoration{
+	dir = 9
+	},
 /turf/open/ground/river/desertdam/clean/shallow,
 /area/desert_dam/exterior/river/riverside_south)
 "dgX" = (
@@ -26556,6 +26827,16 @@
 	dir = 1
 	},
 /area/desert_dam/building/warehouse/warehouse)
+"dhp" = (
+/obj/structure/desertdam/decals/road{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "dhs" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -26671,6 +26952,7 @@
 	dir = 4;
 	on = 1
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/lobby)
 "djg" = (
@@ -26735,6 +27017,9 @@
 /obj/structure/platform,
 /obj/structure/platform{
 	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 10
 	},
 /turf/open/ground/coast/corner{
 	dir = 8
@@ -27668,6 +27953,7 @@
 "duD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge{
 	dir = 4
 	},
@@ -28048,6 +28334,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/prison/blue{
 	dir = 1
 	},
@@ -28231,6 +28518,10 @@
 /obj/item/reagent_containers/food/snacks/cookie,
 /turf/open/floor/prison/kitchen,
 /area/desert_dam/building/cafeteria/cafeteria)
+"dAi" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen,
+/area/desert_dam/building/medical/north_wing_hallway)
 "dAk" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/bun,
@@ -28311,14 +28602,9 @@
 /turf/open/floor/prison/kitchen,
 /area/desert_dam/building/cafeteria/cafeteria)
 "dBh" = (
-/obj/structure/desertdam/decals/road{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/landing/landing_pad_two_external)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/prison/plate,
+/area/desert_dam/exterior/valley/valley_northwest)
 "dBi" = (
 /obj/machinery/door/airlock/mainship/generic,
 /turf/open/floor/freezer,
@@ -28502,6 +28788,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/prison/bright_clean/two,
 /area/desert_dam/building/dorms/restroom)
 "dCo" = (
@@ -28590,6 +28877,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/prison/whitegreen/full,
 /area/desert_dam/building/dorms/pool)
 "dCW" = (
@@ -28624,6 +28912,7 @@
 /area/desert_dam/building/medical/surgery_room_one)
 "dDn" = (
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen{
 	dir = 10
 	},
@@ -28851,10 +29140,19 @@
 /obj/structure/cable,
 /turf/open/floor/tile/green/whitegreen,
 /area/desert_dam/building/lab_northwest/west_lab_xenoflora)
+"dFO" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "dFP" = (
 /obj/structure/platform,
 /obj/structure/platform{
 	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 10
 	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/filtration_a)
@@ -28866,6 +29164,7 @@
 /area/desert_dam/exterior/river/riverside_east)
 "dFS" = (
 /obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 1
 	},
@@ -28909,6 +29208,9 @@
 /obj/structure/platform,
 /obj/structure/platform{
 	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 6
 	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/filtration_a)
@@ -28990,6 +29292,9 @@
 	dir = 4
 	},
 /obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 6
+	},
 /turf/open/ground/river/desertdam/clean/deep_water_clean,
 /area/desert_dam/exterior/river/filtration_a)
 "dHe" = (
@@ -29379,6 +29684,9 @@
 	},
 /area/desert_dam/exterior/river_mouth/southern)
 "dKM" = (
+/obj/structure/platform{
+	dir = 4
+	},
 /turf/open/ground/coast/corner{
 	dir = 1
 	},
@@ -29625,6 +29933,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/freezer,
 /area/desert_dam/building/security/prison)
+"dPi" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison,
+/area/desert_dam/building/substation/northeast)
 "dPj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
@@ -29683,6 +29995,7 @@
 "dRi" = (
 /obj/item/clothing/head/surgery/blue,
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
@@ -29735,10 +30048,12 @@
 	dir = 2;
 	name = "\improper Containment Pen"
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/freezer,
 /area/desert_dam/building/medical/virology_wing)
 "dTp" = (
 /obj/item/trash/sosjerky,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 6
 	},
@@ -29764,6 +30079,12 @@
 /obj/structure/desertdam/decals/road,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/river/riverside_south)
+"dTI" = (
+/obj/machinery/sleep_console,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen,
+/area/desert_dam/building/medical/emergency_room)
 "dTK" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/edge{
 	dir = 10
@@ -29857,8 +30178,18 @@
 /area/desert_dam/building/hydroponics/hydroponics_storage)
 "dWp" = (
 /obj/effect/decal/cleanable/blood,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/prison/whitegreen/full,
 /area/desert_dam/building/dorms/pool)
+"dWr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 8
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
 "dWy" = (
 /obj/structure/rack,
 /turf/open/floor/prison/whitegreen/full,
@@ -30093,6 +30424,9 @@
 	dir = 4
 	},
 /obj/structure/flora/rock/pile/alt3,
+/obj/structure/platform_decoration{
+	dir = 6
+	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "eaG" = (
@@ -30433,6 +30767,7 @@
 /area/desert_dam/building/water_treatment_one/breakroom)
 "eeh" = (
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 6
 	},
@@ -30733,6 +31068,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/south_tunnel)
+"ekU" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/twoside,
+/area/desert_dam/exterior/valley/valley_medical)
 "ekW" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -31105,6 +31446,10 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"exd" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_mining)
 "exn" = (
 /obj/structure/flora/desert/grass/eleven,
 /obj/effect/ai_node,
@@ -31140,6 +31485,12 @@
 	},
 /turf/open/floor/prison/kitchen,
 /area/desert_dam/building/cafeteria/cafeteria)
+"eyh" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen{
+	dir = 4
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
 "eyi" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -31156,6 +31507,11 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_south)
+"eyW" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen,
+/area/desert_dam/building/medical/east_wing_hallway)
 "ezm" = (
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 4
@@ -31337,6 +31693,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen,
 /area/desert_dam/building/medical/treatment_room)
 "eFb" = (
@@ -31357,6 +31714,9 @@
 	},
 /obj/structure/platform{
 	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 5
 	},
 /turf/open/ground/river/desertdam/clean/shallow_edge{
 	dir = 8
@@ -31571,6 +31931,7 @@
 /area/desert_dam/interior/dam_interior/workshop)
 "eMH" = (
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
@@ -31611,6 +31972,11 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"eOh" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/desert_dam/exterior/valley/valley_medical)
 "eOn" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -31754,11 +32120,11 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/west_tunnel)
 "eRw" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall/r_wall,
 /area/desert_dam/building/dorms/restroom)
 "eRA" = (
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 6
 	},
@@ -31797,6 +32163,9 @@
 /obj/structure/platform{
 	dir = 4
 	},
+/obj/structure/platform_decoration{
+	dir = 6
+	},
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 8
 	},
@@ -31808,6 +32177,7 @@
 /area/desert_dam/exterior/river/riverside_east)
 "eSD" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/corner,
 /area/desert_dam/building/medical/west_wing_hallway)
 "eSH" = (
@@ -31899,6 +32269,11 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"eUI" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/tile/white,
+/area/desert_dam/building/medical/chemistry)
 "eUP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -32003,6 +32378,10 @@
 	},
 /turf/open/floor/prison/plate,
 /area/desert_dam/exterior/valley/valley_northwest)
+"eXS" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/sterilewhite,
+/area/desert_dam/building/medical/emergency_room)
 "eYf" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -32110,6 +32489,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_mining)
+"fbY" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 4
+	},
+/area/desert_dam/building/medical/virology_wing)
 "fcj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -32379,6 +32764,7 @@
 /area/desert_dam/interior/caves/temple)
 "fiZ" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 1
 	},
@@ -32602,6 +32988,18 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/building/security/staffroom)
+"fqE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 1
+	},
+/area/desert_dam/building/medical/north_wing_hallway)
 "fqF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/gloves/latex,
@@ -33040,6 +33438,7 @@
 /obj/effect/decal/medical_decals/triage/edge{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
@@ -33136,6 +33535,7 @@
 /area/desert_dam/interior/east_engineering)
 "fGe" = (
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
 	},
@@ -33225,6 +33625,7 @@
 	name = "\improper Medical Lobby"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen,
 /area/desert_dam/building/medical/lobby)
 "fIz" = (
@@ -33466,6 +33867,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/bar/bar_restroom)
+"fPJ" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/landing/landing_pad_two_external)
 "fPM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/bright_clean,
@@ -33494,6 +33901,7 @@
 "fQw" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/decal/medical_decals/triage/bottom,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 8
 	},
@@ -33802,11 +34210,15 @@
 /area/desert_dam/exterior/landing/landing_pad_two_external)
 "fXS" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
 "fXU" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/closed/wall/desert/invincible,
 /area/desert_dam/interior/dam_interior/hanger)
 "fXW" = (
@@ -34022,6 +34434,7 @@
 "gdk" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/medical_decals/triage/bottom,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen{
 	dir = 4
 	},
@@ -34153,11 +34566,12 @@
 /turf/open/floor/prison/bright_clean/two,
 /area/desert_dam/building/administration/control_room)
 "ghJ" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
+/obj/structure/desertdam/decals/road{
+	dir = 1
 	},
-/turf/closed/mineral/smooth,
-/area/desert_dam/exterior/rock)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_northwest)
 "ghL" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -34183,6 +34597,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/full,
 /area/desert_dam/building/medical/virology_wing)
 "gir" = (
@@ -34430,6 +34845,14 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/west_tunnel)
+"goB" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "goN" = (
 /obj/effect/landmark/start/job/xenomorph,
 /obj/structure/cable,
@@ -34902,6 +35325,11 @@
 	dir = 9
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"gGS" = (
+/obj/effect/decal/medical_decals/triage/bottom,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/sterilewhite,
+/area/desert_dam/building/medical/lobby)
 "gHa" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -35171,6 +35599,7 @@
 "gQZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen{
 	dir = 10
 	},
@@ -35217,6 +35646,7 @@
 	req_one_access = null
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating,
 /area/desert_dam/building/medical/virology_wing)
 "gSH" = (
@@ -35226,9 +35656,10 @@
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
 "gSJ" = (
+/obj/effect/ai_node,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/landing/landing_pad_one_external)
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_northwest)
 "gSP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -35297,6 +35728,7 @@
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "gVq" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 4
 	},
@@ -35362,9 +35794,6 @@
 /turf/open/floor/prison,
 /area/desert_dam/interior/lab_northeast/east_lab_excavation)
 "gXw" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
 /turf/open/floor/plating/ground/desertdam/asphalt/threeside{
 	dir = 4
 	},
@@ -35618,6 +36047,9 @@
 	},
 /obj/structure/platform,
 /obj/effect/landmark/weed_node,
+/obj/structure/platform_decoration{
+	dir = 10
+	},
 /turf/open/floor/plating/ground/desertdam/asphalt/tile,
 /area/desert_dam/exterior/valley/valley_mining)
 "heU" = (
@@ -35755,7 +36187,6 @@
 /obj/machinery/door/poddoor/shutters/mainship{
 	id = "northpath1"
 	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
@@ -35769,6 +36200,16 @@
 	dir = 4
 	},
 /area/desert_dam/interior/dam_interior/break_room)
+"hiL" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen{
+	dir = 1
+	},
+/area/desert_dam/building/medical/north_wing_hallway)
 "hiN" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/cavetodirt{
@@ -35796,11 +36237,9 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_civilian)
 "hjo" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/tile,
-/area/desert_dam/exterior/valley/valley_civilian)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_northwest)
 "hjv" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -36040,19 +36479,16 @@
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
 "hrg" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
+/obj/structure/desertdam/decals/road,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/landing/landing_pad_one_external)
+/area/desert_dam/exterior/valley/valley_northwest)
 "hrH" = (
 /obj/machinery/power/apc{
 	start_charge = 0
 	},
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 1
 	},
@@ -36179,6 +36615,7 @@
 	dir = 8;
 	on = 1
 	},
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/wood,
 /area/desert_dam/building/medical/break_room)
 "hvm" = (
@@ -36224,6 +36661,13 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"hwP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 4
+	},
+/area/desert_dam/building/medical/virology_isolation)
 "hwW" = (
 /obj/structure/filingcabinet,
 /obj/machinery/light{
@@ -36249,6 +36693,13 @@
 	},
 /turf/open/floor/prison,
 /area/desert_dam/interior/lab_northeast/east_lab_security_armory)
+"hxK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 1
+	},
+/area/desert_dam/building/medical/treatment_room)
 "hxM" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -36465,6 +36916,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_wilderness)
+"hCs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/sterilewhite,
+/area/desert_dam/building/medical/lobby)
 "hCB" = (
 /obj/structure/desertdam/decals/road{
 	dir = 4
@@ -36480,6 +36936,10 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_cargo)
+"hCN" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen/corner,
+/area/desert_dam/building/medical/north_wing_hallway)
 "hDc" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner,
 /area/desert_dam/exterior/river/riverside_south)
@@ -36528,6 +36988,10 @@
 	dir = 4
 	},
 /area/desert_dam/interior/dam_interior/disposals)
+"hDJ" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/wall,
+/area/desert_dam/building/dorms/restroom)
 "hDM" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/xeno_resin_wall,
@@ -36798,6 +37262,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/freezer,
 /area/desert_dam/building/water_treatment_one/breakroom)
+"hLc" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 4
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
 "hLl" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/chips,
@@ -36945,6 +37417,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_cargo)
+"hOW" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen,
+/area/desert_dam/building/medical/treatment_room)
 "hPi" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating/ground/desertdam/asphalt/twoside,
@@ -37050,11 +37526,9 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
 "hSB" = (
-/obj/machinery/door/airlock/mainship/maint,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/prison,
-/area/desert_dam/building/dorms/hallway_northwing)
+/obj/structure/platform_decoration,
+/turf/open/floor/plating/ground/desertdam/asphalt/twoside,
+/area/desert_dam/exterior/valley/valley_northwest)
 "hSC" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -37242,6 +37716,7 @@
 	on = 1
 	},
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 1
 	},
@@ -37515,6 +37990,15 @@
 	dir = 1
 	},
 /area/desert_dam/building/administration/hallway)
+"ifF" = (
+/obj/structure/desertdam/decals/road{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/landing/landing_pad_two_external)
 "ifM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/lv624/fog_blocker,
@@ -37588,6 +38072,7 @@
 /area/desert_dam/exterior/valley/south_valley_dam)
 "iiN" = (
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen{
 	dir = 10
 	},
@@ -37931,6 +38416,15 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/warehouse/breakroom)
+"itq" = (
+/obj/structure/desertdam/decals/road{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "its" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/decal/medical_decals/doc/four,
@@ -37985,6 +38479,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"ivi" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 1
+	},
+/area/desert_dam/building/medical/west_wing_hallway)
 "ivu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -38015,6 +38515,11 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
+"iwz" = (
+/obj/machinery/light,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen,
+/area/desert_dam/building/medical/north_wing_hallway)
 "iwE" = (
 /obj/structure/desertdam/decals/road/edge/long{
 	dir = 4
@@ -38044,6 +38549,9 @@
 	dir = 8
 	},
 /obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 10
+	},
 /turf/open/floor/plating/ground/dirt{
 	dir = 8
 	},
@@ -38084,6 +38592,13 @@
 	dir = 6
 	},
 /area/desert_dam/exterior/valley/tradeship)
+"iyp" = (
+/obj/machinery/floodlight/colony,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_civilian)
 "iyD" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -38137,6 +38652,12 @@
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean/two,
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
+"izy" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/twoside,
+/area/desert_dam/exterior/valley/valley_mining)
 "izM" = (
 /obj/structure/window/framed/colony,
 /obj/structure/cable,
@@ -38244,6 +38765,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/east_wing_hallway)
 "iDC" = (
@@ -38545,6 +39067,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/west_tunnel)
+"iLI" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 8
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "iLK" = (
 /obj/structure/desertdam/decals/road{
 	dir = 1
@@ -39188,6 +39718,7 @@
 "jea" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen,
 /area/desert_dam/building/medical/emergency_room)
 "jeg" = (
@@ -39641,6 +40172,9 @@
 /obj/structure/platform{
 	dir = 8
 	},
+/obj/structure/platform_decoration{
+	dir = 5
+	},
 /turf/open/ground/river/desertdam/clean/shallow,
 /area/desert_dam/exterior/river/riverside_south)
 "jsP" = (
@@ -39745,14 +40279,14 @@
 /obj/structure/platform{
 	dir = 4
 	},
+/obj/structure/platform_decoration{
+	dir = 9
+	},
 /turf/open/floor/plating/ground/dirt{
 	dir = 8
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
 "jwg" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
 /turf/closed/mineral/smooth,
 /area/desert_dam/exterior/valley/valley_civilian)
 "jwh" = (
@@ -39860,6 +40394,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen,
 /area/desert_dam/building/medical/virology_isolation)
 "jzn" = (
@@ -40712,6 +41247,9 @@
 /obj/structure/platform{
 	dir = 4
 	},
+/obj/structure/platform_decoration{
+	dir = 9
+	},
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 8
 	},
@@ -40775,6 +41313,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen,
 /area/desert_dam/building/medical/north_wing_hallway)
 "jYd" = (
@@ -41039,13 +41578,9 @@
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/dam_interior/control_room)
 "kfn" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 9
-	},
-/area/desert_dam/exterior/landing/landing_pad_two_external)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/desert_dam/exterior/valley/valley_northwest)
 "kfw" = (
 /obj/structure/bed/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -41056,14 +41591,9 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
 "kfF" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/landing/landing_pad_two_external)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_northwest)
 "kfI" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/effect/landmark/xeno_resin_wall,
@@ -41164,7 +41694,6 @@
 	},
 /area/desert_dam/exterior/valley/valley_labs)
 "kjf" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall/r_wall,
 /area/desert_dam/building/dorms/pool)
 "kjh" = (
@@ -41198,6 +41727,14 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_mining)
+"kjP" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "kjQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
@@ -41533,6 +42070,7 @@
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "kug" = (
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 1
 	},
@@ -41714,6 +42252,9 @@
 	dir = 8
 	},
 /obj/effect/landmark/excavation_site_spawner,
+/obj/structure/platform_decoration{
+	dir = 10
+	},
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 6
 	},
@@ -41751,6 +42292,10 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_telecoms)
+"kAc" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge,
+/area/desert_dam/exterior/valley/valley_medical)
 "kAh" = (
 /obj/structure/platform,
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner{
@@ -41833,6 +42378,7 @@
 "kCI" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen{
 	dir = 4
 	},
@@ -41922,14 +42468,20 @@
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
 "kGF" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/plating/ground/desertdam/asphalt/tile,
-/area/desert_dam/exterior/valley/valley_civilian)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/ground/desertdam/asphalt/twoside{
+	dir = 4
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "kHg" = (
 /obj/machinery/sleeper,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/whitegreen,
 /area/desert_dam/building/medical/emergency_room)
+"kHq" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/sterilewhite,
+/area/desert_dam/building/medical/lobby)
 "kHr" = (
 /obj/structure/largecrate/random,
 /obj/effect/decal/cleanable/dirt,
@@ -41957,6 +42509,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/workshop)
+"kHQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/sterilewhite,
+/area/desert_dam/building/medical/primary_storage)
 "kHR" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -42134,6 +42697,7 @@
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "kLZ" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
 	},
@@ -42386,6 +42950,7 @@
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison,
 /area/desert_dam/building/medical/break_room)
 "kSI" = (
@@ -42559,6 +43124,9 @@
 	dir = 4
 	},
 /obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 6
+	},
 /turf/open/ground/coast{
 	dir = 8
 	},
@@ -42703,6 +43271,7 @@
 	dir = 9
 	},
 /obj/effect/ai_node,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_northwing)
 "lbF" = (
@@ -43064,6 +43633,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/north_wing_hallway)
 "low" = (
@@ -43133,6 +43703,9 @@
 	id = "hangar_dam_1";
 	name = "\improper Hangar Blast Doors"
 	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/dam_interior/hanger)
 "lql" = (
@@ -43180,11 +43753,11 @@
 	},
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "lqU" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/closed/mineral/smooth,
-/area/desert_dam/exterior/landing/landing_pad_two_external)
+/turf/closed/wall/r_wall,
+/area/desert_dam/interior/dam_interior/hanger)
 "lrm" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -43216,6 +43789,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/cafeteria/loading)
+"lrS" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating,
+/area/desert_dam/building/medical/east_wing_hallway)
 "lrV" = (
 /obj/item/shard,
 /obj/effect/decal/cleanable/blood/six,
@@ -43671,9 +44248,22 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/interior/dam_interior/central_tunnel)
+"lFt" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/prison,
+/area/desert_dam/building/dorms/hallway_northwing)
 "lFE" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/desert_dam/interior/east_engineering)
+"lFG" = (
+/obj/structure/cable,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 1
+	},
+/area/desert_dam/building/medical/north_wing_hallway)
 "lFQ" = (
 /obj/effect/ai_node,
 /turf/open/ground/river/desertdam/clean/shallow_edge{
@@ -43746,6 +44336,7 @@
 "lHL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 6
 	},
@@ -43789,6 +44380,7 @@
 /area/desert_dam/building/medical/emergency_room)
 "lJv" = (
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 1
 	},
@@ -43924,6 +44516,7 @@
 "lMF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/medical_decals/triage,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen{
 	dir = 1
 	},
@@ -44255,6 +44848,7 @@
 "lZg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/treatment_room)
 "lZj" = (
@@ -44365,6 +44959,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/weed_node,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_northwing)
 "mdd" = (
@@ -44698,6 +45293,7 @@
 	name = "\improper Containment Pen"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen{
 	dir = 8
 	},
@@ -44708,9 +45304,17 @@
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/north_tunnel_entrance)
 "mpj" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/closed/wall,
-/area/desert_dam/building/dorms/pool)
+/obj/effect/decal/warning_stripes/thin,
+/obj/machinery/door/poddoor/shutters/mainship/open{
+	dir = 2;
+	id = "hangar_dam_2";
+	name = "\improper Hangar Shutters"
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/prison/plate,
+/area/desert_dam/interior/dam_interior/hanger)
 "mpL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -45550,6 +46154,10 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
+"mNO" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating,
+/area/desert_dam/building/medical/garage)
 "mNP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
@@ -45911,6 +46519,14 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/dorms/restroom)
+"mYc" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "mYf" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison,
@@ -46384,6 +47000,7 @@
 "nlW" = (
 /obj/machinery/light,
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/wood,
 /area/desert_dam/building/medical/break_room)
 "nmt" = (
@@ -46405,6 +47022,9 @@
 /turf/open/floor/mainship/orange,
 /area/desert_dam/exterior/valley/tradeship)
 "nnb" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/closed/wall/r_wall/unmeltable,
 /area/desert_dam/interior/dam_interior/hanger)
 "nne" = (
@@ -46659,14 +47279,11 @@
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/emergency_room)
 "nxU" = (
-/obj/structure/desertdam/decals/road{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/landing/landing_pad_two_external)
+/turf/closed/mineral/smooth,
+/area/desert_dam/interior/dam_interior/hanger)
 "nxZ" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -46728,6 +47345,7 @@
 	dir = 8;
 	on = 1
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen{
 	dir = 4
 	},
@@ -46923,6 +47541,9 @@
 	id = "hangar_dam_2";
 	name = "\improper Hangar Shutters"
 	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/prison/plate,
 /area/desert_dam/interior/dam_interior/hanger)
 "nDT" = (
@@ -47029,6 +47650,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/north_wing_hallway)
 "nIe" = (
@@ -47681,6 +48303,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/east_wing_hallway)
 "nZu" = (
@@ -47921,7 +48544,6 @@
 /obj/machinery/door/poddoor/shutters/mainship{
 	id = "northpath1"
 	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge{
 	dir = 1
 	},
@@ -48191,6 +48813,10 @@
 	},
 /turf/open/floor/freezer,
 /area/desert_dam/building/water_treatment_two/equipment)
+"opA" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/wall,
+/area/desert_dam/building/dorms/pool)
 "opC" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -48221,13 +48847,11 @@
 /turf/open/floor/prison/darkred/full,
 /area/desert_dam/building/security/deathrow)
 "oqC" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 5
-	},
-/area/desert_dam/exterior/landing/landing_pad_two_external)
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/desert_dam/interior/dam_interior/western_dam_cave)
 "oqI" = (
 /obj/effect/decal/cleanable/blood/six,
 /obj/effect/decal/cleanable/dirt,
@@ -48638,6 +49262,13 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
+"oEq" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 4
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
 "oEr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48728,6 +49359,7 @@
 /area/desert_dam/exterior/valley/valley_medical)
 "oHC" = (
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 5
 	},
@@ -48843,6 +49475,7 @@
 "oJW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/healthanalyzer,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen/corner,
 /area/desert_dam/building/medical/lobby)
 "oKa" = (
@@ -49501,6 +50134,11 @@
 	dir = 6
 	},
 /area/desert_dam/building/church)
+"oZV" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/sterilewhite,
+/area/desert_dam/building/medical/east_wing_hallway)
 "paa" = (
 /obj/structure/cable,
 /turf/closed/wall{
@@ -50117,12 +50755,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen{
 	dir = 4
 	},
 /area/desert_dam/building/medical/virology_wing)
 "ppQ" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall/r_wall,
 /area/desert_dam/building/dorms/hallway_northwing)
 "ppR" = (
@@ -50278,6 +50916,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/cult,
 /area/desert_dam/building/bar/bar)
+"ptm" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 4
+	},
+/area/desert_dam/exterior/valley/valley_civilian)
 "ptA" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -50318,6 +50964,9 @@
 	dir = 8
 	},
 /obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 10
+	},
 /turf/open/ground/river/desertdam/clean/shallow_edge{
 	dir = 8
 	},
@@ -50559,6 +51208,25 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
+"pBO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen,
+/area/desert_dam/building/medical/east_wing_hallway)
+"pBY" = (
+/obj/effect/landmark/weed_node,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "pCq" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
@@ -50749,6 +51417,7 @@
 /area/desert_dam/building/bar/bar)
 "pHF" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 4
 	},
@@ -50776,6 +51445,10 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/dam_interior/CE_office)
+"pHL" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/desert_dam/exterior/valley/valley_medical)
 "pHY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -51050,13 +51723,13 @@
 	},
 /area/desert_dam/exterior/valley/valley_cargo)
 "pOE" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge{
-	dir = 8
+/turf/open/floor/plating/ground/mars/random/cave{
+	dir = 1
 	},
-/area/desert_dam/exterior/valley/valley_civilian)
+/area/desert_dam/interior/dam_interior/western_dam_cave)
 "pOM" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 2
@@ -51217,6 +51890,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen/full,
 /area/desert_dam/building/medical/emergency_room)
 "pSj" = (
@@ -51268,6 +51942,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean/two,
 /area/desert_dam/building/medical/surgery_observation)
+"pTo" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_medical)
 "pTz" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
@@ -51755,6 +52433,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/north_wing_hallway)
 "qho" = (
@@ -52017,6 +52696,7 @@
 	dir = 4;
 	on = 1
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/lobby)
 "qpt" = (
@@ -52430,9 +53110,17 @@
 /turf/open/floor/prison/bright_clean/two,
 /area/desert_dam/building/warehouse/warehouse)
 "qBG" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt,
-/area/desert_dam/exterior/valley/valley_civilian)
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 9
+	},
+/turf/open/ground/river/desertdam/clean/deep_water_clean,
+/area/desert_dam/exterior/river/riverside_central_south)
 "qBV" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -52478,14 +53166,21 @@
 /area/desert_dam/building/hydroponics/hydroponics_storage)
 "qCS" = (
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 4
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
 "qCW" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/desert_dam/exterior/landing/landing_pad_one_external)
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 6
+	},
+/turf/open/ground/river/desertdam/clean/deep_water_clean,
+/area/desert_dam/exterior/river/riverside_central_south)
 "qDb" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/twoside{
 	dir = 4
@@ -52850,6 +53545,7 @@
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "qQt" = (
 /obj/effect/ai_node,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
 	},
@@ -52863,6 +53559,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen{
 	dir = 8
 	},
@@ -52920,6 +53617,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/bright_clean/two,
 /area/desert_dam/building/administration/control_room)
+"qSk" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 5
+	},
+/turf/open/ground/river/desertdam/clean/deep_water_clean,
+/area/desert_dam/exterior/river/riverside_south)
 "qSH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -52999,6 +53708,9 @@
 	},
 /obj/structure/platform{
 	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 9
 	},
 /turf/open/floor/plating/ground/dirt{
 	dir = 8
@@ -53608,6 +54320,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"rkJ" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "rkL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -53697,13 +54415,17 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
 "rmX" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 8
 	},
-/turf/closed/wall{
-	name = "reinforced metal wall"
+/obj/structure/platform_decoration{
+	dir = 10
 	},
-/area/desert_dam/exterior/rock)
+/turf/open/floor/plating/ground/dirt{
+	dir = 8
+	},
+/area/desert_dam/exterior/river/riverside_east)
 "rnb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mainship/mono,
@@ -53972,6 +54694,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen,
 /area/desert_dam/building/medical/virology_wing)
 "rye" = (
@@ -54001,6 +54724,7 @@
 /area/desert_dam/building/hydroponics/hydroponics_loading)
 "ryU" = (
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
 	},
@@ -54069,6 +54793,9 @@
 /obj/structure/platform,
 /obj/structure/platform{
 	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 10
 	},
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 8
@@ -54306,7 +55033,6 @@
 /area/desert_dam/building/medical/office2)
 "rJp" = (
 /obj/machinery/door/airlock/mainship/engineering,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/asteroidplating,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
 "rJu" = (
@@ -54462,6 +55188,12 @@
 	dir = 9
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
+"rNr" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 8
+	},
+/area/desert_dam/building/medical/west_wing_hallway)
 "rNt" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall/prison,
@@ -54523,6 +55255,9 @@
 	},
 /obj/structure/platform{
 	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 9
 	},
 /turf/open/ground/river/desertdam/clean/shallow_edge{
 	dir = 4
@@ -54930,6 +55665,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"rXT" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen{
+	dir = 4
+	},
+/area/desert_dam/building/medical/lobby)
 "rXX" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -55035,6 +55776,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_hydro)
+"sas" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison,
+/area/desert_dam/building/medical/break_room)
 "say" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -55047,6 +55794,7 @@
 	name = "\improper Medical Hallway"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/north_wing_hallway)
 "sbi" = (
@@ -55187,6 +55935,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/treatment_room)
 "sfw" = (
@@ -55316,7 +56065,6 @@
 	id = "dam_checkpoint_east";
 	name = "\improper Checkpoint Lock"
 	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
 "shT" = (
@@ -55422,14 +56170,17 @@
 /turf/open/floor/prison/whitegreen/full,
 /area/desert_dam/building/medical/treatment_room)
 "skZ" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
 	dir = 8
 	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
+/obj/structure/platform_decoration{
+	dir = 5
 	},
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/landing/landing_pad_two_external)
+/turf/open/ground/river/desertdam/clean/deep_water_clean,
+/area/desert_dam/exterior/river/riverside_east)
 "slv" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -55473,6 +56224,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/wood,
 /area/desert_dam/building/medical/break_room)
 "smu" = (
@@ -55870,6 +56622,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/staffroom)
+"sxq" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/mineral/smooth,
+/area/desert_dam/exterior/rock)
 "sxu" = (
 /obj/effect/ai_node,
 /obj/structure/prop/templedoor,
@@ -56201,6 +56959,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_cargo)
+"sIi" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/wood,
+/area/desert_dam/building/medical/break_room)
 "sIv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -56262,9 +57025,9 @@
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/building/security/northern_hallway)
 "sJZ" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/closed/wall/r_wall,
-/area/desert_dam/exterior/rock)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge,
+/area/desert_dam/exterior/valley/valley_medical)
 "sKg" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -56292,6 +57055,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen,
 /area/desert_dam/building/medical/treatment_room)
 "sKZ" = (
@@ -56448,6 +57212,7 @@
 /area/desert_dam/exterior/valley/valley_crashsite)
 "sSm" = (
 /obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen,
 /area/desert_dam/building/medical/virology_wing)
 "sSI" = (
@@ -56497,6 +57262,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen{
 	dir = 1
 	},
@@ -56636,6 +57402,13 @@
 	dir = 8
 	},
 /area/desert_dam/interior/dam_interior/hanger)
+"sZv" = (
+/obj/structure/desertdam/decals/road,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "sZB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
@@ -56858,6 +57631,7 @@
 "teu" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/decal/medical_decals/triage/bottom,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 4
 	},
@@ -57063,6 +57837,12 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/river_mouth/southern)
+"tjO" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen{
+	dir = 1
+	},
+/area/desert_dam/building/medical/east_wing_hallway)
 "tjR" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner2{
 	dir = 4
@@ -57225,6 +58005,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen{
 	dir = 1
 	},
@@ -57244,14 +58025,12 @@
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/building/warehouse/warehouse)
 "tpl" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/desertdam/asphalt/twoside{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/landing/landing_pad_one_external)
+/area/desert_dam/exterior/valley/valley_medical)
 "tpx" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -57317,11 +58096,11 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/edge,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
 "tqQ" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/desertdam/asphalt/twoside{
+	dir = 4
 	},
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/desert_dam/exterior/landing/landing_pad_two_external)
+/area/desert_dam/exterior/valley/valley_medical)
 "trE" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -57808,6 +58587,12 @@
 	},
 /turf/open/floor/bcircuit,
 /area/desert_dam/interior/dam_interior/smes_main)
+"tGp" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 1
+	},
+/area/desert_dam/building/medical/virology_wing)
 "tGC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57865,6 +58650,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_cargo)
+"tHQ" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/wood,
+/area/desert_dam/building/medical/break_room)
 "tIn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/whitegreen{
@@ -57888,6 +58677,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 10
 	},
@@ -58059,6 +58849,7 @@
 	name = "\improper Emergency Room"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/emergency_room)
 "tNP" = (
@@ -58406,6 +59197,7 @@
 "tWZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen{
 	dir = 8
 	},
@@ -58841,6 +59633,9 @@
 	id = "hangar_dam_1";
 	name = "\improper Hangar Blast Doors"
 	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/hanger)
 "ujg" = (
@@ -59113,6 +59908,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/dam_interior/engine_west_wing)
+"usi" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_civilian)
 "usl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -59193,6 +59994,7 @@
 /area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
 "utM" = (
 /obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/desert_dam/exterior/valley/valley_medical)
 "utN" = (
@@ -59373,6 +60175,7 @@
 "uxT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/east_wing_hallway)
 "uyc" = (
@@ -59565,6 +60368,15 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/twoside/regular,
 /area/desert_dam/interior/dam_interior/south_tunnel)
+"uEU" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 4
+	},
+/area/desert_dam/building/medical/virology_wing)
 "uFz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
@@ -60334,6 +61146,10 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
+"vaU" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/desert_dam/exterior/valley/valley_medical)
 "vbj" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
@@ -60364,6 +61180,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen{
 	dir = 8
 	},
@@ -60552,6 +61369,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/southern_hallway)
+"vhQ" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen{
+	dir = 1
+	},
+/area/desert_dam/building/medical/emergency_room)
 "vih" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge{
 	dir = 4
@@ -60587,6 +61410,10 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"viE" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen,
+/area/desert_dam/building/medical/virology_wing)
 "viH" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/dirttosand,
@@ -60731,6 +61558,9 @@
 /obj/structure/platform{
 	dir = 8
 	},
+/obj/structure/platform_decoration{
+	dir = 5
+	},
 /turf/open/floor/plating/ground/mars/random/cave{
 	dir = 8
 	},
@@ -60815,6 +61645,10 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_three_external)
+"voG" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/prison/green,
+/area/desert_dam/building/dorms/hallway_northwing)
 "voI" = (
 /turf/open/ground/river/desertdam/clean/shallow_edge/corner2{
 	dir = 1
@@ -60835,6 +61669,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/desert_dam/building/warehouse/warehouse)
+"vpC" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/desert_dam/exterior/valley/valley_mining)
 "vpK" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -60950,6 +61788,11 @@
 	dir = 1
 	},
 /area/desert_dam/exterior/river/riverside_east)
+"vuh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen,
+/area/desert_dam/building/medical/north_wing_hallway)
 "vul" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/desert_dam/exterior/valley/valley_cargo)
@@ -61171,6 +62014,18 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/valley/valley_labs)
+"vAa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 1
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "vAf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -61600,6 +62455,11 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/cult,
 /area/desert_dam/building/church)
+"vLK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen/full,
+/area/desert_dam/building/medical/emergency_room)
 "vLM" = (
 /obj/item/weapon/gun/pistol/holdout,
 /obj/structure/toilet,
@@ -61686,9 +62546,6 @@
 /turf/open/floor/prison/plate,
 /area/desert_dam/interior/dam_interior/hanger)
 "vPg" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
 /turf/open/floor/plating/ground/desertdam/asphalt/threeside{
 	dir = 8
 	},
@@ -61841,6 +62698,13 @@
 	dir = 5
 	},
 /area/desert_dam/building/security/prison)
+"vTS" = (
+/obj/structure/cable,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen{
+	dir = 1
+	},
+/area/desert_dam/building/medical/north_wing_hallway)
 "vUc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61852,11 +62716,14 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/desert_dam/exterior/valley/valley_wilderness)
 "vUI" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 4
 	},
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/desert_dam/exterior/valley/valley_civilian)
+/area/desert_dam/building/medical/west_wing_hallway)
 "vUR" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt{
@@ -61999,6 +62866,7 @@
 	name = "\improper Medical Lobby"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/lobby)
 "vYZ" = (
@@ -62154,6 +63022,10 @@
 	dir = 1
 	},
 /area/desert_dam/interior/dam_interior/western_dam_cave)
+"wbL" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/prison/whitegreen/full,
+/area/desert_dam/building/dorms/pool)
 "wbM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -62386,6 +63258,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/dam_interior/smes_main)
+"wgW" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/valley/valley_civilian)
 "whf" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -62498,6 +63376,7 @@
 "wiU" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen,
 /area/desert_dam/building/medical/north_wing_hallway)
 "wiW" = (
@@ -62908,6 +63787,12 @@
 	},
 /turf/open/floor/prison/marked,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
+"wxe" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/whitegreen{
+	dir = 1
+	},
+/area/desert_dam/building/medical/virology_isolation)
 "wxq" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -62937,6 +63822,12 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
+"wyH" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/desert_dam/exterior/valley/valley_medical)
 "wyJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -63024,6 +63915,7 @@
 /area/desert_dam/interior/east_engineering)
 "wCu" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen{
 	dir = 1
 	},
@@ -63056,6 +63948,9 @@
 /obj/effect/landmark/patrol_point{
 	id = "TGMC_12";
 	name = "TGMC exit point 12"
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_two_external)
@@ -63392,6 +64287,12 @@
 /obj/structure/platform,
 /turf/open/floor/plating/ground/desertdam/grate/alternate,
 /area/desert_dam/exterior/river/riverside_east)
+"wMD" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/desert_dam/exterior/landing/landing_pad_two_external)
 "wMF" = (
 /turf/closed/wall/mainship,
 /area/desert_dam/exterior/valley/tradeship)
@@ -63420,6 +64321,7 @@
 	dir = 8;
 	on = 1
 	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/dorms/pool)
 "wNx" = (
@@ -64206,13 +65108,12 @@
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
 "xiB" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
-/area/desert_dam/exterior/valley/valley_civilian)
+/area/desert_dam/building/medical/west_wing_hallway)
 "xjh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/whitegreen/full,
@@ -64240,6 +65141,9 @@
 /area/desert_dam/exterior/valley/valley_crashsite)
 "xkF" = (
 /obj/effect/ai_node,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/plating/ground/mars/random/cave/rock{
 	dir = 4
 	},
@@ -64308,6 +65212,9 @@
 	dir = 4
 	},
 /obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 6
+	},
 /turf/open/ground/river/desertdam/clean/shallow_edge{
 	dir = 4
 	},
@@ -64422,11 +65329,10 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
 "xpp" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 8
-	},
-/area/desert_dam/exterior/landing/landing_pad_one_external)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/wood,
+/area/desert_dam/building/medical/break_room)
 "xpw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -64447,9 +65353,6 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
 /turf/open/floor/plating/ground/desertdam/asphalt/threeside{
 	dir = 8
 	},
@@ -64459,17 +65362,16 @@
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/surgery_room_two)
 "xqF" = (
-/obj/structure/desertdam/decals/road{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/mainship/open{
-	dir = 8;
-	id = "dam_checkpoint_east";
-	name = "\improper Checkpoint Lock"
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/desert_dam/exterior/landing/landing_pad_one_external)
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/tile/white,
+/area/desert_dam/building/medical/chemistry)
 "xqL" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -64920,6 +65822,7 @@
 "xDU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen,
 /area/desert_dam/building/medical/emergency_room)
 "xEa" = (
@@ -64980,6 +65883,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/decal/medical_decals/triage/bottom,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen{
 	dir = 8
 	},
@@ -64991,9 +65895,17 @@
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
 "xFV" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/closed/wall/r_wall,
-/area/desert_dam/building/cafeteria/cafeteria)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen{
+	dir = 4
+	},
+/area/desert_dam/building/medical/west_wing_hallway)
+"xFY" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 8
+	},
+/area/desert_dam/building/medical/north_wing_hallway)
 "xGi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -65007,7 +65919,6 @@
 	id = "dam_checkpoint_east";
 	name = "\improper Checkpoint Lock"
 	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
 "xGl" = (
@@ -65166,6 +66077,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_wilderness)
+"xLg" = (
+/obj/structure/cable,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 4
+	},
+/area/desert_dam/building/medical/treatment_room)
 "xLh" = (
 /obj/effect/decal/cleanable/blood/six,
 /turf/open/floor/prison/bright_clean/two,
@@ -65194,6 +66112,7 @@
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "xMd" = (
 /obj/structure/cable,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/whitegreen,
 /area/desert_dam/building/medical/emergency_room)
 "xMl" = (
@@ -65264,9 +66183,7 @@
 	},
 /area/desert_dam/exterior/landing/landing_pad_one_external)
 "xND" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/wall/r_wall,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
 "xNJ" = (
@@ -65649,6 +66566,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/desert_dam/interior/dam_interior/workshop)
+"xYR" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/sterilewhite,
+/area/desert_dam/building/medical/lobby)
 "xZe" = (
 /obj/structure/desertdam/decals/road{
 	dir = 1
@@ -66112,6 +67034,10 @@
 	dir = 1
 	},
 /area/desert_dam/building/medical/treatment_room)
+"ykV" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/prison/whitegreen/corner,
+/area/desert_dam/building/medical/east_wing_hallway)
 "ylf" = (
 /obj/structure/desertdam/decals/road/edge{
 	dir = 4
@@ -66169,6 +67095,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/tile/purple/whitepurple,
 /area/desert_dam/building/medical/chemistry)
 "ymj" = (
@@ -66929,8 +67856,8 @@ pkn
 tFb
 tFb
 tFb
-lkN
-rCV
+tFb
+tFb
 rCV
 rCV
 rCV
@@ -67163,8 +68090,8 @@ gox
 gox
 rCV
 rCV
-lkN
 rCV
+lkN
 rCV
 rCV
 rCV
@@ -67397,8 +68324,8 @@ gox
 gox
 rCV
 rCV
-lkN
 rCV
+lkN
 rCV
 rCV
 rCV
@@ -67631,8 +68558,8 @@ lZS
 lZS
 lZS
 rCV
-lkN
 rCV
+lkN
 rCV
 rCV
 rCV
@@ -67865,8 +68792,8 @@ kbX
 kbX
 kbX
 hva
-xND
-rCV
+xfr
+nxU
 rCV
 rCV
 rCV
@@ -68099,8 +69026,8 @@ rzW
 rzW
 rzW
 ocH
-xND
-rCV
+xfr
+lkN
 rCV
 rCV
 rCV
@@ -68333,7 +69260,7 @@ ijY
 aQU
 aQU
 ghT
-xND
+xfr
 xkF
 rCV
 rCV
@@ -68567,8 +69494,8 @@ aQU
 aQU
 aQU
 lNY
-xND
-qJA
+xfr
+oqC
 vlR
 nPH
 nPH
@@ -68801,8 +69728,8 @@ aQU
 aQU
 aQU
 lNY
-xND
-qJA
+xfr
+oqC
 qJA
 qqj
 qJA
@@ -69035,8 +69962,8 @@ aQU
 aQU
 aQU
 lNY
-xND
-nns
+xfr
+pOE
 nee
 qJA
 nPH
@@ -69269,8 +70196,8 @@ aQU
 aQU
 aQU
 lNY
-xND
-qJA
+xfr
+oqC
 qJA
 qJA
 nPH
@@ -69503,8 +70430,8 @@ aQU
 aQU
 aQU
 lNY
-xND
-qJA
+xfr
+oqC
 qJA
 rCV
 rCV
@@ -69737,8 +70664,8 @@ aQU
 aQU
 aQU
 ghT
-xND
-qJA
+xfr
+oqC
 rCV
 rCV
 rCV
@@ -69971,8 +70898,8 @@ aQU
 aQU
 aQU
 lNY
-xND
-rCV
+xfr
+lkN
 rCV
 rCV
 rCV
@@ -70203,10 +71130,10 @@ aQU
 oUi
 ijY
 eyi
-hrg
+fdY
 uAI
 xND
-rCV
+tFb
 rCV
 rCV
 rCV
@@ -70671,7 +71598,7 @@ aQU
 aQU
 aQU
 lNY
-bhe
+pxR
 nnb
 bhN
 bik
@@ -70905,7 +71832,7 @@ aQU
 aQU
 aQU
 lNY
-bhe
+pxR
 nnb
 ftK
 jEF
@@ -71139,7 +72066,7 @@ aQU
 oUi
 aQU
 lNY
-bhe
+pxR
 cfn
 bhP
 bhP
@@ -71373,7 +72300,7 @@ aQU
 oUi
 aQU
 lNY
-bhe
+pxR
 cfn
 sBS
 bhP
@@ -71841,7 +72768,7 @@ aQU
 aQU
 ijY
 fhf
-tpl
+rzW
 cfn
 bhQ
 bhP
@@ -72075,7 +73002,7 @@ aQU
 aQU
 aQU
 aQU
-xWm
+aQU
 cfn
 bhP
 eVi
@@ -72309,7 +73236,7 @@ aQU
 oUi
 aQU
 aQU
-xWm
+aQU
 cfn
 bhR
 dZa
@@ -72543,7 +73470,7 @@ aQU
 oUi
 aQU
 aQU
-xWm
+aQU
 cfn
 bhP
 bhP
@@ -72777,7 +73704,7 @@ aQU
 aQU
 aQU
 aQU
-xWm
+aQU
 cfn
 bhP
 sBS
@@ -73011,7 +73938,7 @@ aQU
 aQU
 aQU
 aQU
-xWm
+aQU
 cfn
 bhP
 sBS
@@ -73245,8 +74172,8 @@ aQU
 aQU
 aQU
 aQU
-xWm
-wwd
+aQU
+lqU
 eQW
 rcO
 rcO
@@ -73479,7 +74406,7 @@ aQU
 oUi
 aQU
 aQU
-xWm
+aQU
 uiU
 bhT
 uTt
@@ -73713,7 +74640,7 @@ aQU
 oUi
 ijY
 aQU
-xWm
+aQU
 bhy
 srK
 bhz
@@ -74181,7 +75108,7 @@ fdY
 fdY
 fdY
 bnw
-bhe
+pxR
 uiU
 bhT
 bhT
@@ -74415,8 +75342,8 @@ kxH
 rCV
 iDQ
 iDQ
-bhe
-wwd
+pxR
+lqU
 lsc
 qly
 qly
@@ -74649,8 +75576,8 @@ rCV
 rCV
 iAq
 iDQ
-bhe
-bhB
+pxR
+mpj
 bhP
 bhP
 azH
@@ -74838,52 +75765,52 @@ acu
 acu
 rCV
 lkN
-tFb
-tFb
-tFb
-tFb
-tFb
-tFb
-sJZ
-sJZ
+rCV
+rCV
+rCV
+rCV
+rCV
+rCV
+tZQ
+tZQ
 ogI
 his
-sJZ
-sJZ
-tFb
-tFb
-tFb
-pkn
-pkn
-tFb
-tFb
-tFb
-tFb
-tFb
-pkn
-pkn
-xpp
-tFb
-tFb
+tZQ
+tZQ
+rCV
+rCV
+rCV
+gox
+gox
+rCV
+rCV
+rCV
+rCV
+rCV
+gox
+gox
+kxH
+rCV
+rCV
 bAF
 rJp
 bAF
-xqF
+iHh
 xGk
 xGk
 shS
 bAF
 bAF
-tFb
-tFb
-tFb
-tFb
-tFb
-tFb
-tFb
-qCW
-gSJ
-bhe
+rCV
+rCV
+rCV
+rCV
+rCV
+rCV
+rCV
+utE
+iDQ
+pxR
 nDR
 bhP
 bhP
@@ -75071,54 +75998,54 @@ acu
 (39,1,1) = {"
 acu
 rCV
-rCV
-rCV
-rCV
-rCV
-rCV
-rCV
-rCV
-rCV
-rCV
-apa
-kBb
-rCV
-rCV
-rCV
-rCV
-rCV
-rCV
-rCV
-rCV
-rCV
-rCV
-rCV
-rCV
-rCV
-rCV
-rCV
-rCV
-bDO
-iNZ
+lkN
+aUY
+aVa
+bhe
+bqs
+bwV
+tFb
+tFb
+tFb
+cmH
+cpT
+tFb
+tFb
+tFb
+tFb
+tFb
+tFb
+tFb
+tFb
+tFb
+tFb
+tFb
+tFb
+tFb
+tFb
+tFb
+tFb
+czQ
+dBh
 qQt
 tIR
-apz
-eRe
-aqg
-asa
+ghJ
+gSJ
+hjo
+hrg
 aWh
-bDO
-rCV
-rCV
-rCV
-rCV
-rCV
-rCV
-rCV
-xMI
-aiZ
-aoE
-bhB
+czQ
+tFb
+tFb
+tFb
+tFb
+tFb
+tFb
+tFb
+kfn
+kfF
+kGF
+mpj
 sBS
 dZa
 bhP
@@ -81660,7 +82587,7 @@ aNp
 aNp
 aNp
 aNp
-aNp
+hSB
 beX
 idZ
 beX
@@ -91346,7 +92273,7 @@ pMR
 diQ
 dTH
 rdd
-dEo
+qSk
 mFz
 chm
 dvB
@@ -93211,7 +94138,7 @@ cpv
 lYE
 dGA
 dGA
-dHA
+bUs
 pYp
 dfc
 dgF
@@ -93641,12 +94568,12 @@ cig
 cgC
 aEt
 cgC
-chB
+qBG
 cld
 cld
 cld
 cld
-cig
+qCW
 qDb
 cgC
 oVm
@@ -95040,17 +95967,17 @@ bwv
 cgC
 bwv
 cgU
-chB
-cig
+qBG
+qCW
 cgC
 aEt
 cgC
-chB
+qBG
 cld
 cld
 cld
 cld
-cig
+qCW
 qDb
 oVm
 cgC
@@ -96686,9 +97613,9 @@ dCt
 dCt
 dCt
 dCt
-chB
+qBG
 cld
-cig
+qCW
 qDb
 cgC
 cgC
@@ -98383,7 +99310,7 @@ okO
 cEh
 chM
 cDf
-cDf
+mNO
 dnP
 mtl
 jXq
@@ -99300,7 +100227,7 @@ ckB
 coN
 ciR
 crA
-bLF
+hCs
 vYQ
 crA
 cvM
@@ -99308,7 +100235,7 @@ crA
 crA
 cvM
 crA
-crD
+kHq
 vYQ
 crA
 cCf
@@ -100013,7 +100940,7 @@ hnn
 jxa
 gro
 uyc
-cCi
+eXS
 cCi
 nuV
 xCZ
@@ -100235,18 +101162,18 @@ cnH
 coQ
 cpC
 cjV
-luE
-crD
+xYR
+kHq
 qoX
 oJW
-crE
-crE
-crE
+rXT
+rXT
+rXT
 gVq
 kLZ
 djf
-bLF
-uyc
+hCs
+gGS
 cCg
 dQY
 tIn
@@ -100716,7 +101643,7 @@ sHL
 hxS
 ctS
 cCg
-cEp
+vhQ
 cEp
 uus
 osI
@@ -100930,9 +101857,9 @@ jXq
 ciR
 cjr
 cjq
-ckH
-clI
-vLa
+xqF
+ajR
+eUI
 ymh
 coR
 cpD
@@ -100955,7 +101882,7 @@ gbr
 xBi
 bKa
 cgP
-lJr
+dTI
 cCf
 rCV
 rCV
@@ -101164,7 +102091,7 @@ jXq
 ciR
 ciR
 cjV
-ckH
+xqF
 clL
 cjV
 cnJ
@@ -101395,15 +102322,15 @@ sLI
 chr
 qhF
 vXl
-jXq
+sJZ
 cjs
-tXV
+xiB
 jzY
 aSb
 vKT
 cnK
 cjX
-cmx
+rNr
 cqt
 rRU
 myA
@@ -101420,7 +102347,7 @@ fQw
 cCj
 cDp
 fiZ
-xCZ
+vLK
 pSf
 xDU
 iqt
@@ -101471,7 +102398,7 @@ bcc
 diQ
 dTH
 rdd
-dEo
+qSk
 dEn
 dEn
 dEn
@@ -101864,7 +102791,7 @@ chs
 cia
 sHs
 sbo
-yjS
+vUI
 kof
 ckM
 yjS
@@ -102097,15 +103024,15 @@ vis
 chr
 dBN
 dnP
-jXq
+sJZ
 cjs
 cjZ
-ckN
+xFV
 vGw
 ckN
 ckN
 uXz
-cpG
+ivi
 cqw
 uHP
 kTu
@@ -102331,7 +103258,7 @@ cgN
 cht
 ilz
 cix
-sDT
+tpl
 cjv
 cka
 cka
@@ -102340,7 +103267,7 @@ cka
 cka
 cka
 cpH
-jVC
+aLr
 crL
 cpH
 ctW
@@ -102348,7 +103275,7 @@ ctX
 ctX
 ctX
 ctX
-cyd
+kHQ
 cyW
 ctX
 ctX
@@ -102565,7 +103492,7 @@ cgN
 chu
 ciu
 chr
-ciU
+tqQ
 cjv
 ckb
 ckb
@@ -102576,7 +103503,7 @@ cka
 cpI
 jVC
 lFU
-crM
+dAi
 ctX
 cuY
 cvT
@@ -102593,7 +103520,7 @@ cEy
 oyT
 cGg
 oaD
-cHc
+hOW
 cEG
 cJC
 cKu
@@ -102810,7 +103737,7 @@ cka
 cpI
 qPy
 rKM
-crM
+dAi
 ctX
 cuZ
 jZX
@@ -103044,7 +103971,7 @@ cka
 cpJ
 oDZ
 lFU
-crM
+dAi
 ctX
 cva
 iZW
@@ -103278,7 +104205,7 @@ coT
 aaQ
 oob
 vFD
-csR
+iwz
 ctW
 ctW
 ctW
@@ -103362,7 +104289,7 @@ rCV
 rCV
 rCV
 dKM
-cAY
+dJE
 dEZ
 dHe
 dHe
@@ -103512,7 +104439,7 @@ cka
 cpL
 obg
 uZc
-csS
+xFY
 ctY
 cvb
 cvb
@@ -103529,7 +104456,7 @@ lJv
 cFp
 qQz
 gQZ
-cHc
+hOW
 cEG
 cJF
 sAK
@@ -103997,7 +104924,7 @@ sfs
 cFq
 nnh
 cHc
-cHc
+hOW
 cIH
 cJG
 cKx
@@ -104211,10 +105138,10 @@ ckg
 ckg
 ckg
 cka
-yiG
+vTS
 cqA
 lFU
-csT
+hCN
 ctY
 gOd
 cvW
@@ -104445,7 +105372,7 @@ cjy
 cjy
 cjy
 cjy
-cpM
+hiL
 cqA
 uZc
 wiU
@@ -104679,10 +105606,10 @@ vFv
 cmB
 vGI
 cjy
-yiG
-cqA
+vTS
+fqE
 jXN
-lFU
+vuh
 ctY
 gOd
 cvW
@@ -104704,7 +105631,7 @@ cIJ
 cJG
 iIq
 tCs
-cLY
+hwP
 cLY
 fkJ
 uam
@@ -104895,7 +105822,7 @@ kMb
 kMb
 pLT
 dLT
-ccO
+rmX
 caH
 cen
 cdw
@@ -104929,11 +105856,11 @@ cAt
 miO
 cCu
 cDu
-cEC
+xLg
 jfe
 rHt
 cHc
-cHc
+hOW
 cIH
 cJG
 cKx
@@ -105167,7 +106094,7 @@ cED
 xId
 raS
 cHf
-cHc
+hOW
 cHL
 cHL
 cHL
@@ -105381,7 +106308,7 @@ cjy
 cjy
 cjy
 cjy
-yiG
+vTS
 fSC
 uZc
 crM
@@ -105398,7 +106325,7 @@ cBt
 cCw
 cDu
 fGe
-ykT
+hxK
 sKY
 cHg
 eeh
@@ -105632,7 +106559,7 @@ cyp
 cyp
 cyp
 cEG
-ykT
+hxK
 eEW
 cEG
 cHL
@@ -106081,7 +107008,7 @@ qyf
 tdo
 hUR
 oKU
-oKU
+sas
 kSk
 qhj
 nbC
@@ -106099,7 +107026,7 @@ tPv
 nZu
 nZu
 nZu
-nZu
+dWr
 sDZ
 xxp
 cHi
@@ -106321,8 +107248,8 @@ lov
 wDK
 sjB
 csV
-cud
-vMO
+oEq
+hLc
 qsI
 dGG
 pgB
@@ -106338,10 +107265,10 @@ gZj
 cGq
 cxH
 cHL
-cIK
-cIK
+lrS
+lrS
 cKC
-cIK
+lrS
 cHL
 cMZ
 cNH
@@ -106551,7 +107478,7 @@ ffv
 qmn
 ckk
 coU
-cpL
+lFG
 iTe
 pBn
 csT
@@ -106559,14 +107486,14 @@ cub
 qCS
 cwd
 cwV
-cxH
-cvg
+ykV
+eyh
 cze
 qCS
-cvg
-cvg
+eyh
+eyh
 qCS
-cvg
+eyh
 cwd
 tyj
 aHL
@@ -106578,7 +107505,7 @@ cHL
 cHL
 cHL
 cNa
-cNH
+wxe
 jzi
 lYq
 cJG
@@ -106783,9 +107710,9 @@ tTs
 hZn
 tTR
 noh
-cjG
+tHQ
 cjy
-yiG
+vTS
 iTe
 pBn
 crM
@@ -107019,7 +107946,7 @@ wef
 tTR
 cnQ
 cjy
-cpM
+hiL
 iTe
 mEm
 csR
@@ -107251,9 +108178,9 @@ tUy
 xmk
 wdR
 uZW
-ceZ
+sIi
 coU
-yiG
+vTS
 iTe
 pBn
 crM
@@ -107485,9 +108412,9 @@ tUy
 fYM
 yhy
 cmF
-cjG
+tHQ
 coU
-yiG
+vTS
 iTe
 iyZ
 lFU
@@ -107503,7 +108430,7 @@ dre
 cBx
 cBx
 dyW
-tih
+oZV
 cEM
 dPD
 nVv
@@ -107719,9 +108646,9 @@ tUy
 dCw
 scl
 gNX
-cjG
+tHQ
 coU
-yiG
+vTS
 eLs
 mEm
 lFU
@@ -107748,7 +108675,7 @@ cKE
 cLp
 cHN
 cHO
-cIP
+tGp
 rxq
 cHO
 cHN
@@ -107953,7 +108880,7 @@ fpC
 ckZ
 ubw
 cjG
-cjG
+tHQ
 coU
 yiG
 xwW
@@ -107971,7 +108898,7 @@ cBy
 cBy
 cCy
 czf
-cEM
+tjO
 jre
 lKI
 cHj
@@ -107984,7 +108911,7 @@ cHN
 wTF
 cIP
 ipq
-cLp
+viE
 cPP
 cLu
 cAe
@@ -108183,10 +109110,10 @@ chZ
 jXq
 ciV
 smf
-tTR
+xpp
 hvk
-tTR
-cjG
+xpp
+tHQ
 nlW
 cjy
 cpM
@@ -108439,7 +109366,7 @@ cAB
 cAB
 cAB
 cAB
-cEM
+tjO
 uis
 oYY
 uJs
@@ -108652,7 +109579,7 @@ iMk
 cjT
 cjT
 cjT
-cjT
+bNV
 cjT
 mbd
 cjT
@@ -108677,7 +109604,7 @@ kug
 pAz
 tTo
 flo
-cHQ
+uEU
 cHQ
 cHQ
 cKH
@@ -108886,7 +109813,7 @@ cdw
 cdw
 cdw
 hgO
-cdw
+vaU
 cdw
 cdw
 cdw
@@ -108919,7 +109846,7 @@ cJM
 ppA
 nzH
 cJM
-cJM
+fbY
 dTp
 cPS
 gNh
@@ -109609,7 +110536,7 @@ cAG
 cAG
 cAG
 cAG
-cEM
+tjO
 tyj
 cGt
 vMx
@@ -109843,7 +110770,7 @@ cpz
 nSN
 nSN
 cDA
-cEM
+tjO
 jre
 jXv
 snM
@@ -110060,11 +110987,11 @@ aMz
 vfH
 mrv
 aNh
-aNh
+dPi
 ceX
 acN
 jiY
-caH
+ckK
 rCV
 rCV
 rCV
@@ -110295,10 +111222,10 @@ sqC
 aNh
 aNh
 aMz
-caH
-cbD
-jXq
-lDe
+ckK
+vAa
+kAc
+eOh
 aOG
 rCV
 rCV
@@ -110533,7 +111460,7 @@ aMz
 iEU
 jXq
 aYE
-cdv
+wyH
 rCV
 rCV
 rCV
@@ -110767,9 +111694,9 @@ aNC
 cbD
 jXq
 caH
-cdw
+pTo
 aOG
-cOk
+cLJ
 rCV
 rCV
 rCV
@@ -110779,10 +111706,10 @@ iHA
 iHA
 rJm
 cAG
-cEM
-cEM
-jXv
-snM
+tjO
+tjO
+pBO
+eyW
 cub
 cIX
 cJN
@@ -111003,8 +111930,8 @@ jXq
 caH
 jEa
 cdv
-cOk
-cOk
+cLJ
+cLJ
 rCV
 rCV
 rCV
@@ -111239,7 +112166,7 @@ cdw
 cdw
 cdv
 utM
-cOk
+cLJ
 rCV
 rCV
 rCV
@@ -111473,8 +112400,8 @@ cdw
 owP
 cdw
 xaO
-cdv
-cOk
+wyH
+cLJ
 rCV
 rCV
 rCV
@@ -111709,9 +112636,9 @@ cdw
 coI
 cdw
 oHC
-cer
-cer
-cer
+rkJ
+rkJ
+rkJ
 rCV
 nXY
 cDF
@@ -111929,11 +112856,11 @@ aYE
 caH
 lDe
 caH
-caH
+pHL
 aYE
 caH
 caH
-caH
+pHL
 cbD
 jXq
 lDe
@@ -111942,7 +112869,7 @@ caH
 caH
 caH
 caH
-caH
+pHL
 caH
 fPP
 caH
@@ -112163,11 +113090,11 @@ cjT
 him
 him
 mbd
-cjT
+bNV
 cjT
 cjT
 mbd
-cjT
+bNV
 sgm
 cbG
 cbH
@@ -112176,7 +113103,7 @@ cbH
 cbH
 dgl
 cbH
-cbH
+ekU
 cbH
 brz
 brz
@@ -112187,7 +113114,7 @@ brz
 brz
 wSU
 brz
-brz
+izy
 brz
 brz
 bWD
@@ -112421,7 +113348,7 @@ ohd
 iaj
 yhu
 ohd
-bnA
+vpC
 bnA
 bnA
 ltO
@@ -112651,11 +113578,11 @@ aUU
 lsJ
 aUU
 aUU
-bjV
-bjV
+exd
+exd
 bCK
-bjV
-bjV
+exd
+exd
 bKI
 bnA
 bFF
@@ -113882,33 +114809,33 @@ cXw
 dbQ
 duD
 del
-dwJ
+lFt
 mcz
-dwJ
+lFt
 lby
-dAD
-dBy
+voG
+hDJ
 dCg
-dBy
+hDJ
 dCg
-dBy
+hDJ
 dCg
-dBy
+hDJ
 dCg
-dBy
+hDJ
 dCg
-dIk
+opA
 dyt
 wNu
 dWp
-dJG
-dJG
+wbL
+wbL
 dCV
-dJG
-dIk
-rCV
-rCV
-rCV
+wbL
+opA
+uaV
+uaV
+sxq
 rCV
 acu
 "}
@@ -114112,14 +115039,14 @@ pRI
 jqE
 ras
 cto
-crW
+sZv
 cUc
-hjo
-kGF
-xFV
+cko
+cko
+daO
 ppQ
 ppQ
-hSB
+dzs
 ppQ
 eRw
 eRw
@@ -114132,17 +115059,17 @@ eRw
 eRw
 eRw
 kjf
-mpj
-mpj
-mpj
-mpj
-mpj
-mpj
-mpj
-mpj
-uaV
-ghJ
+dIk
+dIk
+dIk
+dIk
+dIk
+dIk
+dIk
+dIk
 rCV
+rCV
+sxq
 rCV
 acu
 "}
@@ -114348,7 +115275,7 @@ ncv
 cmb
 cXx
 ojA
-hjo
+cko
 xLK
 xLK
 xLK
@@ -114375,8 +115302,8 @@ rCV
 rCV
 rCV
 rCV
-ghJ
 rCV
+sxq
 rCV
 acu
 "}
@@ -114580,9 +115507,9 @@ dpJ
 veQ
 hji
 hqD
-cok
+iLI
 mEf
-pOE
+cok
 hXU
 hXU
 hXU
@@ -114609,8 +115536,8 @@ rCV
 rCV
 rCV
 rCV
-ghJ
 rCV
+sxq
 rCV
 acu
 "}
@@ -114814,9 +115741,9 @@ wFp
 mDV
 crX
 cmN
+ptm
 cod
 cod
-xiB
 mmS
 mmS
 bEW
@@ -114843,8 +115770,8 @@ rCV
 rCV
 rCV
 rCV
-ghJ
 rCV
+sxq
 rCV
 acu
 "}
@@ -115048,9 +115975,9 @@ dpL
 cto
 crW
 rVj
-cpZ
+mYc
 csi
-ghJ
+rCV
 fYm
 fYm
 fYm
@@ -115077,8 +116004,8 @@ rCV
 rCV
 rCV
 rCV
-ghJ
 rCV
+sxq
 rCV
 acu
 "}
@@ -115282,9 +116209,9 @@ dpI
 cto
 crW
 cmN
-ctm
+goB
 rCV
-ghJ
+rCV
 fYm
 vLM
 gKP
@@ -115311,8 +116238,8 @@ wsw
 wsw
 rCV
 rCV
-ghJ
 rCV
+sxq
 rCV
 acu
 "}
@@ -115516,9 +116443,9 @@ pRI
 jqE
 crW
 cmN
+sxq
 rCV
 rCV
-ghJ
 fYm
 fYm
 bDq
@@ -115545,8 +116472,8 @@ cNJ
 wsw
 wsw
 rCV
-ghJ
 rCV
+sxq
 rCV
 acu
 "}
@@ -115750,9 +116677,9 @@ dpI
 cto
 crW
 cmN
+sxq
 rCV
 rCV
-ghJ
 fYm
 bvq
 aSw
@@ -115779,8 +116706,8 @@ wsw
 pcA
 rCV
 rCV
-ghJ
 rCV
+sxq
 rCV
 acu
 "}
@@ -115984,9 +116911,9 @@ dpI
 cto
 crW
 rVj
+sxq
 rCV
 rCV
-ghJ
 fYm
 bRB
 tMH
@@ -116013,8 +116940,8 @@ iBL
 iBL
 rCV
 rCV
-ghJ
 rCV
+sxq
 rCV
 acu
 "}
@@ -116218,9 +117145,9 @@ qdp
 jqE
 crW
 cvw
+sxq
 rCV
 rCV
-ghJ
 fYm
 hwW
 aSw
@@ -116247,8 +117174,8 @@ kPt
 rCV
 rCV
 rCV
-ghJ
 rCV
+sxq
 rCV
 acu
 "}
@@ -116452,9 +117379,9 @@ dpI
 cto
 crW
 ctm
+sxq
 rCV
 rCV
-ghJ
 fYm
 krW
 hvV
@@ -116481,8 +117408,8 @@ xLK
 xLK
 lZG
 rCV
-ghJ
 rCV
+sxq
 rCV
 acu
 "}
@@ -116686,9 +117613,9 @@ dpI
 cto
 crW
 ctm
+sxq
 rCV
 rCV
-ghJ
 fYm
 xJg
 aUt
@@ -116715,8 +117642,8 @@ xLK
 xLK
 lUB
 wsw
-ghJ
 rCV
+sxq
 rCV
 acu
 "}
@@ -116920,9 +117847,9 @@ pRI
 jqE
 pom
 ctm
+sxq
 rCV
 rCV
-ghJ
 rCV
 wsw
 rCV
@@ -116949,8 +117876,8 @@ xLK
 xLK
 xLK
 lUB
-ghJ
 rCV
+sxq
 rCV
 acu
 "}
@@ -117154,9 +118081,9 @@ dpI
 cto
 crW
 ctm
+sxq
 rCV
 rCV
-ghJ
 rCV
 wsw
 wsw
@@ -117183,8 +118110,8 @@ xLK
 xLK
 xLK
 xLK
-ghJ
 rCV
+sxq
 rCV
 acu
 "}
@@ -117388,9 +118315,9 @@ dpI
 cto
 crW
 ctm
-cwu
+wgW
 rCV
-ghJ
+rCV
 iBL
 iBL
 fEE
@@ -117417,8 +118344,8 @@ xLK
 xLK
 xLK
 xLK
-ghJ
 rCV
+sxq
 rCV
 acu
 "}
@@ -117622,9 +118549,9 @@ pRI
 jqE
 crW
 fgI
+sxq
 rCV
-rCV
-aUY
+sHc
 nYf
 hXU
 hXU
@@ -117651,8 +118578,8 @@ hXU
 fJE
 pVD
 xLK
-bqs
-rCV
+lZG
+sxq
 rCV
 acu
 "}
@@ -117856,9 +118783,9 @@ gOn
 cto
 crW
 ctm
+sxq
 rCV
-rCV
-aVa
+fEE
 nFr
 izf
 rNW
@@ -117885,8 +118812,8 @@ iXJ
 nFr
 jIb
 xLK
-bqs
-wsw
+lZG
+wMD
 rCV
 acu
 "}
@@ -118090,9 +119017,9 @@ dpI
 cto
 crW
 pfV
-ctn
+kjP
 rCV
-ghJ
+rCV
 jpO
 gvo
 gvo
@@ -118119,8 +119046,8 @@ gvo
 hXz
 uop
 xLK
-bqs
-wsw
+lZG
+wMD
 rCV
 acu
 "}
@@ -118324,9 +119251,9 @@ pRI
 jqE
 crW
 aKm
-aKm
+usi
 rCV
-ghJ
+rCV
 mqF
 gvo
 gvo
@@ -118353,8 +119280,8 @@ gvo
 oVQ
 uop
 xLK
-oqC
-rCV
+lUB
+sxq
 rCV
 acu
 "}
@@ -118558,9 +119485,9 @@ dpI
 cto
 pom
 cvw
-aKm
+usi
 rCV
-ghJ
+rCV
 tbc
 gvo
 gvo
@@ -118587,8 +119514,8 @@ gvo
 hZm
 uop
 xLK
-tqQ
-rCV
+xLK
+sxq
 rCV
 acu
 "}
@@ -118703,12 +119630,12 @@ kMb
 kMb
 kMb
 bUN
-bwV
+kMb
 bAS
-afL
+skZ
 agJ
 qdS
-afL
+skZ
 avT
 avT
 agJ
@@ -118792,7 +119719,7 @@ dpI
 cto
 crW
 cvw
-aKm
+usi
 pfV
 jwg
 eYW
@@ -118821,8 +119748,8 @@ gvo
 ijn
 uop
 xLK
-lqU
-rCV
+hgC
+sxq
 rCV
 acu
 "}
@@ -119026,7 +119953,7 @@ wUy
 jqE
 crW
 dzG
-aKm
+usi
 xAV
 jwg
 aVA
@@ -119055,8 +119982,8 @@ gvo
 yhL
 uop
 xLK
-kfn
-wsw
+vrY
+wMD
 rCV
 acu
 "}
@@ -119260,9 +120187,9 @@ cUb
 cto
 crW
 cvw
-aKm
+usi
 cpZ
-vUI
+cwu
 mqF
 gvo
 gvo
@@ -119289,8 +120216,8 @@ gvo
 oVQ
 uop
 xLK
-bqs
-rCV
+lZG
+sxq
 rCV
 acu
 "}
@@ -119494,9 +120421,9 @@ cto
 cto
 crW
 cvw
-aKm
+usi
 fgI
-vUI
+cwu
 tbc
 gvo
 gvo
@@ -119523,8 +120450,8 @@ gvo
 hZm
 uop
 xLK
-bqs
-rCV
+lZG
+sxq
 rCV
 acu
 "}
@@ -119728,9 +120655,9 @@ wEO
 jqE
 crW
 cvw
-aKm
+usi
 mrx
-vUI
+cwu
 eYW
 gvo
 gvo
@@ -119757,8 +120684,8 @@ gvo
 ijn
 uop
 xLK
-bqs
-wsw
+lZG
+wMD
 rCV
 acu
 "}
@@ -119962,9 +120889,9 @@ cto
 cto
 crW
 dzG
-aKm
+usi
 ctm
-vUI
+cwu
 aVA
 gvo
 gvo
@@ -119991,8 +120918,8 @@ gvo
 yhL
 uop
 xLK
-oqC
-rCV
+lUB
+sxq
 rCV
 acu
 "}
@@ -120196,9 +121123,9 @@ qqa
 cto
 crW
 cvw
-aKm
+usi
 ctm
-vUI
+cwu
 ndY
 gvo
 gvo
@@ -120225,8 +121152,8 @@ gvo
 oVQ
 uop
 xLK
-tqQ
-rCV
+xLK
+sxq
 rCV
 acu
 "}
@@ -120403,36 +121330,36 @@ rCV
 rCV
 rCV
 rCV
-cmH
-qBG
-cmH
-cmH
-cmH
-cmH
-qBG
-cmH
-cmH
-cmH
-cmH
-cmH
-cmH
-czQ
-cmH
-cmH
+aKm
+kPN
+aKm
+aKm
+aKm
+aKm
+kPN
+aKm
+aKm
+aKm
+aKm
+aKm
+aKm
+evU
+aKm
+aKm
 rCV
 rCV
 rCV
 rCV
-cmH
-cmH
+aKm
+aKm
 cCH
 wEO
 jqE
 crW
 dzG
-fCL
+iyp
 lPn
-ghJ
+rCV
 tbc
 gvo
 gvo
@@ -120459,8 +121386,8 @@ gvo
 jKI
 fAg
 xLK
-ghJ
 rCV
+sxq
 rCV
 acu
 "}
@@ -120638,14 +121565,14 @@ rCV
 rCV
 rCV
 rCV
-cmH
+aKm
 rCV
 rCV
-cmH
-cpT
-cmH
-cmH
-cmH
+aKm
+tKg
+aKm
+aKm
+aKm
 rCV
 rCV
 rCV
@@ -120664,9 +121591,9 @@ cto
 cto
 crW
 cvw
-aKm
+usi
 rCV
-ghJ
+rCV
 nFr
 kVU
 tQm
@@ -120693,8 +121620,8 @@ vWw
 nFr
 jIb
 hgC
-ghJ
 rCV
+sxq
 rCV
 acu
 "}
@@ -120898,9 +121825,9 @@ cto
 cto
 crW
 cvw
+sxq
 rCV
 rCV
-ghJ
 bmQ
 mmS
 mmS
@@ -120927,8 +121854,8 @@ mmS
 fJE
 ttd
 jYe
-ghJ
 rCV
+sxq
 rCV
 acu
 "}
@@ -121132,9 +122059,9 @@ xHh
 jqE
 crY
 daT
+itq
 daT
-daT
-nxU
+ycz
 ycz
 ycz
 ycz
@@ -121161,8 +122088,8 @@ ycz
 ycz
 ycz
 ycz
-nxU
 ycz
+ifF
 vKS
 acu
 "}
@@ -121366,11 +122293,8 @@ cto
 cto
 cto
 kYD
-sfi
+pBY
 cto
-kfF
-dXU
-dXU
 qeH
 dXU
 dXU
@@ -121395,8 +122319,11 @@ dXU
 qeH
 dXU
 dXU
-kfF
+qeH
 dXU
+dXU
+qeH
+fPJ
 dXU
 acu
 "}
@@ -121600,14 +122527,8 @@ qqa
 cto
 cto
 dvb
+dFO
 cto
-cto
-skZ
-etF
-dXU
-xVv
-dXU
-dXU
 xVv
 etF
 dXU
@@ -121615,6 +122536,12 @@ xVv
 dXU
 dXU
 xVv
+etF
+dXU
+xVv
+dXU
+dXU
+xVv
 dXU
 etF
 xVv
@@ -121629,8 +122556,8 @@ dXU
 xVv
 etF
 dXU
-skZ
-dXU
+xVv
+fPJ
 dXU
 acu
 "}
@@ -121834,17 +122761,14 @@ cmb
 cmb
 sxN
 cmb
-sxN
+dhp
 cmb
-dBh
-aVd
-gXe
-gXe
 gXe
 aVd
 gXe
 gXe
 gXe
+aVd
 gXe
 gXe
 gXe
@@ -121863,7 +122787,10 @@ gXe
 gXe
 gXe
 gXe
-dBh
+gXe
+gXe
+gXe
+gXe
 wDc
 gXe
 acu
@@ -122068,9 +122995,9 @@ rCV
 rCV
 rCV
 rCV
+sxq
 rCV
-rCV
-rmX
+ebs
 ebs
 ebs
 ebs
@@ -122097,8 +123024,8 @@ xLK
 xLK
 gbX
 tZQ
-ghJ
 rCV
+sxq
 rCV
 acu
 "}
@@ -122302,9 +123229,9 @@ rCV
 rCV
 rCV
 rCV
+sxq
 rCV
 rCV
-ghJ
 rCV
 rCV
 rCV
@@ -122331,8 +123258,8 @@ oud
 oud
 rCV
 rCV
-ghJ
 rCV
+sxq
 rCV
 acu
 "}
@@ -122536,9 +123463,7 @@ rCV
 rCV
 rCV
 rCV
-rCV
-rCV
-ghJ
+sxq
 uaV
 uaV
 uaV
@@ -122550,23 +123475,25 @@ uaV
 uaV
 uaV
 uaV
-uaV
-uaV
-eBa
-eBa
-eBa
-eBa
 uaV
 uaV
 uaV
 uaV
 eBa
+eBa
+eBa
+eBa
 uaV
 uaV
 uaV
 uaV
-ghJ
-rCV
+eBa
+uaV
+uaV
+uaV
+uaV
+uaV
+sxq
 rCV
 acu
 "}


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It's time for Chigusa's yearly patch.
Here's a list of what's been changed/fixed.

-platforms have now proper junctions so they don't intersect awkwardly 
-fixed blue disk generator having a duplicate
-fixed xenos being able to build literally right next to LZ1
-gave xenos some more prebuilt resin structures
-adjusted shutters so marines can more easily fortify both LZs

## Why It's Good For The Game

Fixes good, bugs bad. Maybe the extra resin will help xenos survive for 5 minutes longer.

## Changelog
:cl:
balance: Chigusa now has some more prebuilt resin structures on Chigusa
balance: Chigusa LZs are slightly bigger so marines can build fortifications more easily.
fix: Chigusa LZ1 now has a proper building exclusion zone again.
fix: Removed the duplicate blue disk generator in Chigusa.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
