### PR TITLE
Icy Cave rebalance: Three enterances to northeast ship

### DIFF
--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -3,12 +3,15 @@
 /turf/open/space/basic,
 /area/space)
 "ab" = (
-/obj/effect/decal/cleanable/blood,
+/obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "ac" = (
-/obj/structure/cable,
+/obj/effect/landmark/patrol_point{
+	id = "SOM_21";
+	name = "SOM exit point 21"
+	},
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "ad" = (
@@ -118,11 +121,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
-"ay" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/ai_node,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/crashed_ship)
 "az" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -205,44 +203,36 @@
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "aO" = (
-/turf/open/floor/plating/dmg2,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/crashed_ship)
 "aP" = (
 /obj/effect/landmark/corpsespawner/doctor,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
 "aQ" = (
-/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "aR" = (
-/obj/effect/spawner/random/ammo/rifle,
-/obj/effect/spawner/random/gun/rifles,
-/obj/effect/spawner/random/ammo/rifle,
-/obj/effect/spawner/random/ammo/rifle,
-/obj/effect/spawner/random/ammo/rifle,
-/obj/effect/spawner/random/ammo/rifle,
-/obj/effect/spawner/random/ammo/rifle,
-/obj/effect/spawner/random/ammo/rifle,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/crashed_ship)
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/rock)
 "aS" = (
-/obj/structure/closet/crate/solar,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/crashed_ship)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/rock)
 "aT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
 "aU" = (
-/obj/machinery/power/apc/drained,
-/obj/structure/cable,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/crashed_ship)
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/dmg3,
+/area/icy_caves/caves/northern)
 "aV" = (
-/obj/structure/closet/toolcloset,
-/turf/open/floor/plating/mainship,
+/turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/crashed_ship)
 "aW" = (
 /obj/structure/cable,
@@ -269,6 +259,20 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
+"bd" = (
+/obj/structure/closet/crate/medical,
+/obj/item/defibrillator,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/fire,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/crashed_ship)
 "be" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice/thin/end,
@@ -279,13 +283,11 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "bg" = (
-/obj/machinery/power/smes,
-/obj/structure/cable,
+/obj/structure/closet/toolcloset,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "bi" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/ai_node,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "bj" = (
@@ -293,7 +295,8 @@
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
 "bk" = (
-/obj/effect/landmark/corpsespawner/engineer,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "bl" = (
@@ -313,14 +316,7 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
 "bo" = (
-/obj/structure/closet/crate/science,
-/obj/item/stack/sheet/mineral/phoron/medium_stack,
-/obj/machinery/light/built{
-	dir = 4
-	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
+/obj/machinery/power/smes,
 /obj/structure/cable,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
@@ -346,35 +342,23 @@
 	},
 /area/icy_caves/outpost/refinery)
 "bs" = (
-/obj/structure/closet/crate/medical,
-/obj/item/defibrillator,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/fire,
-/obj/item/reagent_containers/glass/beaker/bluespace,
-/obj/item/reagent_containers/glass/beaker/bluespace,
-/obj/item/reagent_containers/glass/beaker/bluespace,
-/obj/item/reagent_containers/glass/beaker/bluespace,
-/obj/item/reagent_containers/glass/beaker/bluespace,
-/obj/item/reagent_containers/glass/beaker/bluespace,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/crashed_ship)
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/dmg1,
+/area/icy_caves/caves/northern)
 "bt" = (
-/obj/item/stack/sheet/mineral/gold{
-	amount = 10
-	},
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/crashed_ship)
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/rock)
 "bu" = (
-/obj/structure/closet/crate/science,
-/obj/item/ore/phoron,
-/obj/item/ore/phoron,
-/obj/item/ore/phoron,
-/obj/item/ore/phoron,
-/obj/item/ore/phoron,
-/obj/item/ore/phoron,
-/obj/item/ore/phoron,
-/obj/item/ore/phoron,
+/obj/effect/spawner/random/ammo/rifle,
+/obj/effect/spawner/random/gun/rifles,
+/obj/effect/spawner/random/ammo/rifle,
+/obj/effect/spawner/random/ammo/rifle,
+/obj/effect/spawner/random/ammo/rifle,
+/obj/effect/spawner/random/ammo/rifle,
+/obj/effect/spawner/random/ammo/rifle,
+/obj/effect/spawner/random/ammo/rifle,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "bv" = (
@@ -385,19 +369,28 @@
 	},
 /area/icy_caves/outpost/security)
 "bw" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/closet/crate/trashcart,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "bx" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/structure/closet/crate/science,
+/obj/item/stack/sheet/mineral/phoron/medium_stack,
+/obj/machinery/light/built{
+	dir = 4
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
 /obj/structure/cable,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "bz" = (
-/turf/closed/shuttle{
-	icon_state = "burst_r"
+/obj/effect/landmark/patrol_point{
+	id = "SOM_24";
+	name = "SOM exit point 24"
 	},
-/area/icy_caves/caves/crashed_ship)
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/northern)
 "bB" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -627,8 +620,7 @@
 /turf/open/floor/mainship_hull,
 /area/icy_caves/caves/northwestmonorail)
 "cM" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/plating/dmg2,
 /area/icy_caves/caves/crashed_ship)
 "cO" = (
 /obj/structure/window/framed/colony/reinforced,
@@ -672,8 +664,8 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "db" = (
-/obj/machinery/light,
-/obj/effect/landmark/excavation_site_spawner,
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "dc" = (
@@ -1246,6 +1238,11 @@
 	},
 /turf/open/floor/cult,
 /area/icy_caves/caves/chapel)
+"gp" = (
+/turf/closed/ice/straight{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "gr" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/northwestmonorail/morgue)
@@ -1576,6 +1573,11 @@
 	dir = 1
 	},
 /area/icy_caves/caves/alienstuff)
+"is" = (
+/turf/closed/shuttle{
+	icon_state = "burst_r"
+	},
+/area/icy_caves/caves/rock)
 "it" = (
 /obj/machinery/light{
 	dir = 8
@@ -2844,6 +2846,11 @@
 /obj/effect/landmark/sensor_tower_patrol,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"ov" = (
+/turf/closed/ice/corner{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "ow" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside/center)
@@ -2869,6 +2876,11 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"oB" = (
+/obj/machinery/light,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/crashed_ship)
 "oD" = (
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 1
@@ -3040,8 +3052,13 @@
 	},
 /area/icy_caves/caves)
 "ps" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/dmg1,
+/obj/item/stack/sandbags_empty{
+	amount = 25
+	},
+/obj/item/stack/barbed_wire/half_stack,
+/obj/effect/landmark/excavation_site_spawner,
+/obj/structure/closet/crate/secure/phoron,
+/turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "pt" = (
 /obj/effect/decal/cleanable/blood,
@@ -3954,6 +3971,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"te" = (
+/obj/item/stack/sheet/mineral/gold{
+	amount = 10
+	},
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/crashed_ship)
 "tf" = (
 /turf/closed/shuttle/wall3,
 /area/icy_caves/caves/northern)
@@ -4349,11 +4372,7 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "uE" = (
-/obj/effect/landmark/patrol_point{
-	id = "SOM_24";
-	name = "SOM exit point 24"
-	},
-/turf/open/floor/plating/ground/ice,
+/turf/closed/wall/mainship,
 /area/icy_caves/caves/northern)
 "uH" = (
 /obj/machinery/vending/medical,
@@ -5098,6 +5117,11 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/prison/bright_clean/two,
 /area/icy_caves/caves/northwestmonorail)
+"yc" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/crashed_ship)
 "yd" = (
 /obj/structure/monorail,
 /obj/machinery/door/poddoor/mainship/indestructible{
@@ -5201,6 +5225,11 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail)
+"yB" = (
+/turf/closed/ice/end{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
 "yC" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -5587,7 +5616,7 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail/hallway)
 "Aa" = (
-/obj/structure/closet/crate/trashcart,
+/obj/structure/cable,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "Ab" = (
@@ -5931,6 +5960,18 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
+"BA" = (
+/obj/structure/closet/crate/science,
+/obj/item/ore/phoron,
+/obj/item/ore/phoron,
+/obj/item/ore/phoron,
+/obj/item/ore/phoron,
+/obj/item/ore/phoron,
+/obj/item/ore/phoron,
+/obj/item/ore/phoron,
+/obj/item/ore/phoron,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/crashed_ship)
 "BB" = (
 /obj/structure/cryofeed,
 /turf/open/floor/engine,
@@ -6420,10 +6461,8 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/alienstuff)
 "DR" = (
-/obj/effect/landmark/patrol_point{
-	id = "SOM_21";
-	name = "SOM exit point 21"
-	},
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "DS" = (
@@ -6645,6 +6684,9 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/outside)
+"ER" = (
+/turf/closed/wall/mainship,
+/area/icy_caves/caves/rock)
 "ES" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -6701,6 +6743,10 @@
 "Ff" = (
 /turf/open/floor/tile/dark/blue2,
 /area/icy_caves/outpost/office)
+"Fg" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/crashed_ship)
 "Fh" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/revolver/cmb,
@@ -7568,12 +7614,7 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail)
 "IO" = (
-/obj/item/stack/sandbags_empty{
-	amount = 25
-	},
-/obj/item/stack/barbed_wire/half_stack,
-/obj/effect/landmark/excavation_site_spawner,
-/obj/structure/closet/crate/secure/phoron,
+/obj/structure/closet/crate/solar,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "IP" = (
@@ -10886,8 +10927,8 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "Xr" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/dmg3,
+/obj/effect/landmark/corpsespawner/engineer,
+/turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
 "Xs" = (
 /obj/machinery/landinglight/ds1/delaythree{
@@ -25412,17 +25453,17 @@ WG
 WG
 WG
 WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-Il
-ot
-Tc
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
 SR
 SR
 SR
@@ -25567,20 +25608,20 @@ WG
 WG
 WG
 WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-Qo
-ST
-ot
-OJ
-SR
+eQ
+eQ
+eQ
+aR
+aS
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+bl
 im
 SR
 SR
@@ -25721,22 +25762,22 @@ WG
 WG
 WG
 WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-Qo
-ZP
-YK
-YK
+eQ
+eQ
+eQ
+eQ
+aR
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+aS
+eQ
 SR
-bl
+SR
 SR
 SR
 SR
@@ -25874,23 +25915,23 @@ WG
 WG
 WG
 WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-Il
-Qh
-KM
-Vz
-Zt
+eQ
+eQ
+aR
+eQ
+aS
+eQ
+aR
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
 SR
 SR
 SR
@@ -26029,15 +26070,15 @@ WG
 WG
 WG
 WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
+eQ
+eQ
+aR
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
 WG
 WG
 WG
@@ -26184,14 +26225,14 @@ WG
 WG
 WG
 WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
+eQ
+eQ
+bt
+eQ
+eQ
+eQ
+eQ
+eQ
 WG
 WG
 WG
@@ -26339,11 +26380,11 @@ WG
 WG
 WG
 WG
-WG
-WG
-WG
-WG
-WG
+eQ
+eQ
+aR
+eQ
+eQ
 WG
 WG
 WG
@@ -26495,10 +26536,10 @@ WG
 WG
 WG
 WG
-WG
-WG
-WG
-WG
+eQ
+aR
+eQ
+eQ
 WG
 WG
 WG
@@ -26650,10 +26691,10 @@ WG
 WG
 WG
 WG
-WG
-WG
-WG
-WG
+eQ
+aR
+aS
+eQ
 WG
 WG
 WG
@@ -26805,9 +26846,10 @@ WG
 WG
 WG
 WG
-WG
-WG
-WG
+eQ
+eQ
+eQ
+eQ
 SO
 SO
 SO
@@ -26815,7 +26857,6 @@ SO
 SO
 SO
 SO
-WG
 WG
 WG
 WG
@@ -26960,19 +27001,19 @@ SO
 SO
 SO
 SO
-SO
-SO
-SO
-Qo
+eQ
+eQ
+eQ
+eQ
+aV
 MQ
 MQ
 MQ
 MQ
 MQ
 MQ
-MQ
+ER
 qR
-WG
 WG
 WG
 WG
@@ -27118,17 +27159,17 @@ MQ
 MQ
 MQ
 MQ
+aO
+aO
+aO
 MQ
-MQ
-MQ
-aR
+bu
 sH
 sH
-bs
+bd
 MQ
-bz
+is
 qR
-WG
 WG
 WG
 WG
@@ -27276,15 +27317,15 @@ eJ
 MQ
 zO
 sH
+sH
 MQ
-Aa
+bw
 aj
 sH
-bt
+te
 MQ
-bz
+is
 qR
-WG
 WG
 WG
 Qo
@@ -27430,17 +27471,17 @@ kr
 sH
 aJ
 MQ
-ay
+AN
+bi
 sH
 bc
 AN
-aQ
 bi
+DR
 aN
 MQ
-MQ
+ER
 qR
-WG
 WG
 Il
 Qw
@@ -27587,16 +27628,16 @@ ah
 sH
 bc
 sH
+sH
 aN
 MQ
 sH
 sH
 sH
-bu
+BA
 MQ
-bz
+is
 qR
-WG
 WG
 Qo
 ot
@@ -27744,15 +27785,15 @@ aN
 MQ
 sH
 sH
+sH
 MQ
-aS
 IO
+ps
 sH
 sH
 MQ
-bz
+is
 pH
-SO
 Qo
 Qw
 VI
@@ -27900,15 +27941,15 @@ ah
 MQ
 sH
 sH
+sH
 MQ
 MQ
 MQ
 MQ
 MQ
 MQ
-MQ
+ER
 Qw
-ZI
 ZI
 VI
 Tc
@@ -28056,15 +28097,15 @@ MQ
 MQ
 AN
 sH
-MQ
+sH
 uE
+bz
 SR
-SR
+eQ
 Xu
 ZI
 VB
 VI
-ZI
 VB
 VI
 Tc
@@ -28211,16 +28252,16 @@ RN
 aw
 sH
 Oi
+sH
 nS
-Xr
+aU
 SR
 im
 SR
 SR
-SR
+eQ
 Lm
-MM
-SR
+ov
 Lm
 Po
 MM
@@ -28367,9 +28408,9 @@ Qo
 DC
 aJ
 sH
-aO
+sH
 cM
-SR
+PI
 SR
 SR
 SR
@@ -28522,9 +28563,10 @@ Qo
 oh
 nS
 sH
-ay
+AN
+bi
 oh
-ps
+bs
 SR
 SR
 bl
@@ -28532,7 +28574,6 @@ im
 SR
 SR
 im
-SR
 SR
 SR
 SR
@@ -28680,8 +28721,8 @@ MQ
 MQ
 sH
 sH
-MQ
-SR
+sH
+uE
 SR
 SR
 SR
@@ -28836,15 +28877,15 @@ mL
 MQ
 aJ
 sH
+sH
 MQ
 MQ
-aO
+cM
 nS
 MQ
 MQ
-MQ
-BL
-SR
+ER
+yB
 SR
 Zx
 PI
@@ -28992,15 +29033,15 @@ aC
 MQ
 sH
 sH
+sH
 MQ
-aV
+bg
 sH
 oh
-bw
+Fg
 MQ
-bz
-ST
-SR
+is
+gp
 MH
 IC
 Zt
@@ -29147,16 +29188,16 @@ AN
 sH
 bc
 sH
+sH
 aN
 MQ
-aU
 ab
 bk
+Xr
 sH
 MQ
-bz
+is
 Lm
-ZI
 OJ
 KU
 IC
@@ -29302,17 +29343,17 @@ sH
 kr
 sH
 MQ
-aQ
+sH
+bi
 AN
 bc
 sH
-ab
-ay
+bk
 db
+oB
 MQ
-MQ
+ER
 xD
-RN
 RG
 PK
 KU
@@ -29458,17 +29499,17 @@ aq
 mL
 mL
 MQ
-sH
-sH
+aQ
+aQ
+aQ
 MQ
-DR
 ac
+Aa
 sH
 sH
 MQ
-bz
+is
 qR
-WG
 RN
 Lx
 Tu
@@ -29614,17 +29655,17 @@ MQ
 MQ
 MQ
 MQ
-MQ
-MQ
-MQ
+aV
+aV
+aV
 aV
 bg
 bo
 bx
+yc
 MQ
-bz
+is
 qR
-WG
 WG
 oW
 oW
@@ -29632,7 +29673,7 @@ RN
 Qh
 PK
 SR
-SR
+bl
 SR
 bl
 SR
@@ -29770,24 +29811,24 @@ oW
 oW
 oW
 RN
-YW
-YW
+eQ
+eQ
+aV
+aV
 MQ
 MQ
 MQ
 MQ
 MQ
-MQ
-MQ
+ER
 qR
 WG
 WG
 WG
 WG
-WG
-Lx
-ZB
-PK
+eQ
+eQ
+aR
 SR
 SR
 SR
@@ -29926,10 +29967,11 @@ WG
 WG
 WG
 WG
-oW
-oW
-oW
-oW
+eQ
+eQ
+eQ
+eQ
+eQ
 oW
 oW
 oW
@@ -29939,12 +29981,11 @@ WG
 WG
 WG
 WG
-WG
-WG
-RN
-Lx
-ZB
-Tu
+eQ
+eQ
+aR
+aS
+eQ
 PK
 SR
 SR
@@ -30082,6 +30123,11 @@ WG
 WG
 WG
 WG
+eQ
+eQ
+eQ
+eQ
+eQ
 WG
 WG
 WG
@@ -30089,18 +30135,13 @@ WG
 WG
 WG
 WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-RN
-Lx
-XJ
+eQ
+eQ
+eQ
+aR
+eQ
+eQ
+eQ
 Lx
 PK
 SR
@@ -30238,24 +30279,24 @@ WG
 WG
 WG
 WG
+eQ
+eQ
+aS
+eQ
+eQ
+eQ
 WG
 WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-oW
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+aR
+eQ
+eQ
+eQ
 oW
 RN
 Lx
@@ -30395,21 +30436,21 @@ WG
 WG
 WG
 WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
+aR
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+aS
+aR
+eQ
+eQ
 WG
 WG
 WG
@@ -30552,18 +30593,18 @@ WG
 WG
 WG
 WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
+eQ
 WG
 WG
 WG
@@ -30709,13 +30750,13 @@ WG
 WG
 WG
 WG
-WG
-WG
-WG
-WG
-WG
-WG
-WG
+eQ
+eQ
+eQ
+aS
+eQ
+eQ
+eQ
 WG
 WG
 WG


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Some xeno player complained about this part of map, which is a natural fort for marines to use for nuke. Easy to add in, will throw off map balance, so we will see.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Three enterances to northeast crashed ship in Icy Cave
balance: Marines will have to choose another location to turn on nuke in Crash beside this
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
