### PR TITLE
Increases ammo count of big 10x24 ammo box

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -346,8 +346,8 @@ Turn() or Shift() as there is virtually no overhead. ~N
 	flags_equip_slot = ITEM_SLOT_BACK
 	var/base_icon_state = "big_ammo_box"
 	var/default_ammo = /datum/ammo/bullet/rifle
-	var/bullet_amount = 800
-	var/max_bullet_amount = 800
+	var/bullet_amount = 2400
+	var/max_bullet_amount = 2400
 	var/caliber = CALIBER_10X24_CASELESS
 
 /obj/item/big_ammo_box/update_icon_state()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This seems to have been there since before ammo packets were a thing. They're inferior now since a backpack can fit 150x8 rounds for a total of 1200 rounds, or 5 boxes for 750 and have space left for anything else.

Since the big ammo box takes up the backpack slot that you can't change on the fly by, say, dumping a few ammo packets to make space for something else, it should probably have been buffed since the introduction of packets. Count increased to 2400 as per MJP's suggestion so as to make it 2x the amount of rounds you'd be able to fit in a full backpack of equivalent ammo packets.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Big 10x24 ammo box now fits 2400 rounds from 800
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
