### PR TITLE
Adds an new event, ion storm

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -1,0 +1,43 @@
+/datum/round_event_control/ion_storm
+	name = "Communication Blackout"
+	typepath = /datum/round_event/ion_storm
+	weight = 7
+	earliest_start = 60 MINUTES
+	max_occurrences = 1
+
+	gamemode_blacklist = list("Crash")
+
+/datum/round_event_control/ion_storm/can_spawn_event(players_amt, gamemode)
+	return ..()
+
+/datum/round_event/ion_storm/
+	announce_when = 0
+
+/datum/round_event/ion_storm/start()
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/fix_comms), 1 MINUTES)
+	for(var/obj/machinery/telecomms/C AS in GLOB.telecomms_list)
+		if(C.machine_stat & (NOPOWER|BROKEN|DISABLED))
+			continue
+		C.machine_stat |= NOPOWER|BROKEN|DISABLED
+
+/datum/round_event/ion_storm/announce()
+	var/alert = pick( "Ionospheric anomalies detected. Temporary telecommunication failure imminent. Please contact you*%fj00)`5vc-BZZT",
+		"Ionospheric anomalies detected. Temporary telecommunication failu*3mga;b4;'1v¬-BZZZT",
+		"Ionospheric anomalies detected. Temporary telec#MCi46:5.;@63-BZZZZT",
+		"Ionospheric anomalies dete'fZ\\kg5_0-BZZZZZT",
+		"Ionospheri:%£ MCayj^j<.3-BZZZZZZT",
+		"#4nd%;f4y6,>£%-BZZZZZZZT",
+	)
+	priority_announce(alert)
+
+/datum/round_event/ion_storm/proc/disable_comms(/obj/machinery/telecomms/C)
+	var/comms_knockout_timer = pick(1,1.5,1.7,2,2.3,2.5,3,4,8)
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/fix_comms), comms_knockout_timer MINUTES)
+
+/datum/round_event/ion_storm/proc/fix_comms()
+	for(var/obj/machinery/telecomms/C AS in GLOB.telecomms_list)
+		var/area/A = get_area(C)
+		if(A.power_environ == FALSE)
+			C.machine_stat = NOPOWER //remove the broken flags from before, so marines can still use the machines after they fix the area power
+			continue
+		C.machine_stat = NONE

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -1232,6 +1232,7 @@
 #include "code\modules\error_handler\error_viewer.dm"
 #include "code\modules\events\_events.dm"
 #include "code\modules\events\intel_computer.dm"
+#include "code\modules\events\ion_storm.dm"
 #include "code\modules\factory\howtopaper.dm"
 #include "code\modules\factory\machines.dm"
 #include "code\modules\factory\parts.dm"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It's a new event, Tivi wants more of them and I sat down and made some.

Ion storm is a low probability event that temporarily knocks comms offline for a period of between 1-4 minutes. It's basically TG's comms blackout, but it doesn't use emp_act() so we have more control over the duration.

## Why It's Good For The Game

More events good.

## Changelog
:cl:
add: Added a new event, ion storm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
