### PR TITLE
Flashbangs no longer spawn naturally

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -862,7 +862,6 @@
 /area/bigredv2/outside/marshal_office)
 "aji" = (
 /obj/structure/table,
-/obj/item/explosive/grenade/flashbang,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "ajj" = (

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -11681,10 +11681,6 @@
 "ldz" = (
 /obj/item/flash,
 /obj/structure/table/reinforced,
-/obj/item/explosive/grenade/flashbang{
-	pixel_x = 7;
-	pixel_y = 2
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},

--- a/_maps/map_files/Vapor_Processing/Vapor_Processing.dmm
+++ b/_maps/map_files/Vapor_Processing/Vapor_Processing.dmm
@@ -1824,10 +1824,6 @@
 "jD" = (
 /obj/item/flash,
 /obj/structure/table/reinforced,
-/obj/item/explosive/grenade/flashbang{
-	pixel_x = 7;
-	pixel_y = 2
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},

--- a/_maps/map_files/desertdam/desertdam.dmm
+++ b/_maps/map_files/desertdam/desertdam.dmm
@@ -14076,7 +14076,6 @@
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bGv" = (
 /obj/structure/table,
-/obj/item/explosive/grenade/flashbang,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/staffroom)
 "bGw" = (

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -7519,10 +7519,6 @@
 "IH" = (
 /obj/item/flash,
 /obj/structure/table/reinforced,
-/obj/item/explosive/grenade/flashbang{
-	pixel_x = 7;
-	pixel_y = 2
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},

--- a/_maps/modularmaps/big_red/bigredsecornervar3.dmm
+++ b/_maps/modularmaps/big_red/bigredsecornervar3.dmm
@@ -921,8 +921,6 @@
 /area/bigredv2/caves/undergroundrobotics)
 "Zu" = (
 /obj/structure/rack,
-/obj/item/explosive/grenade/flashbang,
-/obj/item/explosive/grenade/flashbang,
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 8
 	},

--- a/_maps/modularmaps/big_red/bigredsecornervar6.dmm
+++ b/_maps/modularmaps/big_red/bigredsecornervar6.dmm
@@ -573,8 +573,6 @@
 /area/bigredv2/caves/secomplex)
 "Iv" = (
 /obj/structure/rack,
-/obj/item/explosive/grenade/flashbang,
-/obj/item/explosive/grenade/flashbang,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "IY" = (

--- a/_maps/modularmaps/lv624/cargo_bay.dmm
+++ b/_maps/modularmaps/lv624/cargo_bay.dmm
@@ -338,8 +338,6 @@
 /area/lv624/lazarus/quartstorage)
 "Nb" = (
 /obj/structure/largecrate,
-/obj/item/explosive/grenade/flashbang,
-/obj/item/explosive/grenade/flashbang,
 /turf/open/floor/plating,
 /area/lv624/lazarus/quartstorage)
 "Ne" = (

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -386,7 +386,6 @@
 	products = list(
 		/obj/item/restraints/handcuffs = 8,
 		/obj/item/restraints/handcuffs/zip = 10,
-		/obj/item/explosive/grenade/flashbang = 4,
 		/obj/item/flash = 5,
 		/obj/item/reagent_containers/food/snacks/donut/normal = 12,
 		/obj/item/storage/box/evidence = 6,

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -189,7 +189,6 @@
 	new /obj/item/storage/belt/security(src)
 	new /obj/item/flash(src)
 	new /obj/item/reagent_containers/spray/pepper(src)
-	new /obj/item/explosive/grenade/flashbang(src)
 	new /obj/item/weapon/baton(src)
 	new /obj/item/weapon/gun/energy/taser(src)
 	new /obj/item/clothing/glasses/sunglasses/sechud(src)


### PR DESCRIPTION
## About The Pull Request
Per title. SoM flashbangs should remain unaffected.
Thanks, Rio!

## Why It's Good For The Game
Flashbangs have no place in normal gameplay. They've only been used to grief, and with the recent addition of pulling objects (#11011), xenos can pull flashbangs into fire and force them to trigger. These things can stun for up to **20 seconds.**

## Changelog
:cl: Lewdcifer
del: Flashbangs no longer spawn naturally.
/:cl: