### PR TITLE
Some misc fixes for the hyperscale guns

### DIFF
--- a/code/controllers/subsystem/greyscale.dm
+++ b/code/controllers/subsystem/greyscale.dm
@@ -39,6 +39,13 @@ SUBSYSTEM_DEF(greyscale)
 			cache_list(gun.colorable_colors, gun.item_icons[key])
 		qdel(gun)
 
+	for(var/obj/item/attachable/attachment_type AS in subtypesof(/obj/item/attachable))
+		if(!initial(attachment_type.greyscale_config))
+			continue
+		var/obj/item/attachable/attachment = new attachment_type()
+		cache_list(attachment.colorable_colors, attachment.greyscale_config)
+		qdel(attachment)
+
 	return ..()
 
 ///Proc built to handle cacheing the nested lists of armor colors found in code/modules/clothing/modular_armor

--- a/code/datums/loadout/item_representation/_item_representation.dm
+++ b/code/datums/loadout/item_representation/_item_representation.dm
@@ -49,7 +49,7 @@
 /datum/item_representation/proc/get_tgui_data()
 	var/list/tgui_data = list()
 	var/icon/icon_to_convert
-	if(greyscale_colors)
+	if(greyscale_colors && initial(item_type.greyscale_config))
 		icon_to_convert = icon(SSgreyscale.GetColoredIconByType(initial(item_type.greyscale_config), greyscale_colors), initial(item_type.icon_state), dir = SOUTH)
 	else
 		icon_to_convert = icon(initial(item_type.icon), initial(item_type.icon_state), SOUTH)


### PR DESCRIPTION

## About The Pull Request
Caches hyperscaled attachments.
Allows loadout icons to be displayed correctly in case of greyscale_colors being set and not greyscale_config

## Why It's Good For The Game
fixes

## Changelog
:cl:
fix: Caches hyperscaled attachments.
fix: Allows loadout icons to be displayed correctly in case of greyscale_colors being set and not greyscale_config.

/:cl: