### PR TITLE
LMG fix and light cannon nerf

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -739,7 +739,7 @@ datum/ammo/bullet/revolver/tp44
 /datum/ammo/bullet/rifle/mech/lmg
 	damage = 20
 	penetration = 20
-	damage_type = 0.7
+	damage_falloff = 0.7
 
 /*
 //================================================
@@ -1439,14 +1439,14 @@ datum/ammo/bullet/revolver/tp44
 /datum/ammo/tx54/mech
 	name = "30mm fragmentation grenade"
 	bonus_projectiles_type = /datum/ammo/bullet/tx54_spread/mech
-	damage = 35
+	damage = 30
 	penetration = 20
 	projectile_greyscale_colors = "#4f0303"
 
 /datum/ammo/bullet/tx54_spread/mech
-	damage = 35
+	damage = 25
 	penetration = 20
-	sundering = 3
+	sundering = 2
 
 //10-gauge Micro rail shells - aka micronades
 /datum/ammo/bullet/micro_rail


### PR DESCRIPTION
## About The Pull Request

Fixes lmg not dealing damage and nerfs the light cannon.

## Why It's Good For The Game

LMG working good, light cannon not critting crushers in 3 hits also good (it crits them in 5 hits instead now)

## Changelog
:cl:
balance: mech light cannon's main projectile and spread projectiles deal less damage
fix: fixed the mech lmg not dealing damage

/:cl:

