### PR TITLE
Belt Harness now works for Plasma Cutter

### DIFF
--- a/code/game/objects/items/tools/mining_tools.dm
+++ b/code/game/objects/items/tools/mining_tools.dm
@@ -309,3 +309,43 @@
 	cut_apart(user, O.name, O)
 	qdel(O)
 	return TRUE
+
+/obj/item/tool/pickaxe/plasmacutter/throw_at(atom/target, range, speed, thrower)
+	if( harness_check(thrower) )
+		to_chat(usr, span_warning("\The [src] clanks on the ground."))
+	else
+		return ..()
+
+/obj/item/tool/pickaxe/plasmacutter/dropped(mob/user)
+	. = ..()
+
+	harness_check(user)
+
+/obj/item/tool/pickaxe/plasmacutter/proc/harness_check(mob/user)
+	if(!ishuman(user))
+		return FALSE
+	var/mob/living/carbon/human/owner = user
+	var/obj/item/B = owner.belt	//if they don't have a magharness, are they wearing a harness belt?
+	if(!istype(B, /obj/item/belt_harness))
+		return FALSE
+	var/obj/item/I = owner.wear_suit
+	if(!is_type_in_list(I, list(/obj/item/clothing/suit/storage, /obj/item/clothing/suit/armor, /obj/item/clothing/suit/modular)))
+		return FALSE
+	addtimer(CALLBACK(src, .proc/harness_return, user), 0.3 SECONDS, TIMER_UNIQUE)
+	return TRUE
+
+/obj/item/tool/pickaxe/plasmacutter/proc/harness_return(mob/living/carbon/human/user)
+	if(!isturf(loc) || QDELETED(user) || !isnull(user.s_store) && !isnull(user.back))
+		return
+
+	user.equip_to_slot_if_possible(src, SLOT_S_STORE, warning = FALSE)
+	if(user.s_store == src)
+		var/obj/item/I = user.wear_suit
+		to_chat(user, span_warning("[src] snaps into place on [I]."))
+		user.update_inv_s_store()
+		return
+
+	user.equip_to_slot_if_possible(src, SLOT_BACK, warning = FALSE)
+	if(user.back == src)
+		to_chat(user, span_warning("[src] snaps into place on your back."))
+	user.update_inv_back()


### PR DESCRIPTION

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Xeno drag pretty much ensures PCs can be dragged and melted. PC feels in an even rougher state.
This should help slightly and make Xenos put in a bit more effort to deal with PC spam. (Watch out for primo rounies.)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Belt Harness now works with Plasma Cutter
balance: Belt Harness now works with Plasma Cutter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
