### PR TITLE
Makes engineering storage module fit filled sandbags

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/storage.dm
+++ b/code/modules/clothing/modular_armor/attachments/storage.dm
@@ -169,6 +169,7 @@
 		/obj/item/stack/rods,
 		/obj/item/stack/cable_coil,
 		/obj/item/stack/sandbags_empty,
+		/obj/item/stack/sandbags,
 		/obj/item/stack/razorwire,
 		/obj/item/tool/shovel/etool,
 		/obj/item/tool/wrench,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Engie storage for armor can now take filled sandbags
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
With all the other great storage modules, it was an annoying handicap not being able to carry filled sandbags in it. Grenade and injector modules are great choices, and engie module does the same thing as a webbing (which also fits empty sandbags and tools), so I feel like this is a fair compromise for what are seldom use barricades.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: engineering storage module can fit filled sandbags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
