### PR TITLE
you can no longer be moved when manning mounted guns by humans and a fix

### DIFF
--- a/code/datums/elements/deployable_item.dm
+++ b/code/datums/elements/deployable_item.dm
@@ -55,6 +55,8 @@
 	var/list/modifiers = params2list(params)
 	if(!modifiers["ctrl"] || modifiers["right"] || get_turf(user) == location || !(user.Adjacent(object)) || !location)
 		return
+	if(ISDIAGONALDIR(get_dir(user,location)))
+		return
 	INVOKE_ASYNC(src, .proc/finish_deploy, item_in_active_hand, user, location)
 	return COMSIG_KB_ACTIVATED
 

--- a/code/modules/projectiles/mounted.dm
+++ b/code/modules/projectiles/mounted.dm
@@ -7,6 +7,8 @@
 	layer = TANK_BARREL_LAYER
 	use_power = FALSE
 	hud_possible = list(MACHINE_HEALTH_HUD, MACHINE_AMMO_HUD)
+	///Stores user old move resist and apply on unset interaction
+	var/user_old_move_resist
 
 ///generates the icon based on how much ammo it has.
 /obj/machinery/deployable/mounted/update_icon_state(mob/user)
@@ -139,7 +141,8 @@
 		action.give_action(operator)
 
 	gun.set_gun_user(operator)
-
+	user_old_move_resist = operator.move_resist
+	operator.move_resist = MOVE_FORCE_STRONG
 
 ///Begins the Firing Process, does custom checks before calling the guns start_fire()
 /obj/machinery/deployable/mounted/proc/start_fire(datum/source, atom/object, turf/location, control, params)
@@ -265,6 +268,7 @@
 
 	operator = null
 	gun?.set_gun_user(null)
+	user.move_resist = user_old_move_resist
 
 ///makes sure you can see and or use the gun
 /obj/machinery/deployable/mounted/check_eye(mob/user)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
you can no longer be moved while using mounted guns (only applies to marines xenos can still push and shuffle you) also removes being able to deploy deployables diagonally because you cannot get on the gun even if your behind it you have to click it diagonally, breaks aiming, and it breaks turning
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
pvt pisser shitter can no longer stop you from getting the epic frag by pushing you
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: can no longer be moved while manning mounted gun
fix: can no longer deploy mounted gun diagonally since it breaks stuff
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
