### PR TITLE
LV 624 minor balance-related changes

### DIFF
--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -1803,11 +1803,12 @@
 /turf/open/ground/river,
 /area/lv624/ground/sand2)
 "aQc" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/engine/cult{
-	dir = 2
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
 	},
-/area/lv624/ground/caves/east1)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple)
 "aQg" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -1972,6 +1973,11 @@
 	dir = 2
 	},
 /area/lv624/lazarus/main_hall)
+"aSS" = (
+/obj/structure/table/mainship,
+/obj/effect/decal/sandytile,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple)
 "aSV" = (
 /obj/structure/jungle/plantbot1,
 /turf/open/ground/grass,
@@ -3260,11 +3266,6 @@
 	},
 /turf/open/floor,
 /area/lv624/ground/sand5)
-"bvU" = (
-/obj/structure/bed/nest,
-/obj/effect/decal/sandytile,
-/turf/open/floor/tile/whiteyellow/full,
-/area/lv624/lazarus/sandtemple)
 "bvY" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -5097,6 +5098,11 @@
 /obj/machinery/landinglight/ds1/delaythree,
 /turf/open/floor/plating,
 /area/shuttle/drop1/lz1)
+"dwp" = (
+/obj/effect/decal/sandytile,
+/obj/structure/jungle/vines,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple)
 "dwO" = (
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 1
@@ -5467,7 +5473,6 @@
 	},
 /area/lv624/lazarus/spaceport)
 "dSf" = (
-/obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/engine/cult{
 	dir = 2
@@ -5507,10 +5512,13 @@
 /turf/open/floor/tile/blue/whitebluefull,
 /area/lv624/lazarus/corporate_affairs)
 "dUf" = (
-/obj/effect/ai_node,
+/obj/effect/decal/sandytile,
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
+	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/central1)
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple)
 "dUD" = (
 /obj/structure/table,
 /obj/item/tool/shovel/spade,
@@ -6098,11 +6106,6 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central1)
-"eGK" = (
-/obj/structure/table/mainship,
-/obj/effect/decal/sandytile,
-/turf/open/floor/tile/whiteyellow/full,
-/area/lv624/lazarus/sandtemple)
 "eHL" = (
 /obj/structure/table/reinforced/flipped{
 	dir = 8
@@ -7145,6 +7148,13 @@
 	},
 /turf/open/floor/plating/platebotc,
 /area/lv624/lazarus/quartstorage/outdoors)
+"fXl" = (
+/obj/structure/fakeplatform{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple)
 "fXn" = (
 /obj/structure/jungle/vines,
 /turf/closed/wall,
@@ -7673,12 +7683,12 @@
 	},
 /area/lv624/ground/river1)
 "gBC" = (
-/obj/structure/stairs/seamless{
-	dir = 4
-	},
+/obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/sandtemple)
+/turf/open/floor/engine/cult{
+	dir = 2
+	},
+/area/lv624/ground/caves/east1)
 "gCL" = (
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
@@ -7779,6 +7789,11 @@
 "gKr" = (
 /turf/closed/mineral/smooth,
 /area/lv624/ground/caves/rock)
+"gKG" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central5)
 "gLd" = (
 /obj/structure/jungle/vines,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -7819,13 +7834,10 @@
 	},
 /area/lv624/ground/river1)
 "gMF" = (
-/obj/machinery/door/airlock/sandstone{
-	desc = "This strange temple is covered in runes. It looks extremely ancient.";
-	name = "Strange Temple"
-	},
+/obj/effect/ai_node,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/sandtemple)
+/area/lv624/ground/caves/central1)
 "gMJ" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
@@ -7954,8 +7966,8 @@
 	},
 /area/lv624/ground/compound/c)
 "gRH" = (
-/obj/structure/platform_decoration{
-	dir = 1
+/obj/structure/stairs/seamless{
+	dir = 4
 	},
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
@@ -7971,9 +7983,11 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle3)
 "gSY" = (
-/obj/structure/fakeplatform{
-	dir = 4
+/obj/machinery/door/airlock/sandstone{
+	desc = "This strange temple is covered in runes. It looks extremely ancient.";
+	name = "Strange Temple"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
 "gTa" = (
@@ -8660,13 +8674,6 @@
 	},
 /turf/open/floor/tile/bar,
 /area/lv624/lazarus/canteen)
-"hMk" = (
-/obj/structure/fakeplatform{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/sandtemple)
 "hMI" = (
 /obj/machinery/light{
 	dir = 4
@@ -9439,13 +9446,6 @@
 "iJa" = (
 /turf/open/ground/grass/grass2,
 /area/lv624/ground/jungle9)
-"iJe" = (
-/obj/item/tool/kitchen/utensil/spoon,
-/obj/structure/table/mainship,
-/obj/item/reagent_containers/food/snacks/stew,
-/obj/structure/jungle/vines,
-/turf/open/floor/tile/whiteyellow/full,
-/area/lv624/lazarus/sandtemple)
 "iJC" = (
 /obj/vehicle/train/cargo/engine,
 /obj/effect/landmark/weed_node,
@@ -10918,11 +10918,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/quartstorage)
-"koA" = (
-/obj/effect/decal/sandytile,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/tile/whiteyellow/full,
-/area/lv624/lazarus/sandtemple)
 "koS" = (
 /turf/open/floor,
 /area/lv624/ground/jungle7)
@@ -13579,8 +13574,11 @@
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/secure_storage)
 "nor" = (
+/obj/structure/platform_decoration{
+	dir = 1
+	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/bcircuit/off,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
 "not" = (
 /obj/effect/landmark/weed_node,
@@ -14091,6 +14089,10 @@
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle6)
+"nWu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/redfloor,
+/area/lv624/lazarus/sandtemple)
 "nWy" = (
 /obj/structure/jungle/vines/heavy,
 /turf/open/ground/grass,
@@ -14393,9 +14395,10 @@
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle9)
 "osJ" = (
-/obj/effect/decal/sandytile,
-/obj/structure/jungle/vines,
-/turf/open/floor/tile/whiteyellow/full,
+/obj/structure/fakeplatform{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
 "osS" = (
 /obj/structure/window/framed/colony/reinforced,
@@ -17750,6 +17753,11 @@
 	},
 /turf/open/floor/tile/red/full,
 /area/lv624/lazarus/security)
+"shQ" = (
+/obj/effect/decal/sandytile,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple)
 "six" = (
 /obj/structure/catwalk,
 /turf/open/ground/coast/corner2,
@@ -17864,11 +17872,6 @@
 /obj/item/reagent_containers/food/snacks/stew,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/sandtemple)
-"srE" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/central5)
 "srR" = (
 /obj/structure/cargo_container/nt{
 	dir = 8
@@ -19513,12 +19516,6 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/secure_storage)
-"unl" = (
-/obj/effect/decal/sandytile,
-/obj/effect/ai_node,
-/obj/structure/jungle/vines,
-/turf/open/floor/tile/whiteyellow/full,
-/area/lv624/lazarus/sandtemple)
 "unr" = (
 /obj/item/clothing/mask/facehugger/dead,
 /turf/open/floor/tile/purple/whitepurple{
@@ -19951,7 +19948,7 @@
 /area/lv624/ground/jungle5)
 "uQw" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/prison/redfloor,
+/turf/open/floor/bcircuit/off,
 /area/lv624/lazarus/sandtemple)
 "uQH" = (
 /obj/structure/stairs/seamless{
@@ -20678,6 +20675,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central4)
+"vHF" = (
+/obj/effect/decal/sandytile,
+/obj/effect/ai_node,
+/obj/structure/jungle/vines,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple)
 "vHO" = (
 /turf/open/floor/marking/warning/corner,
 /area/lv624/lazarus/spaceport)
@@ -20928,6 +20931,13 @@
 	dir = 4
 	},
 /area/lv624/ground/sand3)
+"vYu" = (
+/obj/item/tool/kitchen/utensil/spoon,
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/food/snacks/stew,
+/obj/structure/jungle/vines,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple)
 "vYI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8
@@ -21892,6 +21902,11 @@
 	dir = 8
 	},
 /area/lv624/ground/jungle5)
+"wYK" = (
+/obj/structure/bed/nest,
+/obj/effect/decal/sandytile,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple)
 "wYW" = (
 /turf/open/floor/tile/red/full,
 /area/lv624/lazarus/security)
@@ -35032,7 +35047,7 @@ aIm
 luP
 wfH
 luP
-srE
+gKG
 kfX
 aIm
 vAA
@@ -50038,7 +50053,7 @@ aia
 eEW
 aia
 aia
-dUf
+gMF
 aia
 aia
 vID
@@ -54991,7 +55006,7 @@ alB
 gKr
 gKr
 aaH
-dSf
+gBC
 aaH
 gKr
 gKr
@@ -55017,7 +55032,7 @@ oRZ
 ucZ
 qWa
 eYX
-uQw
+nWu
 eYX
 hxa
 xsN
@@ -55520,12 +55535,12 @@ sDq
 gKr
 alB
 aaH
-aQc
+dSf
 aaQ
 avM
 aaQ
 aaQ
-aQc
+dSf
 htq
 dUK
 mcN
@@ -55546,11 +55561,11 @@ nwU
 gKr
 oRZ
 jTp
-nor
+uQw
 bYe
 eYX
 bYe
-nor
+uQw
 tyv
 oRZ
 iQu
@@ -55725,7 +55740,7 @@ oRZ
 ucZ
 hxa
 bYe
-uQw
+nWu
 bYe
 hxa
 ucZ
@@ -56053,7 +56068,7 @@ alB
 sDq
 sDq
 aaH
-aQc
+dSf
 aaH
 hdX
 hdX
@@ -56252,7 +56267,7 @@ gKr
 nwU
 gKr
 oRZ
-gRH
+nor
 auI
 buQ
 iwX
@@ -56430,13 +56445,13 @@ nwU
 gKr
 aiO
 auK
-gSY
+osJ
 hbf
 bOl
 bOl
 bOl
 ydP
-hMk
+fXl
 tXS
 qfl
 vCy
@@ -57135,7 +57150,7 @@ jNf
 bfw
 mpL
 bOl
-gMF
+gSY
 bsq
 bsq
 fnP
@@ -57663,7 +57678,7 @@ mcN
 aah
 gLx
 xaN
-gBC
+gRH
 xaN
 nwU
 oRZ
@@ -58733,9 +58748,9 @@ oRZ
 slg
 bsq
 bOl
-osJ
+dwp
 aiO
-unl
+vHF
 bOl
 jNf
 tRU
@@ -58908,8 +58923,8 @@ gKr
 oRZ
 oRZ
 bYX
-bsq
-fnP
+hlO
+bOl
 aiO
 aiO
 bOl
@@ -59088,7 +59103,7 @@ bsq
 bsq
 fuw
 bOl
-fuw
+dUf
 jQc
 fuw
 bOl
@@ -59443,11 +59458,11 @@ oUH
 crq
 sqP
 aiO
-iJe
+vYu
 fdO
 bOl
 bOl
-koA
+shQ
 vCy
 vCy
 vCy
@@ -59619,7 +59634,7 @@ hlO
 bsq
 lnN
 bsq
-puz
+aQc
 puz
 bsq
 bOl
@@ -60327,7 +60342,7 @@ vcW
 bsq
 bsq
 bsq
-bsq
+hlO
 bsq
 bsq
 bOl
@@ -61215,7 +61230,7 @@ vFe
 jNf
 sqN
 qfl
-eGK
+aSS
 jQc
 bOl
 bOl
@@ -61394,7 +61409,7 @@ dAn
 qfl
 bOl
 lIu
-bvU
+wYK
 gXQ
 gXQ
 gKr

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -314,6 +314,7 @@
 /turf/open/floor/plating,
 /area/lv624/ground/caves/central1)
 "alh" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/marking/bot,
 /area/lv624/ground/caves/central1)
 "alm" = (
@@ -826,7 +827,7 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand6)
 "awp" = (
-/obj/structure/platform{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -1802,12 +1803,11 @@
 /turf/open/ground/river,
 /area/lv624/ground/sand2)
 "aQc" = (
-/obj/structure/jungle/vines,
-/obj/structure/bed/chair/comfy/black{
-	dir = 8
+/obj/effect/landmark/weed_node,
+/turf/open/floor/engine/cult{
+	dir = 2
 	},
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/sandtemple)
+/area/lv624/ground/caves/east1)
 "aQg" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -3260,6 +3260,11 @@
 	},
 /turf/open/floor,
 /area/lv624/ground/sand5)
+"bvU" = (
+/obj/structure/bed/nest,
+/obj/effect/decal/sandytile,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple)
 "bvY" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -3769,7 +3774,7 @@
 /turf/open/floor,
 /area/lv624/ground/compound/n)
 "bYe" = (
-/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/prison/redfloor,
 /area/lv624/lazarus/sandtemple)
 "bYj" = (
@@ -3796,10 +3801,7 @@
 "bYX" = (
 /obj/structure/jungle/vines,
 /obj/machinery/power/apc/hyper,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 4;
-	icon_state = "grassdirt_corner2"
-	},
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
 "bZe" = (
 /obj/effect/ai_node,
@@ -4064,7 +4066,6 @@
 	pixel_x = -1;
 	pixel_y = -31
 	},
-/obj/structure/showcase,
 /obj/effect/decal/sandytile,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/sandtemple)
@@ -4838,7 +4839,7 @@
 /turf/open/floor/tile/barber,
 /area/lv624/lazarus/kitchen)
 "dgO" = (
-/obj/structure/platform{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/ground/grass,
@@ -4935,10 +4936,10 @@
 	},
 /area/lv624/lazarus/sandtemple)
 "dol" = (
-/obj/structure/platform{
+/obj/effect/decal/sandytile,
+/obj/structure/fakeplatform{
 	dir = 1
 	},
-/obj/effect/decal/sandytile,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/sandtemple)
 "dos" = (
@@ -5449,9 +5450,7 @@
 	pixel_x = 1;
 	pixel_y = -31
 	},
-/obj/structure/showcase,
 /obj/effect/decal/sandytile,
-/obj/structure/spider/stickyweb,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/sandtemple)
 "dRM" = (
@@ -5468,11 +5467,12 @@
 	},
 /area/lv624/lazarus/spaceport)
 "dSf" = (
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 8;
-	icon_state = "grassdirt_corner2"
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/engine/cult{
+	dir = 2
 	},
-/area/lv624/lazarus/sandtemple)
+/area/lv624/ground/caves/east1)
 "dSp" = (
 /obj/item/bedsheet/rd,
 /obj/item/toy/bikehorn/rubberducky,
@@ -5507,13 +5507,10 @@
 /turf/open/floor/tile/blue/whitebluefull,
 /area/lv624/lazarus/corporate_affairs)
 "dUf" = (
-/obj/effect/decal/sandytile,
-/obj/structure/jungle/vines,
-/obj/structure/bed/chair/comfy/black{
-	dir = 4
-	},
-/turf/open/floor/tile/whiteyellow/full,
-/area/lv624/lazarus/sandtemple)
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central1)
 "dUD" = (
 /obj/structure/table,
 /obj/item/tool/shovel/spade,
@@ -6101,6 +6098,11 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central1)
+"eGK" = (
+/obj/structure/table/mainship,
+/obj/effect/decal/sandytile,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple)
 "eHL" = (
 /obj/structure/table/reinforced/flipped{
 	dir = 8
@@ -7671,10 +7673,11 @@
 	},
 /area/lv624/ground/river1)
 "gBC" = (
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 8
+/obj/structure/stairs/seamless{
+	dir = 4
 	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
 "gCL" = (
 /obj/structure/jungle/vines,
@@ -7816,8 +7819,12 @@
 	},
 /area/lv624/ground/river1)
 "gMF" = (
+/obj/machinery/door/airlock/sandstone{
+	desc = "This strange temple is covered in runes. It looks extremely ancient.";
+	name = "Strange Temple"
+	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/bcircuit/off,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
 "gMJ" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
@@ -7947,10 +7954,11 @@
 	},
 /area/lv624/ground/compound/c)
 "gRH" = (
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 4
+/obj/structure/platform_decoration{
+	dir = 1
 	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
 "gRT" = (
 /turf/open/ground/coast/corner{
@@ -7963,10 +7971,8 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle3)
 "gSY" = (
-/obj/structure/jungle/vines,
-/obj/machinery/door/airlock/sandstone{
-	desc = "This strange temple is covered in runes. It looks extremely ancient.";
-	name = "Strange Temple"
+/obj/structure/fakeplatform{
+	dir = 4
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
@@ -8026,10 +8032,8 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle6)
 "gXQ" = (
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 4;
-	icon_state = "grassdirt_corner"
-	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/sandtemple)
 "gYm" = (
 /obj/structure/cable,
@@ -8539,8 +8543,8 @@
 /turf/open/floor,
 /area/lv624/ground/sand8)
 "hDt" = (
-/obj/structure/platform,
 /obj/effect/landmark/weed_node,
+/obj/structure/fakeplatform,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
 "hDA" = (
@@ -8632,7 +8636,7 @@
 /turf/open/floor/marking/bot,
 /area/lv624/lazarus/spaceport)
 "hKs" = (
-/obj/structure/platform,
+/obj/structure/fakeplatform,
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/lazarus/sandtemple)
 "hKX" = (
@@ -8656,6 +8660,13 @@
 	},
 /turf/open/floor/tile/bar,
 /area/lv624/lazarus/canteen)
+"hMk" = (
+/obj/structure/fakeplatform{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple)
 "hMI" = (
 /obj/machinery/light{
 	dir = 4
@@ -8927,8 +8938,8 @@
 	},
 /area/lv624/lazarus/security)
 "iaS" = (
-/obj/structure/platform,
 /obj/effect/decal/sandytile,
+/obj/structure/fakeplatform,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/sandtemple)
 "ibj" = (
@@ -9428,6 +9439,13 @@
 "iJa" = (
 /turf/open/ground/grass/grass2,
 /area/lv624/ground/jungle9)
+"iJe" = (
+/obj/item/tool/kitchen/utensil/spoon,
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/food/snacks/stew,
+/obj/structure/jungle/vines,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple)
 "iJC" = (
 /obj/vehicle/train/cargo/engine,
 /obj/effect/landmark/weed_node,
@@ -10900,6 +10918,11 @@
 	},
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/quartstorage)
+"koA" = (
+/obj/effect/decal/sandytile,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple)
 "koS" = (
 /turf/open/floor,
 /area/lv624/ground/jungle7)
@@ -11286,8 +11309,8 @@
 	pixel_y = 3
 	},
 /obj/structure/table/mainship,
-/obj/structure/jungle/vines,
 /obj/item/reagent_containers/food/snacks/xemeatpie,
+/obj/structure/jungle/vines,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/sandtemple)
 "kLK" = (
@@ -11843,7 +11866,7 @@
 /turf/open/floor/wood,
 /area/lv624/lazarus/corporate_affairs)
 "lpp" = (
-/obj/structure/platform{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -12141,10 +12164,9 @@
 /area/lv624/ground/jungle5)
 "lIu" = (
 /obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 4;
-	icon_state = "grassdirt_corner"
-	},
+/obj/structure/bed/nest,
+/obj/effect/decal/sandytile,
+/turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/sandtemple)
 "lIF" = (
 /obj/structure/table/woodentable,
@@ -13143,7 +13165,7 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle3)
 "mPb" = (
-/obj/structure/platform{
+/obj/structure/fakeplatform{
 	dir = 4
 	},
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -13557,10 +13579,8 @@
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/secure_storage)
 "nor" = (
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1;
-	icon_state = "grassdirt_corner2"
-	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/bcircuit/off,
 /area/lv624/lazarus/sandtemple)
 "not" = (
 /obj/effect/landmark/weed_node,
@@ -14048,12 +14068,6 @@
 /obj/effect/decal/riverdecal,
 /turf/open/ground/river,
 /area/lv624/ground/river1)
-"nVx" = (
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
-	},
-/area/lv624/lazarus/sandtemple)
 "nVy" = (
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle3)
@@ -14163,13 +14177,6 @@
 	dir = 4
 	},
 /area/lv624/ground/jungle6)
-"ocN" = (
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 4;
-	icon_state = "grassdirt_corner"
-	},
-/area/lv624/lazarus/sandtemple)
 "ocO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/grille,
@@ -14386,13 +14393,9 @@
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle9)
 "osJ" = (
-/obj/structure/jungle/plantbot1{
-	icon_state = "alienplant1";
-	layer = 4.13;
-	luminosity = 2;
-	pixel_y = 18
-	},
-/turf/open/floor/plating/ground/dirtgrassborder,
+/obj/effect/decal/sandytile,
+/obj/structure/jungle/vines,
+/turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/sandtemple)
 "osS" = (
 /obj/structure/window/framed/colony/reinforced,
@@ -15138,10 +15141,10 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle10)
 "pnk" = (
-/obj/structure/platform{
+/obj/effect/decal/sandytile,
+/obj/structure/fakeplatform{
 	dir = 4
 	},
-/obj/effect/decal/sandytile,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/sandtemple)
 "pnl" = (
@@ -15581,6 +15584,7 @@
 "pRj" = (
 /obj/structure/table/mainship,
 /obj/item/weapon/twohanded/spear,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/darkish,
 /area/lv624/lazarus/sandtemple)
 "pRC" = (
@@ -16874,6 +16878,13 @@
 /obj/structure/platform{
 	dir = 4
 	},
+/obj/structure/jungle/plantbot1{
+	icon_state = "alienplant1";
+	layer = 4.13;
+	luminosity = 2;
+	pixel_y = 18
+	},
+/obj/structure/jungle/vines,
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 8;
 	icon_state = "grassdirt_corner2"
@@ -17453,7 +17464,7 @@
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
 "rRZ" = (
-/obj/structure/platform{
+/obj/structure/fakeplatform{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/dirt,
@@ -17850,10 +17861,14 @@
 "sqP" = (
 /obj/item/tool/kitchen/utensil/spoon,
 /obj/structure/table/mainship,
-/obj/structure/jungle/vines,
 /obj/item/reagent_containers/food/snacks/stew,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/sandtemple)
+"srE" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central5)
 "srR" = (
 /obj/structure/cargo_container/nt{
 	dir = 8
@@ -18224,6 +18239,7 @@
 /area/lv624/lazarus/main_hall)
 "sTn" = (
 /obj/structure/platform_decoration,
+/obj/structure/jungle/vines,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
 "sTw" = (
@@ -19113,11 +19129,8 @@
 /turf/open/floor,
 /area/lv624/lazarus/spaceport2)
 "tRU" = (
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1;
-	icon_state = "grassdirt_corner2"
-	},
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
 "tRZ" = (
 /obj/structure/catwalk,
@@ -19500,6 +19513,12 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/secure_storage)
+"unl" = (
+/obj/effect/decal/sandytile,
+/obj/effect/ai_node,
+/obj/structure/jungle/vines,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple)
 "unr" = (
 /obj/item/clothing/mask/facehugger/dead,
 /turf/open/floor/tile/purple/whitepurple{
@@ -19833,10 +19852,8 @@
 /area/lv624/lazarus/spaceport2)
 "uIT" = (
 /obj/structure/bed/chair/comfy/black,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1;
-	icon_state = "grassdirt_corner2"
-	},
+/obj/effect/decal/sandytile,
+/turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/sandtemple)
 "uIV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -19867,7 +19884,6 @@
 /obj/item/tank/nitrogen,
 /obj/structure/rack,
 /obj/effect/decal/sandytile,
-/obj/structure/jungle/vines,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/sandtemple)
 "uLn" = (
@@ -19934,7 +19950,8 @@
 /turf/open/floor/plating/asteroidfloor,
 /area/lv624/ground/jungle5)
 "uQw" = (
-/turf/open/floor/plating/ground/dirtgrassborder,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/redfloor,
 /area/lv624/lazarus/sandtemple)
 "uQH" = (
 /obj/structure/stairs/seamless{
@@ -20694,6 +20711,7 @@
 /obj/structure/stairs/seamless{
 	dir = 4
 	},
+/obj/structure/jungle/vines,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/sandtemple)
 "vMc" = (
@@ -21121,9 +21139,7 @@
 /area/lv624/lazarus/sandtemple)
 "wiQ" = (
 /obj/structure/flora/ausbushes/sunnybush,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	icon_state = "grassdirt_corner"
-	},
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
 "wjg" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -21617,7 +21633,7 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle1)
 "wJJ" = (
-/obj/structure/platform{
+/obj/structure/fakeplatform{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/dirt,
@@ -25789,7 +25805,7 @@ kLK
 abc
 abc
 abc
-abc
+kLK
 dqp
 abc
 aym
@@ -25966,13 +25982,13 @@ abc
 abc
 abc
 abc
-kLK
+abc
 dqp
 abc
 kLK
 abc
 abc
-kLK
+abc
 abc
 abc
 eoT
@@ -26148,7 +26164,7 @@ jLM
 abc
 abc
 abc
-abc
+kLK
 abc
 kLK
 abc
@@ -26307,17 +26323,17 @@ gKr
 gKr
 gKr
 gKr
-abc
-abc
-eoT
-eoT
-abc
-abc
-abc
-abc
-abc
-abc
 kLK
+abc
+eoT
+eoT
+abc
+abc
+abc
+abc
+abc
+abc
+abc
 abc
 bZr
 abc
@@ -26674,7 +26690,7 @@ kLK
 abc
 abc
 abc
-abc
+kLK
 aym
 aym
 aym
@@ -26682,7 +26698,7 @@ aym
 aym
 aym
 aym
-abc
+kLK
 abc
 abc
 abc
@@ -26839,7 +26855,7 @@ gKr
 gKr
 gKr
 abc
-kLK
+abc
 abc
 abc
 abc
@@ -27015,7 +27031,7 @@ gKr
 gKr
 gKr
 gKr
-abc
+kLK
 abc
 abc
 abc
@@ -27721,7 +27737,7 @@ gKr
 gKr
 gKr
 gKr
-abc
+kLK
 abc
 abc
 kLK
@@ -27733,10 +27749,10 @@ abc
 abc
 abc
 qWu
+kLK
 abc
 abc
-abc
-abc
+kLK
 aym
 aym
 gKr
@@ -27913,7 +27929,7 @@ akj
 abc
 abc
 abc
-kLK
+abc
 abc
 aym
 aym
@@ -28085,7 +28101,7 @@ abc
 abc
 abc
 abc
-abc
+kLK
 ivV
 abc
 abc
@@ -28264,12 +28280,12 @@ abc
 abc
 gKr
 ivV
+kLK
 abc
 abc
 abc
 abc
-abc
-abc
+kLK
 aym
 alB
 gKr
@@ -28441,7 +28457,7 @@ abc
 gKr
 gKr
 ivV
-kLK
+abc
 abc
 abc
 mEU
@@ -28622,7 +28638,7 @@ abc
 abc
 abc
 abc
-kLK
+abc
 abc
 aym
 alB
@@ -28834,7 +28850,7 @@ heN
 alB
 gKr
 gKr
-cAu
+gsZ
 cAu
 cAu
 cAu
@@ -28972,11 +28988,11 @@ abc
 abc
 gKr
 ivV
+kLK
 abc
 abc
 abc
-abc
-abc
+kLK
 aym
 aym
 alB
@@ -29152,7 +29168,7 @@ ivV
 ivV
 abc
 abc
-kLK
+abc
 abc
 aym
 gKr
@@ -29320,7 +29336,7 @@ abc
 abc
 abc
 bZr
-abc
+kLK
 abc
 abc
 abc
@@ -30206,7 +30222,7 @@ abc
 cke
 abc
 cke
-abc
+kLK
 eoT
 eoT
 dqp
@@ -30222,7 +30238,7 @@ gKr
 gKr
 gKr
 gKr
-abc
+kLK
 eoT
 eoT
 eoT
@@ -30560,10 +30576,10 @@ abc
 cke
 abc
 cke
-abc
+kLK
 eoT
 eoT
-abc
+kLK
 abc
 abc
 kLK
@@ -31261,11 +31277,11 @@ gKr
 gKr
 gKr
 gKr
-abc
 kLK
 abc
 abc
 abc
+kLK
 eoT
 eoT
 abc
@@ -31638,7 +31654,7 @@ abc
 abc
 dqp
 abc
-abc
+kLK
 evp
 cTi
 evp
@@ -31792,7 +31808,7 @@ gKr
 gKr
 gKr
 gKr
-abc
+kLK
 abc
 abc
 abc
@@ -32525,15 +32541,15 @@ aym
 ivV
 aym
 aym
+tpS
 bfR
 bfR
 bfR
+tpS
 bfR
 bfR
 bfR
-bfR
-bfR
-bfR
+tpS
 bfR
 aym
 aym
@@ -32542,7 +32558,7 @@ aym
 alB
 gKr
 aIm
-aIm
+ifX
 aIm
 aIm
 kfX
@@ -32706,7 +32722,7 @@ bfR
 oJP
 bfR
 bfR
-tpS
+bfR
 bfR
 bfR
 bfR
@@ -32718,7 +32734,7 @@ bfR
 aWe
 kfX
 aIm
-ifX
+aIm
 aIm
 aIm
 aIm
@@ -32877,9 +32893,9 @@ kLK
 abc
 abc
 hXH
-bfR
-bfR
 tpS
+bfR
+bfR
 gcF
 bfR
 oJP
@@ -33039,7 +33055,7 @@ abc
 abc
 abc
 eoT
-abc
+kLK
 abc
 abc
 kLK
@@ -33063,7 +33079,7 @@ bfR
 bfR
 bfR
 bfR
-tpS
+bfR
 bfR
 bfR
 bfR
@@ -33411,14 +33427,14 @@ alB
 gKr
 gKr
 aym
-bfR
-bfR
+tpS
 bfR
 bfR
 tpS
 bfR
 bfR
 bfR
+tpS
 bfR
 bfR
 bfR
@@ -33769,7 +33785,7 @@ aIm
 aIm
 aIm
 aIm
-aIm
+ifX
 aIm
 aIm
 ifX
@@ -33958,7 +33974,7 @@ aIm
 kfX
 aIm
 aIm
-aIm
+ifX
 gKr
 gKr
 aym
@@ -34272,7 +34288,7 @@ gKr
 gKr
 gKr
 gKr
-kFx
+gnk
 kFx
 kFx
 kFx
@@ -34458,7 +34474,7 @@ kFx
 kFx
 aax
 kFx
-kFx
+gnk
 kFx
 kFx
 gKr
@@ -34477,7 +34493,7 @@ aIm
 aIm
 luP
 luP
-aIm
+ifX
 aIm
 aIm
 ifX
@@ -34653,7 +34669,7 @@ gKr
 gKr
 aIm
 aIm
-ifX
+aIm
 aIm
 gKr
 aIm
@@ -34805,7 +34821,7 @@ kFx
 kFx
 kFx
 kFx
-gnk
+kFx
 kFx
 kFx
 kFx
@@ -34829,7 +34845,7 @@ gKr
 gKr
 gKr
 aIm
-aIm
+ifX
 aIm
 gKr
 gKr
@@ -35016,7 +35032,7 @@ aIm
 luP
 wfH
 luP
-vAA
+srE
 kfX
 aIm
 vAA
@@ -35157,7 +35173,7 @@ kFx
 kFx
 gnk
 kFx
-kFx
+gnk
 kFx
 kFx
 kFx
@@ -35537,7 +35553,7 @@ gKr
 gKr
 gKr
 gKr
-aIm
+ifX
 aIm
 aIm
 luP
@@ -35547,7 +35563,7 @@ aIm
 aIm
 aIm
 aIm
-aIm
+ifX
 alB
 gKr
 luP
@@ -35898,7 +35914,7 @@ ifX
 aIm
 aIm
 aIm
-aIm
+ifX
 gKr
 gKr
 gKr
@@ -36250,7 +36266,7 @@ aIm
 vAA
 aIm
 aIm
-aIm
+ifX
 gKr
 gKr
 gKr
@@ -36424,7 +36440,7 @@ kFx
 gnk
 jsp
 aIm
-aIm
+ifX
 gKr
 gKr
 gKr
@@ -37828,7 +37844,7 @@ kFx
 gnk
 kFx
 kFx
-kFx
+gnk
 kFx
 kFx
 kFx
@@ -38538,12 +38554,12 @@ gnk
 kFx
 kDo
 jQf
+gnk
 kFx
 kFx
 kFx
 kFx
-kFx
-kFx
+gnk
 wAq
 aym
 aym
@@ -39448,7 +39464,7 @@ aIm
 aIm
 gKr
 aIm
-aIm
+ifX
 aIm
 gKr
 aIm
@@ -44190,7 +44206,7 @@ vCy
 vCy
 vCy
 hGA
-hGA
+jcX
 gKr
 gKr
 kFx
@@ -44551,7 +44567,7 @@ gKr
 aax
 kFx
 aax
-kFx
+gnk
 kFx
 kFx
 iLn
@@ -46319,7 +46335,7 @@ gKr
 gKr
 gKr
 gKr
-kFx
+gnk
 kFx
 kFx
 kFx
@@ -47557,7 +47573,7 @@ evp
 evp
 evp
 gKr
-kFx
+gnk
 kFx
 avz
 gnk
@@ -48270,7 +48286,7 @@ gKr
 gKr
 utV
 uJy
-kFx
+gnk
 jQf
 nwU
 gKr
@@ -50022,7 +50038,7 @@ aia
 eEW
 aia
 aia
-vND
+dUf
 aia
 aia
 vID
@@ -51080,7 +51096,7 @@ aia
 aia
 aia
 aia
-gYS
+aia
 aia
 gKr
 gKr
@@ -51433,7 +51449,7 @@ aia
 aia
 aia
 aia
-aia
+gYS
 aia
 aia
 gKr
@@ -52654,7 +52670,7 @@ gKr
 gKr
 gKr
 gKr
-aia
+gYS
 aia
 aia
 aia
@@ -53552,7 +53568,7 @@ gKr
 gKr
 aia
 aia
-aia
+gYS
 aia
 aia
 gKr
@@ -53728,7 +53744,7 @@ evp
 gKr
 gKr
 aia
-gYS
+aia
 aia
 aia
 aia
@@ -53905,7 +53921,7 @@ gKr
 gKr
 gKr
 aah
-mcN
+aah
 aah
 aah
 aah
@@ -54083,7 +54099,7 @@ gKr
 gKr
 aah
 aah
-aah
+mcN
 aah
 aah
 gKr
@@ -54804,7 +54820,7 @@ alB
 alB
 alB
 gKr
-aah
+mcN
 aah
 aah
 aah
@@ -54975,7 +54991,7 @@ alB
 gKr
 gKr
 aaH
-mNv
+dSf
 aaH
 gKr
 gKr
@@ -55001,8 +55017,8 @@ oRZ
 ucZ
 qWa
 eYX
+uQw
 eYX
-bYe
 hxa
 xsN
 oRZ
@@ -55504,15 +55520,15 @@ sDq
 gKr
 alB
 aaH
-aaQ
+aQc
 aaQ
 avM
 aaQ
 aaQ
-aaQ
+aQc
 htq
 dUK
-aah
+mcN
 aah
 aah
 aah
@@ -55530,11 +55546,11 @@ nwU
 gKr
 oRZ
 jTp
-hxa
+nor
+bYe
 eYX
-eYX
-eYX
-hxa
+bYe
+nor
 tyv
 oRZ
 iQu
@@ -55693,7 +55709,7 @@ aah
 adx
 aah
 aah
-aah
+mcN
 gKr
 gKr
 gKr
@@ -55709,9 +55725,9 @@ oRZ
 ucZ
 hxa
 bYe
-eYX
-eYX
-gMF
+uQw
+bYe
+hxa
 ucZ
 oRZ
 iQu
@@ -56037,7 +56053,7 @@ alB
 sDq
 sDq
 aaH
-aaQ
+aQc
 aaH
 hdX
 hdX
@@ -56236,7 +56252,7 @@ gKr
 nwU
 gKr
 oRZ
-nBJ
+gRH
 auI
 buQ
 iwX
@@ -56414,13 +56430,13 @@ nwU
 gKr
 aiO
 auK
-gYX
+gSY
 hbf
 bOl
 bOl
 bOl
 ydP
-gYX
+hMk
 tXS
 qfl
 vCy
@@ -56559,14 +56575,14 @@ aah
 aah
 aah
 aah
+mcN
 aah
-aah
 gKr
 gKr
 gKr
 gKr
 gKr
-aah
+mcN
 aah
 aah
 aah
@@ -57116,10 +57132,10 @@ aah
 aah
 pca
 jNf
-jQc
+bfw
 mpL
 bOl
-ics
+gMF
 bsq
 bsq
 fnP
@@ -57130,7 +57146,7 @@ awF
 aiO
 oCH
 slg
-bsq
+hlO
 vCy
 vCy
 vCy
@@ -57292,7 +57308,7 @@ aah
 aah
 aah
 iyS
-hlO
+bsq
 bsq
 hQb
 cpI
@@ -57446,7 +57462,7 @@ gKr
 gKr
 gKr
 aah
-aah
+mcN
 aah
 aah
 aah
@@ -57463,7 +57479,7 @@ aah
 aah
 aah
 aah
-aah
+mcN
 aah
 aah
 aah
@@ -57643,11 +57659,11 @@ aah
 aah
 aah
 ght
-aah
+mcN
 aah
 gLx
 xaN
-xaN
+gBC
 xaN
 nwU
 oRZ
@@ -57655,8 +57671,8 @@ oRZ
 iaS
 tyv
 rRZ
-nor
-aEc
+bsq
+bsq
 bsq
 hDt
 tyv
@@ -57819,7 +57835,7 @@ aah
 aah
 aah
 aah
-mcN
+aah
 aah
 aah
 aah
@@ -57832,8 +57848,8 @@ oRZ
 nBJ
 wJJ
 cYq
-dSf
-uxu
+bsq
+bsq
 bsq
 nBJ
 awp
@@ -57994,7 +58010,7 @@ aah
 aah
 dUK
 aah
-wwb
+dUK
 aah
 aah
 aah
@@ -58015,7 +58031,7 @@ bOl
 bOl
 sTn
 rmE
-qfl
+oRZ
 vCy
 vCy
 vCy
@@ -58142,7 +58158,7 @@ gKr
 gKr
 gKr
 gKr
-aah
+mcN
 aah
 aah
 aah
@@ -58191,7 +58207,7 @@ iwX
 iwX
 iwX
 vKj
-qfl
+oRZ
 qfl
 vCy
 vCy
@@ -58348,7 +58364,7 @@ gKr
 mcN
 aah
 aah
-aah
+mcN
 aah
 aah
 aah
@@ -58545,7 +58561,7 @@ jNf
 bOl
 fnP
 bOl
-oRZ
+qfl
 qfl
 vCy
 vCy
@@ -58715,14 +58731,14 @@ gKr
 gKr
 oRZ
 slg
-slg
+bsq
 bOl
-bOl
+osJ
 aiO
-jNf
+unl
 bOl
 jNf
-slg
+tRU
 qfl
 vCy
 vCy
@@ -58892,15 +58908,15 @@ gKr
 oRZ
 oRZ
 bYX
-slg
+bsq
 fnP
 aiO
 aiO
 bOl
 bOl
-bsq
+bOl
 tRU
-aiO
+tRU
 vCy
 vCy
 vCy
@@ -59067,17 +59083,17 @@ mcN
 sDq
 gKr
 qfl
-aiO
-uQw
+tRU
+bsq
 bsq
 fuw
 bOl
-dUf
+fuw
 jQc
 fuw
-bsq
-dSf
-dnP
+bOl
+bfw
+tRU
 vCy
 vCy
 vCy
@@ -59244,8 +59260,8 @@ aah
 sDq
 gKr
 oRZ
-aiO
-osJ
+tRU
+bsq
 bsq
 crq
 crq
@@ -59253,8 +59269,8 @@ kLF
 fdO
 crq
 bOl
-bsq
-bsq
+bOl
+tRU
 vCy
 vCy
 vCy
@@ -59421,17 +59437,17 @@ aah
 aah
 wsX
 oRZ
-dnP
-uxu
+bsq
+bsq
 oUH
 crq
 sqP
 aiO
-sqP
-crq
+iJe
+fdO
 bOl
 bOl
-bOl
+koA
 vCy
 vCy
 vCy
@@ -59574,7 +59590,7 @@ aah
 cUD
 uzK
 aah
-aah
+mcN
 aah
 aah
 aah
@@ -59595,15 +59611,15 @@ aah
 aah
 aah
 aah
-aah
+mcN
 wsX
 ojZ
 bsq
 hlO
 bsq
 lnN
-slg
-aQc
+bsq
+puz
 puz
 bsq
 bOl
@@ -59779,10 +59795,10 @@ uYi
 bOl
 jNf
 bsq
-tRU
-gBC
-tKb
-aEc
+bsq
+bsq
+bsq
+bsq
 vcW
 bOl
 bOl
@@ -59944,7 +59960,7 @@ gKr
 mlO
 sDq
 sDq
-aah
+mcN
 aah
 aah
 aah
@@ -59955,11 +59971,11 @@ gmL
 ewD
 bOl
 bsq
-nor
-ocN
-aiO
-aiO
-uQw
+bsq
+tRU
+tRU
+tRU
+bsq
 bsq
 jNf
 bOl
@@ -60127,16 +60143,16 @@ aah
 mcN
 aah
 aah
-aah
+uzK
 bsq
 vcW
 hlO
 bsq
-nVx
-aiO
-aiO
+tRU
+tRU
+tRU
 wiQ
-uxu
+bsq
 bsq
 bOl
 bOl
@@ -60304,15 +60320,15 @@ aah
 dUK
 aah
 aah
-aah
+vUk
 bOl
 bsq
 vcW
 bsq
-iDU
-gRH
-gRH
-uxu
+bsq
+bsq
+bsq
+bsq
 bsq
 bOl
 fnP
@@ -60475,7 +60491,7 @@ uzK
 kSK
 mcN
 uzK
-aah
+mcN
 aah
 aah
 aah
@@ -60487,7 +60503,7 @@ bsq
 bOl
 bOl
 bsq
-slg
+bsq
 vcW
 bsq
 bOl
@@ -60664,13 +60680,13 @@ qfl
 tPY
 qfl
 qfl
-oRZ
+qfl
 ics
 qfl
 qfl
-oRZ
-gSY
-oRZ
+qfl
+ics
+qfl
 qfl
 qfl
 gKr
@@ -60844,7 +60860,7 @@ qfl
 sqN
 bOl
 sqN
-oRZ
+qfl
 uLb
 jQc
 bnl
@@ -61021,11 +61037,11 @@ qfl
 sqN
 bfw
 sqN
-oRZ
+qfl
 vWj
 dlN
 uIT
-tKb
+bOl
 qfl
 gKr
 evp
@@ -61170,7 +61186,7 @@ aah
 mcN
 aah
 aah
-aah
+mcN
 aym
 aym
 gKr
@@ -61198,12 +61214,12 @@ qfl
 vFe
 jNf
 sqN
-oRZ
-sEE
-nor
+qfl
+eGK
+jQc
+bOl
+bOl
 gXQ
-aiO
-aiO
 gKr
 gKr
 gKr
@@ -61375,12 +61391,12 @@ gKr
 gKr
 tli
 dAn
-oRZ
-nor
+qfl
+bOl
 lIu
-aiO
-aiO
-aiO
+bvU
+gXQ
+gXQ
 gKr
 evp
 evp
@@ -61552,11 +61568,11 @@ gKr
 qfl
 sEE
 qfl
-oRZ
+qfl
 gXQ
-aiO
-aiO
-aiO
+gXQ
+gXQ
+gXQ
 gKr
 gKr
 evp
@@ -61729,9 +61745,9 @@ qfl
 qfl
 qfl
 qfl
-oRZ
-aiO
-aiO
+qfl
+gXQ
+gXQ
 gKr
 gKr
 gKr


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. The weed node placement in most places in the northern caves is now significantly more uniform. Xenos no longer have to spend 5 minutes patching holes in the weeds in the hive at the beginning of the round, in an area that should already be completely covered.
2. The Blue Disk temple(NE one) is now less overgrown. There is more area for weeds to spread, and part of the hive is now extended into it. This should, hopefully, make it at least slightly desirable to hold for xenos... while it is over the river, the previous design was heavily favoring a marine push into it, as the grass made it impossible for xenos to effectively fortify.

![image](https://user-images.githubusercontent.com/54787585/194776499-b220ace6-de81-4934-8269-891b8a436ceb.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
LV sucks pretty bad right now, hopefully this should make it a little better, as xenos have a pretty hard time on this map. It is effectively THE "hit and run ambush map", but now that marines are able to keep the pace with xeno's speed and can take more damage, that is effectively nullified, leaving it in a spot where 40% of the map is uninhabitable for xenos with little benefit for trying to use the flanking routes. This is meant to make at least one of the disks realistically defendable for xenos, though this isn't really a massive change. Also, whoever did the weed placement originally had parkinsons or something.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: LV624 has better cave weed placement
tweak: LV624 blue disk temple is no longer ridiculously overgrown, as the xenos have done some groundkeeping.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
