### PR TITLE
Max sunder for tanky xeno's POC !DONT MERGE!

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -41,6 +41,8 @@
 	stomp_damage = 45
 	crest_toss_distance = 3
 
+	sunder_max = 80
+
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
 		/datum/action/xeno_action/watch_xeno,
@@ -91,6 +93,8 @@
 	stomp_damage = 50
 	crest_toss_distance = 4
 
+	sunder_max = 70
+
 /datum/xeno_caste/crusher/elder
 	upgrade_name = "Elder"
 	caste_desc = "A huge tanky xenomorph. It looks pretty strong."
@@ -120,6 +124,7 @@
 	stomp_damage = 55
 	crest_toss_distance = 5
 
+	sunder_max = 60
 /datum/xeno_caste/crusher/ancient
 	upgrade_name = "Ancient"
 	caste_desc = "It always has the right of way."
@@ -148,6 +153,7 @@
 	stomp_damage = 60
 	crest_toss_distance = 6
 
+	sunder_max = 50
 
 /datum/xeno_caste/crusher/primordial
 	upgrade_name = "Primordial"
@@ -173,6 +179,9 @@
 	// *** Abilities *** //
 	stomp_damage = 60
 	crest_toss_distance = 6
+
+
+	sunder_max = 40
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
@@ -47,6 +47,8 @@
 	crest_defense_slowdown = 0.8
 	fortify_armor = 50
 
+	sunder_max = 80
+
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
 		/datum/action/xeno_action/watch_xeno,
@@ -62,6 +64,7 @@
 	upgrade_name = "Young"
 
 	upgrade = XENO_UPGRADE_ZERO
+
 
 /datum/xeno_caste/defender/mature
 	upgrade_name = "Mature"
@@ -89,6 +92,8 @@
 	crest_defense_armor = 26
 	crest_defense_slowdown = 0.8
 	fortify_armor = 52
+
+	sunder_max = 70
 
 /datum/xeno_caste/defender/elder
 	upgrade_name = "Elder"
@@ -118,6 +123,8 @@
 	crest_defense_armor = 30
 	crest_defense_slowdown = 0.8
 	fortify_armor = 55
+
+	sunder_max = 60
 
 /datum/xeno_caste/defender/ancient
 	upgrade_name = "Ancient"
@@ -149,6 +156,8 @@
 	crest_defense_slowdown = 0.8
 	fortify_armor = 55
 
+	sunder_max = 50
+
 /datum/xeno_caste/defender/primordial
 	upgrade_name = "Primordial"
 	caste_desc = "Alien with an incredibly tough and armored head crest able to endure even the strongest hits."
@@ -175,6 +184,8 @@
 	crest_defense_armor = 30
 	crest_defense_slowdown = 0.8
 	fortify_armor = 55
+
+	sunder_max = 40
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this PR adds a max sunder that isant 100% to defender and crusher. number subject to change

## Why It's Good For The Game

I'd like to see how these xenos would play with a max sunder cap. and how that would shift there potential around. If this could be test merged by some balance maintainer and gather some community feedback on how it feels. the values I used now are just hat toss but curious how they will have

## Changelog
:cl:
balance: Crusher and defender have a max sunder
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
