### PR TITLE
fire stack proc fix and cleanup

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -126,7 +126,7 @@
 
 /mob/living/carbon/human/IgniteMob()
 	. = ..()
-	if(.)
+	if(on_fire == TRUE)
 		if(!stat && !(species.species_flags & NO_PAIN))
 			emote("scream")
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -204,11 +204,8 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 		victim.apply_damage(fire_burst_damage, BURN, null, armor_block, updating_health = TRUE) //Placeholder damage, will be a ammo var
 
 		staggerstun(victim, proj, 30, stagger = 0.5, slowdown = 0.5, shake = 0)
-
-		var/living_hard_armor = victim.hard_armor.getRating("fire")
-		if(victim.get_fire_resist() > 0 && living_hard_armor < 100) //won't ignite fully fireproof mobs
-			victim.adjust_fire_stacks(CEILING(5 - (living_hard_armor * 0.1), 1))
-			victim.IgniteMob()
+		victim.adjust_fire_stacks(5)
+		victim.IgniteMob()
 
 
 /datum/ammo/proc/fire_bonus_projectiles(obj/projectile/main_proj, atom/shooter, atom/source, range, speed, angle, target)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -915,7 +915,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	if(proj.ammo.flags_ammo_behavior & AMMO_INCENDIARY)
 		adjust_fire_stacks(proj.ammo.incendiary_strength)
 		if(IgniteMob())
-			feedback_flags |= (BULLET_FEEDBACK_FIRE|BULLET_FEEDBACK_SCREAM)
+			feedback_flags |= (BULLET_FEEDBACK_FIRE)
 
 	if(proj.ammo.flags_ammo_behavior & AMMO_SUNDERING)
 		adjust_sunder(proj.sundering)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -913,13 +913,8 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 				damage = max(0, damage - (damage * living_soft_armor * 0.01))
 
 	if(proj.ammo.flags_ammo_behavior & AMMO_INCENDIARY)
-		//We are checking the total distributed mob's armor now, not just the limb.
-		//Fire mod represents our fire resistance, while hard armor represents certain armor's resistance to burning material sticking to it.
-		var/fire_mod = get_fire_resist()
-		var/fire_hard_armor = get_hard_armor("fire", BODY_ZONE_CHEST)
-		if(fire_mod > 0 && fire_hard_armor < 100) //If the modifier is not bigger than zero or the hard armor is 100 then the armor fully absorbs this effect.
-			adjust_fire_stacks(CEILING(proj.ammo.incendiary_strength * fire_mod * ((100- fire_hard_armor) * 0.01), 1)) //We could add an ammo fire strength in time, as a variable.
-			IgniteMob()
+		adjust_fire_stacks(proj.ammo.incendiary_strength)
+		if(IgniteMob())
 			feedback_flags |= (BULLET_FEEDBACK_FIRE|BULLET_FEEDBACK_SCREAM)
 
 	if(proj.ammo.flags_ammo_behavior & AMMO_SUNDERING)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Incendiary ammo and volkite weapons were applying fire armour to the amount of fire stacks being passed for adjust_fire_stacks(), when the proc already does this internally.

Also cleaned up the incendiary ammo code more generally, as ignite() also checks for fire immunity, so that didn't need to be done in projectile code either.

The last notable change is that you will now scream every time anything successfully ignites you, regardless of whether you're already on fire.

Currently this is inconsistant, incendiary projectiles will always trigger a scream, but walking through fire for example will only trigger it if you weren't already on fire.

This means standing in fire/running through a flaming corridor will trigger screams periodically instead of just once.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fixes good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fire stacks will no longer check fire armour twice in some instances
refactor: Slight clean up to incendiary ammo code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
