### PR TITLE
Refactors SSauras to be more consistant and to respect MC_CHECK_TICK

### DIFF
--- a/code/controllers/subsystem/aura.dm
+++ b/code/controllers/subsystem/aura.dm
@@ -11,9 +11,13 @@ SUBSYSTEM_DEF(aura)
 	var/stage = 1
 
 /datum/controller/subsystem/aura/fire(resumed)
+	var/current_resume = FALSE
+	if(resumed)
+		current_resume = TRUE
 	if(stage == 1)
-		if(!resumed)
+		if(!current_resume)
 			current_cache = active_auras.Copy()
+		current_resume = FALSE
 		while(current_cache.len)
 			var/datum/aura_bearer/bearer = current_cache[current_cache.len]
 			current_cache.len--
@@ -24,8 +28,9 @@ SUBSYSTEM_DEF(aura)
 				return
 		stage = 2
 	if(stage == 2)
-		if(!resumed)
+		if(!current_resume)
 			current_cache = GLOB.xeno_mob_list.Copy()
+		current_resume = FALSE
 		while(current_cache.len)
 			var/mob/living/carbon/xenomorph/xeno = current_cache[current_cache.len]
 			current_cache.len--
@@ -36,8 +41,9 @@ SUBSYSTEM_DEF(aura)
 				return
 		stage = 3
 	if(stage == 3)
-		if(!resumed)
+		if(!current_resume)
 			current_cache = GLOB.human_mob_list.Copy()
+		current_resume = FALSE
 		while(current_cache.len)
 			var/mob/living/carbon/human/human = current_cache[current_cache.len]
 			current_cache.len--

--- a/code/controllers/subsystem/aura.dm
+++ b/code/controllers/subsystem/aura.dm
@@ -7,7 +7,7 @@ SUBSYSTEM_DEF(aura)
 	var/list/active_auras = list() //We can't use a normal subsystem processing list because as soon as an aura_bearer leaves the list it needs to die
 
 /datum/controller/subsystem/aura/fire(resumed)
-	end_phero_pulses()
+	finish_aura_cycles()
 	for(var/datum/aura_bearer/bearer AS in active_auras)
 		bearer.process()
 
@@ -20,7 +20,11 @@ SUBSYSTEM_DEF(aura)
 	. =  new /datum/aura_bearer(center, type, range, strength, duration, faction)
 	active_auras += .
 
-/datum/controller/subsystem/aura/proc/end_phero_pulses()
+/**
+ * Iterates through all mobs which may have been affected by auras and completes their aura cycles which applies effects and clears received auras afterwards.
+ * Does act on all humans / xenos instead of the more constrained lists applying auras works on due to the possibility of mobs having changed z, died, done weird things, and so on.
+**/
+/datum/controller/subsystem/aura/proc/finish_aura_cycles()
 	for(var/mob/living/carbon/xenomorph/xeno AS in GLOB.xeno_mob_list)
 		xeno.finish_aura_cycle()
 	for(var/mob/living/carbon/human/human AS in GLOB.human_mob_list)

--- a/code/controllers/subsystem/aura.dm
+++ b/code/controllers/subsystem/aura.dm
@@ -7,6 +7,7 @@ SUBSYSTEM_DEF(aura)
 	var/list/active_auras = list() //We can't use a normal subsystem processing list because as soon as an aura_bearer leaves the list it needs to die
 
 /datum/controller/subsystem/aura/fire(resumed)
+	end_phero_pulses()
 	for(var/datum/aura_bearer/bearer AS in active_auras)
 		bearer.process()
 
@@ -18,6 +19,13 @@ SUBSYSTEM_DEF(aura)
 		return
 	. =  new /datum/aura_bearer(center, type, range, strength, duration, faction)
 	active_auras += .
+
+/datum/controller/subsystem/aura/proc/end_phero_pulses()
+	for(var/mob/living/carbon/xenomorph/xeno AS in GLOB.xeno_mob_list)
+		xeno.finish_aura_cycle()
+	for(var/mob/living/carbon/human/human AS in GLOB.human_mob_list)
+		human.finish_aura_cycle()
+
 
 ///The thing that actually pushes out auras to nearby mobs.
 /datum/aura_bearer

--- a/code/game/objects/machinery/overwatch.dm
+++ b/code/game/objects/machinery/overwatch.dm
@@ -782,7 +782,7 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 		return
 	var/aura_strength = skills.getRating("leadership") - 1
 	var/aura_target = pick_order_target()
