### PR TITLE
Vali Necro Warning Adjustment

### DIFF
--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -69,7 +69,7 @@
 	///Vali movement speed buff is this value
 	var/movement_boost = 0
 	///How much time left on vali heal till necrosis occurs
-	var/vali_necro_timer = world.time - processing_start
+	var/vali_necro_timer
 
 	/**
 	 * This list contains the vali stat increases that correspond to each reagent
@@ -187,6 +187,7 @@
 
 	wearer.adjustToxLoss(-tox_heal*boost_amount)
 	wearer.heal_limb_damage(6*boost_amount*brute_heal_amp, 6*boost_amount*burn_heal_amp)
+	vali_necro_timer = world.time - processing_start
 	if(connected_weapon && vali_necro_timer < 20 SECONDS)
 		wearer.adjustStaminaLoss(-7*stamina_regen_amp*((20 - (vali_necro_timer)/10)/20)) //stamina gain scales inversely with passed time, up to 20 seconds
 	if(vali_necro_timer > 10 SECONDS && vali_necro_timer < 20 SECONDS)

--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -68,6 +68,8 @@
 	var/stamina_regen_amp = 1
 	///Vali movement speed buff is this value
 	var/movement_boost = 0
+	///How much time left on vali heal till necrosis occurs
+	var/vali_necro_timer = world.time - processing_start
 
 	/**
 	 * This list contains the vali stat increases that correspond to each reagent
@@ -185,11 +187,11 @@
 
 	wearer.adjustToxLoss(-tox_heal*boost_amount)
 	wearer.heal_limb_damage(6*boost_amount*brute_heal_amp, 6*boost_amount*burn_heal_amp)
-	if(connected_weapon && world.time - processing_start < 20 SECONDS)
-		wearer.adjustStaminaLoss(-7*stamina_regen_amp*((20 - (world.time - processing_start)/10)/20)) //stamina gain scales inversely with passed time, up to 20 seconds
-	if(world.time - processing_start > 10 SECONDS && world.time - processing_start < 20 SECONDS)
-		to_chat(wearer, span_bold("WARNING: You have [(200 - (world.time - processing_start))/10] seconds before necrotic tissue forms on your limbs."))
-		if(world.time - processing_start > 15 SECONDS && world.time - processing_start < 20 SECONDS)
+	if(connected_weapon && vali_necro_timer < 20 SECONDS)
+		wearer.adjustStaminaLoss(-7*stamina_regen_amp*((20 - (vali_necro_timer)/10)/20)) //stamina gain scales inversely with passed time, up to 20 seconds
+	if(vali_necro_timer > 10 SECONDS && vali_necro_timer < 20 SECONDS)
+		to_chat(wearer, span_bold("WARNING: You have [(200 - (vali_necro_timer))/10] seconds before necrotic tissue forms on your limbs."))
+		if(vali_necro_timer > 15 SECONDS)
 			wearer.overlay_fullscreen("degeneration", /obj/screen/fullscreen/infection, 1)
 			to_chat(wearer, span_highdanger("The process of necrosis begins to set in. Turn it off before it's too late!"))
 
@@ -234,7 +236,7 @@
 	if(boost_on)
 		STOP_PROCESSING(SSobj, src)
 		wearer.clear_fullscreen("degeneration")
-		var/necrotized_counter = FLOOR(min(world.time-processing_start, 20 SECONDS)/200 + (world.time-processing_start-20 SECONDS)/100, 1)
+		var/necrotized_counter = FLOOR(min(vali_necro_timer, 20 SECONDS)/200 + (vali_necro_timer-20 SECONDS)/100, 1)
 		if(necrotized_counter >= 1)
 			for(var/X in shuffle(wearer.limbs))
 				var/datum/limb/L = X

--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -188,13 +188,15 @@
 	wearer.adjustToxLoss(-tox_heal*boost_amount)
 	wearer.heal_limb_damage(6*boost_amount*brute_heal_amp, 6*boost_amount*burn_heal_amp)
 	vali_necro_timer = world.time - processing_start
-	if(connected_weapon && vali_necro_timer < 20 SECONDS)
+	if(vali_necro_timer > 20 SECONDS)
+		return
+	if(connected_weapon)
 		wearer.adjustStaminaLoss(-7*stamina_regen_amp*((20 - (vali_necro_timer)/10)/20)) //stamina gain scales inversely with passed time, up to 20 seconds
-	if(vali_necro_timer > 10 SECONDS && vali_necro_timer < 20 SECONDS)
+	if(vali_necro_timer > 10 SECONDS)
 		to_chat(wearer, span_bold("WARNING: You have [(200 - (vali_necro_timer))/10] seconds before necrotic tissue forms on your limbs."))
-		if(vali_necro_timer > 15 SECONDS)
-			wearer.overlay_fullscreen("degeneration", /obj/screen/fullscreen/infection, 1)
-			to_chat(wearer, span_highdanger("The process of necrosis begins to set in. Turn it off before it's too late!"))
+	if(vali_necro_timer > 15 SECONDS)
+		wearer.overlay_fullscreen("degeneration", /obj/screen/fullscreen/infection, 1)
+		to_chat(wearer, span_highdanger("The process of necrosis begins to set in. Turn it off before it's too late!"))
 
 /**
  *	Opens the radial menu with everything

--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -237,6 +237,7 @@
 	if(boost_on)
 		STOP_PROCESSING(SSobj, src)
 		wearer.clear_fullscreen("degeneration")
+		vali_necro_timer = world.time - processing_start
 		var/necrotized_counter = FLOOR(min(vali_necro_timer, 20 SECONDS)/200 + (vali_necro_timer-20 SECONDS)/100, 1)
 		if(necrotized_counter >= 1)
 			for(var/X in shuffle(wearer.limbs))

--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -187,9 +187,10 @@
 	wearer.heal_limb_damage(6*boost_amount*brute_heal_amp, 6*boost_amount*burn_heal_amp)
 	if(connected_weapon && world.time - processing_start < 20 SECONDS)
 		wearer.adjustStaminaLoss(-7*stamina_regen_amp*((20 - (world.time - processing_start)/10)/20)) //stamina gain scales inversely with passed time, up to 20 seconds
-	if(world.time - processing_start > 12 SECONDS && world.time - processing_start < 15 SECONDS)
-		wearer.overlay_fullscreen("degeneration", /obj/screen/fullscreen/infection, 1)
+	if(world.time - processing_start > 10 SECONDS && world.time - processing_start < 19 SECONDS)
 		to_chat(wearer, span_highdanger("WARNING: You have [(200 - (world.time - processing_start))/10] seconds before necrotic tissue forms on your limbs."))
+		if(world.time - processing_start > 17)
+			wearer.overlay_fullscreen("degeneration", /obj/screen/fullscreen/infection, 1)
 
 /**
  *	Opens the radial menu with everything

--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -187,10 +187,11 @@
 	wearer.heal_limb_damage(6*boost_amount*brute_heal_amp, 6*boost_amount*burn_heal_amp)
 	if(connected_weapon && world.time - processing_start < 20 SECONDS)
 		wearer.adjustStaminaLoss(-7*stamina_regen_amp*((20 - (world.time - processing_start)/10)/20)) //stamina gain scales inversely with passed time, up to 20 seconds
-	if(world.time - processing_start > 10 SECONDS && world.time - processing_start < 19 SECONDS)
-		to_chat(wearer, span_highdanger("WARNING: You have [(200 - (world.time - processing_start))/10] seconds before necrotic tissue forms on your limbs."))
-		if(world.time - processing_start > 17)
+	if(world.time - processing_start > 10 SECONDS && world.time - processing_start < 20 SECONDS)
+		to_chat(wearer, span_bold("WARNING: You have [(200 - (world.time - processing_start))/10] seconds before necrotic tissue forms on your limbs."))
+		if(world.time - processing_start > 15 SECONDS && world.time - processing_start < 20 SECONDS)
 			wearer.overlay_fullscreen("degeneration", /obj/screen/fullscreen/infection, 1)
+			to_chat(wearer, span_highdanger("The process of necrosis begins to set in. Turn it off before it's too late!"))
 
 /**
  *	Opens the radial menu with everything


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently Vali alerts to impending after 12 secs, giving necro hud and periodic text warnings. Changes to two step warning, with text warning only at 10 secs onwards, and necro hud appearing at <s>17</s> 15 secs onwards. This translates to text warning appearing at 10 seconds left and necro hud appearing at 3 seconds left. Values still undecided until tested.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Current vali warning is imprecise and misleading imo. The margin of 8 seconds on the warning is too wide and defeats the purpose of the warning. Also the text alerts are inconsistent and don't happen at consistent intervals, so you can't rely on them that well. Splitting the warning into text and hud at different intervals would be better I think. Text warning will be there to let you know that necro is approaching and allow you to look over to see that exactish time remaining. However, the hud warning will trigger close before necro hits, giving an actually useful warning to let you know that you have to turn off vali NOW or you will get necro. 
Feedback and thoughts from vali users would be greatly appreciated as this is only my experience with it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Vali necro warning divided into two warnings at separate intervals. Will first give warning with how much time remaining starting at 10secs onwards. Second warning will begin 15secs onwards and give the necro hud and an additional warning.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
