### PR TITLE
LV 2022 Rework

### DIFF
--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -1549,6 +1549,7 @@
 /area/lv624/ground/sand8)
 "aLd" = (
 /obj/effect/landmark/weed_node,
+/obj/structure/jungle/vines,
 /turf/open/floor,
 /area/lv624/ground/river1)
 "aLn" = (
@@ -1769,11 +1770,9 @@
 /turf/open/floor/freezer,
 /area/lv624/lazarus/kitchen)
 "aPE" = (
-/obj/structure/cable,
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 5
-	},
-/area/lv624/lazarus/fitness)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/bot,
+/area/lv624/ground/sand5)
 "aPI" = (
 /turf/open/ground/coast/corner2{
 	dir = 2
@@ -2355,9 +2354,10 @@
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/research)
 "bbw" = (
-/obj/structure/jungle/planttop1,
+/obj/effect/landmark/weed_node,
+/obj/item/ammo_casing,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand8)
+/area/lv624/ground/sand7)
 "bbL" = (
 /turf/open/ground/coast/corner2{
 	dir = 4
@@ -2379,9 +2379,10 @@
 	},
 /area/lv624/ground/river2)
 "bcd" = (
-/obj/item/weapon/claymore/mercsword/machete,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle3)
+/area/lv624/ground/sand2)
 "bce" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = /obj/item/storage/backpack;
@@ -2536,8 +2537,11 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle9)
 "bfw" = (
-/turf/open/floor/plating/catwalk,
-/area/lv624/ground/sand8)
+/obj/effect/decal/sandytile,
+/obj/effect/decal/sandytile,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple)
 "bfK" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/dirt,
@@ -3453,10 +3457,9 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central2)
 "bEf" = (
-/obj/structure/jungle/vines,
-/obj/structure/window/framed/colony,
-/turf/open/floor/plating,
-/area/lv624/lazarus/fitness)
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
 "bEl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -3981,6 +3984,7 @@
 /turf/closed/wall/r_wall,
 /area/lv624/ground/jungle2)
 "cmk" = (
+/obj/structure/sign/safety/hazard,
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
 	dir = 4
 	},
@@ -4905,6 +4909,11 @@
 	dir = 8
 	},
 /area/lv624/lazarus/security)
+"dlN" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple)
 "dlV" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -5644,6 +5653,7 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle3)
 "edz" = (
+/obj/structure/sign/safety/hazard,
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
 	dir = 8
 	},
@@ -6244,6 +6254,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/lv624/lazarus/captain)
+"eRR" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/space/basic,
+/area/lv624/ground/caves/rock)
 "eSl" = (
 /obj/item/analyzer,
 /turf/open/floor/plating/ground/dirt,
@@ -6738,10 +6752,10 @@
 	},
 /area/lv624/ground/caves/rock)
 "fxm" = (
-/obj/structure/window_frame/colony,
-/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/landmark/weed_node,
+/obj/structure/jungle/vines,
 /turf/open/floor/plating,
-/area/lv624/lazarus/overgrown)
+/area/lv624/ground/river1)
 "fxx" = (
 /turf/open/floor/tile/white/warningstripe{
 	dir = 8
@@ -7886,6 +7900,7 @@
 	},
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
+/obj/item/ammo_casing,
 /turf/open/floor/plating/warning{
 	dir = 2
 	},
@@ -8516,6 +8531,7 @@
 /area/lv624/ground/sand8)
 "hDt" = (
 /obj/structure/platform,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
 "hDA" = (
@@ -9303,6 +9319,11 @@
 /area/lv624/lazarus/chapel)
 "iBW" = (
 /obj/structure/jungle/vines,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/item/weapon/claymore/mercsword/machete,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle3)
 "iCb" = (
@@ -10091,10 +10112,10 @@
 /turf/open/floor,
 /area/lv624/ground/sand7)
 "jya" = (
-/obj/structure/jungle/planttop1,
-/obj/structure/fence,
-/turf/open/floor/plating/ground/dirtgrassborder,
-/area/lv624/ground/jungle3)
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3)
 "jyt" = (
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle4)
@@ -11096,6 +11117,7 @@
 /area/lv624/ground/jungle7)
 "kCI" = (
 /obj/effect/landmark/weed_node,
+/obj/structure/jungle/vines,
 /turf/open/floor/plating/dmg3,
 /area/lv624/ground/river1)
 "kDo" = (
@@ -11230,6 +11252,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/blue/whitebluefull,
 /area/lv624/lazarus/corporate_affairs)
+"kKQ" = (
+/obj/structure/sign/safety/hazard,
+/turf/closed/gm/dense,
+/area/lv624/lazarus/spaceport2)
 "kKT" = (
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor,
@@ -12271,10 +12297,8 @@
 	},
 /area/lv624/ground/filtration)
 "lSc" = (
-/obj/structure/fence,
-/turf/open/floor/plating/ground/dirtgrassborder/corner2{
-	dir = 1
-	},
+/obj/structure/jungle/vines,
+/turf/closed/wall,
 /area/lv624/ground/jungle6)
 "lSo" = (
 /obj/effect/spawner/modularmap/lv624/domes,
@@ -12918,6 +12942,9 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/west1)
+"mFi" = (
+/turf/open/floor/plating/dmg3,
+/area/lv624/ground/sand7)
 "mFr" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/machinery/door/poddoor/mainship{
@@ -14954,10 +14981,6 @@
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/quartstorage)
 "pdN" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 1;
-	name = "\improper Leisure Dome"
-	},
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 5
 	},
@@ -15050,6 +15073,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/lv624/lazarus/engineering)
+"pmd" = (
+/obj/structure/catwalk,
+/obj/structure/jungle/vines,
+/turf/open/ground/coast,
+/area/lv624/ground/river1)
 "pmg" = (
 /obj/structure/sign/botany,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -16447,9 +16475,10 @@
 /turf/open/floor/plating,
 /area/lv624/ground/sand8)
 "qUJ" = (
-/obj/structure/jungle/plantbot1,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle3)
+/obj/structure/catwalk,
+/obj/structure/jungle/vines,
+/turf/open/ground/river,
+/area/lv624/ground/river1)
 "qUL" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight,
@@ -17825,6 +17854,11 @@
 /obj/structure/fence,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle2)
+"str" = (
+/obj/effect/ai_node,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/lv624/ground/jungle3)
 "sud" = (
 /obj/effect/decal/tracks/human1/wet{
 	dir = 8
@@ -18473,8 +18507,8 @@
 /area/lv624/lazarus/sandtemple)
 "tlk" = (
 /obj/structure/jungle/vines,
-/turf/closed/wall,
-/area/lv624/ground/compound/sw)
+/turf/open/floor/plating/dmg1,
+/area/lv624/ground/river1)
 "tlr" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4
@@ -19179,6 +19213,7 @@
 "tZa" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/fence,
+/obj/structure/jungle/vines,
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 8;
 	icon_state = "grassdirt_corner2"
@@ -20639,12 +20674,12 @@
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/quart)
 "vMu" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 4;
-	icon_state = "grassdirt_corner2"
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1;
+	name = "\improper Leisure Dome"
 	},
-/area/lv624/ground/jungle3)
+/turf/open/floor/plating,
+/area/lv624/lazarus/fitness)
 "vMC" = (
 /obj/item/stack/sheet/wood,
 /turf/open/floor/tile/purple/taupepurple{
@@ -20677,6 +20712,7 @@
 "vPf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
+/obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle3)
 "vPC" = (
@@ -22230,10 +22266,9 @@
 	},
 /area/lv624/ground/jungle10)
 "xwr" = (
-/obj/effect/decal/remains/xeno,
-/obj/structure/jungle/planttop1,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle3)
+/obj/structure/jungle/vines,
+/turf/open/floor,
+/area/lv624/ground/river1)
 "xwu" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -25088,8 +25123,8 @@ lxu
 lxu
 cOs
 rtU
-bpE
-cjm
+xLz
+xLz
 xLz
 rtU
 nmn
@@ -25265,8 +25300,8 @@ xLz
 xLz
 xLz
 xLz
-xoT
-cOs
+xLz
+xLz
 xLz
 xLz
 mkw
@@ -25632,7 +25667,7 @@ hVJ
 hVJ
 hVJ
 nmn
-fxm
+izQ
 mkw
 izQ
 nmn
@@ -28248,7 +28283,7 @@ cAu
 cAu
 cAu
 cAu
-cAu
+sbj
 cAu
 cAu
 cAu
@@ -28668,7 +28703,7 @@ bch
 gjH
 xFL
 eZJ
-xFL
+qHh
 obk
 mOs
 mOs
@@ -28847,7 +28882,7 @@ fjU
 xFL
 xFL
 obk
-mOs
+bch
 mOs
 mOs
 mOs
@@ -29201,7 +29236,7 @@ xFL
 xFL
 xFL
 gRt
-mOs
+cQj
 mOs
 mOs
 mOs
@@ -29313,7 +29348,7 @@ cAu
 cAu
 cAu
 cAu
-cAu
+bEf
 tZS
 are
 are
@@ -29378,7 +29413,7 @@ ocU
 wUH
 xFL
 gRt
-mOs
+bch
 mOs
 mOs
 mOs
@@ -29473,7 +29508,7 @@ evp
 evp
 gsZ
 cAu
-gsZ
+bbw
 cAu
 cAu
 gsZ
@@ -29483,13 +29518,13 @@ cAu
 aWb
 gsZ
 cAu
-cAu
-cAu
+blH
+blH
 cAu
 gsZ
 cAu
 cAu
-cAu
+gsZ
 cAu
 tZS
 are
@@ -29555,7 +29590,7 @@ sqa
 njd
 xFL
 gRt
-mOs
+bch
 mOs
 mOs
 mOs
@@ -29650,7 +29685,7 @@ evp
 evp
 aWy
 cAu
-cAu
+blH
 cAu
 fRf
 blH
@@ -29732,7 +29767,7 @@ ffO
 xFL
 xFL
 wit
-mOs
+bch
 mOs
 mOs
 mOs
@@ -29899,7 +29934,7 @@ xFL
 xFL
 gRt
 bch
-bch
+cQj
 bch
 bch
 bch
@@ -29909,7 +29944,7 @@ syE
 xFL
 xFL
 kQA
-vXZ
+vGi
 mOs
 mOs
 mOs
@@ -30021,8 +30056,8 @@ cAu
 cAu
 gsZ
 cAu
-tga
-are
+mFi
+qFz
 are
 are
 are
@@ -30086,7 +30121,7 @@ ffO
 caQ
 xFL
 kQA
-vXZ
+vGi
 mOs
 mOs
 mOs
@@ -30194,23 +30229,23 @@ hRy
 pRC
 dGl
 gQl
-cAu
+blH
 cAu
 cAu
 cAu
 mZo
-qbR
+sBf
 xZG
-qbR
-qbR
+sBf
+sBf
 xkb
 odE
-qbR
+sBf
 xZG
-qbR
-odE
+sBf
+rpQ
 tZa
-csH
+lSc
 obc
 tlt
 nny
@@ -30260,7 +30295,7 @@ gfH
 jBQ
 obn
 ffO
-xFL
+qHh
 xFL
 gRt
 bch
@@ -30356,8 +30391,8 @@ evp
 evp
 evp
 gsZ
-cAu
-cAu
+blH
+blH
 biV
 jnE
 rxF
@@ -30373,16 +30408,16 @@ nlg
 wdN
 cAu
 cAu
-cAu
+sbj
 cAu
 jxU
-odE
+rpQ
 qFz
 xZG
 xZG
 xHS
 aWz
-xZG
+qUJ
 xZG
 kBt
 aWz
@@ -30558,7 +30593,7 @@ odE
 odE
 odE
 wFb
-alD
+fxm
 odE
 odE
 odE
@@ -30610,7 +30645,7 @@ hlK
 hlK
 hlK
 hlK
-bch
+cQj
 bch
 gMO
 ffO
@@ -30726,16 +30761,16 @@ nlg
 hRy
 wdN
 cAu
+cAu
 gsZ
 cAu
-cAu
 jxU
-odE
-wFb
+rpQ
+tlk
 aWz
 odE
 odE
-xHS
+xwr
 wFb
 odE
 alD
@@ -30791,7 +30826,7 @@ bch
 bch
 pae
 ffO
-xFL
+qHh
 xFL
 gRt
 bch
@@ -30908,7 +30943,7 @@ cAu
 cAu
 ldV
 odE
-qFz
+pmd
 xZG
 xZG
 aLd
@@ -31085,17 +31120,17 @@ cAu
 cAu
 rHw
 qbR
-qbR
+sBf
 qbR
 odE
-qbR
-qbR
-qbR
-qbR
+sBf
+sBf
+sBf
+sBf
 xZG
 odE
 hgP
-lSc
+csH
 mnA
 mnA
 mnA
@@ -31125,7 +31160,7 @@ mxb
 gqy
 qEO
 yiV
-yiV
+oZt
 yiV
 hlK
 hlK
@@ -31260,8 +31295,8 @@ blH
 cAu
 gsZ
 cAu
-tga
-are
+mFi
+qFz
 are
 are
 are
@@ -31679,7 +31714,7 @@ ffO
 xFL
 xFL
 kez
-mOs
+cQj
 mOs
 mOs
 mOs
@@ -31856,7 +31891,7 @@ ffO
 caQ
 xFL
 fXn
-mOs
+bch
 mOs
 mOs
 mOs
@@ -31965,8 +32000,8 @@ aSm
 eLz
 wdN
 cAu
-gsZ
 cAu
+gsZ
 cAu
 cAu
 tZS
@@ -32034,7 +32069,7 @@ xFL
 xFL
 gRt
 mQx
-mOs
+bch
 mOs
 mOs
 mOs
@@ -32188,8 +32223,8 @@ jBk
 ylq
 vAe
 yiV
+oZt
 yiV
-yiV
 hlK
 hlK
 hlK
@@ -32203,7 +32238,7 @@ hlK
 hlK
 hlK
 hlK
-bch
+cQj
 bch
 gMO
 ffO
@@ -32211,7 +32246,7 @@ xFL
 xFL
 gRt
 bch
-mOs
+bch
 mOs
 mOs
 mOs
@@ -32388,8 +32423,8 @@ xFL
 xFL
 gRt
 bch
-mOs
-mOs
+bch
+bch
 mOs
 mOs
 mOs
@@ -32489,8 +32524,8 @@ cAu
 cAu
 cAu
 cAu
-cAu
-cAu
+blH
+blH
 cAu
 cAu
 cAu
@@ -32565,8 +32600,8 @@ xFL
 xFL
 wit
 bch
-mOs
-mOs
+bch
+bch
 mOs
 mOs
 mOs
@@ -32675,7 +32710,7 @@ cAu
 gsZ
 cAu
 cAu
-cAu
+sbj
 cAu
 tZS
 are
@@ -32742,9 +32777,9 @@ caQ
 xFL
 gRt
 bch
-mOs
-mOs
-mOs
+bch
+bch
+bch
 mOs
 mOs
 mOs
@@ -32919,9 +32954,9 @@ xFL
 xFL
 gRt
 bch
-mOs
-mOs
-mOs
+bch
+bch
+bch
 mOs
 mOs
 mOs
@@ -33096,9 +33131,9 @@ xFL
 xFL
 gRt
 bch
-mOs
-mOs
-mOs
+bch
+cQj
+bch
 mOs
 mOs
 mOs
@@ -33273,9 +33308,9 @@ xFL
 xFL
 fXn
 gjs
-mOs
-mOs
-mOs
+bch
+bch
+bch
 mOs
 mOs
 mOs
@@ -33441,8 +33476,8 @@ xFL
 qHh
 xFL
 xFL
-xwr
-qUJ
+xkr
+xFL
 xFL
 xFL
 ffO
@@ -33450,8 +33485,8 @@ xFL
 xFL
 kez
 bch
-mOs
-mOs
+bch
+bch
 mOs
 mOs
 mOs
@@ -33627,7 +33662,7 @@ tmG
 uaf
 lqJ
 bgw
-vIs
+bgw
 vIs
 vIs
 vIs
@@ -33786,25 +33821,25 @@ xgZ
 gJI
 gaO
 xnA
-rhp
+eRR
 rhp
 jro
 bch
-mOs
-mOs
+cQj
+bch
 bch
 gjs
 mOs
 bch
 bch
 bch
-jya
+gMO
 ffO
 xFL
 xFL
 gRt
 bch
-mOs
+bch
 bch
 mOs
 mOs
@@ -33955,15 +33990,15 @@ rRx
 rRx
 rRx
 rRx
-rRx
-vWz
+kKQ
+tSf
 tSf
 tSf
 bdP
 odC
 tSf
 vWz
-tBK
+tSf
 tBK
 gLd
 bch
@@ -34320,7 +34355,7 @@ vvX
 uvP
 rRx
 ovM
-bch
+cQj
 bch
 mOs
 mOs
@@ -34511,8 +34546,8 @@ ffO
 caQ
 xFL
 gRt
-mOs
-mOs
+bch
+bch
 bch
 bch
 mOs
@@ -34579,7 +34614,7 @@ gKr
 gKr
 aIm
 aIm
-aIm
+ifX
 aIm
 gKr
 aIm
@@ -34681,14 +34716,14 @@ mOs
 mOs
 mQx
 bch
-bch
+cQj
 bch
 gMO
 xFE
 fjU
 xFL
 gRt
-mOs
+bch
 bch
 bch
 bch
@@ -35211,7 +35246,7 @@ mOs
 mOs
 mOs
 bch
-bch
+cQj
 bch
 bch
 wit
@@ -35220,7 +35255,7 @@ xFL
 xFL
 wit
 bcz
-bch
+cQj
 mOs
 mOs
 bch
@@ -35391,12 +35426,12 @@ bck
 bch
 bch
 bch
-gjH
+gMO
 ffO
 caQ
 xFL
-jtj
-nxu
+gRt
+bch
 bch
 mOs
 mOs
@@ -35507,7 +35542,7 @@ gKr
 gKr
 gKr
 cAu
-cAu
+sbj
 cAu
 uwf
 cAu
@@ -35572,8 +35607,8 @@ vPf
 xoE
 xFL
 xFL
-xFL
-obk
+gRt
+bch
 bch
 mOs
 mOs
@@ -35745,12 +35780,12 @@ bck
 mOs
 mOs
 qVt
-mzD
-vMu
-xFL
+gMO
 qHh
 xFL
-obk
+qHh
+gRt
+bch
 bch
 bch
 bch
@@ -35922,12 +35957,12 @@ bck
 bch
 bch
 qVt
-mQx
-gjH
+str
 xFL
 xFL
 xFL
-obk
+gRt
+bch
 bch
 mOs
 bch
@@ -36099,12 +36134,12 @@ qTs
 qTs
 qTs
 wyg
+gMO
+xFL
+xFL
+xFL
+gRt
 bch
-gjH
-xFL
-xFL
-xFL
-obk
 bch
 bch
 bch
@@ -36272,7 +36307,6 @@ fwf
 fBO
 dKx
 bch
-bch
 bck
 bck
 bch
@@ -36286,7 +36320,8 @@ bch
 bch
 bch
 bch
-mOs
+bch
+bch
 fIY
 psZ
 "}
@@ -36347,7 +36382,7 @@ kFx
 kFx
 kFx
 kFx
-kFx
+gnk
 jsp
 aIm
 aIm
@@ -36449,21 +36484,21 @@ gQX
 wbt
 hmG
 bch
+xOT
+xOT
+xOT
+xOT
+xOT
+xOT
+xOT
+xOT
+xOT
+xOT
+xOT
+xOT
+xOT
 bch
-xOT
-xOT
-xOT
-xOT
-xOT
-xOT
-xOT
-xOT
-xOT
-xOT
-xOT
-xOT
-xOT
-mOs
+bch
 fIY
 psZ
 "}
@@ -36621,10 +36656,9 @@ uej
 uvP
 jkz
 edz
-vWz
+tSf
 jdL
 qOp
-jig
 nxu
 bch
 xOT
@@ -36640,7 +36674,8 @@ xOT
 xOT
 xOT
 xOT
-gWm
+cQj
+bch
 fIY
 psZ
 "}
@@ -36801,7 +36836,6 @@ ybc
 yaB
 xQg
 xBB
-xFL
 obk
 bch
 xOT
@@ -36817,7 +36851,8 @@ xOT
 xOT
 xOT
 xOT
-mOs
+bch
+bch
 fIY
 psZ
 "}
@@ -36978,7 +37013,6 @@ ybc
 yaB
 mOO
 xBB
-bcd
 obk
 leQ
 xOT
@@ -36994,7 +37028,8 @@ xOT
 xOT
 xOT
 xOT
-gWm
+cQj
+bch
 fIY
 psZ
 "}
@@ -37154,8 +37189,7 @@ pQz
 ybc
 yaB
 mOO
-xBB
-xFL
+iBW
 jtj
 xOT
 xOT
@@ -37172,6 +37206,7 @@ xOT
 xOT
 xOT
 xOT
+bch
 fIY
 psZ
 "}
@@ -37329,10 +37364,9 @@ eek
 uvP
 cnX
 cmk
-vWz
+tSf
 xzw
 xBB
-iBW
 xFL
 xOT
 xOT
@@ -37349,6 +37383,7 @@ xOT
 xOT
 xOT
 xOT
+bch
 fIY
 psZ
 "}
@@ -37510,7 +37545,6 @@ tSf
 gQX
 vzW
 rTU
-rTU
 xOT
 xOT
 xOT
@@ -37526,6 +37560,7 @@ xOT
 xOT
 xOT
 xOT
+bch
 cUt
 psZ
 "}
@@ -37686,7 +37721,6 @@ mOs
 mOs
 jro
 hfr
-iBW
 rXz
 xOT
 xOT
@@ -37703,6 +37737,7 @@ xOT
 xOT
 xOT
 xOT
+bch
 mOs
 psZ
 "}
@@ -37863,7 +37898,6 @@ mOs
 bch
 fLY
 hfr
-xFL
 aiv
 xOT
 xOT
@@ -37880,6 +37914,7 @@ xOT
 xOT
 xOT
 xOT
+bch
 mOs
 psZ
 "}
@@ -38040,7 +38075,6 @@ mOs
 bch
 jro
 qXi
-wTp
 tfy
 tuX
 xOT
@@ -38056,6 +38090,7 @@ xOT
 xOT
 xOT
 xOT
+bch
 bch
 mOs
 psZ
@@ -38218,7 +38253,6 @@ mOs
 jro
 bck
 bch
-bch
 bcz
 xOT
 xOT
@@ -38234,6 +38268,7 @@ xOT
 xOT
 xOT
 bch
+cQj
 mOs
 psZ
 "}
@@ -38396,20 +38431,20 @@ jro
 bch
 bck
 bch
+xOT
+xOT
+xOT
+xOT
+xOT
+xOT
+xOT
+xOT
+xOT
+xOT
+xOT
+xOT
+xOT
 bch
-xOT
-xOT
-xOT
-xOT
-xOT
-xOT
-xOT
-xOT
-xOT
-xOT
-xOT
-xOT
-xOT
 bch
 mOs
 psZ
@@ -38572,7 +38607,6 @@ mOs
 jro
 bch
 nVy
-bch
 bck
 xOT
 xOT
@@ -38587,6 +38621,7 @@ xOT
 xOT
 xOT
 xOT
+bch
 bch
 mOs
 psZ
@@ -38749,7 +38784,6 @@ cQj
 jro
 bch
 mIe
-mIe
 bch
 bch
 bcz
@@ -38760,6 +38794,7 @@ xOT
 xOT
 xOT
 xOT
+bch
 bch
 bch
 bch
@@ -38930,8 +38965,7 @@ mIe
 bck
 bch
 bch
-mIe
-bch
+bck
 gMO
 xFL
 nAu
@@ -38939,6 +38973,7 @@ xFL
 gRt
 bch
 bch
+cQj
 bch
 bch
 mOs
@@ -39107,13 +39142,13 @@ mIe
 bck
 mPA
 mIe
-mIe
-bch
+bck
 gMO
 xFL
 rGj
 xFL
 gRt
+bch
 bch
 bch
 bch
@@ -39284,13 +39319,13 @@ bch
 bck
 bck
 mIe
-mIe
-bch
+bck
 gMO
 xFL
 oVV
 xFL
 gRt
+bch
 bch
 bch
 bch
@@ -39461,13 +39496,13 @@ bch
 bch
 mIe
 mIe
-mIe
 bck
 fXn
 xFL
 oVV
 xFL
 wit
+bch
 bch
 bch
 mOs
@@ -39547,7 +39582,7 @@ aIm
 luP
 aBd
 aIm
-aIm
+ifX
 gKr
 gKr
 aIm
@@ -39638,13 +39673,13 @@ bch
 bch
 bch
 mIe
-mIe
-bch
+bck
 gMO
 xFL
 oVV
 xFL
 gRt
+cQj
 bch
 bch
 mOs
@@ -39816,12 +39851,12 @@ bch
 bck
 bch
 bch
-bch
 gMO
 xFL
 rGj
 xFL
 gRt
+bch
 bch
 bch
 mOs
@@ -39989,8 +40024,7 @@ rnv
 rnv
 xNG
 xNG
-xNG
-tlk
+ycp
 xNG
 xNG
 xNG
@@ -39998,7 +40032,8 @@ ycp
 xLK
 vpP
 xLK
-xYe
+ycp
+ruI
 xQi
 bpx
 bpx
@@ -40053,7 +40088,7 @@ gKr
 jQf
 jQf
 kFx
-kFx
+gnk
 jQf
 jQf
 kFx
@@ -40172,10 +40207,10 @@ xLK
 xLK
 xLK
 xLK
-xLK
 vpP
 uac
-ycp
+xYe
+ruI
 bpx
 mjn
 bpx
@@ -40349,10 +40384,10 @@ fVy
 uWG
 uWG
 uWG
-uWG
 uVA
 xLK
 xYe
+ruI
 bpx
 bpx
 bpx
@@ -40526,10 +40561,10 @@ xLK
 uDk
 xLK
 xLK
-xLK
 uDk
 xLK
 xYe
+ruI
 xQi
 bpx
 bpx
@@ -40591,7 +40626,7 @@ kFx
 kFx
 kFx
 kFx
-aax
+jya
 kFx
 jQf
 gKr
@@ -40705,8 +40740,8 @@ ycp
 wxC
 wxC
 wxC
-wxC
 ycp
+ruI
 bpx
 bpx
 xQi
@@ -40962,7 +40997,7 @@ gKr
 gQt
 iNP
 iNP
-jVV
+mst
 jVV
 aDt
 aJD
@@ -41124,7 +41159,7 @@ gnk
 kFx
 jQf
 kFx
-kFx
+gnk
 jQf
 gKr
 gKr
@@ -41330,7 +41365,7 @@ jVV
 jVV
 bpQ
 jVV
-jVV
+mst
 jVV
 bpJ
 dqK
@@ -41471,7 +41506,7 @@ gKr
 gKr
 kFx
 aax
-kFx
+gnk
 kFx
 kFx
 kFx
@@ -41680,7 +41715,7 @@ bab
 aJD
 aDt
 jVV
-jVV
+mst
 jVV
 jVV
 tZS
@@ -41997,7 +42032,7 @@ gKr
 gKr
 gKr
 gKr
-kFx
+gnk
 kFx
 kFx
 kFx
@@ -42011,7 +42046,7 @@ kFx
 kFx
 jQf
 kFx
-kFx
+gnk
 kFx
 gKr
 gKr
@@ -42548,7 +42583,7 @@ gKr
 aym
 agv
 agv
-agv
+dqS
 agv
 aym
 klL
@@ -42717,7 +42752,7 @@ gKr
 gKr
 gKr
 kFx
-kFx
+gnk
 gKr
 nwU
 gKr
@@ -42888,7 +42923,7 @@ kFx
 kFx
 kFx
 kFx
-kFx
+gnk
 gKr
 gKr
 gKr
@@ -43962,7 +43997,7 @@ agv
 dqS
 agv
 agv
-agv
+dqS
 agv
 agv
 dqS
@@ -45368,7 +45403,7 @@ kFx
 kFx
 jQf
 nwU
-aen
+gKr
 aen
 aen
 aen
@@ -45545,7 +45580,7 @@ gnk
 kFx
 jQf
 nwU
-aen
+gKr
 aen
 aen
 aen
@@ -45722,7 +45757,7 @@ kFx
 kFx
 jQf
 nwU
-aen
+gKr
 aen
 xFy
 aen
@@ -45899,7 +45934,7 @@ kFx
 kFx
 jQf
 nwU
-aen
+gKr
 aen
 aen
 pOk
@@ -46076,7 +46111,7 @@ kFx
 gnk
 jQf
 nwU
-aen
+gKr
 aen
 aen
 aen
@@ -46253,7 +46288,7 @@ kFx
 kFx
 jQf
 nwU
-aen
+gKr
 aen
 aen
 aen
@@ -46430,7 +46465,7 @@ kFx
 kFx
 jQf
 nwU
-aen
+gKr
 xFy
 aen
 aen
@@ -46607,7 +46642,7 @@ aax
 jQf
 jQf
 nwU
-aen
+gKr
 aen
 aen
 aen
@@ -46784,7 +46819,7 @@ kFx
 jQf
 gKr
 nwU
-aen
+gKr
 aen
 aen
 aen
@@ -46961,7 +46996,7 @@ kFx
 jQf
 gKr
 nwU
-aen
+gKr
 aen
 aen
 xFy
@@ -47138,7 +47173,7 @@ kFx
 jQf
 gKr
 nwU
-aen
+gKr
 aen
 aen
 aen
@@ -47564,8 +47599,8 @@ qZD
 qZD
 qZD
 rXm
-kDA
 aJp
+kDA
 reF
 kDA
 kDA
@@ -47691,7 +47726,7 @@ wZn
 wZn
 wZn
 ygV
-bbw
+ajG
 ajG
 ajG
 nMg
@@ -48376,7 +48411,7 @@ bzw
 jlH
 vWg
 gKr
-gKr
+aen
 xFy
 aen
 aen
@@ -48624,7 +48659,7 @@ xjn
 vcl
 vcl
 vUs
-wgH
+vUs
 wgH
 wgH
 vUs
@@ -48800,10 +48835,10 @@ cIl
 dDC
 aES
 aWT
-bEf
-aPE
+aWT
+vUs
 pdN
-vcl
+vMu
 mHk
 aES
 aES
@@ -48913,7 +48948,7 @@ aut
 aws
 awV
 axk
-ati
+aPE
 aqW
 azz
 aBm
@@ -48931,7 +48966,7 @@ ajR
 ajR
 ajR
 bbL
-bfw
+aRA
 akI
 nMg
 aKr
@@ -50844,7 +50879,7 @@ ahN
 alA
 amK
 aut
-aut
+nwb
 aen
 aen
 aen
@@ -51730,7 +51765,7 @@ wVH
 ati
 aoc
 amM
-aen
+xFy
 bDG
 aen
 pOk
@@ -52089,11 +52124,11 @@ asf
 asf
 asf
 amJ
-asf
+ajy
 amJ
 aoE
 asf
-asf
+ajy
 asf
 auu
 awu
@@ -52469,7 +52504,7 @@ dqS
 ajG
 ajG
 ajG
-ajG
+lwf
 nMg
 eAz
 obM
@@ -52622,7 +52657,7 @@ arG
 asf
 asf
 auj
-asf
+ajy
 asf
 kNP
 avT
@@ -52986,12 +53021,12 @@ asf
 asf
 aqU
 agv
-agv
+dqS
 ayy
 agv
 agv
 agv
-agv
+dqS
 agv
 agv
 qMX
@@ -53515,7 +53550,7 @@ asf
 gKr
 gKr
 asf
-asf
+ajy
 gKr
 gKr
 gKr
@@ -53525,7 +53560,7 @@ agv
 gKr
 gKr
 gKr
-agv
+dqS
 riM
 riM
 gKr
@@ -54233,7 +54268,7 @@ gKr
 riM
 agv
 agv
-qMX
+bcd
 riM
 gKr
 gKr
@@ -58819,7 +58854,7 @@ oRZ
 oRZ
 bYX
 slg
-bOl
+fnP
 aiO
 aiO
 bOl
@@ -59525,7 +59560,7 @@ aah
 wsX
 ojZ
 bsq
-bsq
+hlO
 bsq
 lnN
 slg
@@ -60941,15 +60976,15 @@ gKr
 tsW
 gcl
 knh
-bsq
+hlO
 sEE
 qfl
 sqN
-jQc
+bfw
 sqN
 oRZ
 vWj
-vcW
+dlN
 uIT
 tKb
 qfl

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -6254,10 +6254,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/lv624/lazarus/captain)
-"eRR" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/space/basic,
-/area/lv624/ground/caves/rock)
 "eSl" = (
 /obj/item/analyzer,
 /turf/open/floor/plating/ground/dirt,
@@ -33845,7 +33841,7 @@ xgZ
 gJI
 gaO
 xnA
-eRR
+jLv
 rhp
 jro
 bch

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -45,13 +45,6 @@
 	dir = 4
 	},
 /area/lv624/lazarus/spaceport)
-"abA" = (
-/obj/machinery/door/airlock/colony/engineering/smes{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
 "acj" = (
 /obj/structure/fence,
 /obj/effect/decal/riverdecal/edge{
@@ -67,6 +60,12 @@
 	},
 /turf/open/floor,
 /area/lv624/ground/sand9)
+"acL" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "adg" = (
 /obj/structure/jungle/vines/heavy,
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
@@ -307,10 +306,6 @@
 "akI" = (
 /turf/closed/wall,
 /area/lv624/ground/sand8)
-"akK" = (
-/obj/item/weapon/gun/smg/uzi,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
 "akW" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -483,10 +478,10 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand6)
 "aoH" = (
-/obj/item/ammo_casing,
-/obj/item/ammo_casing,
+/obj/structure/rack,
+/obj/effect/spawner/random/powercell,
 /turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "aoL" = (
 /obj/item/stack/sheet/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -553,11 +548,12 @@
 /turf/closed/shuttle/wall3,
 /area/lv624/lazarus/crashed_ship)
 "aqs" = (
-/obj/effect/decal/tracks/wheels/bloody{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
 	},
 /turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "aqx" = (
 /turf/closed/wall,
 /area/lv624/ground/sand2)
@@ -588,13 +584,11 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand6)
 "arI" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 1
-	},
+/obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/plating/warning{
-	dir = 1
+	dir = 4
 	},
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "arP" = (
 /obj/machinery/landinglight/ds1/delaythree{
 	dir = 1
@@ -648,9 +642,12 @@
 /turf/open/floor/plating,
 /area/lv624/ground/sand6)
 "atK" = (
-/obj/structure/jungle/vines/heavy,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle4)
+/obj/effect/decal/remains/xeno,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
+	},
+/area/lv624/ground/jungle3)
 "atL" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -945,11 +942,17 @@
 /turf/open/ground/coast,
 /area/lv624/ground/caves/central3)
 "axY" = (
-/obj/machinery/floodlight/colony{
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand5)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/engineering)
 "axZ" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor,
@@ -979,20 +982,17 @@
 /turf/open/floor,
 /area/lv624/ground/sand2)
 "ayl" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 4
-	},
-/turf/open/floor/plating/warning{
-	dir = 4
-	},
-/area/lv624/lazarus/tablefort)
+/obj/machinery/vending/coffee,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "aym" = (
 /turf/closed/wall/cult,
 /area/lv624/ground/caves/rock)
 "ayp" = (
-/obj/item/ammo_casing,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand2)
+/obj/effect/landmark/weed_node,
+/obj/item/trash/candy,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "ayu" = (
 /obj/structure/cargo_container/horizontal{
 	dir = 1
@@ -1142,13 +1142,18 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central5)
 "aBh" = (
-/obj/item/ammo_casing,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand8)
+/obj/structure/sign/electricshock,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/engineering)
 "aBi" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand2)
+/obj/machinery/power/geothermal,
+/obj/structure/lattice,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/engineering)
 "aBm" = (
 /obj/structure/cargo_container/green{
 	dir = 8
@@ -1185,35 +1190,28 @@
 /turf/open/floor,
 /area/lv624/ground/sand2)
 "aCv" = (
-/obj/machinery/floodlight,
-/obj/item/ammo_casing,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
 /turf/open/floor/plating/warning{
-	dir = 9
+	dir = 8
 	},
-/area/lv624/lazarus/tablefort)
-"aCy" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 1
-	},
-/obj/item/ammo_casing,
-/turf/open/floor/plating/warning{
-	dir = 1
-	},
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "aCA" = (
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand3)
 "aCD" = (
-/turf/open/floor/plating/warning{
-	dir = 1
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Engineering Dome"
 	},
-/area/lv624/lazarus/tablefort)
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "aCK" = (
-/obj/machinery/floodlight,
-/turf/open/floor/plating/warning{
-	dir = 5
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Engineering Dome"
 	},
-/area/lv624/lazarus/tablefort)
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "aCL" = (
 /turf/open/floor/marking/loadingarea{
 	dir = 1
@@ -1244,13 +1242,8 @@
 	},
 /area/lv624/ground/sand8)
 "aDJ" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 8
-	},
-/turf/open/floor/plating/warning{
-	dir = 8
-	},
-/area/lv624/lazarus/tablefort)
+/turf/closed/wall,
+/area/lv624/ground/sand7)
 "aDK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
@@ -1259,20 +1252,19 @@
 	},
 /area/lv624/lazarus/hydroponics)
 "aDM" = (
-/obj/item/ammo_magazine/smg/uzi/extended,
+/obj/structure/largecrate/random,
 /turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "aDP" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
 	dir = 4
 	},
 /area/lv624/ground/jungle7)
 "aDZ" = (
-/obj/item/ammo_casing,
-/obj/item/ammo_casing,
-/obj/item/ammo_casing,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "aEc" = (
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 4;
@@ -1280,9 +1272,9 @@
 	},
 /area/lv624/lazarus/sandtemple)
 "aEp" = (
-/obj/item/ammo_casing,
+/obj/item/clothing/head/hardhat/orange,
 /turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "aEz" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/ground/grass,
@@ -1294,14 +1286,10 @@
 	},
 /area/lv624/ground/jungle6)
 "aEP" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 2
-	},
-/obj/item/ammo_magazine/smg/uzi/extended,
-/turf/open/floor/plating/warning{
-	dir = 2
-	},
-/area/lv624/lazarus/tablefort)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand8)
 "aES" = (
 /turf/open/ground/grass,
 /area/lv624/ground/jungle9)
@@ -1314,13 +1302,12 @@
 /turf/open/ground/river,
 /area/lv624/ground/river2)
 "aEW" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 2
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 1
 	},
-/turf/open/floor/plating/warning{
-	dir = 2
-	},
-/area/lv624/lazarus/tablefort)
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/engineering)
 "aFf" = (
 /obj/machinery/vending/nanomed{
 	dir = 8
@@ -1342,10 +1329,6 @@
 	dir = 5
 	},
 /area/lv624/lazarus/spaceport2)
-"aFw" = (
-/obj/item/attachable/reddot,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
 "aFx" = (
 /turf/open/floor/marking/warning,
 /area/lv624/ground/sand2)
@@ -1375,18 +1358,14 @@
 /turf/open/floor/plating,
 /area/lv624/ground/sand8)
 "aGO" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 1
-	},
-/obj/item/healthanalyzer,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/obj/structure/largecrate/random,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "aGP" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor,
+/area/lv624/ground/compound/n)
 "aGV" = (
 /obj/structure/showcase{
 	desc = "An ancient, dusty tomb with strange alien writing. It's best not to touch it.";
@@ -1396,9 +1375,12 @@
 /turf/open/floor/tile/darkish,
 /area/lv624/lazarus/sandtemple)
 "aGW" = (
-/obj/item/flashlight/lantern,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Engineering Dome"
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "aGZ" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirt,
@@ -1466,15 +1448,9 @@
 "aIC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
-"aIO" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 8
-	},
-/obj/item/explosive/grenade/incendiary,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
 "aIQ" = (
 /obj/structure/girder,
 /turf/open/ground/river,
@@ -1484,11 +1460,13 @@
 /turf/open/floor/plating,
 /area/lv624/ground/filtration)
 "aJp" = (
-/obj/structure/table/reinforced/flipped{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/purple/whitepurplecorner{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/fitness)
 "aJs" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/jungle/vines/heavy,
@@ -1561,26 +1539,21 @@
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
 /area/lv624/ground/compound/c)
 "aKO" = (
-/turf/open/floor/plating/warning{
-	dir = 8
-	},
-/area/lv624/lazarus/tablefort)
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "aKZ" = (
 /obj/structure/catwalk,
 /turf/open/ground/river,
 /area/lv624/ground/sand8)
 "aLd" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 8
-	},
-/obj/item/explosive/grenade/m15,
-/obj/item/ammo_magazine/smg/m25,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/lv624/ground/river1)
 "aLn" = (
-/obj/item/attachable/quickfire,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/engineering)
 "aLp" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 2
@@ -1593,17 +1566,13 @@
 /obj/effect/ai_node,
 /turf/open/ground/grass/grass2,
 /area/lv624/ground/jungle6)
-"aLu" = (
-/obj/structure/table,
-/obj/item/storage/belt/marine,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
 "aLB" = (
-/obj/item/ammo_magazine/smg/m25,
-/obj/item/ammo_magazine/smg/m25,
-/obj/item/ammo_magazine/smg/m25,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	on = 1
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "aLD" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
@@ -1652,18 +1621,6 @@
 	dir = 4
 	},
 /area/lv624/lazarus/security)
-"aLQ" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 4
-	},
-/obj/item/ammo_magazine/smg/m25,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
-"aMn" = (
-/turf/open/floor/plating/warning{
-	dir = 4
-	},
-/area/lv624/lazarus/tablefort)
 "aMo" = (
 /obj/structure/fence,
 /turf/open/floor/plating/catwalk,
@@ -1696,7 +1653,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/lv624/lazarus/engineering)
+/area/lv624/lazarus/fitness)
 "aNg" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -1743,16 +1700,17 @@
 /turf/open/ground/river,
 /area/lv624/ground/river2)
 "aNE" = (
-/obj/machinery/floodlight,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
-"aNK" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
-/obj/item/weapon/gun/smg/m25,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"aNK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "aNM" = (
 /obj/item/weapon/baseballbat/metal,
 /obj/item/weapon/baseballbat/metal{
@@ -1763,23 +1721,13 @@
 	dir = 4
 	},
 /area/lv624/lazarus/fitness)
-"aNR" = (
-/obj/structure/table,
-/obj/item/storage/backpack/marine,
-/obj/item/explosive/grenade/incendiary,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
 "aOj" = (
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/river2)
 "aOm" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 4
-	},
-/obj/item/explosive/grenade/incendiary,
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/obj/item/weapon/gun/pistol/rt3,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "aOB" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
@@ -1810,11 +1758,9 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand2)
 "aPb" = (
-/obj/item/ammo_casing,
-/turf/open/floor/plating/warning{
-	dir = 8
-	},
-/area/lv624/lazarus/tablefort)
+/obj/structure/cable,
+/turf/open/floor/plating/warning,
+/area/lv624/lazarus/engineering)
 "aPe" = (
 /turf/closed/wall,
 /area/lv624/ground/river2)
@@ -1823,24 +1769,11 @@
 /turf/open/floor/freezer,
 /area/lv624/lazarus/kitchen)
 "aPE" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/o2{
-	pixel_x = 4;
-	pixel_y = 6
+/obj/structure/cable,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
 	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
-"aPG" = (
-/obj/item/ammo_casing,
-/turf/open/floor/plating/warning{
-	dir = 4
-	},
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/fitness)
 "aPI" = (
 /turf/open/ground/coast/corner2{
 	dir = 2
@@ -1899,15 +1832,17 @@
 	dir = 8
 	},
 /area/lv624/ground/compound/c)
-"aQN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+"aQr" = (
+/obj/machinery/floodlight/colony{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
-	},
-/area/lv624/ground/jungle3)
+/obj/structure/catwalk,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"aQs" = (
+/obj/machinery/floodlight/colony,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle10)
 "aQR" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/ammo/rifle,
@@ -1917,8 +1852,9 @@
 /turf/open/floor/plating/platebot,
 /area/lv624/lazarus/secure_storage)
 "aQV" = (
-/turf/open/ground/river,
-/area/lv624/ground/sand4)
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "aQY" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/plating/ground/dirt,
@@ -1997,10 +1933,9 @@
 /turf/open/floor/wood,
 /area/lv624/lazarus/corporate_affairs)
 "aSm" = (
-/turf/open/ground/coast/corner2{
-	dir = 2
-	},
-/area/lv624/ground/sand1)
+/obj/item/attachable/quickfire,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "aSq" = (
 /turf/open/floor/plating/warning{
 	dir = 10
@@ -2020,16 +1955,18 @@
 	},
 /area/lv624/lazarus/sleep_male)
 "aSC" = (
-/turf/open/ground/coast/corner{
-	dir = 1
-	},
-/area/lv624/ground/sand8)
+/obj/structure/rack,
+/obj/effect/spawner/random/tool,
+/turf/open/floor/plating/warning,
+/area/lv624/lazarus/engineering)
 "aSG" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 8
+/obj/machinery/light{
+	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/power/geothermal,
 /turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "aSP" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/green/whitegreencorner{
@@ -2041,12 +1978,14 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle6)
 "aSX" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 4
+/obj/machinery/power/geothermal,
+/obj/structure/lattice,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating/warning{
+	dir = 5
 	},
-/obj/item/attachable/suppressor,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "aTd" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/dirt,
@@ -2066,13 +2005,15 @@
 /turf/open/ground/river,
 /area/lv624/ground/river1)
 "aTU" = (
-/obj/effect/decal/tracks/wheels/bloody{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Engineering Dome"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plating/warning{
-	dir = 8
-	},
-/area/lv624/lazarus/tablefort)
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "aTX" = (
 /turf/open/floor/mech_bay_recharge_floor/asteroid,
 /area/lv624/ground/caves/central5)
@@ -2094,12 +2035,11 @@
 	},
 /area/lv624/ground/jungle7)
 "aUz" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 2
-	},
-/obj/item/ammo_casing,
+/obj/structure/cable,
+/obj/machinery/power/geothermal,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "aUE" = (
 /obj/effect/decal/warning_stripes/thick{
 	dir = 5
@@ -2107,12 +2047,13 @@
 /turf/open/floor,
 /area/lv624/lazarus/spaceport)
 "aUW" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 2
-	},
-/obj/item/explosive/grenade/incendiary,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "aVg" = (
 /turf/open/ground/coast{
 	dir = 9
@@ -2133,14 +2074,20 @@
 	},
 /area/lv624/ground/river2)
 "aVq" = (
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 8
+/obj/effect/ai_node,
+/turf/open/floor/plating/warning{
+	dir = 5
 	},
-/area/lv624/ground/river1)
+/area/lv624/ground/sand7)
 "aVH" = (
 /obj/structure/jungle/vines/heavy,
 /turf/open/ground/river,
 /area/lv624/ground/river3)
+"aVI" = (
+/obj/effect/decal/remains/xeno,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
 "aVL" = (
 /obj/structure/jungle/vines/heavy,
 /obj/structure/jungle/vines/heavy,
@@ -2163,10 +2110,9 @@
 /turf/open/ground/river,
 /area/lv624/ground/river2)
 "aWb" = (
-/turf/open/ground/coast{
-	dir = 4
-	},
-/area/lv624/ground/sand1)
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
 "aWd" = (
 /obj/structure/jungle/vines,
 /obj/structure/jungle/vines/heavy,
@@ -2193,11 +2139,13 @@
 	dir = 1
 	},
 /area/lv624/ground/river2)
+"aWy" = (
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
 "aWz" = (
-/turf/open/ground/coast/corner2{
-	dir = 2
-	},
-/area/lv624/ground/sand8)
+/turf/open/floor/plating/dmg3,
+/area/lv624/ground/river1)
 "aWF" = (
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 4
@@ -2220,14 +2168,9 @@
 	},
 /area/lv624/ground/jungle7)
 "aWT" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 4
-	},
-/obj/item/ammo_magazine/smg/uzi/extended,
-/turf/open/floor/plating/warning{
-	dir = 4
-	},
-/area/lv624/lazarus/tablefort)
+/obj/structure/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/lazarus/fitness)
 "aWU" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
@@ -2257,15 +2200,6 @@
 	dir = 8
 	},
 /area/lv624/ground/compound/c)
-"aXL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 4
-	},
-/area/lv624/ground/jungle3)
 "aXQ" = (
 /obj/machinery/landinglight/ds1{
 	dir = 4
@@ -2283,18 +2217,6 @@
 	dir = 4
 	},
 /area/lv624/ground/river2)
-"aYf" = (
-/obj/effect/landmark/corpsespawner/engineer{
-	corpseback = /obj/item/storage/backpack;
-	corpseidjob = "Engineer";
-	corpseshoes = /obj/item/clothing/shoes/black;
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Everett Mison"
-	},
-/turf/open/floor/plating/warning{
-	dir = 8
-	},
-/area/lv624/lazarus/engineering)
 "aYm" = (
 /obj/structure/jungle/vines,
 /obj/structure/jungle/vines/heavy,
@@ -2323,7 +2245,7 @@
 /area/lv624/ground/river2)
 "aYI" = (
 /turf/open/ground/grass/beach,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "aYJ" = (
 /obj/structure/inflatable/door,
 /turf/open/floor/tile/red/yellowfull,
@@ -2360,9 +2282,9 @@
 	},
 /area/lv624/ground/river2)
 "aZI" = (
-/obj/structure/jungle/vines/heavy,
-/turf/open/ground/grass,
-/area/lv624/lazarus/atmos/outside)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/lv624/ground/jungle4)
 "aZO" = (
 /obj/structure/girder,
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
@@ -2380,7 +2302,7 @@
 /turf/open/floor/tile/red/yellowfull,
 /area/lv624/ground/sand4)
 "bai" = (
-/turf/open/ground/coast/corner2{
+/turf/open/ground/coast{
 	dir = 8
 	},
 /area/lv624/ground/sand8)
@@ -2390,19 +2312,18 @@
 	},
 /area/shuttle/drop1/lz1)
 "bau" = (
-/turf/open/ground/coast/corner{
-	dir = 4
-	},
-/area/lv624/ground/sand8)
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/lv624/lazarus/fitness)
 "baw" = (
 /obj/structure/jungle/vines/heavy,
 /obj/structure/jungle/vines,
 /turf/closed/wall,
-/area/lv624/ground/compound)
+/area/lv624/ground/jungle9)
 "bax" = (
 /obj/structure/jungle/vines/heavy,
 /turf/closed/wall,
-/area/lv624/ground/compound)
+/area/lv624/ground/jungle9)
 "bba" = (
 /obj/structure/table,
 /turf/open/floor/tile/purple/whitepurple{
@@ -2410,11 +2331,12 @@
 	},
 /area/lv624/lazarus/research)
 "bbb" = (
-/obj/machinery/floodlight,
+/obj/machinery/power/geothermal,
+/obj/structure/cable,
 /turf/open/floor/plating/warning{
-	dir = 10
+	dir = 4
 	},
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "bbc" = (
 /turf/open/ground/coast/corner2{
 	dir = 8
@@ -2425,7 +2347,7 @@
 /turf/open/ground/grass/beach{
 	dir = 4
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "bbv" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -2433,11 +2355,9 @@
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/research)
 "bbw" = (
-/obj/machinery/floodlight,
-/turf/open/floor/plating/warning{
-	dir = 6
-	},
-/area/lv624/lazarus/tablefort)
+/obj/structure/jungle/planttop1,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand8)
 "bbL" = (
 /turf/open/ground/coast/corner2{
 	dir = 4
@@ -2459,10 +2379,9 @@
 	},
 /area/lv624/ground/river2)
 "bcd" = (
-/obj/structure/jungle/vines/heavy,
-/obj/structure/window_frame/colony,
-/turf/open/floor/plating,
-/area/lv624/ground/compound)
+/obj/item/weapon/claymore/mercsword/machete,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
 "bce" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = /obj/item/storage/backpack;
@@ -2508,7 +2427,7 @@
 "bcZ" = (
 /obj/structure/jungle/planttop1,
 /turf/closed/wall,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "bde" = (
 /obj/structure/flora/grass/green,
 /obj/structure/jungle/vines,
@@ -2526,17 +2445,18 @@
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle1)
 "bdv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 1
-	},
-/turf/open/floor/tile/purple/whitepurplecorner{
-	dir = 4
-	},
-/area/lv624/lazarus/fitness)
+/turf/open/floor/plating/warning,
+/area/lv624/lazarus/engineering)
 "bdC" = (
 /obj/item/tool/shovel,
 /turf/open/floor/tile/red/yellowfull,
 /area/lv624/ground/sand4)
+"bdH" = (
+/obj/machinery/floodlight,
+/obj/item/ammo_casing,
+/obj/effect/landmark/dropship_start_location,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "bdK" = (
 /obj/structure/cable,
 /turf/open/floor/tile/blue/whiteblue{
@@ -2590,7 +2510,7 @@
 /turf/open/ground/grass/beach{
 	dir = 8
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "beS" = (
 /obj/machinery/floodlight/colony,
 /obj/structure/catwalk,
@@ -2607,7 +2527,8 @@
 	},
 /area/lv624/ground/jungle7)
 "bfl" = (
-/obj/item/ammo_casing,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/sand8)
 "bfs" = (
@@ -2654,22 +2575,21 @@
 "bgs" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "bgt" = (
 /turf/open/ground/coast/corner{
 	dir = 1
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "bgu" = (
 /turf/open/ground/coast{
 	dir = 8
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "bgw" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/jungle/vines,
-/turf/open/ground/grass/grass2,
-/area/lv624/lazarus/atmos)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
 "bgE" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/floodlight/colony,
@@ -2792,7 +2712,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "biS" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/structure/sink,
@@ -2801,9 +2721,13 @@
 	},
 /area/lv624/lazarus/hydroponics)
 "biV" = (
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/river1)
+/obj/structure/table/reinforced/flipped{
+	dir = 1
+	},
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/ground/caves/rock)
 "bjb" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/machinery/door/poddoor/mainship{
@@ -2905,9 +2829,9 @@
 	},
 /area/lv624/ground/river3)
 "blH" = (
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/ground/river,
-/area/lv624/ground/sand1)
+/obj/item/ammo_casing,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
 "blJ" = (
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle7)
@@ -2930,6 +2854,7 @@
 /area/lv624/ground/sand8)
 "bmp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
 "bms" = (
@@ -3093,10 +3018,6 @@
 	},
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
-"bqj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor,
-/area/lv624/ground/sand8)
 "bqv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3218,14 +3139,9 @@
 /turf/open/floor/plating/catwalk,
 /area/lv624/ground/sand9)
 "brw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 8
-	},
-/area/lv624/ground/jungle3)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle4)
 "brx" = (
 /obj/structure/disposalpipe/segment/corner,
 /turf/open/floor/plating/catwalk,
@@ -3276,6 +3192,7 @@
 "bsp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/docking_port/stationary/crashmode,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/sand8)
 "bsq" = (
@@ -3297,11 +3214,6 @@
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle6)
-"btY" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/spawner/random/trash,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle3)
 "buJ" = (
 /obj/effect/decal/cleanable/blood/splatter/animated,
 /obj/structure/cable,
@@ -3324,7 +3236,7 @@
 	},
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "bvi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -3346,7 +3258,7 @@
 "bvY" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "bwz" = (
 /obj/structure/girder,
 /turf/open/floor/plating/ground/dirt,
@@ -3403,6 +3315,11 @@
 	dir = 5
 	},
 /area/lv624/lazarus/security)
+"byN" = (
+/obj/effect/decal/remains/human,
+/obj/item/ammo_casing,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "byO" = (
 /obj/structure/rack,
 /obj/item/storage/pouch/flare/full,
@@ -3434,7 +3351,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
+/area/lv624/lazarus/fitness)
 "bAa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -3462,12 +3379,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/catwalk,
 /area/lv624/ground/river2)
-"bBh" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/warning{
-	dir = 2
-	},
-/area/lv624/lazarus/engineering)
 "bBF" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -3483,16 +3394,21 @@
 	},
 /area/lv624/lazarus/security)
 "bCB" = (
-/turf/open/ground/coast,
-/area/lv624/ground/sand7)
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "bCC" = (
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "bDj" = (
-/obj/effect/ai_node,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "bDk" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/window/framed/colony,
@@ -3537,8 +3453,10 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central2)
 "bEf" = (
-/turf/closed/wall/r_wall,
-/area/lv624/ground/jungle9)
+/obj/structure/jungle/vines,
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating,
+/area/lv624/lazarus/fitness)
 "bEl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -3556,15 +3474,6 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
-"bFr" = (
-/obj/structure/jungle/planttop1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/jungle/vines/heavy,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle3)
 "bFC" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/ai_node,
@@ -3632,6 +3541,13 @@
 	},
 /turf/open/floor/wood,
 /area/lv624/lazarus/bar)
+"bJd" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 2
+	},
+/obj/item/ammo_casing,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "bKq" = (
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/plating/ground/dirt,
@@ -3679,8 +3595,15 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/freezer,
 /area/lv624/lazarus/kitchen)
+"bNp" = (
+/obj/structure/table,
+/obj/item/ammo_casing,
+/obj/item/attachable/suppressor,
+/obj/effect/spawner/random/gun/sidearms,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "bNu" = (
-/turf/open/ground/river,
+/turf/open/floor/plating,
 /area/lv624/ground/sand7)
 "bNN" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
@@ -3734,27 +3657,18 @@
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/research)
 "bPO" = (
-/obj/structure/table,
-/obj/item/ammo_casing,
-/obj/item/attachable/suppressor,
-/obj/effect/spawner/random/gun/sidearms,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "bQd" = (
 /turf/open/floor/tile/blue/whiteblue{
 	dir = 1
 	},
 /area/lv624/lazarus/corporate_affairs)
-"bQi" = (
-/obj/item/clothing/under/shorts/blue,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/tile/purple/whitepurplecorner{
-	dir = 4
-	},
-/area/lv624/lazarus/fitness)
 "bQu" = (
 /obj/structure/bed/stool,
 /turf/open/floor/tile/bar,
@@ -3787,14 +3701,6 @@
 	dir = 8
 	},
 /area/lv624/ground/compound/n)
-"bRZ" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle3)
 "bSe" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
@@ -3812,6 +3718,10 @@
 	dir = 4
 	},
 /area/lv624/lazarus/main_hall)
+"bSS" = (
+/obj/item/attachable/reddot,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "bTH" = (
 /obj/machinery/computer/nuke_disk_generator/blue,
 /turf/open/floor/plating/ground/dirt,
@@ -3847,13 +3757,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/ground/ruin)
-"bXv" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/purple/whitepurplecorner{
-	dir = 4
-	},
-/area/lv624/lazarus/fitness)
 "bXC" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -3949,10 +3852,6 @@
 /obj/item/trash/cigbutt,
 /turf/open/floor/wood,
 /area/lv624/lazarus/bar)
-"cda" = (
-/obj/structure/jungle/vines,
-/turf/open/ground/grass,
-/area/lv624/lazarus/hop)
 "cdn" = (
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
@@ -4029,6 +3928,13 @@
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/sleep_female)
+"ciD" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 1
+	},
+/obj/item/healthanalyzer,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "cjm" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
 	dir = 4
@@ -4048,13 +3954,6 @@
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/west1)
-"ckg" = (
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 8;
-	icon_state = "grassdirt_corner2"
-	},
-/area/lv624/ground/jungle3)
 "ckO" = (
 /obj/structure/jungle/vines,
 /obj/structure/flora/tree/jungle/small,
@@ -4070,17 +3969,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/quartstorage)
-"clk" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle3)
 "clB" = (
 /obj/item/bedsheet/rd,
 /obj/item/cane,
 /obj/structure/bed/fancy,
 /obj/effect/decal/cleanable/blood/splatter/animated,
 /turf/open/floor/grimy,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "cmh" = (
 /obj/structure/jungle/vines,
 /turf/closed/wall/r_wall,
@@ -4251,10 +4146,11 @@
 /obj/structure/jungle/plantbot1,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle10)
-"cuO" = (
-/obj/effect/decal/tracks/wheels/bloody,
+"cvf" = (
+/obj/effect/decal/remains/human,
+/obj/item/weapon/gun/smg/m25,
 /turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/ground/caves/rock)
 "cvU" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/dirt,
@@ -4332,11 +4228,6 @@
 "cAu" = (
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand7)
-"cAE" = (
-/obj/structure/jungle/vines/heavy,
-/obj/effect/ai_node,
-/turf/open/ground/grass/grass2,
-/area/lv624/lazarus/atmos)
 "cAM" = (
 /obj/structure/table,
 /obj/item/trash/cheesie,
@@ -4350,12 +4241,13 @@
 /turf/open/floor/tile/bar,
 /area/lv624/lazarus/canteen)
 "cBi" = (
-/turf/open/ground/coast/corner,
-/area/lv624/ground/sand7)
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "cBS" = (
 /obj/structure/catwalk,
 /turf/open/ground/grass/beach,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "cCc" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/gm/dense,
@@ -4390,6 +4282,10 @@
 /obj/effect/decal/warning_stripes/thick,
 /turf/open/floor,
 /area/lv624/lazarus/spaceport)
+"cEi" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "cEv" = (
 /obj/item/stack/sheet/wood,
 /obj/effect/ai_node,
@@ -4419,11 +4315,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/n)
-"cGb" = (
-/obj/effect/landmark/weed_node,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
 "cGS" = (
 /obj/structure/sink,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -4481,7 +4372,13 @@
 /turf/open/ground/coast{
 	dir = 4
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
+"cIE" = (
+/obj/effect/decal/tracks/wheels/bloody{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "cIW" = (
 /obj/structure/window_frame/colony/reinforced,
 /obj/item/shard,
@@ -4517,9 +4414,11 @@
 /turf/open/ground/river,
 /area/lv624/ground/jungle6)
 "cLI" = (
-/obj/effect/decal/cleanable/blood,
+/obj/structure/bed/stool,
+/obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "cLP" = (
 /turf/open/ground/coast/corner2{
 	dir = 8
@@ -4544,9 +4443,9 @@
 /turf/open/floor/tile/barber,
 /area/lv624/lazarus/main_hall)
 "cMv" = (
-/obj/effect/landmark/weed_node,
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/atmos/outside)
+/area/lv624/ground/jungle4)
 "cMD" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -4607,6 +4506,11 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
 /area/lv624/ground/river1)
+"cPY" = (
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/ground/caves/rock)
 "cQj" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/grass,
@@ -4742,10 +4646,13 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/east1)
 "cUP" = (
-/obj/effect/ai_node,
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
 "cUZ" = (
 /obj/structure/table/woodentable,
 /obj/item/megaphone,
@@ -4807,12 +4714,10 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
 "cYR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/ground/dirtgrassborder/corner2{
-	dir = 8
 	},
 /area/lv624/ground/jungle3)
 "cZk" = (
@@ -4864,7 +4769,7 @@
 	dir = 4
 	},
 /turf/open/floor/grimy,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "dcQ" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
@@ -4954,15 +4859,18 @@
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/atmos/outside)
+/area/lv624/ground/jungle9)
 "diA" = (
-/obj/structure/catwalk,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/river1)
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/cable,
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/engineering)
 "diR" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/jungle/vines,
-/turf/open/ground/grass,
+/turf/closed/gm/dense,
 /area/lv624/ground/jungle3)
 "djI" = (
 /obj/structure/disposalpipe/trunk{
@@ -4985,7 +4893,7 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/jungle/vines/heavy,
 /turf/open/ground/grass/grass2,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "dle" = (
 /obj/structure/jungle/vines,
 /turf/open/ground/grass/grass2,
@@ -4997,11 +4905,6 @@
 	dir = 8
 	},
 /area/lv624/lazarus/security)
-"dll" = (
-/turf/open/floor/plating/warning{
-	dir = 2
-	},
-/area/lv624/lazarus/engineering)
 "dlV" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -5015,7 +4918,7 @@
 /turf/open/ground/grass/beach{
 	dir = 1
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "dnP" = (
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 4
@@ -5100,11 +5003,6 @@
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle9)
-"drB" = (
-/obj/item/ammo_casing,
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
 "drU" = (
 /obj/structure/table/mainship,
 /obj/structure/window/reinforced{
@@ -5135,13 +5033,6 @@
 	dir = 2
 	},
 /area/lv624/lazarus/sleep_male)
-"dsM" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
 "dte" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -5181,6 +5072,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/lv624/ground/compound/n)
+"dvU" = (
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8;
+	icon_state = "grassdirt_corner"
+	},
+/area/lv624/ground/jungle4)
 "dwa" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/plating/ground/dirt,
@@ -5209,7 +5106,7 @@
 "dxb" = (
 /obj/structure/table/woodentable,
 /turf/open/floor/grimy,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "dxn" = (
 /obj/effect/ai_node,
 /turf/open/floor/marking/warning{
@@ -5328,16 +5225,14 @@
 /obj/effect/ai_node,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle3)
+"dGl" = (
+/obj/effect/spawner/random/gun/shotgun,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "dGQ" = (
 /obj/item/ammo_casing,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
-"dGU" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 8
-	},
-/area/lv624/ground/jungle3)
 "dHa" = (
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/landmark/lv624/fog_blocker,
@@ -5395,9 +5290,10 @@
 	},
 /area/lv624/ground/jungle6)
 "dKw" = (
-/obj/item/stack/sheet/metal,
-/obj/item/stack/sheet/metal,
-/turf/open/floor/plating,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	icon_state = "grassdirt_corner2"
+	},
 /area/lv624/ground/jungle3)
 "dKx" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
@@ -5492,7 +5388,7 @@
 /turf/open/ground/grass/beach{
 	dir = 1
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "dPb" = (
 /obj/structure/cargo_container/nt{
 	dir = 8
@@ -5503,7 +5399,7 @@
 /obj/structure/table/woodentable,
 /obj/item/taperecorder,
 /turf/open/floor/grimy,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "dPs" = (
 /obj/structure/cable,
 /turf/open/floor/tile/whiteyellow{
@@ -5517,18 +5413,14 @@
 /turf/open/floor/tile/neutral,
 /area/lv624/lazarus/spaceport)
 "dPS" = (
-/obj/structure/jungle/vines/heavy,
 /turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 4
+	dir = 4;
+	icon_state = "grassdirt_corner"
 	},
-/area/lv624/ground/jungle3)
+/area/lv624/lazarus/overgrown)
 "dQe" = (
 /turf/closed/wall,
 /area/lv624/ground/jungle9)
-"dQW" = (
-/obj/structure/foamedmetal,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/overgrown)
 "dQY" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -5921,6 +5813,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/jungle7)
 "eoN" = (
@@ -6014,6 +5907,15 @@
 	dir = 1
 	},
 /area/lv624/lazarus/spaceport)
+"evm" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 2
+	},
+/turf/open/floor,
+/area/lv624/ground/jungle6)
 "evp" = (
 /turf/closed/mineral/smooth/indestructible,
 /area/lv624/ground/caves/rock)
@@ -6076,11 +5978,9 @@
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
 "eyo" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/dirtgrassborder/corner2{
-	dir = 1
-	},
-/area/lv624/ground/river1)
+/obj/structure/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle4)
 "eyD" = (
 /obj/structure/disposalpipe/broken{
 	dir = 1
@@ -6088,9 +5988,8 @@
 /turf/open/ground/river,
 /area/lv624/ground/river2)
 "eyK" = (
-/obj/effect/spawner/random/drink_cans,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/ground/dirt,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/ground/grass,
 /area/lv624/ground/jungle3)
 "eyN" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -6106,10 +6005,11 @@
 /turf/open/floor,
 /area/lv624/ground/sand8)
 "ezy" = (
-/obj/structure/window_frame/colony,
-/obj/structure/jungle/vines/heavy,
-/turf/open/floor/plating,
-/area/lv624/ground/jungle4)
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4;
+	icon_state = "grassdirt_corner"
+	},
+/area/lv624/ground/jungle10)
 "ezO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
@@ -6125,6 +6025,12 @@
 	dir = 1
 	},
 /area/lv624/lazarus/overgrown)
+"eBw" = (
+/obj/machinery/floodlight,
+/turf/open/floor/plating/warning{
+	dir = 10
+	},
+/area/lv624/ground/caves/rock)
 "eBC" = (
 /obj/machinery/power/apc,
 /obj/structure/cable,
@@ -6184,11 +6090,14 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central1)
-"eGr" = (
-/obj/effect/decal/remains/human,
-/obj/item/ammo_casing,
+"eHL" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 8
+	},
+/obj/item/explosive/grenade/m15,
+/obj/item/ammo_magazine/smg/m25,
 /turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/ground/caves/rock)
 "eHW" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -6204,12 +6113,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/quartstorage)
-"eJu" = (
-/obj/effect/spawner/random/tool,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 4
-	},
-/area/lv624/ground/jungle3)
 "eJN" = (
 /obj/structure/table/woodentable,
 /obj/item/pinpointer,
@@ -6253,6 +6156,10 @@
 	dir = 5
 	},
 /area/lv624/lazarus/research)
+"eLz" = (
+/obj/item/weapon/gun/smg/uzi,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "eMv" = (
 /obj/item/stack/sheet/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -6274,7 +6181,7 @@
 /obj/structure/jungle/vines,
 /obj/effect/ai_node,
 /turf/open/floor/plating/platebotc,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "eOh" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -6291,14 +6198,14 @@
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 5
 	},
-/area/lv624/lazarus/engineering)
+/area/lv624/lazarus/fitness)
 "eOC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "eOR" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/structure/barricade/wooden,
@@ -6334,23 +6241,18 @@
 	pixel_y = 30
 	},
 /obj/item/trash/cheesie,
-/obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "eSl" = (
 /obj/item/analyzer,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand4)
 "eSt" = (
-/obj/structure/jungle/vines,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/turf/open/floor/plating/ground/dirtgrassborder/corner{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle3)
+/area/lv624/ground/jungle4)
 "eSB" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -6371,10 +6273,6 @@
 	},
 /turf/open/floor/grimy,
 /area/lv624/lazarus/captain)
-"eUz" = (
-/obj/structure/girder,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle3)
 "eUP" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/ground/coast/corner{
@@ -6382,8 +6280,8 @@
 	},
 /area/lv624/ground/jungle4)
 "eUU" = (
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder/corner2,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle4)
 "eUV" = (
 /obj/structure/bed/chair/wood/normal{
@@ -6395,18 +6293,21 @@
 /turf/closed/wall,
 /area/lv624/lazarus/hydroponics)
 "eVA" = (
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	dir = 1;
+	name = "\improper Leisure Dome"
+	},
 /obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
 	},
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/n)
+/area/lv624/lazarus/fitness)
 "eWg" = (
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 4
-	},
-/area/lv624/lazarus/atmos/outside)
+/obj/item/reagent_containers/food/snacks/worm,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/lv624/ground/jungle3)
 "eXy" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/dirt,
@@ -6452,7 +6353,7 @@
 /obj/structure/window_frame/colony,
 /obj/structure/jungle/vines,
 /turf/open/floor/plating,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "eYX" = (
 /turf/open/shuttle/dropship/fourteen,
 /area/lv624/lazarus/sandtemple)
@@ -6468,12 +6369,11 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle3)
 "faL" = (
-/obj/machinery/power/geothermal,
-/obj/structure/lattice,
 /obj/structure/cable,
-/turf/open/floor/plating/warning{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
+/turf/open/floor/plating,
 /area/lv624/lazarus/engineering)
 "fbf" = (
 /obj/effect/landmark/weed_node,
@@ -6490,7 +6390,7 @@
 /turf/open/ground/grass/beach{
 	dir = 4
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "fbO" = (
 /obj/item/toy/inflatable_duck,
 /obj/effect/landmark/start/job/survivor,
@@ -6616,11 +6516,6 @@
 	dir = 9
 	},
 /area/lv624/lazarus/hydroponics)
-"fiw" = (
-/obj/structure/foamedmetal,
-/obj/machinery/vending/coffee,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
 "fiA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
@@ -6648,10 +6543,6 @@
 /obj/structure/table,
 /turf/open/floor/tile/barber,
 /area/lv624/lazarus/kitchen)
-"fkB" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
 "fkN" = (
 /turf/open/floor/tile/white/warningstripe{
 	dir = 5
@@ -6669,6 +6560,10 @@
 "flD" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
 /area/lv624/ground/jungle4)
+"flG" = (
+/obj/effect/landmark/corpsespawner/colonist,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "flN" = (
 /obj/effect/ai_node,
 /turf/open/floor/marking/warning{
@@ -6688,7 +6583,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "fmL" = (
 /obj/structure/jungle/vines/heavy,
 /turf/open/ground/grass,
@@ -6730,8 +6625,13 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle3)
 "frw" = (
-/turf/open/ground/coast/corner,
-/area/lv624/ground/sand4)
+/obj/structure/table/reinforced/flipped{
+	dir = 8
+	},
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/ground/caves/rock)
 "frN" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
@@ -6743,12 +6643,11 @@
 	},
 /area/lv624/ground/jungle9)
 "fsD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Engineering Dome"
 	},
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark,
+/turf/open/floor/plating/platebotc,
 /area/lv624/lazarus/engineering)
 "fty" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
@@ -6796,8 +6695,10 @@
 	},
 /area/lv624/ground/river3)
 "fvs" = (
-/turf/open/ground/coast,
-/area/lv624/ground/sand4)
+/obj/item/ammo_casing,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "fwb" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -6830,6 +6731,12 @@
 /obj/structure/flora/tree/jungle/small,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle7)
+"fxa" = (
+/obj/item/ammo_casing,
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/ground/caves/rock)
 "fxm" = (
 /obj/structure/window_frame/colony,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -6937,10 +6844,9 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle2)
 "fCG" = (
-/turf/open/ground/coast/corner{
-	dir = 1
-	},
-/area/lv624/ground/sand7)
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle4)
 "fCK" = (
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 1
@@ -6956,16 +6862,6 @@
 	dir = 9
 	},
 /area/lv624/lazarus/sleep_female)
-"fCU" = (
-/obj/structure/foamedmetal,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
-"fDk" = (
-/obj/structure/window_frame/colony,
-/obj/item/shard,
-/turf/open/floor/plating,
-/area/lv624/ground/jungle4)
 "fDn" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
@@ -7044,15 +6940,17 @@
 /turf/open/floor/plating/asteroidfloor,
 /area/lv624/ground/jungle5)
 "fJQ" = (
-/obj/structure/jungle/vines/heavy,
-/turf/open/ground/grass/grass2,
-/area/lv624/ground/jungle6)
+/obj/machinery/floodlight,
+/turf/open/floor/plating/warning{
+	dir = 5
+	},
+/area/lv624/ground/caves/rock)
 "fKd" = (
-/obj/effect/decal/remains/human,
-/obj/item/ammo_casing,
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/obj/structure/jungle/vines{
+	pixel_y = 1
+	},
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
 "fKR" = (
 /obj/structure/cargo_container/nt{
 	dir = 1
@@ -7106,9 +7004,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/wood,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "fPn" = (
 /obj/structure/cargo_container{
 	dir = 1
@@ -7128,22 +7025,18 @@
 /turf/open/floor/tile/barber,
 /area/lv624/lazarus/kitchen)
 "fQf" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 2
-	},
-/obj/effect/decal/remains/human,
-/obj/item/ammo_casing,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/obj/effect/landmark/start/job/survivor,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "fQu" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle10)
 "fRf" = (
-/turf/open/ground/coast{
-	dir = 4
-	},
-/area/lv624/ground/sand4)
+/obj/structure/ore_box,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
 "fRO" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/ground/river,
@@ -7217,9 +7110,11 @@
 	},
 /area/lv624/lazarus/spaceport)
 "fWV" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/ground/river,
-/area/lv624/ground/jungle4)
+/obj/effect/decal/remains/human,
+/obj/item/ammo_casing,
+/obj/item/ammo_casing,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "fWZ" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/engine/cult{
@@ -7238,9 +7133,7 @@
 /area/lv624/lazarus/quartstorage/outdoors)
 "fXn" = (
 /obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 4
-	},
+/turf/closed/wall,
 /area/lv624/ground/jungle3)
 "fXp" = (
 /obj/structure/barricade/wooden{
@@ -7266,13 +7159,15 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle4)
 "fYW" = (
-/obj/structure/rack,
-/obj/item/shard,
-/obj/effect/ai_node,
-/turf/open/floor/tile/purple/whitepurplecorner{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
 	},
-/area/lv624/lazarus/fitness)
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/engineering)
 "fZv" = (
 /obj/structure/flora/grass/green,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -7707,7 +7602,7 @@
 "gwA" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/grimy,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "gwV" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -7716,12 +7611,10 @@
 /turf/open/floor,
 /area/lv624/ground/sand8)
 "gxf" = (
-/obj/effect/decal/cleanable/blood/splatter/animated,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/purple/whitepurplecorner{
-	dir = 4
-	},
-/area/lv624/lazarus/fitness)
+/obj/structure/catwalk,
+/obj/effect/ai_node,
+/turf/open/ground/river,
+/area/lv624/ground/river1)
 "gxL" = (
 /obj/structure/table,
 /obj/item/clothing/suit/apron,
@@ -7737,10 +7630,11 @@
 	},
 /area/lv624/ground/jungle3)
 "gAb" = (
-/obj/effect/decal/cleanable/blood,
-/obj/item/ammo_casing,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/obj/structure/extinguisher_cabinet{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "gAy" = (
 /obj/effect/landmark/patrol_point{
 	id = "SOM_13";
@@ -7850,10 +7744,10 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand5)
 "gJD" = (
-/turf/open/ground/coast/corner2{
-	dir = 2
+/turf/open/floor/plating/warning{
+	dir = 9
 	},
-/area/lv624/ground/sand4)
+/area/lv624/ground/sand7)
 "gJI" = (
 /obj/structure/jungle/vines,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
@@ -7914,9 +7808,13 @@
 /turf/open/floor/bcircuit/off,
 /area/lv624/lazarus/sandtemple)
 "gMJ" = (
-/obj/machinery/power/apc/drained,
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Engineering Dome"
+	},
 /obj/structure/cable,
-/turf/open/floor/tile/dark,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/lv624/lazarus/engineering)
 "gMO" = (
 /obj/structure/fence,
@@ -7982,6 +7880,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/lv624/ground/filtration)
+"gQl" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 2
+	},
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/warning{
+	dir = 2
+	},
+/area/lv624/ground/caves/rock)
 "gQt" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/effect/landmark/xeno_resin_wall,
@@ -8013,13 +7921,6 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle3)
-"gRw" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/plating/warning{
-	dir = 1
-	},
-/area/lv624/lazarus/engineering)
 "gRx" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
@@ -8038,9 +7939,10 @@
 	},
 /area/lv624/ground/river1)
 "gSs" = (
-/obj/structure/jungle/vines/heavy,
-/turf/closed/wall,
-/area/lv624/ground/jungle4)
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
 "gSY" = (
 /obj/structure/jungle/vines,
 /obj/machinery/door/airlock/sandstone{
@@ -8087,10 +7989,15 @@
 	dir = 4
 	},
 /area/lv624/lazarus/engineering)
+"gVt" = (
+/obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/smg/uzi,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "gVY" = (
 /obj/structure/ore_box,
 /turf/open/ground/river,
-/area/lv624/ground/sand4)
+/area/lv624/ground/river1)
 "gWm" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/closed/gm/dense,
@@ -8106,12 +8013,13 @@
 	},
 /area/lv624/lazarus/sandtemple)
 "gYm" = (
-/obj/item/ammo_casing,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
 	},
-/turf/open/floor,
-/area/lv624/ground/sand8)
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "gYH" = (
 /obj/structure/bed,
 /obj/machinery/light,
@@ -8131,6 +8039,12 @@
 	dir = 5
 	},
 /area/lv624/ground/river2)
+"gYV" = (
+/obj/effect/decal/tracks/wheels/bloody{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "gYX" = (
 /obj/structure/platform{
 	dir = 4
@@ -8178,7 +8092,7 @@
 /turf/open/ground/coast/corner{
 	dir = 8
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "hcU" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/marking/loadingarea{
@@ -8220,6 +8134,14 @@
 /obj/structure/fence,
 /turf/open/floor/plating/platebotc,
 /area/lv624/lazarus/quartstorage/outdoors)
+"hei" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 4
+	},
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/ground/caves/rock)
 "hel" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 2
@@ -8236,6 +8158,10 @@
 "hes" = (
 /turf/closed/wall,
 /area/lv624/lazarus/quartstorage)
+"heN" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4)
 "heP" = (
 /obj/structure/closet,
 /turf/open/floor/tile/purple/taupepurple{
@@ -8361,7 +8287,7 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "hlt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -8379,10 +8305,8 @@
 	},
 /area/lv624/ground/compound/c)
 "hlK" = (
-/obj/structure/window_frame/colony,
-/obj/item/shard,
-/turf/open/floor/plating,
-/area/lv624/ground/jungle3)
+/turf/open/space/basic,
+/area/lv624/lazarus/atmos)
 "hlO" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
@@ -8397,10 +8321,15 @@
 	},
 /area/lv624/ground/river1)
 "hma" = (
-/turf/open/ground/coast/corner2{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/area/lv624/ground/jungle6)
+/obj/machinery/power/apc/drained,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
 "hmn" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/plating/ground/dirtgrassborder,
@@ -8423,6 +8352,15 @@
 /obj/structure/largecrate/random,
 /turf/open/floor,
 /area/lv624/lazarus/spaceport)
+"hnK" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 4
+	},
+/obj/item/ammo_magazine/smg/uzi/extended,
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/ground/caves/rock)
 "hnV" = (
 /obj/structure/closet/lasertag/red,
 /turf/open/floor/tile/purple/whitepurplecorner{
@@ -8489,22 +8427,23 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/east1)
+"htS" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 2
+	},
+/obj/item/explosive/grenade/incendiary,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "hur" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/chapel{
 	dir = 8
 	},
 /area/lv624/lazarus/chapel)
-"hwj" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/plating/warning{
-	dir = 4
-	},
-/area/lv624/lazarus/engineering)
 "hwp" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/grass/grass2,
-/area/lv624/lazarus/atmos/outside)
+/area/lv624/ground/jungle9)
 "hwv" = (
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 6
@@ -8524,6 +8463,12 @@
 /obj/effect/decal/riverdecal,
 /turf/open/floor,
 /area/lv624/ground/sand8)
+"hyF" = (
+/obj/item/ammo_casing,
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/ground/caves/rock)
 "hyH" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -8592,15 +8537,14 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central4)
 "hFf" = (
-/obj/effect/spawner/random/technology_scanner,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle3)
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle4)
 "hFU" = (
 /obj/structure/catwalk,
 /turf/open/ground/coast{
 	dir = 1
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "hGr" = (
 /obj/item/ammo_casing,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
@@ -8621,7 +8565,7 @@
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "hHd" = (
 /obj/structure/rack,
 /obj/item/clothing/head/soft/grey,
@@ -8674,11 +8618,6 @@
 	dir = 2
 	},
 /area/lv624/lazarus/sleep_male)
-"hLs" = (
-/obj/structure/jungle/vines,
-/obj/structure/window/framed/colony,
-/turf/open/floor/plating,
-/area/lv624/ground/jungle9)
 "hLz" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 2
@@ -8691,14 +8630,6 @@
 	},
 /turf/open/floor/tile/bar,
 /area/lv624/lazarus/canteen)
-"hMy" = (
-/obj/machinery/door/airlock/mainship/engineering/free_access{
-	dir = 1;
-	name = "\improper Engineering Dome"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
 "hMI" = (
 /obj/machinery/light{
 	dir = 4
@@ -8722,15 +8653,10 @@
 /turf/open/floor/wood,
 /area/lv624/lazarus/bar)
 "hNQ" = (
-/obj/structure/jungle/vines/heavy,
-/turf/open/ground/coast{
-	dir = 1
+/turf/open/floor/plating/warning{
+	dir = 8
 	},
-/area/lv624/ground/jungle6)
-"hNZ" = (
-/obj/structure/girder,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle4)
+/area/lv624/ground/caves/rock)
 "hOp" = (
 /obj/structure/jungle/vines/heavy{
 	pixel_y = 26
@@ -8739,7 +8665,7 @@
 /area/lv624/ground/ruin)
 "hOy" = (
 /turf/open/ground/coast/corner2,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "hOG" = (
 /obj/item/contraband/poster,
 /obj/machinery/light/small{
@@ -8812,20 +8738,18 @@
 	},
 /area/lv624/ground/compound/se)
 "hRy" = (
-/turf/open/ground/coast/corner,
-/area/lv624/ground/sand1)
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "hRG" = (
 /obj/structure/table/woodentable,
 /obj/item/trash/chips,
 /obj/effect/ai_node,
 /turf/open/floor/wood,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "hRR" = (
-/obj/structure/jungle/vines/heavy,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
-	},
-/area/lv624/ground/jungle3)
+/obj/effect/spawner/random/trash,
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/lv624/lazarus/overgrown)
 "hSm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -8844,11 +8768,10 @@
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle6)
 "hTr" = (
-/obj/effect/decal/tracks/wheels/bloody{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "hUd" = (
 /obj/structure/bed,
 /obj/item/bedsheet/mime,
@@ -8868,12 +8791,6 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle7)
-"hUU" = (
-/obj/structure/jungle/vines/heavy,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 8
-	},
-/area/lv624/ground/jungle3)
 "hVc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/power/apc/drained{
@@ -8896,9 +8813,12 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/overgrown)
 "hVM" = (
-/obj/structure/jungle/vines,
-/turf/closed/wall,
-/area/lv624/ground/jungle2)
+/obj/machinery/power/smes/buildable/empty{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/engineering)
 "hVV" = (
 /turf/open/floor/marking/warning{
 	dir = 9
@@ -8921,7 +8841,7 @@
 /obj/structure/flora/grass/green,
 /obj/structure/jungle/vines/heavy,
 /turf/open/ground/grass/grass2,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "hXH" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirt,
@@ -8941,10 +8861,6 @@
 	},
 /turf/open/floor/tile/red/full,
 /area/lv624/lazarus/security)
-"hZF" = (
-/obj/effect/spawner/random/trash,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle3)
 "hZN" = (
 /obj/structure/flora/pottedplant,
 /obj/machinery/light/spot,
@@ -8975,15 +8891,9 @@
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
 "iaA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/obj/structure/cable,
-/turf/open/floor/tile/purple/whitepurplecorner{
-	dir = 4
-	},
-/area/lv624/lazarus/fitness)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle4)
 "iaQ" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/red/redtaupe{
@@ -9280,10 +9190,6 @@
 	},
 /turf/open/floor/tile/barber,
 /area/lv624/lazarus/kitchen)
-"ivu" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/river1)
 "ivB" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
@@ -9292,14 +9198,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/cult,
 /area/lv624/ground/caves/rock)
-"iwB" = (
-/obj/structure/jungle/vines,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle3)
 "iwC" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
@@ -9324,23 +9222,19 @@
 /obj/structure/sign/safety/hazard,
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/canteen)
-"ixP" = (
-/obj/effect/decal/cleanable/blood/splatter/animated,
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 5
-	},
-/area/lv624/lazarus/fitness)
-"ixU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+"ixN" = (
+/obj/structure/table,
+/obj/item/storage/belt/marine,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "iyl" = (
-/obj/machinery/power/apc,
-/obj/structure/cable,
 /turf/open/floor/wood,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
+"iyN" = (
+/turf/open/floor/plating/ground/dirtgrassborder{
+	icon_state = "grassdirt_corner2"
+	},
+/area/lv624/ground/jungle6)
 "iyS" = (
 /obj/structure/stairs/seamless{
 	dir = 1
@@ -9367,7 +9261,7 @@
 "izw" = (
 /obj/structure/catwalk,
 /turf/open/ground/coast,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "izA" = (
 /obj/structure/window_frame/wood,
 /turf/open/floor/wood/broken,
@@ -9384,7 +9278,7 @@
 /turf/open/ground/coast{
 	dir = 1
 	},
-/area/lv624/ground/jungle10)
+/area/lv624/ground/river1)
 "iAC" = (
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/canteen)
@@ -9457,11 +9351,11 @@
 /turf/open/ground/river,
 /area/lv624/lazarus/fitness)
 "iEH" = (
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/ground/coast{
-	dir = 1
-	},
-/area/lv624/ground/jungle6)
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor,
+/area/lv624/ground/sand8)
 "iEJ" = (
 /turf/open/floor/wood,
 /area/lv624/ground/jungle8)
@@ -9531,12 +9425,8 @@
 	},
 /area/lv624/lazarus/overgrown)
 "iJT" = (
-/obj/machinery/door/poddoor/mainship{
-	dir = 4;
-	id = "secure_blast";
-	name = "\improper Secure Armory Blast Door"
-	},
 /obj/structure/cable,
+/obj/machinery/door/airlock/mainship/security/glass/free_access,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/secure_storage)
 "iKa" = (
@@ -9547,16 +9437,16 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/jungle/vines/heavy,
 /turf/open/ground/grass/grass2,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "iKP" = (
 /obj/effect/spawner/random/toolbox,
 /obj/structure/rack,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/quart)
 "iLn" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3)
 "iLu" = (
 /obj/structure/girder/displaced,
 /turf/open/floor/plating,
@@ -9574,8 +9464,11 @@
 /turf/open/floor/tile/bar,
 /area/lv624/lazarus/canteen)
 "iMC" = (
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/obj/structure/table/reinforced,
+/obj/item/trash/pistachios,
+/obj/item/t_scanner,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "iMS" = (
 /obj/structure/table,
 /obj/item/tool/extinguisher,
@@ -9583,11 +9476,6 @@
 	dir = 5
 	},
 /area/lv624/lazarus/hydroponics)
-"iNk" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/ai_node,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle3)
 "iNo" = (
 /obj/item/weapon/claymore/mercsword/machete,
 /obj/effect/ai_node,
@@ -9627,9 +9515,13 @@
 /turf/open/floor/bcircuit/off,
 /area/lv624/lazarus/sandtemple)
 "iRH" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/bookcase,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "iRM" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -9696,13 +9588,11 @@
 /turf/open/ground/grass/beach{
 	dir = 4
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "iVz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
+/obj/item/ammo_magazine/pistol,
+/obj/machinery/light,
+/turf/open/floor/plating/warning,
 /area/lv624/lazarus/engineering)
 "iVB" = (
 /obj/effect/ai_node,
@@ -9808,7 +9698,7 @@
 /obj/structure/fence,
 /obj/structure/jungle/vines,
 /turf/open/ground/grass/grass2,
-/area/lv624/lazarus/atmos/outside)
+/area/lv624/ground/jungle9)
 "jaQ" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "\improper Nexus Dome"
@@ -9865,6 +9755,12 @@
 	icon_state = "grassdirt_corner2"
 	},
 /area/lv624/lazarus/sandtemple)
+"jeF" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "jeR" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/grass/grass2,
@@ -9886,11 +9782,11 @@
 	dir = 4
 	},
 /area/lv624/lazarus/main_hall)
-"jgF" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/spawner/random/trash,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle3)
+"jgG" = (
+/obj/effect/decal/cleanable/blood,
+/obj/item/ammo_casing,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "jgP" = (
 /obj/structure/fence,
 /obj/effect/decal/riverdecal/edge{
@@ -9981,9 +9877,9 @@
 	},
 /area/lv624/lazarus/sleep_female)
 "jnE" = (
-/obj/structure/girder,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand7)
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "jnG" = (
 /obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 8;
@@ -10001,7 +9897,7 @@
 /obj/item/storage/fancy/cigarettes/dromedaryco,
 /obj/item/clothing/glasses/sunglasses,
 /turf/open/floor/wood,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "joc" = (
 /turf/open/ground/coast{
 	dir = 4
@@ -10035,7 +9931,7 @@
 /obj/item/clothing/glasses/regular,
 /obj/effect/decal/cleanable/blood/splatter/animated,
 /turf/open/floor/grimy,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "jrj" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -10066,15 +9962,6 @@
 "jsE" = (
 /turf/closed/wall,
 /area/lv624/lazarus/main_hall)
-"jsN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/turf/open/floor/tile/purple/whitepurplecorner{
-	dir = 4
-	},
-/area/lv624/lazarus/fitness)
 "jtj" = (
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 8;
@@ -10198,14 +10085,15 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle6)
 "jxU" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
-"jya" = (
-/turf/open/floor/plating/ground/dirtgrassborder/corner2{
-	dir = 4
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
 	},
+/turf/open/floor,
+/area/lv624/ground/sand7)
+"jya" = (
+/obj/structure/jungle/planttop1,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle3)
 "jyt" = (
 /turf/open/floor/plating/ground/dirtgrassborder,
@@ -10235,7 +10123,7 @@
 /obj/structure/jungle/plantbot1,
 /obj/structure/jungle/vines,
 /turf/open/ground/grass/grass2,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "jAv" = (
 /obj/item/shard,
 /obj/structure/jungle/vines/heavy,
@@ -10251,9 +10139,9 @@
 	},
 /area/lv624/lazarus/quartstorage)
 "jAz" = (
-/obj/effect/landmark/weed_node,
 /obj/structure/cable,
-/turf/open/floor/tile/dark,
+/obj/structure/cable,
+/turf/open/floor/plating/warning,
 /area/lv624/lazarus/engineering)
 "jBk" = (
 /turf/open/ground/coast{
@@ -10277,9 +10165,9 @@
 	},
 /area/lv624/lazarus/sleep_male)
 "jCh" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/ground/river,
-/area/lv624/ground/sand1)
+/obj/machinery/floodlight,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "jCs" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/purple/whitepurple{
@@ -10419,7 +10307,7 @@
 "jJD" = (
 /obj/structure/catwalk,
 /turf/open/ground/coast/corner,
-/area/lv624/ground/river1)
+/area/lv624/ground/sand7)
 "jJI" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/blue/whiteblue{
@@ -10473,9 +10361,13 @@
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
 "jMQ" = (
-/obj/effect/landmark/excavation_site_spawner,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand2)
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Engineering Dome"
+	},
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "jNf" = (
 /obj/effect/decal/sandytile,
 /obj/effect/ai_node,
@@ -10512,11 +10404,8 @@
 	},
 /area/lv624/lazarus/bar)
 "jNQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/lv624/lazarus/engineering)
 "jOu" = (
 /obj/effect/landmark/start/job/survivor,
@@ -10557,14 +10446,11 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central3)
 "jQr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/turf/open/ground/coast{
+	dir = 1;
+	icon_state = "beachcorner"
 	},
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 5
-	},
-/area/lv624/lazarus/fitness)
+/area/lv624/ground/sand8)
 "jQy" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
 /area/lv624/ground/jungle3)
@@ -10577,7 +10463,7 @@
 /obj/item/trash/popcorn,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "jRy" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/plating/platebot,
@@ -10705,8 +10591,11 @@
 	},
 /area/lv624/lazarus/main_hall)
 "kag" = (
-/obj/effect/spawner/random/gun/sidearms,
-/turf/open/floor/tile/dark,
+/obj/machinery/door/airlock/colony/engineering/smes{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/lv624/lazarus/engineering)
 "kau" = (
 /turf/open/floor/plating/ground/dirtgrassborder,
@@ -10754,10 +10643,12 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle7)
 "kez" = (
-/obj/structure/jungle/vines/heavy,
-/obj/structure/sign/safety/hazard,
-/turf/closed/wall/r_wall,
-/area/lv624/lazarus/spaceport2)
+/obj/structure/jungle/vines,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/lv624/ground/jungle3)
 "keK" = (
 /turf/open/floor/grimy,
 /area/lv624/lazarus/bar)
@@ -10829,7 +10720,7 @@
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
 	dir = 1
 	},
-/area/lv624/lazarus/atmos/outside)
+/area/lv624/ground/jungle9)
 "khX" = (
 /turf/open/floor/marking/warning/corner{
 	dir = 4
@@ -10867,6 +10758,11 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle9)
+"kiZ" = (
+/obj/machinery/floodlight,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "kju" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/open/floor/tile/purple/whitepurplecorner{
@@ -11118,6 +11014,10 @@
 	},
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
+"kwk" = (
+/obj/item/tool/shovel,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
 "kwq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -11195,15 +11095,9 @@
 	},
 /area/lv624/ground/jungle7)
 "kCI" = (
-/obj/effect/ai_node,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/tile/purple/whitepurplecorner{
-	dir = 4
-	},
-/area/lv624/lazarus/fitness)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/dmg3,
+/area/lv624/ground/river1)
 "kDo" = (
 /turf/closed/wall/cult,
 /area/lv624/ground/caves/central3)
@@ -11217,12 +11111,14 @@
 /turf/open/ground/grass/beach/corner{
 	dir = 8
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "kDA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
 "kDJ" = (
 /obj/structure/jungle/vines,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -11230,11 +11126,14 @@
 	},
 /area/lv624/ground/jungle9)
 "kEa" = (
-/obj/effect/decal/remains/human,
-/obj/item/ammo_casing,
-/obj/item/ammo_casing,
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Engineering Dome"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "kEp" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirt,
@@ -11254,15 +11153,6 @@
 	},
 /turf/open/floor/tile/bar,
 /area/lv624/lazarus/canteen)
-"kFe" = (
-/obj/machinery/door/airlock/mainship/engineering/free_access{
-	dir = 1;
-	name = "\improper Engineering Dome"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
 "kFx" = (
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central3)
@@ -11432,15 +11322,17 @@
 	},
 /area/lv624/ground/jungle5)
 "kQA" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/atmos)
-"kQG" = (
-/obj/machinery/door/airlock/mainship/engineering/free_access{
-	name = "\improper Engineering Dome"
+/obj/structure/jungle/vines/heavy,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
+/area/lv624/ground/jungle3)
+"kQG" = (
+/obj/machinery/colony_floodlight_switch{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
 /area/lv624/lazarus/engineering)
 "kQY" = (
 /obj/effect/landmark/corpsespawner/prisoner,
@@ -11517,10 +11409,6 @@
 	dir = 4
 	},
 /area/lv624/lazarus/corporate_affairs)
-"kUr" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/river1)
 "kUt" = (
 /obj/structure/jungle/plantbot1,
 /turf/open/ground/grass,
@@ -11567,20 +11455,11 @@
 	dir = 5
 	},
 /area/lv624/lazarus/research)
-"kWv" = (
-/obj/structure/jungle/vines/heavy,
-/turf/open/floor/plating/ground/dirtgrassborder/corner,
-/area/lv624/ground/jungle4)
-"kWy" = (
-/obj/effect/decal/remains/human,
-/obj/structure/table/reinforced/flipped{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
 "kWA" = (
-/turf/open/floor/wood,
-/area/lv624/lazarus/hop)
+/obj/structure/rack,
+/obj/item/flashlight,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "kXF" = (
 /obj/item/trash/cheesie,
 /obj/structure/window/reinforced{
@@ -11691,10 +11570,11 @@
 	},
 /area/lv624/lazarus/security)
 "ldV" = (
-/obj/structure/window_frame/colony/reinforced,
-/obj/structure/foamedmetal,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/plating/dmg3,
+/area/lv624/ground/sand7)
 "lej" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
@@ -11834,6 +11714,21 @@
 	dir = 6
 	},
 /area/lv624/ground/jungle7)
+"llQ" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 2
+	},
+/obj/item/ammo_magazine/smg/uzi/extended,
+/turf/open/floor/plating/warning{
+	dir = 2
+	},
+/area/lv624/ground/caves/rock)
+"llU" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/plating/ground/dirtgrassborder/corner{
+	dir = 8
+	},
+/area/lv624/ground/jungle10)
 "llX" = (
 /turf/open/ground/coast{
 	dir = 1
@@ -11914,13 +11809,10 @@
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/ground/ruin)
 "lqJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/jungle/vines/heavy,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 8
+	dir = 1
 	},
 /area/lv624/ground/jungle3)
 "lrC" = (
@@ -12221,20 +12113,15 @@
 	},
 /area/lv624/ground/jungle8)
 "lJu" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 1;
-	name = "\improper Leisure Dome"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
+/turf/open/floor/plating,
 /area/lv624/lazarus/engineering)
 "lJS" = (
 /obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle4)
 "lKP" = (
@@ -12383,6 +12270,12 @@
 	dir = 2
 	},
 /area/lv624/ground/filtration)
+"lSc" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 1
+	},
+/area/lv624/ground/jungle6)
 "lSo" = (
 /obj/effect/spawner/modularmap/lv624/domes,
 /turf/open/space/basic,
@@ -12392,13 +12285,6 @@
 	dir = 4
 	},
 /area/lv624/lazarus/main_hall)
-"lSv" = (
-/obj/structure/foamedmetal,
-/obj/structure/extinguisher_cabinet{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
 "lSR" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/dirt,
@@ -12413,10 +12299,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/n)
-"lTj" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/atmos/outside)
 "lTr" = (
 /obj/structure/closet/coffin,
 /turf/open/floor/tile/chapel{
@@ -12424,8 +12306,6 @@
 	},
 /area/lv624/lazarus/chapel)
 "lTu" = (
-/obj/machinery/power/geothermal,
-/obj/structure/lattice,
 /obj/structure/cable,
 /turf/open/floor/plating/warning{
 	dir = 4
@@ -12442,12 +12322,13 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle10)
 "lUT" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
+/obj/structure/jungle/vines{
+	pixel_y = 1
 	},
-/obj/machinery/power/monitor,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/lv624/ground/jungle4)
 "lVb" = (
 /obj/effect/decal/cleanable/blood/splatter/animated,
 /obj/structure/table/reinforced/flipped{
@@ -12472,12 +12353,6 @@
 	dir = 4
 	},
 /area/lv624/lazarus/quartstorage/outdoors)
-"lWw" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
 "lXk" = (
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central4)
@@ -12541,10 +12416,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
-"mbg" = (
-/obj/structure/fence,
-/turf/open/floor/plating/ground/dirtgrassborder,
-/area/lv624/lazarus/atmos/outside)
 "mbh" = (
 /obj/structure/jungle/plantbot1,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -12570,6 +12441,15 @@
 	dir = 8
 	},
 /area/lv624/ground/jungle5)
+"mcn" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 1
+	},
+/obj/item/ammo_casing,
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/ground/caves/rock)
 "mcM" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirt,
@@ -12586,12 +12466,6 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/wood,
 /area/lv624/lazarus/bar)
-"mei" = (
-/obj/structure/fence,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
-	},
-/area/lv624/lazarus/atmos/outside)
 "mex" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -12644,6 +12518,16 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle6)
+"mhd" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor,
+/area/lv624/ground/jungle6)
 "mhi" = (
 /obj/structure/jungle/plantbot1/alien,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -12694,11 +12578,9 @@
 	},
 /area/lv624/lazarus/sleep_female)
 "mjW" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/white/warningstripe{
-	dir = 8
-	},
-/area/lv624/lazarus/fitness)
+/obj/machinery/power/port_gen/pacman/super,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "mjZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -12721,9 +12603,15 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/overgrown)
 "mkE" = (
-/obj/item/clothing/head/hardhat/orange,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
 "mkI" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -12792,10 +12680,17 @@
 /obj/structure/jungle/planttop1,
 /turf/open/ground/grass,
 /area/lv624/ground/compound/ne)
+"mnA" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
+	},
+/area/lv624/ground/jungle6)
 "mnT" = (
-/obj/structure/jungle/vines/heavy,
-/turf/closed/wall,
-/area/lv624/ground/jungle3)
+/turf/open/floor/marking/warning/corner{
+	dir = 4
+	},
+/area/lv624/lazarus/spaceport2)
 "moV" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -12823,7 +12718,7 @@
 	icon_state = "wooden_chair_wings"
 	},
 /turf/open/floor/wood,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "mqG" = (
 /obj/machinery/shower{
 	pixel_y = 16
@@ -12874,7 +12769,7 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
 	},
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "msZ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -12887,13 +12782,6 @@
 	dir = 1
 	},
 /area/lv624/lazarus/quartstorage/outdoors)
-"mts" = (
-/obj/effect/landmark/weed_node,
-/obj/structure/cable,
-/turf/open/floor/plating/warning{
-	dir = 2
-	},
-/area/lv624/lazarus/engineering)
 "mtB" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -12910,8 +12798,9 @@
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
 /area/lv624/ground/jungle8)
 "mvX" = (
-/turf/open/ground/river,
-/area/lv624/ground/sand1)
+/obj/item/ammo_magazine/smg/uzi/extended,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "mwl" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -13012,13 +12901,6 @@
 	dir = 1
 	},
 /area/lv624/lazarus/security)
-"mEe" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/barber,
-/area/lv624/lazarus/fitness)
 "mEg" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
@@ -13066,11 +12948,9 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/quartstorage)
 "mHk" = (
-/obj/effect/decal/tracks/wheels/bloody{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/obj/structure/jungle/vines,
+/turf/closed/wall,
+/area/lv624/lazarus/fitness)
 "mHW" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
@@ -13078,10 +12958,8 @@
 	},
 /area/lv624/ground/jungle7)
 "mIe" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 4
-	},
+/obj/structure/jungle/vines,
+/turf/closed/gm/dense,
 /area/lv624/ground/jungle3)
 "mIg" = (
 /obj/structure/rack,
@@ -13133,10 +13011,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
 /area/lv624/ground/jungle6)
-"mKo" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/ground/grass,
-/area/lv624/ground/caves/rock)
 "mKv" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/cable,
@@ -13234,9 +13108,9 @@
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/lazarus/overgrown)
 "mPA" = (
-/turf/open/floor/plating/ground/dirtgrassborder/corner2{
-	dir = 8
-	},
+/obj/structure/jungle/vines,
+/obj/structure/jungle/vines,
+/turf/open/ground/grass,
 /area/lv624/ground/jungle3)
 "mPT" = (
 /obj/structure/cable,
@@ -13270,11 +13144,12 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle3)
 "mQZ" = (
-/obj/structure/jungle/vines,
-/turf/open/ground/coast{
+/obj/effect/ai_node,
+/obj/effect/decal/tracks/wheels/bloody{
 	dir = 1
 	},
-/area/lv624/ground/jungle6)
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "mRv" = (
 /obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 4;
@@ -13288,15 +13163,6 @@
 	dir = 8
 	},
 /area/lv624/ground/jungle7)
-"mSF" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/warning{
-	dir = 4
-	},
-/area/lv624/lazarus/tablefort)
 "mSN" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -13319,16 +13185,9 @@
 /turf/open/floor,
 /area/lv624/ground/river2)
 "mUe" = (
-/obj/structure/sign/electricshock{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/warning{
-	dir = 1
-	},
+/obj/effect/spawner/random/powercell,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
 /area/lv624/lazarus/engineering)
 "mUi" = (
 /obj/structure/window/framed/colony/reinforced,
@@ -13343,10 +13202,6 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle7)
-"mVF" = (
-/obj/item/stack/sheet/metal,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle3)
 "mWo" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 2
@@ -13389,11 +13244,12 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/c)
 "mXs" = (
-/obj/structure/jungle/vines,
-/turf/open/ground/coast/corner{
-	dir = 4
+/obj/effect/decal/remains/human,
+/obj/structure/table/reinforced/flipped{
+	dir = 1
 	},
-/area/lv624/ground/jungle6)
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "mXE" = (
 /obj/structure/jungle/vines,
 /obj/structure/jungle/vines/heavy,
@@ -13425,19 +13281,22 @@
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "mZo" = (
-/obj/machinery/light,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/turf/open/floor/plating,
+/area/lv624/ground/sand7)
+"mZB" = (
+/obj/structure/table,
+/obj/item/storage/backpack/marine,
+/obj/item/explosive/grenade/incendiary,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "mZT" = (
 /obj/structure/jungle/vines,
 /turf/closed/wall/r_wall,
@@ -13484,14 +13343,10 @@
 /turf/open/floor/cult/clock,
 /area/lv624/lazarus/bar)
 "nck" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 8
-	},
-/obj/effect/decal/remains/human,
-/turf/open/floor/plating/warning{
-	dir = 8
-	},
-/area/lv624/lazarus/tablefort)
+/obj/machinery/light,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "nct" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -13499,13 +13354,9 @@
 	},
 /area/lv624/ground/jungle8)
 "ncx" = (
-/obj/structure/flora/ausbushes,
-/turf/open/ground/river,
-/area/lv624/ground/jungle4)
-"ncE" = (
-/obj/structure/jungle/plantbot1,
-/turf/open/ground/grass/grass2,
-/area/lv624/ground/jungle3)
+/obj/structure/jungle/planttop1,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle10)
 "ncI" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -13555,7 +13406,7 @@
 /turf/open/ground/grass/beach{
 	dir = 1
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "nfa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -13570,11 +13421,6 @@
 	dir = 1
 	},
 /area/lv624/lazarus/spaceport2)
-"nfJ" = (
-/obj/effect/decal/cleanable/blood,
-/obj/item/weapon/gun/smg/uzi,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
 "ngJ" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -13628,9 +13474,9 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle9)
 "nlg" = (
-/obj/structure/flora/ausbushes/genericbush,
-/turf/open/ground/river,
-/area/lv624/ground/jungle4)
+/obj/item/ammo_casing,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "nlZ" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 2
@@ -13754,9 +13600,15 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/lv624/ground/sand5)
+"nwe" = (
+/obj/effect/decal/tracks/wheels/bloody{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "nww" = (
 /turf/open/ground/grass/beach/corner,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "nwx" = (
 /obj/structure/cargo_container/green{
 	dir = 4
@@ -13764,20 +13616,25 @@
 /turf/open/floor,
 /area/lv624/lazarus/spaceport)
 "nwS" = (
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/atmos)
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/lv624/ground/jungle4)
 "nwU" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/smooth,
 /area/lv624/ground/caves/rock)
 "nxk" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand2)
+/obj/structure/largecrate/random/barrel/yellow,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "nxu" = (
-/turf/open/ground/grass/grass2,
-/area/lv624/lazarus/atmos)
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8;
+	icon_state = "grassdirt_corner"
+	},
+/area/lv624/ground/jungle3)
 "nxQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/broken_bottle,
@@ -13800,11 +13657,6 @@
 "nzi" = (
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle7)
-"nzy" = (
-/turf/open/floor/plating/ground/dirtgrassborder{
-	icon_state = "grassdirt_corner2"
-	},
-/area/lv624/ground/jungle3)
 "nzN" = (
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 1
@@ -13859,19 +13711,9 @@
 	dir = 4
 	},
 /area/lv624/lazarus/corporate_affairs)
-"nCQ" = (
-/obj/effect/spawner/random/powercell,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
 "nCU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/purple/whitepurplecorner{
-	dir = 4
-	},
-/area/lv624/lazarus/fitness)
+/turf/open/space/basic,
+/area/lv624/lazarus/hop)
 "nDq" = (
 /obj/structure/table,
 /obj/item/tool/surgery/scalpel{
@@ -14045,9 +13887,9 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand7)
 "nOk" = (
-/obj/structure/jungle/vines,
+/obj/structure/noticeboard,
 /turf/closed/wall/r_wall,
-/area/lv624/ground/compound/n)
+/area/lv624/lazarus/engineering)
 "nOt" = (
 /obj/structure/table/reinforced/flipped{
 	dir = 8
@@ -14109,12 +13951,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/quartstorage/outdoors)
-"nSN" = (
-/obj/effect/decal/remains/xeno,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
-	},
-/area/lv624/ground/jungle3)
 "nSW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -14157,9 +13993,6 @@
 /obj/effect/decal/riverdecal,
 /turf/open/ground/river,
 /area/lv624/ground/river1)
-"nVr" = (
-/turf/closed/wall/r_wall,
-/area/lv624/lazarus/hop)
 "nVx" = (
 /obj/structure/jungle/vines,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -14167,8 +14000,7 @@
 	},
 /area/lv624/lazarus/sandtemple)
 "nVy" = (
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder/corner,
+/turf/closed/gm/dense,
 /area/lv624/ground/jungle3)
 "nWg" = (
 /obj/item/stack/sheet/metal{
@@ -14247,9 +14079,8 @@
 /area/lv624/ground/jungle3)
 "obn" = (
 /obj/structure/jungle/vines/heavy,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 1
-	},
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle3)
 "obI" = (
 /obj/effect/landmark/weed_node,
@@ -14314,13 +14145,23 @@
 /turf/open/ground/grass/grass2,
 /area/lv624/ground/jungle9)
 "odC" = (
-/obj/structure/jungle/vines,
-/obj/structure/sign/safety/hazard,
-/turf/closed/wall/r_wall,
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1
+	},
+/turf/open/floor/marking/warning{
+	dir = 10
+	},
 /area/lv624/lazarus/spaceport2)
 "odE" = (
 /turf/open/floor/plating,
 /area/lv624/ground/river1)
+"odG" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 4
+	},
+/obj/item/attachable/suppressor,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "odQ" = (
 /obj/effect/ai_node,
 /obj/effect/landmark/xeno_resin_door,
@@ -14338,9 +14179,8 @@
 /turf/open/floor/plating,
 /area/lv624/ground/river2)
 "ofY" = (
-/obj/machinery/power/apc/drained,
-/obj/structure/cable,
-/obj/effect/ai_node,
+/obj/structure/rack,
+/obj/item/shard,
 /turf/open/floor/tile/purple/whitepurplecorner{
 	dir = 4
 	},
@@ -14380,11 +14220,6 @@
 /obj/structure/largecrate/supply/supplies/tables_racks,
 /turf/open/floor/plating,
 /area/lv624/lazarus/quartstorage)
-"oji" = (
-/obj/structure/window_frame/colony/reinforced,
-/obj/item/shard,
-/turf/open/floor/plating,
-/area/lv624/lazarus/hop)
 "ojJ" = (
 /obj/structure/jungle/vines,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -14395,7 +14230,7 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
-/area/lv624/lazarus/atmos/outside)
+/area/lv624/ground/jungle9)
 "ojZ" = (
 /obj/structure/table/mainship,
 /obj/structure/window/reinforced{
@@ -14407,9 +14242,9 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
 "okL" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/closed/wall/r_wall,
-/area/lv624/lazarus/spaceport)
+/obj/effect/spawner/modularmap/lv624/domes,
+/turf/open/space/basic,
+/area/lv624/lazarus/hop)
 "okZ" = (
 /obj/machinery/light{
 	dir = 8
@@ -14419,14 +14254,10 @@
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
 "olA" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 8
-	},
-/obj/item/ammo_casing,
-/obj/item/ammo_magazine/smg/m25,
-/obj/effect/spawner/random/ammo/sidearm,
+/obj/structure/cable,
+/obj/machinery/power/geothermal,
 /turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "olR" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
 	dir = 4
@@ -14447,25 +14278,9 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle9)
-"onf" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/jungle/vines/heavy,
-/obj/effect/ai_node,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle3)
 "oot" = (
 /obj/structure/bed/stool,
 /turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
-"ooQ" = (
-/obj/effect/landmark/corpsespawner/engineer{
-	corpseback = /obj/item/storage/backpack;
-	corpseidjob = "Engineer";
-	corpseshoes = /obj/item/clothing/shoes/black;
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Wes Uvin"
-	},
-/turf/open/floor/plating,
 /area/lv624/lazarus/engineering)
 "oqd" = (
 /obj/effect/landmark/weed_node,
@@ -14581,7 +14396,7 @@
 "owB" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/grimy,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "owU" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirt,
@@ -14589,7 +14404,7 @@
 "oxg" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/ground/grass,
-/area/lv624/lazarus/spaceport)
+/area/lv624/ground/jungle1)
 "oxp" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/wood{
@@ -14665,7 +14480,7 @@
 	},
 /obj/effect/decal/cleanable/blood/splatter/animated,
 /turf/open/floor/grimy,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "oAv" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/machinery/door/poddoor/mainship{
@@ -14697,7 +14512,7 @@
 "oDM" = (
 /obj/machinery/light/small,
 /turf/open/floor/wood,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "oDN" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner2,
 /area/lv624/ground/jungle9)
@@ -14708,7 +14523,7 @@
 "oEc" = (
 /obj/structure/jungle/vines/heavy,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/river1)
+/area/lv624/ground/sand7)
 "oEf" = (
 /obj/structure/fence,
 /obj/effect/decal/riverdecal/edge{
@@ -14861,11 +14676,6 @@
 /obj/structure/girder,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle5)
-"oLw" = (
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 8
-	},
-/area/lv624/lazarus/atmos/outside)
 "oMa" = (
 /obj/structure/table/gamblingtable,
 /turf/open/floor/wood,
@@ -14914,7 +14724,7 @@
 "oPy" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/grimy,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "oQi" = (
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/compound/se)
@@ -14922,6 +14732,14 @@
 /obj/effect/ai_node,
 /turf/open/floor,
 /area/lv624/ground/sand8)
+"oRC" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 4
+	},
+/obj/item/explosive/grenade/incendiary,
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "oRG" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
 	dir = 4
@@ -15035,7 +14853,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "oXS" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -15050,6 +14868,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
 "oYf" = (
@@ -15069,14 +14888,14 @@
 /turf/open/floor,
 /area/lv624/ground/sand5)
 "oZt" = (
-/obj/item/stack/sheet/metal,
-/obj/item/tool/lighter/random,
-/turf/open/floor/plating/ground/dirtgrassborder/corner,
-/area/lv624/ground/jungle3)
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle4)
 "oZL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
 "oZY" = (
@@ -15091,9 +14910,8 @@
 /area/lv624/lazarus/chapel)
 "pae" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
-	},
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle3)
 "pal" = (
 /obj/effect/decal/remains/human,
@@ -15159,7 +14977,7 @@
 /turf/open/ground/grass/beach/corner{
 	dir = 1
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "pfG" = (
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/compound/n)
@@ -15219,19 +15037,19 @@
 /turf/open/floor,
 /area/lv624/ground/river2)
 "piE" = (
-/obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
-	},
 /obj/structure/cable,
-/turf/open/floor/plating/platebot,
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
 /area/lv624/lazarus/engineering)
 "pjS" = (
-/obj/effect/decal/tracks/wheels/bloody{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand2)
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "pmg" = (
 /obj/structure/sign/botany,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -15248,7 +15066,7 @@
 /turf/open/ground/coast{
 	dir = 1
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "pmZ" = (
 /obj/structure/window/framed/colony,
 /obj/structure/disposalpipe/segment{
@@ -15260,11 +15078,9 @@
 /area/lv624/ground/filtration)
 "pnb" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/ground/grass,
-/area/lv624/ground/jungle3)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
 "pnk" = (
 /obj/structure/platform{
 	dir = 4
@@ -15289,15 +15105,11 @@
 	},
 /area/lv624/ground/jungle6)
 "poE" = (
-/obj/machinery/door/poddoor/mainship{
-	dir = 4;
-	id = "secure_blast";
-	name = "\improper Secure Armory Blast Door"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/door/airlock/mainship/security/glass/free_access,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/secure_storage)
 "ppi" = (
@@ -15340,6 +15152,11 @@
 /obj/structure/window_frame/colony/reinforced,
 /turf/open/floor/plating,
 /area/lv624/lazarus/quartstorage)
+"psK" = (
+/obj/item/ammo_casing,
+/obj/effect/spawner/random/gun/sidearms,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "psO" = (
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 8
@@ -15384,9 +15201,9 @@
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
 /area/lv624/ground/jungle7)
 "pwD" = (
-/obj/structure/jungle/vines/heavy,
-/turf/closed/wall,
-/area/lv624/ground/jungle2)
+/obj/effect/landmark/corpsespawner/colonist,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "pxj" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/marking/warning/corner{
@@ -15394,10 +15211,11 @@
 	},
 /area/lv624/lazarus/spaceport)
 "pxs" = (
-/turf/open/ground/coast/corner2{
-	dir = 2
-	},
-/area/lv624/ground/sand7)
+/obj/item/ammo_casing,
+/obj/item/ammo_casing,
+/obj/item/ammo_casing,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "pxI" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
@@ -15412,18 +15230,17 @@
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
 "pyF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
 /obj/structure/cable,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/n)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "pyH" = (
-/obj/structure/jungle/vines/heavy,
+/obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
+	dir = 8;
+	icon_state = "grassdirt_corner2"
 	},
-/area/lv624/ground/jungle4)
+/area/lv624/ground/jungle3)
 "pzx" = (
 /obj/structure/jungle/vines/heavy,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -15466,7 +15283,7 @@
 "pDe" = (
 /obj/structure/catwalk,
 /turf/open/ground/river,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "pDg" = (
 /obj/structure/jungle/vines/heavy,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -15696,13 +15513,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/research)
-"pQs" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
 "pQz" = (
 /turf/open/floor/marking/warning{
 	dir = 6
@@ -15713,6 +15523,12 @@
 /obj/item/weapon/twohanded/spear,
 /turf/open/floor/tile/darkish,
 /area/lv624/lazarus/sandtemple)
+"pRC" = (
+/obj/item/ammo_casing,
+/obj/item/ammo_casing,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "pRL" = (
 /obj/machinery/landinglight/ds1{
 	dir = 4
@@ -15743,11 +15559,11 @@
 	dir = 8
 	},
 /turf/open/floor/grimy,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "pSl" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/ground/river,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "pSp" = (
 /turf/open/floor/plating/icefloor/warnplate,
 /area/shuttle/drop1/lz1)
@@ -15764,10 +15580,13 @@
 /turf/open/floor,
 /area/lv624/lazarus/spaceport2)
 "pSQ" = (
-/obj/effect/decal/remains/xeno,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand5)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/largecrate/random,
+/obj/structure/sign/electricshock,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "pTe" = (
 /turf/open/floor/marking/warning/corner{
 	dir = 1
@@ -15801,15 +15620,18 @@
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/main_hall)
 "pUq" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/obj/structure/cable,
+/obj/effect/landmark/corpsespawner/scientist,
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/engineering)
 "pUC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/grimy,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "pVg" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -15825,10 +15647,11 @@
 /turf/open/floor,
 /area/lv624/ground/caves/central1)
 "pVN" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand7)
+/obj/machinery/floodlight,
+/turf/open/floor/plating/warning{
+	dir = 6
+	},
+/area/lv624/ground/caves/rock)
 "pWs" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -15872,10 +15695,6 @@
 	},
 /turf/open/floor/wood,
 /area/lv624/lazarus/corporate_affairs)
-"pXN" = (
-/obj/item/stack/sheet/metal,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle3)
 "pXS" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -15908,10 +15727,11 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/quart)
 "pZJ" = (
-/turf/open/ground/coast{
+/obj/structure/bed/chair/office/light{
 	dir = 1
 	},
-/area/lv624/ground/jungle10)
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "pZM" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -15930,11 +15750,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand1)
-"qbC" = (
-/obj/item/ammo_casing,
-/obj/effect/spawner/random/gun/sidearms,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
 "qbE" = (
 /obj/structure/window/reinforced/tinted,
 /obj/machinery/door/window,
@@ -15965,7 +15780,7 @@
 	},
 /obj/structure/jungle/vines/heavy,
 /turf/open/ground/grass/grass2,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "qfl" = (
 /turf/closed/wall/r_wall/chigusa,
 /area/lv624/lazarus/sandtemple)
@@ -15989,7 +15804,7 @@
 /area/lv624/lazarus/research)
 "qhD" = (
 /obj/effect/ai_node,
-/turf/open/ground/grass/grass2,
+/turf/open/floor/plating/ground/dirtgrassborder/corner,
 /area/lv624/lazarus/overgrown)
 "qhK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -16007,13 +15822,6 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
 /area/lv624/lazarus/chapel)
-"qjc" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/ai_node,
-/turf/open/floor/engine/cult{
-	dir = 2
-	},
-/area/lv624/ground/caves/central5)
 "qkL" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/tile/whiteyellow/full,
@@ -16058,6 +15866,10 @@
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle7)
+"qof" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/lv624/ground/sand7)
 "qoW" = (
 /obj/structure/cargo_container{
 	dir = 8
@@ -16106,17 +15918,11 @@
 	},
 /area/lv624/lazarus/sleep_female)
 "qqT" = (
-/obj/structure/jungle/planttop1,
-/turf/open/ground/grass/grass2,
-/area/lv624/ground/jungle3)
-"qrh" = (
-/obj/machinery/door/airlock/mainship/engineering/free_access{
-	dir = 1;
-	name = "\improper Engineering Dome"
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/area/lv624/ground/caves/rock)
 "qrv" = (
 /obj/structure/barricade/metal{
 	dir = 1
@@ -16160,12 +15966,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/research)
-"qum" = (
-/obj/structure/foamedmetal,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
 "quz" = (
 /obj/structure/table/reinforced/flipped{
 	dir = 2
@@ -16239,11 +16039,9 @@
 /turf/open/ground/river,
 /area/lv624/ground/jungle1)
 "qyg" = (
-/obj/structure/cable,
-/obj/effect/spawner/random/ammo/sidearm,
-/turf/open/floor/plating/warning{
-	dir = 2
-	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/ears/earmuffs,
+/turf/open/floor/plating,
 /area/lv624/lazarus/engineering)
 "qyu" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
@@ -16296,6 +16094,15 @@
 /obj/structure/bed,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/secure_storage)
+"qzi" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 8
+	},
+/obj/item/ammo_casing,
+/obj/item/ammo_magazine/smg/m25,
+/obj/effect/spawner/random/ammo/sidearm,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "qzQ" = (
 /obj/structure/jungle/vines,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -16406,7 +16213,7 @@
 /obj/structure/jungle/planttop1,
 /obj/structure/jungle/vines/heavy,
 /turf/open/ground/grass/grass2,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "qGL" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -16418,10 +16225,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle3)
-"qHA" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/atmos)
 "qHC" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -16456,6 +16259,16 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle9)
+"qIR" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/floodlight/colony{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/lv624/ground/jungle6)
 "qJo" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/drinks/drinkingglass{
@@ -16498,7 +16311,7 @@
 "qMM" = (
 /obj/effect/ai_node,
 /turf/open/ground/grass/grass2,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "qMX" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
@@ -16556,24 +16369,24 @@
 	},
 /area/lv624/ground/jungle1)
 "qPw" = (
-/obj/effect/decal/remains/human,
-/obj/item/weapon/gun/smg/m25,
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "qPW" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/ground/river,
 /area/lv624/ground/river1)
 "qPY" = (
-/obj/structure/foamedmetal,
-/obj/machinery/door/airlock/mainship/engineering/free_access{
-	dir = 1;
-	name = "\improper Engineering Dome"
-	},
-/obj/structure/jungle/vines/heavy,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plating/platebotc,
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/sensor_tower,
+/turf/open/floor/tile/dark,
 /area/lv624/lazarus/engineering)
 "qQz" = (
 /obj/structure/jungle/vines,
@@ -16591,9 +16404,11 @@
 	},
 /area/lv624/ground/jungle6)
 "qRV" = (
-/obj/effect/spawner/random/melee,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle3)
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8;
+	icon_state = "grassdirt_corner"
+	},
+/area/lv624/ground/jungle10)
 "qSs" = (
 /obj/effect/landmark/fob_sentry_rebel,
 /turf/open/floor/tile/dark,
@@ -16603,9 +16418,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 8
-	},
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle3)
 "qSG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -16622,10 +16435,10 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle3)
 "qTM" = (
-/obj/effect/landmark/weed_node,
+/obj/structure/cable,
 /obj/effect/ai_node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand8)
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "qUB" = (
 /obj/structure/fence,
 /obj/effect/decal/riverdecal/edge{
@@ -16634,8 +16447,8 @@
 /turf/open/floor/plating,
 /area/lv624/ground/sand8)
 "qUJ" = (
-/obj/structure/window_frame/colony,
-/turf/open/floor/plating/ground/dirtgrassborder,
+/obj/structure/jungle/plantbot1,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle3)
 "qUL" = (
 /obj/structure/table/reinforced,
@@ -16681,6 +16494,12 @@
 /obj/structure/jungle/vines,
 /turf/open/floor/bcircuit/off,
 /area/lv624/lazarus/sandtemple)
+"qWj" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "qWt" = (
 /obj/structure/jungle/vines,
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
@@ -16756,7 +16575,7 @@
 /turf/open/floor/plating/warning{
 	dir = 5
 	},
-/area/lv624/ground/river1)
+/area/lv624/ground/sand7)
 "qYB" = (
 /obj/effect/decal/sandytile,
 /turf/open/floor/tile/whiteyellow/full,
@@ -16774,17 +16593,15 @@
 	},
 /area/lv624/ground/jungle6)
 "qZD" = (
-/turf/closed/wall,
-/area/lv624/lazarus/engineering)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/fitness)
 "qZG" = (
 /obj/item/clothing/glasses/regular,
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/lv624/lazarus/corporate_affairs)
-"raB" = (
-/obj/item/stack/sheet/metal,
-/turf/open/floor/plating,
-/area/lv624/ground/jungle4)
 "raM" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/marking/loadingarea{
@@ -16839,31 +16656,21 @@
 /area/lv624/lazarus/spaceport)
 "rdX" = (
 /turf/open/ground/coast,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "reF" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 1
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/ai_node,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
 	},
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/area/lv624/lazarus/fitness)
 "reH" = (
 /obj/item/tool/shovel,
 /turf/open/floor/tile/green/greentaupe{
 	dir = 1
 	},
 /area/lv624/lazarus/hydroponics)
-"reX" = (
-/obj/structure/jungle/vines,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
-	},
-/area/lv624/ground/jungle3)
 "rfa" = (
 /obj/structure/largecrate/cow,
 /turf/open/floor/tile/green/greentaupe{
@@ -17034,6 +16841,7 @@
 	dir = 1
 	},
 /obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/sand8)
 "roq" = (
@@ -17064,17 +16872,10 @@
 /obj/structure/jungle/vines,
 /turf/open/floor/plating,
 /area/lv624/ground/river1)
-"rqn" = (
-/obj/effect/decal/remains/xeno,
-/obj/effect/ai_node,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle3)
 "rqK" = (
-/obj/structure/sign/safety/hazard,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
-	},
-/area/lv624/lazarus/spaceport2)
+/obj/effect/spawner/modularmap/lv624/domes,
+/turf/open/space/basic,
+/area/lv624/lazarus/atmos)
 "rqN" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
@@ -17159,15 +16960,25 @@
 /turf/open/ground/grass,
 /area/lv624/lazarus/overgrown)
 "rvn" = (
-/turf/closed/wall,
-/area/lv624/lazarus/atmos)
+/turf/open/floor/plating/ground/dirtgrassborder{
+	icon_state = "grassdirt_corner"
+	},
+/area/lv624/ground/jungle6)
 "rvs" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand2)
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/engineering)
 "rwU" = (
-/obj/structure/girder,
-/turf/open/ground/grass,
+/obj/structure/jungle/vines,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle3)
 "rxh" = (
 /obj/structure/jungle/vines/heavy,
@@ -17180,6 +16991,11 @@
 	dir = 9
 	},
 /area/lv624/lazarus/spaceport)
+"rxF" = (
+/obj/item/ammo_casing,
+/obj/item/ammo_casing,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "rxM" = (
 /obj/item/stack/sheet/wood,
 /obj/structure/cable,
@@ -17199,11 +17015,11 @@
 /turf/open/floor/tile/bar,
 /area/lv624/lazarus/canteen)
 "rzf" = (
-/obj/item/ammo_casing,
-/obj/item/ammo_casing,
-/obj/effect/ai_node,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/obj/effect/spawner/random/tool,
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/engineering)
 "rzg" = (
 /obj/structure/girder,
 /turf/open/floor/plating/ground/dirt,
@@ -17247,7 +17063,7 @@
 /turf/open/ground/coast/corner2{
 	dir = 8
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "rBS" = (
 /obj/effect/decal/cleanable/blood/splatter/animated,
 /obj/effect/ai_node,
@@ -17389,13 +17205,14 @@
 	},
 /area/lv624/lazarus/hydroponics)
 "rHw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/effect/ai_node,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
+/area/lv624/ground/sand7)
 "rHK" = (
 /obj/structure/table,
 /obj/item/analyzer/plant_analyzer{
@@ -17436,22 +17253,24 @@
 	dir = 8
 	},
 /area/lv624/ground/jungle7)
+"rIN" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 8
+	},
+/obj/item/explosive/grenade/incendiary,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "rJe" = (
 /obj/item/tool/crowbar,
 /turf/open/floor,
 /area/lv624/lazarus/spaceport2)
 "rKh" = (
-/obj/structure/window/framed/colony/reinforced,
-/obj/machinery/door/poddoor/mainship{
-	density = 0;
-	dir = 2;
-	icon_state = "pdoor0";
-	id = "nexus_blast";
-	name = "\improper Nexus Blast Door";
-	opacity = 0
+/obj/structure/closet/radiation,
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/plating,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/engineering)
 "rKm" = (
 /obj/effect/decal/warning_stripes/thick{
 	dir = 8
@@ -17462,9 +17281,12 @@
 /turf/open/ground/coast/corner,
 /area/lv624/ground/jungle6)
 "rKU" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/barber,
-/area/lv624/lazarus/fitness)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plating/warning,
+/area/lv624/lazarus/engineering)
 "rLd" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/ground/coast/corner2{
@@ -17524,6 +17346,14 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle8)
+"rPZ" = (
+/obj/effect/decal/tracks/wheels/bloody{
+	dir = 4
+	},
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/ground/caves/rock)
 "rQD" = (
 /obj/structure/flora/grass/brown,
 /turf/open/ground/grass,
@@ -17534,7 +17364,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "rQR" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/computer/intel_computer,
@@ -17562,10 +17392,6 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
-"rSR" = (
-/obj/structure/jungle/vines,
-/turf/open/ground/grass,
-/area/lv624/lazarus/atmos/outside)
 "rSY" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/green/greentaupe{
@@ -17623,7 +17449,11 @@
 "rVo" = (
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
+"rWi" = (
+/obj/effect/decal/tracks/wheels/bloody,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "rWv" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
 	dir = 8
@@ -17634,11 +17464,13 @@
 /turf/open/ground/grass/grass2,
 /area/lv624/ground/jungle5)
 "rXm" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/effect/ai_node,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
 	},
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/area/lv624/lazarus/fitness)
 "rXz" = (
 /obj/structure/jungle/vines/heavy,
 /turf/open/floor/plating/ground/dirt,
@@ -17757,6 +17589,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/lv624/lazarus/captain)
+"sbj" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
 "scP" = (
 /obj/structure/rack,
 /obj/item/storage/box/MRE,
@@ -17804,12 +17640,6 @@
 	dir = 8
 	},
 /area/lv624/ground/jungle6)
-"sfH" = (
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
-	},
-/area/lv624/ground/jungle4)
 "sfI" = (
 /obj/structure/jungle/vines/heavy,
 /turf/open/ground/coast/corner2{
@@ -17919,15 +17749,6 @@
 /obj/structure/stairs/cornerdark/seamless,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/sandtemple)
-"spG" = (
-/obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/plating/warning{
-	dir = 2
-	},
-/area/lv624/lazarus/engineering)
 "spO" = (
 /turf/open/floor/grimy,
 /area/lv624/lazarus/captain)
@@ -17980,7 +17801,7 @@
 /obj/structure/foamedmetal,
 /obj/structure/jungle/vines/heavy,
 /turf/open/ground/grass/grass2,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "ssg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash,
@@ -18003,7 +17824,7 @@
 "ssW" = (
 /obj/structure/fence,
 /turf/open/ground/grass,
-/area/lv624/lazarus/atmos/outside)
+/area/lv624/ground/jungle2)
 "sud" = (
 /obj/effect/decal/tracks/human1/wet{
 	dir = 8
@@ -18022,13 +17843,19 @@
 "svN" = (
 /turf/closed/wall,
 /area/lv624/lazarus/research)
+"swH" = (
+/obj/item/flashlight/lantern,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "swL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
 "sxg" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -18061,6 +17888,13 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/drop2/lz2)
+"syU" = (
+/obj/machinery/floodlight,
+/obj/item/ammo_casing,
+/turf/open/floor/plating/warning{
+	dir = 9
+	},
+/area/lv624/ground/caves/rock)
 "syY" = (
 /obj/item/tool/mop,
 /obj/structure/rack,
@@ -18097,9 +17931,9 @@
 /turf/open/floor/wood,
 /area/lv624/lazarus/corporate_affairs)
 "sCh" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand2)
+/obj/machinery/vending/snack,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "sCN" = (
 /obj/structure/jungle/vines/heavy,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -18114,10 +17948,6 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/wood,
 /area/lv624/ground/jungle8)
-"sDK" = (
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/river1)
 "sEE" = (
 /obj/structure/table/mainship,
 /turf/open/floor/plating/ground/dirt,
@@ -18142,7 +17972,7 @@
 /turf/open/ground/coast/corner2{
 	dir = 4
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "sGu" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -18197,7 +18027,7 @@
 "sIA" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "sIO" = (
 /obj/structure/jungle/vines,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -18275,10 +18105,6 @@
 	},
 /turf/open/floor/wood,
 /area/lv624/lazarus/corporate_affairs)
-"sOO" = (
-/obj/structure/jungle/vines,
-/turf/open/ground/grass/grass2,
-/area/lv624/lazarus/atmos)
 "sPF" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/jungle/vines,
@@ -18401,6 +18227,10 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/west1)
+"sYh" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/lv624/ground/jungle6)
 "sYy" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
@@ -18415,7 +18245,7 @@
 /obj/structure/jungle/vines,
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "sZl" = (
 /obj/structure/showcase,
 /obj/structure/window/reinforced{
@@ -18426,7 +18256,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "sZq" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/ground/river,
@@ -18468,9 +18298,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/grass,
 /area/lv624/lazarus/main_hall)
-"tbP" = (
-/turf/closed/wall,
-/area/lv624/ground/jungle2)
 "tca" = (
 /obj/structure/jungle/vines,
 /turf/open/ground/river,
@@ -18501,7 +18328,7 @@
 /turf/open/ground/grass/beach{
 	dir = 8
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "tdK" = (
 /obj/structure/closet,
 /obj/item/clothing/shoes/mime,
@@ -18538,18 +18365,18 @@
 /turf/open/floor/marking/bot,
 /area/lv624/lazarus/quartstorage)
 "tfy" = (
-/obj/structure/foamedmetal,
 /turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 4
+	dir = 4;
+	icon_state = "grassdirt_corner"
 	},
-/area/lv624/lazarus/overgrown)
+/area/lv624/ground/jungle3)
 "tfB" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/ground/grass,
 /area/lv624/lazarus/overgrown)
 "tga" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/ground/coast/corner,
+/obj/structure/catwalk,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand7)
 "tgh" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -18569,15 +18396,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/gm/dense,
 /area/lv624/ground/caves/rock)
-"the" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/purple/whitepurplecorner{
-	dir = 4
-	},
-/area/lv624/lazarus/fitness)
 "thg" = (
 /obj/structure/jungle/vines,
 /turf/open/ground/grass/grass2,
@@ -18619,11 +18437,11 @@
 	},
 /area/lv624/lazarus/sleep_male)
 "tjl" = (
-/obj/machinery/floodlight,
-/obj/item/ammo_casing,
-/obj/effect/landmark/dropship_start_location,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "tjL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/ai_node,
@@ -18654,9 +18472,9 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
 "tlk" = (
-/obj/effect/decal/cleanable/blood/splatter/animated,
-/turf/closed/gm/dense,
-/area/lv624/ground/caves/rock)
+/obj/structure/jungle/vines,
+/turf/closed/wall,
+/area/lv624/ground/compound/sw)
 "tlr" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4
@@ -18673,14 +18491,15 @@
 	},
 /area/lv624/lazarus/engineering)
 "tmt" = (
-/obj/effect/landmark/corpsespawner/colonist,
+/obj/structure/cable,
+/obj/structure/bookcase,
+/obj/item/book/manual/engineering_singularity_safety,
 /turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "tmG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 4
-	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle3)
 "tnH" = (
 /obj/structure/stairs/seamless,
@@ -18712,6 +18531,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle3)
+"tpN" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 2
+	},
+/obj/effect/decal/remains/human,
+/obj/item/ammo_casing,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "tpS" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/engine/cult{
@@ -18725,7 +18552,7 @@
 "tqo" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "tqI" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/freezer,
@@ -18776,9 +18603,11 @@
 	},
 /area/lv624/ground/jungle6)
 "ttW" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/obj/structure/jungle/vines{
+	pixel_y = 1
+	},
+/turf/open/ground/grass,
+/area/lv624/ground/jungle10)
 "tue" = (
 /obj/structure/barricade/wooden{
 	dir = 1
@@ -18855,10 +18684,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/broken,
 /area/lv624/lazarus/bar)
-"txm" = (
-/obj/structure/foamedmetal,
-/turf/open/ground/grass/grass2,
-/area/lv624/lazarus/atmos)
 "txt" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor,
@@ -18873,6 +18698,12 @@
 	dir = 4
 	},
 /area/lv624/ground/jungle5)
+"txW" = (
+/obj/machinery/floodlight/colony{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
 "tyv" = (
 /obj/structure/showcase/six,
 /turf/open/floor/tile/darkish,
@@ -18943,14 +18774,9 @@
 /turf/closed/gm/dense,
 /area/lv624/lazarus/spaceport2)
 "tBS" = (
-/obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
-	},
-/obj/effect/ai_node,
-/obj/structure/cable,
-/turf/open/floor/plating/platebot,
-/area/lv624/lazarus/engineering)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/fitness)
 "tCc" = (
 /obj/structure/jungle/vines/heavy,
 /turf/open/ground/grass,
@@ -19058,16 +18884,21 @@
 /area/lv624/lazarus/overgrown)
 "tIT" = (
 /obj/machinery/light,
-/obj/structure/foamedmetal,
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 4
 	},
 /area/lv624/lazarus/overgrown)
 "tIW" = (
-/obj/structure/window_frame/colony,
-/obj/item/shard,
-/turf/open/floor/plating,
-/area/lv624/ground/jungle2)
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Engineering Dome"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plating/warning,
+/area/lv624/lazarus/engineering)
 "tIX" = (
 /turf/open/floor/marking/warning{
 	dir = 4
@@ -19189,15 +19020,14 @@
 	},
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/sandtemple)
+"tRq" = (
+/obj/item/trash/chips,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "tRD" = (
-/obj/structure/hoop{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/open/floor/tile/white/warningstripe{
-	dir = 2
-	},
-/area/lv624/lazarus/fitness)
+/obj/item/weapon/claymore/mercsword/machete,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle4)
 "tRK" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/ground/coast/corner2{
@@ -19255,6 +19085,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/marking/bot,
 /area/lv624/lazarus/quartstorage)
+"tUj" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4)
 "tUl" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4
@@ -19331,10 +19166,9 @@
 	},
 /area/lv624/ground/sand8)
 "tYC" = (
-/obj/effect/decal/remains/xeno,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand2)
+/obj/effect/spawner/random/tool,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "tYV" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 2
@@ -19343,17 +19177,17 @@
 /turf/open/floor,
 /area/lv624/ground/sand8)
 "tZa" = (
-/obj/structure/flora/ausbushes/fernybush,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle10)
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8;
+	icon_state = "grassdirt_corner2"
+	},
+/area/lv624/ground/jungle6)
 "tZm" = (
 /obj/structure/jungle/vines,
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/sleep_male)
-"tZo" = (
-/obj/structure/window/framed/colony,
-/turf/open/floor/plating,
-/area/lv624/ground/jungle2)
 "tZr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
@@ -19367,10 +19201,8 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/sw)
 "uaf" = (
-/obj/structure/jungle/vines/heavy,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle3)
 "ual" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -19397,7 +19229,7 @@
 "ucr" = (
 /obj/structure/bed/chair/office/light,
 /turf/open/floor/grimy,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "ucR" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced{
@@ -19573,10 +19405,7 @@
 	},
 /area/lv624/lazarus/corporate_affairs)
 "ukZ" = (
-/obj/machinery/power/monitor{
-	name = "Main Power Grid Monitoring"
-	},
-/obj/structure/cable,
+/obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/engineering)
 "ulD" = (
@@ -19593,12 +19422,11 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
 	},
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "ulX" = (
-/obj/structure/window_frame/colony,
-/obj/structure/jungle/vines/heavy,
-/turf/open/floor/plating,
-/area/lv624/ground/jungle3)
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
 "unr" = (
 /obj/item/clothing/mask/facehugger/dead,
 /turf/open/floor/tile/purple/whitepurple{
@@ -19653,15 +19481,6 @@
 /obj/structure/jungle/vines/heavy,
 /turf/open/ground/river,
 /area/lv624/ground/river1)
-"upv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/warning{
-	dir = 4
-	},
-/area/lv624/lazarus/engineering)
 "upO" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/ai_node,
@@ -19738,18 +19557,16 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/secure_storage)
 "utf" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 2
+/obj/machinery/power/monitor{
+	name = "Main Power Grid Monitoring"
 	},
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating/warning{
-	dir = 2
-	},
-/area/lv624/lazarus/tablefort)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "utn" = (
 /obj/structure/jungle/vines/heavy,
 /turf/open/floor/plating/ground/dirtgrassborder,
@@ -19780,9 +19597,10 @@
 	},
 /area/lv624/lazarus/overgrown)
 "uvg" = (
-/obj/structure/window_frame/colony/reinforced,
-/obj/structure/jungle/vines,
-/turf/open/floor/plating,
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/powercell,
+/obj/item/folder,
+/turf/open/floor/tile/dark,
 /area/lv624/lazarus/engineering)
 "uvP" = (
 /turf/open/floor/marking/warning,
@@ -19837,10 +19655,22 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand9)
+"uzD" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 8
+	},
+/obj/item/weapon/gun/smg/m25,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "uzK" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/east1)
+"uAl" = (
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/rock)
 "uBz" = (
 /obj/structure/rack,
 /obj/machinery/light,
@@ -19881,11 +19711,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/sw)
-"uDn" = (
-/turf/open/ground/coast/corner{
-	dir = 4
-	},
-/area/lv624/ground/jungle6)
 "uDA" = (
 /obj/structure/rack,
 /turf/open/floor/tile/purple/whitepurplecorner{
@@ -19916,7 +19741,7 @@
 "uGS" = (
 /obj/effect/decal/cleanable/blood/splatter/animated,
 /turf/open/floor/grimy,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "uIA" = (
 /obj/machinery/door/poddoor/mainship{
 	dir = 2;
@@ -19947,14 +19772,6 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/quartstorage/outdoors)
-"uJs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/turf/open/floor/plating/warning{
-	dir = 2
-	},
-/area/lv624/lazarus/engineering)
 "uJy" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 2
@@ -19987,6 +19804,7 @@
 "uLA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/weed_node,
+/obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
 "uLT" = (
@@ -19996,6 +19814,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/marking/bot,
 /area/lv624/lazarus/spaceport)
+"uMQ" = (
+/obj/structure/jungle/vines/heavy,
+/turf/closed/wall,
+/area/lv624/lazarus/fitness)
 "uNb" = (
 /obj/structure/closet,
 /obj/item/clothing/glasses/sunglasses,
@@ -20006,14 +19828,12 @@
 	dir = 2
 	},
 /area/lv624/lazarus/sleep_male)
-"uNe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
 "uNG" = (
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/floor/plating/ground/dirtgrassborder/corner2,
-/area/lv624/ground/jungle6)
+/obj/effect/decal/remains/human,
+/obj/item/ammo_casing,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "uNU" = (
 /obj/machinery/landinglight/ds1/delaythree,
 /turf/open/floor/plating,
@@ -20032,7 +19852,7 @@
 /turf/open/ground/coast/corner2{
 	dir = 1
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "uQd" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/cult,
@@ -20099,11 +19919,6 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
-"uTQ" = (
-/obj/machinery/floodlight,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
 "uTZ" = (
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 8
@@ -20129,7 +19944,7 @@
 /turf/open/ground/grass/beach/corner{
 	dir = 4
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "uVd" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/open/floor/tile/green/greentaupe{
@@ -20181,7 +19996,7 @@
 /obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/atmos/outside)
+/area/lv624/ground/jungle2)
 "uWG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
@@ -20241,10 +20056,20 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
 "vdj" = (
-/obj/effect/decal/remains/xeno,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand8)
+/obj/machinery/vending/tool,
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/engineering)
+"vdn" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/ground/caves/rock)
 "vds" = (
 /obj/structure/bed,
 /obj/structure/window/reinforced{
@@ -20267,16 +20092,7 @@
 "veM" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/wood,
-/area/lv624/lazarus/hop)
-"vfg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/warning{
-	dir = 1
-	},
-/area/lv624/lazarus/engineering)
+/area/lv624/lazarus/captain)
 "vfk" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
@@ -20309,9 +20125,6 @@
 /obj/effect/attach_point/electronics/dropship1,
 /turf/open/floor/plating,
 /area/shuttle/drop1/lz1)
-"vga" = (
-/turf/open/ground/grass/grass2,
-/area/lv624/lazarus/atmos/outside)
 "vgb" = (
 /obj/structure/jungle/vines,
 /turf/closed/gm/dense,
@@ -20371,7 +20184,7 @@
 /obj/structure/jungle/vines/heavy,
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "vkR" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirt,
@@ -20385,7 +20198,7 @@
 "vmz" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "vmI" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -20465,12 +20278,19 @@
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
 /area/lv624/ground/jungle6)
 "vqG" = (
-/obj/effect/ai_node,
-/obj/effect/decal/tracks/wheels/bloody{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
+"vqK" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor,
+/area/lv624/ground/jungle6)
 "vrh" = (
 /obj/structure/kitchenspike,
 /obj/machinery/light/small{
@@ -20500,8 +20320,9 @@
 	},
 /area/lv624/lazarus/secure_storage)
 "vsk" = (
-/obj/structure/foamedmetal,
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirtgrassborder/corner{
+	dir = 8
+	},
 /area/lv624/lazarus/overgrown)
 "vso" = (
 /obj/effect/decal/cleanable/blood,
@@ -20529,7 +20350,7 @@
 	name = "\improper Nexus Dome Director's Quarter"
 	},
 /turf/open/floor/plating,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "vsX" = (
 /obj/structure/catwalk,
 /obj/effect/decal/riverdecal,
@@ -20567,7 +20388,7 @@
 /area/lv624/ground/jungle6)
 "vuY" = (
 /turf/open/ground/river,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "vvl" = (
 /obj/structure/largecrate/random/barrel/yellow,
 /turf/open/floor,
@@ -20619,11 +20440,11 @@
 	dir = 8
 	},
 /area/lv624/ground/jungle1)
-"vzi" = (
-/obj/structure/jungle/vines,
-/obj/machinery/power/apc,
-/turf/open/ground/grass/grass2,
-/area/lv624/lazarus/atmos)
+"vzE" = (
+/obj/item/ammo_magazine/smg/uzi/extended,
+/obj/effect/spawner/random/melee,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "vzI" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
@@ -20646,10 +20467,6 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle4)
-"vAv" = (
-/obj/structure/jungle/vines/heavy,
-/turf/closed/wall,
-/area/lv624/lazarus/atmos)
 "vAz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
@@ -20735,10 +20552,6 @@
 	},
 /turf/open/floor/vault,
 /area/lv624/lazarus/quartstorage)
-"vFO" = (
-/obj/structure/window_frame/colony,
-/turf/open/floor/plating,
-/area/lv624/ground/jungle3)
 "vFU" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/ground/coast/corner{
@@ -20811,11 +20624,6 @@
 	},
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/sandtemple)
-"vKT" = (
-/obj/effect/spawner/random/tool,
-/obj/item/frame/rack,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle3)
 "vMc" = (
 /obj/structure/table,
 /obj/item/megaphone,
@@ -20831,9 +20639,12 @@
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/quart)
 "vMu" = (
-/obj/structure/jungle/vines,
-/turf/closed/wall,
-/area/lv624/lazarus/atmos)
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4;
+	icon_state = "grassdirt_corner2"
+	},
+/area/lv624/ground/jungle3)
 "vMC" = (
 /obj/item/stack/sheet/wood,
 /turf/open/floor/tile/purple/taupepurple{
@@ -20866,9 +20677,7 @@
 "vPf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 1
-	},
+/turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle3)
 "vPC" = (
 /turf/closed/wall/r_wall,
@@ -20954,14 +20763,6 @@
 "vUs" = (
 /turf/closed/wall,
 /area/lv624/lazarus/fitness)
-"vUy" = (
-/obj/structure/jungle/plantbot1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle3)
 "vUT" = (
 /obj/effect/spawner/random/trash,
 /turf/open/ground/grass,
@@ -20994,7 +20795,7 @@
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle5)
 "vWz" = (
-/obj/structure/jungle/vines,
+/obj/structure/sign/safety/hazard,
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/spaceport2)
 "vXj" = (
@@ -21055,6 +20856,7 @@
 "vZz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/weed_node,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/jungle7)
 "vZQ" = (
@@ -21075,7 +20877,7 @@
 /obj/structure/flora/grass/brown,
 /obj/structure/jungle/vines/heavy,
 /turf/open/ground/grass/grass2,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "wbc" = (
 /turf/closed/wall/sulaco,
 /area/lv624/lazarus/crashed_ship)
@@ -21097,6 +20899,14 @@
 "wdr" = (
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/sleep_male)
+"wdN" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 2
+	},
+/turf/open/floor/plating/warning{
+	dir = 2
+	},
+/area/lv624/ground/caves/rock)
 "wee" = (
 /obj/structure/flora/pottedplant,
 /obj/item/trash/cheesie,
@@ -21189,10 +20999,8 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
 "whp" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/power/geothermal,
+/obj/structure/dispenser/oxygen,
+/obj/structure/largecrate/random,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/lv624/lazarus/engineering)
@@ -21201,7 +21009,7 @@
 /turf/open/ground/coast{
 	dir = 4
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "whI" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -21255,17 +21063,16 @@
 "wjy" = (
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
+"wjP" = (
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/ground/caves/rock)
 "wjU" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
-"wkj" = (
-/obj/structure/jungle/vines/heavy,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	icon_state = "grassdirt_corner2"
-	},
-/area/lv624/ground/jungle3)
 "wkB" = (
 /obj/structure/disposalpipe/junction/flipped{
 	dir = 8
@@ -21274,15 +21081,10 @@
 /turf/open/floor/plating/catwalk,
 /area/lv624/ground/river2)
 "wkF" = (
-/obj/effect/landmark/weed_node,
+/obj/machinery/vending/engineering,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/tile/purple/whitepurplecorner{
-	dir = 4
-	},
-/area/lv624/lazarus/fitness)
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "wkG" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4
@@ -21322,12 +21124,6 @@
 	dir = 8
 	},
 /area/lv624/lazarus/secure_storage)
-"wmQ" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 8
-	},
-/area/lv624/ground/jungle3)
 "wmU" = (
 /turf/closed/wall,
 /area/lv624/ground/jungle4)
@@ -21383,9 +21179,13 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle1)
 "wqg" = (
-/obj/effect/spawner/random/gun/shotgun,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/power/monitor,
 /turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/area/lv624/lazarus/engineering)
 "wqy" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 2
@@ -21400,9 +21200,6 @@
 /obj/structure/table/mainship,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
-"wqT" = (
-/turf/open/ground/grass,
-/area/lv624/lazarus/atmos/outside)
 "wrq" = (
 /obj/structure/cable,
 /turf/open/floor/tile/chapel{
@@ -21427,10 +21224,6 @@
 	dir = 9
 	},
 /area/lv624/lazarus/sleep_female)
-"wsU" = (
-/obj/structure/jungle/vines,
-/turf/closed/wall,
-/area/lv624/ground/compound)
 "wsX" = (
 /turf/closed/wall/r_wall/chigusa,
 /area/lv624/ground/caves/east1)
@@ -21584,10 +21377,6 @@
 	dir = 1
 	},
 /area/lv624/ground/caves/central3)
-"wCh" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/closed/gm/dense,
-/area/lv624/ground/jungle3)
 "wCI" = (
 /obj/item/stack/sheet/wood{
 	amount = 50
@@ -21668,11 +21457,8 @@
 	},
 /area/lv624/ground/compound/n)
 "wFb" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/purple/whitepurplecorner{
-	dir = 4
-	},
-/area/lv624/lazarus/fitness)
+/turf/open/floor/plating/dmg1,
+/area/lv624/ground/river1)
 "wFh" = (
 /obj/structure/closet/open,
 /obj/item/clothing/under/colonist,
@@ -21701,13 +21487,8 @@
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/canteen)
 "wGb" = (
-/obj/structure/bed/stool,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/warning,
 /area/lv624/lazarus/engineering)
 "wGw" = (
 /obj/structure/bed/chair{
@@ -21731,14 +21512,15 @@
 	},
 /area/lv624/lazarus/hydroponics)
 "wIb" = (
-/obj/machinery/computer/intel_computer,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/ground/sand8)
 "wIe" = (
 /obj/effect/decal/cleanable/blood/splatter/animated,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/grimy,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "wIo" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -21794,13 +21576,19 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/secure_storage)
-"wLL" = (
-/obj/structure/jungle/vines/heavy,
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 8
+"wLZ" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/o2{
+	pixel_x = 4;
+	pixel_y = 6
 	},
-/area/lv624/ground/jungle3)
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "wMT" = (
 /obj/machinery/conveyor/inverted{
 	dir = 9
@@ -21840,10 +21628,11 @@
 /turf/open/floor/wood,
 /area/lv624/lazarus/bar)
 "wPF" = (
-/turf/open/ground/coast/corner{
-	dir = 8
+/obj/structure/jungle/vines{
+	pixel_y = 1
 	},
-/area/lv624/ground/jungle10)
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/lv624/ground/jungle6)
 "wPG" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -21852,8 +21641,12 @@
 /turf/open/floor/tile/barber,
 /area/lv624/lazarus/kitchen)
 "wQv" = (
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/atmos/outside)
+/obj/structure/jungle/vines,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/lv624/ground/jungle10)
 "wQw" = (
 /obj/structure/closet/cabinet,
 /turf/open/floor/tile/purple/whitepurplecorner{
@@ -21867,7 +21660,7 @@
 "wRf" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/platebotc,
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
 "wRx" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/purple/whitepurple{
@@ -21938,16 +21731,15 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/jungle7)
 "wUp" = (
-/obj/structure/foamedmetal,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/item/clothing/under/shorts/blue,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
 	},
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/area/lv624/lazarus/fitness)
 "wUH" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/plating/ground/dirt,
@@ -22011,12 +21803,6 @@
 	dir = 8
 	},
 /area/lv624/ground/jungle5)
-"wYm" = (
-/obj/structure/foamedmetal,
-/obj/machinery/vending/engineering,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
 "wYW" = (
 /turf/open/floor/tile/red/full,
 /area/lv624/lazarus/security)
@@ -22086,10 +21872,6 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
-"xbL" = (
-/obj/structure/jungle/vines/heavy,
-/turf/open/ground/grass/grass2,
-/area/lv624/lazarus/atmos)
 "xcz" = (
 /obj/structure/fence,
 /turf/open/ground/grass,
@@ -22188,11 +21970,11 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle3)
 "xgW" = (
-/obj/machinery/power/smes/buildable/empty{
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plating/platebotc,
-/area/lv624/lazarus/engineering)
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/fitness)
 "xgZ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/dirt,
@@ -22269,20 +22051,14 @@
 /obj/item/book/manual/research_and_development,
 /obj/item/book/manual/security_space_law,
 /turf/open/floor/wood,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "xkb" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
+/obj/structure/girder,
+/turf/open/ground/river,
+/area/lv624/ground/river1)
 "xkr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 8
-	},
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle3)
 "xlM" = (
 /obj/effect/decal/cleanable/blood,
@@ -22293,11 +22069,8 @@
 	},
 /area/lv624/lazarus/main_hall)
 "xlS" = (
-/obj/machinery/door/poddoor/mainship{
-	dir = 4;
-	id = "secure_blast";
-	name = "\improper Secure Armory Blast Door"
-	},
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/secure_storage)
 "xmB" = (
@@ -22319,7 +22092,9 @@
 "xnA" = (
 /obj/structure/jungle/vines/heavy,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/plating/ground/dirt,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
 /area/lv624/ground/jungle3)
 "xoc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -22339,13 +22114,7 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 8
-	},
-/area/lv624/ground/jungle3)
-"xoI" = (
-/obj/structure/window/framed/colony,
-/turf/open/floor/plating,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle3)
 "xoL" = (
 /turf/closed/mineral/smooth/indestructible,
@@ -22463,9 +22232,7 @@
 "xwr" = (
 /obj/effect/decal/remains/xeno,
 /obj/structure/jungle/planttop1,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 4
-	},
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle3)
 "xwu" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -22483,16 +22250,11 @@
 	dir = 8
 	},
 /area/lv624/ground/jungle5)
-"xxp" = (
-/obj/structure/grille/broken,
-/obj/structure/foamedmetal,
-/turf/open/floor/plating/platebot,
-/area/lv624/lazarus/engineering)
 "xys" = (
-/obj/item/ammo_magazine/smg/uzi/extended,
-/obj/effect/spawner/random/melee,
-/turf/open/floor/plating,
-/area/lv624/lazarus/tablefort)
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "xyJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/weed_node,
@@ -22505,6 +22267,15 @@
 	},
 /turf/open/floor/tile/bar,
 /area/lv624/lazarus/canteen)
+"xzu" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 8
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/ground/caves/rock)
 "xzw" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -22576,7 +22347,7 @@
 	},
 /obj/item/tool/wrench,
 /turf/open/floor/wood,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "xEv" = (
 /obj/structure/jungle/plantbot1/alien,
 /obj/structure/jungle/vines,
@@ -22603,6 +22374,11 @@
 "xFL" = (
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle3)
+"xFQ" = (
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
 "xGc" = (
 /obj/structure/bed/stool,
 /obj/machinery/light{
@@ -22674,13 +22450,8 @@
 	},
 /area/lv624/lazarus/hydroponics)
 "xHS" = (
-/obj/machinery/power/geothermal,
-/obj/structure/lattice,
-/obj/structure/cable,
-/turf/open/floor/plating/warning{
-	dir = 5
-	},
-/area/lv624/lazarus/engineering)
+/turf/open/floor,
+/area/lv624/ground/river1)
 "xIW" = (
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/landmark/weed_node,
@@ -22797,14 +22568,9 @@
 /turf/open/space/basic,
 /area/lv624/lazarus/internal_affairs)
 "xPn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/purple/whitepurplecorner{
-	dir = 4
-	},
-/area/lv624/lazarus/fitness)
+/obj/machinery/computer/nuke_disk_generator/blue,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "xPG" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -22832,6 +22598,12 @@
 	dir = 1
 	},
 /area/lv624/lazarus/overgrown)
+"xQz" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor,
+/area/lv624/ground/jungle6)
 "xQA" = (
 /obj/item/ammo_casing,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -22897,7 +22669,14 @@
 /turf/open/ground/coast{
 	dir = 8
 	},
-/area/lv624/lazarus/atmos)
+/area/lv624/ground/jungle9)
+"xUK" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 4
+	},
+/obj/item/ammo_magazine/smg/m25,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/rock)
 "xVF" = (
 /obj/effect/ai_node,
 /turf/open/floor/wood,
@@ -22920,12 +22699,18 @@
 	dir = 4
 	},
 /area/lv624/ground/jungle4)
+"xWp" = (
+/obj/machinery/floodlight/colony{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
 "xWz" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/grimy,
-/area/lv624/lazarus/hop)
+/area/lv624/lazarus/captain)
 "xWM" = (
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle6)
@@ -22982,10 +22767,12 @@
 /turf/open/floor/tile/barber,
 /area/lv624/lazarus/main_hall)
 "xZW" = (
-/obj/machinery/power/geothermal,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
+/obj/structure/hoop{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/tile/white/warningstripe,
+/area/lv624/lazarus/fitness)
 "yaB" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/closed/wall/r_wall,
@@ -23041,11 +22828,9 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/main_hall)
 "ycA" = (
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 8
-	},
-/area/lv624/ground/jungle3)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle4)
 "ycL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
@@ -23056,14 +22841,13 @@
 /turf/open/floor/plating,
 /area/shuttle/drop1/lz1)
 "yda" = (
-/obj/machinery/colony_floodlight_switch{
-	pixel_y = 30
+/obj/structure/jungle/vines{
+	pixel_y = 1
 	},
-/obj/effect/decal/warning_stripes{
-	pixel_y = 30
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
 	},
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/area/lv624/ground/jungle4)
 "ydn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/dirt,
@@ -23104,9 +22888,6 @@
 /obj/structure/rack,
 /turf/open/floor/plating/platebotc,
 /area/lv624/lazarus/quartstorage/outdoors)
-"ygU" = (
-/turf/closed/wall,
-/area/lv624/lazarus/atmos/outside)
 "ygV" = (
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/engineering)
@@ -23150,9 +22931,10 @@
 /area/lv624/lazarus/engineering)
 "yiU" = (
 /turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
+	dir = 1;
+	icon_state = "grassdirt_corner2"
 	},
-/area/lv624/lazarus/atmos/outside)
+/area/lv624/ground/jungle6)
 "yiV" = (
 /turf/open/ground/grass,
 /area/lv624/ground/jungle4)
@@ -23163,15 +22945,14 @@
 /turf/open/floor/plating/ground/dirtgrassborder/corner2,
 /area/lv624/ground/jungle5)
 "yjF" = (
-/obj/structure/flora/grass/green,
-/obj/structure/foamedmetal,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle9)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "yjT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/atmos/outside)
+/area/lv624/ground/jungle2)
 "ykr" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -23220,12 +23001,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle3)
-"ylj" = (
-/obj/structure/foamedmetal,
-/obj/structure/dispenser/oxygen,
-/obj/structure/largecrate/random,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
 "ylq" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
@@ -23850,7 +23625,7 @@ gKr
 gKr
 gKr
 gKr
-lXk
+dOp
 lXk
 gKr
 gKr
@@ -23914,10 +23689,10 @@ hNl
 mVi
 lnT
 uQN
-mOs
-mOs
-mOs
-wnj
+lTN
+lTN
+lTN
+lTN
 lTN
 wnj
 wnj
@@ -23929,7 +23704,7 @@ lTN
 wnj
 wnj
 mOs
-bcg
+mOs
 mOs
 mOs
 mOs
@@ -24023,7 +23798,7 @@ gKr
 gKr
 hEd
 lXk
-lXk
+dOp
 lXk
 vHz
 lXk
@@ -24091,11 +23866,11 @@ mVi
 tfB
 mVi
 uQN
-mOs
-mOs
-mOs
-mOs
-mOs
+lTN
+lTN
+lTN
+lTN
+lTN
 lTN
 lTN
 bcg
@@ -24222,7 +23997,7 @@ evp
 alB
 gKr
 gKr
-lXk
+dOp
 lXk
 hEd
 hEd
@@ -24257,10 +24032,10 @@ rtU
 lzI
 nmn
 iYO
-hVJ
+qNl
 tIH
 fPI
-tfy
+jVL
 jVL
 jVL
 nmn
@@ -24437,8 +24212,8 @@ teg
 bII
 teg
 nmn
-dQW
-dQW
+hVJ
+qNl
 hVJ
 bhN
 nmn
@@ -24620,7 +24395,7 @@ kqq
 uuY
 tJx
 qhD
-vsk
+jVL
 vsk
 nmn
 mOs
@@ -24768,7 +24543,7 @@ tca
 tca
 tca
 gBt
-brc
+puA
 emm
 bqz
 lTN
@@ -24796,9 +24571,9 @@ kke
 kke
 tWU
 evH
-vUT
-vsk
-vsk
+hRR
+hVJ
+uuY
 nmn
 mOs
 mOs
@@ -24904,7 +24679,7 @@ gKr
 gKr
 gKr
 hEd
-lXk
+dOp
 hEd
 lXk
 lXk
@@ -24935,7 +24710,7 @@ lXk
 lXk
 lXk
 lXk
-lXk
+dOp
 vHz
 gKr
 gKr
@@ -24973,9 +24748,9 @@ mVi
 mVi
 mVi
 mVi
-mVi
-vsk
-vsk
+eBs
+kke
+dPS
 nmn
 mOs
 mOs
@@ -25095,7 +24870,7 @@ lXk
 hEd
 hEd
 lXk
-lXk
+dOp
 lXk
 hEd
 hEd
@@ -25151,7 +24926,7 @@ mVi
 nmn
 nmn
 gsx
-vsk
+mVi
 nmn
 nmn
 mOs
@@ -25178,8 +24953,8 @@ vGi
 dFx
 bch
 bck
-mOs
-mOs
+bch
+bch
 bch
 bch
 iHd
@@ -25465,10 +25240,10 @@ dOp
 lXk
 lXk
 lXk
+dOp
 lXk
 lXk
-lXk
-ivu
+gsZ
 gKr
 oEc
 tZS
@@ -25504,8 +25279,8 @@ evH
 tHi
 mPf
 pNJ
-dQW
-dQW
+qNl
+hVJ
 dYc
 mOs
 mOs
@@ -25645,9 +25420,9 @@ lXk
 lXk
 lXk
 lXk
-vTe
-sDK
-sDK
+cAu
+lSR
+lSR
 tZS
 are
 are
@@ -25680,9 +25455,9 @@ jVL
 vkv
 fbQ
 dMw
-dQW
-dQW
-dQW
+hVJ
+hVJ
+hVJ
 dYc
 mOs
 mOs
@@ -25792,14 +25567,14 @@ hEd
 lXk
 vHz
 hEd
-lXk
+dOp
 lXk
 lXk
 lXk
 dOp
 lXk
 lXk
-vHz
+tUj
 lXk
 mJR
 vHz
@@ -25822,15 +25597,15 @@ lXk
 hEd
 hEd
 lXk
-vTe
-aWG
-diA
+cAu
+gJD
+tga
 tZS
 are
 are
 xZG
 gBt
-ivu
+rtU
 vZQ
 cOs
 xLz
@@ -25861,10 +25636,10 @@ fxm
 mkw
 izQ
 nmn
-mOs
-mOs
-mOs
-mOs
+qqT
+qqT
+qqT
+vwq
 nbQ
 lse
 vsi
@@ -25966,7 +25741,7 @@ gKr
 gKr
 gKr
 hEd
-lXk
+dOp
 lXk
 lXk
 lXk
@@ -25987,10 +25762,10 @@ hEd
 lXk
 lXk
 lXk
-gKr
 gKr
 alB
 gKr
+gKr
 hEd
 lXk
 lXk
@@ -25999,15 +25774,15 @@ lXk
 hEd
 hEd
 lXk
-vTe
-odE
-qbR
+cAu
+bNu
+aDJ
 qbR
 vji
 qbR
 qbR
 odE
-kUr
+wWk
 xLz
 xLz
 mbP
@@ -26037,11 +25812,11 @@ fPI
 puA
 puA
 xLz
-mOs
-mOs
-mOs
-mOs
-mOs
+xLz
+xLz
+xLz
+xLz
+xvY
 nbQ
 nbQ
 mxa
@@ -26164,9 +25939,9 @@ hEd
 dOp
 lXk
 lXk
-gKr
-gKr
 alB
+gKr
+gKr
 gKr
 hEd
 vHz
@@ -26176,15 +25951,15 @@ lXk
 lXk
 lXk
 vHz
-vTe
-odE
+cAu
+bNu
 jJD
 wuP
 amV
 nVk
 kBt
 urf
-vTe
+xLz
 xLz
 xLz
 lZZ
@@ -26211,21 +25986,21 @@ rtU
 qrD
 xLz
 xLz
-rtU
 xLz
+rtU
 wWk
 xLz
-mOs
-mOs
-mOs
-mOs
-mOs
+xLz
+pnb
+xLz
+xvY
+wnj
 nbQ
 nbQ
 nbQ
 xlS
 iJT
-xlS
+ulX
 nbQ
 nbQ
 bIw
@@ -26341,10 +26116,10 @@ lXk
 lXk
 lXk
 lXk
-gKr
-gKr
 alB
 gKr
+gKr
+gKr
 hEd
 hEd
 lXk
@@ -26354,14 +26129,14 @@ lXk
 lXk
 cAu
 cAu
-alD
-odE
+qof
+bNu
 nVk
 ybg
 are
 kBt
 alD
-vTe
+xLz
 xLz
 xLz
 lZZ
@@ -26392,12 +26167,12 @@ xLz
 xLz
 xLz
 xLz
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
+xLz
+xLz
+xLz
+xvY
+wnj
+wnj
 nbQ
 jvw
 mYr
@@ -26504,7 +26279,7 @@ hEd
 lXk
 lXk
 lXk
-lXk
+dOp
 lXk
 hEd
 hEd
@@ -26518,9 +26293,9 @@ lXk
 vHz
 lXk
 hEd
-gKr
-gKr
 alB
+gKr
+gKr
 gKr
 gKr
 hEd
@@ -26531,14 +26306,14 @@ cAu
 gsZ
 cAu
 cAu
-odE
-qbR
+bNu
+aDJ
 qbR
 cPD
 oyI
 qbR
 odE
-ivu
+rtU
 xLz
 xLz
 mbP
@@ -26569,17 +26344,17 @@ vSi
 vSi
 vSi
 kSi
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
+xLz
+xLz
+xLz
+kSi
+wnj
+uUv
 nbQ
 nbQ
 xlS
 poE
-xlS
+ulX
 bIw
 cmh
 lTN
@@ -26587,7 +26362,7 @@ lTN
 jNj
 mOs
 mOs
-bch
+vGi
 mOs
 tgT
 kPr
@@ -26695,9 +26470,9 @@ vHz
 lXk
 hEd
 hEd
-gKr
-gKr
 alB
+gKr
+gKr
 gKr
 gKr
 gKr
@@ -26715,7 +26490,7 @@ xZG
 xZG
 xZG
 nMJ
-vTe
+xLz
 xLz
 mbP
 mbP
@@ -26745,13 +26520,13 @@ wnj
 wnj
 wnj
 wnj
+dpe
+xLz
+xLz
+xLz
+xvY
 wnj
 wnj
-wnj
-mOs
-mOs
-mOs
-mOs
 wnj
 dpe
 dFf
@@ -26871,10 +26646,10 @@ lXk
 lXk
 lXk
 hEd
-gKr
-gKr
-gKr
 alB
+gKr
+gKr
+gKr
 gKr
 gKr
 gKr
@@ -26892,7 +26667,7 @@ are
 are
 cLP
 gMu
-vTe
+xLz
 xLz
 lZZ
 iWk
@@ -26922,12 +26697,12 @@ jUY
 wnj
 fQu
 otJ
+dpe
+puA
+xLz
+xLz
+wQv
 wnj
-wUU
-wnj
-wnj
-lTN
-wEJ
 cuu
 wnj
 dpe
@@ -27048,10 +26823,10 @@ lXk
 tpt
 hEd
 hEd
-gKr
-gKr
-gKr
 alB
+gKr
+gKr
+gKr
 gKr
 gKr
 gKr
@@ -27068,7 +26843,7 @@ are
 are
 are
 gBt
-ivu
+rtU
 xLz
 wWk
 dYR
@@ -27099,14 +26874,14 @@ qpS
 wnj
 otJ
 wnj
-bYr
-uUv
-bYr
-wnj
+dpe
+xLz
+rtU
+xLz
+xvY
 liw
 lxu
-jUY
-wnj
+qRV
 kSi
 xLz
 nSW
@@ -27224,11 +26999,11 @@ lXk
 lXk
 hEd
 hEd
-gKr
-gKr
-gKr
-gKr
 alB
+gKr
+gKr
+gKr
+gKr
 gKr
 gKr
 gKr
@@ -27245,7 +27020,7 @@ are
 are
 are
 gBt
-vTe
+xLz
 xLz
 xLz
 lZZ
@@ -27276,14 +27051,14 @@ olR
 wUU
 wnj
 wnj
-bYr
-wnj
-wnj
-wnj
+dpe
+xLz
+xLz
+xLz
+xvY
 dIO
 cpV
 qpS
-wnj
 dpe
 xLz
 nSW
@@ -27295,7 +27070,7 @@ mOs
 mOs
 mOs
 mOs
-mOs
+vGi
 mOs
 tgT
 tgT
@@ -27401,11 +27176,11 @@ lXk
 lXk
 hEd
 hEd
-gKr
+alB
 evp
 evp
 evp
-cTi
+evp
 evp
 evp
 gKr
@@ -27422,7 +27197,7 @@ are
 are
 are
 gBt
-vTe
+xLz
 xLz
 xLz
 mbP
@@ -27453,14 +27228,14 @@ wnj
 wUU
 wnj
 wnj
-wnj
-wnj
-bYr
-wUU
+dpe
+xLz
+xLz
+puA
+xvY
 iYn
 bIS
-olR
-wnj
+ezy
 dpe
 xLz
 nSW
@@ -27472,7 +27247,7 @@ wnj
 mOs
 mOs
 mOs
-mOs
+vGi
 mOs
 mOs
 mOs
@@ -27527,7 +27302,7 @@ abc
 abc
 abc
 abc
-abc
+kLK
 abc
 alB
 ivV
@@ -27577,12 +27352,12 @@ lXk
 hEd
 hEd
 hEd
+alB
 gKr
-gKr
 evp
 evp
 evp
-cTi
+evp
 evp
 evp
 gKr
@@ -27599,7 +27374,7 @@ are
 are
 are
 gBt
-ivu
+rtU
 xLz
 xLz
 rtU
@@ -27629,13 +27404,13 @@ ykS
 kSi
 ykS
 ykS
-kSi
-ykS
-ykS
-ykS
-ykS
 ykS
 kSi
+xLz
+xLz
+xLz
+kSi
+ykS
 ykS
 ykS
 kSi
@@ -27649,7 +27424,7 @@ wnj
 wnj
 mOs
 mOs
-mOs
+vGi
 mOs
 mOs
 mOs
@@ -27752,31 +27527,31 @@ hEd
 hEd
 hEd
 hEd
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-cTi
-evp
-evp
-gKr
-gKr
+alB
+alB
 gKr
 gKr
 cAu
 cAu
 cAu
 cAu
+cAu
+cAu
+cAu
+cAu
+gKr
+gKr
+cAu
+cAu
+cAu
+gsZ
 cAu
 tZS
 are
 are
 are
 gBt
-vTe
+xLz
 xLz
 xLz
 xLz
@@ -27826,7 +27601,7 @@ mOs
 mOs
 mOs
 mOs
-bch
+vGi
 mOs
 mOs
 mOs
@@ -27926,23 +27701,23 @@ lXk
 lXk
 hEd
 hEd
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
+alB
+alB
 alB
 gKr
 gKr
-gKr
-gKr
-gKr
-gKr
+gsZ
+cAu
+cAu
+cAu
+cAu
+gsZ
+cAu
+cAu
+cAu
+cAu
+gsZ
+cAu
 cAu
 cAu
 xrX
@@ -27953,7 +27728,7 @@ are
 are
 are
 gBt
-ivu
+rtU
 xLz
 wWk
 xLz
@@ -28102,35 +27877,35 @@ lXk
 lXk
 hEd
 crG
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
 alB
 gKr
 gKr
 gKr
 gKr
-gKr
-gKr
 cAu
 cAu
 cAu
 cAu
-vTe
+fRf
+cAu
+cAu
+cAu
+kwk
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
 tZS
 are
 are
 are
 gBt
-vTe
+xLz
 xLz
 xLz
 xLz
@@ -28278,25 +28053,25 @@ lXk
 lXk
 hEd
 hEd
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
 alB
 gKr
 gKr
-gKr
-gKr
-gKr
-gKr
+cAu
+gsZ
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
 cAu
 gsZ
 cAu
@@ -28307,14 +28082,14 @@ are
 are
 are
 gBt
-ivu
+rtU
 xLz
 xLz
 rtU
 xLz
 xLz
 xLz
-rtU
+xLz
 mbP
 lZZ
 mRv
@@ -28454,26 +28229,26 @@ lXk
 lXk
 lXk
 hEd
-gKr
+alB
 evp
 evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-cTi
-evp
-evp
-gKr
-gKr
-gKr
-gKr
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
 cAu
 cAu
 cAu
@@ -28484,28 +28259,28 @@ are
 are
 are
 gBt
-vTe
-vTe
+xLz
+xLz
 bpE
-bIS
-bIS
 bIS
 cjm
 xLz
-rtU
 xLz
 xLz
 xLz
-rtU
+xLz
+xLz
+xLz
+xLz
 dFf
 xLz
 xLz
+xLz
+xLz
+xLz
 rtU
-bpE
-bIS
-bIS
-bIS
-olR
+xLz
+xvY
 wUU
 bYr
 wnj
@@ -28626,31 +28401,31 @@ lXk
 dOp
 lXk
 lXk
+dOp
+lXk
 hEd
 hEd
 hEd
-hEd
-hEd
-gKr
+alB
 evp
 evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-cTi
-evp
-evp
-gKr
-gKr
-gKr
-gKr
+cAu
+cAu
+cAu
+fRf
+cAu
+cAu
+kwk
+cAu
+cAu
+cAu
+cAu
+cAu
+xWp
+cAu
+cAu
+cAu
+cAu
 cAu
 cAu
 cAu
@@ -28662,27 +28437,27 @@ cNT
 are
 mbF
 fez
-vTe
+xLz
 qpS
-wnj
-wnj
-wnj
-dIO
-xLz
-dFf
+aQs
+kSi
+rtU
 xLz
 xLz
-dFf
+aVI
 xLz
 xLz
 dFf
+rtU
 xLz
-bpE
-olR
-wnj
-wnj
-wnj
-wnj
+dFf
+xLz
+rtU
+xLz
+xLz
+xLz
+xLz
+xvY
 wnj
 wnj
 wnj
@@ -28700,7 +28475,7 @@ wnj
 wnj
 wnj
 bYr
-ubU
+dpe
 xLz
 nSW
 xLz
@@ -28773,7 +28548,7 @@ abc
 abc
 abc
 abc
-abc
+kLK
 abc
 aym
 alB
@@ -28802,76 +28577,76 @@ lXk
 lXk
 lXk
 hEd
-hEd
-hEd
+lXk
+lXk
+lXk
 gKr
-gKr
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-cTi
-evp
-evp
-gKr
-gKr
-gKr
-gKr
+alB
+alB
 gKr
 cAu
 cAu
+gsZ
 cAu
-tZS
+cAu
+cAu
+cAu
+gsZ
+cAu
+cAu
+cAu
+cAu
+gsZ
+cAu
+cAu
+cAu
+cAu
+gsZ
+cAu
+cAu
+cAu
+cAu
+bpJ
+gge
 are
 are
 are
 aoC
 are
 gBt
-vTe
-xoT
-jUY
-uUv
-wnj
-iYn
-bIS
-cjm
 xLz
-bpE
-bIS
-bIS
-bIS
-bIS
-bIS
-olR
+xoT
+llU
+dpe
+xLz
+xLz
+xLz
+xLz
+xLz
+xLz
+xLz
+xLz
+xLz
+xLz
+xLz
+xLz
+kSi
+vSi
+vSi
+vSi
+kSi
 wnj
 wnj
-bYr
-bYr
-uUv
 wnj
-lTN
-lTN
-lTN
+wnj
 wnj
 fQu
 wnj
-mOs
-mOs
-lTN
-lTN
-lTN
+wnj
+wnj
+wnj
+ncx
+cuu
 wnj
 wnj
 kBI
@@ -28893,8 +28668,8 @@ bch
 gjH
 xFL
 eZJ
-rAG
-dKx
+xFL
+obk
 mOs
 mOs
 mOs
@@ -28935,12 +28710,12 @@ sXN
 abc
 abc
 abc
+kLK
 abc
 abc
 abc
 abc
-abc
-abc
+kLK
 abc
 abc
 abc
@@ -28979,38 +28754,38 @@ lXk
 hEd
 hEd
 hEd
-gKr
-hEd
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-cTi
-evp
-evp
-gKr
-gKr
-gKr
+lXk
+lXk
+heN
+alB
 gKr
 gKr
 cAu
 cAu
 cAu
-gRT
-bre
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+xGi
+cAu
+cAu
+cAu
+cAu
+fRf
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+tZS
+are
+are
 fUp
 are
 are
@@ -29019,37 +28794,37 @@ mbF
 fez
 wWk
 qpS
+dpe
+xLz
+xLz
+xLz
+kSi
+vSi
+vSi
+vSi
+vSi
+vSi
+vSi
+vSi
+vSi
+kSi
+wnj
+bYr
+bYr
 wnj
 wnj
 wnj
 wnj
-iYn
-bIS
-olR
-lTN
-lTN
-dle
-lTN
-lTN
-wnj
-wUU
 wnj
 wnj
 wnj
 wnj
 wnj
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-lTN
-lTN
+wnj
+wnj
+wnj
+wnj
+wnj
 liw
 lxu
 jUY
@@ -29070,8 +28845,8 @@ gfH
 pLo
 fjU
 xFL
+xFL
 obk
-bch
 mOs
 mOs
 mOs
@@ -29155,78 +28930,78 @@ vHz
 lXk
 hEd
 gKr
+alB
+heN
+heN
+cAu
 gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-cTi
-cTi
-evp
-gKr
-gKr
-gKr
-gKr
-gKr
-gsZ
+cAu
+cAu
+cAu
+cAu
+aWb
+cAu
+cAu
+cAu
+kwk
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
 cAu
 cAu
 gsZ
+cAu
 tZS
 are
 are
 are
 are
 are
+are
+are
 mbF
-wPF
+fez
 dlV
+dpe
+xLz
+xLz
+xLz
+xvY
 wnj
 wnj
+wnj
+wnj
+wnj
+bYr
+wnj
+wUU
+wnj
+wnj
+wnj
+wnj
+uUv
+lTN
+lTN
+lTN
+wnj
+lTN
+lTN
+lTN
+wnj
 lTN
 lTN
 lTN
 lTN
-jNj
-lTN
-mOs
-mOs
-mOs
-lTN
-lTN
-lTN
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-lTN
+wnj
 dIO
 uiZ
 qpS
@@ -29247,8 +29022,8 @@ oUK
 wit
 caQ
 xFL
-obk
-bch
+xFL
+wit
 bck
 mOs
 mOs
@@ -29291,7 +29066,7 @@ abc
 abc
 abc
 abc
-abc
+kLK
 eoT
 eoT
 abc
@@ -29331,35 +29106,33 @@ wyB
 lXk
 lXk
 hEd
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
 alB
 gKr
-gKr
-gKr
-gKr
-gKr
-gKr
+cAu
+gsZ
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+kwk
+cAu
+cAu
+cAu
+cAu
 cAu
 cAu
 cAu
@@ -29371,10 +29144,28 @@ are
 are
 are
 are
+are
+are
 iAe
 qpS
+dpe
+xLz
+xLz
+xLz
+xvY
 wnj
 wnj
+wnj
+uUv
+lTN
+lTN
+lTN
+wnj
+wnj
+lTN
+wnj
+lTN
+lTN
 lTN
 mOs
 mOs
@@ -29386,24 +29177,8 @@ mOs
 mOs
 mOs
 mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
+lTN
+lTN
 iYn
 bIS
 olR
@@ -29424,8 +29199,8 @@ xFL
 xFL
 xFL
 xFL
-obk
-bch
+xFL
+gRt
 mOs
 mOs
 mOs
@@ -29508,49 +29283,64 @@ mJR
 lXk
 lXk
 hEd
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
 alB
 gKr
-gKr
-gKr
-gKr
-gKr
-gKr
+cAu
+cAu
+cAu
+cAu
+gsZ
+cAu
+cAu
+evp
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+aWb
+cAu
+cAu
+cAu
 cAu
 cAu
 cAu
 cAu
 tZS
 are
+are
+are
 fUp
 are
 are
 are
 are
-pZJ
+gBt
 qpS
-tZa
+kSi
+xLz
+rtU
+puA
+kSi
+wnj
+wnj
+wnj
+lTN
+mOs
+mOs
+lTN
+lTN
+lTN
+wnj
+wnj
 mOs
 mOs
 mOs
@@ -29565,23 +29355,8 @@ mOs
 mOs
 mOs
 mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
+lTN
+lTN
 wnj
 wUU
 wnj
@@ -29601,8 +29376,8 @@ edi
 edi
 ocU
 wUH
-obk
-bch
+xFL
+gRt
 mOs
 mOs
 mOs
@@ -29685,48 +29460,65 @@ wyB
 lXk
 lXk
 hEd
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
 alB
 gKr
-gKr
-gKr
-gKr
-gKr
+cAu
+cAu
+cAu
+cAu
+lSR
+lSR
+evp
+evp
+evp
+gsZ
+cAu
+gsZ
+cAu
+cAu
+gsZ
+cAu
+blH
+cAu
+aWb
+gsZ
+cAu
+cAu
+cAu
+cAu
+gsZ
 cAu
 cAu
 cAu
 cAu
 tZS
 are
+are
+are
 aoC
 are
 are
 are
 aXW
-pZJ
+gBt
 qpS
+dpe
+xLz
+xLz
+xLz
+xvY
+wnj
+wnj
+lTN
+mOs
+mOs
+mOs
+mOs
+mOs
+ttW
+wnj
+ttW
+ttW
 mOs
 mOs
 mOs
@@ -29741,24 +29533,7 @@ mOs
 mOs
 mOs
 mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
+lTN
 wnj
 wnj
 bYr
@@ -29778,8 +29553,8 @@ xFL
 xFL
 sqa
 njd
-obk
-bch
+xFL
+gRt
 mOs
 mOs
 mOs
@@ -29862,39 +29637,37 @@ mJR
 lXk
 hEd
 hEd
-gKr
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
 alB
 gKr
-gKr
+cAu
+cAu
+cAu
+lSR
+lSR
 evp
-gKr
+evp
+evp
+evp
+aWy
+cAu
+cAu
+cAu
+fRf
+blH
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
 cAu
 xrX
-cAu
-cAu
 tZS
 are
 are
@@ -29902,50 +29675,52 @@ are
 are
 are
 are
-pZJ
+are
+are
+gBt
 qpS
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
+dpe
+xLz
+xLz
+xLz
+xvY
+wnj
 wnj
 mOs
+mOs
+mOs
+mOs
+mOs
+mOs
+mOs
+ttW
+wnj
+wnj
+mOs
+mOs
+mOs
+mOs
+mOs
+mOs
+mOs
+mOs
+mOs
+mOs
+mOs
+mOs
+mOs
+mOs
+lTN
+wnj
+wnj
 wnj
 kSi
 vSi
-vSi
-vSi
 kSi
-vSi
-vSi
+xLz
+xLz
+xLz
+kSi
 vSi
 vSi
 kSi
@@ -29955,8 +29730,8 @@ eOh
 wit
 ffO
 xFL
-obk
-bch
+xFL
+wit
 mOs
 mOs
 mOs
@@ -30039,48 +29814,65 @@ hEd
 hEd
 hEd
 gKr
-gKr
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
 alB
 gKr
-gKr
+cAu
+cAu
+cAu
+lSR
 evp
-gKr
+evp
+evp
+evp
 cAu
-gsZ
 cAu
 cAu
+cAu
+cAu
+cAu
+blH
+blH
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+aWb
+cAu
+cAu
+cAu
+cAu
+cAu
+gJD
 tZS
 are
 are
 are
 are
 are
+are
+are
 fUp
-llX
+gBt
 auH
+sYh
+nny
+nny
+nny
+aWH
+avd
+mOs
+mOs
+mOs
+mOs
+mOs
+mOs
+mOs
+mKd
+ePq
+sVv
+eSF
 mOs
 mOs
 mOs
@@ -30093,47 +29885,30 @@ mOs
 mOs
 mOs
 mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-liw
-lxu
-jUY
-wnj
-wnj
-mOs
-mOs
-mOs
-mOs
-mOs
+yiV
+eyo
+yiV
+yiV
+yiV
+flD
+sVv
+eSF
+gMO
+xFL
+xFL
+xFL
+gRt
 bch
 bch
 bch
 bch
-gjH
+bch
+bch
+gMO
 syE
 xFL
-hRR
-vGi
+xFL
+kQA
 vXZ
 mOs
 mOs
@@ -30182,10 +29957,10 @@ abc
 abc
 abc
 abc
+kLK
 abc
 abc
-abc
-abc
+kLK
 eoT
 gKr
 gKr
@@ -30216,48 +29991,65 @@ gKr
 gKr
 gKr
 gKr
-gKr
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
 alB
-gKr
-gKr
+lSR
+cAu
+gsZ
+cAu
+lSR
 evp
-gKr
+evp
+evp
+evp
 cAu
 cAu
 cAu
+syU
+frw
+xzu
+frw
+frw
+rPZ
+hNQ
+hyF
+frw
+frw
+frw
+frw
+eBw
 cAu
-tZS
+cAu
+gsZ
+cAu
+tga
 are
 are
 are
 are
 are
 are
-llX
-auH
+are
+are
+are
+gBt
+qIR
+sYh
+nny
+nny
+nny
+aWH
+auJ
+mOs
+mOs
+mOs
+mOs
+mOs
+mOs
+avd
+wPF
+tlt
+tRD
+lUT
 mOs
 mOs
 mOs
@@ -30269,48 +30061,31 @@ mOs
 mOs
 mOs
 mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-gjH
-wUH
-obk
-mQx
-cQj
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-vXZ
+yiV
+eyo
+yiV
+yiV
+oZt
+yiV
+jyt
+cMv
+vAe
+gMO
+fjU
+caQ
+xFL
+gRt
+bch
+bch
+bch
+bch
+vGi
 vGi
 obn
-lqJ
-hUU
-uaf
-vGi
+ffO
+caQ
+xFL
+kQA
 vXZ
 mOs
 mOs
@@ -30393,49 +30168,65 @@ gKr
 evp
 evp
 evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
+cTi
+lSR
+cAu
+cAu
+cAu
 evp
 evp
 evp
 evp
 evp
-evp
-evp
-gKr
-alB
-gKr
-evp
-gKr
+cAu
+cAu
+cAu
+biV
+mvX
+hRy
+hRy
+mvX
+cIE
+jCh
+fvs
+hRy
+hRy
+pRC
+dGl
+gQl
 cAu
 cAu
 cAu
 cAu
-tZS
-are
-fUp
-are
-are
-are
-are
-llX
-lGv
-avd
+mZo
+qbR
+xZG
+qbR
+qbR
+xkb
+odE
+qbR
+xZG
+qbR
+odE
+tZa
+csH
+obc
+tlt
+nny
+csH
+auJ
+mOs
+mOs
+mOs
+mOs
+mOs
+mOs
+fKd
+qWF
+sdf
+yda
+gdw
 mOs
 mOs
 mOs
@@ -30446,48 +30237,32 @@ mOs
 mOs
 mOs
 mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mzD
-wTp
-neQ
+eyo
+yiV
+yiV
+yiV
+yiV
+yiV
+yiV
+eSt
+tIo
+yiV
+hlK
+hlK
+hlK
+hlK
+hlK
 bch
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
 bch
-vGi
-bFr
+bch
+bch
+gfH
 jBQ
-bch
-bch
+obn
+ffO
+xFL
+xFL
+gRt
 bch
 mOs
 mOs
@@ -30570,64 +30345,64 @@ gKr
 evp
 evp
 evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
-gKr
-alB
-gKr
-evp
-gKr
-gKr
+cTi
+xFQ
 cAu
 cAu
 cAu
-tZS
-are
-are
-are
-are
-are
-are
-llX
-auH
+evp
+evp
+evp
+evp
+evp
+gsZ
+cAu
+cAu
+biV
+jnE
+rxF
+gVt
+hRy
+gYV
+mQZ
+nwe
+rWi
+aQV
+rxF
+nlg
+wdN
+cAu
+cAu
+cAu
+cAu
+jxU
+odE
+qFz
+xZG
+xZG
+xHS
+aWz
+xZG
+xZG
+kBt
+aWz
+evm
+nny
+nny
+nny
+nny
+aWH
+auJ
+mOs
+mOs
+mOs
+mOs
+mOs
+mOs
 avd
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
+fKd
+fKd
+yiV
 mOs
 mOs
 mxb
@@ -30638,33 +30413,33 @@ mxb
 mOs
 mOs
 mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-rwU
-bcz
+eyo
+yiV
+oZt
+yiV
+iaA
+yiV
+yiV
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
 bch
-vwq
-tlk
-mOs
-mnT
-mnT
-cQj
-cQj
 bch
-bch
-bch
-bch
-bch
-qVt
-bch
-bcz
-bch
+wit
+ffO
+xFL
+xFL
+wit
 xgM
 mOs
 mOs
@@ -30747,62 +30522,62 @@ gKr
 gKr
 gKr
 gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
 alB
-gKr
-gKr
-gKr
+lSR
 cAu
 cAu
-gsZ
-tZS
-cNT
-are
-are
-are
-are
-fUp
-llX
-auH
+cAu
+evp
+evp
+evp
+evp
+evp
+cAu
+cAu
+cAu
+mcn
+hRy
+nlg
+hRy
+rIN
+eHL
+uzD
+qzi
+jeF
+nlg
+nlg
+hRy
+wdN
+cAu
+cAu
+cAu
+cAu
+ldV
+kCI
+odE
+odE
+odE
+wFb
+alD
+odE
+odE
+odE
+xHS
+vqK
+pCF
+nny
+nny
+nny
+aWH
 avd
-mOs
-mOs
-mOs
-mOs
-mOs
 mOs
 mOs
 jxI
 jxI
 avd
-avd
-avd
-avd
+auJ
+auJ
+auJ
 iPh
 yiV
 nKS
@@ -30818,30 +30593,30 @@ yiV
 yiV
 yiV
 yiV
-mOs
-mOs
-mOs
-mOs
-mnT
-vFO
-jig
-mIe
-vwq
-mOs
-mOs
-mOs
-wit
-rwU
-vFO
+yiV
+yiV
+oZt
+yiV
 hlK
-wit
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
 bch
-jQy
-jig
-aXL
-jwy
 bch
-bch
+gMO
+ffO
+xFL
+xFL
+gRt
 bch
 mOs
 mOs
@@ -30924,54 +30699,54 @@ gKr
 gKr
 gKr
 gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
 alB
-gKr
-gKr
-gKr
+lSR
 cAu
 cAu
 cAu
-tZS
-are
-cNT
-are
-are
-are
-are
-hNQ
-auH
+evp
+evp
+evp
+evp
+evp
+cAu
+aWb
+cAu
+biV
+pxs
+rxF
+cBi
+vzE
+cBi
+hRy
+byN
+psK
+hRy
+nlg
+hRy
+wdN
+cAu
+gsZ
+cAu
+cAu
+jxU
+odE
+wFb
+aWz
+odE
+odE
+xHS
+wFb
+odE
+alD
+wFb
+xQz
+wIo
+nny
+nny
+nny
+aWH
 avd
-mOs
-mOs
-mOs
-mOs
-mOs
 mOs
 jxI
 jxI
@@ -30981,44 +30756,44 @@ avd
 avd
 yft
 avd
-flD
-sVv
-sVv
-sVv
-sVv
-sVv
-sVv
-lkH
-eSF
-qEO
-qEO
-mxb
-gqy
-qEO
 yiV
-mOs
-mOs
-mOs
-ulX
-gjH
-eyK
-xFL
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
+yiV
+yiV
+yiV
+yiV
+yiV
+yiV
+yiV
+yiV
+yiV
+yiV
+yiV
+yiV
+yiV
+oZt
+yiV
+yiV
+yiV
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
 bch
 bch
-gjH
-fjU
+pae
 ffO
-mPA
-jwy
-bch
+xFL
+xFL
+gRt
 bch
 mOs
 mOs
@@ -31101,54 +30876,54 @@ gKr
 gKr
 gKr
 gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
 alB
-gKr
-gKr
-gKr
+lSR
+gsZ
+cAu
+evp
+evp
+evp
+evp
+evp
+evp
 cAu
 cAu
 cAu
-tZS
-are
-are
-are
-are
-are
-are
-mQZ
-pNZ
+wjP
+jnE
+nlg
+ciD
+mvX
+aSm
+mZB
+bCB
+hRy
+bJd
+nlg
+nlg
+hRy
+cAu
+cAu
+cAu
+cAu
+ldV
+odE
+qFz
+xZG
+xZG
+aLd
+odE
+gxf
+xZG
+kBt
+odE
+mhd
+nny
+nny
+tlt
+nny
+aWH
 avd
-jxI
-avd
-avd
-mOs
-mOs
 jxI
 jxI
 avd
@@ -31157,45 +30932,45 @@ avd
 avd
 aEz
 iPh
-uLT
-vuK
-qwQ
-hQs
-hQs
-hQs
-hQs
-hQs
-crZ
-wpf
-sVv
-sVv
-sVv
-lkH
-eSF
+xMw
+yiV
+yiV
+yiV
+yiV
+yiV
 nKS
-mOs
-mOs
-mOs
-ulX
-gjH
-xFL
-xFL
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-dKw
+yiV
+yiV
+yiV
+yiV
+yiV
+iaA
+yiV
+yiV
+yiV
+yiV
+yiV
+yiV
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
 bch
-gjH
-xFL
+bch
+gMO
 ffO
+caQ
 xFL
-obk
-bch
+gRt
 bch
 bck
 mOs
@@ -31243,7 +31018,7 @@ abc
 abc
 abc
 abc
-abc
+kLK
 dqp
 abc
 abc
@@ -31278,101 +31053,101 @@ evp
 evp
 evp
 evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
+cTi
+lSR
+cAu
+cAu
 evp
 evp
 evp
 evp
 evp
 evp
-evp
-gKr
-gKr
-alB
-evp
-evp
-gKr
 cAu
 cAu
 cAu
-fCG
-bre
-are
-fUp
-are
-are
-cLP
-mXs
-hyH
-jxI
-jxI
-jxI
-jxI
-fJQ
-jxI
+wjP
+kiZ
+jnE
+qWj
+flG
+ixN
+bdH
+wLZ
+jgG
+tpN
+nlg
+jCh
+nlg
+cAu
+cAu
+cAu
+cAu
+rHw
+qbR
+qbR
+qbR
+odE
+qbR
+qbR
+qbR
+qbR
+xZG
+odE
+hgP
+lSc
+mnA
+mnA
+mnA
+csH
+avd
 jxI
 avd
 avd
 avd
-iPh
 avd
 avd
-uLT
-uNG
-qwQ
-wEq
-xSn
-xSn
-utH
-xSn
-pNy
-sjH
-hQs
-hQs
-hQs
-hQs
-crZ
-wpf
+avd
+avd
+avd
+flD
+sVv
+sVv
+sVv
+sVv
+sVv
+sVv
+lkH
 eSF
-mOs
-mOs
-mOs
-gSs
-gjH
+qEO
+qEO
+mxb
+gqy
+qEO
+yiV
+yiV
+yiV
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+oUK
+wit
+ffO
 xFL
-njd
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-bch
-mnT
-bch
-mzD
-jya
-sqa
 xFL
-obk
-bch
+wit
 bch
 bck
 mOs
@@ -31413,7 +31188,7 @@ gKr
 gKr
 gKr
 abc
-abc
+kLK
 abc
 abc
 abc
@@ -31455,49 +31230,49 @@ cTi
 evp
 evp
 evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
+cTi
+lSR
+cAu
+cAu
 evp
 evp
 evp
 evp
 evp
 evp
-evp
-gKr
-gKr
-nwU
-evp
-evp
-gKr
 gsZ
 cAu
 cAu
+wjP
+hRy
+rxF
+mXs
+cEi
+bCB
+bNp
+fWV
+nlg
+htS
+jnE
+hRy
+hRy
+blH
 cAu
-gRT
-bre
+gsZ
+cAu
+tga
+are
+are
+are
+are
+are
+are
 are
 are
 are
 gBt
-obc
-kYP
-iuG
+aQr
+auH
 avd
 avd
 avd
@@ -31507,49 +31282,49 @@ yft
 avd
 avd
 avd
+avd
+xMw
+avd
 uLT
 aWF
-aWF
-klc
-rKR
-rLd
-xSn
-xSn
-xSn
-xSn
-pNy
-xSn
-xSn
-utH
-xSn
-xSn
-xSn
-sjH
-eUP
-meC
+vuK
+qwQ
+hQs
+hQs
+hQs
+hQs
+hQs
+crZ
+wpf
+sVv
+sVv
+sVv
+lkH
+eSF
+fCG
 yiV
-mOs
-gSs
-gSs
-gjH
-njd
-eUz
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-mOs
-bch
-wit
-wit
-bch
-mzD
-brw
-wTp
-dKx
-bch
+yiV
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+xFL
+xFL
+ffO
+xFL
+xFL
+gRt
 bck
 bck
 mOs
@@ -31590,7 +31365,7 @@ gKr
 gKr
 gKr
 abc
-kLK
+abc
 abc
 abc
 abc
@@ -31632,101 +31407,101 @@ cTi
 evp
 evp
 evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-nwU
-evp
-evp
-gKr
-xrX
+cTi
+lSR
 cAu
 cAu
 cAu
-xrX
+evp
+evp
+evp
+evp
+evp
+cAu
+cAu
+blH
+biV
+nlg
+hRy
+rxF
+cvf
+hRy
+hRy
+nlg
+mvX
+hRy
+nlg
+hRy
+wdN
+blH
+cAu
+cAu
+cAu
+aVq
 tZS
 are
 are
 are
+are
+are
+are
+are
+are
 mbF
-joc
 hBg
 auH
 avd
 avd
-avd
+xMw
 avd
 yft
 avd
 avd
 tku
-uLT
-tSg
-rKR
-joc
-joc
-qwK
+avd
+rvn
+aWF
+aWF
+klc
+lcm
+qwQ
+wEq
 xSn
-xSn
-xSn
-uBF
-xSn
-xSn
-xSn
-xSn
-xSn
-xSn
-ncx
 xSn
 utH
-jBk
-vAe
+xSn
+pNy
+sjH
+hQs
+hQs
+hQs
+hQs
+crZ
+wpf
+dvU
 yiV
 yiV
-ezy
-flD
-mld
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+rqK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+caQ
 xFL
-vXZ
-mOs
-mOs
-mOs
-mOs
-jig
-jwy
-rlF
-bch
-cQj
-xoI
-wCh
-bck
-iwB
-rqn
-bch
-bck
+ffO
+xhU
+xFL
+gRt
 bck
 mOs
 mOs
@@ -31770,7 +31545,7 @@ abc
 abc
 abc
 abc
-kLK
+abc
 abc
 eoT
 eoT
@@ -31809,37 +31584,33 @@ cTi
 evp
 evp
 evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
+cTi
+lSR
+cAu
+cAu
+cAu
 evp
 evp
 evp
 evp
 evp
-evp
-evp
-gKr
-gKr
-nwU
-evp
-evp
-gKr
-gKr
+cAu
+cAu
+cAu
+biV
+hRy
+nlg
+hRy
+acL
+xUK
+oRC
+xUK
+odG
+hRy
+nlg
+cEi
+wdN
+cAu
 cAu
 cAu
 cAu
@@ -31849,7 +31620,11 @@ are
 are
 are
 are
-kXK
+are
+are
+are
+are
+are
 llX
 kYP
 aWF
@@ -31859,51 +31634,51 @@ aWF
 aWF
 iuG
 avd
-iPh
-xWM
-sup
-gpn
-kXK
-kXK
-kXK
-nlg
-xSn
-uBF
-xSn
-xSn
-uBF
+avd
+rvn
+iyN
+rKR
+joc
+joc
+joc
+rLd
 xSn
 xSn
 xSn
-fWV
+xSn
+pNy
+xSn
+xSn
+utH
 xSn
 xSn
 xSn
-jBk
+sjH
+eUP
 meC
 yiV
 ixs
-yiV
-jyt
-fjU
-qHh
-vXZ
-mOs
-mOs
-mOs
-xhU
-jgF
-obk
-cQj
-rqn
-bch
-mVF
-bch
-bck
-eSt
-bch
-bch
-bck
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+xFL
+xFL
+ffO
+xFL
+xFL
+kez
 mOs
 mOs
 mOs
@@ -31945,11 +31720,11 @@ gKr
 gKr
 abc
 abc
+abc
+abc
 kLK
 abc
 abc
-abc
-abc
 eoT
 eoT
 eoT
@@ -31958,7 +31733,7 @@ abc
 eoT
 abc
 eoT
-abc
+kLK
 abc
 eoT
 eoT
@@ -31986,47 +31761,47 @@ cTi
 evp
 evp
 evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-nwU
-evp
-evp
-gKr
-gKr
-cAu
-cAu
+cTi
+lSR
 cAu
 gsZ
+cAu
+cAu
+evp
+evp
+evp
+evp
+cAu
+cAu
+blH
+biV
+nlg
+bSS
+nlg
+hRy
+aQV
+jnE
+hRy
+hRy
+flG
+uNG
+mvX
+llQ
+cAu
+cAu
+cAu
+cAu
+cAu
 tZS
 are
 are
 are
+are
+are
+are
+are
 fUp
-kXK
+are
 fXB
 joc
 joc
@@ -32038,9 +31813,9 @@ kYP
 aWF
 aWF
 tSg
-aCY
+sup
+gpn
 kXK
-sZq
 kXK
 kXK
 xSn
@@ -32057,30 +31832,30 @@ pNy
 xSn
 mlR
 jBk
-pyH
-mxb
+vAe
 yiV
 yiV
-jyt
-hZF
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+eOh
+fXn
+ffO
+caQ
 xFL
-hRR
-mOs
-mOs
-vKT
-xFL
-qRV
-nSN
-bch
-mOs
-bch
-jQy
-jig
-jwy
-qVt
-qqT
-jBQ
-bck
+fXn
 mOs
 mOs
 mOs
@@ -32129,7 +31904,7 @@ abc
 abc
 abc
 abc
-abc
+kLK
 bZr
 abc
 eoT
@@ -32163,38 +31938,34 @@ alB
 gKr
 gKr
 gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-nwU
-gKr
-gKr
-gKr
-gKr
+alB
+lSR
 cAu
+cAu
+cAu
+cAu
+cAu
+evp
+evp
+evp
+cAu
+cAu
+cAu
+biV
+hRy
+jnE
+swH
+dGl
+jnE
+jCh
+hRy
+nlg
+hRy
+aSm
+eLz
+wdN
+cAu
+gsZ
 cAu
 cAu
 cAu
@@ -32203,7 +31974,11 @@ are
 are
 are
 are
-kXK
+are
+are
+are
+are
+are
 kXK
 bPe
 kXK
@@ -32234,30 +32009,30 @@ xSn
 xSn
 vaT
 cCI
-sfH
-mOs
-hNZ
+vAe
 yiV
-wmU
-vXZ
-wLL
-uaf
-onf
-mOs
-mOs
-fjU
-xFL
-nSN
-mOs
+yiV
+yiV
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
 bch
-mnT
-gjH
-caQ
+bch
 pae
-qVt
-bch
-bch
-bch
+ffO
+xFL
+xFL
+gRt
 mQx
 mOs
 mOs
@@ -32339,38 +32114,34 @@ gKr
 alB
 gKr
 gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-nwU
-gKr
-gKr
-gKr
-gKr
+luP
+luP
+uAl
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+evp
+evp
+gsZ
+cAu
+cAu
+fJQ
+vdn
+hei
+hei
+hei
+cPY
+cPY
+fxa
+hei
+hei
+hnK
+hei
+pVN
+cAu
 cAu
 cAu
 cAu
@@ -32380,7 +32151,11 @@ are
 are
 are
 are
-wWI
+are
+are
+are
+are
+aXW
 kXK
 kXK
 kXK
@@ -32411,30 +32186,30 @@ utH
 xSn
 jBk
 ylq
-pyH
-mOs
-mOs
+vAe
 yiV
-wmU
-mOs
-mOs
-cQj
-bch
-mQx
-mOs
-mOs
-wTp
-eJu
-mOs
-mOs
-mnT
-mzD
-dGU
-dKx
-qVt
-rlF
+yiV
+yiV
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
 bch
 bch
+gMO
+ffO
+xFL
+xFL
+gRt
 bch
 mOs
 mOs
@@ -32516,48 +32291,48 @@ gKr
 alB
 gKr
 gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-nwU
-gKr
-gKr
-gKr
-gKr
+aIm
+aIm
+kfX
+cAu
+cAu
+cAu
+cAu
 gsZ
+cAu
+cAu
+cAu
+cAu
+aWb
+cAu
+cAu
+cAu
+cAu
+blH
+blH
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
 cAu
 cAu
 cAu
 tZS
 are
+are
+are
+are
+are
 fUp
 are
 aoC
-hma
+cLP
 leN
 mhb
 kXK
@@ -32588,30 +32363,30 @@ xSn
 xSn
 jBk
 rct
-pyH
+vAe
 yiV
-mOs
 yiV
-fDk
-mOs
-mOs
-mKo
-bcz
-btY
-mQx
-mOs
-vXZ
-vXZ
-mOs
-mOs
+yiV
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
 hlK
 bch
-bch
-bch
-qVt
-vgb
-mOs
-vgb
+eyK
+gMO
+ffO
+xFL
+xFL
+gRt
 bch
 mOs
 mOs
@@ -32653,7 +32428,7 @@ gKr
 gKr
 gKr
 gKr
-kLK
+abc
 abc
 abc
 eoT
@@ -32694,47 +32469,47 @@ alB
 gKr
 aIm
 aIm
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-nwU
-evp
-evp
-gKr
+aIm
+aIm
+kfX
+cAu
 gKr
 cAu
 cAu
 cAu
+cAu
+cAu
+cAu
+aWy
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+gsZ
 cAu
 tZS
 are
 are
 are
 are
-llX
+are
+are
+are
+are
+gBt
 lcm
 tYg
 nyl
@@ -32765,30 +32540,30 @@ xSn
 mlR
 jBk
 vwZ
-pyH
+vAe
 yiV
-mOs
+nKS
 yiV
-raB
-mOs
-mOs
-mOs
-mOs
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
+hlK
 bch
 bch
-iNk
-hFf
-vXZ
-mOs
-bch
-bch
-bch
-bck
-bck
-qVt
-mOs
-mOs
-bch
+fXn
+ffO
+xFL
+xFL
+wit
 bch
 mOs
 mOs
@@ -32832,7 +32607,7 @@ gKr
 gKr
 abc
 abc
-abc
+kLK
 eoT
 eoT
 eoT
@@ -32857,7 +32632,7 @@ bfR
 oJP
 bfR
 bfR
-bfR
+tpS
 bfR
 bfR
 bfR
@@ -32874,44 +32649,44 @@ aIm
 aIm
 aIm
 ifX
-gKr
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-nwU
-evp
-evp
+alB
+alB
+alB
 gKr
 gKr
 cAu
+gsZ
 cAu
 cAu
-xrX
+gsZ
+cAu
+cAu
+cAu
+cAu
+gsZ
+cAu
+cAu
+aWb
+cAu
+gsZ
+cAu
+cAu
+cAu
+gsZ
+cAu
+cAu
+cAu
+cAu
 tZS
 are
 are
 are
+are
+are
+are
+are
 jtm
-llX
+gBt
 slw
 omd
 tYg
@@ -32946,26 +32721,26 @@ vAe
 yiV
 yiV
 yiV
-gSs
-mnT
-mnT
-mnT
-mnT
-oZt
-jig
-jwy
-wit
-ulX
-vFO
-vFO
-wit
+yiV
 bch
-jQy
-jig
-xkr
 bch
-mOs
 bch
+hlK
+hlK
+hlK
+hlK
+hlK
+bch
+bch
+gfH
+jBQ
+bch
+bch
+gMO
+ffO
+caQ
+xFL
+gRt
 bch
 mOs
 mOs
@@ -33024,14 +32799,14 @@ abc
 kLK
 abc
 bZr
-abc
+kLK
 abc
 abc
 hXH
 bfR
 bfR
-bfR
-qjc
+tpS
+gcF
 bfR
 oJP
 bfR
@@ -33054,41 +32829,41 @@ gKr
 gKr
 gKr
 gKr
-gKr
-gKr
+alB
+alB
 evp
-evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
-gKr
-gKr
-nwU
-evp
-evp
-gKr
 gKr
 cAu
 cAu
-pVN
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+gsZ
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
 cAu
 tZS
 are
 are
 are
+are
+are
+are
+are
 sUi
-llX
+gBt
 auH
 qWF
 sdf
@@ -33121,28 +32896,28 @@ utH
 jBk
 vAe
 qEO
-yiV
-yiV
-flD
-mld
+wmU
+nwS
+nwS
+oUK
+wit
+oUK
+dKw
 xFL
-obk
+caQ
+xFL
+pyH
+oUK
 wit
-qUJ
-pXN
-obk
+oUK
+oUK
+oUK
+cYR
 wit
-jQy
-jig
-jig
-jwy
-bch
-gjH
-fjU
-aQN
-bch
-bch
-bch
+ffO
+xFL
+xFL
+gRt
 bch
 mOs
 mOs
@@ -33193,7 +32968,7 @@ eoT
 abc
 abc
 abc
-abc
+kLK
 abc
 abc
 abc
@@ -33233,29 +33008,25 @@ luP
 luP
 luP
 gKr
-evp
-evp
-evp
-evp
-evp
-evp
+cTi
 gKr
 gKr
 gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
 gKr
 gKr
-nwU
-evp
-evp
 gKr
 cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+gsZ
 cAu
 cAu
 cAu
@@ -33265,7 +33036,11 @@ are
 are
 are
 are
-llX
+are
+are
+are
+are
+gBt
 auH
 avd
 avd
@@ -33298,28 +33073,28 @@ xSn
 jBk
 vAe
 yiV
-flD
-sVv
-vuK
+eUU
+pgQ
+pgQ
 xFL
 xFL
-ckg
-dPS
-wkj
 xFL
-jtj
-jig
-nzy
+xFL
+xFL
+xFL
 xFL
 fjU
-obk
-rlF
-gjH
 xFL
-cYR
-jwy
-bch
-bch
+xFL
+fjU
+xFL
+xkr
+xFL
+xFL
+ffO
+xFL
+xFL
+gRt
 bch
 mOs
 mOs
@@ -33410,28 +33185,24 @@ luP
 ifX
 luP
 gKr
-gKr
-evp
-evp
-evp
-evp
-evp
+alB
 gKr
 gKr
 gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
 gKr
 gKr
-nwU
-evp
-evp
 gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+cAu
+cAu
+cAu
+txW
+cAu
+cAu
 cAu
 cAu
 cAu
@@ -33442,7 +33213,11 @@ are
 are
 are
 are
-llX
+are
+are
+are
+are
+gBt
 auH
 avd
 mOs
@@ -33475,28 +33250,28 @@ xJs
 cCI
 vAe
 oOu
-jyt
+eUU
 pgQ
 lJS
 xFL
-iBW
-rXz
-rXz
-rXz
-rXz
-rXz
-rXz
 xFL
-qHh
 xFL
-obk
-bch
-gjH
+caQ
+xFL
+xFL
+xFL
+xFL
+xFL
+gSs
+xFL
+xFL
+xFL
+xFL
 caQ
 ffd
-obk
-bch
-voQ
+xFL
+xFL
+fXn
 gjs
 mOs
 mOs
@@ -33538,7 +33313,7 @@ gKr
 gKr
 gKr
 gKr
-abc
+kLK
 abc
 abc
 abc
@@ -33588,6 +33363,7 @@ aIm
 vAA
 gKr
 gKr
+alB
 gKr
 gKr
 gKr
@@ -33602,24 +33378,23 @@ gKr
 gKr
 gKr
 gKr
-gKr
-gKr
-gKr
-nwU
-gKr
-gKr
-gKr
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
 gsZ
-cAu
-cAu
-cAu
-cBi
-dqK
+gRT
+bre
+are
+are
+are
 are
 are
 are
 fUp
-llX
+gBt
 auH
 mOs
 mOs
@@ -33651,30 +33426,30 @@ tFc
 tIo
 haT
 vzI
-kWv
+yiV
 eUU
-atK
+pgQ
 hSF
-rXz
+xFL
 fjU
 xFL
-rXz
-iBW
-aiv
-wmQ
-wTp
-wmQ
-wTp
-wTp
-xwr
-jBQ
-gjH
 xFL
-bRZ
-obk
-bck
-bck
-mOs
+fjU
+xFL
+qHh
+xFL
+qHh
+xFL
+xFL
+xwr
+qUJ
+xFL
+xFL
+ffO
+xFL
+xFL
+kez
+bch
 mOs
 mOs
 mOs
@@ -33765,6 +33540,7 @@ aIm
 aIm
 aIm
 gKr
+alB
 gKr
 gKr
 gKr
@@ -33779,24 +33555,23 @@ gKr
 gKr
 gKr
 gKr
-gKr
-gKr
-gKr
-nwU
 gKr
 gKr
 gKr
 cAu
 cAu
 cAu
-xrX
-bCB
+cAu
+cAu
+gRT
+bre
+are
 fUp
 are
 are
 are
 are
-iEH
+iAe
 auH
 auJ
 mOs
@@ -33826,32 +33601,32 @@ tIo
 lZJ
 gdw
 qEO
-mOs
-qEO
-jyt
-lJS
-atK
-atK
+hFf
+yiV
+oZt
+wmU
+pgQ
+pgQ
 fjU
-xFL
-xFL
-clk
-aiv
-uaf
-mOs
-bch
-bch
-bch
-mOs
-bch
-rlF
-mzD
-wTp
+wit
+eOh
+eOh
+eOh
+eOh
+eOh
+eOh
+eOh
+wit
+eOh
+eOh
+atK
+eOh
+wit
 qSA
 tmG
-vIs
-vIs
-vIs
+uaf
+lqJ
+bgw
 vIs
 vIs
 vIs
@@ -33943,6 +33718,7 @@ aIm
 ifX
 gKr
 gKr
+alB
 gKr
 gKr
 gKr
@@ -33956,24 +33732,23 @@ gKr
 gKr
 gKr
 gKr
-gKr
-gKr
-gKr
-nwU
 gKr
 gKr
 gKr
 cAu
 cAu
-xrX
-tga
-pxs
+cAu
+cAu
+cAu
+sbj
+tZS
+are
 are
 are
 aTC
 are
 cLP
-uDn
+gMu
 auH
 avd
 mOs
@@ -33998,15 +33773,15 @@ iwC
 qpo
 mbm
 lwB
-rhp
-rhp
-rhp
+ycA
+ycA
+ycA
 bAn
 lwB
-rhp
-rhp
-rhp
-xgZ
+ycA
+brw
+brw
+aZI
 xgZ
 gJI
 gaO
@@ -34014,7 +33789,7 @@ xnA
 rhp
 rhp
 jro
-mOs
+bch
 mOs
 mOs
 bch
@@ -34023,12 +33798,12 @@ mOs
 bch
 bch
 bch
-gfH
-vUy
+jya
+ffO
+xFL
+xFL
+gRt
 bch
-mOs
-mOs
-mOs
 mOs
 bch
 mOs
@@ -34119,32 +33894,32 @@ aIm
 aIm
 aIm
 gKr
-evp
-evp
-evp
-evp
-evp
+gKr
+alB
 gKr
 gKr
 gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
 gKr
 gKr
-nwU
-evp
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
 gKr
 gKr
 cAu
+gsZ
 cAu
 cAu
-bCB
-bNu
+cAu
+cAu
+tZS
+are
 are
 are
 are
@@ -34182,16 +33957,16 @@ rRx
 rRx
 rRx
 vWz
-rRx
 tSf
 tSf
+bdP
 odC
+tSf
 vWz
-kez
 tBK
 tBK
 gLd
-mOs
+bch
 mOs
 mOs
 mOs
@@ -34200,12 +33975,12 @@ mQx
 bch
 xgM
 bck
-bck
-iwB
-rlF
-bck
-mOs
-mOs
+rwU
+ffO
+xFL
+xFL
+gRt
+bch
 bch
 bch
 mOs
@@ -34297,31 +34072,31 @@ aIm
 aIm
 gKr
 gKr
-evp
-evp
-evp
-evp
+gKr
+alB
 gKr
 gKr
 gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
 gKr
 gKr
-nwU
-evp
 gKr
 gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+cAu
+cAu
+cAu
 cAu
 cAu
 gsZ
-bCB
-bNu
+tZS
+are
 are
 are
 are
@@ -34361,8 +34136,8 @@ wKQ
 wKQ
 wKQ
 wKQ
-wKQ
-wKQ
+mnT
+vbu
 wKQ
 wKQ
 hiy
@@ -34376,14 +34151,14 @@ bck
 bck
 bck
 bck
-nVy
+bck
 fXn
-qOp
-ycA
+ffO
+xFL
+xFL
+fXn
 bck
-bck
-bck
-bch
+jBQ
 bch
 mOs
 mOs
@@ -34474,31 +34249,31 @@ aIm
 aIm
 aIm
 gKr
-evp
-evp
-evp
-evp
+gKr
+alB
 gKr
 gKr
 gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
 gKr
 gKr
-nwU
-evp
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
 gKr
 gKr
 cAu
 cAu
 cAu
-bCB
-bNu
+cAu
+cAu
+cAu
+tZS
+are
 are
 are
 are
@@ -34553,12 +34328,12 @@ mOs
 bck
 bck
 bck
-gjH
-xFL
+bch
+gMO
 ffO
-mPA
-jwy
-bcz
+xFL
+xFL
+gRt
 bch
 bch
 bch
@@ -34653,29 +34428,29 @@ aIm
 gKr
 gKr
 evp
-evp
-evp
+alB
 gKr
 gKr
 gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
 gKr
 gKr
-nwU
-evp
 gKr
 gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+cAu
+cAu
 gsZ
 cAu
 cAu
-bCB
-bNu
+tZS
+are
 are
 are
 are
@@ -34730,12 +34505,12 @@ mOs
 bcz
 bch
 rlF
-gjH
-eZJ
-ffO
-xFL
-obk
 bch
+eWg
+ffO
+caQ
+xFL
+gRt
 mOs
 mOs
 bch
@@ -34763,7 +34538,7 @@ jQf
 jQf
 kFx
 kFx
-kFx
+gnk
 kFx
 kFx
 kFx
@@ -34830,29 +34605,29 @@ aIm
 aIm
 gKr
 gKr
-evp
-evp
+alB
 gKr
 gKr
 gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
 gKr
 gKr
-nwU
-evp
 gKr
-jnE
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
 cAu
 cAu
 cAu
-bCB
-bNu
+cAu
+cAu
+tZS
+are
 are
 are
 are
@@ -34907,12 +34682,12 @@ mOs
 mQx
 bch
 bch
-gjH
-caQ
+bch
+gMO
 xFE
 fjU
-obk
-bch
+xFL
+gRt
 mOs
 bch
 bch
@@ -35008,6 +34783,7 @@ aIm
 aIm
 gKr
 gKr
+alB
 gKr
 gKr
 gKr
@@ -35021,14 +34797,13 @@ gKr
 gKr
 gKr
 gKr
-nwU
 gKr
-gKr
-jnE
 cAu
-xGi
 cAu
-bCB
+cAu
+cAu
+cAu
+tZS
 are
 are
 are
@@ -35084,12 +34859,12 @@ bch
 bch
 bch
 rlF
-gjH
-xFL
+bch
+gMO
 xBB
 qHh
-obk
-bch
+xFL
+gRt
 bch
 bch
 bch
@@ -35185,6 +34960,7 @@ ifX
 aIm
 gKr
 gKr
+alB
 gKr
 gKr
 gKr
@@ -35198,7 +34974,6 @@ gKr
 gKr
 gKr
 gKr
-nwU
 gKr
 cAu
 cAu
@@ -35260,13 +35035,13 @@ mOs
 mOs
 bch
 gfH
-ncE
-gjH
-fjU
+jBQ
+bch
+pae
 xBB
 xFL
-mPA
-jwy
+xFL
+gRt
 gIu
 bch
 mOs
@@ -35363,6 +35138,7 @@ aIm
 gKr
 gKr
 gKr
+alB
 gKr
 gKr
 gKr
@@ -35375,7 +35151,6 @@ gKr
 gKr
 gKr
 gKr
-nwU
 gKr
 xrX
 cAu
@@ -35438,12 +35213,12 @@ mOs
 bch
 bch
 bch
-gjH
-xFL
+bch
+wit
 yli
 xFL
 xFL
-obk
+wit
 bcz
 bch
 mOs
@@ -35540,19 +35315,19 @@ aIm
 aIm
 gKr
 gKr
+alB
 gKr
 gKr
 gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
 gKr
 gKr
-nwU
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
 gKr
 cAu
 cAu
@@ -35609,19 +35384,19 @@ tBK
 kdu
 bch
 cQj
-mOs
+bch
 mOs
 mOs
 bck
 bch
 bch
-mzD
-jya
+bch
+gjH
 ffO
 caQ
 xFL
-obk
-bch
+jtj
+nxu
 bch
 mOs
 mOs
@@ -35718,18 +35493,18 @@ luP
 aIm
 gKr
 gKr
+alB
 gKr
 gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
 gKr
 gKr
-nwU
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
 gKr
 cAu
 cAu
@@ -35783,7 +35558,7 @@ cRC
 kYG
 uvP
 rRx
-pnb
+kdu
 gFU
 jLv
 bck
@@ -35795,10 +35570,10 @@ mOs
 ipa
 vPf
 xoE
-wTp
-wTp
-dKx
-bch
+xFL
+xFL
+xFL
+obk
 bch
 mOs
 mOs
@@ -35895,17 +35670,17 @@ aIm
 ifX
 gKr
 gKr
+alB
 gKr
 gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
 gKr
-nwU
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
 gKr
 gKr
 cAu
@@ -35961,7 +35736,7 @@ mFI
 uvP
 rRx
 mOs
-bch
+cQj
 jro
 bch
 mOs
@@ -35970,13 +35745,13 @@ bck
 mOs
 mOs
 qVt
-jQy
-jtY
-jwy
-mQx
-jQy
-jig
-jwy
+mzD
+vMu
+xFL
+qHh
+xFL
+obk
+bch
 bch
 bch
 mQx
@@ -36034,7 +35809,7 @@ gnk
 kFx
 jQf
 kFx
-kFx
+gnk
 kFx
 aym
 aym
@@ -36073,16 +35848,16 @@ aIm
 aIm
 gKr
 gKr
+alB
 gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
 gKr
-nwU
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
 gKr
 gsZ
 cAu
@@ -36147,13 +35922,13 @@ bck
 bch
 bch
 qVt
-mCb
-wit
+mQx
+gjH
+xFL
+xFL
+xFL
 obk
 bch
-gjH
-wit
-obk
 mOs
 bch
 bch
@@ -36250,16 +36025,16 @@ aIm
 aIm
 luP
 gKr
+alB
 gKr
-evp
-evp
-evp
-evp
-evp
-evp
-evp
 gKr
-nwU
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
+gKr
 gKr
 cAu
 cAu
@@ -36324,13 +36099,13 @@ qTs
 qTs
 qTs
 wyg
-mzD
-wTp
-dKx
 bch
-mzD
-wTp
-dKx
+gjH
+xFL
+xFL
+xFL
+obk
+bch
 bch
 bch
 bch
@@ -36428,6 +36203,7 @@ aIm
 luP
 luP
 gKr
+alB
 gKr
 gKr
 gKr
@@ -36435,7 +36211,6 @@ gKr
 gKr
 gKr
 gKr
-nwU
 gKr
 gKr
 cAu
@@ -36605,6 +36380,7 @@ aIm
 aIm
 luP
 gKr
+alB
 gKr
 gKr
 gKr
@@ -36612,7 +36388,6 @@ gKr
 gKr
 gKr
 gKr
-nwU
 gKr
 cAu
 xrX
@@ -36673,7 +36448,7 @@ yaB
 gQX
 wbt
 hmG
-mOs
+bch
 bch
 xOT
 xOT
@@ -36782,6 +36557,7 @@ ifX
 aIm
 luP
 gKr
+alB
 gKr
 gKr
 gKr
@@ -36789,7 +36565,6 @@ gKr
 gKr
 gKr
 gKr
-nwU
 gKr
 xrX
 cAu
@@ -36846,11 +36621,11 @@ uej
 uvP
 jkz
 edz
-tSf
+vWz
 jdL
 qOp
-mOs
-mOs
+jig
+nxu
 bch
 xOT
 xOT
@@ -36959,13 +36734,13 @@ aIm
 aIm
 luP
 gKr
+alB
 gKr
 gKr
 gKr
 gKr
 gKr
 gKr
-nwU
 gKr
 gKr
 xVG
@@ -37022,12 +36797,12 @@ vEW
 hIe
 vbu
 hiy
-rqK
+ybc
 yaB
 xQg
 xBB
-mOs
-mOs
+xFL
+obk
 bch
 xOT
 xOT
@@ -37092,7 +36867,7 @@ kFx
 jsp
 kFx
 aax
-kFx
+gnk
 kFx
 kFx
 gnk
@@ -37136,13 +36911,13 @@ aIm
 aIm
 luP
 gKr
+alB
 gKr
 gKr
 gKr
 gKr
 gKr
 gKr
-nwU
 gKr
 xVG
 xVG
@@ -37203,8 +36978,8 @@ ybc
 yaB
 mOO
 xBB
-xFL
-mOs
+bcd
+obk
 leQ
 xOT
 xOT
@@ -37313,12 +37088,12 @@ vAA
 aIm
 luP
 gKr
+alB
 gKr
 gKr
 gKr
 gKr
 gKr
-nwU
 gKr
 gKr
 xVG
@@ -37376,12 +37151,12 @@ srR
 vvX
 uoM
 pQz
-rqK
+ybc
 yaB
 mOO
 xBB
 xFL
-obk
+jtj
 xOT
 xOT
 xOT
@@ -37490,12 +37265,12 @@ aIm
 aIm
 luP
 gKr
+alB
 gKr
 gKr
 gKr
 gKr
 gKr
-nwU
 gKr
 xVG
 xVG
@@ -37554,11 +37329,11 @@ eek
 uvP
 cnX
 cmk
-tSf
+vWz
 xzw
 xBB
 iBW
-obk
+xFL
 xOT
 xOT
 xOT
@@ -37628,7 +37403,7 @@ kFx
 kFx
 kFx
 kFx
-kFx
+gnk
 kFx
 kFx
 kFx
@@ -37667,11 +37442,11 @@ aIm
 ifX
 luP
 luP
+alB
 gKr
 gKr
 gKr
 gKr
-nwU
 gKr
 gKr
 xVG
@@ -37735,7 +37510,7 @@ tSf
 gQX
 vzW
 rTU
-reX
+rTU
 xOT
 xOT
 xOT
@@ -37844,11 +37619,11 @@ aIm
 aIm
 aIm
 luP
+alB
 gKr
 gKr
 gKr
 gKr
-nwU
 gKr
 xVG
 xVG
@@ -37912,7 +37687,7 @@ mOs
 jro
 hfr
 iBW
-hRR
+rXz
 xOT
 xOT
 xOT
@@ -38021,10 +37796,10 @@ ifX
 aIm
 aIm
 luP
+alB
 gKr
 gKr
-nwU
-nwU
+gKr
 gKr
 gKr
 xVG
@@ -38088,8 +37863,8 @@ mOs
 bch
 fLY
 hfr
-mOs
-hRR
+xFL
+aiv
 xOT
 xOT
 xOT
@@ -38198,8 +37973,8 @@ aIm
 aIm
 ifX
 luP
+alB
 gKr
-nwU
 gKr
 gKr
 gKr
@@ -38265,8 +38040,8 @@ mOs
 bch
 jro
 qXi
-mOs
-mOs
+wTp
+tfy
 tuX
 xOT
 xOT
@@ -38383,7 +38158,7 @@ xVG
 qbo
 xVG
 xVG
-kUr
+sYy
 bpJ
 boA
 dqK
@@ -38442,8 +38217,8 @@ mOs
 mOs
 jro
 bck
-mOs
-mOs
+bch
+bch
 bcz
 xOT
 xOT
@@ -38560,7 +38335,7 @@ xVG
 xVG
 xVG
 xVG
-vTe
+xVG
 tZS
 are
 are
@@ -38620,7 +38395,7 @@ mOs
 jro
 bch
 bck
-mOs
+bch
 bch
 xOT
 xOT
@@ -38682,7 +38457,7 @@ gKr
 gKr
 gKr
 gKr
-kFx
+gnk
 kFx
 kFx
 gnk
@@ -38736,7 +38511,7 @@ xVG
 xVG
 xVG
 xVG
-vTe
+xVG
 bpJ
 dqK
 are
@@ -38796,9 +38571,9 @@ mOs
 mOs
 jro
 bch
+nVy
 bch
-mOs
-bch
+bck
 xOT
 xOT
 xOT
@@ -38941,11 +38716,11 @@ avd
 avd
 aJX
 avd
-qWF
-bry
-sdf
-sdf
-sdf
+xWM
+obc
+nny
+nny
+yiU
 sdf
 bry
 sdf
@@ -38973,13 +38748,13 @@ mOs
 cQj
 jro
 bch
-bck
-bck
+mIe
+mIe
 bch
 bch
 bcz
 bch
-bcz
+voQ
 xOT
 xOT
 xOT
@@ -39151,13 +38926,13 @@ rhp
 upO
 bch
 diR
+mIe
 bck
-gjs
 bch
 bch
+mIe
 bch
-bch
-wit
+gMO
 xFL
 nAu
 xFL
@@ -39328,11 +39103,11 @@ mOs
 mOs
 bck
 diR
+mIe
 bck
-bch
-bch
-bch
-bch
+mPA
+mIe
+mIe
 bch
 gMO
 xFL
@@ -39504,12 +39279,12 @@ mFr
 mFr
 mZT
 bck
+mIe
+bch
 bck
-bch
-bch
-bch
-bch
-bch
+bck
+mIe
+mIe
 bch
 gMO
 xFL
@@ -39684,11 +39459,11 @@ cQj
 bch
 bch
 bch
-bch
-bch
-bch
-bch
-wit
+mIe
+mIe
+mIe
+bck
+fXn
 xFL
 oVV
 xFL
@@ -39862,8 +39637,8 @@ bch
 bch
 bch
 bch
-bch
-bch
+mIe
+mIe
 bch
 gMO
 xFL
@@ -40038,7 +39813,7 @@ cQj
 bch
 bch
 bch
-bch
+bck
 bch
 bch
 bch
@@ -40215,7 +39990,7 @@ rnv
 xNG
 xNG
 xNG
-ycp
+tlk
 xNG
 xNG
 xNG
@@ -41208,10 +40983,10 @@ xVG
 qbo
 xVG
 xVG
-hRy
-aWb
-aWb
-aWb
+bpJ
+boA
+boA
+boA
 dqK
 are
 are
@@ -41381,13 +41156,13 @@ jVV
 jVV
 jVV
 jVV
-hRy
-aWb
-aWb
-aWb
-aSm
-mvX
-blH
+bpJ
+boA
+boA
+boA
+dqK
+are
+sUi
 are
 are
 are
@@ -41557,14 +41332,14 @@ bpQ
 jVV
 jVV
 jVV
-frw
-aSm
-mvX
-mvX
-mvX
-mvX
-mvX
-mvX
+bpJ
+dqK
+are
+are
+are
+are
+are
+are
 are
 are
 are
@@ -41731,15 +41506,15 @@ jVV
 cAk
 jVV
 jVV
-frw
-fRf
-fRf
-gJD
-mvX
-mvX
-mvX
-mvX
-mvX
+bpJ
+boA
+boA
+dqK
+are
+are
+are
+are
+are
 sUi
 are
 are
@@ -41908,14 +41683,14 @@ jVV
 jVV
 jVV
 jVV
-fvs
-aQV
-aQV
+tZS
+are
+are
 gVY
-mvX
-mvX
-jCh
-blH
+are
+are
+cNT
+sUi
 are
 are
 are
@@ -42085,10 +41860,10 @@ jVV
 jVV
 iud
 mst
-fvs
-aQV
-aQV
-aQV
+tZS
+are
+are
+are
 are
 are
 are
@@ -42154,7 +41929,7 @@ wNs
 cFK
 cIl
 xYe
-mOs
+aES
 mOs
 mOs
 mOs
@@ -42262,10 +42037,10 @@ jVV
 jVV
 jVV
 jVV
-fvs
-aQV
-aQV
-aQV
+tZS
+are
+are
+are
 are
 are
 are
@@ -42630,8 +42405,8 @@ ajz
 are
 cLP
 gMu
-biV
-vTe
+lcm
+nny
 auH
 iPh
 aEz
@@ -42806,8 +42581,8 @@ bbc
 jYw
 fBk
 gMu
-eyo
-aVq
+slw
+sdf
 sdf
 ttA
 avd
@@ -42948,13 +42723,13 @@ nwU
 gKr
 gKr
 agv
+agv
+agv
+agv
+agv
+agv
+agv
 dqS
-agv
-agv
-agv
-agv
-agv
-agv
 agv
 ajG
 ajG
@@ -42981,8 +42756,8 @@ ghC
 aSq
 lQx
 aVn
-aVq
-aVq
+sdf
+sdf
 ttA
 avd
 avd
@@ -43129,7 +42904,7 @@ agv
 qMX
 agv
 agv
-dqS
+agv
 agv
 agv
 qMX
@@ -43302,6 +43077,7 @@ gKr
 gKr
 agv
 agv
+dqS
 agv
 agv
 agv
@@ -43309,11 +43085,10 @@ agv
 agv
 agv
 agv
-agv
-qTM
+xHg
 ajG
-aWk
-aDu
+ajG
+ajG
 ajG
 ajG
 aQg
@@ -43462,7 +43237,7 @@ jsp
 kFx
 jQf
 jQf
-kFx
+gnk
 gKr
 gKr
 gKr
@@ -43476,21 +43251,21 @@ gKr
 gKr
 gKr
 agv
+dqS
 agv
 agv
 agv
 agv
 agv
+dqS
 agv
 agv
-agv
-agv
-agv
-agv
+aym
+aym
 ajG
 xHg
-aSz
-anZ
+lwf
+aWk
 aDu
 ajG
 czF
@@ -43662,12 +43437,12 @@ agv
 agv
 agv
 agv
-agv
-agv
+aym
+aym
+ajG
 ajG
 ajG
 aSz
-ajR
 aYL
 ajG
 ajG
@@ -43828,23 +43603,23 @@ gKr
 gKr
 aen
 aen
-xFy
+aen
 agv
 agv
 agv
 agv
-dqS
+aGm
 agv
 agv
 agv
 agv
-agv
-agv
-aOC
-aRA
-aRA
-aWz
-ajR
+aym
+aym
+aGZ
+ajG
+ajG
+ajG
+aSz
 anZ
 bdQ
 akI
@@ -44003,9 +43778,10 @@ nwU
 gKr
 gKr
 aen
+xFy
 aen
 aen
-aen
+aGZ
 agv
 agv
 agv
@@ -44017,11 +43793,10 @@ agv
 agv
 agv
 agv
-aAx
-ajR
-ajR
-ajR
-ajR
+ajG
+ajG
+ajG
+aSz
 ajR
 beS
 bfV
@@ -44184,21 +43959,21 @@ aen
 aen
 aen
 agv
+dqS
 agv
 agv
 agv
 agv
 agv
+dqS
 agv
-aGm
 agv
 agv
-iVO
-aAx
-aRC
-ajR
-ajR
-ajR
+agv
+lwf
+ajG
+ajG
+aSz
 ajR
 ajR
 bfV
@@ -44354,12 +44129,12 @@ gKr
 nwU
 gKr
 aen
-xFy
 aen
 aen
 aen
 aen
 aen
+aen
 agv
 agv
 agv
@@ -44368,15 +44143,15 @@ agv
 agv
 agv
 agv
-dqS
 agv
 agv
-aOE
-aSd
-ajR
-ajR
-ajR
-ajR
+agv
+agv
+ajG
+ajG
+ajG
+aSz
+aRC
 ajR
 aGH
 aKZ
@@ -44538,21 +44313,21 @@ pOk
 aen
 aen
 agv
-dqS
-agv
-agv
-agv
-qMX
-jMQ
 agv
 agv
 agv
 agv
-qMX
+agv
+agv
+agv
+agv
+agv
+agv
+agv
+ajG
+ajG
+ajG
 aSz
-ajR
-ajR
-ajR
 ajR
 ajR
 ajR
@@ -44633,7 +44408,7 @@ dQe
 cIl
 cIl
 cIl
-cbO
+dQe
 yfp
 yfp
 yfp
@@ -44704,32 +44479,32 @@ kFx
 aax
 kFx
 kFx
-gKr
-nwU
-gKr
+kFx
+iLn
+kFx
 aen
 aen
 aen
-xFy
 aen
 aen
-aen
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-aSC
-aSd
-ajR
-ajR
+ygV
+jNQ
+jNQ
+jNQ
+ygV
+ygV
+wZn
+aCK
+wZn
+ygV
+ygV
+ygV
+ygV
+ygV
+ajG
+ajG
+ajG
+aSz
 ajR
 ajR
 ajR
@@ -44806,11 +44581,11 @@ mOs
 hde
 pOJ
 xnf
-mbg
-wQv
-wQv
-wQv
-mei
+cst
+cIl
+cIl
+cIl
+iHj
 hwp
 yfp
 yfp
@@ -44882,31 +44657,31 @@ kFx
 jQf
 kFx
 kFx
-nwU
-gKr
+iLn
+gnk
 aen
 aen
+xFy
 aen
 aen
-aen
-aen
-aen
-agv
-agv
-agv
-agv
-dqS
-agv
-agv
-dqS
-agv
+jNQ
+jNQ
+wqg
+piE
+piE
+diA
+piE
+tch
+iVz
+ygV
+mjW
 nxk
-agv
-agv
+nxk
+ygV
+ajG
+ajG
 lwf
-aSC
-aSd
-ajR
+aSz
 ajR
 ajR
 ajR
@@ -44983,12 +44758,12 @@ aES
 xfO
 erg
 hYO
-mbg
-wQv
-wQv
-cMv
-mei
-vga
+cst
+cIl
+cIl
+wNs
+iHj
+iJa
 yfp
 yfp
 yfp
@@ -45059,31 +44834,31 @@ aax
 kFx
 aax
 kFx
-nwU
-gKr
+iLn
+kFx
 aen
 aen
 aen
 aen
 aen
-aen
-aen
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-iVO
-sCh
-agv
-agv
+jNQ
+whp
+aPb
+lTu
+gUN
+rzf
+gUN
+aKO
+bdv
+wZn
+pZJ
+yiA
+yjF
+ygV
 ajG
 ajG
-aSC
-aSd
+ajG
+jQr
 bai
 alH
 aGH
@@ -45159,13 +44934,13 @@ aET
 aET
 xVL
 rYb
-eWg
-mbg
-lTj
-wQv
-wQv
-mei
-wqT
+sHO
+cst
+oDS
+cIl
+cIl
+iHj
+aES
 yfp
 yfp
 yfp
@@ -45239,29 +45014,29 @@ aax
 nwU
 gKr
 gKr
+avJ
 aen
 aen
 aen
-aen
-aen
-aen
-agv
-agv
-agv
-agv
-dqS
-agv
-dqS
-agv
-agv
-dqS
-agv
-agv
+fsD
+qTM
+wGb
+qVR
+ukf
+ukf
+aUz
+fYW
+bdv
+wZn
+tYC
+tRq
+yiA
+ygV
 ajG
 bKq
 ajG
-aSC
-bau
+ajG
+ajG
 beU
 akI
 nMg
@@ -45332,17 +45107,17 @@ thL
 aES
 mOs
 mOs
-rSR
-rSR
+aET
+aET
 ojP
-wqT
-wqT
-vAv
+aES
+aES
+bax
 vkA
 eOf
 vkA
-vAv
-wqT
+bax
+aES
 yfp
 yfp
 yfp
@@ -45416,27 +45191,27 @@ jsp
 jsp
 nwU
 gKr
-gKr
 aen
 aen
+xFy
 aen
-aen
-aen
-agv
-agv
-agv
-agv
-agv
+ygV
+qTM
+bdv
+tch
+tch
+tch
+tch
 rvs
-ayp
-ayp
-agv
+rKU
+tIW
+gYm
 pjS
-agv
-agv
+yiA
+ygV
 ajG
 ajG
-lwf
+ajG
 ajG
 ajG
 ajG
@@ -45509,29 +45284,29 @@ aES
 aES
 mOs
 aET
-aZI
+wSP
 baw
-bcd
+vkA
 vkA
 bCC
 bcZ
 jAj
-sOO
-sOO
-rvn
-wqT
-wqT
-vga
-wqT
-vga
+naG
+naG
+dQe
+aES
+aES
+iJa
+aES
+iJa
 yfp
 yfp
 yfp
 yfp
 yfp
-wQv
-wQv
-yiU
+tXt
+tXt
+dpl
 ssW
 bpx
 xQi
@@ -45593,25 +45368,25 @@ kFx
 kFx
 jQf
 nwU
-gKr
 aen
 aen
-xFy
-dsm
 aen
-agv
-agv
+aen
+jNQ
+wkF
+jAz
+aSX
 aBi
-agv
-agv
-agv
-agv
-ayp
+aBi
+bbb
+pUq
+bdv
+ygV
 sCh
-agv
+vqG
 ayp
-ayp
-aBh
+ygV
+lwf
 ajG
 ajG
 ajG
@@ -45686,29 +45461,29 @@ aET
 aET
 mOs
 bde
-aZI
+wSP
 bax
-nxu
-sOO
-sOO
-sOO
-sOO
-xbL
-bgw
-rvn
+iJa
+naG
+naG
+naG
+naG
+mPX
+rUq
+dQe
 vkA
 vkA
-vAv
+bax
 hwp
 hwp
-mbg
-wQv
+cst
+cIl
 dih
-yjT
+bOY
 yjT
 yjT
 uWA
-yiU
+dpl
 ssW
 bpx
 rUK
@@ -45770,29 +45545,29 @@ gnk
 kFx
 jQf
 nwU
-gKr
-aen
-dsm
 aen
 aen
 aen
-agv
-dqS
-agv
-ayp
+aen
+jNQ
+tmd
+piE
+axY
 aCv
-aDJ
+aCv
+aCv
+yiA
 nck
-aDJ
-aDJ
+ygV
+ygV
 aTU
-aKO
-aPb
-aDJ
-aDJ
-aDJ
-aDJ
-bbb
+ygV
+ygV
+ygV
+ygV
+ygV
+ygV
+ajG
 ajG
 ajG
 ajG
@@ -45863,30 +45638,30 @@ aES
 naG
 aES
 xMs
-rSR
+aET
 bCC
-xbL
-sOO
-bgw
-nxu
-xbL
-nxu
-sOO
-sOO
+mPX
+naG
+rUq
+iJa
+mPX
+iJa
+naG
+naG
 waV
-xbL
-vMu
-vAv
-wqT
+mPX
+rpf
+bax
+aES
 khW
-oLw
-oLw
-oLw
-vUs
-ixP
-xaI
-vUs
-ygU
+rYb
+rYb
+rYb
+nCU
+nCU
+nCU
+nCU
+nCU
 bpx
 bpx
 bqO
@@ -45947,30 +45722,30 @@ kFx
 kFx
 jQf
 nwU
-gKr
 aen
 aen
+xFy
 aen
-dsm
-aen
-agv
-agv
-agv
-ayp
+ygV
+ygV
+jMQ
+aBh
+ygV
+vdj
 arI
-aDM
-iMC
-iMC
+arI
+aSC
+nOk
 aDM
 aqs
 aNE
-drB
-iMC
-iMC
-rzf
-wqg
-utf
+olA
+olA
+olA
+sTw
+wZn
 ajG
+lwf
 ajG
 ajG
 aKr
@@ -46040,9 +45815,9 @@ aES
 aES
 xMs
 iJa
-wqT
+aES
 vkA
-xbL
+mPX
 nww
 bbq
 iVb
@@ -46053,21 +45828,21 @@ iVb
 iVb
 uUS
 dkv
-vAv
-wqT
-vUs
-vcl
-vcl
-vcl
-vUs
-ofY
+bax
+aES
 nCU
-dHc
-vUs
-vcl
-vcl
-wNt
-pwD
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
 bpx
 mOs
 mOs
@@ -46124,31 +45899,31 @@ kFx
 kFx
 jQf
 nwU
-gKr
-gKr
-gKr
+aen
+aen
+aen
 pOk
-aen
-aen
-iVO
-agv
-agv
-agv
-arI
-bDj
-aoH
-nfJ
-iMC
-mHk
+ygV
+ygV
+tch
+aDM
+ygV
+ygV
+ygV
+ygV
+ygV
+ygV
+qPY
+tch
 vqG
 hTr
-cuO
-cLI
-aoH
-aEp
-aEW
-aBh
-lwf
+aDZ
+tch
+sTw
+wZn
+ajG
+ajG
+ajG
 nMg
 aKr
 qfn
@@ -46217,8 +45992,8 @@ weB
 pWs
 pWs
 pWs
-vAv
-vAv
+bax
+bax
 qem
 aYI
 rBD
@@ -46229,22 +46004,22 @@ vuY
 pSl
 vuY
 dmA
-xbL
-vAv
-wqT
-vcl
-uDA
-gim
-hnV
-laT
-gxf
+mPX
+bax
+aES
 nCU
-wgH
-jtZ
-uDA
-uDA
-fYW
-tIW
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
 bpx
 mOs
 mOs
@@ -46300,30 +46075,30 @@ kFx
 kFx
 gnk
 jQf
-gKr
 nwU
-gKr
-gKr
 aen
 aen
 aen
-agv
-agv
-tYC
-ayp
-aCy
+aen
+ygV
+rKh
+aKO
+yiA
+wZn
+aGO
+aGO
+qyg
+uvg
 iMC
-aEp
-iMC
-aIO
-aLd
+tch
+yiA
 aNK
 olA
 aSG
-aEp
-aEp
-iMC
-aEW
+olA
+sTw
+wZn
+ajG
 ajG
 ajG
 nMg
@@ -46371,10 +46146,10 @@ qfO
 gPV
 qfO
 mic
-wZn
+bau
 aMN
 bzL
-wZn
+bau
 xMs
 aES
 aES
@@ -46396,7 +46171,7 @@ xKv
 xKv
 bCC
 qGH
-nxu
+iJa
 aYI
 pmS
 rVo
@@ -46406,22 +46181,22 @@ bgu
 uPL
 vuY
 dmA
-xbL
+mPX
 ssc
-wqT
-vcl
-aoT
-bXv
-wgH
-wgH
-pal
+aES
 nCU
-cRe
-fxx
-wZd
-mjW
-iqd
-tZo
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
 bpx
 bpx
 mOs
@@ -46477,31 +46252,31 @@ kFx
 kFx
 kFx
 jQf
-gKr
-gKr
 nwU
-gKr
-gKr
 aen
-pSQ
-agv
-agv
-agv
-ayp
-arI
+aen
+aen
+aen
+ygV
+ygV
+hTr
+hTr
+gMJ
+lma
+lma
 aDZ
-aoH
-pUq
+lma
+lma
 xys
-pUq
-iMC
-eGr
-qbC
-iMC
-aEp
-iMC
-aEW
-ajG
+gvo
+pSQ
+ygV
+ygV
+ygV
+ygV
+ygV
+ygV
+aYX
 ajG
 ngS
 pYM
@@ -46548,11 +46323,11 @@ mic
 qfO
 qfO
 qfO
-qZD
+vUs
 eOn
-lJu
-qZD
-qZD
+xaI
+vUs
+aES
 aES
 aES
 aET
@@ -46572,33 +46347,33 @@ fye
 xKv
 xKv
 wRf
-nxu
+iJa
 qMM
 aYI
 sGt
 hbN
-kQA
-qHA
+wNs
+oDS
 vmz
 rdX
 vuY
 dmA
-xbL
-txm
-wqT
-vUs
-tTQ
-wgH
-wgH
-aMK
-wgH
+mPX
+lhZ
+aES
 nCU
-dVT
-tzj
-tzj
-tzj
-tRD
-tbP
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
 bpx
 bqO
 mOs
@@ -46654,32 +46429,32 @@ kFx
 kFx
 kFx
 jQf
-gKr
-gKr
-gKr
 nwU
-gKr
+aen
+xFy
 aen
 aen
-agv
-iVO
-agv
-iVO
-aCD
-bDj
-aEp
-aGO
+ygV
+rKh
+yiA
+yiA
+wZn
 aDM
-aLn
-aNR
-aLB
-iMC
-aUz
-aEp
-aEp
-iMC
+tch
+bDj
+kQG
+aGO
+tch
+yiA
+tjl
+ygV
+jRy
+cKj
+dMP
+knO
+wZn
 qmg
-gYm
+qmg
 hfE
 aKr
 qfn
@@ -46720,20 +46495,20 @@ hlt
 aHI
 uYP
 uYP
-uCZ
-ygV
-ygV
-ygV
-ygV
-ygV
-yiA
-upv
-yiA
-ygV
-ygV
-ygV
-bEf
-dDC
+vUs
+vcl
+vcl
+vcl
+vUs
+vUs
+hma
+dHc
+vUs
+vcl
+vcl
+wNt
+uMQ
+aES
 aES
 mOs
 aES
@@ -46749,34 +46524,34 @@ xKv
 xKv
 xKv
 vkA
-xbL
-nxu
+mPX
+iJa
 cBS
 pDe
 hFU
-nwS
+cIl
 bgs
-qHA
+oDS
 izw
 pDe
 dOS
-cAE
+rxh
 ssc
-vUs
-vUs
-sAv
-wgH
-wgH
-wgH
-wgH
 nCU
-fkN
-rnp
-rnp
-rnp
-aOO
-vUs
-vUs
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
 bpx
 mOs
 psZ
@@ -46831,34 +46606,34 @@ kFx
 aax
 jQf
 jQf
-gKr
-gKr
-gKr
 nwU
-gKr
 aen
-dsm
-agv
-agv
-dqS
-agv
+aen
+aen
+aen
+ygV
+ygV
+ygV
+ygV
+ygV
+ygV
 aCD
-uTQ
-bDj
-aGP
+ygV
+ygV
+ygV
 tmt
-aLu
+yiA
 tjl
-aPE
+ygV
 gAb
 fQf
-aEp
-aNE
-aEp
+faL
+pyF
+kEa
 bfl
-ajG
-lZC
-aJY
+aEP
+iEH
+wIb
 fFk
 qmg
 vCy
@@ -46883,7 +46658,7 @@ bmp
 bmp
 uLA
 bmp
-xMv
+aGP
 lcT
 dvK
 xMv
@@ -46897,20 +46672,20 @@ cGa
 exl
 uYP
 uYP
-ygV
-ygV
-fkB
-gUN
-gUN
-hwj
-gUN
-rHw
-qyg
-xZW
-xZW
-xZW
-wZn
-dDC
+vcl
+uDA
+gim
+hnV
+laT
+dHc
+mkE
+wgH
+jtZ
+uDA
+uDA
+ofY
+aRP
+aES
 aES
 mOs
 xTV
@@ -46925,35 +46700,35 @@ weB
 sGu
 sGu
 sGu
-rvn
-vAv
-nxu
+dQe
+bax
+iJa
 aYI
 vuY
 pmS
-nwS
-qHA
-nwS
+cIl
+oDS
+cIl
 bgt
 uPL
 dmA
-xbL
-txm
-vcl
-wgH
-nvX
-wgH
-wgH
-wgH
-nvX
+mPX
+lhZ
 nCU
-wgH
-wgH
-nvX
-wgH
-wgH
-nvX
-vcl
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
 bpx
 mOs
 psZ
@@ -47008,35 +46783,35 @@ kFx
 kFx
 jQf
 gKr
-gKr
-gKr
-gKr
 nwU
-gKr
+aen
+aen
+aen
+aen
 aen
 aen
 agv
 agv
-agv
-agv
-aCD
-iMC
+jNQ
+utf
+tch
+yiA
 aoH
-kWy
+ygV
 iRH
 aLB
 bPO
 kEa
-aEp
+pyF
 aUW
-bDj
-iMC
-iMC
+lJu
+hWC
+wZn
 kHE
 kHE
 hVr
 rog
-bqj
+bfl
 bsp
 vCy
 vCy
@@ -47074,20 +46849,20 @@ xmB
 vkR
 uYP
 rdh
-ygV
-ylj
-dll
-qVR
-ukf
-ukf
-faL
-vfg
-bBh
-yiA
-ooQ
-xkb
-ldV
-yjF
+vcl
+aoT
+wgH
+nvX
+wgH
+pal
+xGM
+cRe
+fxx
+wZd
+fxx
+iqd
+vcl
+aES
 aES
 aES
 xfO
@@ -47102,9 +46877,9 @@ pXB
 aKN
 qrw
 boU
-rSR
+aET
 vkA
-xbL
+mPX
 aYI
 vuY
 sGt
@@ -47114,23 +46889,23 @@ hbN
 tqo
 rdX
 dmA
-cAE
-xbL
-tek
-wgH
-kRJ
-rKU
-kRJ
-kRJ
-rKU
-xGM
-wgH
-wgH
-wgH
-wFb
-wgH
-wgH
-tek
+rxh
+mPX
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+okL
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
 bpx
 mOs
 psZ
@@ -47185,31 +46960,31 @@ kFx
 kFx
 jQf
 gKr
-gKr
-gKr
-gKr
 nwU
-gKr
+aen
+aen
+aen
+xFy
 aen
 xFy
 iVO
 agv
-iVO
-agv
-arI
+jNQ
+xPn
+tch
 aEp
-iMC
-aoH
+kWA
+ygV
 qPw
-iMC
-iMC
-aEp
-aDM
-iMC
-aEp
-iMC
-aEW
-ajG
+tch
+tch
+aGW
+sTw
+pwD
+unO
+ygV
+ygV
+aYX
 ajG
 nMg
 pYM
@@ -47251,20 +47026,20 @@ hlt
 uYP
 uYP
 uYP
-ygV
-lSv
-uJs
-uNe
-cGb
-uNe
-uNe
-gRw
-mts
+vUs
+tTQ
+wgH
+wgH
+aMK
+wgH
+xGM
+dVT
+tzj
+tzj
+tzj
 xZW
-whp
-xZW
-wZn
-yjF
+vUs
+aES
 aES
 aES
 xVL
@@ -47279,7 +47054,7 @@ pXB
 uQM
 aRs
 bps
-rSR
+aET
 vkA
 iKK
 aYI
@@ -47292,22 +47067,22 @@ cIu
 hOy
 neS
 hXF
-xbL
-xjn
-wgH
-kRJ
-xJa
-xJa
-xJa
-kRJ
-iaA
-wgH
-wgH
-jTE
-wgH
-wgH
-wgH
-vcl
+mPX
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
 bqO
 mOs
 psZ
@@ -47362,30 +47137,30 @@ kFx
 kFx
 jQf
 gKr
-gKr
-gKr
-gKr
 nwU
-gKr
+aen
+aen
+aen
+aen
 dsm
 aen
-dqS
 agv
 agv
-dqS
-arI
-iMC
-aEp
-iMC
-aJp
-aLQ
-aOm
-aLQ
-aSX
-iMC
-aEp
-iRH
+jNQ
+hVM
 aEW
+aDZ
+yiA
+ygV
+mzp
+tch
+aOm
+ygV
+knO
+oot
+gJd
+wZn
+ajG
 ajG
 lwf
 nMg
@@ -47427,22 +47202,22 @@ uYP
 hlt
 uYP
 uYP
-pyF
-qPY
-qum
-spG
-xHS
-lTu
-lTu
-lTu
-mUe
-qZD
-qZD
-qZD
-qZD
-ygV
-ygV
-weB
+vUs
+vUs
+sAv
+wgH
+wgH
+wgH
+nvX
+xGM
+fkN
+rnp
+rnp
+rnp
+aOO
+vUs
+vUs
+pWs
 pWs
 pWs
 weB
@@ -47456,9 +47231,9 @@ pXB
 xMJ
 aXI
 bzK
-rSR
-vMu
-vzi
+aET
+rpf
+naG
 kDw
 tcY
 tcY
@@ -47468,23 +47243,23 @@ tcY
 tcY
 tcY
 pfv
-vMu
-vMu
-vUs
-vUs
-kRJ
-xJa
-xJa
-iEv
-kRJ
-jsN
-bdv
-wgH
-wgH
-wgH
-jUW
-vUs
-vUs
+rpf
+rpf
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
 bqO
 mOs
 psZ
@@ -47539,30 +47314,30 @@ kFx
 kFx
 jQf
 jQf
-gKr
-gKr
-gKr
 nwU
-gKr
-gKr
+aen
+aen
+aen
+aen
+aen
 dsm
 agv
 iVO
-ayp
-ayp
-arI
-aEp
-aFw
-aEp
-iMC
+jNQ
+hVM
+aEW
+tch
+tch
+kag
+tch
 cLI
-bDj
-iMC
-iMC
-tmt
-fKd
-aDM
-aEP
+qAH
+ygV
+eEK
+mUe
+gJd
+wZn
+ajG
 ajG
 ajG
 nMg
@@ -47604,21 +47379,21 @@ uYP
 hlt
 vkR
 uYP
-dki
-ygV
-wYm
-tch
-tmd
-tmd
-aYf
-tmd
-jNQ
-qZD
-jRy
-cKj
-dMP
-knO
-wZn
+vcl
+wgH
+nvX
+wgH
+wgH
+wgH
+wgH
+xGM
+wgH
+wgH
+wgH
+wgH
+wgH
+wgH
+vcl
 xKv
 xKv
 oCn
@@ -47634,33 +47409,33 @@ xcz
 xcz
 jUy
 jal
-vAv
+bax
 eYN
 bCC
 vkA
-vAv
-sOO
-bgw
-nxu
-rvn
+bax
+naG
+rUq
+iJa
+dQe
 vkA
 vkA
-wsU
+rpf
 iJa
 aES
-vUs
-mEe
-fbO
-xJa
-xJa
-kRJ
-wkF
-wgH
-wgH
-nvX
-wgH
-uBz
-vUs
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
 ohH
 bpx
 mOs
@@ -47716,30 +47491,30 @@ kFx
 gnk
 kFx
 jQf
-gKr
-gKr
-gKr
-gKr
 nwU
+xFy
+aen
 gKr
 gKr
+gKr
+aen
 agv
-agv
-agv
-ayp
-arI
-iMC
-bDj
-aGW
-wqg
-bDj
-aNE
-iMC
-aEp
-iMC
-aLn
-akK
+qMX
+jNQ
+hVM
 aEW
+tch
+yiA
+ygV
+tcT
+gvo
+qUL
+ygV
+mks
+lrC
+aLn
+wZn
+ajG
 ajG
 ajG
 nMg
@@ -47782,20 +47557,20 @@ nxS
 wFT
 gbg
 eVA
-ygV
-qZD
-kQG
+kDA
 qZD
 qZD
-lUT
+qZD
+qZD
+qZD
 rXm
-mZo
-qZD
+kDA
+aJp
 reF
-lWw
 kDA
 kDA
-kFe
+aJp
+tek
 xhp
 ual
 xhp
@@ -47815,29 +47590,29 @@ qrw
 sIO
 sIO
 wEg
-vAv
+bax
 vkA
 sZf
 vkA
-vMu
+rpf
 vjE
 mPX
 aET
 dDC
 aES
-aRP
-kRJ
-kRJ
-kRJ
-kRJ
-kRJ
-kCI
-wgH
-wgH
-wgH
-wFb
-xZn
-vcl
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
 ohH
 bqO
 mOs
@@ -47893,29 +47668,29 @@ kFx
 aax
 kFx
 jQf
-gKr
-gKr
-gKr
-gKr
-gKr
 nwU
+aen
+aen
 gKr
+gKr
+gKr
+aen
+dqS
 agv
-agv
-agv
-agv
-aCK
-mSF
+ygV
+wZn
+wZn
+ygV
+ygV
+ygV
 ayl
-ayl
-ayl
-aMn
-aMn
-aPG
-ayl
-ayl
-aWT
-ayl
+sTw
+sTw
+ygV
+wZn
+wZn
+wZn
+ygV
 bbw
 ajG
 ajG
@@ -47958,21 +47733,21 @@ uYP
 dki
 uYP
 uYP
-uYP
-ygV
-yda
-lma
-ukZ
-qZD
-tcT
+xjn
+wgH
+kRJ
+xJa
+xJa
+xJa
+kRJ
 cUP
-jxU
-qrh
-pQs
-iLn
-ttW
-hWC
-ldV
+wgH
+wgH
+jTE
+wgH
+wgH
+wgH
+vcl
 xKv
 xKv
 xKv
@@ -48002,19 +47777,19 @@ mPX
 naG
 dDC
 aES
-vcl
-oAq
-kju
-wQw
-wgH
-wgH
-bQi
-wgH
-aFf
-syY
-aNM
-uDA
-vcl
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
 bpx
 bqO
 mOs
@@ -48070,25 +47845,25 @@ kFx
 kFx
 kFx
 jQf
-gKr
-gKr
 nwU
-nwU
-nwU
-gKr
-gKr
+aen
+aen
+aen
+aen
+aen
+aen
+agv
+agv
+agv
+agv
 dqS
 agv
 agv
-agv
-dqS
-agv
-agv
-agv
-agv
-agv
-agv
-agv
+ygV
+ukZ
+aCK
+ukZ
+ygV
 ajG
 ajG
 ajG
@@ -48135,22 +47910,22 @@ gbr
 dki
 uYP
 uYP
-uYP
-ygV
-wIb
-jAz
-mkE
-qZD
-gMJ
+vUs
+vUs
+kRJ
+xJa
+xJa
+iEv
+kRJ
 swL
-iVz
-hMy
-ixU
-gvo
-unO
-ygV
-ygV
-weB
+wgH
+wgH
+wgH
+wgH
+jUW
+vUs
+vUs
+sGu
 sGu
 sGu
 weB
@@ -48179,19 +47954,19 @@ mPX
 aET
 dDC
 aES
-vUs
-xjn
-vcl
-vcl
-wgH
-xPn
-the
-wgH
-vUs
-vcl
-vcl
-vcl
-vUs
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
+nCU
 xQi
 mOs
 mOs
@@ -48248,11 +48023,11 @@ kFx
 jQf
 jQf
 nwU
-nwU
-gKr
-gKr
-gKr
-gKr
+aen
+aen
+aen
+xFy
+aen
 aen
 agv
 agv
@@ -48262,15 +48037,15 @@ agv
 agv
 agv
 agv
-dqS
 agv
 agv
 agv
-ajG
-vdj
-ajG
+agv
 ajG
 ajG
+ajG
+ajG
+lwf
 ajG
 ajG
 ajG
@@ -48313,19 +48088,19 @@ dki
 exl
 uYP
 uYP
-ygV
+vUs
 xgW
-piE
-sTw
-qZD
-mzp
-fsD
-kag
-qZD
-knO
-oot
-gJd
-wZn
+fbO
+xJa
+xJa
+kRJ
+wgH
+wgH
+wgH
+wgH
+wgH
+uBz
+vUs
 aES
 wWN
 wWN
@@ -48360,11 +48135,11 @@ xMs
 aES
 aES
 rpf
-hLs
-jQr
-pdN
-vcl
-hVM
+nCU
+nCU
+nCU
+nCU
+nCU
 xQi
 xQi
 bpx
@@ -48425,28 +48200,28 @@ kFx
 jQf
 nwU
 gKr
-gKr
-gKr
+avJ
 aen
 aen
 aen
 aen
+aen
+agv
+agv
+dqS
 agv
 agv
 agv
 agv
+dqS
 agv
 agv
 agv
-ayp
-ayp
 agv
-agv
-agv
-ajG
-ajG
-ajG
 lwf
+ajG
+ajG
+ajG
 ajG
 ajG
 ajG
@@ -48490,20 +48265,20 @@ ovm
 uYP
 uYP
 rdh
-ygV
-xgW
+aRP
+kRJ
 tBS
-lma
-abA
-lma
-wGb
-qAH
-qZD
-eEK
-nCQ
-gJd
-wZn
-wWN
+kRJ
+kRJ
+kRJ
+wgH
+nvX
+wgH
+wgH
+nvX
+xZn
+vcl
+aES
 wWN
 aES
 xfO
@@ -48602,23 +48377,23 @@ jlH
 vWg
 gKr
 gKr
+xFy
 aen
 aen
 aen
 aen
 aen
-axY
-dqS
 agv
 agv
 agv
-dqS
 agv
-iVO
-aGZ
-ayp
 agv
-dqS
+agv
+asw
+agv
+agv
+agv
+agv
 aOC
 aRA
 aRA
@@ -48667,19 +48442,19 @@ hlt
 uYP
 uYP
 uYP
-ygV
-xgW
-piE
-gvo
-qZD
-dsM
+vcl
+oAq
+kju
+wQw
+wgH
+wgH
 wUp
-qUL
-qZD
-mks
-lrC
-xxp
-ldV
+wgH
+aFf
+syY
+aNM
+uDA
+vcl
 aES
 aES
 aES
@@ -48844,20 +48619,20 @@ hlt
 uYP
 iFE
 kEp
-nOk
-uvg
-wZn
-ygV
-ygV
-fiw
-fCU
-fiw
-ygV
-wZn
-wZn
-ldV
-ygV
-nkE
+vUs
+xjn
+vcl
+vcl
+vUs
+wgH
+wgH
+wgH
+vUs
+vcl
+vcl
+vcl
+vUs
+aES
 xMs
 aES
 aES
@@ -49021,15 +48796,15 @@ hlt
 exl
 qNG
 cIl
+cIl
 dDC
 aES
-aES
-aES
+aWT
 bEf
-wZn
-kQG
-wZn
-ygV
+aPE
+pdN
+vcl
+mHk
 aES
 aES
 aES
@@ -50128,7 +49903,7 @@ ruh
 hHK
 wEB
 qVK
-cda
+aET
 aET
 aET
 mXP
@@ -50305,8 +50080,8 @@ qVK
 qVK
 qVK
 qVK
-nVr
-nVr
+qVK
+qVK
 aET
 aET
 aES
@@ -50479,11 +50254,11 @@ xuv
 veM
 rQF
 ulW
-nVr
+qVK
 pSj
 jqP
 clB
-nVr
+qVK
 aET
 efi
 aET
@@ -50656,12 +50431,12 @@ xuv
 xjB
 rQF
 jRu
-nVr
+qVK
 gwA
 oAs
 uGS
-nVr
-nVr
+qVK
+qVK
 aET
 tzb
 dsh
@@ -50832,13 +50607,13 @@ vgu
 xuv
 sZl
 hle
-kWA
+iyl
 hGO
-nVr
-nVr
+qVK
+qVK
 wIe
 owB
-nVr
+qVK
 aES
 aET
 dsh
@@ -51015,8 +50790,8 @@ sIA
 vsS
 dcr
 oPy
-nVr
-nVr
+qVK
+qVK
 aES
 fvl
 vvV
@@ -51189,11 +50964,11 @@ biL
 jnW
 hRG
 oDM
-nVr
+qVK
 pUC
 ucr
 dxb
-oji
+bkU
 aES
 dsh
 vvV
@@ -51366,11 +51141,11 @@ oXD
 mYW
 eOC
 msV
-nVr
+qVK
 pUC
 xWz
 dPf
-rKh
+pLf
 aES
 dsh
 rqN
@@ -51538,16 +51313,16 @@ ozc
 eeM
 xuv
 xuv
-nVr
-nVr
+qVK
+qVK
 bvY
 flZ
 bvY
-nVr
+qVK
 bva
-nVr
-nVr
-nVr
+qVK
+qVK
+qVK
 iPZ
 jsE
 vvV
@@ -55256,7 +55031,7 @@ sJh
 mYO
 tGb
 tGb
-okL
+tGb
 oxg
 oxg
 twQ
@@ -57916,7 +57691,7 @@ uYo
 euA
 iol
 mOs
-mOs
+bdh
 gCL
 gCL
 bdh
@@ -58624,8 +58399,8 @@ uYo
 euA
 iol
 mOs
-ehh
-mOs
+gCL
+bdh
 gCL
 gCL
 bdh
@@ -58801,7 +58576,7 @@ uYo
 euA
 iol
 ghe
-mOs
+bdh
 mOs
 mOs
 mOs

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -6976,12 +6976,13 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand4)
 "fLY" = (
-/obj/structure/jungle/vines,
-/obj/effect/ai_node,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/ground/grass,
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle3)
 "fMv" = (
 /obj/structure/jungle/plantbot1/alien,
@@ -8468,6 +8469,11 @@
 /obj/effect/ai_node,
 /turf/open/floor,
 /area/lv624/ground/sand2)
+"hwx" = (
+/obj/item/ammo_casing,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
 "hxa" = (
 /turf/open/floor/bcircuit/off,
 /area/lv624/lazarus/sandtemple)
@@ -11662,6 +11668,11 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle9)
+"lhQ" = (
+/obj/structure/jungle/vines,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/lv624/ground/jungle3)
 "lhZ" = (
 /obj/structure/foamedmetal,
 /turf/open/ground/grass/grass2,
@@ -13597,6 +13608,13 @@
 	dir = 4
 	},
 /area/lv624/ground/jungle5)
+"nsJ" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/lv624/ground/jungle6)
 "ntl" = (
 /obj/structure/rack,
 /obj/item/stack/medical/heal_pack/advanced/bruise_pack,
@@ -15176,6 +15194,10 @@
 	dir = 4
 	},
 /area/lv624/ground/jungle10)
+"psp" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/ground/river1)
 "psJ" = (
 /obj/structure/window_frame/colony/reinforced,
 /turf/open/floor/plating,
@@ -18507,6 +18529,7 @@
 /area/lv624/lazarus/sandtemple)
 "tlk" = (
 /obj/structure/jungle/vines,
+/obj/effect/ai_node,
 /turf/open/floor/plating/dmg1,
 /area/lv624/ground/river1)
 "tlr" = (
@@ -19518,7 +19541,6 @@
 /area/lv624/ground/river1)
 "upO" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/ai_node,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
@@ -22259,6 +22281,12 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle1)
+"xvz" = (
+/obj/structure/catwalk,
+/obj/effect/decal/riverdecal,
+/obj/effect/ai_node,
+/turf/open/ground/river,
+/area/lv624/ground/river1)
 "xvY" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -26166,7 +26194,7 @@ cAu
 cAu
 qof
 bNu
-nVk
+xvz
 ybg
 are
 kBt
@@ -27047,7 +27075,7 @@ lSR
 lSR
 cAu
 cAu
-cAu
+xrX
 cAu
 cAu
 tZS
@@ -28103,7 +28131,7 @@ cAu
 cAu
 cAu
 cAu
-cAu
+xrX
 cAu
 cAu
 cAu
@@ -28312,7 +28340,7 @@ xLz
 xLz
 xLz
 xLz
-xLz
+wWk
 rtU
 xLz
 xvY
@@ -28452,7 +28480,7 @@ cAu
 cAu
 kwk
 cAu
-cAu
+xrX
 cAu
 cAu
 cAu
@@ -28484,7 +28512,7 @@ xLz
 xLz
 dFf
 rtU
-xLz
+wWk
 dFf
 xLz
 rtU
@@ -28655,7 +28683,7 @@ llU
 dpe
 xLz
 xLz
-xLz
+wWk
 xLz
 xLz
 xLz
@@ -28976,7 +29004,7 @@ cAu
 cAu
 aWb
 cAu
-cAu
+xrX
 cAu
 kwk
 cAu
@@ -28990,7 +29018,7 @@ cAu
 cAu
 cAu
 cAu
-cAu
+xrX
 cAu
 cAu
 gsZ
@@ -29020,7 +29048,7 @@ bYr
 wnj
 wUU
 wnj
-wnj
+otJ
 wnj
 wnj
 uUv
@@ -29145,11 +29173,11 @@ alB
 gKr
 cAu
 gsZ
+xrX
 cAu
 cAu
 cAu
-cAu
-cAu
+xrX
 cAu
 cAu
 cAu
@@ -29336,7 +29364,7 @@ cAu
 cAu
 cAu
 cAu
-cAu
+xrX
 cAu
 cAu
 cAu
@@ -29539,7 +29567,7 @@ gBt
 qpS
 dpe
 xLz
-xLz
+wWk
 xLz
 xvY
 wnj
@@ -29866,7 +29894,7 @@ cAu
 cAu
 cAu
 blH
-blH
+hwx
 cAu
 cAu
 cAu
@@ -29905,7 +29933,7 @@ mOs
 mOs
 mOs
 mKd
-ePq
+nsJ
 sVv
 eSF
 mOs
@@ -29924,13 +29952,13 @@ yiV
 eyo
 yiV
 yiV
-yiV
+fCG
 flD
 sVv
 eSF
 gMO
 xFL
-xFL
+qHh
 xFL
 gRt
 bch
@@ -30037,7 +30065,7 @@ evp
 evp
 evp
 cAu
-cAu
+xrX
 cAu
 syU
 frw
@@ -30053,7 +30081,7 @@ frw
 frw
 eBw
 cAu
-cAu
+xrX
 gsZ
 cAu
 mFi
@@ -30207,7 +30235,7 @@ cTi
 lSR
 cAu
 cAu
-cAu
+xrX
 evp
 evp
 evp
@@ -30595,13 +30623,13 @@ odE
 wFb
 fxm
 odE
-odE
+psp
 odE
 xHS
 vqK
 pCF
 nny
-nny
+lEk
 nny
 aWH
 avd
@@ -30629,7 +30657,7 @@ yiV
 yiV
 yiV
 yiV
-yiV
+fCG
 oZt
 yiV
 hlK
@@ -30760,7 +30788,7 @@ hRy
 nlg
 hRy
 wdN
-cAu
+xrX
 cAu
 gsZ
 cAu
@@ -30923,7 +30951,7 @@ evp
 evp
 cAu
 cAu
-cAu
+xrX
 wjP
 jnE
 nlg
@@ -31268,7 +31296,7 @@ evp
 cTi
 lSR
 cAu
-cAu
+xrX
 evp
 evp
 evp
@@ -31978,14 +32006,14 @@ lSR
 cAu
 cAu
 cAu
-cAu
+xrX
 cAu
 evp
 evp
 evp
 cAu
 cAu
-cAu
+xrX
 biV
 hRy
 jnE
@@ -32355,7 +32383,7 @@ cAu
 cAu
 cAu
 cAu
-cAu
+xrX
 cAu
 cAu
 tZS
@@ -32513,7 +32541,7 @@ cAu
 cAu
 cAu
 cAu
-cAu
+xrX
 cAu
 aWy
 cAu
@@ -32523,7 +32551,7 @@ cAu
 cAu
 cAu
 cAu
-cAu
+xrX
 blH
 blH
 cAu
@@ -32694,7 +32722,7 @@ gsZ
 cAu
 cAu
 gsZ
-cAu
+xrX
 cAu
 cAu
 cAu
@@ -32882,7 +32910,7 @@ cAu
 cAu
 gsZ
 cAu
-cAu
+xrX
 cAu
 cAu
 cAu
@@ -33116,7 +33144,7 @@ xFL
 xFL
 xFL
 xFL
-xFL
+qHh
 xFL
 fjU
 xFL
@@ -33241,7 +33269,7 @@ cAu
 cAu
 cAu
 cAu
-cAu
+xrX
 cAu
 tZS
 are
@@ -34480,7 +34508,7 @@ gKr
 gKr
 gKr
 cAu
-cAu
+xrX
 gsZ
 cAu
 cAu
@@ -35959,7 +35987,7 @@ bch
 qVt
 str
 xFL
-xFL
+qHh
 xFL
 gRt
 bch
@@ -36497,8 +36525,8 @@ xOT
 xOT
 xOT
 xOT
-bch
-bch
+mQx
+mQx
 fIY
 psZ
 "}
@@ -37560,7 +37588,7 @@ xOT
 xOT
 xOT
 xOT
-bch
+mQx
 cUt
 psZ
 "}
@@ -37896,8 +37924,8 @@ uvP
 tSf
 mOs
 bch
-fLY
-hfr
+gLd
+lhQ
 aiv
 xOT
 xOT
@@ -38621,8 +38649,8 @@ xOT
 xOT
 xOT
 xOT
-bch
-bch
+mQx
+mQx
 mOs
 psZ
 "}
@@ -38959,7 +38987,7 @@ rhp
 rhp
 rhp
 upO
-bch
+mQx
 diR
 mIe
 bck
@@ -38972,10 +39000,10 @@ nAu
 xFL
 gRt
 bch
-bch
+mQx
 cQj
 bch
-bch
+mQx
 mOs
 mOs
 psZ
@@ -39667,8 +39695,8 @@ pJt
 xVF
 wor
 uGM
-bch
-bch
+mQx
+mQx
 bch
 bch
 bch
@@ -39853,11 +39881,11 @@ bch
 bch
 gMO
 xFL
-rGj
+fLY
 xFL
 gRt
 bch
-bch
+mQx
 bch
 mOs
 mOs

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -22630,10 +22630,6 @@
 "xOT" = (
 /turf/open/space/basic,
 /area/lv624/lazarus/internal_affairs)
-"xPn" = (
-/obj/machinery/computer/nuke_disk_generator/blue,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
 "xPG" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -47033,7 +47029,7 @@ xFy
 iVO
 agv
 jNQ
-xPn
+sTw
 tch
 aEp
 kWA

--- a/_maps/modularmaps/lv624/auxbotany.dmm
+++ b/_maps/modularmaps/lv624/auxbotany.dmm
@@ -1,0 +1,886 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"at" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 4
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"ax" = (
+/turf/open/floor/tile/green/whitegreen{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"aX" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 10
+	},
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"cn" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 4
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"ct" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/landmark/excavation_site_spawner,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"cU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 4
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"dr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	dir = 1;
+	name = "\improper Auxillary Hydroponics Dome"
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/hydroponics/aux)
+"dA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/hydroponics/aux)
+"ef" = (
+/turf/template_noop,
+/area/template_noop)
+"es" = (
+/turf/open/floor/tile/green/whitegreencorner{
+	dir = 4
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"eI" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"eQ" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 6
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"fd" = (
+/turf/open/floor/tile/green/whitegreencorner{
+	dir = 8
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"ga" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 6
+	},
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"gi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/decal/warning_stripes/thick,
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"iF" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/obj/effect/decal/warning_stripes/thick{
+	dir = 9
+	},
+/obj/effect/decal/warning_stripes/thick,
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"iN" = (
+/turf/closed/wall,
+/area/lv624/lazarus/hydroponics/aux)
+"jW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/hydroponics/aux)
+"kA" = (
+/turf/open/floor/tile/green/whitegreen{
+	dir = 10
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"kI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/effect/decal/warning_stripes/thick{
+	dir = 10
+	},
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"lX" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/lv624/lazarus/hydroponics/aux)
+"mQ" = (
+/obj/effect/decal/warning_stripes/thick,
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"mV" = (
+/turf/open/floor/tile/green/whitegreen{
+	dir = 2
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"mZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"nQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 8
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"oO" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 8
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"pt" = (
+/obj/structure/table,
+/obj/effect/spawner/random/melee,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 10
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"pD" = (
+/obj/structure/table,
+/obj/item/tool/minihoe,
+/obj/item/tool/shovel,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 4
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"qf" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/green/whitegreencorner{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"qq" = (
+/obj/structure/table,
+/obj/item/analyzer/plant_analyzer,
+/obj/item/analyzer/plant_analyzer,
+/turf/open/floor/tile/green/whitegreen,
+/area/lv624/lazarus/hydroponics/aux)
+"rr" = (
+/obj/item/tool/shovel/spade,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"su" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thick,
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"tr" = (
+/obj/item/clothing/under/colonist,
+/turf/open/floor/tile/green/whitegreencorner{
+	dir = 4
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"tO" = (
+/obj/structure/table,
+/obj/item/tool/hatchet{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"uj" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/tile/green/whitegreencorner,
+/area/lv624/lazarus/hydroponics/aux)
+"uC" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 8
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"vn" = (
+/turf/open/floor/tile/green/whitegreencorner{
+	dir = 2
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"ww" = (
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"wH" = (
+/turf/open/floor/tile/green/whitegreen,
+/area/lv624/lazarus/hydroponics/aux)
+"xA" = (
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"xU" = (
+/obj/machinery/light,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/tile/green/whitegreen,
+/area/lv624/lazarus/hydroponics/aux)
+"xV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/hydroponics/aux)
+"yj" = (
+/turf/open/floor/tile/green/whitegreen{
+	dir = 8
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"ym" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	dir = 4;
+	name = "\improper Auxillary Hydroponics Dome"
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/hydroponics/aux)
+"za" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 4
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"zx" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/landmark/start/job/survivor,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 8
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"AF" = (
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	dir = 4;
+	name = "\improper Auxillary Hydroponics Dome"
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/hydroponics/aux)
+"Bl" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/lv624/lazarus/hydroponics/aux)
+"Bw" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/hydroponics/aux)
+"BD" = (
+/obj/item/tool/minihoe,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"BV" = (
+/turf/open/floor/tile/green/whitegreen{
+	dir = 6
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"BW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/hydroponics/aux)
+"CJ" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/effect/decal/warning_stripes/thick{
+	dir = 5
+	},
+/obj/effect/decal/warning_stripes/thick,
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"DR" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"DS" = (
+/obj/structure/closet/crate/hydroponics/prespawned,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 4
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"DT" = (
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/hydroponics/aux)
+"DW" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/hydroponics/aux)
+"En" = (
+/obj/machinery/smartfridge,
+/turf/open/floor/tile/green/whitegreen,
+/area/lv624/lazarus/hydroponics/aux)
+"Ep" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/hydroponics/aux)
+"Gh" = (
+/turf/open/floor/tile/green/whitegreencorner,
+/area/lv624/lazarus/hydroponics/aux)
+"Gi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"GC" = (
+/obj/structure/table,
+/obj/item/tool/shovel/spade,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 8
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"Hy" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/effect/ai_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/hydroponics/aux)
+"IT" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/hydroponics/aux)
+"IZ" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/clothing/suit/apron,
+/obj/item/clothing/under/colonist,
+/turf/open/floor/tile/green/whitegreen,
+/area/lv624/lazarus/hydroponics/aux)
+"Jy" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"Ks" = (
+/obj/structure/extinguisher_cabinet,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"Kw" = (
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"Ln" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/decal/warning_stripes/thick,
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"LL" = (
+/obj/machinery/smartfridge/seeds,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"Mh" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 8
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"MA" = (
+/obj/machinery/light,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/tile/green/whitegreen,
+/area/lv624/lazarus/hydroponics/aux)
+"Nt" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/hydroponics/aux)
+"NM" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Atmospherics Condenser"
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/hydroponics/aux)
+"OT" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"PD" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 4
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"PW" = (
+/turf/open/floor/tile/green/whitegreencorner{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"Qn" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 9
+	},
+/obj/effect/decal/warning_stripes/thick,
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"QR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/hydroponics/aux)
+"Rn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/hydroponics/aux)
+"RH" = (
+/obj/item/tool/shovel,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"Sf" = (
+/turf/open/floor/tile/green/whitegreen{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"SU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"Tt" = (
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"TE" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/hydroponics/aux)
+"TS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/structure/cable,
+/turf/open/floor/tile/green/whitegreen,
+/area/lv624/lazarus/hydroponics/aux)
+"UH" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 8
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"Vq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/effect/decal/warning_stripes/thick{
+	dir = 6
+	},
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"Wh" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 8
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"Wz" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/tile/green/whitegreen,
+/area/lv624/lazarus/hydroponics/aux)
+"WZ" = (
+/obj/machinery/alarm,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"Xp" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 5
+	},
+/obj/effect/decal/warning_stripes/thick,
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"YC" = (
+/turf/open/floor/tile/green/whitegreen{
+	dir = 4
+	},
+/area/lv624/lazarus/hydroponics/aux)
+
+(1,1,1) = {"
+ef
+ef
+ef
+ef
+ef
+Bw
+lX
+AF
+lX
+Bw
+ef
+ef
+ef
+ef
+ef
+"}
+(2,1,1) = {"
+ef
+Bw
+lX
+lX
+lX
+Bw
+Ks
+yj
+kA
+Bw
+lX
+lX
+lX
+Bw
+ef
+"}
+(3,1,1) = {"
+ef
+lX
+Qn
+xA
+aX
+TE
+Tt
+Nt
+fd
+Mh
+UH
+GC
+pt
+lX
+ef
+"}
+(4,1,1) = {"
+ef
+lX
+mQ
+BD
+Ln
+dA
+Gi
+Rn
+uj
+at
+es
+DT
+qq
+lX
+ef
+"}
+(5,1,1) = {"
+ef
+lX
+CJ
+ct
+Vq
+iN
+Tt
+QR
+wH
+iN
+tO
+es
+IZ
+lX
+ef
+"}
+(6,1,1) = {"
+Bw
+Bw
+Bl
+NM
+iN
+iN
+Kw
+jW
+wH
+iN
+iN
+OT
+xU
+Bw
+Bw
+"}
+(7,1,1) = {"
+lX
+ax
+oO
+zx
+Wh
+yj
+PW
+BW
+fd
+nQ
+yj
+PW
+fd
+kA
+lX
+"}
+(8,1,1) = {"
+dr
+mZ
+Ep
+xV
+xV
+xV
+xV
+Hy
+xV
+IT
+xV
+xV
+Ep
+TS
+dr
+"}
+(9,1,1) = {"
+lX
+ww
+za
+cn
+PD
+YC
+tr
+BW
+Gh
+YC
+YC
+es
+vn
+BV
+lX
+"}
+(10,1,1) = {"
+Bw
+Bw
+Bl
+NM
+iN
+iN
+DR
+BW
+mV
+iN
+iN
+eI
+MA
+Bw
+Bw
+"}
+(11,1,1) = {"
+ef
+lX
+iF
+Jy
+kI
+iN
+WZ
+BW
+mV
+iN
+LL
+qf
+En
+lX
+ef
+"}
+(12,1,1) = {"
+ef
+lX
+su
+xA
+gi
+dA
+SU
+DW
+fd
+uC
+PW
+DT
+Wz
+lX
+ef
+"}
+(13,1,1) = {"
+ef
+lX
+Xp
+rr
+ga
+TE
+RH
+BW
+vn
+at
+DS
+pD
+eQ
+lX
+ef
+"}
+(14,1,1) = {"
+ef
+Bw
+lX
+lX
+lX
+Bw
+Sf
+cU
+BV
+Bw
+lX
+lX
+lX
+Bw
+ef
+"}
+(15,1,1) = {"
+ef
+ef
+ef
+ef
+ef
+Bw
+lX
+ym
+lX
+Bw
+ef
+ef
+ef
+ef
+ef
+"}

--- a/_maps/modularmaps/lv624/lvhydrobridge1.dmm
+++ b/_maps/modularmaps/lv624/lvhydrobridge1.dmm
@@ -19,11 +19,13 @@
 /area/lv624/ground/river2)
 "f" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/lv624/ground/river2)
 "g" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/decal/riverdecal/edge,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/river2)
 "h" = (
@@ -38,12 +40,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/ai_node,
 /obj/effect/decal/riverdecal,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/lv624/ground/river2)
 "k" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/weed_node,
 /obj/effect/decal/riverdecal,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/river2)
 "m" = (
@@ -107,6 +111,7 @@
 /area/lv624/ground/river2)
 "z" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/river2)
 "A" = (
@@ -149,6 +154,7 @@
 /area/lv624/ground/river2)
 "K" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/ground/river,
 /area/lv624/ground/river2)
 "M" = (
@@ -179,6 +185,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/river2)
 "R" = (
@@ -186,11 +193,13 @@
 /obj/effect/decal/riverdecal/edge{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/river2)
 "S" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/decal/riverdecal,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/river2)
 "T" = (

--- a/_maps/modularmaps/lv624/lvhydrobridge2.dmm
+++ b/_maps/modularmaps/lv624/lvhydrobridge2.dmm
@@ -56,6 +56,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/river2)
 "r" = (
@@ -82,6 +83,7 @@
 /area/lv624/ground/river2)
 "B" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/river2)
 "D" = (
@@ -94,6 +96,7 @@
 "G" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/river2)
 "I" = (

--- a/_maps/modularmaps/lv624/lvhydrobridge3.dmm
+++ b/_maps/modularmaps/lv624/lvhydrobridge3.dmm
@@ -15,6 +15,7 @@
 /area/lv624/ground/river2)
 "d" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/river2)
 "e" = (
@@ -56,6 +57,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/river2)
 "r" = (
@@ -73,6 +75,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/ai_node,
 /obj/effect/decal/cleanable/blood/gibs,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/river2)
 "w" = (
@@ -106,6 +109,7 @@
 "F" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/corpsespawner/colonist,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/river2)
 "H" = (

--- a/_maps/modularmaps/lv624/lvhydrobridge4.dmm
+++ b/_maps/modularmaps/lv624/lvhydrobridge4.dmm
@@ -15,6 +15,7 @@
 /area/lv624/ground/river2)
 "d" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/river2)
 "e" = (
@@ -51,6 +52,7 @@
 /area/lv624/ground/river2)
 "p" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/ground/river,
 /area/lv624/ground/river2)
 "q" = (
@@ -58,6 +60,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/river2)
 "r" = (
@@ -74,6 +77,7 @@
 "u" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/ai_node,
+/obj/structure/cable,
 /turf/open/ground/river,
 /area/lv624/ground/river2)
 "w" = (

--- a/code/game/area/lv624.dm
+++ b/code/game/area/lv624.dm
@@ -369,6 +369,9 @@
 	icon_state = "hydro"
 	ceiling = CEILING_GLASS
 
+/area/lv624/lazarus/hydroponics/aux
+	name = "\improper Auxillary Hydroponics"
+
 /area/lv624/lazarus/bar
 	name = "\improper Bar"
 	icon_state = "kitchen"

--- a/code/modules/mapping/modular_mapping.dm
+++ b/code/modules/mapping/modular_mapping.dm
@@ -266,6 +266,14 @@
 	template_height = 15
 	keepcentered = TRUE
 
+/datum/map_template/modular/lv624/dome_internal_affairs
+	name = "LV auxillary botany dome"
+	mappath = "_maps/modularmaps/lv624/auxbotany.dmm"
+	modular_id = "lvdome"
+	template_width = 15
+	template_height = 15
+	keepcentered = TRUE
+
 /datum/map_template/modular/bigred/eastone
 	name = "Big red east caves"
 	mappath = "_maps/modularmaps/big_red/bigredcavevar1.dmm"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Before:

![image](https://user-images.githubusercontent.com/22431091/192114485-14ebed97-0d4b-4207-bab9-bcf246a019a6.png)

After:

![image](https://user-images.githubusercontent.com/22431091/192114434-38e56cc2-c7ac-47d1-b7d9-1ef360e32426.png)



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I think the current LV is not as good as the other maps on offer. The first goal of this PR is to make the whole general western area of the map more playable for both the xenos and marines, as currently it's just a lot of grass, water and a huge cliffside on both sides of the river, hard to approach for both xenos and marines. To address this, I opened up the southwestern exit out of the LZ and added a dome and paths around it for easier navigation. The cliffside north of the river has been cut open a tablefort area has been added. This area has a miner, so marines have a reason to go for it. It also has a bridge to get to it across the river, xenos no longer have to suffer over the tiny 2 tile bridge to attack the red disk, they have more options and I think that's good. The exit of this bridge can also be flanked via the little passage through the cliffside, so you shouldn't go all in on it, either.

The second goal is getting engineering back to where it used to be. On every single other map engineering is very difficult to get to and it's a goal for the marines to get to, so I don't think marines should get it so easily. This should make it similar to other maps in the sense its just outside the caves, so it can be taken with a good push and held. The semi-open areas around it should allow marines to not have to push through a narrow bottleneck, as well. The area where enginerring was is now just the recreation area that used to be there before.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
expansion: Various changes and additions to LV, check github for more info.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
