### PR TITLE
Removes randomized starting nutrition for Marines/SOM

### DIFF
--- a/code/datums/jobs/job/marines.dm
+++ b/code/datums/jobs/job/marines.dm
@@ -12,7 +12,7 @@
 		return
 	var/mob/living/carbon/human/human_spawn = C
 	if(!(human_spawn.species.species_flags & ROBOTIC_LIMBS))
-		human_spawn.set_nutrition(250))
+		human_spawn.set_nutrition(250)
 	if(!human_spawn.assigned_squad)
 		CRASH("after_spawn called for a marine without an assigned_squad")
 	to_chat(M, {"\nYou have been assigned to: <b><font size=3 color=[human_spawn.assigned_squad.color]>[lowertext(human_spawn.assigned_squad.name)] squad</font></b>.

--- a/code/datums/jobs/job/marines.dm
+++ b/code/datums/jobs/job/marines.dm
@@ -11,8 +11,6 @@
 	if(!ishuman(C))
 		return
 	var/mob/living/carbon/human/human_spawn = C
-	if(!(human_spawn.species.species_flags & ROBOTIC_LIMBS))
-		human_spawn.set_nutrition(rand(60, 250))
 	if(!human_spawn.assigned_squad)
 		CRASH("after_spawn called for a marine without an assigned_squad")
 	to_chat(M, {"\nYou have been assigned to: <b><font size=3 color=[human_spawn.assigned_squad.color]>[lowertext(human_spawn.assigned_squad.name)] squad</font></b>.

--- a/code/datums/jobs/job/marines.dm
+++ b/code/datums/jobs/job/marines.dm
@@ -11,6 +11,8 @@
 	if(!ishuman(C))
 		return
 	var/mob/living/carbon/human/human_spawn = C
+	if(!(human_spawn.species.species_flags & ROBOTIC_LIMBS))
+		human_spawn.set_nutrition(250))
 	if(!human_spawn.assigned_squad)
 		CRASH("after_spawn called for a marine without an assigned_squad")
 	to_chat(M, {"\nYou have been assigned to: <b><font size=3 color=[human_spawn.assigned_squad.color]>[lowertext(human_spawn.assigned_squad.name)] squad</font></b>.

--- a/code/datums/jobs/job/sonsofmars.dm
+++ b/code/datums/jobs/job/sonsofmars.dm
@@ -31,7 +31,7 @@
 		return
 	var/mob/living/carbon/human/human_spawn = C
 	if(!(human_spawn.species.species_flags & ROBOTIC_LIMBS))
-		human_spawn.set_nutrition(250))
+		human_spawn.set_nutrition(250)
 	if(!human_spawn.assigned_squad)
 		CRASH("after_spawn called for a marine without an assigned_squad")
 	to_chat(M, {"\nYou have been assigned to: <b><font size=3 color=[human_spawn.assigned_squad.color]>[lowertext(human_spawn.assigned_squad.name)] squad</font></b>.

--- a/code/datums/jobs/job/sonsofmars.dm
+++ b/code/datums/jobs/job/sonsofmars.dm
@@ -30,6 +30,8 @@
 	if(!ishuman(C))
 		return
 	var/mob/living/carbon/human/human_spawn = C
+	if(!(human_spawn.species.species_flags & ROBOTIC_LIMBS))
+		human_spawn.set_nutrition(250))
 	if(!human_spawn.assigned_squad)
 		CRASH("after_spawn called for a marine without an assigned_squad")
 	to_chat(M, {"\nYou have been assigned to: <b><font size=3 color=[human_spawn.assigned_squad.color]>[lowertext(human_spawn.assigned_squad.name)] squad</font></b>.

--- a/code/datums/jobs/job/sonsofmars.dm
+++ b/code/datums/jobs/job/sonsofmars.dm
@@ -30,8 +30,6 @@
 	if(!ishuman(C))
 		return
 	var/mob/living/carbon/human/human_spawn = C
-	if(!(human_spawn.species.species_flags & ROBOTIC_LIMBS))
-		human_spawn.set_nutrition(rand(60, 250))
 	if(!human_spawn.assigned_squad)
 		CRASH("after_spawn called for a marine without an assigned_squad")
 	to_chat(M, {"\nYou have been assigned to: <b><font size=3 color=[human_spawn.assigned_squad.color]>[lowertext(human_spawn.assigned_squad.name)] squad</font></b>.


### PR DESCRIPTION
## About The Pull Request

Eliminates the random hunger system from marine spawning, starting marines and SOM at full nutrition levels.

## Why It's Good For The Game

I don't believe that anyone actually likes dealing with decreased spawning nutrition. It's a hinderance for exactly 20 seconds until you can make it to the marine food vendor and eat two nutrition bars, which is already an obstruction to round-start procedure - something you'll have to do, every single round, adding nothing but tedium.

Low starting nutrition is only noticeable if you _forget_ to manage it, and potentially debilitating if you do. Personally, I don't believe that possibility adds anything positive to the gameplay experience.

## Changelog
:cl:
qol: Marines and SOM no longer have randomized hunger on spawn
/:cl:
