### PR TITLE
Telecom fixes & Marine ships fixes. 

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -15660,7 +15660,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "Xh" = (
-/obj/machinery/computer/telecomms/monitor,
+/obj/machinery/computer/telecomms/monitor/preset,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "Xi" = (
@@ -16280,7 +16280,7 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "Zh" = (
-/obj/machinery/computer/telecomms/server,
+/obj/machinery/computer/telecomms/server/preset,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "Zj" = (

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -164,6 +164,17 @@
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"aC" = (
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/obj/machinery/door/poddoor/shutters/mainship/open/hangar{
+	dir = 2
+	},
+/turf/open/floor/stairs/rampbottom{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "aD" = (
 /obj/item/paper/crumpled{
 	pixel_x = -4;
@@ -655,6 +666,9 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 1
 	},
@@ -845,15 +859,16 @@
 /obj/machinery/door_control/mainship/droppod{
 	dir = 1
 	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 8
 	},
 /area/mainship/hallways/hangar/droppod)
 "cF" = (
 /obj/structure/sign/poster,
+/obj/machinery/cic_maptable/droppod_maptable,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar/droppod)
 "cG" = (
@@ -1018,9 +1033,16 @@
 	},
 /area/mainship/hallways/hangar)
 "da" = (
-/obj/machinery/light/mainship,
-/obj/machinery/cic_maptable/droppod_maptable,
-/turf/open/floor/mainship/mono,
+/obj/structure/cable,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 1
+	},
 /area/mainship/hallways/hangar/droppod)
 "db" = (
 /obj/effect/decal/siding{
@@ -1872,8 +1894,10 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 2;
-	id = "hangar_lockdown"
+	dir = 2
+	},
+/obj/machinery/door/poddoor/shutters/mainship/open/hangar{
+	dir = 2
 	},
 /turf/open/floor/stairs/rampbottom{
 	dir = 1
@@ -1917,8 +1941,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor/mainship{
-	dir = 2;
-	id = "hangar_lockdown"
+	dir = 2
+	},
+/obj/machinery/door/poddoor/shutters/mainship/open/hangar{
+	dir = 2
 	},
 /turf/open/floor/stairs/rampbottom{
 	dir = 1
@@ -2197,7 +2223,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "gp" = (
 /obj/structure/cable,
@@ -2363,17 +2389,13 @@
 /turf/open/floor/mainship/red/full,
 /area/mainship/command/cic)
 "gQ" = (
-/obj/machinery/door_control/mainship/ammo{
+/obj/structure/droppod,
+/obj/structure/dropprop,
+/obj/machinery/light/mainship{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2;
-	id = "hangar_lockdown"
-	},
-/turf/open/floor/stairs/rampbottom{
-	dir = 1
-	},
-/area/mainship/hallways/hangar)
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/hangar/droppod)
 "gR" = (
 /obj/machinery/door/poddoor/mainship,
 /turf/open/floor/mainship/stripesquare,
@@ -2533,6 +2555,14 @@
 /obj/machinery/door/firedoor/mainship,
 /obj/structure/sign/pods,
 /turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar/droppod)
+"hq" = (
+/obj/structure/droppod,
+/obj/structure/dropprop,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar/droppod)
 "ht" = (
 /obj/structure/toilet{
@@ -2723,6 +2753,13 @@
 /obj/machinery/holopad,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
+"hR" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/machinery/door_control/mainship/ammo,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar)
 "hS" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -3382,8 +3419,10 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 2;
-	id = "hangar_lockdown"
+	dir = 2
+	},
+/obj/machinery/door/poddoor/shutters/mainship/open/hangar{
+	dir = 2
 	},
 /turf/open/floor/stairs/rampbottom{
 	dir = 1
@@ -3845,7 +3884,7 @@
 "lb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "lc" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
@@ -4378,6 +4417,9 @@
 "mA" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/keycard_auth,
+/obj/item/radio{
+	pixel_x = 6
+	},
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
@@ -4530,7 +4572,7 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "mZ" = (
-/obj/machinery/computer/telecomms/monitor,
+/obj/machinery/computer/telecomms/monitor/preset,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "nb" = (
@@ -5887,7 +5929,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "rf" = (
-/obj/machinery/computer/telecomms/server,
+/obj/machinery/computer/telecomms/server/preset,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "rg" = (
@@ -6019,6 +6061,19 @@
 	dir = 9
 	},
 /area/mainship/squads/general)
+"rD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/obj/machinery/door/poddoor/shutters/mainship/open/hangar{
+	dir = 2
+	},
+/turf/open/floor/stairs/rampbottom{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "rE" = (
 /obj/item/radio/intercom/general{
 	dir = 1
@@ -7298,16 +7353,21 @@
 	pixel_x = -4;
 	pixel_y = 9
 	},
-/obj/machinery/door_control/old/cic/hangar{
-	pixel_x = -4;
-	pixel_y = 2
-	},
 /obj/machinery/door_control/old/cic/armory{
 	pixel_x = -4;
 	pixel_y = -5
 	},
 /obj/machinery/light/mainship,
-/obj/item/radio,
+/obj/machinery/door_control/old/cic/hangar_shutters{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/machinery/door_control/old/medbay{
+	id = "Medbay";
+	name = "Medbay Lockdown";
+	pixel_x = 6;
+	pixel_y = -5
+	},
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
 "vw" = (
@@ -9444,6 +9504,11 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/living/grunt_rnr)
+"BB" = (
+/obj/structure/cable,
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "BD" = (
 /obj/machinery/door/poddoor/shutters/mainship/cell,
 /obj/machinery/door/airlock/mainship/research/glass/cell,
@@ -11312,8 +11377,10 @@
 /area/mainship/hallways/hangar)
 "GV" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 2;
-	id = "hangar_lockdown"
+	dir = 2
+	},
+/obj/machinery/door/poddoor/shutters/mainship/open/hangar{
+	dir = 2
 	},
 /turf/open/floor/stairs/rampbottom{
 	dir = 1
@@ -13580,6 +13647,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
+"MO" = (
+/obj/machinery/door_control/mainship/droppod,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "MP" = (
 /obj/effect/landmark/start/job/medicalofficer,
 /turf/open/floor/mainship/sterile/dark,
@@ -13876,7 +13947,6 @@
 /area/mainship/hallways/aft_hallway)
 "NG" = (
 /obj/structure/table/woodentable,
-/obj/structure/paper_bin,
 /obj/item/clipboard{
 	pixel_x = -6;
 	pixel_y = 2
@@ -14689,6 +14759,10 @@
 /obj/item/reagent_containers/food/snacks/cheeseburger,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
+"Qa" = (
+/obj/item/radio/intercom/general,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "Qb" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/machinery/holopad,
@@ -15871,6 +15945,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"Tp" = (
+/obj/machinery/door_control/mainship/hangar,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "Tq" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/black{
@@ -15936,10 +16014,14 @@
 	},
 /area/mainship/medical/operating_room_one)
 "Tz" = (
-/obj/machinery/light/mainship,
+/obj/structure/sign/poster,
 /obj/structure/table/mainship/nometal,
 /obj/machinery/computer/droppod_control,
-/turf/open/floor/mainship/mono,
+/obj/machinery/light/mainship,
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar/droppod)
 "TB" = (
 /obj/machinery/light/mainship{
@@ -16130,9 +16212,6 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 4
 	},
@@ -16143,6 +16222,11 @@
 	},
 /obj/effect/landmark/start/job/cmo,
 /obj/machinery/light/mainship,
+/obj/machinery/door_control/old/medbay{
+	id = "Medbay";
+	name = "Medbay Lockdown";
+	pixel_x = 25
+	},
 /turf/open/floor/wood,
 /area/mainship/medical/medical_science)
 "Uf" = (
@@ -17734,12 +17818,11 @@
 /area/mainship/hull/lower_hull)
 "YC" = (
 /obj/structure/cable,
-/obj/machinery/door_control/mainship/droppod{
-	dir = 8
-	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 2;
-	id = "hangar_lockdown"
+	dir = 2
+	},
+/obj/machinery/door/poddoor/shutters/mainship/open/hangar{
+	dir = 2
 	},
 /turf/open/floor/stairs/rampbottom{
 	dir = 1
@@ -43477,7 +43560,7 @@ cu
 Wf
 lX
 lX
-lX
+gQ
 lX
 lX
 lX
@@ -43742,11 +43825,11 @@ Wf
 hc
 az
 ap
-ap
+YU
 ml
 ap
-YU
 ap
+YU
 ap
 ap
 ap
@@ -43998,7 +44081,7 @@ cF
 Ur
 ha
 az
-sD
+MO
 ap
 nB
 ap
@@ -44251,7 +44334,7 @@ lX
 lX
 lX
 cg
-da
+Ur
 Ur
 hp
 az
@@ -44768,7 +44851,7 @@ ct
 gh
 fD
 xo
-KN
+rD
 lb
 go
 fd
@@ -45025,7 +45108,7 @@ cS
 dr
 GV
 CB
-VG
+aC
 ap
 Zx
 eJ
@@ -45535,12 +45618,12 @@ lX
 lX
 lX
 lX
-dX
-Tz
+da
+Ur
 Ur
 hG
-vh
-ap
+az
+Tp
 Zx
 uZ
 ZA
@@ -45793,7 +45876,7 @@ lX
 lX
 lX
 dX
-cF
+Tz
 Ur
 CB
 az
@@ -46052,9 +46135,9 @@ RQ
 ex
 Ud
 Ur
-CB
+BB
 az
-ap
+Qa
 Zx
 eJ
 ZA
@@ -46304,7 +46387,7 @@ aq
 Wf
 lX
 lX
-lX
+hq
 lX
 lX
 lX
@@ -50164,7 +50247,7 @@ bD
 ap
 gC
 az
-CB
+BB
 az
 oe
 bP
@@ -50419,7 +50502,7 @@ an
 ak
 an
 aO
-kB
+bV
 az
 CB
 az
@@ -51705,7 +51788,7 @@ aF
 ap
 fn
 rI
-gQ
+VG
 Yb
 QD
 ap
@@ -51965,7 +52048,7 @@ az
 az
 ja
 az
-nL
+hR
 an
 wg
 SH

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -9988,7 +9988,7 @@
 /turf/open/floor/mainship/tcomms,
 /area/sulaco/telecomms)
 "bbX" = (
-/obj/machinery/computer/telecomms/monitor,
+/obj/machinery/computer/telecomms/monitor/preset,
 /turf/open/floor/prison,
 /area/sulaco/telecomms/office)
 "bbY" = (
@@ -10094,6 +10094,7 @@
 /area/sulaco/telecomms)
 "bdf" = (
 /obj/machinery/computer/telecomms/server,
+/obj/machinery/computer/telecomms/server/preset,
 /turf/open/floor/prison,
 /area/sulaco/telecomms/office)
 "bdg" = (

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -1052,6 +1052,7 @@
 /area/mainship/shipboard/port_point_defense)
 "adD" = (
 /obj/machinery/telecomms/server/presets/charlie,
+/obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "adF" = (
@@ -2633,6 +2634,7 @@
 /area/mainship/living/commandbunks)
 "baN" = (
 /obj/machinery/telecomms/server/presets/cas,
+/obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "baO" = (
@@ -3134,7 +3136,8 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "bgf" = (
-/obj/machinery/computer/telecomms/server,
+/obj/machinery/camera/autoname/mainship,
+/obj/machinery/computer/telecomms/server/preset,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "bgu" = (
@@ -3574,7 +3577,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "bkb" = (
-/obj/machinery/computer/telecomms/monitor,
+/obj/machinery/computer/telecomms/monitor/preset,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "bkc" = (
@@ -3980,6 +3983,7 @@
 /obj/item/folder/black,
 /obj/structure/paper_bin,
 /obj/item/tool/pen,
+/obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/ce_room)
 "blm" = (
@@ -6099,6 +6103,7 @@
 /area/mainship/engineering/lower_engineering)
 "bHG" = (
 /obj/machinery/power/monitor,
+/obj/structure/cable,
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/lower_engineering)
 "bHH" = (
@@ -10591,6 +10596,7 @@
 "gbk" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/power/monitor,
+/obj/structure/cable,
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
@@ -10664,6 +10670,7 @@
 /area/mainship/living/cafeteria_starboard)
 "ggr" = (
 /obj/structure/bed/chair/office/dark,
+/obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/ce_room)
 "ghz" = (

--- a/code/game/objects/machinery/door_control.dm
+++ b/code/game/objects/machinery/door_control.dm
@@ -327,6 +327,10 @@
 	name = "Hangar Lockdown"
 	id = "hangar_lockdown"
 
+/obj/machinery/door_control/old/cic/hangar_shutters
+	id = "hangar_shutters"
+	name = "Hangar Shutters"
+
 /obj/machinery/door_control/old/cic/armory
 	name = "Armory Lockdown"
 	id = "cic_armory"

--- a/code/game/objects/machinery/doors/poddoor.dm
+++ b/code/game/objects/machinery/doors/poddoor.dm
@@ -207,9 +207,13 @@
 	name = "\improper Combat Information Center Blast Door"
 	id = "cic_lockdown_rebel"
 
-/obj/machinery/door/poddooor/mainship/hangar
+/obj/machinery/door/poddoor/mainship/hangar
 	name = "\improper Hangar Lockdown"
 	id = "hangar_lockdown"
+
+/obj/machinery/door/poddoor/mainship/hangar/second
+	name = "\improper Hangar Shutters"
+	id = "hangar_shutters"
 
 /obj/machinery/door/poddoor/mainship/umbilical
 	name = "Umbilical Airlock"

--- a/code/game/objects/machinery/doors/shutters.dm
+++ b/code/game/objects/machinery/doors/shutters.dm
@@ -132,6 +132,9 @@
 	id = "sd_lockdown"
 	resistance_flags = RESIST_ALL
 
+/obj/machinery/door/poddoor/shutters/mainship/open/hangar
+	name = "\improper Hangar Shutters"
+	id = "hangar_shutters"
 
 /obj/machinery/door/poddoor/shutters/mainship/open/checkpoint
 	name = "Checkpoint Shutters"

--- a/code/game/objects/machinery/telecomms/computers/logbrowser.dm
+++ b/code/game/objects/machinery/telecomms/computers/logbrowser.dm
@@ -15,6 +15,8 @@
 
 	circuit = /obj/item/circuitboard/computer/comm_server
 
+/obj/machinery/computer/telecomms/server/preset
+	network = "tcommsat"
 
 /obj/machinery/computer/telecomms/server/interact(mob/user)
 	var/dat

--- a/code/game/objects/machinery/telecomms/computers/telemonitor.dm
+++ b/code/game/objects/machinery/telecomms/computers/telemonitor.dm
@@ -19,6 +19,8 @@
 	var/temp = ""				// temporary feedback messages
 	circuit = /obj/item/circuitboard/computer/comm_monitor
 
+/obj/machinery/computer/telecomms/monitor/preset
+	network = "tcommsat"
 
 /obj/machinery/computer/telecomms/monitor/interact(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
This is a fat PR, because splitting changes is an horrible pain, and this took me hours.

Changes contained : 
- Telecoms rooms have 2 computers used to monitor them. They are not set to "Tcommsat" by default, which makes them useless for the layman.  This PR changes that by creating 2 subtypes and replacing all the consoles.
- Theseus Power monitors lacked cables underneath, rendering them useless. 
- Theseus telecoms room lacked cameras. 
- Some pod doors were called poddooor, which was obviously a typo.
- Fixed the POS not having working hangar shutters. The issue was that they were firelocks, and not proper shutters. 
- Fixed the POS having medical shutters, but no button to activate them. I've given the CIC and CMO a button for it. 

That was really painful.

## Why It's Good For The Game
For telecoms, it makes diagnostics easier for everyone.
The power changes are helpful for engineers wondering how much power is actually flowing through the powergrid.
The bugs with POS hangar are finally eradicated. 

## Changelog
:cl:
fix: fixed Theseus not having cameras in telecoms.
fix: Fixed Theseus not having working power monitors.
fix: Fixed all ships having non preset telecommunications monitors.
fix: Fixed POS hangar shutters not working
fix: Fixed POS Medical shutters not having an associated button
/:cl:
