### PR TITLE
Fixes plasteel cades not wiring with the FOB drone

### DIFF
--- a/code/modules/mining/remote_fob/remote_fob_actions_misc.dm
+++ b/code/modules/mining/remote_fob/remote_fob_actions_misc.dm
@@ -115,7 +115,7 @@
 		if(console.metal_remaining <= 1)
 			fobdrone.balloon_alert(owner, "Not enough material for razor-wiring")
 			return
-
+		cade.wire()
 		console.metal_remaining -=2
 		fobdrone.balloon_alert(owner, "Barricade placed with wiring. [console.plasteel_remaining] plasteel sheets, [console.metal_remaining] metal sheets remaining.")
 		return


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes plasteel cades not being wired by the FOB drone when it has do_wiring 
## Why It's Good For The Game
its a fix

## Changelog
:cl:
fix: Fixed plasteel cades not being wired by LZ drones.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
