### PR TITLE
Fix 1 engineering APC having a missing wire

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -8517,6 +8517,7 @@
 /obj/machinery/firealarm{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/lower_engine_monitoring)
 "yR" = (


### PR DESCRIPTION
## About The Pull Request
Engineering on POS has 1 APC with no wire underneath it. This PR fixes this issue. 

## Why It's Good For The Game
Fix good.

## Changelog
:cl:
fix: fixed a missing wire on POS
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
