### PR TITLE
Shrike's Psychic Fling rebalancing

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -55,8 +55,8 @@
 	name = "Psychic Fling"
 	action_icon_state = "fling"
 	mechanics_text = "Sends an enemy or an item flying. A close ranged ability."
-	cooldown_timer = 12 SECONDS
-	plasma_cost = 100
+	cooldown_timer = 6 SECONDS
+	plasma_cost = 50
 	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_FLING
 	target_flags = XABB_MOB_TARGET
 
@@ -113,7 +113,7 @@
 	succeed_activate()
 	add_cooldown()
 	if(ishuman(victim))
-		victim.apply_effects(1, 0.1) 	// The fling stuns you enough to remove your gun, otherwise the marine effectively isn't stunned for long.
+		victim.apply_effects(0.1, 0.1) 	// The fling stuns you enough to remove your gun, otherwise the marine effectively isn't stunned.
 		shake_camera(victim, 2, 1)
 
 	var/facing = get_dir(owner, victim)


### PR DESCRIPTION
## About The Pull Request
Shrike's Psychic Fling has been rebalanced to be the same as in #10418 and #10489.
This reduces the cooldown from 12 seconds to 6 seconds, and the plasma cost from 100 to 50. Conversely, the stun duration has been reduced from 1.0 to 0.1, essentially only making Fling force any wielded items to drop. This makes it a highly spammable ability, altering its effectiveness and utility.

## Why It's Good For The Game
Losenis's changes to Psychic Fling were arguably more enjoyable than what we have currently, changing the gameplay to something more interesting.

## Changelog
:cl: Lewdcifer
balance: Shrike Psychic Fling; cooldown 12s > 6s, plasma cost 100 > 50. Stun duration 1.0 > 0.1.
/:cl: