### PR TITLE
Cleans up some map spawned gear

### DIFF
--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -6619,7 +6619,7 @@
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/hydroponics/south)
 "aFm" = (
-/obj/item/ammo_magazine/shotgun{
+/obj/item/ammo_magazine/shotgun/buckshot{
 	pixel_x = 6;
 	pixel_y = -4
 	},
@@ -7333,7 +7333,7 @@
 "aIs" = (
 /obj/structure/closet/crate,
 /obj/item/ammo_magazine/shotgun/incendiary,
-/obj/item/ammo_magazine/shotgun,
+/obj/item/ammo_magazine/shotgun/buckshot,
 /turf/open/floor/tile/dark/blue2{
 	dir = 6
 	},
@@ -8799,7 +8799,7 @@
 /turf/open/floor/freezer,
 /area/ice_colony/surface/bar/canteen)
 "aPz" = (
-/obj/item/ammo_magazine/shotgun,
+/obj/item/ammo_magazine/shotgun/buckshot,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/ice_colony/surface/bar/bar)
@@ -21513,8 +21513,8 @@
 /area/ice_colony/underground/reception)
 "bOz" = (
 /obj/structure/rack,
-/obj/item/ammo_magazine/shotgun,
-/obj/item/ammo_magazine/shotgun{
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot{
 	pixel_x = 6;
 	pixel_y = -4
 	},
@@ -25986,7 +25986,7 @@
 "fnQ" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/shotgun/pump/cmb,
-/obj/item/ammo_magazine/shotgun,
+/obj/item/ammo_magazine/shotgun/buckshot,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/dark,
 /area/ice_colony/surface/hangar/checkpoint)

--- a/_maps/map_files/Research_Outpost/Research_Outpost.dmm
+++ b/_maps/map_files/Research_Outpost/Research_Outpost.dmm
@@ -2787,7 +2787,7 @@
 /area/outpost/medbay)
 "nj" = (
 /obj/structure/table,
-/obj/item/ammo_magazine/shotgun,
+/obj/item/ammo_magazine/shotgun/buckshot,
 /obj/item/ammo_magazine/shotgun/buckshot,
 /turf/open/floor/tile/dark/red2{
 	dir = 1
@@ -4907,8 +4907,8 @@
 "wD" = (
 /obj/structure/closet/secure_closet/security,
 /obj/item/weapon/gun/shotgun/pump/cmb,
-/obj/item/ammo_magazine/shotgun,
-/obj/item/ammo_magazine/shotgun,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
 /obj/item/attachable/flashlight,
 /obj/item/attachable/heavy_barrel,
 /obj/item/attachable/reddot,
@@ -6043,7 +6043,7 @@
 /area/outpost/yard/south_east)
 "BL" = (
 /obj/structure/table,
-/obj/item/ammo_magazine/shotgun,
+/obj/item/ammo_magazine/shotgun/buckshot,
 /turf/open/floor/tile/dark/red2{
 	dir = 8
 	},
@@ -8024,7 +8024,7 @@
 "Ll" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/shotgun/pump/cmb,
-/obj/item/ammo_magazine/shotgun,
+/obj/item/ammo_magazine/shotgun/buckshot,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/dark/red2,
 /area/outpost/brig/armoury)
@@ -9033,6 +9033,7 @@
 	},
 /obj/structure/paper_bin,
 /obj/effect/spawner/random/plushie{
+	
 	},
 /turf/open/floor/tile/dark/brown2{
 	dir = 8
@@ -9236,8 +9237,8 @@
 /obj/structure/closet/secure_closet/security,
 /obj/item/attachable/gyro,
 /obj/item/attachable/reddot,
-/obj/item/ammo_magazine/shotgun,
-/obj/item/ammo_magazine/shotgun,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
 /obj/item/weapon/gun/shotgun/double,
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/red2,

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -10171,7 +10171,7 @@
 /area/icy_caves/caves/rock)
 "UG" = (
 /obj/structure/rack,
-/obj/item/ammo_magazine/shotgun,
+/obj/item/ammo_magazine/shotgun/buckshot,
 /obj/item/weapon/gun/shotgun/pump/cmb,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)

--- a/code/game/objects/effects/spawners/random.dm
+++ b/code/game/objects/effects/spawners/random.dm
@@ -436,13 +436,13 @@
 		return pick(/obj/item/weapon/gun/rifle/standard_assaultrifle,\
 					/obj/item/weapon/gun/rifle/standard_carbine,\
 					/obj/item/weapon/gun/rifle/standard_skirmishrifle,\
-					/obj/item/weapon/gun/rifle/tx11,\
+					/obj/item/weapon/gun/rifle/tx11/scopeless,\
 					/obj/item/weapon/gun/smg/standard_smg,\
 					/obj/item/weapon/gun/smg/standard_machinepistol,\
 					/obj/item/weapon/gun/rifle/standard_dmr,\
 					/obj/item/weapon/gun/rifle/standard_br,\
 					/obj/item/weapon/gun/rifle/chambered,\
-					/obj/item/weapon/gun/shotgun/pump/bolt,\
+					/obj/item/weapon/gun/shotgun/pump/bolt/unscoped,\
 					/obj/item/weapon/gun/shotgun/double/martini,\
 					/obj/item/weapon/gun/pistol/standard_pistol,\
 					/obj/item/weapon/gun/pistol/standard_heavypistol,\
@@ -453,7 +453,6 @@
 					/obj/item/weapon/gun/shotgun/double/derringer,\
 					/obj/item/weapon/gun/rifle/pepperball,\
 					/obj/item/weapon/gun/shotgun/pump/lever/repeater,\
-					/obj/item/weapon/gun/shotgun/pump/bolt,\
 					/obj/item/weapon/gun/shotgun/double/marine,\
 					/obj/item/weapon/gun/rifle/standard_autoshotgun,\
 					/obj/item/weapon/gun/shotgun/combat/standardmarine)
@@ -466,7 +465,7 @@
 
 /obj/effect/spawner/random/gun/shotgun/item_to_spawn()
 		return pick(/obj/item/weapon/gun/shotgun/pump/lever/repeater,\
-					/obj/item/weapon/gun/shotgun/pump/bolt,\
+					/obj/item/weapon/gun/shotgun/pump/bolt/unscoped,\
 					/obj/item/weapon/gun/shotgun/pump/cmb,\
 					/obj/item/weapon/gun/shotgun/double/marine,\
 					/obj/item/weapon/gun/rifle/standard_autoshotgun,\
@@ -494,7 +493,7 @@
 		return pick(/obj/item/weapon/gun/rifle/standard_assaultrifle,\
 					/obj/item/weapon/gun/rifle/standard_carbine,\
 					/obj/item/weapon/gun/rifle/standard_skirmishrifle,\
-					/obj/item/weapon/gun/rifle/tx11)
+					/obj/item/weapon/gun/rifle/tx11/scopeless)
 
 
 ///random sidearms
@@ -557,7 +556,6 @@
 					/obj/item/ammo_magazine/pistol/derringer,\
 					/obj/item/ammo_magazine/rifle/pepperball,\
 					/obj/item/ammo_magazine/shotgun/flechette,\
-					/obj/item/ammo_magazine/shotgun,\
 					/obj/item/ammo_magazine/rifle/tx15_slug)
 
 
@@ -570,8 +568,7 @@
 
 /obj/effect/spawner/random/ammo/shotgun/item_to_spawn()
 		return pick(/obj/item/ammo_magazine/shotgun/buckshot,\
-					/obj/item/ammo_magazine/shotgun/flechette,\
-					/obj/item/ammo_magazine/shotgun)
+					/obj/item/ammo_magazine/shotgun/flechette)
 
 
 ///random machinegun ammunition
@@ -649,13 +646,13 @@
 		list(/obj/item/weapon/gun/rifle/standard_assaultrifle, /obj/item/ammo_magazine/rifle/standard_assaultrifle, /obj/item/ammo_magazine/rifle/standard_assaultrifle, /obj/item/ammo_magazine/rifle/standard_assaultrifle,),
 		list(/obj/item/weapon/gun/rifle/standard_carbine, /obj/item/ammo_magazine/rifle/standard_carbine, /obj/item/ammo_magazine/rifle/standard_carbine, /obj/item/ammo_magazine/rifle/standard_carbine,),
 		list(/obj/item/weapon/gun/rifle/standard_skirmishrifle, /obj/item/ammo_magazine/rifle/standard_skirmishrifle, /obj/item/ammo_magazine/rifle/standard_skirmishrifle, /obj/item/ammo_magazine/rifle/standard_skirmishrifle,),
-		list(/obj/item/weapon/gun/rifle/tx11, /obj/item/ammo_magazine/rifle/tx11, /obj/item/ammo_magazine/rifle/tx11, /obj/item/ammo_magazine/rifle/tx11,),
+		list(/obj/item/weapon/gun/rifle/tx11/scopeless, /obj/item/ammo_magazine/rifle/tx11, /obj/item/ammo_magazine/rifle/tx11, /obj/item/ammo_magazine/rifle/tx11,),
 		list(/obj/item/weapon/gun/smg/standard_smg, /obj/item/ammo_magazine/smg/standard_smg, /obj/item/ammo_magazine/smg/standard_smg, /obj/item/ammo_magazine/smg/standard_smg,),
 		list(/obj/item/weapon/gun/smg/standard_machinepistol, /obj/item/ammo_magazine/smg/standard_machinepistol, /obj/item/ammo_magazine/smg/standard_machinepistol, /obj/item/ammo_magazine/smg/standard_machinepistol,),
 		list(/obj/item/weapon/gun/rifle/standard_dmr, /obj/item/ammo_magazine/rifle/standard_dmr, /obj/item/ammo_magazine/rifle/standard_dmr, /obj/item/ammo_magazine/rifle/standard_dmr,),
 		list(/obj/item/weapon/gun/rifle/standard_br, /obj/item/ammo_magazine/rifle/standard_br, /obj/item/ammo_magazine/rifle/standard_br, /obj/item/ammo_magazine/rifle/standard_br,),
 		list(/obj/item/weapon/gun/rifle/chambered, /obj/item/ammo_magazine/rifle/chamberedrifle, /obj/item/ammo_magazine/rifle/chamberedrifle, /obj/item/ammo_magazine/rifle/chamberedrifle,),
-		list(/obj/item/weapon/gun/shotgun/pump/bolt, /obj/item/ammo_magazine/rifle/bolt, /obj/item/ammo_magazine/rifle/bolt, /obj/item/ammo_magazine/rifle/bolt,),
+		list(/obj/item/weapon/gun/shotgun/pump/bolt/unscoped, /obj/item/ammo_magazine/rifle/bolt, /obj/item/ammo_magazine/rifle/bolt, /obj/item/ammo_magazine/rifle/bolt,),
 		list(/obj/item/weapon/gun/shotgun/double/martini, /obj/item/ammo_magazine/rifle/martini, /obj/item/ammo_magazine/rifle/martini, /obj/item/ammo_magazine/rifle/martini,),
 		list(/obj/item/weapon/gun/pistol/standard_pistol, /obj/item/ammo_magazine/pistol/standard_pistol, /obj/item/ammo_magazine/pistol/standard_pistol, /obj/item/ammo_magazine/pistol/standard_pistol,),
 		list(/obj/item/weapon/gun/pistol/standard_heavypistol, /obj/item/ammo_magazine/pistol/standard_heavypistol, /obj/item/ammo_magazine/pistol/standard_heavypistol, /obj/item/ammo_magazine/pistol/standard_heavypistol,),
@@ -666,10 +663,9 @@
 		list(/obj/item/weapon/gun/shotgun/double/derringer, /obj/item/ammo_magazine/pistol/derringer, /obj/item/ammo_magazine/pistol/derringer, /obj/item/ammo_magazine/pistol/derringer,),
 		list(/obj/item/weapon/gun/rifle/pepperball, /obj/item/ammo_magazine/rifle/pepperball, /obj/item/ammo_magazine/rifle/pepperball, /obj/item/ammo_magazine/rifle/pepperball,),
 		list(/obj/item/weapon/gun/shotgun/pump/lever/repeater, /obj/item/ammo_magazine/packet/p4570, /obj/item/ammo_magazine/packet/p4570, /obj/item/ammo_magazine/packet/p4570,),
-		list(/obj/item/weapon/gun/shotgun/pump/bolt, /obj/item/ammo_magazine/rifle/bolt, /obj/item/ammo_magazine/rifle/bolt, /obj/item/ammo_magazine/rifle/bolt,),
 		list(/obj/item/weapon/gun/shotgun/double/marine, /obj/item/ammo_magazine/shotgun/buckshot, /obj/item/ammo_magazine/shotgun/buckshot, /obj/item/ammo_magazine/shotgun/buckshot,),
 		list(/obj/item/weapon/gun/rifle/standard_autoshotgun, /obj/item/ammo_magazine/rifle/tx15_slug, /obj/item/ammo_magazine/rifle/tx15_slug, /obj/item/ammo_magazine/rifle/tx15_slug,),
-		list(/obj/item/weapon/gun/shotgun/combat/standardmarine, /obj/item/ammo_magazine/shotgun, /obj/item/ammo_magazine/shotgun, /obj/item/ammo_magazine/shotgun,),
+		list(/obj/item/weapon/gun/shotgun/combat/standardmarine, /obj/item/ammo_magazine/shotgun/buckshot, /obj/item/ammo_magazine/shotgun/buckshot, /obj/item/ammo_magazine/shotgun/buckshot,),
 	)
 
 //random rifles
@@ -681,7 +677,7 @@ obj/effect/spawner/random_set/rifle
 		list(/obj/item/weapon/gun/rifle/standard_assaultrifle, /obj/item/ammo_magazine/rifle/standard_assaultrifle, /obj/item/ammo_magazine/rifle/standard_assaultrifle, /obj/item/ammo_magazine/rifle/standard_assaultrifle,),
 		list(/obj/item/weapon/gun/rifle/standard_carbine, /obj/item/ammo_magazine/rifle/standard_carbine, /obj/item/ammo_magazine/rifle/standard_carbine, /obj/item/ammo_magazine/rifle/standard_carbine,),
 		list(/obj/item/weapon/gun/rifle/standard_skirmishrifle, /obj/item/ammo_magazine/rifle/standard_skirmishrifle, /obj/item/ammo_magazine/rifle/standard_skirmishrifle, /obj/item/ammo_magazine/rifle/standard_skirmishrifle,),
-		list(/obj/item/weapon/gun/rifle/tx11, /obj/item/ammo_magazine/rifle/tx11, /obj/item/ammo_magazine/rifle/tx11, /obj/item/ammo_magazine/rifle/tx11,),
+		list(/obj/item/weapon/gun/rifle/tx11/scopeless, /obj/item/ammo_magazine/rifle/tx11, /obj/item/ammo_magazine/rifle/tx11, /obj/item/ammo_magazine/rifle/tx11,),
 	)
 
 //random shotguns
@@ -690,12 +686,12 @@ obj/effect/spawner/random_set/rifle
 	icon_state = "random_shotgun"
 
 	option_list = list(
-		list(/obj/item/weapon/gun/shotgun/pump/bolt, /obj/item/ammo_magazine/rifle/bolt, /obj/item/ammo_magazine/rifle/bolt, /obj/item/ammo_magazine/rifle/bolt,),
+		list(/obj/item/weapon/gun/shotgun/pump/bolt/unscoped, /obj/item/ammo_magazine/rifle/bolt, /obj/item/ammo_magazine/rifle/bolt, /obj/item/ammo_magazine/rifle/bolt,),
 		list(/obj/item/weapon/gun/shotgun/double/marine, /obj/item/ammo_magazine/shotgun/buckshot, /obj/item/ammo_magazine/shotgun/buckshot, /obj/item/ammo_magazine/shotgun/buckshot,),
 		list(/obj/item/weapon/gun/rifle/standard_autoshotgun, /obj/item/ammo_magazine/rifle/tx15_slug, /obj/item/ammo_magazine/rifle/tx15_slug, /obj/item/ammo_magazine/rifle/tx15_slug,),
 		list(/obj/item/weapon/gun/shotgun/combat/standardmarine, /obj/item/ammo_magazine/shotgun/flechette, /obj/item/ammo_magazine/shotgun/flechette, /obj/item/ammo_magazine/shotgun/flechette,),
 		list(/obj/item/weapon/gun/shotgun/pump/t35, /obj/item/ammo_magazine/shotgun/buckshot, /obj/item/ammo_magazine/shotgun/buckshot, /obj/item/ammo_magazine/shotgun/buckshot,),
-		list(/obj/item/weapon/gun/shotgun/pump/cmb, /obj/item/ammo_magazine/shotgun, /obj/item/ammo_magazine/shotgun, /obj/item/ammo_magazine/shotgun,),
+		list(/obj/item/weapon/gun/shotgun/pump/cmb, /obj/item/ammo_magazine/shotgun/buckshot, /obj/item/ammo_magazine/shotgun/buckshot, /obj/item/ammo_magazine/shotgun/buckshot,),
 	)
 
 //random machineguns

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -377,6 +377,8 @@
 
 	placed_overlay_iconstate = "wood"
 
+/obj/item/weapon/gun/shotgun/pump/bolt/unscoped
+	starting_attachment_types = list(/obj/item/attachable/stock/mosin)
 
 //***********************************************************
 // Martini Henry


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces map spawned slugs with buckshot, and makes the tx11 and mosin scopeless.
These are problematic for HvH as they're unbalanced, and are basically decorative for HvX.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No more cheesy map spawn items, better HvH balance
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Groundside will no longer have shotgun slugs or scoped weapons as part of random spawns
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
