### PR TITLE
Replace POS AI Door with an opaque one

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -14807,7 +14807,9 @@
 /area/mainship/engineering/lower_engineering)
 "Qq" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/mainship/ai/glass,
+/obj/machinery/door/airlock/mainship/ai{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/airoom)
 "Qr" = (


### PR DESCRIPTION
## About The Pull Request
The POS AI core door is now a opaque.
This stops the AI from hearing the vending machines ads. 

## Why It's Good For The Game
Ads spam bad.

## Changelog
:cl:
qol: Made the AI unable to hear vending ads. 
/:cl:
