### PR TITLE
Xenomorphs can pull objects again

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -9,7 +9,10 @@
 	var/move_force = MOVE_FORCE_DEFAULT
 	///How much the atom resists being thrown or moved.
 	var/move_resist = MOVE_RESIST_DEFAULT
-	var/drag_delay = 3 //delay (in deciseconds) added to mob's move_delay when pulling it.
+	///Delay added to mob's move_delay when pulling it.
+	var/drag_delay = 3
+	///Wind-up before the mob can pull an object.
+	var/drag_windup = 1.5 SECONDS
 	var/throwing = FALSE
 	var/thrower = null
 	var/turf/throw_source = null

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -133,7 +133,7 @@
 	SIGNAL_HANDLER
 	if(!lunge_target.Adjacent(source))
 		return
-	lunge_grab(source, lunge_target)
+	INVOKE_ASYNC(src, .proc/lunge_grab, source, lunge_target)
 
 ///Do a last check to see if we can grab the target, and then clean up after the throw. Handles an in-place lunge.
 /datum/action/xeno_action/activable/lunge/proc/finish_lunge(datum/source)

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/warrior.dm
@@ -46,7 +46,7 @@
 	..()
 
 /mob/living/carbon/xenomorph/warrior/start_pulling(atom/movable/AM, suppress_message = TRUE, lunge = FALSE)
-	if(!check_state() || agility || !isliving(AM))
+	if(!check_state() || agility)
 		return FALSE
 
 	var/mob/living/L = AM

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -261,6 +261,8 @@
 	return FALSE
 
 /mob/living/carbon/xenomorph/start_pulling(atom/movable/AM, suppress_message = TRUE, bypass_crit_delay = FALSE)
+	if(!do_after(src, AM.drag_windup, TRUE, AM, BUSY_ICON_HOSTILE, BUSY_ICON_HOSTILE))
+		return //A do_after is called, for items with a drag wind-up.
 	if(!Adjacent(AM)) //Logic!
 		return FALSE
 	if(status_flags & INCORPOREAL || AM.status_flags & INCORPOREAL) //Incorporeal things can't grab or be grabbed.
@@ -272,9 +274,11 @@
 		if(L.stat == DEAD) //Can't drag dead human bodies.
 			to_chat(usr,span_xenowarning("This looks gross, better not touch it."))
 			return FALSE
-		do_attack_animation(L, ATTACK_EFFECT_GRAB)
-		pull_speed += XENO_DEADHUMAN_DRAG_SLOWDOWN
+
+	do_attack_animation(L, ATTACK_EFFECT_GRAB)
+	pull_speed += XENO_DEADHUMAN_DRAG_SLOWDOWN
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_GRAB)
+
 	return ..()
 
 /mob/living/carbon/xenomorph/stop_pulling()

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -261,8 +261,8 @@
 	return FALSE
 
 /mob/living/carbon/xenomorph/start_pulling(atom/movable/AM, suppress_message = TRUE, bypass_crit_delay = FALSE)
-	if(!do_after(src, AM.drag_windup, TRUE, AM, BUSY_ICON_HOSTILE, BUSY_ICON_HOSTILE))
-		return //A do_after is called, for items with a drag wind-up.
+	if(!isliving(AM) && AM.drag_windup && !do_after(src, AM.drag_windup, TRUE, AM, BUSY_ICON_HOSTILE, BUSY_ICON_HOSTILE))
+		return //If the target is not a living mob and has a drag_windup defined, calls a do_after. If all conditions are met, it returns.
 	if(!Adjacent(AM)) //Logic!
 		return FALSE
 	if(status_flags & INCORPOREAL || AM.status_flags & INCORPOREAL) //Incorporeal things can't grab or be grabbed.

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -261,8 +261,10 @@
 	return FALSE
 
 /mob/living/carbon/xenomorph/start_pulling(atom/movable/AM, suppress_message = TRUE, bypass_crit_delay = FALSE)
+	if(do_actions)
+		return FALSE //We are already occupied with something.
 	if(!Adjacent(AM))
-		return FALSE //The target we're trying to pull must be adjacent.
+		return FALSE //The target we're trying to pull must be adjacent and anchored. We also cannot be doing anything else.
 	if(status_flags & INCORPOREAL || AM.status_flags & INCORPOREAL)
 		return FALSE //Incorporeal things can't grab or be grabbed.
 	if(AM.anchored)

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -274,11 +274,9 @@
 		if(L.stat == DEAD) //Can't drag dead human bodies.
 			to_chat(usr,span_xenowarning("This looks gross, better not touch it."))
 			return FALSE
-
+		pull_speed += XENO_DEADHUMAN_DRAG_SLOWDOWN
 	do_attack_animation(L, ATTACK_EFFECT_GRAB)
-	pull_speed += XENO_DEADHUMAN_DRAG_SLOWDOWN
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_GRAB)
-
 	return ..()
 
 /mob/living/carbon/xenomorph/stop_pulling()

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -264,7 +264,7 @@
 	if(do_actions)
 		return FALSE //We are already occupied with something.
 	if(!Adjacent(AM))
-		return FALSE //The target we're trying to pull must be adjacent and anchored. We also cannot be doing anything else.
+		return FALSE //The target we're trying to pull must be adjacent and anchored.
 	if(status_flags & INCORPOREAL || AM.status_flags & INCORPOREAL)
 		return FALSE //Incorporeal things can't grab or be grabbed.
 	if(AM.anchored)

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -261,8 +261,6 @@
 	return FALSE
 
 /mob/living/carbon/xenomorph/start_pulling(atom/movable/AM, suppress_message = TRUE, bypass_crit_delay = FALSE)
-	if(!isliving(AM))
-		return FALSE
 	if(!Adjacent(AM)) //Logic!
 		return FALSE
 	if(status_flags & INCORPOREAL || AM.status_flags & INCORPOREAL) //Incorporeal things can't grab or be grabbed.

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -269,7 +269,7 @@
 	if(L.buckled)
 		return FALSE //to stop xeno from pulling marines on roller beds.
 	if(ishuman(L))
-		if(L.stat == DEAD && (SSticker.mode?.flags_round_type & MODE_DEAD_GRAB_FORBIDDEN)) //Can't drag dead human bodies in distress
+		if(L.stat == DEAD) //Can't drag dead human bodies.
 			to_chat(usr,span_xenowarning("This looks gross, better not touch it."))
 			return FALSE
 		do_attack_animation(L, ATTACK_EFFECT_GRAB)

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -261,12 +261,14 @@
 	return FALSE
 
 /mob/living/carbon/xenomorph/start_pulling(atom/movable/AM, suppress_message = TRUE, bypass_crit_delay = FALSE)
+	if(!Adjacent(AM))
+		return FALSE //The target we're trying to pull must be adjacent.
+	if(status_flags & INCORPOREAL || AM.status_flags & INCORPOREAL)
+		return FALSE //Incorporeal things can't grab or be grabbed.
+	if(AM.anchored)
+		return FALSE //We cannot grab anchored items.
 	if(!isliving(AM) && AM.drag_windup && !do_after(src, AM.drag_windup, TRUE, AM, BUSY_ICON_HOSTILE, BUSY_ICON_HOSTILE))
 		return //If the target is not a living mob and has a drag_windup defined, calls a do_after. If all conditions are met, it returns.
-	if(!Adjacent(AM)) //Logic!
-		return FALSE
-	if(status_flags & INCORPOREAL || AM.status_flags & INCORPOREAL) //Incorporeal things can't grab or be grabbed.
-		return FALSE
 	var/mob/living/L = AM
 	if(L.buckled)
 		return FALSE //to stop xeno from pulling marines on roller beds.


### PR DESCRIPTION
## About The Pull Request
Per title. One of Tivi's wishlist items.
Allows xenomorphs to pull objects again. All objects have a pull wind-up of 1.5 seconds; the pull will fail if they are somehow interrupted.

## Why It's Good For The Game
Further encourages xenomorphs to interact with the environment, which leads to a less restrictive gameplay experience.
Bear in mind this implies many other concerns will be enabled, but it is preferable to tackle them rather than take the easy way out.

## Changelog
:cl: Lewdcifer
add: Xenomorphs can now pull objects (again).
/:cl: