### PR TITLE
Crusher Health/Armor changes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -21,7 +21,7 @@
 	plasma_gain = 10
 
 	// *** Health *** //
-	max_health = 325
+	max_health = 280
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_YOUNG_THRESHOLD
@@ -32,7 +32,7 @@
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER|CASTE_CAN_BECOME_KING
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 70, BULLET = 60, LASER = 60, ENERGY = 60, BOMB = 100, BIO = 80, "rad" = 80, FIRE = 25, ACID = 80)
+	soft_armor = list(MELEE = 70, BULLET = 70, LASER = 75, ENERGY = 60, BOMB = 100, BIO = 80, "rad" = 80, FIRE = 25, ACID = 80)
 
 	// *** Minimap Icon *** //
 	minimap_icon = "crusher"
@@ -79,13 +79,13 @@
 	plasma_gain = 15
 
 	// *** Health *** //
-	max_health = 345
+	max_health = 285
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_MATURE_THRESHOLD
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 75, BULLET = 65, LASER = 65, ENERGY = 65, BOMB = 100, BIO = 90, "rad" = 90, FIRE = 30, ACID = 90)
+	soft_armor = list(MELEE = 75, BULLET = 75, LASER = 75, ENERGY = 65, BOMB = 100, BIO = 90, "rad" = 90, FIRE = 30, ACID = 90)
 
 	// *** Abilities *** //
 	stomp_damage = 50
@@ -108,13 +108,13 @@
 	plasma_gain = 30
 
 	// *** Health *** //
-	max_health = 370
+	max_health = 295
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_ELDER_THRESHOLD
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 80, BULLET = 70, LASER = 70, ENERGY = 70, BOMB = 100, BIO = 95, "rad" = 95, FIRE = 35, ACID = 95)
+	soft_armor = list(MELEE = 80, BULLET = 80, LASER = 80, ENERGY = 70, BOMB = 100, BIO = 95, "rad" = 95, FIRE = 35, ACID = 95)
 
 	// *** Abilities *** //
 	stomp_damage = 55
@@ -137,13 +137,13 @@
 	plasma_gain = 30
 
 	// *** Health *** //
-	max_health = 400
+	max_health = 300
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_ANCIENT_THRESHOLD
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 90, BULLET = 75, LASER = 75, ENERGY = 75, BOMB = 100, BIO = 100, "rad" = 100, FIRE = 40, ACID = 100)
+	soft_armor = list(MELEE = 90, BULLET = 85, LASER = 85, ENERGY = 75, BOMB = 100, BIO = 100, "rad" = 100, FIRE = 40, ACID = 100)
 	// *** Abilities *** //
 	stomp_damage = 60
 	crest_toss_distance = 6
@@ -166,10 +166,10 @@
 	plasma_gain = 30
 
 	// *** Health *** //
-	max_health = 400
+	max_health = 300
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 90, BULLET = 75, LASER = 75, ENERGY = 75, BOMB = 100, BIO = 100, "rad" = 100, FIRE = 40, ACID = 100)
+	soft_armor = list(MELEE = 90, BULLET = 85, LASER = 85, ENERGY = 75, BOMB = 100, BIO = 100, "rad" = 100, FIRE = 40, ACID = 100)
 	// *** Abilities *** //
 	stomp_damage = 60
 	crest_toss_distance = 6

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -32,7 +32,7 @@
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER|CASTE_CAN_BECOME_KING
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 70, BULLET = 70, LASER = 75, ENERGY = 60, BOMB = 100, BIO = 80, "rad" = 80, FIRE = 25, ACID = 80)
+	soft_armor = list(MELEE = 70, BULLET = 70, LASER = 70, ENERGY = 60, BOMB = 100, BIO = 80, "rad" = 80, FIRE = 25, ACID = 80)
 
 	// *** Minimap Icon *** //
 	minimap_icon = "crusher"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Crusher Health Scaling
-

Old
325->345->370->400

New
280->285->295->300

Armor Scaling (Ballistic/Laser)
-
Old
60->65->70->75
New
70->75->80->85

Rest unchanged.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes Crusher more vulnerable to high AP weapons which gives high AP weapons a place in the game again, as they've been steadily made irrelevant (Such as Flechette and Slugs) due to sunder being a higher focus, this buffs crusher against Assault Rifles and lower caliber weaponry, and nerfs him against snipers and high AP weapons which should be his soft counter and threats on the battlefield.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Crusher health scaling nerfed to 280/285/295/300 and ballistic/laser armor buffed to 70->75->80->85. Increasing the TTK of low pen weapons and lowering the TTK of high pen weapons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
