### PR TITLE
Autoburst aim fix

### DIFF
--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -670,29 +670,25 @@ should be alright.
 			add_firemode(GUN_FIREMODE_AUTOBURST, user)
 
 ///Calculates aim_fire_delay, can't be below 0
-#define RECALCULATE_AIM_MODE_FIRE_DELAY \
-	var/modification_value = 0; \
-	for(var/key in aim_fire_delay_mods) { \
-		modification_value += aim_fire_delay_mods[key]; \
-	}; \
-	var/old_delay = aim_fire_delay; \
-	aim_fire_delay = max(initial(aim_fire_delay) + modification_value, 0); \
-	if(HAS_TRAIT(src, TRAIT_GUN_IS_AIMING)) { \
-		modify_fire_delay(aim_fire_delay - old_delay); \
-		modify_auto_burst_delay(aim_fire_delay - old_delay); \
-	}
+/obj/item/weapon/gun/proc/recalculate_aim_mode_fire_delay()
+	var/modification_value = 0
+	for(var/key in aim_fire_delay_mods)
+		modification_value += aim_fire_delay_mods[key]
+	var/old_delay = aim_fire_delay
+	aim_fire_delay = max(initial(aim_fire_delay) + modification_value, 0)
+	if(HAS_TRAIT(src, TRAIT_GUN_IS_AIMING))
+		modify_fire_delay(aim_fire_delay - old_delay)
+		modify_auto_burst_delay(aim_fire_delay - old_delay)
 
 ///Adds an aim_fire_delay modificatio value
 /obj/item/weapon/gun/proc/add_aim_mode_fire_delay(source, value)
 	aim_fire_delay_mods[source] = value
-	RECALCULATE_AIM_MODE_FIRE_DELAY
+	recalculate_aim_mode_fire_delay()
 
 ///Removes an aim_fire_delay modificatio value
 /obj/item/weapon/gun/proc/remove_aim_mode_fire_delay(source)
 	aim_fire_delay_mods -= source
-	RECALCULATE_AIM_MODE_FIRE_DELAY
-
-#undef RECALCULATE_AIM_MODE_FIRE_DELAY
+	recalculate_aim_mode_fire_delay()
 
 /obj/item/weapon/gun/proc/toggle_auto_aim_mode(mob/living/carbon/human/user) //determines whether toggle_aim_mode activates at the end of gun/wield proc
 
@@ -715,10 +711,12 @@ should be alright.
 		REMOVE_TRAIT(src, TRAIT_GUN_IS_AIMING, GUN_TRAIT)
 		user.remove_movespeed_modifier(MOVESPEED_ID_AIM_MODE_SLOWDOWN)
 		modify_fire_delay(-aim_fire_delay)
+		modify_auto_burst_delay(-aim_fire_delay)
 		///if your attached weapon has aim mode, stops it from aimming
 		if( (gunattachment) && (/datum/action/item_action/aim_mode in gunattachment.actions_types) )
 			REMOVE_TRAIT(gunattachment, TRAIT_GUN_IS_AIMING, GUN_TRAIT)
 			gunattachment.modify_fire_delay(-aim_fire_delay)
+			gunattachment.modify_auto_burst_delay(-aim_fire_delay)
 		to_chat(user, span_notice("You cease aiming."))
 		return
 	if(!CHECK_BITFIELD(flags_item, WIELDED) && !CHECK_BITFIELD(flags_item, IS_DEPLOYED))
@@ -742,10 +740,12 @@ should be alright.
 	ADD_TRAIT(src, TRAIT_GUN_IS_AIMING, GUN_TRAIT)
 	user.add_movespeed_modifier(MOVESPEED_ID_AIM_MODE_SLOWDOWN, TRUE, 0, NONE, TRUE, aim_speed_modifier)
 	modify_fire_delay(aim_fire_delay)
+	modify_auto_burst_delay(aim_fire_delay)
 	///if your attached weapon has aim mode, makes it aim
 	if( (gunattachment) && (/datum/action/item_action/aim_mode in gunattachment.actions_types) )
 		ADD_TRAIT(gunattachment, TRAIT_GUN_IS_AIMING, GUN_TRAIT)
-		gunattachment:modify_fire_delay(aim_fire_delay)
+		gunattachment.modify_fire_delay(aim_fire_delay)
+		gunattachment.modify_auto_burst_delay(aim_fire_delay)
 	to_chat(user, span_notice("You line up your aim, allowing you to shoot past allies.</b>"))
 
 /// Signal handler to activate the rail attachement of that gun if it's in our active hand

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -679,6 +679,7 @@ should be alright.
 	aim_fire_delay = max(initial(aim_fire_delay) + modification_value, 0); \
 	if(HAS_TRAIT(src, TRAIT_GUN_IS_AIMING)) { \
 		modify_fire_delay(aim_fire_delay - old_delay); \
+		modify_auto_burst_delay(aim_fire_delay - old_delay); \
 	}
 
 ///Adds an aim_fire_delay modificatio value

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1299,7 +1299,7 @@
 	starting_attachment_types = list(/obj/item/attachable/stock/irremoveable/tx11, /obj/item/attachable/scope/mini/tx11)
 	attachable_offset = list("muzzle_x" = 31, "muzzle_y" = 17,"rail_x" = 8, "rail_y" = 20, "under_x" = 16, "under_y" = 13, "stock_x" = 19, "stock_y" = 23)
 	actions_types = list(/datum/action/item_action/aim_mode)
-	aim_fire_delay = 0.15 SECONDS
+	aim_fire_delay = 0.95 SECONDS
 
 	fire_delay = 0.25 SECONDS
 	burst_amount = 3

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1299,7 +1299,7 @@
 	starting_attachment_types = list(/obj/item/attachable/stock/irremoveable/tx11, /obj/item/attachable/scope/mini/tx11)
 	attachable_offset = list("muzzle_x" = 31, "muzzle_y" = 17,"rail_x" = 8, "rail_y" = 20, "under_x" = 16, "under_y" = 13, "stock_x" = 19, "stock_y" = 23)
 	actions_types = list(/datum/action/item_action/aim_mode)
-	aim_fire_delay = 0.95 SECONDS
+	aim_fire_delay = 0.15 SECONDS
 
 	fire_delay = 0.25 SECONDS
 	burst_amount = 3


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So autoburst was never actually made to interact with aimmode penalties directly.
Autoburst will now actually respect aim mode penalties. Note that burst in general is significantly better at aim mode than full auto weapons, due to the penalty only applying between bursts, but that's a balance discussion.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Autoburst respects aim mode penalties
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
