### PR TITLE
Prevents a ui bluescreen at gear customization

### DIFF
--- a/tgui/packages/tgui/interfaces/PlayerPreferences/GearCustomisation.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPreferences/GearCustomisation.tsx
@@ -50,7 +50,7 @@ export const GearCustomization = (props, context) => {
         <Grid.Column>
           <Section title={'Head'}>
             <LabeledList>
-              {bySlot['Head'].map(item => (
+              {bySlot['Head']?.map(item => (
                 <LabeledList.Item
                   key={item.name}
                   label={`${item.name} (${item.cost})`}>
@@ -70,7 +70,7 @@ export const GearCustomization = (props, context) => {
         <Grid.Column>
           <Section title={'Eyewear'}>
             <LabeledList>
-              {bySlot['Eyewear'].map(item => (
+              {bySlot['Eyewear']?.map(item => (
                 <LabeledList.Item
                   key={item.name}
                   label={`${item.name}
@@ -93,7 +93,7 @@ export const GearCustomization = (props, context) => {
         <Grid.Column>
           <Section title={'Mouth'}>
             <LabeledList>
-              {bySlot['Mouth'].map(item => (
+              {bySlot['Mouth']?.map(item => (
                 <LabeledList.Item
                   key={item.name}
                   label={`${item.name} (${item.cost})`}>
@@ -113,7 +113,7 @@ export const GearCustomization = (props, context) => {
         <Grid.Column>
           <Section title={'Undershirt (select one)'}>
             <LabeledList>
-              {clothing['undershirt'].map((item, idx) => (
+              {clothing['undershirt']?.map((item, idx) => (
                 <LabeledList.Item key={item} label={item}>
                   <Button.Checkbox
                     inline
@@ -131,7 +131,7 @@ export const GearCustomization = (props, context) => {
         <Grid.Column>
           <Section title={'Underwear (select one)'}>
             <LabeledList>
-              {clothing['underwear'][gender].map((item, idx) => (
+              {clothing['underwear'][gender]?.map((item, idx) => (
                 <LabeledList.Item key={item} label={item}>
                   <Button.Checkbox
                     inline
@@ -147,7 +147,7 @@ export const GearCustomization = (props, context) => {
         <Grid.Column>
           <Section title={'Backpack (select one)'}>
             <LabeledList>
-              {clothing['backpack'].map((item, idx) => (
+              {clothing['backpack']?.map((item, idx) => (
                 <LabeledList.Item key={item} label={item}>
                   <Button.Checkbox
                     inline


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I'm a little too new to the game to fully know what you're expecting out of these screens, but I assume that you probably don't want a bluescreen that prevents you from using it at all.

In my opinion, selecting a robo species should display a robo and possibly disable gear that they can't wear, but I'm not knowledgeable enough to know which yet.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fixes #10796
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes a bluescreen at the gear customization screen for combat robos.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
