### PR TITLE
Add an update_icon() to the UV's

### DIFF
--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -176,6 +176,8 @@
 	playsound(loc, 'sound/weapons/guns/interact/smartgun_unload.ogg', 25, 1)
 	if(reload_ammo.current_rounds < 1)
 		qdel(reload_ammo)
+	update_icon()
+	hud_set_uav_ammo()
 
 /// Try to equip a turret on the vehicle
 /obj/vehicle/unmanned/proc/equip_turret(obj/item/I, mob/user)


### PR DESCRIPTION
## About The Pull Request
Reloading didn't update the visible ammo count. Now it does.

## Why It's Good For The Game
Clearer.

## Changelog
:cl:
fix: fix unmanned droids not having their ammo counter update until they were fired.
/:cl:
