### PR TITLE
Resin door build time and plasma costs reduced

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -228,8 +228,6 @@
 	switch(X.selected_resin)
 		if(/obj/alien/resin/sticky)
 			build_resin_modifier = 0.5
-		if(/obj/structure/mineral_door/resin)
-			build_resin_modifier = 2
 
 	return (base_wait + scaling_wait - max(0, (scaling_wait * X.health / X.maxHealth))) * build_resin_modifier
 
@@ -328,8 +326,6 @@
 	switch(X.selected_resin)
 		if(/obj/alien/resin/sticky)
 			plasma_cost = initial(plasma_cost) / 3
-		if(/obj/structure/mineral_door/resin)
-			plasma_cost = initial(plasma_cost) * 3
 
 	if(new_resin)
 		add_cooldown(SSmonitor.gamestate == SHUTTERS_CLOSED ? get_cooldown()/2 : get_cooldown())


### PR DESCRIPTION
## About The Pull Request
Per title. These two stats been brought in line with resin wall stats.

## Why It's Good For The Game
Resin doors got smacked really bad between durability nerfs and building costs.
This PR aims to amend that by reducing the building costs, since the durability nerfs were already enough.

## Changelog
:cl: Lewdcifer
balance: Resin door build time and plasma costs reduced (same as resin walls).
/:cl: