### PR TITLE
Anti-personnel landmines no longer trigger on dead mobs

### DIFF
--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -203,8 +203,8 @@ Stepping directly on the mine will also blow it up
 
 	if(linked_mine && isliving(A))
 		var/mob/living/unlucky_person = A
-		// Don't trigger for dead xenos
-		if(isxeno(unlucky_person) && unlucky_person.stat == DEAD)
+		// Don't trigger for dead people
+		if(unlucky_person.stat == DEAD)
 			return
 		linked_mine.trip_mine(A)
 

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -204,7 +204,7 @@ Stepping directly on the mine will also blow it up
 	if(linked_mine && isliving(A))
 		var/mob/living/unlucky_person = A
 		// Don't trigger for dead xenos
-		if(isxeno(A) && A.stat == DEAD)
+		if(isxeno(unlucky_person) && unlucky_person.stat == DEAD)
 			return
 		linked_mine.trip_mine(A)
 

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -202,6 +202,10 @@ Stepping directly on the mine will also blow it up
 		return
 
 	if(linked_mine && isliving(A))
+		var/mob/living/unlucky_person = A
+		// Don't trigger for dead xenos
+		if(isxeno(A) && A.stat == DEAD)
+			return
 		linked_mine.trip_mine(A)
 
 /// PMC specific mine, with IFF for PMC units


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Any mob thats dead can no longer trigger landmines

## Why It's Good For The Game
The amount of times i've seen people blow themselves trying to sell dead xenos and walking through a mind-field is unreal.
I don't see why we should keep this either , it only serves to make landmines even worse(like they aren't already quite niche and weak)


## Changelog
:cl:
balance: Anti-personnel landmines no longer get triggered by dead mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
