### PR TITLE
Attempt to give the AI ranks

### DIFF
--- a/code/datums/jobs/access.dm
+++ b/code/datums/jobs/access.dm
@@ -361,5 +361,11 @@
 			. = size ? "Mk.II " : "Mark II"
 		if("Mk.I")
 			. = size ? "Mk.I " : "Mark I"
+		if("Gn.I")
+			. = size ? "Gn.I " : "Generation I"
+		if("Gn.II")
+			. = size ? "Gn.II " : "Generation II"
+		if("Gn.III")
+			. = size ? "Gn.III " : "Generation III"
 		else
 			. = paygrade + " " //custom paygrade

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -1135,7 +1135,7 @@ In addition, being a Synthetic gives you knowledge in every field and specializa
 	job_category = JOB_CAT_SILICON
 	req_admin_notify = TRUE
 	comm_title = "AI"
-	paygrade = "test"
+	paygrade = ""
 	total_positions = 1
 	selection_color = "#92c255"
 	supervisors = "your laws and the human crew"

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -1135,6 +1135,7 @@ In addition, being a Synthetic gives you knowledge in every field and specializa
 	job_category = JOB_CAT_SILICON
 	req_admin_notify = TRUE
 	comm_title = "AI"
+	paygrade = "test"
 	total_positions = 1
 	selection_color = "#92c255"
 	supervisors = "your laws and the human crew"
@@ -1166,6 +1167,22 @@ In addition, being a Synthetic gives you knowledge in every field and specializa
 		/datum/job/terragov/silicon/synthetic/rebel = SYNTH_POINTS_REGULAR,
 	)
 
+
+
+
+/datum/job/terragov/silicon/ai/after_spawn(mob/living/new_mob, mob/user, latejoin = FALSE)
+	. = ..()
+	var/mob/living/silicon/ai/new_ai = new_mob
+	var/playtime_mins = user?.client?.get_exp(title)
+	if(!playtime_mins || playtime_mins < 1 )
+		return
+	switch(playtime_mins)
+		if(0 to 600) //up to 10 hours
+			new_ai.job.paygrade = "MkI"
+		if(601 to 3000) // 10 to 50 hrs
+			new_ai.job.paygrade = "MkII"
+		if(3001 to INFINITY) // more than 50 hrs
+			new_ai.job.paygrade = "MkIII"
 
 /datum/job/terragov/silicon/ai/get_special_name(client/preference_source)
 	return preference_source.prefs.ai_name

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -1174,15 +1174,15 @@ In addition, being a Synthetic gives you knowledge in every field and specializa
 	. = ..()
 	var/mob/living/silicon/ai/new_ai = new_mob
 	var/playtime_mins = user?.client?.get_exp(title)
-	if(!playtime_mins || playtime_mins < 1 )
-		return
+	// if(!playtime_mins || playtime_mins < 1 )
+	// 	return
 	switch(playtime_mins)
 		if(0 to 600) //up to 10 hours
-			new_ai.job.paygrade = "MkI"
+			new_ai.job.paygrade = "Gn.I"
 		if(601 to 3000) // 10 to 50 hrs
-			new_ai.job.paygrade = "MkII"
+			new_ai.job.paygrade = "Gn.II"
 		if(3001 to INFINITY) // more than 50 hrs
-			new_ai.job.paygrade = "MkIII"
+			new_ai.job.paygrade = "Gn.III"
 
 /datum/job/terragov/silicon/ai/get_special_name(client/preference_source)
 	return preference_source.prefs.ai_name

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -127,6 +127,19 @@ GLOBAL_LIST_INIT(freqtospan, list(
 			return ""
 
 		return "[get_paygrades(J.paygrade, TRUE, gender)] "
+	else if(isAI(speaker))
+		var/mob/living/silicon/ai/AI = speaker
+
+		var/paygrade = AI.get_paygrade()
+		if(paygrade)
+			return "[paygrade]"
+
+		var/datum/job/J = AI.job
+		if(!istype(J))
+			return ""
+
+		return "[get_paygrades(J.paygrade, TRUE, NEUTER)] "
+
 	else
 		return ""
 

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -138,7 +138,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		if(!istype(J))
 			return ""
 
-		return "[get_paygrades(J.paygrade, TRUE, NEUTER)] "
+		return "[get_paygrades(J.paygrade, TRUE, gender)] "
 
 	else
 		return ""

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -363,6 +363,9 @@
 		stat("Number of living marines:", "[SSticker.mode.count_humans_and_xenos()[1]]")
 
 
+/mob/living/silicon/ai/get_paygrade(size = 1)
+	return get_paygrades(job.paygrade, size, gender)
+
 /mob/living/silicon/ai/fully_replace_character_name(oldname, newname)
 	. = ..()
 


### PR DESCRIPTION
## About The Pull Request
The AI is the last job without ranks. This PR seeks to add them.
The current placeholder ranks are Gn.I to Gn.III, meaning generation. 

The issue is that it only works for the non radio voices currently : 
![image](https://user-images.githubusercontent.com/24830358/192370370-432059e8-2b93-49ec-828a-b34f9ba647a1.png)


## Why It's Good For The Game
Funny rank fluff is good.

## Changelog
:cl:
add: Added ranks for the AI
/:cl:

