### PR TITLE
Gives the AI the ability cancel SD

### DIFF
--- a/code/game/objects/machinery/self_destruct.dm
+++ b/code/game/objects/machinery/self_destruct.dm
@@ -83,7 +83,7 @@
 			if(!isliving(usr))
 				return
 			var/mob/living/user = usr
-			if(!ismarinecommandjob(user.job))
+			if(!ismarinecommandjob(user.job) || isAI(user))
 				to_chat(usr, span_notice("You don't have the necessary clearance to cancel the emergency destruct system."))
 				return
 			if(SSevacuation.cancel_self_destruct())


### PR DESCRIPTION
## About The Pull Request
Cancelling the SD requires command level access. This PR gives the AI the ability to cancel it. If you ever want to. I can't see when you would, besides after round end. 

## Why It's Good For The Game
More consistency. 

## Changelog
:cl:
fix: Fix Ai not having SD cancelling privileges 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
