### PR TITLE
Corpsmen have sailor ranks instead of marine ranks

### DIFF
--- a/code/datums/jobs/access.dm
+++ b/code/datums/jobs/access.dm
@@ -243,6 +243,8 @@
 			. = size ? "LCPL " : "Lance Corporal"
 		if("E3E")
 			. = size ? "SCPL " : "Section Corporal" //Anachronistic if we're going by common US ranks, above E3 but below E4.
+		if("E3N")
+			. = size ? "SN " : "Seaman" //corpmen's first rank since they are sailors, not marines
 		if("E4")
 			. = size ? "CPL " : "Corporal"
 		if("E5")

--- a/code/datums/jobs/job/marines.dm
+++ b/code/datums/jobs/job/marines.dm
@@ -296,11 +296,11 @@ You may not be a fully-fledged doctor, but you stand between life and death when
 		return
 	switch(playtime_mins)
 		if(0 to 1500) // starting
-			new_human.wear_id.paygrade = "E3"
+			new_human.wear_id.paygrade = "E3N"
 		if(1501 to 6000) // 25 hrs
-			new_human.wear_id.paygrade = "E4"
+			new_human.wear_id.paygrade = "PO3"
 		if(6001 to INFINITY) // 100 hrs
-			new_human.wear_id.paygrade = "E5"
+			new_human.wear_id.paygrade = "PO2"
 
 //Squad Smartgunner
 /datum/job/terragov/squad/smartgunner


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Instead of corpsmen getting lance corporal, corporal, and sergeant, corpsmen get seaman, petty officer third class, and petty officer second class to reflect their Navy background.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

my immersion

See, the US Marine Corps gets their corpsmen from the US Navy since marines ride on navy equipments. We use US ranks, so might as well reflect that.

I also can't wait for the funny SEMEN and GAY SAILOR jokes in game, but that's just military humor in general.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Corpsmen have sailor ranks instead of marine ranks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
