### PR TITLE
fix synthesized instruments

### DIFF
--- a/code/modules/instruments/songs/play_synthesized.dm
+++ b/code/modules/instruments/songs/play_synthesized.dm
@@ -64,7 +64,7 @@
 		var/mob/M = i
 		if(M?.client?.prefs?.toggles_sound & SOUND_INSTRUMENTS_OFF)
 			continue
-		M.playsound_local(get_turf(parent), null, volume, FALSE, K.frequency, null, channel, null, copy)
+		M.playsound_local(get_turf(parent), null, volume, FALSE, K.frequency, null, FALSE, channel, copy)
 		// Could do environment and echo later but not for now
 
 /**


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

currently synthesized instruments tend to bug out if the sound they try to play is too long.

turns out this is because the arguments in a proc call were putting the channel number into is_global and setting the actual channel to null resulting in the sounds getting assigned a random channel, meaning that the instrument will try to update the wrong channels

this just sets is_global to false and replaces null with channel

also would love if anyone could double check this, I am confident this should work but second opinions are nice.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

not having synthesized instruments bug out is nice

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed synthesized instruments
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
