### PR TITLE
Moves Thermal Dampening Tarp to Specialized Tab

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -121,6 +121,7 @@
 			/obj/item/ammo_magazine/flamer_tank/large = 30,
 			/obj/item/ammo_magazine/flamer_tank/backtank = 4,
 			/obj/item/jetpack_marine = 3,
+			/obj/item/bodybag/tarp = 10,
 		),
 		"Heavy Weapons" = list(
 			/obj/structure/closet/crate/mortar_ammo/mortar_kit = 1,
@@ -790,7 +791,6 @@
 			/obj/item/ammo_magazine/rocket/sadar = 3,
 			/obj/item/ammo_magazine/minigun_powerpack = 2,
 			/obj/item/ammo_magazine/shotgun/mbx900 = 2,
-			/obj/item/bodybag/tarp = 10,
 			/obj/item/explosive/plastique = 5,
 			/obj/item/fulton_extraction_pack = 2,
 			/obj/item/clothing/suit/storage/marine/harness/boomvest = 20,


### PR DESCRIPTION
## About The Pull Request

Moves the V1 Thermal Dampening Tarp out of the requisitions operations vendor, and into the Marine Armaments Vendor, Specialized tab.

## Why It's Good For The Game

Hardly anyone uses the V1 Tarp. Given this, whenever someone DOES wish to use one, they have to go out of their way to ask the RO to vend one of their _ten_ free tarps from the access-locked operations vendor.

Given the lack of usage, alongside the face that the tarp isn't overpowered or anything of that sort in practice, I don't see any reason that acquiring one should require two-factor RO verification.

## Changelog
:cl:
qol: Moves the V1 Thermal Dampening Tarp to the Marine Armaments Vendor, Specialized tab.
/:cl:
