### PR TITLE
Evolution towers now count for T3 and T2 xeno slot calculations

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -1054,8 +1054,8 @@ to_chat will check for valid clients itself already so no need to double check f
 	var/threes = length(xenos_by_tier[XENO_TIER_THREE])
 	var/fours = length(xenos_by_tier[XENO_TIER_FOUR])
 
-	tier3_xeno_limit = max(threes, FLOOR((zeros + ones + twos + fours) / 3 + 1, 1))
-	tier2_xeno_limit = max(twos, zeros + ones + fours + 1 - threes)
+	tier3_xeno_limit = max(threes, FLOOR((zeros + ones + twos + fours + evotowers.length) / 3 + 1, 1))
+	tier2_xeno_limit = max(twos, zeros + ones + fours + evotowers.length + 1 - threes)
 
 // ***************************************
 // *********** Corrupted Xenos

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -1054,8 +1054,8 @@ to_chat will check for valid clients itself already so no need to double check f
 	var/threes = length(xenos_by_tier[XENO_TIER_THREE])
 	var/fours = length(xenos_by_tier[XENO_TIER_FOUR])
 
-	tier3_xeno_limit = max(threes, FLOOR(((zeros + ones + twos + fours) * (evotowers.len * 0.2)) / 3 + 1, 1))
-	tier2_xeno_limit = max((twos, zeros + ones + fours) * (evotowers.len * 0.2) + 1 - threes)
+	tier3_xeno_limit = max(threes, FLOOR(((zeros + ones + twos + fours) * (evotowers.len * 0.2 + 1)) / 3 + 1, 1))
+	tier2_xeno_limit = max((twos, zeros + ones + fours) * (evotowers.len * 0.2 + 1) + 1 - threes)
 
 // ***************************************
 // *********** Corrupted Xenos

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -1055,7 +1055,7 @@ to_chat will check for valid clients itself already so no need to double check f
 	var/fours = length(xenos_by_tier[XENO_TIER_FOUR])
 
 	tier3_xeno_limit = max(threes, FLOOR(((zeros + ones + twos + fours) * (evotowers.len * 0.2 + 1)) / 3 + 1, 1))
-	tier2_xeno_limit = max((twos, zeros + ones + fours) * (evotowers.len * 0.2 + 1) + 1 - threes)
+	tier2_xeno_limit = max((twos + zeros + ones + fours) * (evotowers.len * 0.2 + 1) + 1 - threes)
 
 // ***************************************
 // *********** Corrupted Xenos

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -1054,8 +1054,8 @@ to_chat will check for valid clients itself already so no need to double check f
 	var/threes = length(xenos_by_tier[XENO_TIER_THREE])
 	var/fours = length(xenos_by_tier[XENO_TIER_FOUR])
 
-	tier3_xeno_limit = max(threes, FLOOR((zeros + ones + twos + fours + evotowers.length) / 3 + 1, 1))
-	tier2_xeno_limit = max(twos, zeros + ones + fours + evotowers.length + 1 - threes)
+	tier3_xeno_limit = max(threes, FLOOR((zeros + ones + twos + fours + evotowers.len) / 3 + 1, 1))
+	tier2_xeno_limit = max(twos, zeros + ones + fours + evotowers.len + 1 - threes)
 
 // ***************************************
 // *********** Corrupted Xenos

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -1054,8 +1054,8 @@ to_chat will check for valid clients itself already so no need to double check f
 	var/threes = length(xenos_by_tier[XENO_TIER_THREE])
 	var/fours = length(xenos_by_tier[XENO_TIER_FOUR])
 
-	tier3_xeno_limit = max(threes, FLOOR((zeros + ones + twos + fours + evotowers.len) / 3 + 1, 1))
-	tier2_xeno_limit = max(twos, zeros + ones + fours + evotowers.len + 1 - threes)
+	tier3_xeno_limit = max(threes, FLOOR(((zeros + ones + twos + fours) * (evotowers.len * 0.2)) / 3 + 1, 1))
+	tier2_xeno_limit = max((twos, zeros + ones + fours) * (evotowers.len * 0.2) + 1 - threes)
 
 // ***************************************
 // *********** Corrupted Xenos


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Evo towers now count as a xeno for T3 and T2 slot calculations
## Why It's Good For The Game
Evo towers are made to boost evo-speed, yet xenos can never get enough larva generation to justify having these. So making them also permit more slots for T3 and T2 is more than fair , it makes them more viable at all population counts.
## Changelog
:cl:
balance: Evolution towers now multiply xeno count by 20% for each tower, increasing T3 and T2 slots.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
