### PR TITLE
Fixes supply drop console delay message

### DIFF
--- a/code/game/objects/machinery/squad_supply/supply_console.dm
+++ b/code/game/objects/machinery/squad_supply/supply_console.dm
@@ -178,4 +178,4 @@
 	for(var/obj/C in supplies)
 		var/turf/TC = locate(supply_beacon.drop_location.x + x_offset, supply_beacon.drop_location.y + y_offset, supply_beacon.drop_location.z)
 		C.forceMove(TC)
-	supply_pad.visible_message("[icon2html(supply_pad, viewers(src))] [span_boldnotice("Supply drop teleported! Another launch will be available in [launch_cooldown] seconds.")]")
+	supply_pad.visible_message("[icon2html(supply_pad, viewers(src))] [span_boldnotice("Supply drop teleported! Another launch will be available in [launch_cooldown/10] seconds.")]")


### PR DESCRIPTION
## About The Pull Request

Fixes the supply drop console delay message, which will now notify players that they will have a new drop available in _30_ seconds, not _300_.

## Why It's Good For The Game

Polishing.

## Changelog
:cl:
fix: Fixes supply drop console delay message.
/:cl:

