### PR TITLE
Flamer nerf

### DIFF
--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -207,6 +207,10 @@
 			//Checks if turf is resin wall
 			if(turf.density && istype(turf, /turf/closed/wall/resin))
 				walls_penetrated_wide -= 1
+			//Checks if there is a resin door on the turf
+			var/obj/structure/mineral_door/resin/door_to_check = locate() in turf
+			if(door_to_check != null)
+				walls_penetrated_wide -= 1
 			//Check to ensure that we dont burn more walls than specified
 			if(walls_penetrated_wide <= 0)
 				break

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -204,8 +204,10 @@
 	var/list/turf/turfs_by_iteration = list()
 	for(var/turf/turf AS in turfs_to_ignite)
 		if(get_dist(turf, flame_source) == iteration)
-			if(turf.density && istype(turf, /turf/closed/wall/resin)) // preventing flamers from going through more than 2 layers of resin wall
+			//Checks if turf is resin wall
+			if(turf.density && istype(turf, /turf/closed/wall/resin))
 				walls_penetrated_wide -= 1
+			//Check to ensure that we dont burn more walls than specified
 			if(walls_penetrated_wide <= 0)
 				break
 			turfs_by_iteration += turf

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -209,7 +209,7 @@
 				walls_penetrated_wide -= 1
 			//Checks if there is a resin door on the turf
 			var/obj/structure/mineral_door/resin/door_to_check = locate() in turf
-			if(door_to_check != null)
+			if(!isnull(door_to_check))
 				walls_penetrated_wide -= 1
 			//Check to ensure that we dont burn more walls than specified
 			if(walls_penetrated_wide <= 0)

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -55,8 +55,8 @@
 	var/flame_max_range = 6
 	///Max resin wall penetration in tiles.
 	var/flame_max_wall_pen = 3
-	///Max resin wall penetration for wide nozzle
-	var/flame_max_wall_pen_wide = 8
+	///After how many total resin walls the flame wont proceed further
+	var/flame_max_wall_pen_wide = 9
 	///Travel speed of the flames in seconds.
 	var/flame_spread_time = 0.1 SECONDS
 	///Gun based modifier for burn level. Percentage based.

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -54,7 +54,7 @@
 	///Max range of the flamer in tiles.
 	var/flame_max_range = 6
 	///Max resin wall penetration in tiles.
-	var/flame_max_wall_pen = 2
+	var/flame_max_wall_pen = 3
 	///Max resin wall penetration for wide nozzle
 	var/flame_max_wall_pen_wide = 8
 	///Travel speed of the flames in seconds.


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Prevents normal muzzle from penetrating further than 3* tiles into resin walls
![image](https://user-images.githubusercontent.com/63870402/191840197-abdd7276-36e7-4cbc-8705-4112632f3581.png)

Prevents spray muzzle from penetrating as much
![image](https://user-images.githubusercontent.com/63870402/191840154-3f18f3c3-1f96-42f9-b4f6-1f475999272e.png)

## Why It's Good For The Game
Currently spray nozzles are dominating xeno mazes, the justification that I recieved was that flamers need to clear mazes effectively.
This allows you to still clear mazes without the insane spread of fire behind 5 layers of mazes.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: nerfed standard and wide flamer nozzle
code: Made it possible to set flamer penetration on resin walls
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
