### PR TITLE
AI knows dropship points & nb of live marines

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -353,8 +353,14 @@
 
 		stat("Current supply points:", "[round(SSpoints.supply_points[FACTION_TERRAGOV])]")
 
+		stat("Current dropship points:", "[round(SSpoints.dropship_points)]")
+
 		stat("Current alert level:", "[GLOB.marine_main_ship.get_security_level()]")
 
+		var/Ship[] = SSticker.mode.count_humans_and_xenos()
+		var/ShipMarines[] = Ship[1]
+	
+		stat("Number of living marines:", "[ShipMarines]")
 
 
 /mob/living/silicon/ai/fully_replace_character_name(oldname, newname)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -360,7 +360,7 @@
 		var/Ship[] = SSticker.mode.count_humans_and_xenos()
 		var/ShipMarines[] = Ship[1]
 	
-		stat("Number of living marines:", "[ShipMarines]")
+		stat("Number of living marines:", "[SSticker.mode.count_humans_and_xenos()[1]")
 
 
 /mob/living/silicon/ai/fully_replace_character_name(oldname, newname)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -356,9 +356,6 @@
 		stat("Current dropship points:", "[round(SSpoints.dropship_points)]")
 
 		stat("Current alert level:", "[GLOB.marine_main_ship.get_security_level()]")
-
-		var/Ship[] = SSticker.mode.count_humans_and_xenos()
-		var/ShipMarines[] = Ship[1]
 	
 		stat("Number of living marines:", "[SSticker.mode.count_humans_and_xenos()[1]]")
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -360,7 +360,7 @@
 		var/Ship[] = SSticker.mode.count_humans_and_xenos()
 		var/ShipMarines[] = Ship[1]
 	
-		stat("Number of living marines:", "[SSticker.mode.count_humans_and_xenos()[1]")
+		stat("Number of living marines:", "[SSticker.mode.count_humans_and_xenos()[1]]")
 
 
 /mob/living/silicon/ai/fully_replace_character_name(oldname, newname)


### PR DESCRIPTION
## About The Pull Request
This PR gives the AI more stuff in their game tab.
Dropship points are something you might want to know, and they are basically the same as supply points.
Living marines count is quite useful. The code was stolen from the communications console. 

## Why It's Good For The Game
More tools for command to use.

## Changelog
:cl:
add: AI knows dropship points & number of living marines
/:cl:

