### PR TITLE
Revert "Remove untangle's 10 slowdown", but halves the slowdown and makes it apply when manually broken too.

### DIFF
--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -138,7 +138,7 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list( //Those networks can only be 
 #define RAZORWIRE_ENTANGLE_DELAY 5 SECONDS
 #define RAZORWIRE_SOAK 5
 #define RAZORWIRE_MAX_HEALTH 100
-#define RAZORWIRE_SLOWDOWN 10
+#define RAZORWIRE_SLOWDOWN 5
 #define RAZORWIRE_MIN_DAMAGE_MULT_LOW 0.4 //attacking
 #define RAZORWIRE_MAX_DAMAGE_MULT_LOW 0.6
 #define RAZORWIRE_MIN_DAMAGE_MULT_MED 0.8 //climbing into, disentangling or crusher charging it

--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -138,6 +138,7 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list( //Those networks can only be 
 #define RAZORWIRE_ENTANGLE_DELAY 5 SECONDS
 #define RAZORWIRE_SOAK 5
 #define RAZORWIRE_MAX_HEALTH 100
+#define RAZORWIRE_SLOWDOWN 10
 #define RAZORWIRE_MIN_DAMAGE_MULT_LOW 0.4 //attacking
 #define RAZORWIRE_MAX_DAMAGE_MULT_LOW 0.6
 #define RAZORWIRE_MIN_DAMAGE_MULT_MED 0.8 //climbing into, disentangling or crusher charging it

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -108,7 +108,7 @@
 /obj/structure/razorwire/proc/razorwire_untangle(mob/living/entangled)
 	SIGNAL_HANDLER
 	if((entangled.flags_pass & PASSSMALLSTRUCT) || entangled.status_flags & INCORPOREAL)
-		return
+		return FALSE
 	entangled.next_move_slowdown += RAZORWIRE_SLOWDOWN //big slowdown
 	do_razorwire_untangle(entangled)
 	visible_message(span_danger("[entangled] disentangles from [src]!"))
@@ -137,7 +137,9 @@
 
 /obj/structure/razorwire/Destroy()
 	for(var/i in entangled_list)
-		do_razorwire_untangle(i)
+		// sanity incase their flags_pass get changed while in barbed wire (wraith) and they're not liable to be untangled with damage
+		if(!razorwire_untangle(i))
+			do_razorwire_untangle(i)
 	return ..()
 
 

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -109,6 +109,7 @@
 	SIGNAL_HANDLER
 	if((entangled.flags_pass & PASSSMALLSTRUCT) || entangled.status_flags & INCORPOREAL)
 		return
+	entangled.next_move_slowdown += RAZORWIRE_SLOWDOWN //big slowdown
 	do_razorwire_untangle(entangled)
 	visible_message(span_danger("[entangled] disentangles from [src]!"))
 	playsound(src, 'sound/effects/barbed_wire_movement.ogg', 25, TRUE)


### PR DESCRIPTION
Reverts tgstation/TerraGov-Marine-Corps#10625

Why is this good for the game:
Crushers have crazy mobility, even if they get stuck in razorwire now. Razorwire should be extremly punishing , especially when they charge into it at maximum speed.
This is so they can't just instantly start charging back into cover , since they are extremly tanky by default.
This also makes it so breaking the razor-wire with tangled xenos in it still apllies untangle effects.
🆑 
balance: Barbed wire now provides slowdown once again on break-out
balance: Slashing barbed wire by yourself  now still provides slowdown on when its broken.
/🆑 