### PR TITLE
Gelida balance changes

### DIFF
--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -10600,13 +10600,13 @@
 /area/gelida/outdoors/colony_streets/south_west_street)
 "gHe" = (
 /obj/machinery/button/door/open_only/landing_zone/lz2,
-/obj/structure/window/reinforced/extratoughened{
+/obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
-/obj/structure/window/reinforced/extratoughened{
+/obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
-/obj/structure/window/reinforced/toughened,
+/obj/structure/window/reinforced,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/landing_zone_1)
 "gHj" = (
@@ -12985,11 +12985,11 @@
 /obj/machinery/button/door/open_only/landing_zone{
 	dir = 8
 	},
-/obj/structure/window/reinforced/extratoughened,
-/obj/structure/window/reinforced/extratoughened{
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
 	dir = 1
 	},
-/obj/structure/window/reinforced/toughened{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/open/floor/prison/darkbrown/full,

--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -442,7 +442,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
 "aof" = (
-/obj/structure/prop/vehicle/truck{
+/obj/structure/prop/vehicle/truck/destructible{
 	dir = 8;
 	layer = 3.2
 	},
@@ -1499,7 +1499,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
 "aWS" = (
-/obj/structure/prop/vehicle/van{
+/obj/structure/prop/vehicle/van/destructible{
 	layer = 3.1
 	},
 /turf/open/floor/plating,
@@ -2785,7 +2785,7 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
 "bLJ" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck/destructible,
 /turf/open/floor/plating/ground/fakesnow/alt,
 /area/gelida/outdoors/colony_streets/south_street)
 "bMh" = (
@@ -5490,7 +5490,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
 "dtu" = (
-/obj/structure/prop/vehicle/truck{
+/obj/structure/prop/vehicle/truck/destructible{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -5894,7 +5894,7 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/bridges/garden_bridge)
 "dGU" = (
-/obj/structure/prop/vehicle/crane/cranecargo,
+/obj/structure/prop/vehicle/crane/cranecargo/destructible,
 /turf/open/floor/prison,
 /area/gelida/indoors/lone_buildings/storage_blocks)
 "dHe" = (
@@ -6607,7 +6607,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/landing_zone_2)
 "ebK" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck/destructible,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
 	},
@@ -7261,7 +7261,7 @@
 	},
 /area/gelida/indoors/a_block/dorm_north)
 "ewh" = (
-/obj/structure/prop/vehicle/crane,
+/obj/structure/prop/vehicle/crane/destructible,
 /obj/structure/platform/gelida,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/garage)
@@ -8063,7 +8063,7 @@
 /turf/open/floor/tile/dark2,
 /area/gelida/indoors/c_block/mining)
 "eVp" = (
-/obj/structure/prop/vehicle/truck{
+/obj/structure/prop/vehicle/truck/destructible{
 	layer = 3.1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -10099,7 +10099,7 @@
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/c_block/mining)
 "gpA" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck/destructible,
 /turf/open/floor/plating/ground/fakesnow/alt,
 /area/gelida/outdoors/colony_streets/east_central_street)
 "gpR" = (
@@ -11334,7 +11334,7 @@
 /area/gelida/landing_zone_2)
 "hfD" = (
 /obj/item/stack/sheet/metal,
-/obj/structure/prop/vehicle/truck{
+/obj/structure/prop/vehicle/truck/destructible{
 	dir = 8;
 	layer = 3.2
 	},
@@ -11343,7 +11343,7 @@
 	},
 /area/gelida/outdoors/colony_streets/east_central_street)
 "hfL" = (
-/obj/structure/prop/vehicle/truck{
+/obj/structure/prop/vehicle/truck/destructible{
 	dir = 8;
 	layer = 3.1;
 	pixel_x = 6;
@@ -11591,7 +11591,7 @@
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/medical)
 "hmd" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck/destructible,
 /turf/open/floor/plating/ground/fakesnow,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "hmm" = (
@@ -13689,7 +13689,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
 "iBR" = (
-/obj/structure/prop/vehicle/truck{
+/obj/structure/prop/vehicle/truck/destructible{
 	dir = 8;
 	layer = 3.1;
 	pixel_x = 5;
@@ -14250,7 +14250,7 @@
 /turf/closed/wall,
 /area/gelida/indoors/a_block/kitchen)
 "iVJ" = (
-/obj/structure/prop/vehicle/truck{
+/obj/structure/prop/vehicle/truck/destructible{
 	layer = 3.1
 	},
 /turf/open/floor/prison,
@@ -14598,7 +14598,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/casino)
 "jhc" = (
-/obj/structure/prop/vehicle/truck{
+/obj/structure/prop/vehicle/truck/destructible{
 	dir = 8;
 	layer = 3.1;
 	pixel_x = 6;
@@ -15392,7 +15392,7 @@
 /turf/open/floor/prison/cleanmarked,
 /area/gelida/indoors/lone_buildings/storage_blocks)
 "jMq" = (
-/obj/structure/prop/vehicle/truck{
+/obj/structure/prop/vehicle/truck/destructible{
 	dir = 8;
 	layer = 3.1
 	},
@@ -15979,7 +15979,7 @@
 	},
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
 "kdQ" = (
-/obj/structure/prop/vehicle/truck/truckcargo,
+/obj/structure/prop/vehicle/truck/truckcargo/destructible,
 /turf/open/floor/plating/ground/fakesnow,
 /area/gelida/landing_zone_2)
 "kdS" = (
@@ -16746,7 +16746,7 @@
 /obj/structure/fakeplatform{
 	dir = 1
 	},
-/obj/structure/prop/vehicle/truck{
+/obj/structure/prop/vehicle/truck/destructible{
 	layer = 3.1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
@@ -20963,7 +20963,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/dorms)
 "nrX" = (
-/obj/structure/prop/vehicle/truck{
+/obj/structure/prop/vehicle/truck/destructible{
 	layer = 3.2
 	},
 /turf/open/floor/plating/ground/snow/layer0,
@@ -21618,7 +21618,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "nLz" = (
-/obj/structure/prop/vehicle/crane{
+/obj/structure/prop/vehicle/crane/destructible{
 	dir = 1;
 	pixel_x = -10;
 	pixel_y = 6
@@ -24325,7 +24325,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/central_streets)
 "pxr" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck/destructible,
 /turf/open/floor/plating,
 /area/gelida/caves/west_caves)
 "pxX" = (
@@ -25726,7 +25726,7 @@
 /turf/closed/ice_rock/eastWall,
 /area/gelida/outdoors/rock)
 "qol" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck/destructible,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/w_rockies)
 "qoG" = (
@@ -27371,7 +27371,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/east_central_street)
 "rlW" = (
-/obj/structure/prop/vehicle/crane,
+/obj/structure/prop/vehicle/crane/destructible,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "rmn" = (
@@ -27898,7 +27898,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/mining)
 "rFx" = (
-/obj/structure/prop/vehicle/truck,
+/obj/structure/prop/vehicle/truck/destructible,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "rFU" = (
@@ -30651,7 +30651,7 @@
 /turf/open/floor/plating/ground/fakesnow,
 /area/gelida/outdoors/colony_streets/south_west_street)
 "tpP" = (
-/obj/structure/prop/vehicle/truck{
+/obj/structure/prop/vehicle/truck/destructible{
 	dir = 8;
 	layer = 3.1
 	},
@@ -31366,7 +31366,7 @@
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/a_block/fitness)
 "tQB" = (
-/obj/structure/prop/vehicle/crane,
+/obj/structure/prop/vehicle/crane/destructible,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "tQN" = (
@@ -32004,7 +32004,7 @@
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/a_block/admin)
 "ulW" = (
-/obj/structure/prop/vehicle/truck{
+/obj/structure/prop/vehicle/truck/destructible{
 	dir = 8;
 	layer = 3.2
 	},
@@ -32191,7 +32191,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/a_block/medical)
 "usn" = (
-/obj/structure/prop/vehicle/truck{
+/obj/structure/prop/vehicle/truck/destructible{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/snow/layer0,
@@ -33100,7 +33100,7 @@
 	},
 /area/gelida/indoors/a_block/hallway)
 "uZC" = (
-/obj/structure/prop/vehicle/truck{
+/obj/structure/prop/vehicle/truck/destructible{
 	layer = 3.1
 	},
 /turf/open/floor/plating,
@@ -34228,7 +34228,7 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/b_block/bar)
 "vIq" = (
-/obj/structure/prop/vehicle/crawler,
+/obj/structure/prop/vehicle/crawler/destructible,
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/north_street)
 "vIE" = (
@@ -34893,7 +34893,7 @@
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/medical)
 "wfe" = (
-/obj/structure/prop/vehicle/truck{
+/obj/structure/prop/vehicle/truck/destructible{
 	layer = 3.1
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -37460,7 +37460,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/kitchen)
 "xQR" = (
-/obj/structure/prop/vehicle/crawler,
+/obj/structure/prop/vehicle/crawler/destructible,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/outdoors/colony_streets/north_street)
 "xQT" = (
@@ -37499,7 +37499,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
 "xRD" = (
-/obj/structure/prop/vehicle/crane,
+/obj/structure/prop/vehicle/crane/destructible,
 /obj/effect/spawner/random/toolbox{
 	pixel_y = 16
 	},
@@ -37596,7 +37596,7 @@
 	},
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
 "xUg" = (
-/obj/structure/prop/vehicle/crane/cranecargo,
+/obj/structure/prop/vehicle/crane/cranecargo/destructible,
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "xUp" = (
@@ -37941,7 +37941,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/east_central_street)
 "ygI" = (
-/obj/structure/prop/vehicle/crane{
+/obj/structure/prop/vehicle/crane/destructible{
 	dir = 1
 	},
 /turf/open/floor/prison,

--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -4012,7 +4012,7 @@
 /obj/structure/platform_decoration{
 	dir = 4
 	},
-/turf/open/floor/plating/ground/fakesnow/alt,
+/turf/closed/mineral/smooth/snowrock,
 /area/gelida/outdoors/colony_streets/south_west_street)
 "cBH" = (
 /obj/effect/turf_overlay/icerock,
@@ -4984,7 +4984,7 @@
 /obj/structure/platform_decoration{
 	dir = 10
 	},
-/turf/open/floor/plating/ground/snow/layer0,
+/turf/closed/mineral/smooth/snowrock,
 /area/gelida/outdoors/colony_streets/south_west_street)
 "ddH" = (
 /obj/effect/ai_node,
@@ -10596,7 +10596,7 @@
 /obj/structure/platform_decoration{
 	dir = 5
 	},
-/turf/open/floor/plating/ground/fakesnow,
+/turf/closed/mineral/smooth/snowrock,
 /area/gelida/outdoors/colony_streets/south_west_street)
 "gHe" = (
 /obj/machinery/button/door/open_only/landing_zone/lz2,
@@ -13841,7 +13841,7 @@
 	dir = 4
 	},
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/plating/ground/snow/layer0,
+/turf/closed/mineral/smooth/snowrock,
 /area/gelida/outdoors/colony_streets/south_west_street)
 "iHW" = (
 /obj/structure/stairs/cornerdark/seamless{
@@ -26532,6 +26532,10 @@
 	},
 /turf/open/floor/carpet,
 /area/gelida/indoors/a_block/executive)
+"qPl" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/mineral/smooth/snowrock,
+/area/gelida/outdoors/colony_streets/south_west_street)
 "qPo" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -31498,9 +31502,9 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/casino)
 "tTV" = (
-/obj/structure/window/framed/colony/reinforced/hull,
-/turf/open/floor/plating,
-/area/gelida/landing_zone_1)
+/obj/structure/cable,
+/turf/closed/mineral/smooth/snowrock,
+/area/gelida/outdoors/colony_streets/south_west_street)
 "tTZ" = (
 /obj/structure/table/mainship,
 /obj/item/tool/pen/blue{
@@ -31640,6 +31644,9 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/gelida/indoors/b_block/bridge)
+"tYJ" = (
+/turf/closed/mineral/smooth/snowrock,
+/area/gelida/outdoors/colony_streets/south_west_street)
 "tZa" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison,
@@ -35002,7 +35009,7 @@
 	dir = 1
 	},
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/plating/ground/snow/layer0,
+/turf/closed/mineral/smooth/snowrock,
 /area/gelida/outdoors/colony_streets/south_west_street)
 "wjs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -35984,7 +35991,7 @@
 	dir = 8
 	},
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/plating/ground/snow/layer0,
+/turf/closed/mineral/smooth/snowrock,
 /area/gelida/outdoors/colony_streets/south_west_street)
 "wQL" = (
 /turf/open/floor/prison/cellstripe{
@@ -47843,7 +47850,7 @@ wTN
 mEP
 lIB
 nSm
-wTN
+ngP
 wTN
 ndb
 ndb
@@ -48062,10 +48069,10 @@ gEI
 skx
 ddD
 wTN
-tTV
-tTV
-tTV
-wTN
+fuw
+fuw
+fuw
+ngP
 gGM
 cBE
 ndb
@@ -48289,7 +48296,7 @@ wQK
 wQK
 wQK
 iHP
-oHe
+qPl
 gEI
 gEI
 gEI
@@ -48504,13 +48511,13 @@ vYQ
 jqs
 vYQ
 vYQ
-vYQ
-tqi
-tqi
+tTV
+tYJ
+tYJ
 mMH
 tqi
-tqi
-tqi
+tYJ
+tYJ
 ndb
 ndb
 ndb
@@ -48732,7 +48739,7 @@ tqi
 tqi
 tqi
 tqi
-tqi
+tYJ
 ndb
 ndb
 ndb

--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -4201,6 +4201,9 @@
 /obj/structure/stairs/seamless{
 	dir = 4
 	},
+/obj/structure/platform_decoration{
+	dir = 4
+	},
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "cHh" = (
@@ -12185,6 +12188,15 @@
 	},
 /turf/open/floor/prison/cleanmarked,
 /area/gelida/indoors/lone_buildings/storage_blocks)
+"hGT" = (
+/obj/structure/stairs/seamless{
+	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 1
+	},
+/turf/open/floor/prison,
+/area/gelida/indoors/c_block/mining)
 "hHY" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
@@ -48341,7 +48353,7 @@ oJT
 oJT
 oJT
 rCM
-eue
+tzc
 uew
 uew
 kZp
@@ -51448,8 +51460,8 @@ atX
 bJh
 axk
 atX
-nAJ
-eue
+atX
+tzc
 eue
 bPS
 rrz
@@ -51671,7 +51683,7 @@ bLc
 axk
 atX
 nAJ
-eue
+tzc
 eue
 tzc
 rrz
@@ -60251,7 +60263,7 @@ nIN
 pPX
 vjI
 cHg
-cHg
+hGT
 mKd
 wqK
 xJa

--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -16,7 +16,7 @@
 /turf/open/floor/mainship/black/full,
 /area/gelida/indoors/c_block/mining)
 "aal" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -113,7 +113,7 @@
 	name = "Suit Storage Unit";
 	pixel_x = 3
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/prison/whitepurple/full{
@@ -121,7 +121,7 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "abS" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -209,7 +209,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/central_streets)
 "aeg" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/largecrate/random/barrel{
@@ -260,14 +260,10 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/east_central_street)
 "aeZ" = (
-/obj/structure/platform/gelida{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/north_street)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/caves/central_caves)
 "afc" = (
 /obj/structure/table/mainship,
 /obj/item/trash/plate,
@@ -279,13 +275,13 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "afy" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
 	},
 /area/gelida/outdoors/colony_streets/east_central_street)
 "afT" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /obj/effect/ai_node,
@@ -311,9 +307,13 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/lone_buildings/storage_blocks)
 "ahI" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/closed/mineral/smooth/snowrock,
-/area/gelida/landing_zone_2)
+/obj/effect/turf_overlay/icerock{
+	dir = 4
+	},
+/turf/closed/ice_rock/corners{
+	dir = 9
+	},
+/area/gelida/outdoors/rock)
 "ahJ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/item/stack/sheet/wood,
@@ -584,18 +584,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/gelida/caves/central_caves)
-"asT" = (
-/turf/closed/ice_rock/singleT{
+"asZ" = (
+/obj/effect/turf_overlay/icerock{
 	dir = 8
 	},
-/area/gelida/outdoors/rock)
-"asZ" = (
-/obj/structure/bed/chair{
+/obj/effect/turf_overlay/icerock{
 	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
+/turf/closed/ice_rock/corners,
+/area/gelida/outdoors/rock)
 "atx" = (
 /obj/item/fuelCell{
 	layer = 3.1;
@@ -624,14 +621,8 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/security)
 "atX" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/fakesnow,
-/area/gelida/outdoors/colony_streets/north_street)
+/turf/open/floor/plating/ground/ice,
+/area/gelida/outdoors/rock)
 "atY" = (
 /obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison,
@@ -742,11 +733,9 @@
 /turf/open/floor/prison,
 /area/gelida/landing_zone_1)
 "axk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 8
-	},
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/outdoors/rock)
 "axl" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -803,9 +792,15 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/landing_zone_2)
 "azr" = (
-/obj/structure/largecrate,
-/turf/open/floor/plating/ground/fakesnow,
-/area/gelida/outdoors/colony_streets/north_street)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/turf_overlay/icerock{
+	dir = 8
+	},
+/obj/effect/turf_overlay/icerock{
+	dir = 1
+	},
+/turf/closed/ice_rock/corners,
+/area/gelida/outdoors/rock)
 "azt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
@@ -871,7 +866,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorm_north)
 "aAZ" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -902,10 +897,10 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "aDi" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/machinery/floodlight/colony{
@@ -1011,7 +1006,7 @@
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "aGQ" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/prison,
@@ -1064,7 +1059,7 @@
 /obj/structure/fence{
 	layer = 2.9
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/thin,
@@ -1104,7 +1099,7 @@
 /obj/structure/stairs/seamless{
 	dir = 8
 	},
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
 "aKo" = (
@@ -1345,10 +1340,10 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
 "aQR" = (
-/obj/structure/table/mainship,
-/obj/item/binoculars,
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/outdoors/rock)
 "aQU" = (
 /obj/structure/barricade/wooden{
 	dir = 1;
@@ -1368,7 +1363,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "aRp" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/stairs/cornerdark/seamless{
@@ -1473,7 +1468,7 @@
 	},
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
 "aVI" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -1614,11 +1609,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/prison,
 /area/gelida/indoors/lone_buildings/engineering)
-"aZS" = (
-/obj/structure/platform,
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/plating,
-/area/gelida/indoors/c_block/garage)
 "aZV" = (
 /turf/open/floor/mainship/black/full,
 /area/gelida/outdoors/rock)
@@ -1682,14 +1672,14 @@
 	},
 /area/gelida/indoors/a_block/admin)
 "bbO" = (
+/obj/structure/platform_decoration{
+	dir = 9
+	},
 /obj/structure/platform/gelida{
 	dir = 1
 	},
 /obj/structure/platform/gelida{
 	dir = 4
-	},
-/obj/structure/platform_decoration{
-	dir = 9
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/landing_zone_1)
@@ -1755,7 +1745,7 @@
 /turf/open/floor/mainship/black/full,
 /area/gelida/landing_zone_1)
 "bdC" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/grassybush{
@@ -1888,13 +1878,13 @@
 	},
 /area/gelida/outdoors/colony_streets/north_east_street)
 "bhm" = (
-/obj/structure/platform,
-/obj/structure/platform/gelida{
-	dir = 8
-	},
 /obj/structure/platform_decoration{
 	dir = 10
 	},
+/obj/structure/platform/gelida{
+	dir = 8
+	},
+/obj/structure/platform/gelida,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/landing_zone_2)
 "bhE" = (
@@ -1958,11 +1948,11 @@
 	},
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
 "bji" = (
-/obj/structure/platform/gelida{
-	dir = 4
-	},
 /obj/structure/flora/ausbushes/grassybush{
 	layer = 2.9
+	},
+/obj/structure/platform/gelida{
+	dir = 4
 	},
 /turf/open/floor/grass,
 /area/gelida/indoors/a_block/garden)
@@ -2050,7 +2040,7 @@
 /obj/structure/stairs/seamless{
 	dir = 4
 	},
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -2442,7 +2432,7 @@
 /obj/structure/stairs/seamless{
 	dir = 8
 	},
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/cargo)
 "bBO" = (
@@ -2487,7 +2477,7 @@
 	},
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
 "bCz" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/sunnybush{
@@ -2499,10 +2489,10 @@
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/b_block/bridge)
 "bCC" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/structure/platform_decoration{
@@ -2521,7 +2511,7 @@
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "bDO" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -2534,6 +2524,9 @@
 	},
 /obj/structure/platform/gelida{
 	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 5
 	},
 /turf/open/ground/river,
 /area/gelida/indoors/a_block/fitness)
@@ -2575,7 +2568,7 @@
 "bEG" = (
 /obj/item/shard,
 /obj/item/stack/rods,
-/obj/structure/window_frame/colony/reinforced,
+/obj/structure/window_frame/colony,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
 "bFH" = (
@@ -2630,7 +2623,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
 "bGC" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -2687,10 +2680,10 @@
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/lone_buildings/chunk)
 "bIr" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/structure/platform_decoration{
 	dir = 10
 	},
@@ -2717,11 +2710,11 @@
 /turf/open/floor/prison/kitchen,
 /area/gelida/indoors/a_block/kitchen)
 "bJh" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/outdoors/rock)
 "bJk" = (
 /obj/effect/decal/warning_stripes/thick,
 /obj/effect/decal/warning_stripes/thick{
@@ -2769,14 +2762,9 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
 "bLc" = (
-/obj/item/storage/backpack/marine/satchel{
-	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
-	name = "trash bag";
-	pixel_x = 4;
-	pixel_y = 21
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_street)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/outdoors/rock)
 "bLf" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/fakesnow/alt,
@@ -2887,17 +2875,9 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/security)
 "bNN" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/structure/fence{
-	layer = 2.9
-	},
-/turf/open/floor/prison/plate,
-/area/gelida/outdoors/colony_streets/north_street)
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/ice,
+/area/gelida/outdoors/rock)
 "bNT" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark2,
@@ -3101,7 +3081,7 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
 "bUQ" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
@@ -3219,15 +3199,8 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/kitchen)
 "can" = (
-/obj/structure/platform,
-/obj/structure/platform/gelida{
-	dir = 4
-	},
-/obj/structure/platform_decoration{
-	dir = 6;
-	layer = 3.51
-	},
-/turf/open/floor/plating/ground/snow/layer0,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/fakesnow,
 /area/gelida/outdoors/n_rockies)
 "cas" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -3434,11 +3407,11 @@
 	},
 /area/gelida/indoors/b_block/bridge)
 "chD" = (
-/obj/structure/bed/chair{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 6
 	},
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
+/turf/open/floor/plating/ground/fakesnow,
+/area/gelida/outdoors/colony_streets/north_west_street)
 "chO" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/prison/whitegreenfull2,
@@ -3567,13 +3540,13 @@
 /turf/open/floor/plating/ground/ice,
 /area/gelida/caves/west_caves)
 "cmY" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "cnw" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
@@ -3614,7 +3587,7 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/garage)
 "cpG" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/stairs/seamless,
@@ -3661,7 +3634,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "crR" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/effect/ai_node,
@@ -3892,7 +3865,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "cyL" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/landing_zone_1)
 "cyU" = (
@@ -4240,7 +4213,7 @@
 /area/gelida/indoors/a_block/hallway)
 "cHi" = (
 /obj/effect/decal/cleanable/blood/xeno,
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -4281,7 +4254,7 @@
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/south_street)
 "cHY" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/closed/wall/r_wall/unmeltable,
 /area/gelida/landing_zone_1)
 "cIf" = (
@@ -4515,9 +4488,11 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/lone_buildings/storage_blocks)
 "cOZ" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic,
-/turf/open/floor/mainship/black/full,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating/ground/fakesnow/alt,
+/area/gelida/outdoors/colony_streets/north_street)
 "cPh" = (
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/lone_buildings/engineering)
@@ -4586,8 +4561,9 @@
 	},
 /area/gelida/outdoors/colony_streets/north_east_street)
 "cRF" = (
-/obj/structure/largecrate,
-/turf/open/floor/plating/ground/snow/layer0,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/fakesnow,
 /area/gelida/outdoors/colony_streets/north_street)
 "cRL" = (
 /obj/structure/coatrack{
@@ -4618,7 +4594,7 @@
 /turf/open/floor/prison/kitchen,
 /area/gelida/indoors/a_block/fitness)
 "cSm" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -4699,12 +4675,10 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/admin)
 "cVg" = (
-/obj/structure/stairs/seamless,
-/obj/machinery/atmospherics/pipe/manifold/green/hidden,
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow/layer0,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating/ground/fakesnow,
 /area/gelida/outdoors/colony_streets/north_street)
 "cVm" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -4733,7 +4707,7 @@
 /obj/structure/stairs/seamless{
 	dir = 8
 	},
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/prison/blue/plate{
 	dir = 1
 	},
@@ -4773,8 +4747,8 @@
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "cXD" = (
-/obj/structure/platform,
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform,
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/structure/platform_decoration{
@@ -4861,9 +4835,11 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/dorms)
 "cZN" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/plating,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/fakesnow,
+/area/gelida/outdoors/colony_streets/north_east_street)
 "cZX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -4890,7 +4866,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/lone_buildings/spaceport)
 "daV" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -4979,7 +4955,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /obj/structure/cable,
@@ -4998,8 +4974,8 @@
 	},
 /area/gelida/outdoors/colony_streets/north_street)
 "ddD" = (
-/obj/structure/platform,
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform,
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/structure/platform_decoration{
@@ -5014,7 +4990,7 @@
 	},
 /area/gelida/outdoors/colony_streets/south_west_street)
 "ddN" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -5141,16 +5117,8 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
 "dhH" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/stairs/cornerdark/seamless{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/snow/layer0,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/fakesnow,
 /area/gelida/outdoors/colony_streets/north_street)
 "dhP" = (
 /obj/structure/bed/chair{
@@ -5281,12 +5249,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/w_rockies)
-"dnF" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/fakesnow/alt,
-/area/gelida/outdoors/colony_streets/north_street)
 "dnG" = (
 /obj/effect/turf_overlay/icerock,
 /obj/effect/turf_overlay/icerock{
@@ -5409,9 +5371,8 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/admin)
 "dqK" = (
-/obj/structure/platform,
 /obj/effect/decal/cleanable/blood/oil,
-/obj/structure/rack,
+/obj/structure/platform/gelida,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/garage)
 "drf" = (
@@ -5669,7 +5630,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "dyf" = (
-/obj/structure/window/framed/colony/reinforced,
+/obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/gelida/landing_zone_2)
 "dym" = (
@@ -5688,9 +5649,13 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/mining)
 "dzD" = (
-/obj/structure/platform,
+/obj/structure/platform/gelida,
 /obj/structure/platform/gelida{
 	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 6;
+	layer = 3.51
 	},
 /turf/open/ground/river,
 /area/gelida/indoors/a_block/fitness)
@@ -5737,7 +5702,7 @@
 "dBl" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/stripesquare,
-/area/gelida/outdoors/rock)
+/area/gelida/outdoors/w_rockies)
 "dBv" = (
 /obj/machinery/door_control{
 	dir = 1;
@@ -5775,7 +5740,7 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "dCL" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/south_street)
 "dCP" = (
@@ -5969,7 +5934,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/prison/sterilewhite,
@@ -6159,7 +6124,7 @@
 /turf/open/floor/plating/ground/ice,
 /area/gelida/caves/west_caves)
 "dOx" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "dOO" = (
@@ -6481,7 +6446,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/rock)
+/area/gelida/outdoors/w_rockies)
 "dYq" = (
 /obj/machinery/light,
 /obj/machinery/disposal,
@@ -6854,7 +6819,7 @@
 	},
 /area/gelida/indoors/c_block/mining)
 "egA" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -6904,7 +6869,7 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/b_block/bar)
 "eii" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -6966,18 +6931,17 @@
 /area/gelida/indoors/a_block/dorm_north)
 "eon" = (
 /obj/structure/platform_decoration{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/stairs/cornerdark/seamless{
-	dir = 1
+	dir = 9
 	},
 /obj/structure/cable,
-/obj/effect/landmark/weed_node,
+/obj/structure/platform/gelida{
+	dir = 4
+	},
+/obj/structure/platform/gelida{
+	dir = 1
+	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_street)
+/area/gelida/outdoors/colony_streets/north_east_street)
 "eow" = (
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/dorms)
@@ -7007,7 +6971,7 @@
 	},
 /area/gelida/landing_zone_forecon/UD6_Tornado)
 "epv" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -7076,7 +7040,7 @@
 /turf/open/floor/plating/ground/fakesnow/alt,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "erk" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/fence{
@@ -7213,10 +7177,10 @@
 	},
 /area/gelida/outdoors/colony_streets/north_east_street)
 "euX" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/platform_decoration{
@@ -7294,8 +7258,8 @@
 	},
 /area/gelida/indoors/a_block/dorm_north)
 "ewh" = (
-/obj/structure/platform,
 /obj/structure/prop/vehicle/crane,
+/obj/structure/platform/gelida,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/garage)
 "ewj" = (
@@ -7404,24 +7368,12 @@
 /obj/machinery/floodlight,
 /turf/open/floor/prison/cleanmarked,
 /area/gelida/indoors/lone_buildings/storage_blocks)
-"eAM" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 10
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_street)
 "eAQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/b_block/bridge)
-"eBm" = (
-/obj/structure/platform/gelida{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/fakesnow,
-/area/gelida/outdoors/colony_streets/north_street)
 "eBt" = (
 /obj/structure/flora/ausbushes/sunnybush{
 	pixel_y = 10
@@ -7734,7 +7686,7 @@
 	},
 /area/gelida/indoors/a_block/dorm_north)
 "eKa" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/prison,
@@ -8007,19 +7959,6 @@
 	},
 /turf/open/floor/plating/ground/fakesnow,
 /area/gelida/outdoors/colony_streets/north_west_street)
-"eSh" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 5
-	},
-/obj/structure/fence{
-	layer = 2.9
-	},
-/turf/open/floor/prison/plate,
-/area/gelida/outdoors/colony_streets/north_street)
 "eSx" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/turf_overlay/icerock{
@@ -8077,10 +8016,10 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/security)
 "eUo" = (
+/obj/structure/stairs/seamless,
 /obj/structure/platform/gelida{
 	dir = 8
 	},
-/obj/structure/stairs/seamless,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/landing_zone_1)
 "eUv" = (
@@ -8185,10 +8124,10 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "eWZ" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/structure/platform_decoration{
 	dir = 10;
 	layer = 3.51
@@ -8335,10 +8274,10 @@
 	},
 /area/gelida/outdoors/colony_streets/south_street)
 "faS" = (
+/obj/effect/decal/cleanable/blood/oil,
 /obj/structure/platform/gelida{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/garage)
 "fbs" = (
@@ -8489,11 +8428,11 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/admin)
 "fhI" = (
-/obj/structure/window/framed/colony/reinforced,
 /obj/machinery/door/poddoor/shutters/mainship{
 	dir = 4;
 	id = "Sec-Kitchen-Lockdown"
 	},
+/obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/security)
 "fie" = (
@@ -8615,7 +8554,7 @@
 /turf/open/floor/tile/yellow/patch,
 /area/gelida/indoors/a_block/corpo)
 "foy" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/effect/ai_node,
@@ -8718,13 +8657,19 @@
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/corpo)
 "frR" = (
+/obj/structure/platform_decoration{
+	dir = 5
+	},
 /obj/structure/platform/gelida{
 	dir = 8
 	},
-/turf/open/floor/plating/ground/fakesnow,
-/area/gelida/outdoors/colony_streets/north_street)
+/obj/structure/platform/gelida{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/outdoors/colony_streets/north_east_street)
 "fsy" = (
-/obj/structure/window/framed/colony/reinforced,
+/obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/gelida/indoors/b_block/bridge)
 "fsz" = (
@@ -8782,14 +8727,9 @@
 /turf/open/floor/prison,
 /area/gelida/landing_zone_1)
 "fwd" = (
-/obj/item/clothing/mask/facehugger/dead{
-	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
-	name = "????";
-	stat = 2
-	},
-/obj/structure/cable,
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating,
+/area/gelida/indoors/a_block/bridges/op_centre)
 "fwg" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -8806,13 +8746,13 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/bridge)
 "fwH" = (
-/obj/structure/platform,
-/obj/structure/platform/gelida{
-	dir = 4
-	},
 /obj/structure/platform_decoration{
 	dir = 6
 	},
+/obj/structure/platform/gelida{
+	dir = 4
+	},
+/obj/structure/platform/gelida,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/landing_zone_2)
 "fwL" = (
@@ -8824,9 +8764,17 @@
 	},
 /area/gelida/outdoors/colony_streets/south_east_street)
 "fwS" = (
-/obj/structure/noticeboard,
-/turf/closed/wall/r_wall,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
+/obj/structure/fakeplatform{
+	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 9
+	},
+/obj/structure/platform/gelida{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/gelida/indoors/a_block/garden)
 "fxl" = (
 /obj/item/clothing/under/liaison_suit/suspenders{
 	pixel_x = -4;
@@ -9175,12 +9123,17 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/cargo)
 "fMz" = (
-/obj/structure/table/mainship,
-/obj/item/storage/box/matches{
-	pixel_y = 8
+/obj/structure/fakeplatform{
+	dir = 1
 	},
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
+/obj/structure/platform_decoration{
+	dir = 9
+	},
+/obj/structure/platform/gelida{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/gelida/indoors/a_block/garden)
 "fMQ" = (
 /obj/item/clothing/mask/facehugger/dead{
 	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
@@ -9234,10 +9187,15 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/b_block/bar)
 "fOu" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/floor/mainship/black/full,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
+/obj/structure/platform_decoration{
+	dir = 10
+	},
+/obj/structure/platform/gelida{
+	dir = 8
+	},
+/obj/structure/platform/gelida,
+/turf/open/floor/grass,
+/area/gelida/indoors/a_block/garden)
 "fOz" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -9260,7 +9218,7 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "fOW" = (
-/obj/structure/window/framed/colony/reinforced,
+/obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/bridges)
 "fPj" = (
@@ -9376,16 +9334,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/fitness)
-"fTZ" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/fence{
-	layer = 2.9
-	},
-/turf/open/floor/prison/plate,
-/area/gelida/outdoors/colony_streets/north_street)
 "fUc" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -9408,7 +9356,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/a_block/corpo)
 "fUQ" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /turf/open/floor/prison,
@@ -9642,10 +9590,15 @@
 /turf/open/floor/plating/ground/ice,
 /area/gelida/caves/west_caves)
 "gaT" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
+/obj/structure/platform_decoration{
+	dir = 6
+	},
+/obj/structure/platform/gelida{
+	dir = 4
+	},
+/obj/structure/platform/gelida,
+/turf/open/floor/grass,
+/area/gelida/indoors/a_block/garden)
 "gbh" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -9774,12 +9727,9 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/b_block/bar)
 "gfh" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating,
+/area/gelida/indoors/a_block/kitchen)
 "gfl" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
@@ -9992,7 +9942,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/fitness)
 "glq" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/stairs/cornerdark/seamless{
@@ -10097,15 +10047,8 @@
 /turf/closed/wall,
 /area/gelida/indoors/lone_buildings/storage_blocks)
 "gnX" = (
-/obj/structure/platform/gelida{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_street)
+/turf/open/floor/mainship/stripesquare,
+/area/gelida/outdoors/w_rockies)
 "gob" = (
 /obj/machinery/disposal,
 /turf/open/floor/wood,
@@ -10316,9 +10259,11 @@
 	},
 /area/gelida/outdoors/colony_streets/central_streets)
 "gvL" = (
-/obj/machinery/vending/cigarette/colony,
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 1
+	},
+/turf/open/floor/mainship/stripesquare,
+/area/gelida/outdoors/w_rockies)
 "gwj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/prop/mainship/gelida/rails{
@@ -10453,7 +10398,7 @@
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "gAA" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/prison/sterilewhite,
@@ -10639,10 +10584,10 @@
 	},
 /area/gelida/landing_zone_forecon/UD6_Tornado)
 "gGM" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/structure/platform_decoration{
@@ -10780,11 +10725,11 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/a_block/security)
 "gJY" = (
-/obj/structure/platform,
+/obj/structure/platform/gelida,
 /turf/open/ground/river,
 /area/gelida/indoors/a_block/fitness)
 "gKi" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -10803,7 +10748,7 @@
 /turf/open/floor/prison/whitegreen/full,
 /area/gelida/indoors/a_block/fitness)
 "gKN" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/brflowers,
@@ -10989,9 +10934,12 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/landing_zone_1)
 "gPU" = (
-/obj/structure/platform,
+/obj/structure/platform/gelida,
 /obj/structure/platform/gelida{
 	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 10
 	},
 /turf/open/ground/river,
 /area/gelida/indoors/a_block/fitness)
@@ -11028,7 +10976,7 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
 "gQH" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/structure/stairs/seamless{
@@ -11327,10 +11275,9 @@
 	},
 /area/gelida/indoors/a_block/dorm_north)
 "hdk" = (
-/obj/structure/platform_decoration,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/n_rockies)
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating,
+/area/gelida/landing_zone_1)
 "hdB" = (
 /obj/effect/spawner/random/technology_scanner,
 /turf/open/floor/plating,
@@ -11393,7 +11340,6 @@
 	},
 /area/gelida/outdoors/colony_streets/east_central_street)
 "hfL" = (
-/obj/structure/platform,
 /obj/structure/prop/vehicle/truck{
 	dir = 8;
 	layer = 3.1;
@@ -11403,6 +11349,11 @@
 /obj/structure/platform/gelida{
 	dir = 8
 	},
+/obj/structure/platform/gelida,
+/obj/structure/platform_decoration{
+	dir = 10;
+	layer = 3.51
+	},
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/garage)
 "hgb" = (
@@ -11410,17 +11361,9 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/b_block/hydro)
 "hgj" = (
-/obj/structure/platform/gelida{
-	dir = 1
-	},
-/obj/structure/platform/gelida{
-	dir = 8
-	},
-/obj/structure/platform_decoration{
-	dir = 5
-	},
-/turf/open/floor/plating/ground/fakesnow,
-/area/gelida/outdoors/colony_streets/north_street)
+/obj/structure/platform/gelida,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/landing_zone_1)
 "hgq" = (
 /turf/open/floor/prison/greenblue{
 	dir = 1
@@ -11478,8 +11421,11 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
 "hiC" = (
-/turf/closed/wall/r_wall,
-/area/gelida/indoors/a_block/admin)
+/obj/structure/platform/gelida{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/gelida/landing_zone_1)
 "hiI" = (
 /obj/effect/turf_overlay/icerock{
 	dir = 8
@@ -12132,7 +12078,7 @@
 /turf/open/ground/river,
 /area/gelida/indoors/a_block/fitness)
 "hDw" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -12239,16 +12185,12 @@
 	},
 /turf/open/floor/prison/cleanmarked,
 /area/gelida/indoors/lone_buildings/storage_blocks)
-"hGT" = (
-/obj/structure/largecrate/random/secure,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_street)
 "hHY" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/central_streets)
 "hJe" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -12438,7 +12380,7 @@
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/a_block/hallway)
 "hPJ" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /obj/effect/landmark/weed_node,
@@ -12477,22 +12419,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/bridges/garden_bridge)
-"hQK" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 2
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/north_street)
 "hRf" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/monkeyburger{
@@ -12790,7 +12716,7 @@
 /turf/open/floor/plating/ground/fakesnow/alt,
 /area/gelida/outdoors/colony_streets/south_street)
 "hYS" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -13014,6 +12940,9 @@
 /obj/structure/platform/gelida{
 	dir = 4
 	},
+/obj/structure/platform_decoration{
+	dir = 9
+	},
 /turf/open/ground/river,
 /area/gelida/indoors/a_block/fitness)
 "igB" = (
@@ -13054,7 +12983,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/landing_zone_2)
 "ihf" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/effect/ai_node,
@@ -13162,7 +13091,7 @@
 /turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "ijV" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/structure/stairs/seamless,
@@ -13329,16 +13258,16 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "inP" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
-	},
-/obj/structure/platform/gelida{
-	dir = 4
 	},
 /obj/structure/platform_decoration{
 	dir = 9
 	},
 /obj/structure/cable,
+/obj/structure/platform/gelida{
+	dir = 4
+	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "inS" = (
@@ -13410,7 +13339,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorm_north)
 "ira" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/structure/stairs/seamless,
@@ -13448,13 +13377,6 @@
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
 /area/gelida/indoors/b_block/hydro)
-"irW" = (
-/obj/structure/platform/gelida{
-	dir = 4;
-	layer = 5
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/n_rockies)
 "irZ" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
@@ -13544,7 +13466,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "ivp" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/effect/spawner/gibspawner/xeno,
@@ -13577,10 +13499,6 @@
 	},
 /turf/open/floor/grass,
 /area/gelida/indoors/a_block/garden)
-"iwu" = (
-/obj/structure/platform_decoration,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/n_rockies)
 "iwH" = (
 /obj/structure/platform_decoration,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -13690,11 +13608,11 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/lone_buildings/chunk)
 "izf" = (
-/obj/machinery/atmospherics/pipe/manifold/green/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plating/ground/snow/layer0,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/fakesnow/alt,
 /area/gelida/outdoors/colony_streets/north_street)
 "izj" = (
 /obj/structure/curtain/medical,
@@ -13759,15 +13677,19 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
 "iBR" = (
-/obj/structure/platform,
 /obj/structure/prop/vehicle/truck{
 	dir = 8;
 	layer = 3.1;
 	pixel_x = 5;
 	pixel_y = 7
 	},
+/obj/structure/platform/gelida,
 /obj/structure/platform/gelida{
 	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 10;
+	layer = 3.51
 	},
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/garage)
@@ -13890,7 +13812,7 @@
 /turf/open/floor/plating/ground/fakesnow,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "iHe" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/structure/reagent_dispensers/fueltank{
 	layer = 2.9
 	},
@@ -14157,7 +14079,7 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/a_block/executive)
 "iOw" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
@@ -14256,7 +14178,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
 "iSB" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /obj/item/stack/rods,
@@ -14280,7 +14202,7 @@
 /turf/open/floor/prison/cleanmarked,
 /area/gelida/indoors/lone_buildings/storage_blocks)
 "iUg" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -14536,8 +14458,8 @@
 /turf/open/floor/prison,
 /area/gelida/landing_zone_2)
 "jcs" = (
-/obj/structure/platform,
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform,
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/structure/platform_decoration{
@@ -14567,7 +14489,7 @@
 	},
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
 "jdk" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/structure/stairs/seamless{
 	dir = 8
 	},
@@ -14592,7 +14514,7 @@
 	},
 /area/gelida/indoors/a_block/medical)
 "jed" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/machinery/power/port_gen/pacman,
@@ -14609,19 +14531,13 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/a_block/fitness)
-"jeT" = (
-/obj/structure/platform/gelida{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/n_rockies)
 "jfk" = (
 /obj/item/shard,
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/hallway)
 "jfU" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/closet/crate/trashcart,
@@ -14687,7 +14603,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/w_rockies)
 "jib" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -15132,11 +15048,8 @@
 /obj/effect/spawner/random/tool,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
-"jzy" = (
-/turf/closed/wall/r_wall,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
 "jzz" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -15211,16 +15124,8 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/gelida/caves/west_caves)
-"jBZ" = (
-/obj/structure/platform/gelida{
-	dir = 4;
-	layer = 5
-	},
-/obj/structure/largecrate,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_street)
 "jCg" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/closed/wall/r_wall,
 /area/gelida/landing_zone_2)
 "jCt" = (
@@ -15232,7 +15137,7 @@
 /turf/open/floor/prison/cleanmarked,
 /area/lv624/lazarus/console)
 "jCH" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/snow/layer0,
@@ -15368,10 +15273,6 @@
 	dir = 1
 	},
 /area/gelida/indoors/a_block/admin)
-"jKe" = (
-/obj/effect/ai_node,
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
 "jKg" = (
 /obj/item/clothing/under/swimsuit/green{
 	pixel_x = 8;
@@ -15450,7 +15351,7 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/a_block/executive)
 "jLO" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/effect/spawner/gibspawner/xeno,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
@@ -15545,7 +15446,7 @@
 /turf/open/floor/plating/ground/fakesnow/alt,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "jNW" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
@@ -15615,7 +15516,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/bridges/op_centre)
 "jQr" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -15952,9 +15853,6 @@
 /obj/structure/girder/displaced,
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/security)
-"jZt" = (
-/turf/closed/wall/r_wall,
-/area/gelida/indoors/a_block/bridges/corpo)
 "jZM" = (
 /turf/open/floor/plating/ground/fakesnow/alt,
 /area/gelida/outdoors/colony_streets/east_central_street)
@@ -16351,9 +16249,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/central_streets)
-"koG" = (
-/turf/closed/wall/r_wall,
-/area/gelida/indoors/a_block/medical)
 "koL" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -16364,7 +16259,7 @@
 	},
 /area/gelida/outdoors/colony_streets/east_central_street)
 "kpf" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -16419,10 +16314,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/dorm_north)
-"kra" = (
-/obj/structure/largecrate/random/barrel/blue,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_street)
 "krt" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 4
@@ -16456,10 +16347,10 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
 "krZ" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/structure/platform_decoration{
 	dir = 10
 	},
@@ -16527,7 +16418,7 @@
 /turf/open/floor/carpet,
 /area/gelida/indoors/b_block/bar)
 "kuJ" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
@@ -16704,15 +16595,6 @@
 /obj/effect/decal/warning_stripes/stripedsquare/tile/border,
 /turf/open/floor/mainship/black/full,
 /area/gelida/outdoors/colony_streets/north_east_street)
-"kDe" = (
-/obj/item/storage/backpack/marine/satchel{
-	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
-	name = "trash bag";
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_street)
 "kDs" = (
 /obj/structure/bed/chair,
 /turf/open/floor/prison/darkpurple,
@@ -16769,10 +16651,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/medical)
-"kEh" = (
-/obj/structure/largecrate/random/barrel/yellow,
-/turf/open/floor/plating/ground/fakesnow,
-/area/gelida/outdoors/colony_streets/north_street)
 "kEl" = (
 /obj/item/clothing/mask/facehugger/dead{
 	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
@@ -16807,7 +16685,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/security)
 "kEX" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /obj/structure/prop/mainship/gelida/powerccable,
@@ -16853,7 +16731,7 @@
 	},
 /area/gelida/indoors/a_block/hallway)
 "kGX" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /obj/structure/prop/vehicle/truck{
@@ -17010,7 +16888,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -17132,10 +17010,10 @@
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/a_block/fitness)
 "kOy" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/platform_decoration{
@@ -17187,7 +17065,7 @@
 "kRu" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood,
-/obj/structure/window_frame/colony/reinforced,
+/obj/structure/window_frame/colony,
 /turf/open/floor/plating,
 /area/gelida/indoors/b_block/bar)
 "kSR" = (
@@ -17271,14 +17149,14 @@
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/a_block/admin)
 "kVt" = (
-/obj/structure/platform/gelida{
-	dir = 1
+/obj/structure/platform_decoration{
+	dir = 5
 	},
 /obj/structure/platform/gelida{
 	dir = 8
 	},
-/obj/structure/platform_decoration{
-	dir = 5
+/obj/structure/platform/gelida{
+	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/landing_zone_2)
@@ -17416,7 +17294,7 @@
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/south_street)
 "kZQ" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -17461,7 +17339,7 @@
 /turf/open/floor/plating/ground/ice,
 /area/gelida/caves/east_caves)
 "lbx" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/north_east_street)
@@ -17638,7 +17516,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/casino)
 "lgS" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
@@ -17706,7 +17584,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/executive)
 "lib" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/structure/closet/crate/trashcart,
 /obj/item/trash/chips,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -17742,7 +17620,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "lki" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
 	},
@@ -17782,7 +17660,7 @@
 	},
 /area/gelida/indoors/a_block/dorm_north)
 "lkT" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -17904,7 +17782,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
 "lqN" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -18037,7 +17915,7 @@
 /turf/open/floor/plating/heatinggrate,
 /area/gelida/indoors/c_block/bridge)
 "ltP" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/prison/darkred/full,
@@ -18070,10 +17948,6 @@
 	dir = 10
 	},
 /area/gelida/outdoors/colony_streets/north_east_street)
-"luT" = (
-/obj/structure/closet/firecloset/full,
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
 "luX" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 8;
@@ -18094,7 +17968,7 @@
 	},
 /area/gelida/indoors/c_block/mining)
 "lvh" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -18290,10 +18164,10 @@
 	},
 /area/gelida/landing_zone_1)
 "lBo" = (
+/obj/structure/cable,
 /obj/structure/platform/gelida{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "lBH" = (
@@ -18381,7 +18255,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/mining)
 "lFK" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -18413,7 +18287,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/security)
 "lGM" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -18510,7 +18384,7 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/a_block/executive)
 "lJn" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -18519,12 +18393,6 @@
 /obj/machinery/disposal,
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
-"lJv" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/n_rockies)
 "lJE" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/prison/whitegreenfull2,
@@ -18769,23 +18637,12 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/a_block/executive)
 "lSu" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/south_west_street)
-"lSO" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/item/clothing/mask/facehugger/dead{
-	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
-	name = "????";
-	stat = 2
-	},
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
 "lSR" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -18814,7 +18671,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/cargo)
 "lTL" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/prison,
@@ -18843,7 +18700,7 @@
 /obj/structure/stairs/seamless{
 	dir = 4
 	},
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 4
 	},
@@ -18853,7 +18710,7 @@
 /turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "lUP" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -18966,8 +18823,8 @@
 	},
 /area/gelida/outdoors/colony_streets/north_east_street)
 "lYt" = (
-/obj/structure/platform,
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform,
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/platform_decoration{
@@ -19065,7 +18922,7 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/b_block/bar)
 "maT" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -19083,7 +18940,7 @@
 /turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "maV" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/kitchen)
 "mbz" = (
@@ -19254,7 +19111,7 @@
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/a_block/hallway)
 "miD" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/cable,
@@ -19428,10 +19285,10 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
 "mlN" = (
+/obj/effect/landmark/weed_node,
 /obj/structure/platform/gelida{
 	dir = 8
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "mlR" = (
@@ -19441,7 +19298,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/landing_zone_2)
 "mlW" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
@@ -19573,7 +19430,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/casino)
 "mpa" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -19591,12 +19448,12 @@
 	},
 /area/gelida/outdoors/colony_streets/south_street)
 "mpK" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/landing_zone_1)
 "mpV" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
@@ -19610,7 +19467,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/fitness)
 "mqp" = (
-/obj/structure/window/framed/colony/reinforced,
+/obj/structure/window/framed/colony,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/indoors/lone_buildings/outdoor_bot)
 "mqu" = (
@@ -19764,7 +19621,7 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/security)
 "mvG" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
 	},
@@ -19867,9 +19724,6 @@
 	},
 /turf/open/floor/prison/whitegreen/full,
 /area/gelida/indoors/a_block/fitness)
-"mza" = (
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
 "mzo" = (
 /obj/structure/table/woodentable,
 /obj/machinery/reagentgrinder{
@@ -19909,7 +19763,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/kitchen)
 "mAk" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood{
@@ -20127,7 +19981,7 @@
 /turf/open/ground/river,
 /area/gelida/indoors/a_block/fitness)
 "mKd" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/structure/stairs/cornerdark/seamless{
@@ -20223,12 +20077,6 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
-"mNK" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 5
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_street)
 "mOg" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 2
@@ -20238,7 +20086,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/dorm_north)
 "mOi" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/north_west_street)
@@ -20478,7 +20326,7 @@
 /turf/open/floor/prison/cleanmarked,
 /area/gelida/landing_zone_2)
 "mWl" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
 	},
@@ -20497,10 +20345,10 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/casino)
 "mWz" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/platform_decoration{
@@ -20755,17 +20603,17 @@
 	},
 /area/gelida/outdoors/rock)
 "nft" = (
-/obj/structure/platform,
-/obj/structure/platform/gelida{
-	dir = 4
-	},
 /obj/structure/platform_decoration{
 	dir = 6
+	},
+/obj/structure/platform/gelida,
+/obj/structure/platform/gelida{
+	dir = 4
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/landing_zone_1)
 "nfE" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -20833,21 +20681,6 @@
 	},
 /turf/open/floor/plating/heatinggrate,
 /area/gelida/indoors/c_block/bridge)
-"ngB" = (
-/obj/item/storage/backpack/marine/satchel{
-	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
-	name = "trash bag";
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/obj/item/storage/backpack/marine/satchel{
-	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
-	name = "trash bag";
-	pixel_x = 3;
-	pixel_y = -2
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_street)
 "ngP" = (
 /turf/closed/wall/r_wall,
 /area/gelida/landing_zone_1)
@@ -21037,7 +20870,7 @@
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/medical)
 "nnJ" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/east_central_street)
 "nnL" = (
@@ -21053,7 +20886,7 @@
 	},
 /area/gelida/outdoors/rock)
 "nnV" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/north_east_street)
@@ -21094,14 +20927,6 @@
 	},
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/b_block/bar)
-"nra" = (
-/obj/structure/window/framed/colony/reinforced,
-/obj/machinery/door/poddoor/shutters/mainship{
-	dir = 1;
-	id = "Sec-Kitchen-Lockdown"
-	},
-/turf/open/floor/plating,
-/area/gelida/indoors/a_block/security)
 "nrk" = (
 /obj/machinery/door/airlock/mainship/medical{
 	name = "Medical Laboratory Operating Theatre"
@@ -21166,10 +20991,10 @@
 /turf/open/floor/prison/kitchen,
 /area/gelida/indoors/a_block/kitchen)
 "nsE" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/structure/platform_decoration{
@@ -21336,9 +21161,6 @@
 /obj/structure/largecrate/random/barrel/yellow,
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/landing_zone_1)
-"nxz" = (
-/turf/closed/wall/r_wall,
-/area/gelida/indoors/lone_buildings/engineering)
 "nxC" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -21364,7 +21186,7 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
 "nzi" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -21433,7 +21255,7 @@
 /turf/open/floor/prison/whitegreen/full,
 /area/gelida/indoors/a_block/medical)
 "nAi" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -21465,10 +21287,10 @@
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/landing_zone_1)
 "nCJ" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/platform_decoration{
@@ -21543,12 +21365,6 @@
 /obj/structure/foamedmetal,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
-"nFr" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 1
-	},
-/turf/closed/mineral/smooth/snowrock,
-/area/gelida/landing_zone_2)
 "nFA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -21594,7 +21410,7 @@
 /turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/central_streets)
 "nGJ" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/fence{
@@ -21649,7 +21465,7 @@
 /area/gelida/indoors/c_block/mining)
 "nId" = (
 /obj/item/tool/weldingtool,
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
 "nIu" = (
@@ -21684,7 +21500,7 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
 "nIX" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
 	},
@@ -21919,13 +21735,6 @@
 	},
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
-"nPT" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/fakesnow,
-/area/gelida/outdoors/colony_streets/north_street)
 "nQf" = (
 /obj/structure/table/mainship,
 /obj/item/trash/plate{
@@ -22055,7 +21864,7 @@
 /obj/structure/stairs/seamless{
 	dir = 4
 	},
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorm_north)
 "nUT" = (
@@ -22256,7 +22065,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/cargo)
 "obS" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
@@ -22421,8 +22230,8 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/dorms)
 "ohb" = (
-/obj/structure/platform,
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform,
+/obj/structure/fakeplatform{
 	dir = 4;
 	layer = 2.7
 	},
@@ -22520,7 +22329,7 @@
 	},
 /area/gelida/indoors/a_block/dorm_north)
 "olW" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/plating/heatinggrate,
@@ -22621,7 +22430,7 @@
 	},
 /area/gelida/indoors/a_block/bridges)
 "opt" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
@@ -22833,10 +22642,10 @@
 	},
 /area/gelida/indoors/a_block/admin)
 "oxe" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -22848,7 +22657,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "oxY" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /obj/machinery/power/port_gen/pacman/super,
@@ -23110,10 +22919,13 @@
 /obj/structure/platform/gelida{
 	dir = 8
 	},
+/obj/structure/platform_decoration{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/garage)
 "oGt" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -23190,10 +23002,10 @@
 /turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "oIs" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/structure/platform_decoration{
@@ -23236,7 +23048,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/casino)
 "oJo" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/structure/stairs/seamless,
@@ -23440,9 +23252,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/east_central_street)
-"oRo" = (
-/turf/open/floor/plating/ground/fakesnow,
-/area/gelida/caves/central_caves)
 "oRO" = (
 /obj/machinery/light,
 /turf/open/floor/prison,
@@ -23498,7 +23307,7 @@
 	},
 /area/gelida/indoors/a_block/admin)
 "oSV" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/effect/spawner/gibspawner/xeno,
@@ -23566,7 +23375,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "oUg" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -23574,21 +23383,6 @@
 	},
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/south_west_street)
-"oUi" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/structure/platform/gelida{
-	dir = 4
-	},
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/north_street)
 "oUq" = (
 /obj/structure/stairs/seamless{
 	dir = 1
@@ -23662,7 +23456,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/kitchen)
 "oWr" = (
-/obj/structure/platform,
+/obj/structure/platform/gelida,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/landing_zone_2)
 "oWy" = (
@@ -23739,7 +23533,7 @@
 	},
 /area/gelida/indoors/a_block/medical)
 "oYI" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/machinery/light,
 /obj/structure/stairs/cornerdark/seamless{
 	dir = 8
@@ -23871,11 +23665,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/bridges/corpo)
-"pcX" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
 "pdb" = (
 /obj/structure/table/mainship,
 /obj/item/toy/snappop{
@@ -23898,14 +23687,6 @@
 /obj/effect/landmark/corpsespawner/miner,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/cargo)
-"pdw" = (
-/obj/structure/stairs/seamless,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_street)
 "pdD" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/ice,
@@ -24044,7 +23825,7 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
 "pgX" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
@@ -24238,7 +24019,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/central_streets)
 "pmD" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/structure/closet/crate/trashcart,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/east_central_street)
@@ -24317,7 +24098,7 @@
 /obj/structure/fence{
 	layer = 2.9
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/thin,
@@ -24329,7 +24110,7 @@
 	},
 /area/gelida/outdoors/colony_streets/east_central_street)
 "pqI" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -24391,10 +24172,10 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/bridges/corpo_fitness)
 "psP" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/platform_decoration{
@@ -24403,7 +24184,7 @@
 /turf/open/floor/plating/ground/fakesnow/alt,
 /area/gelida/landing_zone_1)
 "pte" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -24526,7 +24307,7 @@
 	dir = 4;
 	layer = 5.3
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
@@ -24696,7 +24477,7 @@
 /turf/open/floor/plating/ground/fakesnow,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "pCG" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "pDx" = (
@@ -24823,9 +24604,6 @@
 	icon_state = "rasputin15"
 	},
 /area/gelida/landing_zone_forecon/UD6_Tornado)
-"pFY" = (
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
 "pGr" = (
 /turf/open/floor/plating{
 	dir = 8
@@ -24853,17 +24631,8 @@
 /obj/structure/cable,
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/lone_buildings/outdoor_bot)
-"pHw" = (
-/obj/structure/table/mainship,
-/obj/item/ashtray/bronze{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/item/toy/plush/farwa,
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
 "pHG" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /mob/living/simple_animal/mouse,
@@ -24931,7 +24700,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_street)
 "pJb" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
@@ -24943,7 +24712,7 @@
 	},
 /area/gelida/landing_zone_forecon/UD6_Tornado)
 "pJh" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/prison,
@@ -25248,7 +25017,7 @@
 /turf/open/floor/prison/kitchen,
 /area/gelida/indoors/a_block/kitchen)
 "pRW" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -25497,9 +25266,6 @@
 "qac" = (
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/c_block/cargo)
-"qat" = (
-/turf/open/floor/plating/ground/fakesnow/alt,
-/area/gelida/caves/central_caves)
 "qaD" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/table/mainship{
@@ -25558,13 +25324,13 @@
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/a_block/medical)
 "qbe" = (
-/obj/structure/platform,
-/obj/structure/platform/gelida{
-	dir = 8
-	},
 /obj/structure/platform_decoration{
 	dir = 10
 	},
+/obj/structure/platform/gelida{
+	dir = 8
+	},
+/obj/structure/platform/gelida,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "qbN" = (
@@ -25653,7 +25419,7 @@
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/corpo)
 "qeN" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/thin,
@@ -25850,7 +25616,7 @@
 /turf/open/floor/plating,
 /area/gelida/caves/west_caves)
 "qlk" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
@@ -25882,25 +25648,6 @@
 	dir = 4
 	},
 /area/gelida/indoors/c_block/mining)
-"qmq" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 2
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/north_street)
 "qmy" = (
 /obj/structure/coatrack{
 	pixel_y = 24
@@ -26092,7 +25839,7 @@
 /area/gelida/indoors/b_block/hydro)
 "qum" = (
 /obj/structure/table/mainship,
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/prison/whitepurple/full{
@@ -26142,12 +25889,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/fakesnow,
 /area/gelida/landing_zone_1)
-"qwI" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
 "qwO" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
@@ -26226,7 +25967,7 @@
 /obj/structure/stairs/seamless{
 	dir = 4
 	},
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
 "qxW" = (
@@ -26240,10 +25981,6 @@
 	icon_state = "56"
 	},
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
-"qyr" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/fakesnow,
-/area/gelida/caves/central_caves)
 "qyJ" = (
 /obj/structure/table/mainship,
 /obj/item/toy/prize/deathripley{
@@ -26409,7 +26146,7 @@
 	},
 /area/gelida/landing_zone_forecon/UD6_Tornado)
 "qES" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/prison,
@@ -26472,7 +26209,7 @@
 /obj/structure/stairs/seamless{
 	dir = 1
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /turf/open/floor/prison/blue/plate{
@@ -26480,7 +26217,7 @@
 	},
 /area/gelida/indoors/a_block/admin)
 "qIh" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/closed/mineral/smooth/snowrock,
 /area/gelida/outdoors/rock)
 "qID" = (
@@ -26537,10 +26274,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
-"qIV" = (
-/obj/structure/largecrate/random/barrel/blue,
-/turf/open/floor/plating/ground/fakesnow/alt,
-/area/gelida/outdoors/colony_streets/north_street)
 "qJg" = (
 /obj/structure/platform_decoration{
 	dir = 4
@@ -26602,7 +26335,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/casino)
 "qKF" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -26743,12 +26476,12 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/security)
 "qOh" = (
-/obj/structure/platform,
-/obj/structure/platform/gelida{
-	dir = 8
-	},
 /obj/structure/platform_decoration{
 	dir = 10
+	},
+/obj/structure/platform/gelida,
+/obj/structure/platform/gelida{
+	dir = 8
 	},
 /turf/open/floor/grass,
 /area/gelida/indoors/a_block/garden)
@@ -26895,10 +26628,6 @@
 	dir = 4
 	},
 /area/gelida/indoors/a_block/dorm_north)
-"qRU" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/rock)
 "qRY" = (
 /obj/structure/barricade/wooden{
 	dir = 1
@@ -27116,7 +26845,6 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/casino)
 "qYn" = (
-/obj/structure/platform,
 /obj/structure/platform_decoration{
 	dir = 10;
 	layer = 3.51
@@ -27128,6 +26856,7 @@
 	dir = 1;
 	pixel_y = 7
 	},
+/obj/structure/platform/gelida,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/garage)
 "qYF" = (
@@ -27220,14 +26949,6 @@
 /obj/machinery/light,
 /turf/open/floor/carpet,
 /area/gelida/indoors/c_block/garage)
-"rbR" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_street)
 "rbU" = (
 /obj/structure/flora/bush{
 	pixel_y = 9
@@ -27238,7 +26959,7 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/kitchen)
 "rbY" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -27557,7 +27278,7 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
 "rku" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/prison,
@@ -27766,18 +27487,6 @@
 "rpT" = (
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/lone_buildings/storage_blocks)
-"rqj" = (
-/obj/structure/platform/gelida{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/structure/platform/gelida{
-	dir = 4
-	},
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/north_street)
 "rqp" = (
 /obj/structure/inflatable,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -27797,7 +27506,7 @@
 /turf/closed/mineral/smooth/snowrock,
 /area/gelida/outdoors/rock)
 "rrz" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
 	},
@@ -27812,11 +27521,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/ground/snow/layer0,
+/turf/open/floor/plating/ground/fakesnow/alt,
 /area/gelida/outdoors/colony_streets/north_street)
 "rso" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -28007,13 +27712,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/sterilewhite/full,
 /area/gelida/indoors/a_block/corpo)
-"rzu" = (
-/obj/structure/platform,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/north_street)
 "rzE" = (
 /obj/machinery/disposal,
 /obj/machinery/light{
@@ -28102,12 +27800,6 @@
 "rCM" = (
 /turf/closed/ice_rock/southWall,
 /area/gelida/outdoors/rock)
-"rCN" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/fakesnow/alt,
-/area/gelida/outdoors/colony_streets/north_street)
 "rCP" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/structure/window{
@@ -28197,18 +27889,10 @@
 /obj/structure/prop/vehicle/truck,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_east_street)
-"rFT" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/fakesnow/alt,
-/area/gelida/outdoors/n_rockies)
 "rFU" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/cargo)
-"rGh" = (
-/obj/structure/closet/crate/trashcart,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_street)
 "rGi" = (
 /obj/structure/inflatable{
 	dir = 1
@@ -28571,10 +28255,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/bridges)
-"rRo" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/fakesnow,
-/area/gelida/outdoors/n_rockies)
 "rRB" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -28877,10 +28557,10 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_street)
 "sdZ" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/platform_decoration{
@@ -29145,7 +28825,7 @@
 /turf/open/floor/carpet,
 /area/gelida/indoors/a_block/executive)
 "snw" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/plating/heatinggrate,
 /area/gelida/indoors/c_block/bridge)
 "snA" = (
@@ -29209,7 +28889,7 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/b_block/bar)
 "soJ" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/ywflowers{
@@ -29228,7 +28908,7 @@
 /turf/open/floor/plating,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "soQ" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -29298,7 +28978,7 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
 "srx" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -29617,10 +29297,6 @@
 /obj/effect/spawner/random/toolbox,
 /turf/open/floor/prison,
 /area/gelida/landing_zone_2)
-"szk" = (
-/obj/structure/largecrate/random/barrel/blue,
-/turf/open/floor/plating/ground/fakesnow,
-/area/gelida/outdoors/colony_streets/north_street)
 "szN" = (
 /obj/machinery/atmospherics/pipe/manifold4w/green/hidden,
 /obj/structure/table/mainship,
@@ -29670,7 +29346,7 @@
 	},
 /area/gelida/outdoors/colony_streets/central_streets)
 "sAT" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/structure/cable,
@@ -29840,14 +29516,14 @@
 /turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "sFg" = (
+/obj/structure/platform_decoration{
+	dir = 9
+	},
 /obj/structure/platform/gelida{
 	dir = 1
 	},
 /obj/structure/platform/gelida{
 	dir = 4
-	},
-/obj/structure/platform_decoration{
-	dir = 9
 	},
 /turf/open/floor/grass,
 /area/gelida/indoors/a_block/garden)
@@ -29944,7 +29620,7 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/a_block/dorms)
 "sJg" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /obj/effect/decal/warning_stripes/thin,
@@ -29986,15 +29662,6 @@
 "sKa" = (
 /turf/open/floor/prison/whitegreen/full,
 /area/gelida/indoors/a_block/fitness)
-"sKf" = (
-/obj/structure/prop/vehicle/truck{
-	dir = 8;
-	layer = 3.1;
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/turf/open/floor/plating/ground/fakesnow/alt,
-/area/gelida/outdoors/colony_streets/north_street)
 "sKj" = (
 /obj/structure/fence{
 	layer = 2.9
@@ -30031,12 +29698,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/casino)
-"sLF" = (
-/obj/structure/platform/gelida{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_street)
 "sLU" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/structure/curtain/temple,
@@ -30062,26 +29723,13 @@
 	dir = 4
 	},
 /area/gelida/indoors/b_block/hydro)
-"sMr" = (
-/obj/structure/platform/gelida{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/north_street)
 "sMv" = (
-/obj/structure/platform,
-/obj/structure/platform/gelida{
-	dir = 8
-	},
 /obj/structure/platform_decoration{
 	dir = 10
+	},
+/obj/structure/platform/gelida,
+/obj/structure/platform/gelida{
+	dir = 8
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/landing_zone_1)
@@ -30101,14 +29749,14 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/c_block/casino)
 "sMO" = (
+/obj/structure/platform_decoration{
+	dir = 5
+	},
 /obj/structure/platform/gelida{
 	dir = 1
 	},
 /obj/structure/platform/gelida{
 	dir = 8
-	},
-/obj/structure/platform_decoration{
-	dir = 5
 	},
 /turf/open/floor/grass,
 /area/gelida/indoors/a_block/garden)
@@ -30143,7 +29791,7 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/c_block/casino)
 "sOL" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -30163,7 +29811,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/bridge)
 "sPA" = (
-/obj/structure/platform,
+/obj/structure/platform/gelida,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "sPO" = (
@@ -30267,7 +29915,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/kitchen)
 "sRQ" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/item/stack/rods,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
@@ -30281,7 +29929,7 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -30416,7 +30064,7 @@
 /turf/open/floor/carpet,
 /area/gelida/indoors/c_block/casino)
 "sXn" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/prison/sterilewhite,
@@ -30488,7 +30136,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/lone_buildings/spaceport)
 "sZP" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -30535,7 +30183,7 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
 "tbd" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/plating/platebot,
@@ -30865,7 +30513,7 @@
 /turf/open/floor/prison/blue,
 /area/gelida/indoors/a_block/admin)
 "tlV" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/east_central_street)
@@ -30946,10 +30594,10 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/security)
 "tnD" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/structure/platform_decoration{
 	dir = 6;
 	layer = 3.51
@@ -30962,7 +30610,7 @@
 /turf/open/floor/plating/ground/fakesnow,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "tnL" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/fakesnow,
@@ -30986,10 +30634,6 @@
 	},
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/a_block/fitness)
-"tpy" = (
-/obj/structure/largecrate/random/barrel/green,
-/turf/open/floor/plating/ground/fakesnow/alt,
-/area/gelida/outdoors/colony_streets/north_street)
 "tpJ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/fakesnow,
@@ -31063,19 +30707,6 @@
 "trM" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_street)
-"tsf" = (
-/obj/structure/platform/gelida{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/fence{
-	layer = 2.9
-	},
-/turf/open/floor/prison/plate,
 /area/gelida/outdoors/colony_streets/north_street)
 "tsA" = (
 /obj/item/ammo_magazine/rifle/tx11{
@@ -31297,7 +30928,7 @@
 /turf/open/floor/plating/ground/fakesnow,
 /area/gelida/caves/east_caves)
 "tAo" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
@@ -31324,10 +30955,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_east_street)
-"tBq" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/plating,
-/area/gelida/indoors/c_block/casino)
 "tBB" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 8
@@ -31346,7 +30973,7 @@
 /obj/structure/stairs/seamless{
 	dir = 8
 	},
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -31410,13 +31037,6 @@
 	dir = 4
 	},
 /area/gelida/outdoors/colony_streets/central_streets)
-"tEe" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 10
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/fakesnow,
-/area/gelida/outdoors/colony_streets/north_street)
 "tES" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/wood,
@@ -31442,8 +31062,8 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/lone_buildings/engineering)
 "tFU" = (
-/obj/structure/platform,
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform,
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/platform_decoration{
@@ -31462,18 +31082,11 @@
 	},
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/garage)
-"tGb" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
 "tGe" = (
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 5
 	},
 /area/gelida/outdoors/colony_streets/south_street)
-"tGk" = (
-/turf/closed/wall/r_wall,
-/area/gelida/indoors/a_block/fitness)
 "tHl" = (
 /obj/effect/turf_overlay/icerock{
 	dir = 1
@@ -31611,7 +31224,7 @@
 /obj/structure/stairs/seamless{
 	dir = 8
 	},
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/mining)
 "tLO" = (
@@ -31674,7 +31287,7 @@
 /turf/open/floor/tile/yellow/patch,
 /area/gelida/indoors/a_block/corpo)
 "tNS" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -31789,7 +31402,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/casino)
 "tRC" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -31822,7 +31435,7 @@
 /turf/open/floor/plating/ground/fakesnow/alt,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "tSO" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /obj/effect/decal/warning_stripes/thin,
@@ -31974,13 +31587,13 @@
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/mining)
 "tXk" = (
-/obj/structure/platform,
-/obj/structure/platform/gelida{
-	dir = 4
-	},
 /obj/structure/platform_decoration{
 	dir = 6
 	},
+/obj/structure/platform/gelida{
+	dir = 4
+	},
+/obj/structure/platform/gelida,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "tXO" = (
@@ -32088,7 +31701,7 @@
 /turf/open/floor/plating/ground/fakesnow,
 /area/gelida/outdoors/colony_streets/north_street)
 "ubR" = (
-/obj/structure/window/framed/colony/reinforced,
+/obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/bridge)
 "uce" = (
@@ -32491,14 +32104,17 @@
 /turf/closed/wall,
 /area/gelida/indoors/a_block/corpo)
 "uoU" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
-	},
-/obj/structure/platform/gelida{
-	dir = 8
 	},
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
+/obj/structure/platform/gelida{
+	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 5
+	},
 /turf/open/floor/grass,
 /area/gelida/indoors/a_block/garden)
 "upa" = (
@@ -32567,7 +32183,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/rock)
+/area/gelida/outdoors/w_rockies)
 "usH" = (
 /obj/machinery/smartfridge/seeds,
 /turf/open/floor/prison/whitegreenfull2,
@@ -32659,7 +32275,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -32677,7 +32293,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "uxl" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -32727,7 +32343,7 @@
 /turf/open/floor/plating/ground/ice,
 /area/gelida/caves/west_caves)
 "uAk" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/stairs/cornerdark/seamless{
@@ -32788,7 +32404,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/kitchen)
 "uDr" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -33004,10 +32620,6 @@
 "uJj" = (
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/bridges)
-"uJz" = (
-/obj/machinery/computer/intel_computer,
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
 "uJO" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
@@ -33232,7 +32844,7 @@
 	},
 /area/gelida/outdoors/colony_streets/central_streets)
 "uRI" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
 "uRS" = (
@@ -33266,7 +32878,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/central_streets)
 "uSq" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/kitchen)
 "uSU" = (
@@ -33426,7 +33038,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/landing_zone_2)
 "uXX" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/effect/landmark/weed_node,
@@ -33594,7 +33206,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "vcW" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/item/shard,
@@ -33731,7 +33343,7 @@
 /turf/closed/wall,
 /area/gelida/indoors/a_block/security)
 "vhD" = (
-/obj/structure/platform,
+/obj/structure/platform/gelida,
 /turf/open/floor/grass,
 /area/gelida/indoors/a_block/garden)
 "vhH" = (
@@ -33829,13 +33441,13 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/lone_buildings/outdoor_bot)
 "vjo" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/kitchen)
 "vjp" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -33848,13 +33460,13 @@
 	},
 /area/gelida/indoors/a_block/admin)
 "vjE" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
 "vjI" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/structure/stairs/cornerdark/seamless,
@@ -33972,7 +33584,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorms)
 "vpG" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /turf/open/floor/prison/darkbrown/full,
@@ -34291,25 +33903,15 @@
 	},
 /area/gelida/indoors/a_block/hallway)
 "vyH" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/prison/darkpurple,
 /area/gelida/indoors/a_block/dorms)
 "vzc" = (
 /obj/structure/table/mainship,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
-"vzg" = (
-/obj/structure/platform_decoration,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/north_street)
 "vzB" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/central_streets)
 "vzI" = (
@@ -34514,8 +34116,8 @@
 	},
 /area/gelida/indoors/c_block/mining)
 "vFk" = (
-/obj/structure/platform,
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform,
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/structure/platform_decoration{
@@ -34576,7 +34178,7 @@
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/north_west_street)
 "vGC" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8;
 	layer = 5.2
 	},
@@ -34878,10 +34480,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_east_street)
-"vSF" = (
-/obj/structure/table/mainship,
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
 "vSV" = (
 /obj/item/trash/kepler{
 	layer = 3.1;
@@ -34919,7 +34517,7 @@
 /area/gelida/indoors/a_block/dorms)
 "vUo" = (
 /obj/item/stack/rods,
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
@@ -34985,10 +34583,6 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/dorm_north)
-"vVs" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/plating,
-/area/gelida/indoors/b_block/hydro)
 "vVO" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/under/colonist,
@@ -35040,14 +34634,14 @@
 /turf/open/floor/plating,
 /area/gelida/landing_zone_2)
 "vXk" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
-	},
-/obj/structure/platform/gelida{
-	dir = 8
 	},
 /obj/structure/platform_decoration{
 	dir = 5
+	},
+/obj/structure/platform/gelida{
+	dir = 8
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_east_street)
@@ -35170,7 +34764,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/security)
 "wcb" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
@@ -35216,7 +34810,7 @@
 /area/gelida/indoors/lone_buildings/storage_blocks)
 "wdm" = (
 /obj/structure/platform_decoration,
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/cargo)
 "wdq" = (
@@ -35299,7 +34893,7 @@
 /turf/open/floor/plating/ground/fakesnow,
 /area/gelida/outdoors/colony_streets/windbreaker)
 "wgj" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /obj/machinery/floodlight/colony{
@@ -35323,7 +34917,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/casino)
 "whb" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /obj/item/stack/sheet/metal,
@@ -35376,10 +34970,6 @@
 	},
 /turf/open/floor/prison,
 /area/gelida/indoors/b_block/hydro)
-"wiX" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
 "wjc" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -35583,7 +35173,7 @@
 	},
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/mainship/stripesquare,
-/area/gelida/outdoors/rock)
+/area/gelida/outdoors/w_rockies)
 "wqi" = (
 /obj/structure/inflatable{
 	dir = 8
@@ -35816,10 +35406,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/hallway)
-"www" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/fakesnow/alt,
-/area/gelida/outdoors/n_rockies)
 "wwL" = (
 /obj/structure/platform_decoration,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -35828,7 +35414,7 @@
 /turf/closed/mineral/smooth/snowrock,
 /area/gelida/outdoors/rock)
 "wwT" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/stairs/seamless,
@@ -35876,7 +35462,7 @@
 	},
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
 "wyb" = (
-/obj/structure/platform,
+/obj/structure/platform/gelida,
 /turf/open/floor/plating,
 /area/gelida/indoors/c_block/garage)
 "wyf" = (
@@ -35898,10 +35484,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_east_street)
-"wAb" = (
-/obj/structure/platform,
-/turf/open/floor/plating/ground/fakesnow,
-/area/gelida/outdoors/n_rockies)
 "wAn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /obj/machinery/light{
@@ -35988,10 +35570,10 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "wDs" = (
+/obj/structure/cable,
 /obj/structure/platform/gelida{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_east_street)
 "wDv" = (
@@ -36201,7 +35783,7 @@
 /turf/open/floor/plating/ground/fakesnow/alt,
 /area/gelida/outdoors/colony_streets/south_west_street)
 "wKD" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/structure/cable,
@@ -36360,9 +35942,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
-"wPs" = (
-/turf/closed/wall/r_wall,
-/area/gelida/indoors/b_block/hydro)
 "wPD" = (
 /obj/structure/rack,
 /turf/open/floor/prison/whitepurple/full{
@@ -36389,7 +35968,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/central_streets)
 "wQK" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
@@ -36401,7 +35980,7 @@
 	},
 /area/gelida/indoors/lone_buildings/storage_blocks)
 "wRo" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/effect/ai_node,
@@ -36532,7 +36111,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/caves/west_caves)
 "wVC" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -36631,7 +36210,7 @@
 /turf/open/floor/plating/ground/fakesnow/alt,
 /area/gelida/outdoors/colony_streets/east_central_street)
 "xar" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
 	dir = 1
@@ -36664,10 +36243,6 @@
 /obj/machinery/disposal,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
-"xbs" = (
-/obj/structure/largecrate/random/barrel/red,
-/turf/open/floor/plating/ground/fakesnow,
-/area/gelida/outdoors/colony_streets/north_street)
 "xbv" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/fakesnow/alt,
@@ -36690,12 +36265,6 @@
 /obj/item/stool,
 /turf/open/floor/prison,
 /area/gelida/indoors/lone_buildings/chunk)
-"xdl" = (
-/obj/machinery/power/apc/drained,
-/obj/structure/bed/chair/wheelchair,
-/obj/structure/cable,
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
 "xef" = (
 /obj/structure/platform_decoration{
 	dir = 4
@@ -36750,12 +36319,12 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/b_block/bridge)
 "xic" = (
-/obj/structure/platform,
-/obj/structure/platform/gelida{
-	dir = 4
-	},
 /obj/structure/platform_decoration{
 	dir = 6
+	},
+/obj/structure/platform/gelida,
+/obj/structure/platform/gelida{
+	dir = 4
 	},
 /turf/open/floor/grass,
 /area/gelida/indoors/a_block/garden)
@@ -36769,16 +36338,12 @@
 /turf/open/floor/prison,
 /area/gelida/outdoors/colony_streets/central_streets)
 "xiB" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular,
 /area/gelida/outdoors/colony_streets/central_streets)
