### PR TITLE
check path proc

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1270,7 +1270,7 @@ GLOBAL_LIST_INIT(survivor_outfits, typecacheof(/datum/outfit/job/survivor))
 /proc/check_path(atom/start, atom/end, bypass_window = FALSE, projectile = FALSE, bypass_xeno = FALSE)
 	var/list/path_to_target = getline(start, end)
 	var/line_count = 1
-	while(line_count < length.path_to_target)
+	while(line_count < length(path_to_target))
 		if(LinkBlocked(path_to_target[line_count], path_to_target[line_count + 1], bypass_window, projectile, bypass_xeno))
 			return FALSE
 		line_count ++

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1257,3 +1257,23 @@ will handle it, but:
 	return	cone_turfs
 
 GLOBAL_LIST_INIT(survivor_outfits, typecacheof(/datum/outfit/job/survivor))
+
+/**
+ *	Draws a line between two atoms, then checks if the path is blocked.
+ *	Variables:
+ *	start -start point of the path
+ *	end - end point of the path
+ *	bypass_window - whether it will go through transparent windows in the same way as lasers
+ *	projectile - whether throwpass will be checked to ignore dense objects in the same way as projectiles
+ *	bypass_xeno - whether to bypass dense xeno structures in the same way as flamers
+ */
+/proc/check_path(atom/start, atom/end, bypass_window = FALSE, projectile = FALSE, bypass_xeno = FALSE)
+	var/list/path_to_target = getline(start, end)
+	var/line_count = 1
+	for(var/path_turf in path_to_target)
+		if(line_count == length(path_to_target))
+			break
+		if(LinkBlocked(path_to_target[line_count], path_to_target[line_count + 1], bypass_window, projectile, bypass_xeno))
+			return FALSE
+		line_count ++
+	return TRUE

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1270,9 +1270,7 @@ GLOBAL_LIST_INIT(survivor_outfits, typecacheof(/datum/outfit/job/survivor))
 /proc/check_path(atom/start, atom/end, bypass_window = FALSE, projectile = FALSE, bypass_xeno = FALSE)
 	var/list/path_to_target = getline(start, end)
 	var/line_count = 1
-	for(var/path_turf in path_to_target)
-		if(line_count == length(path_to_target))
-			break
+	while(line_count < length.path_to_target)
 		if(LinkBlocked(path_to_target[line_count], path_to_target[line_count + 1], bypass_window, projectile, bypass_xeno))
 			return FALSE
 		line_count ++


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adding a generic proc to draw a path between two atoms and check to see if anything is blocking that path, with a few args to tweak it's behavior.
This is useful because procs like get_hear() ignore transparent objects like windows or machinery, and is blocked by opaque atoms like smoke.

I made this for widow, but there's other things it can be used for, so PR'ing it on it's own for now, but let me know if that's not OK.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Useful proc good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Added a check_path proc to see if a path between atoms is blocked
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