-	SSaura.add_emitter(aura_target, command_aura, aura_strength + 4, aura_strength, 15, faction)
+	SSaura.add_emitter(aura_target, command_aura, aura_strength + 4, aura_strength, 30 SECONDS, faction)
 
 	var/message = ""
 	switch(command_aura)

--- a/code/modules/mob/living/carbon/human/life/handle_status_effects.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_status_effects.dm
@@ -13,7 +13,7 @@
 
 	return TRUE
 
-/mob/living/carbon/human/handle_received_auras()
+/mob/living/carbon/human/finish_aura_cycle()
 
 	set_mobility_aura(received_auras[AURA_HUMAN_MOVE] || 0)
 	protection_aura = received_auras[AURA_HUMAN_HOLD] || 0

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -48,10 +48,6 @@
 	if(!(xeno_caste.caste_flags & CASTE_FIRE_IMMUNE) && on_fire) //Sanity check; have to be on fire to actually take the damage.
 		SEND_SIGNAL(src, COMSIG_XENOMORPH_FIRE_BURNING)
 		adjustFireLoss((fire_stacks + 3) * get_fire_resist())
-		if(current_aura)
-			current_aura.suppressed = TRUE
-		if(leader_current_aura)
-			leader_current_aura.suppressed = TRUE
 
 /mob/living/carbon/xenomorph/proc/handle_living_health_updates()
 	if(health < 0)
@@ -159,6 +155,11 @@
 	hud_set_plasma() //update plasma amount on the plasma mob_hud
 
 /mob/living/carbon/xenomorph/finish_aura_cycle()
+	if(!(xeno_caste.caste_flags & CASTE_FIRE_IMMUNE) && on_fire) //Has to be here to prevent desyncing between phero and life, despite making more sense in handle_fire()
+		if(current_aura)
+			current_aura.suppressed = TRUE
+		if(leader_current_aura)
+			leader_current_aura.suppressed = TRUE
 
 	if(frenzy_aura != (received_auras[AURA_XENO_FRENZY] || 0))
 		set_frenzy_aura(received_auras[AURA_XENO_FRENZY] || 0)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -158,7 +158,7 @@
 	gain_plasma(plasma_mod[1])
 	hud_set_plasma() //update plasma amount on the plasma mob_hud
 
-/mob/living/carbon/xenomorph/handle_received_auras()
+/mob/living/carbon/xenomorph/finish_aura_cycle()
 
 	if(frenzy_aura != (received_auras[AURA_XENO_FRENZY] || 0))
 		set_frenzy_aura(received_auras[AURA_XENO_FRENZY] || 0)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -22,10 +22,8 @@
 	handle_slowdown()
 	handle_stagger()
 
-	handle_received_auras()
-
 ///Adjusts our stats based on the auras we've received and care about, then cleans out the list for next tick.
-/mob/living/proc/handle_received_auras()
+/mob/living/proc/finish_aura_cycle()
 	received_auras.Cut() //Living, of course, doesn't care about any
 
 ///Update what auras we'll receive this life tick if it's either new or stronger than current. aura_type as AURA_ define, strength as number.


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Basically, the problem with the aura subsystem at the moment is that it "pulses" mobs on SSaura, but "finishes" cycles (clears phero received while applying effects for what pulsed it, etc.) on Life which is on SSmobs. This means that when SSaura and SSmobs get sufficiently delayed or desynced relative to eachother (high TD tends to cause this), mobs will begin to have cycles they did not receive a pulse from SSauras, leading to mobs not gaining aura effects despite being supposed to.
This addresses said issue by also moving the call of the finishing proc into SSauras, iterating through all humans and xenos to do so. It seemed like the easiest solution to achieve consistancy with only having to iterate through those mobs once per cycle and other possible options to combat the issue that I could think of tended to require more inefficient means than just iterating through those two mob lists once.
If a maintainer has a better idea feel free to suggest so, but if not I think this one should be acceptable.

After some pointers from tivi, this also takes fire() in general and makes it work with MC_CHECK_TICK which should prevent it from taking too much of the MC's time. Also changes phero durations to ticks instead of subsystem ticks and fixes pheromone affecting xenos on fire.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
All auras breaking at moderate TD by cause of subsystems ticking at different times and creating a blind timeframe due to that is a bad thing. This fixes that issue.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Pheromones (And orders) should no longer "flicker" at high TD, remaining consistant instead.
fix: Xenos can no longer receive pheromones when on fire.
refactor: SSauras now includes MC_CHECK_TICK to prevent it from eating too much of the MC's time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