-"xiC" = (
-/obj/structure/cable,
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
 "xiF" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 1
@@ -36804,8 +36369,8 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/fitness)
 "xjG" = (
-/obj/structure/platform,
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform,
+/obj/structure/fakeplatform{
 	dir = 4;
 	layer = 2.9
 	},
@@ -36823,10 +36388,10 @@
 /turf/open/floor/plating/ground/fakesnow/alt,
 /area/gelida/outdoors/colony_streets/south_street)
 "xkC" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /obj/structure/platform_decoration{
 	dir = 6;
 	layer = 3.51
@@ -36886,7 +36451,7 @@
 	layer = 4.3;
 	pixel_y = 16
 	},
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
 /area/gelida/outdoors/colony_streets/north_street)
 "xmk" = (
@@ -36934,8 +36499,8 @@
 	},
 /area/gelida/outdoors/colony_streets/north_street)
 "xmW" = (
-/obj/structure/platform,
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform,
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /obj/structure/platform_decoration{
@@ -37071,11 +36636,6 @@
 /obj/item/shard,
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/a_block/corpo)
-"xsk" = (
-/obj/structure/platform,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/n_rockies)
 "xsO" = (
 /obj/item/storage/belt/champion{
 	anchored = 1;
@@ -37192,21 +36752,21 @@
 	id = "UD6";
 	name = "\improper Shutters"
 	},
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/stairs/seamless,
 /turf/open/floor/plating,
 /area/gelida/landing_zone_forecon/UD6_Typhoon)
 "xwk" = (
+/obj/structure/platform_decoration{
+	dir = 5
+	},
 /obj/structure/platform/gelida{
 	dir = 1
 	},
 /obj/structure/platform/gelida{
 	dir = 8
-	},
-/obj/structure/platform_decoration{
-	dir = 5
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/landing_zone_1)
@@ -37298,7 +36858,7 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "xAn" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement,
@@ -37330,14 +36890,14 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "xBY" = (
-/obj/structure/platform/gelida{
-	dir = 1
+/obj/structure/platform_decoration{
+	dir = 9
 	},
 /obj/structure/platform/gelida{
 	dir = 4
 	},
-/obj/structure/platform_decoration{
-	dir = 9
+/obj/structure/platform/gelida{
+	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/landing_zone_2)
@@ -37461,10 +37021,6 @@
 /obj/structure/platform_decoration,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/landing_zone_1)
-"xFg" = (
-/obj/structure/largecrate/random/secure,
-/turf/open/floor/plating/ground/fakesnow,
-/area/gelida/outdoors/colony_streets/north_street)
 "xFh" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/prison/sterilewhite,
@@ -37562,9 +37118,14 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/b_block/hydro)
 "xIt" = (
-/obj/structure/platform,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/n_rockies)
+/obj/effect/turf_overlay/icerock{
+	dir = 1
+	},
+/obj/effect/turf_overlay/icerock{
+	dir = 8
+	},
+/turf/closed/ice_rock/corners,
+/area/gelida/outdoors/rock)
 "xIu" = (
 /obj/structure/rack,
 /obj/item/frame/table{
@@ -37816,15 +37377,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/admin)
-"xOJ" = (
-/obj/item/clothing/mask/facehugger/dead{
-	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
-	name = "????";
-	stat = 2
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
 "xOM" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
@@ -37861,15 +37413,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/central_streets)
-"xPw" = (
-/obj/structure/platform/gelida{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/gelida/outdoors/colony_streets/north_street)
 "xPG" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -38076,7 +37619,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/mining)
 "xVa" = (
-/obj/structure/platform/gelida{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /obj/structure/largecrate/random/barrel/green{
@@ -38125,14 +37668,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/yellow/patch,
 /area/gelida/indoors/a_block/corpo)
-"xWq" = (
-/obj/machinery/floodlight/colony{
-	layer = 4.3;
-	pixel_y = 9
-	},
-/obj/effect/decal/warning_stripes/stripedsquare/tile/border,
-/turf/open/floor/mainship/black/full,
-/area/gelida/outdoors/colony_streets/north_street)
 "xWH" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
@@ -38249,13 +37784,6 @@
 	dir = 1
 	},
 /area/gelida/outdoors/colony_streets/east_central_street)
-"yaR" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
 "yaS" = (
 /obj/structure/table/mainship,
 /turf/open/floor/prison,
@@ -38393,11 +37921,6 @@
 	dir = 4
 	},
 /area/gelida/indoors/a_block/dorm_north)
-"ygz" = (
-/obj/structure/table/mainship,
-/obj/item/clothing/suit/storage/CMB,
-/turf/open/floor/prison,
-/area/gelida/outdoors/colony_streets/windbreaker/observation)
 "ygA" = (
 /obj/effect/landmark/patrol_point{
 	id = "TGMC_11";
@@ -38486,9 +38009,8 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "yjx" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/fakesnow/alt,
-/area/gelida/outdoors/colony_streets/north_street)
+/turf/open/floor/plating/ground/fakesnow,
+/area/gelida/caves/central_caves)
 "yjB" = (
 /obj/item/stack/rods,
 /obj/structure/window_frame/colony,
@@ -39382,9 +38904,9 @@ ndb
 ndb
 ndb
 lsi
-ken
-ken
-ken
+fBJ
+fBJ
+fBJ
 xUF
 ndb
 ndb
@@ -39604,9 +39126,9 @@ lsi
 lsi
 ndb
 lsi
-ken
-ken
-ken
+fBJ
+fBJ
+fBJ
 xUF
 ndb
 ndb
@@ -39826,9 +39348,9 @@ gse
 lsi
 lsi
 lsi
-ken
-ken
-ken
+fBJ
+fBJ
+fBJ
 xUF
 lsi
 lsi
@@ -40048,12 +39570,12 @@ rOI
 pdJ
 nOL
 pdJ
-nOL
+gnX
 dBl
-nOL
+gnX
 wpL
-nOL
-pdJ
+gnX
+gvL
 ndb
 ndb
 ndb
@@ -40270,9 +39792,9 @@ rOI
 lsi
 lsi
 lsi
-ken
-ken
-ken
+fBJ
+fBJ
+fBJ
 xUF
 lsi
 lsi
@@ -40492,9 +40014,9 @@ ncu
 lsi
 ndb
 lsi
-ken
-ken
-ken
+fBJ
+fBJ
+fBJ
 xUF
 ndb
 ndb
@@ -40714,9 +40236,9 @@ inq
 lsi
 ndb
 lsi
-ken
-ken
-ken
+fBJ
+fBJ
+fBJ
 xUF
 ndb
 ndb
@@ -40936,9 +40458,9 @@ inq
 lsi
 ndb
 lsi
-ken
-ken
-ken
+fBJ
+fBJ
+fBJ
 xUF
 ndb
 ndb
@@ -40952,7 +40474,7 @@ ndb
 ndb
 nvd
 ndb
-oas
+ngP
 hbX
 iFq
 iFq
@@ -41158,9 +40680,9 @@ lsi
 lsi
 lsi
 lsi
-ken
-ken
-ken
+fBJ
+fBJ
+fBJ
 xUF
 ndb
 ndb
@@ -41174,7 +40696,7 @@ ndb
 ndb
 nvd
 ndb
-oas
+ngP
 eHG
 siX
 wDw
@@ -41380,9 +40902,9 @@ ndb
 ndb
 ndb
 lsi
-ken
-ken
-ken
+fBJ
+fBJ
+fBJ
 xUF
 ndb
 ndb
@@ -41401,7 +40923,7 @@ ngP
 wDw
 siX
 siX
-cyL
+hgj
 fyu
 oTb
 xpG
@@ -41602,9 +41124,9 @@ ndb
 ndb
 ndb
 lsi
-ken
-ken
-ken
+fBJ
+fBJ
+fBJ
 xUF
 ndb
 ndb
@@ -41618,7 +41140,7 @@ ndb
 ndb
 gku
 ndb
-oas
+ngP
 rKj
 wDw
 wDw
@@ -41824,9 +41346,9 @@ lsi
 lsi
 lsi
 lsi
-ken
-ken
-ken
+fBJ
+fBJ
+fBJ
 xUF
 ndb
 ndb
@@ -41840,7 +41362,7 @@ ndb
 ndb
 nvd
 ndb
-oas
+ngP
 mLW
 siX
 siX
@@ -42041,14 +41563,14 @@ fBJ
 fBJ
 fBJ
 fBJ
-ken
-qRU
-ken
-ken
-ken
-ken
-qRU
-ken
+fBJ
+oTB
+fBJ
+fBJ
+fBJ
+fBJ
+oTB
+fBJ
 xUF
 ndb
 ndb
@@ -42263,13 +41785,13 @@ fBJ
 fBJ
 qol
 jYY
-ken
-ken
-ken
+fBJ
+fBJ
+fBJ
 dYl
-ken
-ken
-ken
+fBJ
+fBJ
+fBJ
 usn
 xUF
 ndb
@@ -42284,7 +41806,7 @@ tqi
 tqi
 nvd
 ndb
-oas
+ngP
 siX
 wOd
 wOd
@@ -42485,14 +42007,14 @@ fBJ
 fBJ
 fBJ
 fBJ
-ken
-qRU
-ken
+fBJ
+oTB
+fBJ
 dYl
-ken
-ken
-ken
-ken
+fBJ
+fBJ
+fBJ
+fBJ
 xUF
 ndb
 ndb
@@ -42506,7 +42028,7 @@ tqi
 tqi
 nvd
 ndb
-oas
+ngP
 wOd
 wOd
 lIC
@@ -42950,7 +42472,7 @@ tqi
 tqF
 cNp
 ndb
-oas
+ngP
 wOd
 wOd
 wOd
@@ -43621,7 +43143,7 @@ wOd
 wOd
 wOd
 wOd
-cyL
+hgj
 fyu
 oTb
 xpG
@@ -43838,7 +43360,7 @@ qOV
 tqi
 ilJ
 ndb
-oas
+ngP
 wOd
 wOd
 wOd
@@ -43950,7 +43472,7 @@ fBJ
 fBJ
 fBJ
 yiI
-cAW
+fBJ
 fBJ
 fBJ
 fBJ
@@ -44171,9 +43693,9 @@ fBJ
 fBJ
 fBJ
 fBJ
-ghy
-asT
-tQg
+fBJ
+fBJ
+fBJ
 fBJ
 yaB
 fBJ
@@ -44282,7 +43804,7 @@ tqi
 tqi
 ilJ
 ndb
-oas
+ngP
 wOd
 wOd
 wOd
@@ -44290,7 +43812,7 @@ wOd
 wOd
 wOd
 wDS
-jCH
+hiC
 sMv
 pHY
 pHY
@@ -44310,7 +43832,7 @@ pHY
 pHY
 pHY
 xwk
-jCH
+hiC
 qJg
 wOd
 wOd
@@ -44504,7 +44026,7 @@ tqi
 mMH
 nvd
 ndb
-oas
+ngP
 wOd
 wHB
 wDE
@@ -44514,7 +44036,7 @@ itw
 wVl
 lIC
 wDS
-jCH
+hiC
 sMv
 pHY
 pHY
@@ -44530,7 +44052,7 @@ gve
 pHY
 pHY
 xwk
-jCH
+hiC
 qJg
 wOd
 wOd
@@ -44948,7 +44470,7 @@ tqi
 tqi
 ilJ
 ndb
-oas
+ngP
 wOd
 mPk
 aiO
@@ -44961,7 +44483,7 @@ wOd
 wOd
 wOd
 wDS
-jCH
+hiC
 sMv
 fyu
 pHY
@@ -44971,7 +44493,7 @@ pHY
 pHY
 fyu
 xwk
-jCH
+hiC
 qJg
 lIC
 wOd
@@ -45170,7 +44692,7 @@ tqi
 tqi
 nvd
 ndb
-oas
+ngP
 wOd
 rDx
 mUd
@@ -45191,7 +44713,7 @@ oTs
 ydC
 rll
 eUo
-jCH
+hiC
 qJg
 wOd
 wOd
@@ -45356,10 +44878,10 @@ msI
 tFQ
 tFQ
 tFQ
-nxz
+msI
 mQj
 veZ
-nxz
+msI
 igB
 pWH
 tFQ
@@ -45543,10 +45065,10 @@ gwI
 pCd
 yfp
 yfp
-msx
+yfp
 qBP
 ffD
-msx
+yfp
 yfp
 yfp
 cWF
@@ -45614,7 +45136,7 @@ tqi
 tqi
 ilJ
 ndb
-oas
+ngP
 siX
 lBm
 pHY
@@ -45816,7 +45338,7 @@ tqi
 tqF
 tqF
 tqF
-ndb
+nAJ
 tqi
 lGp
 wkg
@@ -45831,8 +45353,8 @@ wkg
 iDj
 tqi
 tqi
-ndb
-ndb
+tqi
+tqi
 tqi
 ilJ
 tqF
@@ -46037,8 +45559,8 @@ uUj
 pvp
 eEw
 tqF
-ndb
-ndb
+nAJ
+nAJ
 tqi
 ckC
 wkg
@@ -46054,7 +45576,7 @@ iDj
 tqi
 tqi
 tqi
-ndb
+tqi
 tqi
 ilJ
 tqF
@@ -46224,9 +45746,9 @@ rsp
 tix
 bkX
 yfp
-msx
+yfp
 uxt
-msx
+yfp
 yfp
 uhx
 sqm
@@ -46259,7 +45781,7 @@ tqi
 tqF
 ndP
 qOV
-ndb
+nAJ
 tqF
 tqi
 ckC
@@ -46280,7 +45802,7 @@ pwy
 tqi
 ilJ
 ndb
-oas
+ngP
 siX
 wOd
 wOd
@@ -46505,9 +46027,9 @@ ngP
 ngP
 ngP
 oas
-fuw
+hdk
 bdo
-fuw
+hdk
 oas
 wOd
 wOd
@@ -46953,7 +46475,7 @@ uug
 gve
 pHY
 pHY
-fuw
+hdk
 wOd
 wOd
 wOd
@@ -47118,7 +46640,7 @@ ghj
 mQd
 ghj
 lLt
-msx
+yfp
 wQe
 gHP
 vaN
@@ -47267,7 +46789,7 @@ rCM
 tzc
 bPS
 tzc
-uew
+iiB
 uew
 iiB
 fZP
@@ -47361,7 +46883,7 @@ nsF
 mfk
 kKK
 cQW
-geX
+lCJ
 dXl
 gdv
 tqi
@@ -47397,7 +46919,7 @@ eEZ
 gve
 gve
 pHY
-fuw
+hdk
 wOd
 wOd
 wOd
@@ -47784,7 +47306,7 @@ lIG
 xBL
 sZV
 reI
-msx
+yfp
 bfA
 gVv
 uky
@@ -48027,7 +47549,7 @@ ucE
 fCL
 kKK
 cQW
-geX
+lCJ
 jph
 gdv
 tqi
@@ -48064,21 +47586,21 @@ ndb
 ndb
 ndb
 ngP
-oas
-oas
 ngP
-oas
+ngP
+ngP
+ngP
 wOd
 wOd
 csz
 wOd
-oas
 ngP
-oas
-oas
 ngP
-oas
-oas
+ngP
+ngP
+ngP
+ngP
+ngP
 ngP
 wTN
 cHY
@@ -48249,7 +47771,7 @@ eoN
 drf
 wXv
 cQW
-geX
+lCJ
 jph
 gdv
 tqi
@@ -48619,7 +48141,7 @@ vPO
 hCr
 obt
 igF
-tGk
+vPO
 cmY
 pRW
 pRW
@@ -48632,7 +48154,7 @@ kcw
 pRW
 pRW
 sSq
-msx
+yfp
 gJD
 odg
 tkC
@@ -50065,7 +49587,7 @@ pkT
 xma
 mMH
 tqi
-ndb
+tqi
 tqi
 tqi
 tqi
@@ -50173,7 +49695,7 @@ vPO
 oDn
 ams
 asK
-tGk
+vPO
 vjp
 vjp
 vjp
@@ -50812,7 +50334,7 @@ uGF
 uGF
 uGF
 peB
-oJT
+mjR
 lOn
 oJT
 oJT
@@ -50970,7 +50492,7 @@ tqi
 tqi
 rrl
 ndb
-tqi
+ndb
 tqi
 tqi
 tqi
@@ -51185,18 +50707,18 @@ tqF
 tqi
 tqi
 tqi
-tqi
-tqi
+ndb
+ndb
 tqi
 tqi
 tqi
 vYQ
-tqi
-tqi
+ndb
+ndb
 tqi
 tqi
 pwy
-tqF
+tqi
 ndb
 ndb
 ndb
@@ -51362,9 +50884,9 @@ jph
 nSf
 jph
 iuJ
-vVs
-vVs
-vVs
+hgb
+hgb
+hgb
 iuJ
 jph
 crF
@@ -51399,26 +50921,26 @@ tqi
 tqi
 tqi
 tqi
+tqi
+tqF
+qOV
+qOV
+tqF
+tqi
+tqi
 ndb
-tqF
-qOV
-qOV
-tqF
-tqi
-tqi
-tqi
-tqi
+ndb
 tqi
 tqi
 tqi
 tqi
 vYQ
 tqi
+ndb
 tqi
 tqi
-tqF
-tqF
-qOV
+tqi
+tqi
 ndb
 ndb
 ndb
@@ -51478,10 +51000,10 @@ uGF
 uGF
 xEg
 uGF
-wLU
-lOn
-oJT
-oJT
+peB
+hTO
+gcf
+mjR
 cBH
 ojq
 uew
@@ -51601,7 +51123,7 @@ tqi
 tqF
 tqF
 qOV
-ndb
+tqF
 tqi
 tqi
 tqi
@@ -51620,8 +51142,8 @@ vgf
 tqi
 tqi
 tqi
-ndb
-ndb
+tqi
+tqi
 tqF
 qOV
 tqF
@@ -51629,7 +51151,7 @@ tqi
 tqi
 tqi
 tqi
-ndb
+tqi
 tqi
 mMH
 tqi
@@ -51638,9 +51160,9 @@ jqs
 tqi
 tqi
 tqi
-tqF
-tqF
-qOV
+tqi
+tqi
+tqi
 ndb
 ndb
 ndb
@@ -51699,14 +51221,14 @@ uGF
 uGF
 uGF
 uGF
-loD
-wLU
-lOn
-oJT
-oJT
+uGF
+atX
+aQR
+bNN
+peB
 ojq
-uew
-uew
+eue
+tzc
 uew
 rrz
 jDy
@@ -51823,8 +51345,8 @@ tqi
 tqi
 tqi
 tqi
-ndb
-ndb
+tqF
+tqF
 tqi
 tqi
 fCu
@@ -51841,8 +51363,8 @@ gZd
 vgf
 tqi
 tqi
-ndb
-ndb
+tqi
+tqi
 tqi
 tqi
 tqF
@@ -51851,18 +51373,18 @@ tqi
 tqi
 tqi
 tqi
-ndb
-ndb
-ndb
+tqi
+tqi
+tqi
 tqi
 tqi
 vYQ
 tqi
-tqF
-tqF
-qOV
-qOV
-tqF
+tqi
+tqi
+tqi
+tqi
+tqi
 ndb
 ndb
 ndb
@@ -51920,16 +51442,16 @@ uGF
 qKf
 uGF
 uGF
+xEg
 uGF
-uGF
-wLU
-lOn
-oJT
-oJT
-rCM
-uew
-kZp
-uew
+atX
+bJh
+axk
+atX
+nAJ
+eue
+eue
+bPS
 rrz
 jDy
 fzq
@@ -52032,7 +51554,7 @@ hLv
 svc
 lNq
 tPp
-vVs
+hgb
 crF
 tqi
 tqi
@@ -52046,7 +51568,7 @@ tqi
 tqi
 tqi
 qOV
-ndb
+tqF
 tqi
 tqi
 fCu
@@ -52074,17 +51596,17 @@ tqi
 tqi
 pwy
 tqi
-ndb
-ndb
-ndb
+tqi
+tqi
+tqi
 tqi
 vYQ
 tqi
+ndb
 tqi
-tqF
-tqF
-tqF
-tqF
+tqi
+tqi
+tqi
 ndb
 ndb
 ndb
@@ -52144,14 +51666,14 @@ uGF
 uGF
 uGF
 uGF
-wLU
-lOn
-oJT
-oJT
-rCM
-uew
-uew
-kZp
+axk
+bLc
+axk
+atX
+nAJ
+eue
+eue
+tzc
 rrz
 jDy
 uwy
@@ -52254,7 +51776,7 @@ bRS
 jlx
 lNq
 tPp
-vVs
+hgb
 crF
 tqi
 tqi
@@ -52297,15 +51819,15 @@ tqF
 nNF
 tqi
 tqi
-ndb
+tqi
 tqi
 tqi
 vYQ
+ndb
+ndb
+ndb
 tqi
 tqi
-tqi
-tqi
-tqF
 ndb
 ndb
 ndb
@@ -52366,14 +51888,14 @@ loD
 uGF
 uGF
 uGF
-wLU
-lOn
-oJT
-cBH
-ojq
-uew
-kZp
-uew
+atX
+bLc
+atX
+atX
+nAJ
+eue
+eue
+tzc
 rZQ
 vPO
 glJ
@@ -52476,7 +51998,7 @@ bRS
 mfO
 lNq
 rCP
-vVs
+hgb
 crF
 tqi
 tqi
@@ -52524,8 +52046,8 @@ tqi
 tqi
 uVz
 tqi
-tqi
-tqi
+ndb
+ndb
 tqi
 tqi
 ndb
@@ -52588,14 +52110,14 @@ loD
 uGF
 gfl
 uGF
-wLU
-lOn
-oJT
-rCM
-uew
-uew
-uew
-iiB
+cAW
+bLc
+atX
+axk
+tzc
+tzc
+eue
+bPS
 sCH
 vPO
 ams
@@ -52698,7 +52220,7 @@ bRS
 bRS
 lNq
 dHv
-vVs
+hgb
 crF
 tqi
 tqi
@@ -52709,8 +52231,8 @@ tqi
 tqi
 tqF
 qOV
-ndb
-ndb
+tqF
+tqF
 tqi
 dqv
 nAi
@@ -52747,7 +52269,7 @@ tqF
 rcx
 tqF
 tqi
-tqi
+ndb
 tqi
 tqi
 ndb
@@ -52810,14 +52332,14 @@ qTf
 qTf
 oFs
 snM
-lOn
-lOn
-oJT
-rCM
-kZp
-uew
-iiB
-gTw
+azr
+hTO
+gcf
+daB
+eue
+tzc
+mXU
+chD
 pUg
 hZX
 jeL
@@ -52890,7 +52412,7 @@ ghj
 lOf
 gyo
 oXh
-msx
+yfp
 hwu
 iMq
 dVx
@@ -52930,7 +52452,7 @@ mMH
 tqi
 tqi
 qOV
-ndb
+tqF
 tqi
 tqi
 tqi
@@ -53036,10 +52558,10 @@ oJT
 oJT
 oJT
 rCM
-uew
-uew
-uew
-vaE
+eue
+eue
+tzc
+sWa
 hdJ
 red
 ams
@@ -53124,7 +52646,7 @@ tix
 uhx
 iuJ
 iuJ
-vVs
+hgb
 iuJ
 iuJ
 oAm
@@ -53258,10 +52780,10 @@ oJT
 oJT
 oJT
 rCM
-uew
-kZp
-uew
-vaE
+eue
+eue
+tzc
+sWa
 tXO
 vPO
 ams
@@ -53303,29 +52825,29 @@ gpd
 eem
 evv
 yfp
-msx
+yfp
 uxt
 uxt
 yfp
 uxt
 uxt
-msx
 yfp
-msx
+yfp
+yfp
 yfp
 yfp
 pAx
 ahO
 yfp
 yfp
-msx
-msx
+yfp
+yfp
 uxt
 uxt
 yfp
 uxt
 uxt
-msx
+yfp
 yfp
 kjE
 gyo
@@ -53480,10 +53002,10 @@ oJT
 oJT
 oJT
 rCM
-uew
-uew
-uew
-pOe
+eue
+eue
+eue
+sWa
 skK
 vPO
 ams
@@ -53703,9 +53225,9 @@ oJT
 oJT
 tHl
 daB
-uew
-uew
-vaE
+eue
+eue
+sWa
 rrz
 jDy
 ams
@@ -53742,9 +53264,9 @@ uew
 crx
 dnH
 yfp
-msx
+yfp
 fWE
-msx
+yfp
 yfp
 sir
 muE
@@ -53772,9 +53294,9 @@ vaN
 ndh
 uhx
 yfp
-msx
+yfp
 uxt
-msx
+yfp
 yfp
 uhx
 fda
@@ -53812,7 +53334,7 @@ iuJ
 iuJ
 iuJ
 iuJ
-wPs
+iuJ
 aal
 aAZ
 aAZ
@@ -53826,7 +53348,7 @@ aAZ
 aAZ
 aAZ
 aal
-uak
+jTv
 jTv
 hnW
 lEJ
@@ -53849,7 +53371,7 @@ aAZ
 aAZ
 aAZ
 aal
-uak
+jTv
 jTv
 imm
 lEJ
@@ -53925,9 +53447,9 @@ oJT
 oJT
 oJT
 rCM
-uew
-uew
-vaE
+eue
+tzc
+sWa
 rrz
 jDy
 fzq
@@ -54147,8 +53669,8 @@ oJT
 oJT
 oJT
 rCM
-uew
-uew
+tzc
+tzc
 pOe
 rrz
 jDy
@@ -54370,7 +53892,7 @@ oJT
 oJT
 rCM
 kZp
-uew
+tzc
 vaE
 rrz
 jDy
@@ -55121,12 +54643,12 @@ hGC
 iuJ
 iuJ
 iuJ
-vVs
-vVs
+hgb
+hgb
 umE
 cxq
-vVs
-vVs
+hgb
+hgb
 iuJ
 iuJ
 bkX
@@ -55366,7 +54888,7 @@ iuJ
 iuJ
 iuJ
 iuJ
-wPs
+iuJ
 lqN
 jib
 jib
@@ -55380,7 +54902,7 @@ jib
 jib
 jib
 lqN
-uak
+jTv
 jTv
 bdC
 xow
@@ -55403,7 +54925,7 @@ jib
 jib
 jib
 lqN
-uak
+jTv
 jTv
 imm
 piP
@@ -55478,7 +55000,7 @@ oJT
 rCM
 uew
 uew
-kZp
+uew
 uew
 uew
 vaE
@@ -55695,11 +55217,11 @@ oJT
 oJT
 oJT
 oJT
-cBH
-oZc
-ojq
-uew
-uew
+oJT
+oJT
+tHl
+gcf
+daB
 uew
 uew
 uew
@@ -55814,8 +55336,8 @@ pNe
 vky
 vky
 vky
-aVS
-aVS
+vky
+vky
 vky
 vky
 vky
@@ -55917,14 +55439,14 @@ oJT
 oJT
 oJT
 oJT
+oJT
+oJT
+oJT
+oJT
 rCM
 uew
 uew
 uew
-kZp
-uew
-uew
-kZp
 vaE
 uew
 kZp
@@ -56013,7 +55535,7 @@ iuJ
 irN
 iuJ
 iuJ
-vVs
+hgb
 iuJ
 iuJ
 uhx
@@ -56041,8 +55563,8 @@ sdU
 sdU
 sdU
 sdU
-aVS
-aVS
+vky
+vky
 vky
 vky
 dvV
@@ -56138,13 +55660,13 @@ oJT
 oJT
 oJT
 oJT
-cBH
-ojq
-uYy
-kZp
-uew
-uew
-uew
+oJT
+oJT
+oJT
+oJT
+oJT
+tHl
+daB
 uew
 uew
 vaE
@@ -56264,7 +55786,7 @@ sdU
 sdU
 sdU
 sdU
-aVS
+vky
 vky
 vky
 dvV
@@ -56360,15 +55882,15 @@ oJT
 oJT
 oJT
 oJT
+oJT
+oJT
+oJT
+oJT
+oJT
+oJT
 rCM
-uYy
-uYy
-uew
-kZp
-uew
-uew
-uew
-kZp
+yjx
+tzc
 vaE
 uew
 uew
@@ -56572,26 +56094,26 @@ xEg
 uGF
 uGF
 uGF
-xEg
+uGF
 eVB
 uGF
-wLU
+peB
+gcf
+gcf
+gcf
+mjR
 oJT
 oJT
 oJT
 oJT
 oJT
 oJT
-rCM
-xKP
-uYy
-jlM
-jlM
-jlM
-jlM
-jlM
-jlM
-iJc
+oJT
+cBH
+ojq
+gfl
+yjx
+eZJ
 jlM
 pnI
 jlM
@@ -56795,27 +56317,27 @@ xEg
 uGF
 uGF
 uGF
-qTf
+aeZ
 uGF
-wLU
+uGF
+gfl
+uGF
+xEg
+peB
+gcf
+mjR
 oJT
 oJT
 oJT
 oJT
-oJT
-oJT
-rCM
-uxf
-uYy
-pKS
-pKS
-pKS
-bNN
-bNN
-eSh
-wGX
-jlM
-jlM
+cBH
+ojq
+xEg
+uGF
+yjx
+cOZ
+cRF
+cVg
 jlM
 jlM
 jlM
@@ -57019,26 +56541,26 @@ uGF
 uGF
 qTf
 gfl
-wLU
+uGF
+uGF
+uGF
+uGF
+ntJ
+uGF
+peB
+mjR
 oJT
 oJT
-oJT
-oJT
-oJT
-oJT
-rCM
-uYy
-uxf
-uYy
-pKS
-bLc
-jlM
-jlM
-fTZ
-wGX
-jlM
-jlM
-jlM
+cBH
+ojq
+uGF
+uGF
+gfl
+yjx
+bBz
+bBz
+eZJ
+ujh
 jlM
 aKo
 mXF
@@ -57051,7 +56573,7 @@ jly
 rYO
 txH
 txH
-ugJ
+txH
 mBa
 mXF
 mXF
@@ -57241,26 +56763,26 @@ gfl
 uGF
 qTf
 uGF
-wLU
-oJT
-oJT
-oJT
-oJT
-oJT
-oJT
-rCM
-uYy
-uYy
-uYy
-pKS
-hGT
-kDe
-jlM
-fTZ
-eAM
-mNK
-nwP
-jlM
+uGF
+uGF
+gfl
+uGF
+ntJ
+gfl
+uGF
+peB
+mjR
+cBH
+ojq
+uGF
+gfl
+uGF
+uGF
+uGF
+yjx
+bBz
+eZJ
+ujh
 ujh
 dpw
 txH
@@ -57461,28 +56983,28 @@ xEg
 uGF
 uGF
 uGF
-qTf
+aeZ
 uGF
-wLU
-oJT
-oJT
-oJT
-oJT
-oJT
-oJT
-rCM
-xKP
-uYy
-pKS
-pKS
-pKS
-rGh
-jlM
-fTZ
+cAW
+uGF
+uGF
+uGF
+ntJ
+uGF
+uGF
+uGF
+peB
+ojq
+uGF
+uGF
+uGF
+uGF
+uGF
+uGF
+yjx
 ujh
-wGX
-jlM
-jlM
+rsm
+ujh
 jlM
 dpw
 txH
@@ -57686,25 +57208,25 @@ oFs
 qTf
 ojq
 hiI
-oJT
-oJT
-oJT
-oJT
-oJT
-oJT
-rCM
-uxf
-uYy
-uYy
-pKS
-cRF
-jlM
-jlM
-fTZ
+gcf
+daB
+xEg
+ntJ
+gfl
+uGF
+xEg
+uGF
+uGF
+uGF
+gfl
+uGF
+gfl
+uGF
+gfl
+yjx
 ujh
-eZJ
+rsm
 jlM
-nwP
 jlM
 dpw
 txH
@@ -57909,24 +57431,24 @@ ojq
 hiI
 oJT
 oJT
-oJT
-oJT
-oJT
-oJT
-cBH
-ojq
-uYy
-uYy
-uYy
-pKS
-kra
-ngB
-jlM
-fTZ
+tHl
+gcf
+daB
+uGF
+uGF
+uGF
+xEg
+uGF
+uGF
+uGF
+uGF
+xEg
+uGF
+uGF
+uGF
 ujh
-eZJ
-jlM
-jlM
+izf
+ujh
 aKo
 wtG
 txH
@@ -58133,21 +57655,21 @@ oJT
 oJT
 oJT
 oJT
-oJT
-oJT
-rCM
-uYy
-uYy
-uYy
-pKS
-pKS
-pKS
-szk
-jlM
-fTZ
-bBz
-eZJ
-jlM
+hOK
+tQg
+uGF
+gfl
+uGF
+uGF
+gfl
+uGF
+uGF
+uGF
+uGF
+gfl
+yjx
+ujh
+rsm
 jlM
 dpw
 txH
@@ -58209,7 +57731,7 @@ msa
 nab
 rlw
 juk
-bZP
+gfh
 opt
 gHP
 vaN
@@ -58355,21 +57877,21 @@ oJT
 oJT
 oJT
 oJT
-oJT
-oJT
 rCM
-uxf
-uYy
-uYy
-uxf
-pKS
-xFg
-tpy
-ujh
-fTZ
-ujh
-rCN
-jlM
+uGF
+gfl
+uGF
+gfl
+uGF
+uGF
+uGF
+ojq
+daB
+uGF
+uGF
+yjx
+bBz
+eZJ
 nwP
 omJ
 txH
@@ -58431,7 +57953,7 @@ eXm
 eNj
 tpQ
 wXG
-bZP
+gfh
 xiB
 gVv
 vaN
@@ -58574,25 +58096,25 @@ oJT
 oJT
 oJT
 oJT
-oJT
-oJT
-oJT
-oJT
-oJT
-rCM
-uYy
-www
-lyG
-lyG
-pKS
-azr
-qIV
-xbs
-fTZ
+cBH
+gcf
+gcf
+ojq
+uGF
+uGF
+gfl
+uGF
+uGF
+uGF
+ojq
+hiI
+tHl
+daB
+uGF
 yjx
+bBz
 eZJ
 ujh
-jlM
 oUq
 eaD
 cuz
@@ -58791,28 +58313,28 @@ uGF
 uGF
 vwm
 wLU
+mjR
 oJT
 oJT
 oJT
-oJT
-oJT
-oJT
-oJT
-oJT
+cBH
+ojq
+xEg
+uGF
+ntJ
+uGF
+uGF
+xEg
+uGF
+ojq
+gcf
+hiI
 oJT
 oJT
 rCM
-uYy
-lyG
-qHh
-pKS
-pKS
-pKS
-bBz
+uGF
+yjx
 ujh
-fTZ
-ujh
-tEe
 izf
 vJy
 uGn
@@ -58868,7 +58390,7 @@ prq
 eNj
 hcR
 qjM
-bZP
+gfh
 rMS
 eNj
 nHW
@@ -58931,7 +58453,7 @@ tSO
 sdU
 sdU
 sdU
-aVS
+vky
 vky
 mWl
 jTv
@@ -59014,29 +58536,29 @@ uGF
 uGF
 uGF
 peB
+mjR
 oJT
-oJT
-oJT
-oJT
-oJT
+cBH
+ojq
+uGF
+uGF
+gfl
+ntJ
+uGF
+gfl
+uGF
+ojq
+hiI
 oJT
 oJT
 oJT
 oJT
 rCM
-uYy
-uYy
-qHh
-lyG
-pKS
+gfl
+uGF
 ujh
-bBz
+rsm
 ujh
-fTZ
-ujh
-bBz
-rbR
-jlM
 bUe
 txH
 ump
@@ -59239,26 +58761,26 @@ uGF
 peB
 gcf
 gcf
-mjR
+uGF
+uGF
+uGF
+uGF
+ntJ
+uGF
+ojq
+gcf
+hiI
 oJT
 oJT
 oJT
 oJT
 oJT
-tHl
-daB
-uxf
-lyG
-uYy
-pKS
-ujh
-ujh
-ujh
-fTZ
-bBz
+rCM
+uGF
+uGF
 ujh
 rsm
-nwP
+dhH
 dpw
 txH
 txH
@@ -59319,7 +58841,7 @@ sQv
 uDa
 nab
 wXG
-bZP
+gfh
 opt
 gVv
 eFf
@@ -59461,25 +58983,25 @@ gfl
 uGF
 nff
 uGF
-peB
-mjR
-oJT
-oJT
-oJT
-oJT
-cBH
+uGF
+uGF
+gfl
+uGF
 ojq
-xKP
-uYy
-pKS
-pKS
-pKS
-kEh
-azr
-fTZ
-vzg
-aeZ
-hQK
+gcf
+hiI
+oJT
+oJT
+oJT
+oJT
+oJT
+oJT
+oJT
+tHl
+daB
+gfl
+jlM
+eZJ
 jlM
 drE
 wtG
@@ -59541,7 +59063,7 @@ sQv
 uDa
 tpQ
 wXG
-bZP
+gfh
 opt
 gHP
 eFf
@@ -59684,24 +59206,24 @@ uGF
 uGF
 uGF
 gfl
-peB
+uGF
+uGF
+ahI
+hiI
+oJT
+rCM
+gcf
 gcf
 mjR
 oJT
 oJT
+oJT
+oJT
+oJT
 rCM
-rFT
-lyG
-uYy
-uYy
-pKS
-rGh
-cRF
+uGF
 jlM
-fTZ
-rzu
-xWq
-sMr
+wGX
 jlM
 ujh
 dpw
@@ -59763,7 +59285,7 @@ sQv
 uDa
 eNj
 wXG
-bZP
+gfh
 opt
 gVv
 cYN
@@ -59906,24 +59428,24 @@ uGF
 gfl
 uGF
 uGF
-ntJ
+uGF
 uGF
 peB
 mjR
-cBH
+oJT
 rCM
-qHh
-lyG
-hdk
-irW
-jzy
-jBZ
-sLF
-sLF
-tsf
-oUi
-rqj
-qmq
+uGF
+uGF
+peB
+mjR
+oJT
+oJT
+oJT
+oJT
+rCM
+gfl
+jlM
+wGX
 jlM
 jlM
 dpw
@@ -59985,7 +59507,7 @@ eNj
 eNj
 eXm
 wXG
-bZP
+gfh
 xiB
 gVv
 gVv
@@ -60128,24 +59650,24 @@ uGF
 uGF
 gfl
 uGF
-ntJ
 uGF
-oRo
+gfl
+uGF
 peB
 gcf
 ojq
-lyG
-iwu
-can
-jzy
-jzy
-cZN
-cZN
-cZN
-cZN
-jzy
-jzy
-gnX
+uGF
+gfl
+uGF
+peB
+mjR
+oJT
+oJT
+oJT
+tHl
+daB
+jlM
+wGX
 nwP
 jlM
 ujh
@@ -60350,24 +59872,24 @@ xEg
 uGF
 uGF
 uGF
+uGF
+xEg
+uGF
 ntJ
 uGF
-oRo
-qyr
-oRo
-oRo
-rRo
-xIt
-jzy
-fwS
-ygz
-aQR
-mza
-vSF
-fMz
-gvL
-jzy
-eon
+xEg
+uGF
+uGF
+uGF
+uGF
+peB
+mjR
+oJT
+oJT
+oJT
+rCM
+jlM
+iJc
 jlM
 ujh
 bBz
@@ -60439,7 +59961,7 @@ soQ
 soQ
 soQ
 uxl
-qZP
+sOb
 sOb
 kel
 kel
@@ -60572,24 +60094,24 @@ uGF
 gfl
 uGF
 gfl
+uGF
+uGF
+gfl
 ntJ
 uGF
-oRo
-qat
-qat
-qHh
-lyG
-xIt
-jzy
-vSF
-vSF
-mza
-mza
-qwI
-mza
-mza
-cOZ
-pdw
+uGF
+gfl
+uGF
+uGF
+uGF
+gfl
+peB
+gcf
+mjR
+oJT
+rCM
+jlM
+wGX
 jSq
 ujh
 bBz
@@ -60652,14 +60174,14 @@ uQh
 iVD
 iVD
 iVD
-bZP
-bZP
-bZP
+gfh
+gfh
+gfh
 iVD
 sOb
-mdD
+pJy
 bEG
-mdD
+pJy
 sOb
 sOb
 qNe
@@ -60794,24 +60316,24 @@ daB
 uGF
 uGF
 uGF
+uGF
+uGF
+uGF
 ntJ
-oRo
-oRo
-qat
-qat
-qHh
-lyG
-xsk
-cZN
-pHw
-xiC
-gaT
-pcX
-fwd
-gfh
-bJh
-fOu
-cVg
+gfl
+uGF
+uGF
+uGF
+uGF
+gfl
+uGF
+uGF
+uGF
+peB
+mjR
+rCM
+jlM
+wGX
 ujh
 bBz
 ubQ
@@ -61016,24 +60538,24 @@ tHl
 gcf
 gcf
 daB
+uGF
+gfl
+uGF
 ntJ
-oRo
-qat
-oRo
-oRo
-lyG
-lyG
-wAb
-cZN
-uJz
-asZ
-pFY
-mza
-mza
-axk
-mza
-jzy
-dhH
+uGF
+xEg
+uGF
+uGF
+gfl
+uGF
+uGF
+uGF
+xEg
+gfl
+peB
+rCM
+jlM
+wGX
 ujh
 ujh
 dpw
@@ -61239,24 +60761,24 @@ oJT
 oJT
 tHl
 daB
-oRo
-oRo
+uGF
+uGF
 ojq
 gcf
 tQg
-lyG
-xIt
-cZN
-wiX
-xiC
-mza
-tGb
-mza
-jzy
-jzy
-jzy
-xPw
+gfl
+uGF
+uGF
+uGF
+gfl
+uGF
+uGF
+uGF
+uGF
+ojq
 jlM
+eZJ
+bBz
 ujh
 drE
 rnh
@@ -61463,24 +60985,24 @@ oJT
 tHl
 gcf
 gcf
-hiI
+asZ
 rCM
-lyG
-rFT
-xsk
-cZN
-luT
-xOJ
-mza
-mza
-jzy
-jzy
-hgj
-frR
-atX
-jlM
-nwP
-jlM
+gfl
+uGF
+cAW
+uGF
+uGF
+gfl
+uGF
+uGF
+uGF
+uGF
+gfl
+ujh
+eZJ
+bBz
+ujh
+ujh
 drE
 wtG
 txH
@@ -61686,22 +61208,22 @@ oJT
 oJT
 oJT
 oJT
-rCM
-lyG
-qHh
+oJT
+gcf
+gcf
 xIt
-cZN
-vSF
-pcX
-mza
-chD
-cZN
-hgj
-dnF
+daB
+uGF
+uGF
+gfl
+uGF
+uGF
+gfl
+yjx
+ujh
+rsm
 bBz
-nPT
-nwP
-jlM
+ujh
 jlM
 jlM
 drE
@@ -61754,22 +61276,22 @@ xqU
 eNj
 hzH
 iVD
-iVD
-iVD
-iVD
+aEa
+aEa
+aEa
 rgH
 vaM
+aEa
+aEa
 iVD
-iVD
-iVD
-bZP
-bZP
-bZP
+gfh
+gfh
+gfh
 iVD
 sOb
-mdD
-mdD
-mdD
+pJy
+pJy
+pJy
 sOb
 sOb
 xDG
@@ -61908,21 +61430,21 @@ oJT
 oJT
 oJT
 oJT
+oJT
+oJT
+oJT
+oJT
 rCM
-lyG
-lyG
-xIt
-cZN
-vSF
-yaR
-jKe
-vSF
-cZN
-eBm
+gfl
+uGF
+uGF
+xEg
+uGF
+yjx
+yjx
 bBz
+izf
 ujh
-eZJ
-jlM
 nwP
 jlM
 jlM
@@ -61976,7 +61498,7 @@ xqU
 xQD
 tpQ
 rsL
-iVD
+aEa
 kmw
 cmw
 lgj
@@ -61993,7 +61515,7 @@ ddN
 ddN
 ddN
 lvh
-qZP
+sOb
 sOb
 gPx
 rfP
@@ -62021,7 +61543,7 @@ etr
 kIe
 bCm
 sOb
-qZP
+sOb
 tRC
 tRC
 tRC
@@ -62130,21 +61652,21 @@ oJT
 oJT
 oJT
 oJT
-rCM
-uYy
-lyG
-xIt
-jzy
-xdl
-xiC
-mza
-lSO
-jzy
-eBm
-sKf
+oJT
+oJT
+oJT
+oJT
+tHl
+daB
+uGF
+gfl
+cAW
+yjx
+yjx
+bBz
+bBz
+rsm
 ujh
-wGX
-jlM
 jlM
 jlM
 jlM
@@ -62204,9 +61726,9 @@ nDe
 neN
 nDe
 qjq
-iVD
-iVD
-iVD
+aEa
+aEa
+aEa
 heL
 tzW
 jZM
@@ -62352,21 +61874,21 @@ oJT
 oJT
 oJT
 oJT
-rCM
-uYy
-uYy
+oJT
+oJT
+oJT
+oJT
+oJT
+tHl
+gcf
+gcf
 xIt
-jzy
-jzy
-cZN
-cZN
-jzy
-jzy
-eBm
+daB
+bBz
 ujh
 ujh
 eZJ
-jlM
+ujh
 jlM
 qxh
 dds
@@ -62398,7 +61920,7 @@ bDO
 bDO
 rbY
 rbY
-hnp
+haP
 jJX
 lzU
 mKq
@@ -62428,8 +61950,8 @@ neN
 neN
 oeB
 dCW
-iVD
-iVD
+aEa
+aEa
 heL
 kHJ
 eux
@@ -62445,11 +61967,11 @@ hsx
 xvC
 xvC
 xvC
-tBq
-tBq
+dhe
+dhe
 xvC
 cGY
-tBq
+dhe
 xvC
 xvC
 bCm
@@ -62463,7 +61985,7 @@ etr
 qfM
 sOb
 sOb
-qZP
+sOb
 qLx
 nIU
 nIU
@@ -62574,29 +62096,29 @@ oJT
 oJT
 oJT
 oJT
-rCM
-uYy
-uxf
-lJv
-jeT
-pKS
-cNT
-cNT
-cNT
-cNT
-ggt
+oJT
+oJT
+oJT
+oJT
+oJT
+oJT
+oJT
+oJT
+oJT
+tHl
+gcf
+tQg
 ilb
-ilb
-nSG
+cZN
 ilb
 ilb
 hWs
-jZt
 lTA
-iwa
-iwa
-iwa
-iwa
+lTA
+lJJ
+lJJ
+lJJ
+lJJ
 lTA
 lJJ
 jbr
@@ -62651,7 +62173,7 @@ neN
 neN
 gqR
 dDo
-iVD
+aEa
 heL
 tzW
 eux
@@ -62796,17 +62318,17 @@ oJT
 oJT
 oJT
 oJT
-rCM
-lyG
-uYy
-uYy
-uYy
-pKS
-ilb
-ilb
-ilb
-ilb
-vby
+oJT
+oJT
+oJT
+oJT
+oJT
+oJT
+oJT
+oJT
+oJT
+oJT
+ojq
 ilb
 ilb
 nSG
@@ -62873,8 +62395,8 @@ neN
 neN
 bJa
 bsh
-iVD
-iVD
+aEa
+aEa
 tzW
 jIb
 eux
@@ -62896,7 +62418,7 @@ mQy
 sEM
 mQy
 gwF
-tBq
+dhe
 jno
 etr
 etr
@@ -62906,7 +62428,7 @@ hto
 aRF
 uWL
 obF
-mdD
+pJy
 vjE
 nIU
 nIU
@@ -63018,16 +62540,16 @@ oJT
 oJT
 oJT
 oJT
-rCM
-qHh
-lyG
-uYy
-pKS
-pKS
-pKS
-ilb
-vby
-ilb
+oJT
+oJT
+oJT
+oJT
+oJT
+oJT
+oJT
+cBH
+gcf
+ojq
 ilb
 ilb
 ilb
@@ -63079,7 +62601,7 @@ cGr
 owG
 dxI
 qWU
-nra
+qOq
 rsL
 tpQ
 hBf
@@ -63118,7 +62640,7 @@ qYl
 mQy
 mQy
 gwF
-tBq
+dhe
 jno
 qTQ
 uyY
@@ -63128,7 +62650,7 @@ hto
 gJz
 gJz
 obF
-mdD
+pJy
 vjE
 nIU
 nIU
@@ -63240,14 +62762,14 @@ oJT
 oJT
 oJT
 oJT
-tHl
-daB
-rRo
-lyG
-uYy
-pKS
-ilb
-juQ
+oJT
+oJT
+oJT
+oJT
+oJT
+cBH
+gcf
+ojq
 ilb
 ilb
 ilb
@@ -63301,7 +62823,7 @@ uqN
 uqN
 aiH
 mKq
-nra
+qOq
 rvL
 eNj
 xqU
@@ -63340,7 +62862,7 @@ jgO
 mQy
 mQy
 gwF
-tBq
+dhe
 jno
 etr
 gJz
@@ -63462,12 +62984,12 @@ oJT
 oJT
 oJT
 oJT
+oJT
+oJT
+oJT
+oJT
 cBH
 ojq
-qHh
-uxf
-uYy
-pKS
 ilb
 ilb
 vby
@@ -63530,7 +63052,7 @@ xqU
 eNj
 imb
 tPv
-iVD
+aEa
 nkE
 pRN
 gqR
@@ -63602,8 +63124,8 @@ pOG
 doO
 eWY
 eWY
-ndb
-ndb
+eWY
+eWY
 eWY
 eWY
 eWY
@@ -63684,29 +63206,29 @@ oJT
 oJT
 oJT
 oJT
-rCM
-lyG
-uYy
-uYy
-pKS
-pKS
-pKS
+oJT
+oJT
+cBH
+gcf
+ojq
+ilb
+ilb
+juQ
 ilb
 ilb
 ilb
 ilb
 ilb
-ilb
-ilb
+juQ
 bEA
 uge
 hWs
-jZt
 lTA
-iwa
-iwa
-iwa
-iwa
+lTA
+lJJ
+lJJ
+lJJ
+lJJ
 lTA
 lJJ
 cYD
@@ -63753,16 +63275,16 @@ lsj
 iVD
 iVD
 aEa
-iVD
-iVD
+aEa
+aEa
 pkH
 neN
 xyo
 neN
 neN
 neN
-iVD
-iVD
+aEa
+aEa
 tzW
 jIb
 jIb
@@ -63823,8 +63345,8 @@ eWY
 pOG
 doO
 eWY
-ndb
-ndb
+eWY
+eWY
 oMo
 eWY
 eWY
@@ -63906,16 +63428,16 @@ oJT
 oJT
 oJT
 oJT
-rCM
-uYy
-uxf
-uYy
-uYy
-pKS
+oJT
+cBH
+ojq
+tyz
 ilb
 ilb
 ilb
 ilb
+tyz
+tyz
 ilb
 vby
 ueJ
@@ -63952,7 +63474,7 @@ nfE
 foy
 nfE
 aVI
-hnp
+haP
 haP
 haP
 ptl
@@ -63976,14 +63498,14 @@ awO
 snA
 lTL
 loO
-iVD
-iVD
+aEa
+aEa
 jxv
 knX
 nsC
 bxh
-iVD
-iVD
+aEa
+aEa
 heL
 dVL
 jIb
@@ -64128,17 +63650,17 @@ oJT
 oJT
 oJT
 oJT
+oJT
 rCM
-uYy
-uYy
-uYy
-uYy
-pKS
+tyz
+tyz
 ilb
 ilb
 ilb
-ilb
-vby
+tyz
+jIg
+jIg
+jIg
 ueJ
 nGk
 ihl
@@ -64175,7 +63697,7 @@ nGk
 wYJ
 tZb
 dOx
-mtN
+fwd
 awO
 ecp
 xjz
@@ -64195,16 +63717,16 @@ awO
 jQg
 kxB
 awO
-mtN
+fwd
 lTL
 loO
 hsx
-iVD
+aEa
 aEa
 mOp
 xQz
 aEa
-iVD
+aEa
 hsx
 dVL
 jIb
@@ -64238,7 +63760,7 @@ hto
 etr
 etr
 wfV
-mdD
+pJy
 vjE
 nIU
 nIU
@@ -64350,16 +63872,16 @@ oJT
 oJT
 oJT
 oJT
-tHl
+oJT
 daB
-uYy
-uYy
-pKS
-pKS
-pKS
+tyz
+tyz
+tyz
 ilb
 ilb
+tyz
 ilb
+tyz
 ueJ
 nGk
 ihl
@@ -64397,7 +63919,7 @@ krt
 nGk
 iOE
 dOx
-mtN
+fwd
 awO
 koL
 xjz
@@ -64417,7 +63939,7 @@ awO
 jQg
 kxB
 awO
-mtN
+fwd
 lTL
 loO
 rdG
@@ -64460,7 +63982,7 @@ hto
 etr
 aRF
 wvS
-mdD
+pJy
 vjE
 nIU
 nIU
@@ -64574,9 +64096,9 @@ oJT
 oJT
 oJT
 rCM
-uYy
-uYy
-uYy
+jIg
+tyz
+tyz
 ilb
 ilb
 ilb
@@ -64619,7 +64141,7 @@ ilb
 hWs
 tZb
 dOx
-mtN
+fwd
 awO
 jpP
 hUv
@@ -64639,7 +64161,7 @@ awO
 vYg
 koL
 awO
-mtN
+fwd
 lTL
 loO
 tzW
@@ -64796,9 +64318,9 @@ oJT
 oJT
 oJT
 rCM
-uYy
-uxf
-uYy
+qHh
+qHh
+lyG
 uYy
 uYy
 ilb
@@ -64841,7 +64363,7 @@ ilb
 hWs
 tZb
 dOx
-mtN
+fwd
 awO
 kxB
 hUv
@@ -64861,7 +64383,7 @@ lMI
 jQg
 kxB
 awO
-mtN
+fwd
 lTL
 loO
 tzW
@@ -64903,9 +64425,9 @@ vPi
 rLY
 bBA
 sOb
-qZP
 sOb
-qZP
+sOb
+sOb
 lTQ
 lTQ
 sOb
@@ -65018,9 +64540,9 @@ oJT
 oJT
 oJT
 rCM
-xKP
-uYy
-uYy
+qHh
+qHh
+lyG
 uYy
 uxf
 juQ
@@ -65241,7 +64763,7 @@ oJT
 oJT
 tHl
 daB
-uYy
+lyG
 uYy
 uYy
 uYy
@@ -65534,7 +65056,7 @@ tzW
 jZM
 jZM
 jZM
-ndb
+eux
 jIb
 jIb
 jaT
@@ -65756,8 +65278,8 @@ cFC
 eux
 bLf
 jZM
-ndb
-ndb
+jZM
+eux
 jIb
 jIb
 jIb
@@ -65979,8 +65501,8 @@ jZM
 jZM
 jZM
 jZM
-ndb
-ndb
+jZM
+eux
 jIb
 vfo
 jIb
@@ -66017,10 +65539,10 @@ mlW
 uGS
 oMs
 oMs
-ndb
-ndb
 uGS
-hUC
+uGS
+uGS
+bfa
 ppv
 eWY
 idc
@@ -66238,7 +65760,7 @@ xcj
 mlW
 oMs
 uGS
-ndb
+uGS
 eWY
 eWY
 eWY
@@ -66395,7 +65917,7 @@ ilb
 hWs
 bgZ
 dOx
-mtN
+fwd
 awO
 kxB
 hUv
@@ -66409,13 +65931,13 @@ xSW
 xSW
 xSW
 xSW
-qOh
+fOu
 mtN
 fJM
 hUv
 kxB
 xkN
-mtN
+fwd
 lTL
 mjh
 tzW
@@ -66617,7 +66139,7 @@ ilb
 hWs
 bgZ
 dOx
-mtN
+fwd
 awO
 kxB
 hUv
@@ -66637,7 +66159,7 @@ pGA
 wrM
 kxB
 jXM
-mtN
+fwd
 lTL
 mjh
 tzW
@@ -66800,7 +66322,7 @@ ojq
 uxf
 uYy
 uYy
-xKP
+can
 jIg
 jIg
 hWs
@@ -66839,7 +66361,7 @@ juQ
 hWs
 bgZ
 nnV
-mtN
+fwd
 awO
 xOM
 uQP
@@ -66859,7 +66381,7 @@ awO
 hUv
 aKv
 awO
-mtN
+fwd
 lTL
 mjh
 rdG
@@ -67022,7 +66544,7 @@ uYy
 uYy
 uYy
 uYy
-uYy
+lyG
 jIg
 tyz
 iHf
@@ -67061,13 +66583,13 @@ ilb
 hWs
 bgZ
 dOx
-mtN
+fwd
 awO
 pup
 fOz
 awO
 mtN
-sFg
+fwS
 tIP
 lcj
 oef
@@ -67081,7 +66603,7 @@ awO
 mmh
 kxB
 awO
-mtN
+fwd
 lTL
 mjh
 hsx
@@ -67282,7 +66804,7 @@ ilb
 ilb
 iHf
 bgZ
-kXC
+snA
 snA
 snA
 gyb
@@ -67290,14 +66812,14 @@ dmn
 snA
 snA
 snA
-sFg
+fMz
 oWd
 oWd
 oWd
 bji
 oWd
 oWd
-xic
+gaT
 snA
 awO
 sDt
@@ -67306,7 +66828,7 @@ awO
 snA
 kOy
 qeN
-koG
+mhj
 mhj
 mhj
 mhj
@@ -67807,10 +67329,10 @@ uGS
 uGS
 oMs
 oMs
+uGS
 oMs
-oMs
-oMs
-oMs
+uGS
+uGS
 fXy
 arf
 pxX
@@ -67831,7 +67353,7 @@ xmm
 xmm
 xmm
 xmm
-gdq
+xmm
 ndb
 ndb
 ndb
@@ -68052,8 +67574,8 @@ xmm
 xmm
 xmm
 xmm
-gcN
-gdq
+nvl
+xmm
 ndb
 ndb
 ndb
@@ -68251,8 +67773,8 @@ oMs
 oMs
 uGS
 oMs
-ndb
-ndb
+nAJ
+nAJ
 uGS
 uGS
 rOn
@@ -68275,7 +67797,7 @@ npE
 npE
 npE
 xmm
-gdq
+xmm
 ndb
 ndb
 ndb
@@ -68457,8 +67979,8 @@ ltL
 ubR
 mlW
 uGS
-ndb
-ndb
+uGS
+uGS
 eWY
 eWY
 eWY
@@ -68474,7 +67996,7 @@ uGS
 qEZ
 uGS
 eWY
-ndb
+nAJ
 uGS
 uGS
 aBZ
@@ -68498,7 +68020,7 @@ jDt
 npE
 npE
 xmm
-gdq
+xmm
 ndb
 ndb
 ndb
@@ -68679,7 +68201,7 @@ ltL
 ubR
 mlW
 uGS
-ndb
+uGS
 eWY
 eWY
 eWY
@@ -68696,7 +68218,7 @@ uGS
 uGS
 eWY
 eWY
-ndb
+nAJ
 uGS
 eWY
 aBZ
@@ -68945,7 +68467,7 @@ npE
 xmm
 npE
 npE
-aom
+ndb
 rIi
 ndb
 pPX
@@ -69167,8 +68689,8 @@ npE
 npE
 xmm
 xmm
-aom
-nFr
+ndb
+rIi
 ndb
 pPX
 hYa
@@ -69390,8 +68912,8 @@ npE
 xmm
 xmm
 xmm
-nFr
-aom
+rIi
+ndb
 pPX
 kgY
 xEZ
@@ -69570,7 +69092,7 @@ eWY
 eWY
 uGS
 uGS
-ndb
+uGS
 udO
 eWY
 eWY
@@ -69613,7 +69135,7 @@ xmm
 nvl
 npE
 tkX
-ahI
+hCY
 eNo
 eNo
 peC
@@ -69759,8 +69281,8 @@ viL
 mhj
 tzW
 jIb
-ndb
-ndb
+eux
+eux
 eux
 jIb
 eux
@@ -69792,7 +69314,7 @@ eWY
 eWY
 eWY
 oMs
-ndb
+uGS
 eWY
 eWY
 eWY
@@ -69835,7 +69357,7 @@ xmm
 xmm
 wNI
 npE
-aom
+ndb
 rkR
 pPX
 lFD
@@ -69982,7 +69504,7 @@ mhj
 tzW
 jIb
 jIb
-ndb
+eux
 jZM
 jZM
 eux
@@ -70204,7 +69726,7 @@ mhj
 tzW
 jIb
 ayL
-ndb
+eux
 eux
 jZM
 jZM
@@ -70250,7 +69772,7 @@ eWY
 eWY
 eWY
 eWY
-ndb
+nAJ
 uGS
 uGS
 aBZ
@@ -70471,9 +69993,9 @@ eWY
 eWY
 eWY
 eWY
-ndb
-ndb
-eWY
+nAJ
+nAJ
+uGS
 uGS
 rOn
 eWY
@@ -70693,9 +70215,9 @@ eWY
 eWY
 eWY
 uGS
-ndb
-eWY
-eWY
+gdq
+uGS
+uGS
 eWY
 aBZ
 fBC
@@ -71483,7 +71005,7 @@ vEM
 qMR
 qMR
 qMR
-inP
+eon
 lBo
 raK
 ilb
@@ -71707,7 +71229,7 @@ asG
 qMR
 qMR
 qMR
-inP
+eon
 jbZ
 ilb
 ilb
@@ -71930,7 +71452,7 @@ vEM
 vEM
 qMR
 qMR
-inP
+eon
 lBo
 jbZ
 ilb
@@ -72027,7 +71549,7 @@ eWY
 eWY
 eWY
 eWY
-ndb
+eWY
 oMs
 rOn
 arf
@@ -72154,7 +71676,7 @@ jMX
 qMR
 qMR
 qMR
-inP
+eon
 lBo
 jbZ
 vby
@@ -72247,9 +71769,9 @@ eWY
 eWY
 eWY
 udO
-ndb
-ndb
-ndb
+eWY
+eWY
+eWY
 uGS
 aBZ
 arf
@@ -72378,7 +71900,7 @@ iLP
 qMR
 qMR
 qMR
-inP
+eon
 jbZ
 ilb
 tyz
@@ -72601,7 +72123,7 @@ bcV
 bcV
 lAi
 omk
-inP
+eon
 jbZ
 tyz
 jIg
@@ -73101,11 +72623,11 @@ nXy
 wyb
 mJc
 nXy
-aZS
+dqK
 dtS
 ijt
 xmb
-tIH
+hjw
 xmb
 ijt
 ijt
@@ -73315,7 +72837,7 @@ eux
 eux
 jZM
 dYO
-iDO
+hjw
 faS
 yar
 yar
@@ -73327,7 +72849,7 @@ dKD
 dxy
 eRT
 qYn
-tIH
+hjw
 xmb
 ijt
 ijt
@@ -73549,7 +73071,7 @@ tqD
 mrh
 mrh
 wyb
-tIH
+hjw
 lLD
 ijt
 ipN
@@ -73771,7 +73293,7 @@ mrh
 mrh
 mrh
 wyb
-tIH
+hjw
 miP
 tUR
 ijt
@@ -73993,7 +73515,7 @@ dNw
 mrh
 mrh
 wyb
-tIH
+hjw
 gzO
 jaw
 ijt
@@ -74171,14 +73693,14 @@ poj
 oBG
 oBG
 oBG
-hiC
 poj
-hiC
+poj
+poj
 oBG
 oBG
 oBG
 oBG
-hiC
+poj
 orh
 cNO
 wsk
@@ -74215,7 +73737,7 @@ mrh
 eDl
 cpl
 dqK
-tIH
+hjw
 tdJ
 cMK
 ijt
@@ -74437,7 +73959,7 @@ eDl
 ejE
 mrh
 ewh
-tIH
+hjw
 pVU
 ijt
 ipN
@@ -75122,8 +74644,8 @@ eWY
 eWY
 uGS
 uGS
-ncH
-ncH
+uGS
+uGS
 uGS
 oMs
 oMs
@@ -75265,7 +74787,7 @@ fZD
 fZD
 rxI
 woU
-vXk
+frR
 ggt
 tyz
 fcY
@@ -75486,7 +75008,7 @@ asG
 qMR
 qMR
 qMR
-vXk
+frR
 ggt
 vby
 tyz
@@ -75706,7 +75228,7 @@ pYo
 qMR
 qMR
 qMR
-vXk
+frR
 cNT
 ggt
 ilb
@@ -75926,7 +75448,7 @@ vEM
 vEM
 qMR
 qMR
-vXk
+frR
 cNT
 ggt
 ilb
@@ -76147,7 +75669,7 @@ pYo
 qMR
 qMR
 qMR
-vXk
+frR
 ggt
 vby
 ilb
@@ -76367,7 +75889,7 @@ vEM
 qMR
 qMR
 qMR
-vXk
+frR
 cNT
 ggt
 vby

--- a/code/game/objects/structures/platforms.dm
+++ b/code/game/objects/structures/platforms.dm
@@ -144,7 +144,3 @@ obj/structure/platform_decoration
 		if(WEST)
 			I.pixel_x = -16
 	overlays += I
-	var/static/list/connections = list(
-		COMSIG_ATOM_EXIT = .proc/on_try_exit
-	)
-	AddElement(/datum/element/connect_loc, connections)

--- a/code/game/objects/structures/platforms.dm
+++ b/code/game/objects/structures/platforms.dm
@@ -19,9 +19,10 @@
 	max_integrity = 1000	//Ditto
 
 /obj/structure/platform/gelida
-	climb_delay = 10 //halved time because on gelida platforms are everywhere
-	obj_integrity = 200 //ditto
-	max_integrity = 200	//ditto
+	coverage = 0
+	climb_delay = 5 //halved time because on gelida platforms are everywhere
+	obj_integrity = 50 //ditto
+	max_integrity = 50	//ditto
 
 /obj/structure/platform/Initialize()
 	. = ..()
@@ -114,3 +115,36 @@ obj/structure/platform_decoration
 
 /obj/structure/platform_decoration/platform2_deco
 	icon_state = "platform2_deco"
+
+/obj/structure/fakeplatform
+	name = "platform"
+	desc = "A square metal surface resting on four legs."
+	icon = 'icons/obj/structures/platforms.dmi'
+	icon_state = "platform"
+	anchored = TRUE
+	density = FALSE //no density these platforms are for looks not for climbing
+	coverage = 0
+	layer = OBJ_LAYER
+	climb_delay = 20 //Leaping a barricade is universally much faster than clumsily climbing on a table or rack
+	resistance_flags = XENO_DAMAGEABLE	//TEMP PATCH UNTIL XENO AI PATHFINDING IS BETTER, SET THIS TO INDESTRUCTIBLE ONCE IT IS - Tivi
+	obj_integrity = 50	//Ditto
+	max_integrity = 50	//Ditto
+
+/obj/structure/fakeplatform/Initialize()
+	. = ..()
+	var/image/I = image(icon, src, "platform_overlay", LADDER_LAYER, dir)//ladder layer puts us just above weeds.
+	switch(dir)
+		if(SOUTH)
+			layer = ABOVE_MOB_LAYER
+			I.pixel_y = -16
+		if(NORTH)
+			I.pixel_y = 16
+		if(EAST)
+			I.pixel_x = 16
+		if(WEST)
+			I.pixel_x = -16
+	overlays += I
+	var/static/list/connections = list(
+		COMSIG_ATOM_EXIT = .proc/on_try_exit
+	)
+	AddElement(/datum/element/connect_loc, connections)

--- a/code/game/objects/structures/prop.dm
+++ b/code/game/objects/structures/prop.dm
@@ -674,6 +674,10 @@
 	resistance_flags = RESIST_ALL
 	layer = ABOVE_MOB_LAYER
 
+/obj/structure/prop/vehicle/van/destructible
+	max_integrity = 200
+	resistance_flags = XENO_DAMAGEABLE
+
 /obj/structure/prop/vehicle/truck
 	name = "truck"
 	desc = "An old truck, seems to be broken down."
@@ -686,9 +690,16 @@
 	resistance_flags = RESIST_ALL
 	layer = ABOVE_MOB_LAYER
 
+/obj/structure/prop/vehicle/truck/destructible
+	max_integrity = 150
+	resistance_flags = XENO_DAMAGEABLE
+
 /obj/structure/prop/vehicle/truck/truckcargo
 	icon_state = "truck_cargo"
 
+/obj/structure/prop/vehicle/truck/truckcargo/destructible
+	max_integrity = 200
+	resistance_flags = XENO_DAMAGEABLE
 /obj/structure/prop/vehicle/crane
 	name = "crane"
 	desc = "An old crane, seems to be broken down."
@@ -701,8 +712,16 @@
 	resistance_flags = RESIST_ALL
 	layer = ABOVE_MOB_LAYER
 
+/obj/structure/prop/vehicle/crane/destructible
+	max_integrity = 300
+	resistance_flags = XENO_DAMAGEABLE
+
 /obj/structure/prop/vehicle/crane/cranecargo
 	icon_state = "crane_cargo"
+
+/obj/structure/prop/vehicle/crane/cranecargo/destructible
+	max_integrity = 300
+	resistance_flags = XENO_DAMAGEABLE
 
 /obj/structure/prop/vehicle/crawler
 	name = "crawler"
@@ -715,6 +734,11 @@
 	bound_width = 64
 	resistance_flags = RESIST_ALL
 	layer = ABOVE_MOB_LAYER
+
+/obj/structure/prop/vehicle/crawler/destructible
+	max_integrity = 200
+	resistance_flags = XENO_DAMAGEABLE
+
 
 /obj/structure/prop/vehicle/crawler/crawler_blue
 	icon_state = "crawler_crate_b"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes some common complaints about Gelida.
I'm going to list the changes out so people can easily read them without having to examine a map.

-Platforms are now 99% percent cosmetic and *shouldn't* block projectiles or require climbing
-A small fraction of platforms are still tangible, but the health has been reduced even further.
-Caves has been slightly expanded south.
-Caves now has even more entrances and exits due to complaints about how easy it is to bottle xenos up.
-Most windows are now regular windows instead of reinforced.
-A number of rock formations that could potentially obstruct crusher lanes have been removed.
-Some platforms have been slightly rearranged to be less obstructive.
-The vehicle roadblocks that covered a large number of routes are now slashable.
-The lockdown button in LZ1 and LZ2 is no longer protected by AI glass

## Why It's Good For The Game

People have been asking for quite some time for the platforms on Gelida to be removed, this PR compromises by making them mostly cosmetic instead of outright removing them.
The other balance changes are minor but still things that have been asked for.

## Changelog
:cl:
balance: Most of Gelida's platforms are now decorative and do not require climbing.
balance: Most of Gelida's platforms do not block shots or projectiles.
balance: The remaining platforms on Gelida that function normally have drastically reduced health.
balance: Gelida caves has been slightly expanded south.
balance: Gelida caves now has a number of new exits and entrances to keep xenos from being bottled up as easily.
balance: Some potential crusher and boiler lanes on Gelida have been cleared of rocks.
balance: Most windows on Gelida are now regular instead of reinforced.
balance: Most structures on Gelida no longer have random r-walls at irregular junctions.
balance: Some platforms have been slightly rearranged.
balance: The Gelida vehicle roadblocks are now destructible.
balance: Gelida lockdown shutters are no longer protected by lockdown glass.
fix: Fixed an lone section of AI nodes on Gelida where minions could potentially have to detour a long way to reach their destination.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
