### PR TITLE
Add mounted gun rotation info

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1058,7 +1058,7 @@
 
 /obj/item/storage/box/visual/magazine/compact/heavymachinegun
 	name = "HMG-08 drum box"
-	desc = "A box specifically designed to hold a large amount ofHMG-08 drum."
+	desc = "A box specifically designed to hold a large amount of HMG-08 drum."
 	storage_slots = 30
 	closed_overlay = "mag_box_small_overlay_mg08"
 	can_hold = list(

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -533,7 +533,7 @@
 			. += span_notice("Use Ctrl-Click on a tile to deploy.")
 		return
 	if(!CHECK_BITFIELD(flags_item, DEPLOYED_NO_ROTATE))
-		. += span_notice("Right Click on a nearby tile to aim rotate towards it.")
+		. += span_notice("Left or Right Click on a nearby tile to aim towards it.")
 		return
 	. += span_notice("Click-Drag to yourself to undeploy.")
 	. += span_notice("Alt-Click to unload.")

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -532,6 +532,9 @@
 		if(CHECK_BITFIELD(flags_item, IS_DEPLOYABLE))
 			. += span_notice("Use Ctrl-Click on a tile to deploy.")
 		return
+	if(!CHECK_BITFIELD(flags_item, DEPLOYED_NO_ROTATE))
+		. += span_notice("Right Click on a nearby tile to aim rotate towards it.")
+		return
 	. += span_notice("Click-Drag to yourself to undeploy.")
 	. += span_notice("Alt-Click to unload.")
 	. += span_notice("Right-Click to perform the guns unique action.")


### PR DESCRIPTION
## About The Pull Request
Rotating a gun like HSG or MG-08 takes right click, but it isn't clear how you do it in game.
This PR adds a little description on examine. 

## Why It's Good For The Game
Better description good.

## Changelog
:cl:
qol: Better description for Mounted guns. 
/:cl:
