### PR TITLE
Correct dropship ammo description

### DIFF
--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -197,7 +197,7 @@
 
 	return turfs_impacted
 
-/obj/structure/ship_ammo/examine/(mob/user)
+/obj/structure/ship_ammo/examine(mob/user)
 	to_chat(user, "Moving this will require some sort of lifter.")
 
 ///////////////

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -71,11 +71,6 @@
 			return TRUE
 		return ..()
 
-
-	examine(mob/user)
-		..()
-		to_chat(user, "Moving this will require some sort of lifter.")
-
 //what to show to the user that examines the weapon we're loaded on.
 /obj/structure/ship_ammo/proc/show_loaded_desc(mob/user)
 	return "It's loaded with \a [src]."
@@ -202,6 +197,9 @@
 
 	return turfs_impacted
 
+/obj/structure/ship_ammo/examine/(mob/user)
+	to_chat(user, "Moving this will require some sort of lifter.")
+
 ///////////////
 
 //30mm gun
@@ -209,7 +207,7 @@
 /obj/structure/ship_ammo/heavygun
 	name = "\improper 30mm ammo crate"
 	icon_state = "30mm_crate"
-	desc = "A crate full of 30mm bullets used on the dropship heavy guns."
+	desc = "A crate full of 30mm bullets used on the dropship heavy guns. Moving this will require some sort of lifter."
 	equipment_type = /obj/structure/dropship_equipment/weapon/heavygun
 	travelling_time =  6 SECONDS
 	ammo_count = 200
@@ -229,9 +227,7 @@
 	. += "It has [ammo_count] round\s."
 
 /obj/structure/ship_ammo/heavygun/show_loaded_desc(mob/user)
-	if(ammo_count)
-		return "It's loaded with \a [src] containing [ammo_count] round\s."
-	return "It's loaded with an empty [name]."
+	return "It's loaded with \a [src] containing [ammo_count] round\s."
 
 /obj/structure/ship_ammo/heavygun/get_turfs_to_impact(turf/impact, attackdir = NORTH)
 	var/turf/beginning = impact
@@ -273,7 +269,7 @@
 /obj/structure/ship_ammo/heavygun/highvelocity
 	name = "high-velocity 30mm ammo crate"
 	icon_state = "30mm_crate_hv"
-	desc = "A crate full of 30mm high-velocity bullets used on the dropship heavy guns."
+	desc = "A crate full of 30mm high-velocity bullets used on the dropship heavy guns. Moving this will require some sort of lifter."
 	travelling_time = 3 SECONDS
 	point_cost = 150
 
@@ -281,7 +277,7 @@
 //railgun
 /obj/structure/ship_ammo/railgun
 	name = "Railgun Ammo"
-	desc = "This is not meant to exist."
+	desc = "This is not meant to exist. Moving this will require some sort of lifter."
 	icon_state = "30mm_crate_hv"
 	icon = 'icons/Marine/mainship_props.dmi'
 	equipment_type = /obj/structure/dropship_equipment/weapon/minirocket_pod
@@ -308,8 +304,9 @@
 		QDEL_IN(src, travelling_time) //deleted after last railgun has fired and impacted the ground.
 
 /obj/structure/ship_ammo/railgun/show_loaded_desc(mob/user)
-	if(ammo_count)
-		to_chat(user, "It's loaded with \a [src] containing [ammo_count] slug\s.")
+	// to_chat(user, "It's loaded with \a [src] containing [ammo_count] slug\s.")
+	return "It's loaded with \a [src] containing [ammo_count] slug\s."
+
 
 /obj/structure/ship_ammo/railgun/examine(mob/user)
 	. = ..()
@@ -320,7 +317,7 @@
 /obj/structure/ship_ammo/laser_battery
 	name = "high-capacity laser battery"
 	icon_state = "laser_battery"
-	desc = "A high-capacity laser battery used to power laser beam weapons."
+	desc = "A high-capacity laser battery used to power laser beam weapons. Moving this will require some sort of lifter."
 	travelling_time = 1 SECONDS
 	ammo_count = 100
 	max_ammo_count = 100
@@ -342,9 +339,7 @@
 
 
 /obj/structure/ship_ammo/laser_battery/show_loaded_desc(mob/user)
-	if(ammo_count)
-		return "It's loaded with \a [src] at [round(100*ammo_count/max_ammo_count)]% charge."
-	return "It's loaded with an empty [name]."
+	return "It's loaded with \a [src] at [round(100*ammo_count/max_ammo_count)]% charge."
 
 /obj/structure/ship_ammo/laser_battery/get_turfs_to_impact(turf/epicenter, attackdir = NORTH)
 	var/turf/beginning = epicenter
@@ -402,7 +397,7 @@
 //this one is air-to-air only
 /obj/structure/ship_ammo/rocket/widowmaker
 	name = "\improper AIM-224 'Widowmaker'"
-	desc = "The AIM-224 is the latest in air to air missile technology. Earning the nickname of 'Widowmaker' from various dropship pilots after improvements to its guidence warhead prevents it from being jammed leading to its high kill rate. Not well suited for ground bombardment, but its high velocity makes it reach its target quickly."
+	desc = "The AIM-224 is the latest in air to air missile technology. Earning the nickname of 'Widowmaker' from various dropship pilots after improvements to its guidence warhead prevents it from being jammed leading to its high kill rate. Not well suited for ground bombardment, but its high velocity makes it reach its target quickly. Moving this will require some sort of lifter."
 	icon_state = "single"
 	travelling_time = 3 SECONDS //not powerful, but reaches target fast
 	ammo_id = ""
@@ -420,7 +415,7 @@
 
 /obj/structure/ship_ammo/rocket/banshee
 	name = "\improper AGM-227 'Banshee'"
-	desc = "The AGM-227 missile is a mainstay of the overhauled dropship fleet against any mobile or armored ground targets. It's earned the nickname of 'Banshee' from the sudden wail that it emitts right before hitting a target. Useful to clear out large areas."
+	desc = "The AGM-227 missile is a mainstay of the overhauled dropship fleet against any mobile or armored ground targets. It's earned the nickname of 'Banshee' from the sudden wail that it emitts right before hitting a target. Useful to clear out large areas. Moving this will require some sort of lifter."
 	icon_state = "banshee"
 	ammo_id = "b"
 	point_cost = 150
@@ -438,7 +433,7 @@
 
 /obj/structure/ship_ammo/rocket/keeper
 	name = "\improper GBU-67 'Keeper II'"
-	desc = "The GBU-67 'Keeper II' is the latest in a generation of laser guided weaponry that spans all the way back to the 20th century. Earning its nickname from a shortening of 'Peacekeeper' which comes from the program that developed its guidance system and the various uses of it during peacekeeping conflicts. Its payload is designed to devastate armored targets."
+	desc = "The GBU-67 'Keeper II' is the latest in a generation of laser guided weaponry that spans all the way back to the 20th century. Earning its nickname from a shortening of 'Peacekeeper' which comes from the program that developed its guidance system and the various uses of it during peacekeeping conflicts. Its payload is designed to devastate armored targets. Moving this will require some sort of lifter."
 	icon_state = "keeper"
 	ammo_id = "k"
 	point_cost = 300
@@ -454,7 +449,7 @@
 
 /obj/structure/ship_ammo/rocket/fatty
 	name = "\improper SM-17 'Fatty'"
-	desc = "The SM-17 'Fatty', an experimental missile utilising a supercooled tanglefoot payload. Harmless to marines, but destroys resin walls around the impact site."
+	desc = "The SM-17 'Fatty', an experimental missile utilising a supercooled tanglefoot payload. Harmless to marines, but destroys resin walls around the impact site. Moving this will require some sort of lifter."
 	icon_state = "fatty"
 	ammo_id = "f"
 	point_cost = 150
@@ -469,7 +464,7 @@
 
 /obj/structure/ship_ammo/rocket/napalm
 	name = "\improper XN-99 'Napalm'"
-	desc = "The XN-99 'Napalm' is an incendiary rocket used to turn specific targeted areas into giant balls of fire for a long time."
+	desc = "The XN-99 'Napalm' is an incendiary rocket used to turn specific targeted areas into giant balls of fire for a long time. Moving this will require some sort of lifter."
 	icon_state = "napalm"
 	ammo_id = "n"
 	point_cost = 200
@@ -494,7 +489,7 @@
 
 /obj/structure/ship_ammo/minirocket
 	name = "mini rocket stack"
-	desc = "A pack of laser guided mini rockets."
+	desc = "A pack of explosive laser guided mini rockets. Moving this will require some sort of lifter."
 	icon_state = "minirocket"
 	icon = 'icons/Marine/mainship_props.dmi'
 	equipment_type = /obj/structure/dropship_equipment/weapon/minirocket_pod
@@ -527,8 +522,8 @@
 	S.start()
 
 /obj/structure/ship_ammo/minirocket/show_loaded_desc(mob/user)
-	if(ammo_count)
-		to_chat(user, "It's loaded with \a [src] containing [ammo_count] minirocket\s.")
+	// to_chat(user, "It's loaded with \a [src] containing [ammo_count] minirocket\s.")
+	return "It's loaded with \a [src] containing [ammo_count] minirocket\s."
 
 /obj/structure/ship_ammo/minirocket/examine(mob/user)
 	. = ..()
@@ -537,7 +532,7 @@
 
 /obj/structure/ship_ammo/minirocket/incendiary
 	name = "incendiary mini rocket stack"
-	desc = "A pack of laser guided incendiary mini rockets."
+	desc = "A pack of laser guided incendiary mini rockets. Moving this will require some sort of lifter."
 	icon_state = "minirocket_inc"
 	point_cost = 200
 	light_explosion_range = 3 //Slightly weaker than standard minirockets
@@ -551,7 +546,7 @@
 
 /obj/structure/ship_ammo/minirocket/smoke
 	name = "smoke mini rocket stack"
-	desc = "A pack of laser guided screening smoke mini rockets."
+	desc = "A pack of laser guided screening smoke mini rockets. Moving this will require some sort of lifter."
 	icon_state = "minirocket_smoke"
 	point_cost = 25
 	cas_effect = /obj/effect/overlay/blinking_laser/smoke
@@ -570,7 +565,7 @@
 
 /obj/structure/ship_ammo/minirocket/tangle
 	name = "Tanglefoot mini rocket stack"
-	desc = "A pack of laser guided mini rockets loaded with plasma-draining Tanglefoot gas."
+	desc = "A pack of laser guided mini rockets loaded with plasma-draining Tanglefoot gas. Moving this will require some sort of lifter."
 	icon_state = "minirocket_tfoot"
 	point_cost = 150
 	devastating_explosion_range = 0
@@ -590,7 +585,7 @@
 
 /obj/structure/ship_ammo/minirocket/illumination
 	name = "illumination rocket-launched flare stack"
-	desc = "A pack of laser guided mini rockets, each loaded with a payload of white-star illuminant and a parachute, while extremely ineffective at damaging the enemy, it is very effective at lighting the battlefield so marines can damage the enemy."
+	desc = "A pack of laser guided mini rockets, each loaded with a payload of white-star illuminant and a parachute, while extremely ineffective at damaging the enemy, it is very effective at lighting the battlefield so marines can damage the enemy. Moving this will require some sort of lifter."
 	icon_state = "minirocket_ilm"
 	point_cost = 25 // Not a real rocket, so its cheap
 	cas_effect = /obj/effect/overlay/blinking_laser/flare

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -197,9 +197,6 @@
 
 	return turfs_impacted
 
-/obj/structure/ship_ammo/examine(mob/user)
-	to_chat(user, "Moving this will require some sort of lifter.")
-
 ///////////////
 
 //30mm gun

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -843,7 +843,7 @@
 
 /obj/structure/dropship_equipment/weapon/heavygun
 	name = "\improper GAU-21 30mm cannon"
-	desc = "A dismounted GAU-21 'Rattler' 30mm rotary cannon. It seems to be missing its feed links and has exposed connection wires. Capable of firing 5200 rounds a minute, feared by many for its power. Earned the nickname 'Rattler' from the vibrations it would cause on dropships in its inital production run."
+	desc = "A dismounted GAU-21 'Rattler' 30mm rotary cannon. It seems to be missing its feed links and has exposed connection wires. Capable of firing 5200 rounds a minute, feared by many for its power. Earned the nickname 'Rattler' from the vibrations it would cause on dropships in its inital production run. Moving this will require some sort of lifter."
 	icon_state = "30mm_cannon"
 	firing_sound = 'sound/weapons/gunship_chaingun.ogg'
 	point_cost = 400


### PR DESCRIPTION
## About The Pull Request
Examining CAS ammo gives you only the description that they need a powerlifter.
On top of that, once loaded, they did not properly give a description of how full they are. Something which would really be obvious to anyone taking a close look.

This PR fixes both of those issues. The chosen solution is the same as is used for CAS guns, so this also standardizes the code a bit. 

## Why It's Good For The Game

Broken descriptions are bad. 

## Changelog
:cl:
fix: fixes broken CAS ammo descriptions. 
/:cl:
