### PR TITLE
Adds a new event, hostile ert

### DIFF
--- a/code/modules/events/hostile_ert.dm
+++ b/code/modules/events/hostile_ert.dm
@@ -24,8 +24,8 @@
 
 /datum/round_event/hostile_ert/start()
 	priority_announce("Attention, ship sensors have detected a hostile vessel approaching at high speeds, all crew standby and prepare to be boarded.", sound = 'sound/misc/interference.ogg')
-	var/minimum_ert = (length(GLOB.alive_human_list_faction[FACTION_TERRAGOV]) * .04) //roughly comes out to 1 at min population of 30
-	var/maximum_ert = (length(GLOB.alive_human_list_faction[FACTION_TERRAGOV]) * .07) //roughly comes out to 2 at min population of 30
+	var/minimum_ert = (length(GLOB.alive_human_list_faction[FACTION_TERRAGOV]) * 0.04) //roughly comes out to 1 at min population of 30
+	var/maximum_ert = (length(GLOB.alive_human_list_faction[FACTION_TERRAGOV]) * 0.07) //roughly comes out to 2 at min population of 30
 	var/selected_ert = pick("CLF Cell","Sectoid Expedition","Sons of Mars Squad","USL Pirate Band","The Bone Zone","Pizza Delivery")
 	for(var/datum/emergency_call/C in SSticker.mode.all_calls)
 		if(C.name == selected_ert)

--- a/code/modules/events/hostile_ert.dm
+++ b/code/modules/events/hostile_ert.dm
@@ -26,7 +26,7 @@
 	priority_announce("Attention, ship sensors have detected a hostile vessel approaching at high speeds, all crew standby and prepare to be boarded.", sound = 'sound/misc/interference.ogg')
 	var/minimum_ert = (length(GLOB.alive_human_list_faction[FACTION_TERRAGOV]) * 0.04) //roughly comes out to 1 at min population of 30
 	var/maximum_ert = (length(GLOB.alive_human_list_faction[FACTION_TERRAGOV]) * 0.07) //roughly comes out to 2 at min population of 30
-	var/selected_ert = pick("CLF Cell","Sectoid Expedition","Sons of Mars Squad","USL Pirate Band","The Bone Zone","Pizza Delivery")
+	var/selected_ert = pick("CLF Cell", "Sectoid Expedition", "Sons of Mars Squad", "USL Pirate Band", "Pizza Delivery")
 	for(var/datum/emergency_call/C in SSticker.mode.all_calls)
 		if(C.name == selected_ert)
 			SSticker.mode.picked_call = C

--- a/code/modules/events/hostile_ert.dm
+++ b/code/modules/events/hostile_ert.dm
@@ -1,0 +1,39 @@
+#define MINIMUM_ERT 2
+#define MAXIMUM_ERT 5
+
+/datum/round_event_control/hostile_ert
+	name = "Hostile ERT"
+	typepath = /datum/round_event/hostile_ert
+	weight = 5
+	earliest_start = 90 MINUTES
+	max_occurrences = 1
+
+	gamemode_blacklist = list("Crash","Combat Patrol","Civil War","Extended")
+	min_players = 50
+
+/datum/round_event_control/hostile_ert/can_spawn_event(players_amt, gamemode)
+	var/xeno_to_marine_ratio = (length(GLOB.alive_xeno_list)/length(GLOB.alive_human_list_faction[FACTION_TERRAGOV]))
+	if(length(GLOB.alive_human_list_faction[FACTION_TERRAGOV]) < 30)
+		return FALSE
+	if(xeno_to_marine_ratio > 0.15)
+		return FALSE
+	else if(SSticker.mode.on_distress_cooldown)
+		return FALSE
+
+	return ..()
+
+/datum/round_event/hostile_ert/
+	announce_when = 0
+
+/datum/round_event/hostile_ert/start()
+	var/selected_ert = pick("CLF Cell","Sectoid Expedition","Sons of Mars Squad","USL Pirate Band","The Bone Zone","Pizza Delivery")
+	for(var/datum/emergency_call/C in SSticker.mode.all_calls)
+		if(C.name == selected_ert)
+			SSticker.mode.picked_call = C
+			break
+	SSticker.mode.picked_call.mob_max = MAXIMUM_ERT
+	SSticker.mode.picked_call.mob_min = MINIMUM_ERT
+	SSticker.mode.picked_call.activate(FALSE)
+
+#undef MAXIMUM_ERT
+#undef MINIMUM_ERT

--- a/code/modules/events/hostile_ert.dm
+++ b/code/modules/events/hostile_ert.dm
@@ -1,10 +1,7 @@
-#define MINIMUM_ERT 2
-#define MAXIMUM_ERT 5
-
 /datum/round_event_control/hostile_ert
 	name = "Hostile ERT"
 	typepath = /datum/round_event/hostile_ert
-	weight = 5
+	weight = 4
 	earliest_start = 90 MINUTES
 	max_occurrences = 1
 
@@ -26,14 +23,14 @@
 	announce_when = 0
 
 /datum/round_event/hostile_ert/start()
+	priority_announce("Attention, ship sensors have detected a hostile vessel approaching at high speeds, all crew standby and prepare to be boarded.", sound = 'sound/misc/interference.ogg')
+	var/minimum_ert = (length(GLOB.alive_human_list_faction[FACTION_TERRAGOV]) * .04) //roughly comes out to 1 at min population of 30
+	var/maximum_ert = (length(GLOB.alive_human_list_faction[FACTION_TERRAGOV]) * .07) //roughly comes out to 2 at min population of 30
 	var/selected_ert = pick("CLF Cell","Sectoid Expedition","Sons of Mars Squad","USL Pirate Band","The Bone Zone","Pizza Delivery")
 	for(var/datum/emergency_call/C in SSticker.mode.all_calls)
 		if(C.name == selected_ert)
 			SSticker.mode.picked_call = C
 			break
-	SSticker.mode.picked_call.mob_max = MAXIMUM_ERT
-	SSticker.mode.picked_call.mob_min = MINIMUM_ERT
+	SSticker.mode.picked_call.mob_max = maximum_ert
+	SSticker.mode.picked_call.mob_min = minimum_ert
 	SSticker.mode.picked_call.activate(FALSE)
-
-#undef MAXIMUM_ERT
-#undef MINIMUM_ERT

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -1231,6 +1231,7 @@
 #include "code\modules\error_handler\error_handler.dm"
 #include "code\modules\error_handler\error_viewer.dm"
 #include "code\modules\events\_events.dm"
+#include "code\modules\events\hostile_ert.dm"
 #include "code\modules\events\intel_computer.dm"
 #include "code\modules\factory\howtopaper.dm"
 #include "code\modules\factory\machines.dm"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It's a new event, Tivi wants more of them and I sat down and made some.

Hostile ERT is very a low chance event that has a chance of spawning an ERT squad of between 1-5 hostiles if the marines are stomping the xenos. It has a low chance of happening, is restricted to a single event, and requires the xenos to have less than 4-5 members left and the marines to have over 30. 

I expect this one might be contentious, and the numbers are open to change, the idea is to give the marines a slight bit of extra challenge if they're just rolling the xenos.

## Why It's Good For The Game

More events good.

## Changelog
:cl:
add: Added a new event, hostile ERT.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
