### PR TITLE
Defiler particles are cleared when staggered or stunned during Emit Gas

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -230,9 +230,11 @@
 	while(count)
 		if(X.stagger) //If we got staggered, return
 			to_chat(X, span_xenowarning("We try to emit toxins but are staggered!"))
+			toggle_particles(FALSE)
 			return
 		if(X.IsStun() || X.IsParalyzed())
 			to_chat(X, span_xenowarning("We try to emit toxins but are disabled!"))
+			toggle_particles(FALSE)
 			return
 		var/turf/T = get_turf(X)
 		playsound(T, 'sound/effects/smoke.ogg', 25)


### PR DESCRIPTION
## About The Pull Request
Fixes an issue where being staggered or stunned during Emit Gas would make you emit particles forever.

## Why It's Good For The Game
Fix good. Eternally stinky Defiler bad.

## Changelog
:cl: Lewdcifer
fix: Defiler particles are cleared correctly when staggered or stunned during Emit Gas.
/:cl: