### PR TITLE
Fixes Ravage pushing anchored atoms

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -112,7 +112,8 @@
 	for(var/atom/movable/ravaged AS in atoms_to_ravage)
 		if(!(ravaged.resistance_flags & XENO_DAMAGEABLE))
 			continue
-		step_away(ravaged, X, 1, 2)
+		if(!ravaged.anchored)
+			step_away(ravaged, X, 1, 2)
 		if(!ishuman(ravaged))
 			ravaged.attack_alien(X, X.xeno_caste.melee_damage)
 			continue


### PR DESCRIPTION
## About The Pull Request
Per title.

## Why It's Good For The Game
Fix good. Ravager being FOB destroyer 9000 bad.

## Changelog
:cl: Lewdcifer
fix: Ravager's Ravage will no longer push anchored atoms.
/:cl: