### PR TITLE
Add AI middle click code, clarify some AI code, unregister signal

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -62,6 +62,7 @@
 		CtrlShiftClickOn(A)
 		return
 	if(modifiers["middle"])
+		MiddleClickOn(A)
 		return
 	if(modifiers["shift"])
 		ShiftClickOn(A)
@@ -111,6 +112,9 @@
 /mob/living/silicon/ai/CtrlClickOn(atom/A)
 	A.AICtrlClick(src)
 
+/mob/living/silicon/ai/MiddleClickOn(atom/A)
+	A.AIMiddleClick(src)
+
 /*
 	The following criminally helpful code is just the previous code cleaned up;
 	I have no idea why it was in atoms.dm instead of respective files.
@@ -125,6 +129,9 @@
 	return
 
 /atom/proc/AICtrlShiftClick()
+	return
+
+/atom/proc/AIMiddleClick()
 	return
 
 /* Airlocks */

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -117,6 +117,7 @@
 	UnregisterSignal(src, COMSIG_MOB_CLICK_ALT)
 	UnregisterSignal(SSdcs, COMSIG_GLOB_OB_LASER_CREATED)
 	UnregisterSignal(SSdcs, COMSIG_GLOB_CAS_LASER_CREATED)
+	UnregisterSignal(SSdcs, COMSIG_GLOB_SHUTTLE_TAKEOFF)
 	return ..()
 
 ///Print order visual to all marines squad hud and give them an arrow to follow the waypoint

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -85,9 +85,9 @@
 
 	RegisterSignal(src, COMSIG_MOB_CLICK_ALT, .proc/send_order)
 	RegisterSignal(src, COMSIG_ORDER_SELECTED, .proc/set_order)
+
 	RegisterSignal(SSdcs, COMSIG_GLOB_OB_LASER_CREATED, .proc/receive_laser_ob)
 	RegisterSignal(SSdcs, COMSIG_GLOB_CAS_LASER_CREATED, .proc/receive_laser_cas)
-
 	RegisterSignal(SSdcs, COMSIG_GLOB_SHUTTLE_TAKEOFF, .proc/shuttle_takeoff_notification)
 
 	var/datum/action/innate/order/attack_order/send_attack_order = new
@@ -115,6 +115,7 @@
 	QDEL_NULL(track)
 	UnregisterSignal(src, COMSIG_ORDER_SELECTED)
 	UnregisterSignal(src, COMSIG_MOB_CLICK_ALT)
+
 	UnregisterSignal(SSdcs, COMSIG_GLOB_OB_LASER_CREATED)
 	UnregisterSignal(SSdcs, COMSIG_GLOB_CAS_LASER_CREATED)
 	UnregisterSignal(SSdcs, COMSIG_GLOB_SHUTTLE_TAKEOFF)


### PR DESCRIPTION
## About The Pull Request
This is a code improvement PR : 

- The AI did not unregister the shuttle takeoff signal. 
- Added and removed a couple spaces in the Ai code.
- Add middle mouse support for the AI. It is not currently used by anything, but it works. Same function as AiCtrlClick.

## Why It's Good For The Game
Code improvements are good.

## Changelog
:cl:
code: Clarified AI code
code: Added middle mouse click support for the AI
code: Unregistered a signal which wasn't before on the AI 
/:cl:

