### PR TITLE
Tell the AI if a turf is underground

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -191,7 +191,7 @@
 		TD.move_camera_by_click()
 
 /turf/AICtrlClick(mob/living/silicon/ai/user)
-	var/message = "Coordinates of selected turf at [loc]. COORDINATES: X:[x] Y:[y]"
+	var/message = "Rangefinding of selected turf at [loc]. COORDINATES: X:[x] Y:[y]"
 	var/area/A = get_area(src)
 	if(istype(A) && A.ceiling >= CEILING_UNDERGROUND)
 		message += " It is underground."


### PR DESCRIPTION
## About The Pull Request
The AI can get coordinates. It can't tell when the turf is underground.

## Why It's Good For The Game
No more fumbling with underground or not tiles. 

## Changelog
:cl:
qol: made it clear when a turf is underground or not
/:cl:
