### PR TITLE
Alters Pheromone tower cost and range

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -211,7 +211,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 /datum/hive_upgrade/building/pherotower
 	name = "Pheromone Tower"
 	desc = "Constructs a tower that emanates a selectable type of pheromone."
-	psypoint_cost = 100
+	psypoint_cost = 150
 	icon = "pherotower"
 	flags_upgrade = ABILITY_DISTRESS
 	building_type = /obj/structure/xeno/pherotower

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -1178,7 +1178,7 @@ TUNNEL
 	///Strength of pheromones given by this tower.
 	var/aura_strength = 5
 	///Radius (in tiles) of the pheromones given by this tower.
-	var/aura_radius = 22
+	var/aura_radius = 50
 
 /obj/structure/xeno/pherotower/Initialize(mapload, hivenum)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Per title. The cost has been increased from 100 to 150, but its range has been increased from 22 to 50.

## Why It's Good For The Game
Unlike xenomorph players, pheromone towers are immobile targets, and their range leaves much to be desired. This allows them to cover a much greater area and amend the issue, but to compensate, the cost has been increased.

## Changelog
:cl: Lewdcifer
balance: Pheromone tower cost 100 > 150, range 22 > 50.
/:cl: