### PR TITLE
Prevents xenos from buckling dead people to things

### DIFF
--- a/code/game/buckling.dm
+++ b/code/game/buckling.dm
@@ -170,6 +170,6 @@
 	return TRUE
 
 /mob/living/carbon/xenomorph/user_can_buckle(mob/living/buckling_mob)
-	if(buckling_mob != src)
+	if(buckling_mob.stat)
 		return FALSE
 	return ..()

--- a/code/game/buckling.dm
+++ b/code/game/buckling.dm
@@ -110,8 +110,8 @@
 
 
 //Wrapper procs that handle sanity and user feedback
-/atom/movable/proc/user_buckle_mob(mob/living/buckling_mob, mob/user, check_loc = TRUE, silent)
-	if(!Adjacent(user, src) || !isturf(user.loc) || user.incapacitated() || buckling_mob.anchored)
+/atom/movable/proc/user_buckle_mob(mob/living/buckling_mob, mob/living/user, check_loc = TRUE, silent)
+	if(!user.user_can_buckle(buckling_mob))
 		return FALSE
 
 	add_fingerprint(user, "buckle")
@@ -156,3 +156,20 @@
 		var/mob/living/pulling_living = unbuckling_living.pulledby
 		pulling_living.set_pull_offsets(unbuckling_living)
 	return unbuckling_living
+
+///Returns TRUE or FALSE depending on whether src can buckle buckling_mob into something
+/mob/living/proc/user_can_buckle(mob/living/buckling_mob)
+	if(!Adjacent(src, buckling_mob))
+		return FALSE
+	if(!isturf(loc))
+		return FALSE
+	if(incapacitated())
+		return FALSE
+	if(buckling_mob.anchored)
+		return FALSE
+	return TRUE
+
+/mob/living/carbon/xenomorph/user_can_buckle(mob/living/buckling_mob)
+	if(buckling_mob != src)
+		return FALSE
+	return ..()


### PR DESCRIPTION
## About The Pull Request
So you don't get stuff like strapping a crit marine to a roller bed and yakkety saxing.
Xenos can still strap people in for mr bones wild ride if they're awake.

## Why It's Good For The Game
Avoid a corpsedrag bypass.

## Changelog
:cl:
balance: Xenos can't buckle other people to stuff if they aren't conscious.
/:cl:
