### PR TITLE
Various improvements on Pillar of Spring 

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -358,10 +358,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/command/airoom)
 "bb" = (
-/obj/structure/cable,
-/obj/machinery/light/mainship/small,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/machinery/holopad,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "bc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -532,7 +531,7 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "bC" = (
 /obj/machinery/light/mainship{
@@ -727,10 +726,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "cb" = (
-/obj/structure/cable,
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar)
+/obj/structure/window/framed/mainship/white,
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/poddoor/shutters/opened/medbay{
+	dir = 2
+	},
+/turf/open/floor/plating/platebotc,
+/area/mainship/medical/chemistry)
 "cc" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/sterile/side,
@@ -2578,9 +2580,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "hz" = (
-/obj/machinery/holopad,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/ntlogo,
+/area/mainship/command/corporateliaison)
 "hA" = (
 /obj/structure/sign/poster{
 	dir = 1
@@ -2945,7 +2946,7 @@
 "iJ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/cobweb2,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "iK" = (
 /obj/machinery/door/firedoor/mainship,
@@ -3070,12 +3071,8 @@
 /turf/open/floor/plating,
 /area/mainship/living/cryo_cells)
 "jc" = (
-/obj/structure/cable,
-/obj/machinery/light/mainship/small{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/turf/open/floor/mainship/ntlogo/nt2,
+/area/mainship/command/corporateliaison)
 "jd" = (
 /obj/machinery/door/airlock/mainship/generic/corporate/quarters,
 /obj/machinery/door/firedoor/mainship,
@@ -4023,6 +4020,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
+/obj/machinery/holopad,
 /turf/open/floor/mainship/black{
 	dir = 10
 	},
@@ -4096,7 +4094,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/mainship/command/corporateliaison)
 "mc" = (
 /obj/effect/decal/warning_stripes/thin,
@@ -4662,6 +4660,7 @@
 	},
 /obj/machinery/door/window,
 /obj/structure/window/reinforced/tinted,
+/obj/item/tool/soap/nanotrasen,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/numbertwobunks)
 "nG" = (
@@ -6202,7 +6201,7 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "sa" = (
 /obj/machinery/door/airlock/mainship/maint{
@@ -6271,7 +6270,7 @@
 /obj/effect/decal/cleanable/cobweb{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "sk" = (
 /obj/structure/sign/poster{
@@ -7089,7 +7088,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/ntlogo/nt3,
 /area/mainship/command/corporateliaison)
 "ux" = (
 /obj/effect/decal/warning_stripes/thin,
@@ -8795,13 +8794,9 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "zs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/mainship/mono,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/floor,
 /area/mainship/command/corporateliaison)
 "zt" = (
 /obj/structure/closet/emcloset,
@@ -9776,18 +9771,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Cg" = (
-/obj/machinery/light/mainship/small{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
-"Ch" = (
 /obj/machinery/holopad,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/black{
-	dir = 5
-	},
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "Ci" = (
 /turf/open/floor/mainship_hull,
@@ -13403,6 +13388,8 @@
 /area/mainship/squads/general)
 "MD" = (
 /obj/structure/window/framed/mainship/white,
+/obj/machinery/door/poddoor/shutters/opened/medbay,
+/obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "MF" = (
@@ -13945,6 +13932,7 @@
 /obj/machinery/shower{
 	pixel_y = 16
 	},
+/obj/item/tool/soap/nanotrasen,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/commandbunks)
 "Oi" = (
@@ -14417,6 +14405,9 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "PF" = (
@@ -14538,7 +14529,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/mainship/command/corporateliaison)
 "PW" = (
 /obj/effect/ai_node,
@@ -14676,7 +14667,7 @@
 /area/mainship/living/starboard_garden)
 "Qo" = (
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/mainship/command/corporateliaison)
 "Qp" = (
 /obj/structure/disposalpipe/segment,
@@ -15602,13 +15593,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "SY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/mainship/command/corporateliaison)
 "SZ" = (
 /obj/structure/cable,
@@ -16357,7 +16342,7 @@
 	dir = 1
 	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "UY" = (
 /turf/closed/wall/mainship,
@@ -16955,7 +16940,7 @@
 /obj/effect/decal/cleanable/cobweb{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "WD" = (
 /obj/structure/table/mainship/nometal,
@@ -43974,8 +43959,8 @@ JR
 WZ
 zW
 Qo
-wO
-wO
+hz
+SY
 Ml
 WZ
 TO
@@ -44229,9 +44214,9 @@ dS
 al
 JR
 WZ
-xP
+zW
 SY
-wO
+jc
 PV
 AB
 Nq
@@ -44486,7 +44471,7 @@ GR
 Pr
 JR
 WZ
-wO
+xP
 zs
 uw
 mb
@@ -44934,7 +44919,7 @@ lR
 lR
 rn
 NS
-NH
+lv
 wi
 uH
 uH
@@ -45035,7 +45020,7 @@ iT
 ts
 PT
 jl
-Cg
+vN
 ew
 zw
 ew
@@ -45200,7 +45185,7 @@ xt
 mL
 Gi
 cB
-cb
+ht
 Vc
 Wp
 BQ
@@ -45483,7 +45468,7 @@ VP
 BQ
 BQ
 BQ
-BQ
+rB
 bh
 BQ
 tT
@@ -46519,7 +46504,7 @@ LP
 Gr
 Bi
 Hv
-Hv
+bb
 el
 Hv
 Av
@@ -46775,7 +46760,7 @@ pt
 Ot
 DJ
 iS
-hz
+Hv
 uP
 el
 lt
@@ -46999,7 +46984,7 @@ xt
 bo
 LO
 cB
-rk
+io
 Gf
 BQ
 sb
@@ -47247,7 +47232,7 @@ NS
 NS
 NS
 NS
-NH
+lv
 wi
 Rh
 Rh
@@ -47560,7 +47545,7 @@ qb
 qb
 nN
 Hi
-Sv
+cb
 oA
 oA
 oA
@@ -49159,7 +49144,7 @@ Pq
 is
 Wd
 Pq
-jc
+AA
 NS
 Ci
 Ci
@@ -51625,7 +51610,7 @@ dq
 BQ
 dq
 Vc
-rk
+io
 Vc
 HK
 rC
@@ -51729,7 +51714,7 @@ KM
 KM
 kj
 Wk
-ew
+GG
 NS
 Ci
 Ci
@@ -52243,7 +52228,7 @@ nw
 nw
 nw
 nw
-ew
+GG
 NS
 Ci
 Ci
@@ -53528,7 +53513,7 @@ im
 to
 OF
 nw
-ew
+GG
 NS
 Ci
 Ci
@@ -53681,7 +53666,7 @@ BQ
 BQ
 by
 Vc
-bb
+Tp
 Vc
 TP
 BM
@@ -53938,7 +53923,7 @@ PQ
 by
 by
 Vc
-io
+rk
 Vc
 Vc
 Vc
@@ -55804,8 +55789,8 @@ cD
 si
 si
 si
-yn
-Ch
+qm
+XM
 si
 si
 si
@@ -56579,7 +56564,7 @@ IQ
 IQ
 Dh
 yL
-yL
+Cg
 nS
 WD
 nS
@@ -56860,7 +56845,7 @@ Hp
 Hp
 QG
 Qk
-Pl
+aQ
 pO
 Ci
 Ci
@@ -59414,7 +59399,7 @@ jQ
 jQ
 jQ
 jQ
-jQ
+Mh
 Ij
 aQ
 xG

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -291,7 +291,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/mainship/sterile/plain,
@@ -1275,6 +1275,7 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "dF" = (
+/obj/machinery/computer/mecha,
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 6
 	},
@@ -1489,6 +1490,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/mainship/stripesquare,
@@ -2382,12 +2386,6 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
-"gZ" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/cult,
-/area/medical/morgue)
 "ha" = (
 /obj/machinery/door/poddoor/mainship/ammo{
 	dir = 2;
@@ -5799,9 +5797,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "qW" = (
@@ -8385,6 +8381,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
@@ -16320,7 +16319,7 @@
 /obj/structure/bed/chair/nometal{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/blue/full,
 /area/mainship/living/briefing)
 "UV" = (
 /turf/closed/wall/mainship,
@@ -40593,7 +40592,7 @@ dn
 pY
 il
 fe
-gZ
+tF
 dy
 JA
 As

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -1642,7 +1642,7 @@
 /area/mainship/hull/lower_hull)
 "eQ" = (
 /obj/machinery/door/airlock/multi_tile/mainship/maint{
-	name = "\Vehicle Hangar"
+	name = "Vehicle Hangar"
 	},
 /obj/machinery/door/firedoor/multi_tile,
 /turf/open/floor/mainship/mono,
@@ -4732,6 +4732,7 @@
 /obj/machinery/door/window{
 	dir = 1
 	},
+/obj/item/tool/soap,
 /turf/open/floor/mainship/sterile/dark,
 /area/sulaco/showers)
 "nR" = (
@@ -5604,7 +5605,7 @@
 /area/mainship/medical/lower_medical)
 "qu" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic/personal{
-	name = "\Pilot Bunks"
+	name = "Pilot Bunks"
 	},
 /obj/machinery/door/firedoor/multi_tile,
 /obj/structure/cable,

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -14391,12 +14391,6 @@
 /obj/machinery/door_control/old/medbay{
 	id = "Medbay";
 	name = "Medbay Lockdown";
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/obj/machinery/door_control/old/medbay{
-	id = "Medbay";
-	name = "Medbay Lockdown";
 	pixel_x = 6;
 	pixel_y = -5
 	},

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -29,7 +29,7 @@
 /obj/effect/decal/cleanable/cobweb{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "ag" = (
 /obj/structure/table/reinforced,
@@ -112,6 +112,9 @@
 /obj/machinery/door/firedoor/mainship{
 	dir = 2;
 	id = "hangar_lockdown"
+	},
+/obj/machinery/door/poddoor/shutters/mainship/open/hangar{
+	dir = 1
 	},
 /turf/open/floor/stairs/rampbottom{
 	dir = 1
@@ -326,7 +329,7 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
+/area/sulaco/showers)
 "aY" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -352,11 +355,7 @@
 /obj/machinery/door_control/ai/exterior{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/floor,
 /area/mainship/command/airoom)
 "bb" = (
 /obj/structure/cable,
@@ -367,7 +366,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
 /area/mainship/engineering/engineering_workshop)
 "be" = (
 /obj/effect/ai_node,
@@ -527,6 +528,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"bB" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "bC" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -618,9 +625,6 @@
 /turf/open/floor/wood,
 /area/mainship/living/chapel)
 "bM" = (
-/obj/machinery/firealarm{
-	dir = 1
-	},
 /obj/machinery/computer/security/marinemainship_network,
 /obj/structure/table/fancywoodentable,
 /turf/open/floor/wood,
@@ -723,15 +727,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "cb" = (
-/obj/effect/landmark/start/latejoin,
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship,
-/area/mainship/living/cryo_cells)
+/obj/structure/cable,
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "cc" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/sterile/side,
@@ -926,7 +925,7 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "cG" = (
-/obj/structure/window/framed/mainship/canterbury,
+/obj/structure/window/framed/mainship,
 /turf/open/floor/plating,
 /area/mainship/living/starboard_garden)
 "cH" = (
@@ -937,9 +936,13 @@
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "cI" = (
-/obj/machinery/researchcomp,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/structure/cable,
+/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/door/firedoor/mainship{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "cJ" = (
 /turf/open/floor/mainship/terragov/north,
 /area/mainship/living/briefing)
@@ -1011,7 +1014,6 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
 	},
-/obj/machinery/holopad,
 /turf/open/floor/mainship/black{
 	dir = 8
 	},
@@ -1045,6 +1047,9 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
 "da" = (
@@ -1634,10 +1639,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "eQ" = (
-/obj/machinery/door/airlock/multi_tile/mainship/maint,
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	name = "\Vehicle Hangar"
+	},
 /obj/machinery/door/firedoor/multi_tile,
 /turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/area/mainship/living/tankerbunks)
 "eR" = (
 /obj/structure/closet/secure_closet/bar/captain,
 /turf/open/floor/wood,
@@ -1657,6 +1664,9 @@
 	name = "Lower Mixed Air Control";
 	output_tag = "mix_lower_out";
 	sensors = list("mix_sensor"="Tank")
+	},
+/obj/machinery/light/mainship{
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
@@ -1687,7 +1697,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/holopad,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "eZ" = (
 /obj/structure/table/mainship/nometal,
@@ -1891,10 +1901,10 @@
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 8
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/blackgeneric{
+/obj/structure/cable,
+/obj/machinery/door/airlock/multi_tile/mainship/blackgeneric/glass{
 	name = "\improper Firing Range Airlock"
 	},
-/obj/structure/cable,
 /turf/open/floor/mainship/red{
 	dir = 8
 	},
@@ -1990,18 +2000,13 @@
 	},
 /area/mainship/engineering/ce_room)
 "fO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/bed/fancy,
-/obj/item/bedsheet/blue,
-/obj/effect/landmark/start/job/corporateliaison,
-/obj/item/toy/plush/farwa,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
-/area/mainship/command/corporateliaison)
+/area/mainship/hull/lower_hull)
 "fQ" = (
 /obj/item/radio/intercom/general{
 	dir = 1
@@ -2048,6 +2053,15 @@
 	dir = 6
 	},
 /area/mainship/living/numbertwobunks)
+"fX" = (
+/obj/structure/morgue{
+	dir = 2
+	},
+/obj/machinery/light/mainship/small{
+	dir = 1
+	},
+/turf/open/floor/cult,
+/area/medical/morgue)
 "fY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2281,7 +2295,7 @@
 	},
 /obj/item/tool/pen,
 /obj/machinery/light/mainship,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
 "gL" = (
 /obj/structure/disposalpipe/segment,
@@ -2367,12 +2381,11 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "gZ" = (
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/light/mainship{
-	dir = 1
+/obj/machinery/shower{
+	dir = 8
 	},
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/port_hallway)
+/turf/open/floor/cult,
+/area/medical/morgue)
 "ha" = (
 /obj/machinery/door/poddoor/mainship/ammo{
 	dir = 2;
@@ -2427,7 +2440,9 @@
 "hf" = (
 /obj/machinery/alarm,
 /obj/machinery/vending/cola,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
 /area/mainship/engineering/engineering_workshop)
 "hg" = (
 /turf/open/floor/mainship/cargo/arrow{
@@ -2464,6 +2479,13 @@
 /obj/item/reagent_containers/food/snacks/chawanmushi,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
+"hl" = (
+/obj/machinery/door/poddoor/mainship/umbilical/south{
+	dir = 2;
+	id = "s_umbilical_outer"
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_umbilical)
 "hm" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -2514,12 +2536,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "ht" = (
-/obj/structure/morgue{
-	dir = 1
-	},
-/obj/machinery/light/mainship/small,
-/turf/open/floor/cult,
-/area/medical/morgue)
+/obj/structure/cable,
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "hu" = (
 /obj/machinery/alarm{
 	dir = 4
@@ -2651,7 +2671,7 @@
 /obj/effect/decal/cleanable/vomit,
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
-/area/mainship/hull/lower_hull)
+/area/sulaco/showers)
 "hO" = (
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 6
@@ -3105,7 +3125,9 @@
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/medical/lower_medical)
 "jj" = (
@@ -3120,7 +3142,7 @@
 	},
 /obj/item/light_bulb/tube,
 /obj/item/tool/taperoll/engineering,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
 "jk" = (
 /obj/machinery/landinglight/ds1/delayone{
@@ -3185,6 +3207,9 @@
 /obj/machinery/door/firedoor/mainship{
 	dir = 2;
 	id = "hangar_lockdown"
+	},
+/obj/machinery/door/poddoor/shutters/mainship/open/hangar{
+	dir = 1
 	},
 /turf/open/floor/stairs/rampbottom{
 	dir = 1
@@ -3255,12 +3280,18 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
 /area/mainship/engineering/engineering_workshop)
 "jF" = (
 /obj/machinery/computer/supplycomp,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"jG" = (
+/obj/machinery/fuelcell_recycler,
+/turf/open/floor/mainship/mono,
+/area/mainship/engineering/engine_core)
 "jH" = (
 /turf/closed/wall/mainship/research/containment/wall/purple,
 /area/mainship/medical/medical_science)
@@ -3381,9 +3412,6 @@
 /obj/item/tool/crowbar,
 /obj/effect/spawner/random/toolbox,
 /obj/item/stack/cable_coil,
-/obj/machinery/light/mainship{
-	dir = 8
-	},
 /obj/item/assembly/timer,
 /obj/item/assembly/infra,
 /turf/open/floor/mainship/black{
@@ -3430,6 +3458,19 @@
 /obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
+"kf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
+/area/mainship/engineering/engineering_workshop)
 "kh" = (
 /obj/machinery/light/mainship,
 /obj/machinery/computer/marine_card,
@@ -3445,7 +3486,7 @@
 /obj/structure/bed/chair/nometal{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
 "kk" = (
 /obj/structure/table/mainship/nometal,
@@ -3459,7 +3500,7 @@
 "kl" = (
 /obj/structure/cable,
 /obj/machinery/light/mainship/small,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "km" = (
 /obj/machinery/door/airlock/mainship/medical,
@@ -3687,7 +3728,9 @@
 /obj/machinery/light/mainship{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
 /area/mainship/engineering/engineering_workshop)
 "kU" = (
 /obj/machinery/light/mainship{
@@ -3741,6 +3784,11 @@
 /obj/structure/window/framed/mainship/white,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
+"ld" = (
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/engineering/engineering_workshop)
 "le" = (
 /turf/closed/wall/mainship,
 /area/mainship/hallways/port_umbilical)
@@ -3830,6 +3878,7 @@
 /area/mainship/medical/lower_medical)
 "lu" = (
 /obj/structure/reagent_dispensers/fueltank,
+/obj/item/radio/intercom/general,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "lv" = (
@@ -3896,7 +3945,7 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "lD" = (
 /obj/machinery/door/firedoor/mainship,
@@ -3938,7 +3987,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "lK" = (
 /turf/open/floor/plating/icefloor/warnplate{
@@ -3998,9 +4047,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
 "lU" = (
-/obj/machinery/door/airlock/mainship/marine/general/corps,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/mainship/cic/armory{
+	dir = 2
+	},
+/turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
 "lV" = (
 /turf/closed/wall/mainship/research/containment/wall/north,
@@ -4163,10 +4216,10 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/obj/structure/sink,
 /obj/effect/landmark/start/job/corporateliaison,
 /obj/effect/decal/cleanable/blood,
 /obj/item/tool/soap/nanotrasen,
+/obj/structure/sink,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "mt" = (
@@ -4234,6 +4287,14 @@
 	dir = 8
 	},
 /area/mainship/shipboard/firing_range)
+"mC" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/white{
+	dir = 4
+	},
+/area/mainship/living/pilotbunks)
 "mD" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/mainship/cargo,
@@ -4398,11 +4459,11 @@
 	},
 /area/mainship/medical/lower_medical)
 "nb" = (
+/obj/structure/ob_ammo/warhead/plasmaloss,
+/obj/structure/ob_ammo/warhead/plasmaloss,
 /obj/structure/rack,
-/obj/structure/ob_ammo/warhead/plasmaloss,
-/obj/structure/ob_ammo/warhead/plasmaloss,
 /turf/open/floor/mainship/red{
-	dir = 1
+	dir = 9
 	},
 /area/mainship/shipboard/weapon_room)
 "nc" = (
@@ -4431,15 +4492,13 @@
 	},
 /area/mainship/medical/lower_medical)
 "ng" = (
-/obj/structure/closet/secure_closet/freezer,
-/obj/item/reagent_containers/food/snacks/sandwich,
-/obj/item/reagent_containers/food/snacks/sandwich,
-/obj/item/reagent_containers/food/snacks/sandwich,
-/obj/item/reagent_containers/food/snacks/sandwich,
-/obj/item/reagent_containers/food/drinks/bottle/sake,
-/obj/item/reagent_containers/food/drinks/bottle/sake,
-/obj/item/reagent_containers/food/drinks/bottle/wine,
-/obj/item/reagent_containers/food/drinks/bottle/wine,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/obj/structure/bed/fancy,
+/obj/item/bedsheet/blue,
+/obj/effect/landmark/start/job/corporateliaison,
+/obj/item/toy/plush/farwa,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "nh" = (
@@ -4665,7 +4724,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "nQ" = (
 /obj/machinery/shower{
@@ -4674,8 +4733,8 @@
 /obj/machinery/door/window{
 	dir = 1
 	},
-/turf/open/floor/mainship/floor,
-/area/mainship/hull/lower_hull)
+/turf/open/floor/mainship/sterile/dark,
+/area/sulaco/showers)
 "nR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -4703,7 +4762,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "nV" = (
 /obj/structure/cable,
@@ -4714,9 +4773,6 @@
 /area/mainship/hallways/stern_hallway)
 "nW" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "nX" = (
@@ -5011,7 +5067,7 @@
 /obj/item/stack/sheet/glass/reinforced{
 	amount = 30
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
 "oS" = (
 /turf/open/floor/plating/mainship/striped{
@@ -5031,9 +5087,6 @@
 /obj/item/roller,
 /obj/item/roller,
 /obj/item/roller,
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "oV" = (
@@ -5091,8 +5144,10 @@
 /obj/machinery/door/airlock/multi_tile/mainship/maint{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/mainship,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "ph" = (
@@ -5162,8 +5217,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
 /area/mainship/engineering/engineering_workshop)
 "pt" = (
 /turf/closed/wall/mainship/white,
@@ -5251,6 +5307,7 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
+/obj/machinery/researchcomp,
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
@@ -5450,13 +5507,10 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/mainship/command/FCDRoffice,
-/obj/machinery/door/airlock/mainship/command/FCDRoffice,
+/obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "qg" = (
-/obj/machinery/firealarm{
-	dir = 4
-	},
 /obj/machinery/loadout_vendor,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
@@ -5526,6 +5580,9 @@
 	dir = 2;
 	id = "hangar_lockdown"
 	},
+/obj/machinery/door/poddoor/shutters/mainship/open/hangar{
+	dir = 1
+	},
 /turf/open/floor/stairs/rampbottom{
 	dir = 1
 	},
@@ -5547,7 +5604,9 @@
 	},
 /area/mainship/medical/lower_medical)
 "qu" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic/personal,
+/obj/machinery/door/airlock/multi_tile/mainship/generic/personal{
+	name = "\Pilot Bunks"
+	},
 /obj/machinery/door/firedoor/multi_tile,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -5649,6 +5708,9 @@
 	dir = 8
 	},
 /area/mainship/squads/general)
+"qJ" = (
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "qK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
@@ -5667,7 +5729,7 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
 "qN" = (
 /obj/machinery/shower{
@@ -5685,7 +5747,6 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "qP" = (
-/obj/structure/bed/chair/wood/wings,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -5693,6 +5754,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/bed/chair/wood/wings,
 /turf/open/floor/tile/chapel{
 	dir = 1
 	},
@@ -5795,15 +5857,11 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
 "re" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light/mainship/small{
+/obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/turf/open/floor/grass,
+/area/mainship/shipboard/firing_range)
 "rf" = (
 /obj/effect/soundplayer,
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
@@ -5955,7 +6013,9 @@
 /area/mainship/command/telecomms)
 "rx" = (
 /obj/structure/window/framed/mainship/white,
-/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
 /obj/machinery/door/poddoor/shutters/mainship{
 	dir = 1;
 	id = "or2privacyshutter";
@@ -6125,7 +6185,6 @@
 	},
 /area/mainship/squads/general)
 "rX" = (
-/obj/machinery/light/mainship,
 /obj/structure/bed/stool{
 	pixel_y = 8
 	},
@@ -6225,7 +6284,7 @@
 /obj/structure/sink,
 /obj/structure/mirror,
 /turf/open/floor/mainship/floor,
-/area/mainship/hull/lower_hull)
+/area/sulaco/showers)
 "sm" = (
 /obj/structure/noticeboard,
 /turf/closed/wall/mainship,
@@ -6237,7 +6296,9 @@
 /area/mainship/living/chapel)
 "so" = (
 /obj/machinery/vending/snack,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
 /area/mainship/engineering/engineering_workshop)
 "sp" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -6338,7 +6399,7 @@
 	name = "\improper Bathroom"
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/area/sulaco/showers)
 "sC" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/light/mainship{
@@ -6540,8 +6601,19 @@
 /obj/structure/bed/chair/nometal{
 	dir = 1
 	},
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = -2
+	},
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
+"ti" = (
+/obj/structure/morgue{
+	dir = 1
+	},
+/obj/machinery/light/mainship/small,
+/turf/open/floor/cult,
+/area/medical/morgue)
 "tj" = (
 /obj/machinery/telecomms/server/presets/cas,
 /turf/open/floor/mainship/tcomms,
@@ -6723,7 +6795,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "tL" = (
 /obj/structure/bed/bunkbed,
@@ -6764,6 +6836,14 @@
 /obj/machinery/self_destruct/console,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
+"tT" = (
+/obj/machinery/holosign_switch{
+	id = "or1sign";
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/operating_room_one)
 "tU" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -6875,7 +6955,9 @@
 /obj/machinery/light/mainship{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
 /area/mainship/engineering/engineering_workshop)
 "ug" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -6896,7 +6978,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
+/area/sulaco/showers)
 "uk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/poddoor/mainship/droppod{
@@ -7131,7 +7213,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "uR" = (
 /obj/structure/safe,
@@ -7150,6 +7232,11 @@
 /obj/item/storage/box/monkeycubes,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
+"uT" = (
+/obj/structure/cable,
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "uU" = (
 /mob/living/simple_animal/catslug/newt,
 /obj/structure/cable,
@@ -7174,8 +7261,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "uX" = (
-/obj/structure/cable,
 /obj/effect/decal/medical_decals/cryo/cell,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
@@ -7304,11 +7391,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "vs" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
 /turf/open/floor/mainship/floor,
-/area/mainship/hull/lower_hull)
+/area/sulaco/showers)
 "vt" = (
 /obj/machinery/door/airlock/mainship/generic/bathroom{
 	dir = 1
@@ -7523,9 +7607,7 @@
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "vX" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
+/obj/machinery/camera/autoname/mainship,
 /turf/open/floor/plating/mainship,
 /area/mainship/hallways/starboard_hallway)
 "vY" = (
@@ -7597,10 +7679,9 @@
 "wh" = (
 /obj/structure/sink,
 /obj/structure/mirror,
-/obj/effect/decal/cleanable/vomit,
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
+/area/sulaco/showers)
 "wi" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 2
@@ -7610,6 +7691,7 @@
 "wj" = (
 /obj/structure/cable,
 /obj/machinery/camera/autoname/mainship,
+/obj/machinery/light/mainship/small,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "wk" = (
@@ -7659,7 +7741,9 @@
 /obj/machinery/door/airlock/multi_tile/mainship/maint{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "ws" = (
@@ -7814,7 +7898,9 @@
 /area/mainship/command/corporateliaison)
 "wP" = (
 /obj/machinery/vending/coffee,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
 /area/mainship/engineering/engineering_workshop)
 "wQ" = (
 /obj/effect/ai_node,
@@ -7975,6 +8061,10 @@
 	dir = 4
 	},
 /area/mainship/hallways/hangar)
+"xm" = (
+/obj/structure/table/mainship/nometal,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "xn" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
@@ -8058,6 +8148,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/holopad,
 /turf/open/floor/mainship,
 /area/mainship/engineering/ce_room)
 "xA" = (
@@ -8422,6 +8513,11 @@
 	dir = 6
 	},
 /area/space)
+"yD" = (
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
+/area/mainship/engineering/engineering_workshop)
 "yE" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /turf/open/floor/engine,
@@ -8478,8 +8574,18 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
 "yP" = (
-/obj/item/radio/intercom/general,
-/turf/closed/wall/mainship,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2;
+	id = "hangar_lockdown"
+	},
+/obj/machinery/door/poddoor/shutters/mainship/open/hangar{
+	dir = 1
+	},
+/turf/open/floor/stairs/rampbottom{
+	dir = 1
+	},
 /area/mainship/hallways/hangar)
 "yQ" = (
 /obj/machinery/marine_selector/gear/medic,
@@ -8689,8 +8795,12 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "zs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "zt" = (
@@ -8828,7 +8938,7 @@
 	dir = 9
 	},
 /obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "zM" = (
 /obj/structure/cable,
@@ -8862,12 +8972,11 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
 "zS" = (
-/obj/structure/cable,
 /obj/machinery/camera/autoname/mainship{
-	dir = 1
+	dir = 8
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/turf/open/floor/grass,
+/area/mainship/shipboard/firing_range)
 "zT" = (
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 10
@@ -8944,6 +9053,11 @@
 "Ae" = (
 /turf/closed/wall/mainship,
 /area/mainship/command/cic)
+"Af" = (
+/turf/open/floor/mainship/orange{
+	dir = 6
+	},
+/area/mainship/engineering/engineering_workshop)
 "Ag" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -9421,6 +9535,9 @@
 /area/mainship/command/cic)
 "Br" = (
 /obj/structure/table/mainship/nometal,
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
 /turf/open/floor/mainship/white,
 /area/mainship/living/pilotbunks)
 "Bs" = (
@@ -9616,8 +9733,8 @@
 	},
 /area/mainship/medical/lower_medical)
 "BZ" = (
-/obj/structure/cable,
 /obj/effect/decal/medical_decals/cryo,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
@@ -9875,6 +9992,11 @@
 /obj/structure/window/framed/mainship,
 /turf/open/floor/plating,
 /area/mainship/engineering/lower_engineering)
+"CL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "CM" = (
 /obj/structure/target_stake,
 /obj/item/target,
@@ -9923,6 +10045,10 @@
 /obj/item/storage/firstaid/adv,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"CS" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/floor,
+/area/sulaco/showers)
 "CT" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -9965,8 +10091,11 @@
 /obj/structure/sink,
 /obj/structure/mirror,
 /obj/structure/cable,
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
 /turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
+/area/sulaco/showers)
 "CZ" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -10013,7 +10142,6 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "Dg" = (
-/obj/structure/bed/chair/wood/wings,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -10021,6 +10149,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/bed/chair/wood/wings,
 /turf/open/floor/tile/chapel{
 	dir = 4
 	},
@@ -10181,6 +10310,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
+"DE" = (
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/mainship/living/starboard_garden)
 "DF" = (
 /obj/structure/closet/secure_closet/req_officer,
 /turf/open/floor/mainship/cargo,
@@ -10324,13 +10462,15 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Ea" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/mainship/small{
-	dir = 4
+/obj/structure/bed/bunkbed,
+/obj/effect/landmark/start/job/squadmarine,
+/obj/effect/landmark/start/job/squadmarine,
+/obj/item/trash/barcardine,
+/obj/machinery/firealarm{
+	dir = 8
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/turf/open/floor/wood,
+/area/mainship/living/cryo_cells)
 "Eb" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/machinery/door/firedoor/mainship,
@@ -10380,7 +10520,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/starboard_hallway)
 "Ek" = (
 /obj/machinery/door/airlock/mainship/command/cic{
@@ -10480,7 +10623,7 @@
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 8
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/blackgeneric{
+/obj/machinery/door/airlock/multi_tile/mainship/blackgeneric/glass{
 	name = "\improper Firing Range Airlock"
 	},
 /turf/open/floor/mainship/red{
@@ -10746,7 +10889,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
 "Fo" = (
 /obj/item/trash/cigbutt{
@@ -11069,6 +11212,9 @@
 "Gi" = (
 /obj/structure/sign/poster,
 /obj/machinery/cic_maptable/droppod_maptable,
+/obj/machinery/door_control/mainship/droppod{
+	dir = 1
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar/droppod)
 "Gj" = (
@@ -11130,8 +11276,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "Gr" = (
-/obj/structure/cable,
 /obj/effect/decal/medical_decals/cryo,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "Gs" = (
@@ -11332,6 +11478,14 @@
 /obj/structure/mirror,
 /turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
+"GX" = (
+/obj/machinery/light/mainship/small{
+	dir = 4
+	},
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
+/area/mainship/command/self_destruct)
 "GY" = (
 /obj/structure/prop/mainship/name_stencil{
 	icon_state = "TGMC4"
@@ -11343,6 +11497,10 @@
 /obj/item/storage/donut_box,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
+"Hc" = (
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "Hd" = (
 /obj/machinery/computer/ordercomp,
 /turf/open/floor/mainship/mono,
@@ -11386,6 +11544,14 @@
 	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/chemistry)
+"Hj" = (
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/mainship/command/airoom)
 "Hk" = (
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
@@ -11668,9 +11834,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Ib" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
 /obj/structure/mirror,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
@@ -12088,12 +12251,12 @@
 /area/mainship/hallways/port_hallway)
 "Jj" = (
 /obj/structure/cable,
-/obj/machinery/door_control/mainship/droppod{
-	dir = 8
-	},
 /obj/machinery/door/firedoor/mainship{
 	dir = 2;
 	id = "hangar_lockdown"
+	},
+/obj/machinery/door/poddoor/shutters/mainship/open/hangar{
+	dir = 1
 	},
 /turf/open/floor/stairs/rampbottom{
 	dir = 1
@@ -12116,7 +12279,7 @@
 	dir = 8
 	},
 /obj/structure/mirror{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hull/lower_hull)
@@ -12129,6 +12292,10 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
+"Jo" = (
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship/tcomms,
+/area/mainship/command/self_destruct)
 "Jp" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 1;
@@ -12297,6 +12464,12 @@
 "JM" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
+"JN" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/tcomms,
+/area/mainship/command/self_destruct)
 "JO" = (
 /obj/machinery/cic_maptable,
 /turf/open/floor/mainship,
@@ -12371,6 +12544,7 @@
 	pixel_x = 4;
 	pixel_y = 6
 	},
+/obj/machinery/light/mainship,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "JY" = (
@@ -12384,6 +12558,12 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
+"Ka" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "Kb" = (
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 1
@@ -12426,6 +12606,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"Kk" = (
+/obj/machinery/researchcomp,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "Kl" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/mainship/tcomms,
@@ -12595,7 +12781,9 @@
 /obj/machinery/light/mainship{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
 /area/mainship/engineering/engineering_workshop)
 "KJ" = (
 /obj/machinery/light/mainship{
@@ -12658,16 +12846,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 6
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "KX" = (
@@ -12711,6 +12896,9 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/chapel)
+"Le" = (
+/turf/closed/wall/mainship,
+/area/sulaco/showers)
 "Lf" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -12828,14 +13016,16 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Lv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/obj/structure/closet/secure_closet/freezer,
+/obj/item/reagent_containers/food/snacks/sandwich,
+/obj/item/reagent_containers/food/snacks/sandwich,
+/obj/item/reagent_containers/food/snacks/sandwich,
+/obj/item/reagent_containers/food/snacks/sandwich,
+/obj/item/reagent_containers/food/drinks/bottle/sake,
+/obj/item/reagent_containers/food/drinks/bottle/sake,
+/obj/item/reagent_containers/food/drinks/bottle/wine,
+/obj/item/reagent_containers/food/drinks/bottle/wine,
+/turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "Lw" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -12947,6 +13137,9 @@
 /turf/open/floor/engine,
 /area/mainship/engineering/port_atmos)
 "LO" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar/droppod)
 "LP" = (
@@ -13048,6 +13241,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/command/airoom)
+"Mf" = (
+/mob/living/simple_animal/corgi/ian,
+/turf/open/floor/mainship/mono,
+/area/mainship/command/cic)
 "Mh" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -13337,7 +13534,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "MX" = (
 /obj/structure/table/mainship/nometal,
@@ -13589,7 +13786,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
 /area/mainship/engineering/engineering_workshop)
 "NJ" = (
 /obj/machinery/door/airlock/mainship/command/CPToffice{
@@ -13828,7 +14027,9 @@
 /obj/structure/ob_ammo/ob_fuel,
 /obj/structure/ob_ammo/ob_fuel,
 /obj/structure/ob_ammo/ob_fuel,
-/turf/open/floor/mainship/red,
+/turf/open/floor/mainship/red{
+	dir = 10
+	},
 /area/mainship/shipboard/weapon_room)
 "Ov" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13848,14 +14049,17 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "Oy" = (
-/obj/structure/morgue{
-	dir = 2
+/obj/machinery/door/firedoor/mainship{
+	dir = 2;
+	id = "hangar_lockdown"
 	},
-/obj/machinery/light/mainship/small{
+/obj/machinery/door/poddoor/shutters/mainship/open/hangar{
 	dir = 1
 	},
-/turf/open/floor/cult,
-/area/medical/morgue)
+/turf/open/floor/stairs/rampbottom{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "Oz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -14145,9 +14349,9 @@
 /area/mainship/shipboard/firing_range)
 "Pw" = (
 /obj/effect/ai_node,
-/obj/machinery/light/mainship/small,
+/obj/machinery/light/mainship,
 /turf/open/floor/mainship/floor,
-/area/mainship/hull/lower_hull)
+/area/sulaco/showers)
 "Px" = (
 /obj/machinery/light/mainship,
 /obj/machinery/cryopod/right,
@@ -14196,9 +14400,16 @@
 	},
 /obj/item/tool/pen,
 /obj/machinery/door_control/old/medbay{
-	dir = 1;
 	id = "Medbay";
-	name = "Medbay Lockdown"
+	name = "Medbay Lockdown";
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/machinery/door_control/old/medbay{
+	id = "Medbay";
+	name = "Medbay Lockdown";
+	pixel_x = 6;
+	pixel_y = -5
 	},
 /turf/open/floor/wood,
 /area/mainship/medical/medical_science)
@@ -14330,7 +14541,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "PW" = (
-/obj/structure/bed/chair/wood/wings,
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -14339,6 +14549,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/bed/chair/wood/wings,
 /turf/open/floor/tile/chapel{
 	dir = 1
 	},
@@ -14464,12 +14675,9 @@
 /turf/open/floor/grass,
 /area/mainship/living/starboard_garden)
 "Qo" = (
-/obj/structure/cable,
-/obj/machinery/light/mainship/small{
-	dir = 8
-	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/area/mainship/command/corporateliaison)
 "Qp" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -14571,7 +14779,7 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
 "QE" = (
 /obj/effect/ai_node,
@@ -14643,15 +14851,15 @@
 	},
 /area/mainship/living/briefing)
 "QP" = (
-/obj/machinery/shower{
-	dir = 8
-	},
 /obj/machinery/door/window{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/rune,
+/obj/machinery/shower{
+	dir = 8
+	},
 /obj/item/tool/kitchen/knife/ritual,
 /obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/rune,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/corporateliaison)
 "QQ" = (
@@ -14877,7 +15085,7 @@
 	},
 /obj/machinery/light/mainship/small,
 /turf/open/floor/mainship/floor,
-/area/mainship/hull/lower_hull)
+/area/sulaco/showers)
 "Ry" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
@@ -14891,6 +15099,9 @@
 "RA" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/door/firedoor/mainship{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "RB" = (
@@ -15076,6 +15287,9 @@
 	pixel_x = -3;
 	pixel_y = 1
 	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "Sf" = (
@@ -15162,6 +15376,10 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/port_hallway)
+"Ss" = (
+/obj/machinery/holopad,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "St" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/mainship{
@@ -15218,13 +15436,13 @@
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
-/obj/machinery/holosign/surgery{
-	id = "or1sign"
-	},
 /obj/machinery/door/airlock/mainship/medical/or/or2{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/holosign/surgery{
+	id = "or2sign"
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
 "SA" = (
@@ -15262,12 +15480,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "SG" = (
-/obj/machinery/light/mainship/small{
+/obj/structure/cable,
+/obj/machinery/light/mainship{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
+/area/sulaco/showers)
 "SH" = (
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/mainship/tcomms,
@@ -15384,12 +15602,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "SY" = (
-/obj/item/ammo_magazine/rifle,
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
-/turf/open/floor/grass,
-/area/mainship/shipboard/firing_range)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/command/corporateliaison)
 "SZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -15442,6 +15662,18 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"Tf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/red{
+	dir = 8
+	},
+/area/mainship/shipboard/weapon_room)
 "Tg" = (
 /obj/effect/decal/warning_stripes/linethick{
 	dir = 1
@@ -15535,11 +15767,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "Tw" = (
 /obj/machinery/vending/cigarette,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
 /area/mainship/engineering/engineering_workshop)
 "Tx" = (
 /obj/machinery/power/apc{
@@ -15628,7 +15862,7 @@
 /obj/effect/decal/warning_stripes/thin,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "TH" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -15659,11 +15893,16 @@
 /area/mainship/shipboard/firing_range)
 "TL" = (
 /obj/effect/decal/cleanable/blood/gibs/robot/limb,
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
 /turf/open/floor/plating/icefloor/warnplate,
 /area/mainship/living/tankerbunks)
 "TM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
 /area/mainship/engineering/engineering_workshop)
 "TN" = (
 /obj/structure/cable,
@@ -15809,9 +16048,6 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/machinery/door_control/mainship/droppod{
-	dir = 1
-	},
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},
@@ -15832,6 +16068,9 @@
 	},
 /area/mainship/medical/medical_science)
 "Uk" = (
+/obj/machinery/firealarm{
+	dir = 1
+	},
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 10
 	},
@@ -16002,7 +16241,7 @@
 	name = "Bathroom"
 	},
 /turf/open/floor/mainship/floor,
-/area/mainship/hull/lower_hull)
+/area/sulaco/showers)
 "UH" = (
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 1
@@ -16106,6 +16345,12 @@
 "UV" = (
 /turf/closed/wall/mainship,
 /area/mainship/engineering/engine_core)
+"UW" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/black,
+/area/mainship/living/pilotbunks)
 "UX" = (
 /obj/structure/cable,
 /obj/machinery/camera/autoname/mainship{
@@ -16142,8 +16387,8 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "Ve" = (
-/obj/structure/cable,
 /obj/machinery/vending/snack,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
@@ -16200,6 +16445,11 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"Vl" = (
+/obj/machinery/cryopod/right,
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship,
+/area/mainship/living/cryo_cells)
 "Vm" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -16221,7 +16471,7 @@
 	},
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/area/mainship/hallways/hangar)
 "Vp" = (
 /turf/open/floor/mainship/ntlogo/nt2,
 /area/mainship/squads/general)
@@ -16314,6 +16564,12 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
+/obj/machinery/door_control/unmeltable{
+	dir = 8;
+	id = "s_umbilical";
+	name = "Air Lock Door Control";
+	pixel_x = 22
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_umbilical)
 "VC" = (
@@ -16366,6 +16622,9 @@
 /obj/machinery/door/firedoor/mainship{
 	dir = 2;
 	id = "hangar_lockdown"
+	},
+/obj/machinery/door/poddoor/shutters/mainship/open/hangar{
+	dir = 1
 	},
 /turf/open/floor/stairs/rampbottom{
 	dir = 1
@@ -16468,8 +16727,8 @@
 	dir = 4;
 	pixel_y = -3
 	},
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
+/turf/open/floor/mainship/sterile/dark,
+/area/sulaco/showers)
 "VZ" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -16566,6 +16825,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Wm" = (
@@ -16595,10 +16855,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "Wp" = (
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/living/pilotbunks)
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/obj/machinery/door_control/mainship/hangar,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "Wq" = (
 /obj/structure/sign/poster{
 	dir = 1
@@ -16658,7 +16920,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange/corner{
+	dir = 1
+	},
 /area/mainship/engineering/engineering_workshop)
 "Wy" = (
 /obj/effect/soundplayer,
@@ -16703,6 +16967,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
+"WF" = (
+/obj/machinery/door/airlock/mainship/maint,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "WG" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -16710,6 +16979,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"WH" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/aft_hallway)
 "WI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -16817,11 +17092,9 @@
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/medical_science)
 "WW" = (
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
+/obj/machinery/door_control/mainship/droppod,
 /turf/open/floor/mainship/mono,
-/area/mainship/living/starboard_garden)
+/area/mainship/hallways/hangar)
 "WX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -16920,7 +17193,7 @@
 /obj/structure/table/mainship/nometal,
 /obj/item/book/manual/atmospipes,
 /obj/item/book/manual/engineering_guide,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
 "Xn" = (
 /turf/open/floor/mainship/floor,
@@ -16934,8 +17207,11 @@
 	dir = 2
 	},
 /obj/structure/cable,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
 /turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar)
+/area/sulaco/showers)
 "Xq" = (
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/black{
@@ -16977,6 +17253,10 @@
 /obj/effect/soundplayer,
 /turf/closed/wall/mainship,
 /area/mainship/command/airoom)
+"Xx" = (
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "Xy" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner{
@@ -17017,6 +17297,15 @@
 	dir = 8
 	},
 /area/mainship/medical/chemistry)
+"XC" = (
+/obj/structure/bed/bunkbed,
+/obj/effect/landmark/start/job/squadmarine,
+/obj/effect/landmark/start/job/squadmarine,
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/mainship/living/cryo_cells)
 "XD" = (
 /obj/structure/window/framed/mainship/hull,
 /turf/open/floor/mainship_hull,
@@ -17025,7 +17314,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
 /area/mainship/engineering/engineering_workshop)
 "XF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -17072,9 +17363,6 @@
 	},
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
-	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
 	},
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 4
@@ -17301,8 +17589,8 @@
 	},
 /area/space)
 "Yw" = (
-/obj/machinery/door/airlock/mainship/ai/glass,
 /obj/structure/cable,
+/obj/machinery/door/airlock/mainship/command/cic,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "Yx" = (
@@ -17425,7 +17713,6 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
-/obj/machinery/researchcomp,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "YO" = (
@@ -17594,12 +17881,12 @@
 	},
 /area/mainship/command/self_destruct)
 "Zl" = (
-/obj/structure/cable,
-/obj/machinery/light/mainship/small{
-	dir = 4
+/obj/machinery/light_switch{
+	pixel_x = 3;
+	pixel_y = -7
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/turf/closed/wall/mainship,
+/area/mainship/command/corporateliaison)
 "Zm" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/frame/table,
@@ -17651,6 +17938,9 @@
 "Zt" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/mainship{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Zu" = (
@@ -17794,6 +18084,9 @@
 /area/mainship/squads/general)
 "ZR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
 /turf/open/floor/mainship/black{
 	dir = 8
 	},
@@ -17838,6 +18131,12 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
+"ZY" = (
+/obj/machinery/holopad,
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
+/area/mainship/command/self_destruct)
 "ZZ" = (
 /obj/structure/bed/chair/nometal,
 /obj/effect/landmark/start/job/shiptech,
@@ -36990,7 +37289,7 @@ bQ
 bQ
 bQ
 bQ
-bQ
+lR
 bQ
 bQ
 bQ
@@ -37504,11 +37803,11 @@ bQ
 bQ
 bQ
 bQ
-bQ
-bQ
-bQ
-bQ
-bQ
+lR
+lR
+lR
+lR
+lR
 bQ
 bQ
 bQ
@@ -37761,11 +38060,11 @@ bQ
 bQ
 bQ
 bQ
+lR
+lR
+lR
 bQ
-bQ
-bQ
-bQ
-bQ
+lR
 bQ
 bQ
 bQ
@@ -38022,7 +38321,7 @@ bQ
 bQ
 bQ
 bQ
-bQ
+lR
 bQ
 bQ
 bQ
@@ -39856,7 +40155,7 @@ ia
 Tm
 XX
 Uo
-XX
+hl
 Ci
 Ci
 YT
@@ -40054,11 +40353,11 @@ lR
 lR
 rn
 dn
-pY
+fX
 il
 SP
 tF
-dy
+ti
 JA
 sk
 aj
@@ -40311,11 +40610,11 @@ lR
 lR
 rn
 dn
-Oy
+pY
 il
 fe
-tF
-ht
+gZ
+dy
 JA
 As
 aj
@@ -40620,7 +40919,7 @@ Lh
 zq
 ux
 nb
-Ub
+Tf
 Ou
 Nj
 yS
@@ -40825,11 +41124,11 @@ NA
 NA
 Ci
 dn
-pY
+fX
 il
 SP
 tF
-dy
+ti
 JA
 jv
 aj
@@ -42117,7 +42416,7 @@ Pc
 Pc
 vS
 vx
-Pc
+xm
 fi
 Lo
 nX
@@ -42139,10 +42438,10 @@ bs
 JA
 Yd
 OB
-re
-OB
+DB
+RD
 Qt
-OB
+RD
 RD
 MS
 RD
@@ -43160,7 +43459,7 @@ xL
 JR
 WZ
 zW
-wO
+Lv
 qO
 Vi
 oG
@@ -43417,7 +43716,7 @@ al
 UE
 WZ
 ND
-wO
+Mw
 Mw
 We
 jX
@@ -43430,7 +43729,7 @@ QQ
 QQ
 Mz
 aM
-Zw
+uT
 cO
 sA
 QQ
@@ -43673,8 +43972,8 @@ dS
 al
 JR
 WZ
-fO
-wO
+zW
+Qo
 wO
 wO
 Ml
@@ -43908,7 +44207,7 @@ DT
 AN
 DT
 pJ
-Wh
+Kk
 NP
 lm
 KP
@@ -43930,8 +44229,8 @@ dS
 al
 JR
 WZ
-Ap
-wO
+xP
+SY
 wO
 PV
 AB
@@ -44187,7 +44486,7 @@ GR
 Pr
 JR
 WZ
-Lv
+wO
 zs
 uw
 mb
@@ -44740,14 +45039,14 @@ Cg
 ew
 zw
 ew
-GG
+ew
 Nx
 GG
 GG
 bA
 GG
 GG
-Qo
+Nx
 af
 NS
 Ci
@@ -44901,9 +45200,9 @@ xt
 mL
 Gi
 cB
-rk
+cb
 Vc
-Es
+Wp
 BQ
 zy
 BQ
@@ -44993,7 +45292,7 @@ iT
 lx
 aj
 aj
-aj
+bB
 WC
 Wy
 yN
@@ -45005,7 +45304,7 @@ UV
 UV
 UV
 UV
-eP
+WF
 NS
 Ci
 Ci
@@ -45187,7 +45486,7 @@ BQ
 BQ
 bh
 BQ
-ED
+tT
 EX
 Fi
 iV
@@ -45216,7 +45515,7 @@ al
 ib
 sO
 sO
-WZ
+Zl
 wO
 Ap
 Mw
@@ -45519,7 +45818,7 @@ yz
 jz
 yz
 Om
-GG
+ew
 NS
 Ci
 Ci
@@ -45673,7 +45972,7 @@ AS
 uk
 js
 Rr
-WY
+yP
 EK
 iC
 Vq
@@ -45744,7 +46043,7 @@ vt
 NK
 NK
 cf
-NK
+Hc
 ZO
 VJ
 CO
@@ -45930,7 +46229,7 @@ Lw
 dr
 VL
 rk
-GJ
+Oy
 BQ
 sb
 Vq
@@ -46443,9 +46742,9 @@ xt
 xB
 cB
 cB
-rk
+cI
 Vc
-BQ
+WW
 sb
 Az
 JP
@@ -46494,7 +46793,7 @@ zd
 qE
 ye
 ye
-ye
+Wj
 qE
 ye
 Cn
@@ -46802,9 +47101,9 @@ RR
 uN
 Cw
 du
-yz
+jG
 UV
-zS
+Nr
 NS
 Ci
 Ci
@@ -46992,7 +47291,7 @@ AV
 hm
 oC
 uy
-cI
+Hv
 DJ
 Ov
 Hv
@@ -47318,7 +47617,7 @@ jx
 jr
 jx
 UV
-ew
+GG
 NS
 Ci
 Ci
@@ -47832,7 +48131,7 @@ yz
 mE
 Ke
 sa
-NH
+lv
 NS
 Ci
 Ci
@@ -48039,7 +48338,7 @@ eF
 ne
 eF
 xX
-WW
+eF
 ye
 ak
 ye
@@ -48293,7 +48592,7 @@ qb
 WO
 hp
 Qn
-XW
+DE
 LW
 IF
 cG
@@ -48554,7 +48853,7 @@ oA
 oA
 oA
 oA
-gZ
+fu
 Sr
 fu
 gc
@@ -48790,15 +49089,15 @@ BA
 BA
 rY
 BA
-BA
 zU
+BA
 IY
 JI
 BA
-BA
 rY
 BA
-zU
+BA
+BA
 BA
 BA
 BA
@@ -49034,12 +49333,12 @@ nU
 lC
 MW
 eY
+CL
+CL
 Bp
 Bp
-Bp
-Bp
-Bp
-Bp
+CL
+CL
 uc
 mS
 jV
@@ -49312,7 +49611,7 @@ iH
 pl
 HG
 BA
-BA
+WH
 Ac
 BA
 BA
@@ -49879,7 +50178,7 @@ wD
 id
 Kr
 Zh
-cq
+ps
 KM
 Jx
 bT
@@ -50121,7 +50420,7 @@ Fa
 zx
 lG
 iD
-Qs
+Mf
 Ae
 eo
 eo
@@ -50393,7 +50692,7 @@ Wk
 Wk
 Wk
 Wk
-cq
+kf
 KM
 lz
 Wk
@@ -50556,7 +50855,7 @@ Vc
 Vc
 Vc
 Zt
-yP
+Vc
 bv
 oF
 Sj
@@ -50841,7 +51140,7 @@ UI
 SC
 cJ
 MZ
-if
+Ss
 rR
 hw
 hw
@@ -51674,10 +51973,10 @@ iT
 lx
 iT
 Wk
-KM
+yD
 YG
-KM
-KM
+ld
+ld
 KI
 XE
 jE
@@ -51685,7 +51984,7 @@ Lx
 TM
 bc
 kT
-KM
+Af
 BO
 dY
 NS
@@ -52177,7 +52476,7 @@ fI
 tb
 tb
 tb
-tb
+Cp
 tb
 JW
 iT
@@ -52425,7 +52724,7 @@ Ui
 Sa
 vh
 Fg
-Xn
+Xx
 Yi
 RC
 Fg
@@ -52450,7 +52749,7 @@ zt
 nw
 Bt
 RM
-pK
+Hj
 pK
 pK
 pK
@@ -52691,7 +52990,7 @@ TZ
 ly
 tb
 ML
-tb
+Cp
 tb
 tb
 iT
@@ -52896,7 +53195,7 @@ UM
 BQ
 BQ
 BQ
-BQ
+ym
 Zf
 uE
 BA
@@ -53125,7 +53424,7 @@ pd
 nW
 Kt
 Vc
-io
+ht
 Vc
 EM
 BM
@@ -53148,12 +53447,12 @@ av
 BQ
 BQ
 BQ
-Vc
-Vc
+Le
+Le
 sB
-Vc
-Vc
-Vc
+Le
+Le
+Le
 Vn
 Id
 Id
@@ -53162,7 +53461,7 @@ Id
 Id
 Id
 Id
-Wp
+pN
 eu
 pN
 Qx
@@ -53405,13 +53704,13 @@ av
 BQ
 UM
 BQ
-Vc
+Le
 CY
 aX
 SG
 uj
 Xp
-rb
+fO
 Id
 rg
 sr
@@ -53421,7 +53720,7 @@ LF
 Id
 gB
 aS
-rJ
+UW
 iw
 eC
 Fe
@@ -53662,12 +53961,12 @@ Vc
 Vc
 Vc
 Vc
-Vc
+Le
 wh
-by
-by
+vs
+vs
 VX
-Vc
+Le
 Da
 Id
 pB
@@ -53919,12 +54218,12 @@ xn
 xn
 xn
 xn
-JA
+Le
 hN
-ff
-ff
+vs
+vs
 nQ
-JA
+Le
 Da
 Id
 IU
@@ -53981,7 +54280,7 @@ Dy
 wv
 wv
 wv
-wv
+ZY
 wv
 wv
 wv
@@ -54176,12 +54475,12 @@ NH
 GG
 GG
 GG
-xK
-lZ
+Xp
+CS
 Pw
-JA
-JA
-JA
+Le
+Le
+Le
 Da
 Id
 Id
@@ -54438,7 +54737,7 @@ sl
 vs
 UG
 Rx
-JA
+Le
 Da
 Id
 cr
@@ -54700,7 +54999,7 @@ Da
 Id
 tC
 dH
-dH
+mC
 CT
 jw
 Id
@@ -55008,7 +55307,7 @@ Qk
 VW
 Di
 Hp
-Hp
+GX
 Hp
 tw
 HO
@@ -55211,7 +55510,7 @@ Yv
 Ci
 NS
 Da
-JA
+YJ
 GW
 pV
 Rn
@@ -55264,15 +55563,15 @@ YV
 Qk
 wY
 za
-AQ
-AQ
-AQ
+JN
+pw
+Jo
 gm
 tS
 fE
-AQ
+JN
 IA
-AQ
+Jo
 VW
 vO
 Qk
@@ -55468,7 +55767,7 @@ lR
 rn
 NS
 Da
-JA
+YJ
 Oe
 Kc
 lN
@@ -55522,12 +55821,12 @@ Qk
 VW
 Bn
 wv
-wv
+Qz
 wv
 Nc
 Sq
 KH
-wv
+ZY
 Qz
 wv
 DL
@@ -55725,7 +56024,7 @@ lR
 rn
 NS
 Da
-JA
+YJ
 Bw
 YJ
 YJ
@@ -56239,7 +56538,7 @@ lR
 rn
 NS
 rb
-aj
+qJ
 Pb
 MV
 MV
@@ -56496,7 +56795,7 @@ bQ
 rn
 NS
 Da
-JA
+YJ
 gW
 Kg
 td
@@ -56509,7 +56808,7 @@ YJ
 en
 en
 tt
-en
+re
 en
 en
 en
@@ -56753,7 +57052,7 @@ bQ
 rn
 NS
 Da
-JA
+YJ
 YJ
 YJ
 YJ
@@ -57289,7 +57588,7 @@ Qa
 Qx
 co
 gk
-yL
+Ka
 mm
 ss
 yL
@@ -58336,12 +58635,12 @@ nK
 Yx
 BT
 KC
-mJ
+Vl
 yv
 yv
 mJ
 KC
-mJ
+Vl
 yv
 yv
 mJ
@@ -58566,8 +58865,8 @@ en
 en
 en
 cT
-SY
-en
+LR
+zS
 tt
 en
 en
@@ -58578,7 +58877,7 @@ sc
 Bs
 ZB
 KC
-FV
+Ea
 nK
 jy
 BT
@@ -58586,20 +58885,20 @@ KC
 BT
 uz
 nK
-BT
+XC
 KC
-BT
+XC
 nK
 nK
 BT
 KC
 mJ
-cb
+qc
 qc
 mJ
 KC
 mJ
-cb
+qc
 qc
 mJ
 pw
@@ -59093,16 +59392,16 @@ IL
 GG
 GG
 GG
-GG
-NH
-Zl
 ew
+lv
+IL
 GG
-NH
 GG
+lv
+ew
 oa
-Ea
-Mh
+Eq
+jQ
 Mh
 uW
 jQ


### PR DESCRIPTION
## About The Pull Request

Big bundled box of little changes. As usual, you gotta pack things together
- Fixed a bunch of cameras on firelocks or glass.
- Made the CL room a little nicer
- Added some markings to engineering to make it look better
- Changed the Synth door from a door labelled 'AI core' to a CIC door
- Added a second fuel cycler to POS
- Added a lil button for the umbilical, besides the OB room. It doesn't let you go to space
- The FCDR office had 2 doors. Removed one
- The FCDR office had 3 firealarms. Left one
- Added Ian back to the CIC
- Brought back the pod shutters
- Brought back the medbay shutters button in the CMO office
- Gave the CPT and FCDR soap in their showers
- Fixed weird mirrors in the hangar bathroom
- Fixed the wrong type of glass in the memorial
- Moved the researcher consoles west into medical, so they aren't so much in the way
- Fixed the Operation Rooms holosigns
- Added missing fire alarms, firelocks and cameras to some new areas, including mech bay
- Fixed the door names for the PO bunks and mech bay
- Remove a tad of vomit in the bathrooms


## Why It's Good For The Game
Most of those changes makes the map look better, and more coherent.


## Changelog
:cl:
fix: fixed a whole bunch of slight mapping issues on POS. Read PR #11145 for more details. 
/:cl:


