### PR TITLE
Ammo hud refactor and gives ammo counter to mechs

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -254,21 +254,21 @@
 	return
 
 ///Add an ammo hud to the user informing of the ammo count of ammo_owner
-/datum/hud/proc/add_ammo_hud(mob/living/user, datum/ammo_owner, list/ammo_type, ammo_count)
+/datum/hud/proc/add_ammo_hud(datum/ammo_owner, list/ammo_type, ammo_count)
 	if(length(ammo_hud_list) >= MAXHUD_POSSIBLE)
 		return
 	var/obj/screen/ammo/ammo_hud = new
 	ammo_hud_list[ammo_owner] = ammo_hud
 	ammo_hud.screen_loc = ammo_hud.ammo_screen_loc_list[length(ammo_hud_list)]
-	ammo_hud.add_hud(user, ammo_owner)
-	ammo_hud.update_hud(user, ammo_type, ammo_count)
+	ammo_hud.add_hud(mymob, ammo_owner)
+	ammo_hud.update_hud(mymob, ammo_type, ammo_count)
 
 ///Remove the ammo hud related to the gun G from the user
-/datum/hud/proc/remove_ammo_hud(mob/living/user, datum/ammo_owner)
+/datum/hud/proc/remove_ammo_hud(datum/ammo_owner)
 	var/obj/screen/ammo/ammo_hud = ammo_hud_list[ammo_owner]
 	if(isnull(ammo_hud))
 		return
-	ammo_hud.remove_hud(user, ammo_owner)
+	ammo_hud.remove_hud(mymob, ammo_owner)
 	qdel(ammo_hud)
 	ammo_hud_list -= ammo_owner
 	var/i = 1
@@ -278,9 +278,9 @@
 		i++
 
 ///Update the ammo hud related to the gun G
-/datum/hud/proc/update_ammo_hud(mob/living/user, datum/ammo_owner, list/ammo_type, ammo_count)
+/datum/hud/proc/update_ammo_hud(datum/ammo_owner, list/ammo_type, ammo_count)
 	var/obj/screen/ammo/ammo_hud = ammo_hud_list[ammo_owner]
-	ammo_hud?.update_hud(user, ammo_type, ammo_count)
+	ammo_hud?.update_hud(mymob, ammo_type, ammo_count)
 
 /obj/screen/action_button/MouseEntered(location, control, params)
 	if (!usr.client?.prefs?.tooltips)

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -253,24 +253,24 @@
 /datum/hud/proc/persistent_inventory_update(mob/viewer)
 	return
 
-///Add an ammo hud to the user informing of the ammo count of G
-/datum/hud/proc/add_ammo_hud(mob/living/user, obj/item/weapon/gun/G)
+///Add an ammo hud to the user informing of the ammo count of ammo_owner
+/datum/hud/proc/add_ammo_hud(mob/living/user, datum/ammo_owner, list/ammo_type, ammo_count)
 	if(length(ammo_hud_list) >= MAXHUD_POSSIBLE)
 		return
 	var/obj/screen/ammo/ammo_hud = new
-	ammo_hud_list[G] = ammo_hud
+	ammo_hud_list[ammo_owner] = ammo_hud
 	ammo_hud.screen_loc = ammo_hud.ammo_screen_loc_list[length(ammo_hud_list)]
-	ammo_hud.add_hud(user, G)
-	ammo_hud.update_hud(user, G)
+	ammo_hud.add_hud(user, ammo_owner)
+	ammo_hud.update_hud(user, ammo_type, ammo_count)
 
 ///Remove the ammo hud related to the gun G from the user
-/datum/hud/proc/remove_ammo_hud(mob/living/user, obj/item/weapon/gun/G)
-	var/obj/screen/ammo/ammo_hud = ammo_hud_list[G]
+/datum/hud/proc/remove_ammo_hud(mob/living/user, datum/ammo_owner)
+	var/obj/screen/ammo/ammo_hud = ammo_hud_list[ammo_owner]
 	if(isnull(ammo_hud))
 		return
-	ammo_hud.remove_hud(user, G)
+	ammo_hud.remove_hud(user, ammo_owner)
 	qdel(ammo_hud)
-	ammo_hud_list -= G
+	ammo_hud_list -= ammo_owner
 	var/i = 1
 	for(var/key in ammo_hud_list)
 		ammo_hud = ammo_hud_list[key]
@@ -278,9 +278,9 @@
 		i++
 
 ///Update the ammo hud related to the gun G
-/datum/hud/proc/update_ammo_hud(mob/living/user, obj/item/weapon/gun/G)
-	var/obj/screen/ammo/ammo_hud = ammo_hud_list[G]
-	ammo_hud?.update_hud(user, G)
+/datum/hud/proc/update_ammo_hud(mob/living/user, datum/ammo_owner, list/ammo_type, ammo_count)
+	var/obj/screen/ammo/ammo_hud = ammo_hud_list[ammo_owner]
+	ammo_hud?.update_hud(user, ammo_type, ammo_count)
 
 /obj/screen/action_button/MouseEntered(location, control, params)
 	if (!usr.client?.prefs?.tooltips)

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -257,6 +257,8 @@
 /datum/hud/proc/add_ammo_hud(datum/ammo_owner, list/ammo_type, ammo_count)
 	if(length(ammo_hud_list) >= MAXHUD_POSSIBLE)
 		return
+	if(ammo_hud_list[ammo_owner])
+		return
 	var/obj/screen/ammo/ammo_hud = new
 	ammo_hud_list[ammo_owner] = ammo_hud
 	ammo_hud.screen_loc = ammo_hud.ammo_screen_loc_list[length(ammo_hud_list)]

--- a/code/_onclick/hud/screen_objects/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/screen_objects.dm
@@ -671,75 +671,65 @@
 
 	usr.hud_used.hidden_inventory_update()
 
-
+/**
+ * HUD ammo indicator
+ *
+ * Displays a number and an icon representing the ammo for up to 4 at a time
+ */
 /obj/screen/ammo
 	name = "ammo"
 	icon = 'icons/mob/ammoHUD.dmi'
 	icon_state = "ammo"
 	screen_loc = ui_ammo1
+	///If the user has already had their warning played for running out of ammo
 	var/warned = FALSE
+	///Holder for playing a out of ammo animation so that it doesnt get cut during updates
+	var/atom/movable/flash_holder
 	///List of possible screen locs
-	var/static/list/ammo_screen_loc_list = list(ui_ammo1, ui_ammo2, ui_ammo3 ,ui_ammo4)
+	var/static/list/ammo_screen_loc_list = list(ui_ammo1, ui_ammo2, ui_ammo3, ui_ammo4)
 
+/obj/screen/ammo/Initialize()
+	. = ..()
+	flash_holder = new
+	flash_holder.icon_state = "frame"
+	flash_holder.icon = icon
+	flash_holder.plane = plane
+	flash_holder.layer = layer+0.001
+	flash_holder.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	vis_contents += flash_holder
 
-/obj/screen/ammo/proc/add_hud(mob/living/user, obj/item/weapon/gun/G)
+/obj/screen/ammo/Destroy()
+	QDEL_NULL(flash_holder)
+	return ..()
 
-	if(isnull(G))
-		CRASH("/obj/screen/ammo/proc/add_hud() has been called from [src] without the required param of G")
+///wrapper to add this to the users screen with a owner
+/obj/screen/ammo/proc/add_hud(mob/living/user, datum/ammo_owner)
+	if(isnull(ammo_owner))
+		CRASH("/obj/screen/ammo/proc/add_hud() has been called from [src] without the required param of ammo_owner")
+	user?.client.screen += src
 
-	if(!user?.client)
-		return
-
-	if(!CHECK_BITFIELD(G.flags_gun_features, GUN_AMMO_COUNTER))
-		return
-
-	user.client.screen += src
-
-
+///wrapper to removing this ammo hud from the users screen
 /obj/screen/ammo/proc/remove_hud(mob/living/user)
 	user?.client?.screen -= src
 
-
-/obj/screen/ammo/proc/update_hud(mob/living/user, obj/item/weapon/gun/G)
-	if(!user?.client?.screen.Find(src))
-		return
-
-	if(!G || !(G.flags_gun_features & GUN_AMMO_COUNTER))
-		remove_hud(user)
-		return
-
-	var/list/ammo_type = G.get_ammo_list()
-	var/rounds
-	if(G.max_rounds && G.rounds && CHECK_BITFIELD(G.flags_gun_features, GUN_AMMO_COUNT_BY_PERCENTAGE))
-		rounds = round((G.rounds / G.max_rounds) * 100)
-	else if (G.rounds && CHECK_BITFIELD(G.flags_gun_features, GUN_AMMO_COUNT_BY_SHOTS_REMAINING))
-		rounds = round(G.rounds / G.rounds_per_shot)
-	else
-		rounds = G.rounds
-	var/hud_state = ammo_type[1]
-	var/hud_state_empty = ammo_type[2]
-
+///actually handles upadating the hud
+/obj/screen/ammo/proc/update_hud(mob/living/user, list/ammo_type, rounds)
 	overlays.Cut()
 
-	var/empty = image('icons/mob/ammoHUD.dmi', src, "[hud_state_empty]")
-
-	if(rounds == 0)
+	if(rounds <= 0)
+		var/hud_state_empty = ammo_type[2]
+		overlays += image('icons/mob/ammoHUD.dmi', src, "o0")
+		var/image/empty_state = image('icons/mob/ammoHUD.dmi', src, "[hud_state_empty]")
+		overlays += empty_state
 		if(warned)
-			overlays += empty
-		else
-			warned = TRUE
-			var/obj/screen/ammo/F = new /obj/screen/ammo(src)
-			F.icon_state = "frame"
-			user.client.screen += F
-			flick("[hud_state_empty]_flash", F)
-			spawn(20)
-				user.client.screen -= F
-				qdel(F)
-				if(G.rounds == 0)
-					overlays += empty
-	else
-		warned = FALSE
-		overlays += image('icons/mob/ammoHUD.dmi', src, "[hud_state]")
+			return
+		warned = TRUE
+		flick("[hud_state_empty]_flash", flash_holder)
+		return
+	var/hud_state = ammo_type[1]
+
+	warned = FALSE
+	overlays += image('icons/mob/ammoHUD.dmi', src, "[hud_state]")
 
 	rounds = num2text(rounds)
 

--- a/code/_onclick/hud/screen_objects/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/screen_objects.dm
@@ -671,6 +671,9 @@
 
 	usr.hud_used.hidden_inventory_update()
 
+
+#define AMMO_HUD_ICON_NORMAL 1
+#define AMMO_HUD_ICON_EMPTY 2
 /**
  * HUD ammo indicator
  *
@@ -717,19 +720,17 @@
 	overlays.Cut()
 
 	if(rounds <= 0)
-		var/hud_state_empty = ammo_type[2]
 		overlays += image('icons/mob/ammoHUD.dmi', src, "o0")
-		var/image/empty_state = image('icons/mob/ammoHUD.dmi', src, "[hud_state_empty]")
+		var/image/empty_state = image('icons/mob/ammoHUD.dmi', src, ammo_type[AMMO_HUD_ICON_EMPTY])
 		overlays += empty_state
 		if(warned)
 			return
 		warned = TRUE
-		flick("[hud_state_empty]_flash", flash_holder)
+		flick("[ammo_type[AMMO_HUD_ICON_EMPTY]]_flash", flash_holder)
 		return
-	var/hud_state = ammo_type[1]
 
 	warned = FALSE
-	overlays += image('icons/mob/ammoHUD.dmi', src, "[hud_state]")
+	overlays += image('icons/mob/ammoHUD.dmi', src, "[ammo_type[AMMO_HUD_ICON_NORMAL]]")
 
 	rounds = num2text(rounds)
 
@@ -748,6 +749,9 @@
 			overlays += image('icons/mob/ammoHUD.dmi', src, "o9")
 			overlays += image('icons/mob/ammoHUD.dmi', src, "t9")
 			overlays += image('icons/mob/ammoHUD.dmi', src, "h9")
+
+#undef AMMO_HUD_ICON_NORMAL
+#undef AMMO_HUD_ICON_EMPTY
 
 /obj/screen/arrow
 	icon = 'icons/Marine/marine-items.dmi'

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -167,7 +167,6 @@
 		user.put_in_hands(new_handful)
 		to_chat(user, span_notice("You grab <b>[rounds]</b> round\s from [src]."))
 		update_icon() //Update the other one.
-		user?.hud_used.update_ammo_hud(user, src)
 		if(current_rounds <= 0 && CHECK_BITFIELD(flags_magazine, MAGAZINE_HANDFUL))
 			user.temporarilyRemoveItemFromInventory(src)
 			qdel(src)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -430,7 +430,8 @@
 		return
 	gun_user = user
 	SEND_SIGNAL(gun_user, COMSIG_GUN_USER_SET, src)
-	gun_user.hud_used.add_ammo_hud(gun_user, src)
+	if(flags_gun_features & GUN_AMMO_COUNTER)
+		gun_user.hud_used.add_ammo_hud(gun_user, src, get_ammo_list(), get_display_ammo_count())
 	if(master_gun)
 		return
 	if(!CHECK_BITFIELD(flags_item, IS_DEPLOYED))
@@ -782,7 +783,7 @@
 			playsound(src, empty_sound, 25, 1)
 			unload(after_fire = TRUE)
 	update_ammo_count()
-	gun_user?.hud_used.update_ammo_hud(gun_user, src)
+	gun_user?.hud_used.update_ammo_hud(gun_user, src, get_ammo_list(), get_display_ammo_count())
 	update_icon()
 	if(dual_wield && (gun_firemode == GUN_FIREMODE_SEMIAUTO || gun_firemode == GUN_FIREMODE_BURSTFIRE))
 		var/obj/item/weapon/gun/inactive_gun = gun_user.get_inactive_held_item()
@@ -1417,10 +1418,19 @@
 	ammo_datum_type = ammo_type
 	return ammo_datum_type
 
+///returns ammo string icon_states to display in the ammo counter of the HUD. list(normal_state, empty_state)
 /obj/item/weapon/gun/proc/get_ammo_list()
 	if(!ammo_datum_type)
 		return list("unknown", "unknown")
 	return list(initial(ammo_datum_type.hud_state), initial(ammo_datum_type.hud_state_empty))
+
+///returns ammo count to display in the ammo counter of the HUD
+/obj/item/weapon/gun/proc/get_display_ammo_count()
+	if(rounds && (flags_gun_features & GUN_AMMO_COUNT_BY_SHOTS_REMAINING))
+		return round(rounds / rounds_per_shot)
+	if(max_rounds && rounds && (flags_gun_features & GUN_AMMO_COUNT_BY_PERCENTAGE))
+		return round((rounds / max_rounds) * 100)
+	return rounds
 
 ///Updates the guns rounds and max_rounds vars based on the contents of chamber_items
 /obj/item/weapon/gun/proc/update_ammo_count()
@@ -1436,7 +1446,7 @@
 				new_rounds++
 		rounds = new_rounds
 		max_rounds = max_chamber_items + 1
-		gun_user?.hud_used.update_ammo_hud(gun_user, src)
+		gun_user?.hud_used.update_ammo_hud(gun_user, src, get_ammo_list(), get_display_ammo_count())
 		return
 	var/total_rounds
 	var/total_max_rounds
@@ -1447,7 +1457,7 @@
 	rounds = total_rounds + (in_chamber ? rounds_per_shot : 0)
 	max_rounds = total_max_rounds
 	update_icon()
-	gun_user?.hud_used.update_ammo_hud(gun_user, src)
+	gun_user?.hud_used.update_ammo_hud(gun_user, src, get_ammo_list(), get_display_ammo_count())
 
 ///Disconnects from a worn magazine.
 /obj/item/weapon/gun/proc/drop_connected_mag(datum/source, mob/user)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -422,7 +422,7 @@
 		UnregisterSignal(gun_user, list(COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEUP, COMSIG_ITEM_ZOOM, COMSIG_ITEM_UNZOOM, COMSIG_MOB_MOUSEDRAG, COMSIG_KB_RAILATTACHMENT, COMSIG_KB_UNDERRAILATTACHMENT, COMSIG_KB_UNLOADGUN, COMSIG_KB_FIREMODE, COMSIG_KB_GUN_SAFETY, COMSIG_KB_UNIQUEACTION, COMSIG_PARENT_QDELETING))
 		gun_user.client?.mouse_pointer_icon = initial(gun_user.client.mouse_pointer_icon)
 		SEND_SIGNAL(gun_user, COMSIG_GUN_USER_UNSET)
-		gun_user.hud_used.remove_ammo_hud(gun_user, src)
+		gun_user.hud_used.remove_ammo_hud(src)
 		gun_user = null
 	if(!user)
 		return
@@ -431,7 +431,7 @@
 	gun_user = user
 	SEND_SIGNAL(gun_user, COMSIG_GUN_USER_SET, src)
 	if(flags_gun_features & GUN_AMMO_COUNTER)
-		gun_user.hud_used.add_ammo_hud(gun_user, src, get_ammo_list(), get_display_ammo_count())
+		gun_user.hud_used.add_ammo_hud(src, get_ammo_list(), get_display_ammo_count())
 	if(master_gun)
 		return
 	if(!CHECK_BITFIELD(flags_item, IS_DEPLOYED))
@@ -783,7 +783,7 @@
 			playsound(src, empty_sound, 25, 1)
 			unload(after_fire = TRUE)
 	update_ammo_count()
-	gun_user?.hud_used.update_ammo_hud(gun_user, src, get_ammo_list(), get_display_ammo_count())
+	gun_user?.hud_used.update_ammo_hud(src, get_ammo_list(), get_display_ammo_count())
 	update_icon()
 	if(dual_wield && (gun_firemode == GUN_FIREMODE_SEMIAUTO || gun_firemode == GUN_FIREMODE_BURSTFIRE))
 		var/obj/item/weapon/gun/inactive_gun = gun_user.get_inactive_held_item()
@@ -1446,7 +1446,7 @@
 				new_rounds++
 		rounds = new_rounds
 		max_rounds = max_chamber_items + 1
-		gun_user?.hud_used.update_ammo_hud(gun_user, src, get_ammo_list(), get_display_ammo_count())
+		gun_user?.hud_used.update_ammo_hud(src, get_ammo_list(), get_display_ammo_count())
 		return
 	var/total_rounds
 	var/total_max_rounds
@@ -1457,7 +1457,7 @@
 	rounds = total_rounds + (in_chamber ? rounds_per_shot : 0)
 	max_rounds = total_max_rounds
 	update_icon()
-	gun_user?.hud_used.update_ammo_hud(gun_user, src, get_ammo_list(), get_display_ammo_count())
+	gun_user?.hud_used.update_ammo_hud(src, get_ammo_list(), get_display_ammo_count())
 
 ///Disconnects from a worn magazine.
 /obj/item/weapon/gun/proc/drop_connected_mag(datum/source, mob/user)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -131,7 +131,7 @@
 		to_chat(user, "[icon2html(src, user)] You [overcharge? "<B>disable</b>" : "<B>enable</b>" ] [src]'s overcharge mode.")
 		overcharge = FALSE
 
-	user?.hud_used.update_ammo_hud(user, src, get_ammo_list(), get_display_ammo_count())
+	user?.hud_used.update_ammo_hud(src, get_ammo_list(), get_display_ammo_count())
 
 	return TRUE
 
@@ -324,7 +324,7 @@
 	base_gun_icon = initial(choice.icon_state)
 	update_icon()
 	to_chat(user, initial(choice.message_to_user))
-	user?.hud_used.update_ammo_hud(user, src, get_ammo_list(), get_display_ammo_count())
+	user?.hud_used.update_ammo_hud(src, get_ammo_list(), get_display_ammo_count())
 
 	if(!in_chamber || !length(chamber_items))
 		return

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -131,9 +131,7 @@
 		to_chat(user, "[icon2html(src, user)] You [overcharge? "<B>disable</b>" : "<B>enable</b>" ] [src]'s overcharge mode.")
 		overcharge = FALSE
 
-	//load_into_chamber()
-
-	user?.hud_used.update_ammo_hud(user, src)
+	user?.hud_used.update_ammo_hud(user, src, get_ammo_list(), get_display_ammo_count())
 
 	return TRUE
 
@@ -326,7 +324,7 @@
 	base_gun_icon = initial(choice.icon_state)
 	update_icon()
 	to_chat(user, initial(choice.message_to_user))
-	user?.hud_used.update_ammo_hud(user, src)
+	user?.hud_used.update_ammo_hud(user, src, get_ammo_list(), get_display_ammo_count())
 
 	if(!in_chamber || !length(chamber_items))
 		return

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -96,14 +96,14 @@
 		return
 	if(attachments_by_slot[ATTACHMENT_SLOT_FLAMER_NOZZLE])
 		light_pilot(TRUE)
-	gun_user?.hud_used.update_ammo_hud(gun_user, src)
+	gun_user?.hud_used.update_ammo_hud(gun_user, src, get_ammo_list(), get_display_ammo_count())
 
 /obj/item/weapon/gun/flamer/unload(mob/living/user, drop = TRUE, after_fire = FALSE)
 	. = ..()
 	if(!.)
 		return
 	light_pilot(FALSE)
-	gun_user?.hud_used.update_ammo_hud(gun_user, src)
+	gun_user?.hud_used.update_ammo_hud(gun_user, src, get_ammo_list(), get_display_ammo_count())
 
 ///Makes the sound of the flamer being lit, and applies the overlay.
 /obj/item/weapon/gun/flamer/proc/light_pilot(light)
@@ -220,7 +220,7 @@
 		flame_turf(turf_to_ignite, gun_user, burn_time, burn_level, fire_color)
 		adjust_current_rounds(chamber_items[current_chamber_position], -1)
 		rounds--
-	gun_user?.hud_used.update_ammo_hud(gun_user, src)
+	gun_user?.hud_used.update_ammo_hud(gun_user, src, get_ammo_list(), get_display_ammo_count())
 	return TRUE
 
 ///Lights the specific turf on fire and processes melting snow or vines and the like.
@@ -365,7 +365,7 @@
 		hydro_active = FALSE
 		if (rounds > 0)
 			light_pilot(TRUE)
-	user.hud_used.update_ammo_hud(user, src)
+	user.hud_used.update_ammo_hud(user, src, get_ammo_list(), get_display_ammo_count())
 	SEND_SIGNAL(src, COMSIG_ITEM_HYDRO_CANNON_TOGGLED)
 	return TRUE
 
@@ -377,7 +377,7 @@
 		water_count -= 7//reagents is not updated in this proc, we need water_count for a updated HUD
 		last_fired = world.time
 		last_use = world.time
-		gun_user.hud_used.update_ammo_hud(gun_user, src)
+		gun_user.hud_used.update_ammo_hud(gun_user, src, get_ammo_list(), get_display_ammo_count())
 		return
 	if(gun_user?.skills.getRating("firearms") < 0)
 		switch(windup_checked)
@@ -405,7 +405,7 @@
 		water_count = reagents.maximum_volume
 		to_chat(user, span_notice("\The [src]'s hydro cannon is refilled with water."))
 		playsound(src.loc, 'sound/effects/refill.ogg', 25, 1, 3)
-		user.hud_used.update_ammo_hud(user, src)
+		user.hud_used.update_ammo_hud(user, src, get_ammo_list(), get_display_ammo_count())
 		return
 
 /obj/item/weapon/gun/flamer/big_flamer/marinestandard/wide

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -96,14 +96,14 @@
 		return
 	if(attachments_by_slot[ATTACHMENT_SLOT_FLAMER_NOZZLE])
 		light_pilot(TRUE)
-	gun_user?.hud_used.update_ammo_hud(gun_user, src, get_ammo_list(), get_display_ammo_count())
+	gun_user?.hud_used.update_ammo_hud(src, get_ammo_list(), get_display_ammo_count())
 
 /obj/item/weapon/gun/flamer/unload(mob/living/user, drop = TRUE, after_fire = FALSE)
 	. = ..()
 	if(!.)
 		return
 	light_pilot(FALSE)
-	gun_user?.hud_used.update_ammo_hud(gun_user, src, get_ammo_list(), get_display_ammo_count())
+	gun_user?.hud_used.update_ammo_hud(src, get_ammo_list(), get_display_ammo_count())
 
 ///Makes the sound of the flamer being lit, and applies the overlay.
 /obj/item/weapon/gun/flamer/proc/light_pilot(light)
@@ -220,7 +220,7 @@
 		flame_turf(turf_to_ignite, gun_user, burn_time, burn_level, fire_color)
 		adjust_current_rounds(chamber_items[current_chamber_position], -1)
 		rounds--
-	gun_user?.hud_used.update_ammo_hud(gun_user, src, get_ammo_list(), get_display_ammo_count())
+	gun_user?.hud_used.update_ammo_hud(src, get_ammo_list(), get_display_ammo_count())
 	return TRUE
 
 ///Lights the specific turf on fire and processes melting snow or vines and the like.
@@ -365,7 +365,7 @@
 		hydro_active = FALSE
 		if (rounds > 0)
 			light_pilot(TRUE)
-	user.hud_used.update_ammo_hud(user, src, get_ammo_list(), get_display_ammo_count())
+	user.hud_used.update_ammo_hud(src, get_ammo_list(), get_display_ammo_count())
 	SEND_SIGNAL(src, COMSIG_ITEM_HYDRO_CANNON_TOGGLED)
 	return TRUE
 
@@ -377,7 +377,7 @@
 		water_count -= 7//reagents is not updated in this proc, we need water_count for a updated HUD
 		last_fired = world.time
 		last_use = world.time
-		gun_user.hud_used.update_ammo_hud(gun_user, src, get_ammo_list(), get_display_ammo_count())
+		gun_user.hud_used.update_ammo_hud(src, get_ammo_list(), get_display_ammo_count())
 		return
 	if(gun_user?.skills.getRating("firearms") < 0)
 		switch(windup_checked)
@@ -405,7 +405,7 @@
 		water_count = reagents.maximum_volume
 		to_chat(user, span_notice("\The [src]'s hydro cannon is refilled with water."))
 		playsound(src.loc, 'sound/effects/refill.ogg', 25, 1, 3)
-		user.hud_used.update_ammo_hud(user, src, get_ammo_list(), get_display_ammo_count())
+		user.hud_used.update_ammo_hud(src, get_ammo_list(), get_display_ammo_count())
 		return
 
 /obj/item/weapon/gun/flamer/big_flamer/marinestandard/wide

--- a/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
@@ -33,6 +33,7 @@
 	projectile_delay = 0.3 SECONDS
 	harmful = TRUE
 	ammo_type = MECHA_AMMO_PISTOL
+	hud_icons = list("pistol", "pistol_empty")
 	fire_mode = GUN_FIREMODE_SEMIAUTO
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/burstpistol
@@ -59,6 +60,7 @@
 	projectile_burst_delay = 0.1 SECONDS
 	harmful = TRUE
 	ammo_type = MECHA_AMMO_BURSTPISTOL
+	hud_icons = list("pistol_light", "pistol_empty")
 	fire_mode = GUN_FIREMODE_AUTOBURST
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/smg
@@ -83,6 +85,7 @@
 	slowdown = 0.15
 	harmful = TRUE
 	ammo_type = MECHA_AMMO_SMG
+	hud_icons = list("smg", "smg_empty")
 	fire_mode = GUN_FIREMODE_AUTOMATIC
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/burstrifle
@@ -108,6 +111,7 @@
 	slowdown = 0.25
 	harmful = TRUE
 	ammo_type = MECHA_AMMO_BURSTRIFLE
+	hud_icons = list("hivelo", "hivelo_empty")
 	fire_mode = GUN_FIREMODE_AUTOBURST
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/assault_rifle
@@ -131,6 +135,7 @@
 	slowdown = 0.2
 	harmful = TRUE
 	ammo_type = MECHA_AMMO_RIFLE
+	hud_icons = list("rifle", "rifle_empty")
 	fire_mode = GUN_FIREMODE_AUTOMATIC
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/shotgun
@@ -154,6 +159,7 @@
 	slowdown = 0.3
 	harmful = TRUE
 	ammo_type = MECHA_AMMO_SHOTGUN
+	hud_icons = list("shotgun_buckshot", "shotgun_empty")
 	fire_mode = GUN_FIREMODE_SEMIAUTO
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/greyscale_lmg
@@ -177,6 +183,7 @@
 	slowdown = 0.3
 	harmful = TRUE
 	ammo_type = MECHA_AMMO_GREY_LMG
+	hud_icons = list("rifle_heavy", "rifle_empty")
 	fire_mode = GUN_FIREMODE_AUTOMATIC
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/light_cannon
@@ -200,6 +207,7 @@
 	slowdown = 0.4
 	harmful = TRUE
 	ammo_type = MECHA_AMMO_LIGHTCANNON
+	hud_icons = list("grenade_airburst", "grenade_empty")
 	fire_mode = GUN_FIREMODE_AUTOMATIC
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser_rifle
@@ -285,6 +293,7 @@
 	slowdown = 1.2
 	harmful = TRUE
 	ammo_type = MECHA_AMMO_HEAVYCANNON
+	hud_icons = list("shell_apcr", "shell_empty")
 	fire_mode = GUN_FIREMODE_SEMIAUTO
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/minigun
@@ -310,6 +319,7 @@
 	windup_delay = 0.5 SECONDS
 	harmful = TRUE
 	ammo_type = MECHA_AMMO_MINIGUN
+	hud_icons = list("smartgun", "smartgun_empty")
 	fire_mode = GUN_FIREMODE_AUTOMATIC
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/sniper
@@ -333,6 +343,7 @@
 	slowdown = 0.6
 	harmful = TRUE
 	ammo_type = MECHA_AMMO_SNIPER
+	hud_icons = list("sniper_supersonic", "sniper_empty")
 	fire_mode = GUN_FIREMODE_SEMIAUTO
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/grenadelauncher
@@ -351,6 +362,7 @@
 	equip_cooldown = 2 SECONDS
 	slowdown = 0.4
 	ammo_type = MECHA_AMMO_GRENADE
+	hud_icons = list("grenade_he", "grenade_empty")
 	fire_mode = GUN_FIREMODE_SEMIAUTO
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/grenadelauncher/proj_init(obj/item/explosive/grenade/nade, mob/user)
@@ -382,6 +394,7 @@
 	slowdown = 0.4
 	harmful = TRUE
 	ammo_type = MECHA_AMMO_FLAMER
+	hud_icons = list("flame", "flame_empty")
 	fire_mode = GUN_FIREMODE_SEMIAUTO
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/rpg
@@ -405,4 +418,5 @@
 	slowdown = 0.7
 	harmful = TRUE
 	ammo_type = MECHA_AMMO_RPG
+	hud_icons = list("rocket_he", "rocket_empty")
 	fire_mode = GUN_FIREMODE_SEMIAUTO

--- a/code/modules/vehicles/mecha/mecha_mob_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_mob_interaction.dm
@@ -69,8 +69,20 @@
 	RegisterSignal(M, COMSIG_LIVING_DO_RESIST, /atom/movable.proc/resisted_against, TRUE)
 	. = ..()
 	update_icon()
+	//tgmc addition start
+	if(istype(equip_by_category[MECHA_R_ARM], /obj/item/mecha_parts/mecha_equipment/weapon/ballistic))
+		var/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/gun = equip_by_category[MECHA_R_ARM]
+		M.hud_used.add_ammo_hud(gun, gun.hud_icons, gun.projectiles)
+	if(istype(equip_by_category[MECHA_L_ARM], /obj/item/mecha_parts/mecha_equipment/weapon/ballistic))
+		var/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/gun = equip_by_category[MECHA_L_ARM]
+		M.hud_used.add_ammo_hud(gun, gun.hud_icons, gun.projectiles)
+	//tgmc addition end
 
 /obj/vehicle/sealed/mecha/remove_occupant(mob/M)
+	//tgmc addition start
+	M.hud_used.remove_ammo_hud(equip_by_category[MECHA_R_ARM])
+	M.hud_used.remove_ammo_hud(equip_by_category[MECHA_L_ARM])
+	//tgmc addition end
 	UnregisterSignal(M, COMSIG_MOB_DEATH)
 	UnregisterSignal(M, COMSIG_MOB_MOUSEDOWN)
 	UnregisterSignal(M, COMSIG_MOB_SAY)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1) No more user passing
2)autodoc
3)Can be given to any datum
4) no longer creates and deletes ammo objects constantly
5) no more spawn
6) other misc cleanups

I folded in mech ammo but I can split it out if you want

## Changelog
:cl:
fix: Ammo HUDs will now always blink when you are out of ammo instead of only the bottommost one
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
