### PR TITLE
Carrier panic drop change

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -207,6 +207,10 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 	if(!.)
 		return FALSE
 	var/mob/living/carbon/xenomorph/carrier/X = owner
+	if(X.health > (X.maxHealth * 0.25))
+		if(!silent)
+			to_chat(X, span_xenowarning("We are not injured enough to panic yet!"))
+		return FALSE
 	if(X.huggers < 1)
 		if(!silent)
 			to_chat(X, span_xenowarning("We do not have any young ones to drop!"))


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Carrier panic drop can now only be used when at 25% of health or under.

Currently panic drop is without question the most powerful ability in the game, and is just used as an insta kill ability, not an 'oh shit' panic ability as intended.

This PR retains its potency, but means you can't be as hilariously aggressive with it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
ggnore button is bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Carrier panic drop can only be used at 25% health or less
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
