### PR TITLE
Removes some bolted/welded varedits on Gelida

### DIFF
--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -6581,15 +6581,15 @@
 /area/gelida/indoors/a_block/dorm_north)
 "eaD" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	locked = 1;
+	locked = 0;
 	name = "\improper Corporation Dome"
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/corpo)
 "ebe" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	locked = 1;
-	welded = 1
+	locked = 0;
+	welded = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/mainship/stripesquare,
@@ -8375,7 +8375,7 @@
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
 	name = "\improper Westlock";
-	welded = 1
+	welded = 0
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/dorms)
@@ -9806,7 +9806,7 @@
 /area/gelida/indoors/a_block/bridges/corpo)
 "ghM" = (
 /obj/machinery/door/airlock/mainship/security/glass{
-	locked = 1;
+	locked = 0;
 	name = "\improper Marshall Office Armory";
 	req_access = null
 	},
@@ -17248,7 +17248,7 @@
 "kXf" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 8;
-	locked = 1;
+	locked = 0;
 	name = "\improper Wildcatters Office"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -18025,7 +18025,7 @@
 /obj/effect/spawner/gibspawner/xeno,
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 8;
-	locked = 1;
+	locked = 0;
 	name = "\improper Wildcatters Office"
 	},
 /turf/open/floor/mainship/stripesquare,
@@ -19814,7 +19814,7 @@
 "mCa" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 2;
-	welded = 1
+	welded = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/mainship/stripesquare,
@@ -20623,7 +20623,7 @@
 /area/gelida/outdoors/colony_streets/north_east_street)
 "nfT" = (
 /obj/machinery/door/airlock/mainship/security/glass{
-	locked = 1;
+	locked = 0;
 	name = "\improper Marshal Office Holding Cell";
 	req_access = null
 	},
@@ -20742,7 +20742,7 @@
 /area/gelida/outdoors/colony_streets/central_streets)
 "niE" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	welded = 1
+	welded = 0
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/bridges/op_centre)
@@ -21716,7 +21716,7 @@
 /area/gelida/outdoors/colony_streets/east_central_street)
 "nOF" = (
 /obj/machinery/door/airlock/mainship/generic{
-	locked = 1;
+	locked = 0;
 	name = "\improper Corporate Liason"
 	},
 /obj/structure/cable,
@@ -24000,7 +24000,7 @@
 "pli" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	welded = 1
+	welded = 0
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/casino)
@@ -24678,7 +24678,7 @@
 "pIB" = (
 /obj/machinery/door/airlock/mainship/medical{
 	dir = 2;
-	locked = 1;
+	locked = 0;
 	name = "Medical Airlock"
 	},
 /turf/open/floor/mainship/stripesquare,
@@ -26803,7 +26803,7 @@
 /area/gelida/indoors/a_block/dorms)
 "qWs" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	welded = 1
+	welded = 0
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/b_block/hydro)
@@ -29968,7 +29968,7 @@
 /area/gelida/outdoors/colony_streets/north_west_street)
 "sTK" = (
 /obj/machinery/door/airlock/mainship/generic{
-	welded = 1
+	welded = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -30557,7 +30557,7 @@
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
 	name = "\improper Canteen";
-	welded = 1
+	welded = 0
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/kitchen)
@@ -31360,7 +31360,7 @@
 /area/gelida/outdoors/rock)
 "tQi" = (
 /obj/machinery/door/airlock/mainship/generic{
-	welded = 1
+	welded = 0
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/cargo)
@@ -32435,7 +32435,7 @@
 "uDB" = (
 /obj/machinery/door/airlock/mainship/medical{
 	dir = 2;
-	locked = 1;
+	locked = 0;
 	name = "Medical Airlock"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -32467,7 +32467,7 @@
 /area/gelida/indoors/c_block/garage)
 "uEs" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	welded = 1
+	welded = 0
 	},
 /obj/structure/cable,
 /turf/open/floor/mainship/stripesquare,
@@ -37740,7 +37740,7 @@
 "xZp" = (
 /obj/machinery/door/airlock/mainship/security/glass{
 	dir = 8;
-	locked = 1;
+	locked = 0;
 	name = "\improper Marshall Head Office";
 	req_access = null
 	},

--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -3890,10 +3890,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/a_block/medical)
-"cyV" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic,
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/a_block/bridges/op_centre)
 "czh" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -6152,8 +6148,7 @@
 "dOS" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Westlock";
-	welded = null
+	name = "\improper Westlock"
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/dorms)
@@ -6199,8 +6194,7 @@
 /area/gelida/caves/west_caves)
 "dQX" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Eastlock";
-	welded = null
+	name = "\improper Eastlock"
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/hallway)
@@ -6579,21 +6573,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/dorm_north)
-"eaD" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	locked = 0;
-	name = "\improper Corporation Dome"
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/a_block/corpo)
-"ebe" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	locked = 0;
-	welded = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/a_block/dorms)
 "ebg" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/plate,
@@ -8374,8 +8353,7 @@
 /obj/structure/platform_decoration,
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Westlock";
-	welded = 0
+	name = "\improper Westlock"
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/dorms)
@@ -9410,8 +9388,7 @@
 "fVE" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Eastlock";
-	welded = null
+	name = "\improper Eastlock"
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/hallway)
@@ -9806,7 +9783,6 @@
 /area/gelida/indoors/a_block/bridges/corpo)
 "ghM" = (
 /obj/machinery/door/airlock/mainship/security/glass{
-	locked = 0;
 	name = "\improper Marshall Office Armory";
 	req_access = null
 	},
@@ -13947,8 +13923,7 @@
 /area/gelida/indoors/a_block/admin)
 "iKo" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Northlock";
-	welded = null
+	name = "\improper Northlock"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/mainship/stripesquare,
@@ -17240,15 +17215,13 @@
 /area/gelida/indoors/a_block/dorms)
 "kWP" = (
 /obj/machinery/door/airlock/mainship/generic{
-	dir = 2;
-	locked = 1
+	dir = 2
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/hallway)
 "kXf" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 8;
-	locked = 0;
 	name = "\improper Wildcatters Office"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -17874,8 +17847,7 @@
 /area/gelida/outdoors/rock)
 "lsj" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 1;
-	locked = 1
+	dir = 1
 	},
 /turf/open/floor/mainship/black/full,
 /area/gelida/indoors/a_block/kitchen)
@@ -18025,7 +17997,6 @@
 /obj/effect/spawner/gibspawner/xeno,
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 8;
-	locked = 0;
 	name = "\improper Wildcatters Office"
 	},
 /turf/open/floor/mainship/stripesquare,
@@ -19811,14 +19782,6 @@
 /obj/effect/spawner/random/tool,
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/garage)
-"mCa" = (
-/obj/machinery/door/airlock/mainship/generic{
-	dir = 2;
-	welded = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/mainship/stripesquare,
-/area/gelida/indoors/a_block/dorms)
 "mCj" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -20623,7 +20586,6 @@
 /area/gelida/outdoors/colony_streets/north_east_street)
 "nfT" = (
 /obj/machinery/door/airlock/mainship/security/glass{
-	locked = 0;
 	name = "\improper Marshal Office Holding Cell";
 	req_access = null
 	},
@@ -20741,9 +20703,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/central_streets)
 "niE" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	welded = 0
-	},
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/bridges/op_centre)
 "niX" = (
@@ -21716,7 +21676,6 @@
 /area/gelida/outdoors/colony_streets/east_central_street)
 "nOF" = (
 /obj/machinery/door/airlock/mainship/generic{
-	locked = 0;
 	name = "\improper Corporate Liason"
 	},
 /obj/structure/cable,
@@ -23999,8 +23958,7 @@
 /area/gelida/outdoors/colony_streets/south_west_street)
 "pli" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 1;
-	welded = 0
+	dir = 1
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/casino)
@@ -24678,7 +24636,6 @@
 "pIB" = (
 /obj/machinery/door/airlock/mainship/medical{
 	dir = 2;
-	locked = 0;
 	name = "Medical Airlock"
 	},
 /turf/open/floor/mainship/stripesquare,
@@ -26802,9 +26759,7 @@
 	},
 /area/gelida/indoors/a_block/dorms)
 "qWs" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	welded = 0
-	},
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/b_block/hydro)
 "qWM" = (
@@ -28424,9 +28379,7 @@
 /turf/open/floor/grass,
 /area/gelida/indoors/a_block/garden)
 "rYJ" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	locked = 1
-	},
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/casino)
 "rYO" = (
@@ -29967,9 +29920,7 @@
 	},
 /area/gelida/outdoors/colony_streets/north_west_street)
 "sTK" = (
-/obj/machinery/door/airlock/mainship/generic{
-	welded = 0
-	},
+/obj/machinery/door/airlock/mainship/generic,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
@@ -30556,8 +30507,7 @@
 "tmm" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "\improper Canteen";
-	welded = 0
+	name = "\improper Canteen"
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/kitchen)
@@ -31359,9 +31309,7 @@
 /turf/closed/ice_rock/singleEnd,
 /area/gelida/outdoors/rock)
 "tQi" = (
-/obj/machinery/door/airlock/mainship/generic{
-	welded = 0
-	},
+/obj/machinery/door/airlock/mainship/generic,
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/cargo)
 "tQv" = (
@@ -32435,7 +32383,6 @@
 "uDB" = (
 /obj/machinery/door/airlock/mainship/medical{
 	dir = 2;
-	locked = 0;
 	name = "Medical Airlock"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -32466,9 +32413,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/garage)
 "uEs" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	welded = 0
-	},
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
 /obj/structure/cable,
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/c_block/casino)
@@ -37740,7 +37685,6 @@
 "xZp" = (
 /obj/machinery/door/airlock/mainship/security/glass{
 	dir = 8;
-	locked = 0;
 	name = "\improper Marshall Head Office";
 	req_access = null
 	},
@@ -46847,7 +46791,7 @@ dZI
 hix
 hix
 cLI
-mCa
+riu
 tfL
 bYk
 jRa
@@ -48845,7 +48789,7 @@ pej
 fqe
 sJb
 tms
-ebe
+ruK
 vqV
 qzk
 ogT
@@ -58124,7 +58068,7 @@ bBz
 eZJ
 ujh
 oUq
-eaD
+jzP
 cuz
 wJx
 jvj
@@ -65037,7 +64981,7 @@ juQ
 hWs
 tZb
 eas
-cyV
+niE
 kxB
 koL
 hUv
@@ -65057,7 +65001,7 @@ kxB
 hUv
 kxB
 nja
-cyV
+niE
 dKU
 loO
 tzW


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Apparently some varedits slipped past me while porting Gelida, and people didn't like the bolts/welds. This PR removes them.

## Why It's Good For The Game

If you ask people what they hate about Gelida, usually they'll bring up bolted doors. Removing them should be a positive.

## Changelog
:cl:
balance: Gelida no longer has bolted or welded doors at roundstart.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
