### PR TITLE
Flashbang sound fix

### DIFF
--- a/code/game/objects/items/explosives/grenades/flashbang.dm
+++ b/code/game/objects/items/explosives/grenades/flashbang.dm
@@ -22,10 +22,11 @@
 
 /obj/item/explosive/grenade/flashbang/prime()
 	var/turf/T = get_turf(src)
+	playsound(T, 'sound/effects/bang.ogg', 50, 1)
 	for(var/obj/structure/closet/L in get_hear(7, T))
 		if(locate(/mob/living/carbon/, L))
 			for(var/mob/living/carbon/M in L)
-				bang(get_turf(src), M)
+				bang(T, M)
 
 
 	for(var/mob/living/carbon/M in get_hear(7, T))
@@ -38,7 +39,6 @@
 /// Added a new proc called 'bang' that takes a location and a person to be banged.
 /obj/item/explosive/grenade/flashbang/proc/bang(turf/T , mob/living/carbon/M)
 	to_chat(M, span_danger("BANG"))
-	playsound(src.loc, 'sound/effects/bang.ogg', 50, 1)
 
 //Checking for protections
 	var/ear_safety = 0


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes flashbangs not actually making a sound if it doesn't successfully flash anyone.

Currently the flashbang sound is triggered when someone is actually flashbanged... this is also triggered for EVERY person that is flashbanged (i.e. flash 5 people, play the sound 5 times).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hearing when your flashbang goes off so you don't run out and stun yourself is good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Flashbangs go bang regardless of  whether someone actually gets flashed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
