### PR TITLE
Set the price of the AI targeter in engineer vendor to 10 as well.

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -61,7 +61,7 @@ GLOBAL_LIST_INIT(engineer_gear_listed_products, list(
 		/obj/structure/closet/crate/uav_crate = list(CAT_ENGSUP, "Iguana Unmanned Vehicle", 50, "black"),
 		/obj/item/attachable/buildasentry = list(CAT_ENGSUP, "Build-A-Sentry Attachment", 30, "black"),
 		/obj/item/binoculars/tactical/range = list(CAT_ENGSUP, "Range Finder", 10, "black"),
-		/obj/item/ai_target_beacon = list(CAT_ENGSUP, "AI remote targeting module", 40, "black"),
+		/obj/item/ai_target_beacon = list(CAT_ENGSUP, "AI remote targeting module", 10, "black"),
 		/obj/item/tool/handheld_charger = list(CAT_ENGSUP, "Hand-held cell charger", 3, "black"),
 		/obj/item/cell/high = list(CAT_ENGSUP, "High capacity powercell", 1, "black"),
 		/obj/item/cell/rtg/small = list(CAT_ENGSUP, "Recharger powercell", 5, "black"),


### PR DESCRIPTION
## About The Pull Request
The AI targeting module was intended to be 10 in req and in the engineering vendor. 
I forgot it during the PR which introduced it. 

## Why It's Good For The Game
It was the intended price. 
Also, 40 is very expensive when you could invest in a lot of mines, razorburn, turrets, UV or whatever else. 

## Changelog
:cl:
balance: Set the AI artillery aiming module to 10 in engineering vendor also
/:cl:
