### PR TITLE
Disabled intel events for Combat Patrol and sensor capture

### DIFF
--- a/code/modules/events/intel_computer.dm
+++ b/code/modules/events/intel_computer.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/intel_computer
 	weight = 25
 
-	gamemode_blacklist = list("Crash")
+	gamemode_blacklist = list("Crash", "Combat Patrol", "Sensor Capture")
 
 /datum/round_event_control/intel_computer/can_spawn_event(players_amt, gamemode)
 	if(length(GLOB.intel_computers) <= 0)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This event does nothing in these modes, so disabling it like it is in crash.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Pointless thing be pointless
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The intel event will no longer trigger in Combat Patrol or Sensor capture
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
