### PR TITLE
Panic Hugger Rebalance

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -185,7 +185,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 	action_icon_state = "carrier_panic"
 	mechanics_text = "Drop all stored huggers in a fit of panic. Uses all remaining plasma!"
 	plasma_cost = 10
-	cooldown_timer = 50 SECONDS
+	cooldown_timer =180 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_DROP_ALL_HUGGER
 	use_state_flags = XACT_USE_LYING
 
@@ -207,7 +207,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 	if(!.)
 		return FALSE
 	var/mob/living/carbon/xenomorph/carrier/X = owner
-	if(X.health > (X.maxHealth * 0.25))
+	if(X.health > (X.maxHealth * 0.4))
 		if(!silent)
 			to_chat(X, span_xenowarning("We are not injured enough to panic yet!"))
 		return FALSE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases threshold for Carrier's panic drop to 40%.
Increases the cooldown to 3 minutes so it's not as spammable.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
In it's initial state panic drop was used as more of an offensive tool rather than in the case of panic.

In it's current state, it's barely useable as carriers aren't the most durable castes and most forms of damage will just skip out the 25% health threshold resulting in crit with no chance to use the ability at all.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Increased panic drop activation threshold to 40% health.
balance: Increased panic drop's cooldown to 180 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
