### PR TITLE
Adds M43 Sunfury mk1 to marine vendor and some tweaks about it

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -29,6 +29,9 @@
 			/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_mlaser = -1,
 			/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol = -1,
 			/obj/item/weapon/gun/energy/lasgun/lasrifle/tesla = 2,
+			/obj/item/cell/lasgun/M43 = -1,
+			/obj/item/cell/lasgun/M43/highcap = 20,
+			/obj/item/weapon/gun/energy/lasgun/M43 = -1,
 		),
 		"SMGs" = list(
 			/obj/item/weapon/gun/smg/standard_smg = -1,
@@ -168,6 +171,8 @@
 			/obj/item/attachable/flamer_nozzle/long = -1,
 			/obj/item/attachable/stock/t19stock = -1,
 			/obj/item/attachable/stock/t35stock = -1,
+			/obj/item/attachable/efflens = -1,
+			/obj/item/attachable/widelens = -1,
 		),
 		"Boxes" = list(
 			/obj/item/ammo_magazine/packet/p9mm = -1,

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -188,8 +188,8 @@
 
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_ENERGY|GUN_AMMO_COUNT_BY_SHOTS_REMAINING|GUN_NO_PITCH_SHIFT_NEAR_EMPTY|GUN_SHOWS_AMMO_REMAINING
 	starting_attachment_types = list(
-	/obj/item/attachable/stock/lasgun,
-	/obj/item/attachable/pulselens,
+		/obj/item/attachable/stock/lasgun,
+		/obj/item/attachable/pulselens,
 	)
 
 	attachable_offset = list("muzzle_x" = 32, "muzzle_y" = 18,"rail_x" = 12, "rail_y" = 23, "under_x" = 23, "under_y" = 15, "stock_x" = 22, "stock_y" = 12)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -146,9 +146,16 @@
 	force = 20 //Large and hefty! Includes stock bonus.
 	icon_state = "m43"
 	item_state = "m43"
-	max_shots = 50 //codex stuff
+	max_shots = 30 //codex stuff
 	load_method = CELL //codex stuff
 	ammo_datum_type = /datum/ammo/energy/lasgun/M43
+	default_ammo_type = /obj/item/cell/lasgun/M43
+	allowed_ammo_types = list(
+	/obj/item/cell/lasgun/M43/highcap,
+	/obj/item/cell/lasgun/M43,
+	/obj/item/cell/lasgun/M43/recharger,
+	)
+
 	ammo_diff = null
 	rounds_per_shot = ENERGY_STANDARD_AMMO_COST
 	attachable_allowed = list(
@@ -170,10 +177,21 @@
 		/obj/item/attachable/efflens,
 		/obj/item/attachable/pulselens,
 		/obj/item/attachable/stock/lasgun,
+		/obj/item/attachable/scope/marine,
+		/obj/item/weapon/gun/flamer/mini_flamer,
+		/obj/item/attachable/motiondetector,
+		/obj/item/weapon/gun/shotgun/combat/masterkey,
+		/obj/item/weapon/gun/rifle/pepperball/pepperball_mini,
+		/obj/item/weapon/gun/grenade_launcher/underslung,
+		/obj/item/weapon/gun/pistol/plasma_pistol,
 	)
 
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_ENERGY|GUN_AMMO_COUNT_BY_SHOTS_REMAINING|GUN_NO_PITCH_SHIFT_NEAR_EMPTY|GUN_SHOWS_AMMO_REMAINING
-	starting_attachment_types = list(/obj/item/attachable/stock/lasgun)
+	starting_attachment_types = list(
+	/obj/item/attachable/stock/lasgun,
+	/obj/item/attachable/pulselens,
+	)
+
 	attachable_offset = list("muzzle_x" = 32, "muzzle_y" = 18,"rail_x" = 12, "rail_y" = 23, "under_x" = 23, "under_y" = 15, "stock_x" = 22, "stock_y" = 12)
 	ammo_level_icon = "m43"
 	accuracy_mult_unwielded = 0.5 //Heavy and unwieldy; you don't one hand this.

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -151,9 +151,9 @@
 	ammo_datum_type = /datum/ammo/energy/lasgun/M43
 	default_ammo_type = /obj/item/cell/lasgun/M43
 	allowed_ammo_types = list(
-	/obj/item/cell/lasgun/M43/highcap,
-	/obj/item/cell/lasgun/M43,
-	/obj/item/cell/lasgun/M43/recharger,
+		/obj/item/cell/lasgun/M43/highcap,
+		/obj/item/cell/lasgun/M43,
+		/obj/item/cell/lasgun/M43/recharger,
 	)
 
 	ammo_diff = null

--- a/code/modules/projectiles/magazines/energy.dm
+++ b/code/modules/projectiles/magazines/energy.dm
@@ -24,7 +24,7 @@
 
 /obj/item/cell/lasgun/M43/highcap// Large battery
 	name = "\improper M43 highcap lasgun battery"
-	desc = "An advanced, ultrahigh capacity battery used to power the M43 lasgun; has sixty percent more charge capacity than standard laspacks."
+	desc = "An advanced, ultrahigh capacity battery used to power the M43 lasgun; has 220 percent charge capacity of standard laspacks."
 	charge_overlay = "m43_e"
 	icon_state = "m43_e"
 	maxcharge = 1600
@@ -38,6 +38,14 @@
 	self_recharge = TRUE
 	charge_amount = 25 // 10%, 1 shot
 	charge_delay = 2 SECONDS
+
+/obj/item/cell/lasgun/M43/recharger// Selfrechargeable battery
+	name = "\improper M43-R lasgun battery"
+	desc = "An advanced, selfrechargeable version of high density battery used to power the M43 lasgun."
+	self_recharge = TRUE
+	charge_amount = 25 // 10%, 2 shots
+	charge_delay = 2 SECONDS
+
 
 /obj/item/cell/lasgun/M43/practice
 	name = "\improper M43-P lasgun battery"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -363,6 +363,26 @@ WEAPONS
 	cost = 5
 	available_against_xeno_only = TRUE
 
+/datum/supply_packs/weapons/m43_h
+	name = "M43-H Highcapacity cell"
+	contains = list(/obj/item/cell/lasgun/M43/highcap)
+	cost = 1
+
+/datum/supply_packs/weapons/m43_r
+	name = "M43-R Selfrechargeable cell"
+	contains = list(/obj/item/cell/lasgun/M43/recharger)
+	cost = 5
+
+/datum/supply_packs/weapons/heatlens
+	name = "M43 Heatlense attachment"
+	contains = list(/obj/item/attachable/heatlens)
+	cost = 10
+
+/datum/supply_packs/weapons/focuslens
+	name = "M43 Focuslense attachment"
+	contains = list(/obj/item/attachable/focuslens)
+	cost = 10
+
 /datum/supply_packs/weapons/zx76
 	name = "ZX-76 Twin-Barrled Burst Shotgun"
 	contains = list(/obj/item/weapon/gun/shotgun/zx76)


### PR DESCRIPTION

## About The Pull Request

Basically pr adds m43 sunfury mk1 and things to it in marine vendor:
*Adds 20 high cap mags to sunfury (80 shots)
*Adds basic mags (30 shots)
*Adds selfrechargeable mags (30 shots) req only
![image](https://user-images.githubusercontent.com/114332059/192135559-45d6cd66-4a94-4e49-a0d6-81085d0a5915.png)

*All sunfury's from vendor have pulse lense for auto mode
*Adds efficiency and wide lenses to marine vendor
![image](https://user-images.githubusercontent.com/114332059/192135586-cd048bb2-9c56-40ff-844e-d78cabae7cf1.png)

*Adds selfrechargeable cells, high cap cells, focus lens, heat lens to reqs (fit to sunfury only).
![image](https://user-images.githubusercontent.com/114332059/192135630-3fdfc2cd-0c52-4b68-af67-02280691a7bd.png)

*More attachement for sunfury (flamer, underslug, masterkey, tactical sensor, PP-7, T-47, pepperball)
![image](https://user-images.githubusercontent.com/114332059/192135680-554f8a53-e75f-4b36-b9e1-8b5c7d129283.png)

## Why It's Good For The Game

Adding a new (old) laser gun, with a few tweaks to make it fun and playable, I didn't change the gun's damage and rate of fire. A self-charging battery does not charge instantly, if you want to shoot non-stop then you need 3-4 mags and that's about 20 points in req. By itself, Sunfury doesn't hit very hard, it doesn't have IFF and aim mode, so I consider those attachments is fair and not going to break balance. Pulse fire is fun.

## Changelog
:cl:
add: M43 Sunfury mk1 to marine vendor and things to it
add: M43 Sunfury mk1 selfrechargeable cell
expansion: Expands list of M43 Sunfury mk1 attachements
fix: Fix M43 sunfury mk1 codex ammo amount
/:cl:

