### PR TITLE
M3 Harness and Leather Jackets now accept Jaeger modules

### DIFF
--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -129,7 +129,6 @@
 	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, "rad" = 0, FIRE = 0, ACID = 0)
 	slowdown = 0
 	flags_atom = NONE
-	flags_item = SYNTH_RESTRICTED
 
 	attachments_by_slot = list(
 		ATTACHMENT_SLOT_MODULE,

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -130,6 +130,26 @@
 	slowdown = 0
 	flags_atom = NONE
 
+	attachments_by_slot = list(
+		ATTACHMENT_SLOT_MODULE,
+		ATTACHMENT_SLOT_BADGE,
+	)
+	attachments_allowed = list(
+		/obj/item/armor_module/module/better_shoulder_lamp,
+		/obj/item/armor_module/module/valkyrie_autodoc,
+		/obj/item/armor_module/module/fire_proof,
+		/obj/item/armor_module/module/tyr_extra_armor,
+		/obj/item/armor_module/module/tyr_extra_armor/mark1,
+		/obj/item/armor_module/module/mimir_environment_protection,
+		/obj/item/armor_module/module/mimir_environment_protection/mark1,
+		/obj/item/armor_module/module/hlin_explosive_armor,
+		/obj/item/armor_module/module/ballistic_armor,
+		/obj/item/armor_module/module/chemsystem,
+		/obj/item/armor_module/module/eshield,
+		/obj/item/armor_module/armor/badge,
+	)
+	light_range = 5
+
 /obj/item/clothing/suit/storage/marine/M3IS
 	name = "\improper M3-IS pattern marine armor"
 	desc = "A standard Marine M3 Integrated Storage Pattern Chestplate. Increased encumbrance and storage capacity."

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -132,7 +132,6 @@
 
 	attachments_by_slot = list(
 		ATTACHMENT_SLOT_MODULE,
-		ATTACHMENT_SLOT_BADGE,
 	)
 	attachments_allowed = list(
 		/obj/item/armor_module/module/better_shoulder_lamp,
@@ -146,7 +145,6 @@
 		/obj/item/armor_module/module/ballistic_armor,
 		/obj/item/armor_module/module/chemsystem,
 		/obj/item/armor_module/module/eshield,
-		/obj/item/armor_module/armor/badge,
 	)
 	light_range = 5
 

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -129,6 +129,7 @@
 	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, "rad" = 0, FIRE = 0, ACID = 0)
 	slowdown = 0
 	flags_atom = NONE
+	flags_item = SYNTH_RESTRICTED
 
 	attachments_by_slot = list(
 		ATTACHMENT_SLOT_MODULE,


### PR DESCRIPTION
## About The Pull Request
Per title.

## Why It's Good For The Game
Just because they look different or have 0 armor and no slowdown doesn't mean they shouldn't get access to a crucial part of marine equipment.

## Changelog
:cl: Lewdcifer
balance: M3 Harness and Leather jackets now accept Jaeger modules.
/:cl: