### PR TITLE
Increases count of big 10x20 ammo box

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -825,6 +825,7 @@
 		),
 		"Ammo Boxes" = list(
 			/obj/item/big_ammo_box = 1,
+			/obj/item/big_ammo_box/smg = 1,
 			/obj/item/shotgunbox = 1,
 			/obj/item/shotgunbox/buckshot = 1,
 			/obj/item/shotgunbox/flechette = 1,

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -533,8 +533,8 @@ Turn() or Shift() as there is virtually no overhead. ~N
 	icon_state = "big_ammo_box_m25"
 	base_icon_state = "big_ammo_box_m25"
 	default_ammo = /datum/ammo/bullet/smg
-	var/bullet_amount = 4500
-	var/max_bullet_amount = 4500
+	bullet_amount = 4500
+	max_bullet_amount = 4500
 
 /obj/item/shotgunbox/buckshot
 	name = "Buckshot Ammo Box"

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -533,6 +533,8 @@ Turn() or Shift() as there is virtually no overhead. ~N
 	icon_state = "big_ammo_box_m25"
 	base_icon_state = "big_ammo_box_m25"
 	default_ammo = /datum/ammo/bullet/smg
+	var/bullet_amount = 4500
+	var/max_bullet_amount = 4500
 
 /obj/item/shotgunbox/buckshot
 	name = "Buckshot Ammo Box"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Same rationale as #11248. Found it while editing that one, figured it'd be neat to have in actual rounds. Backpack count full of ammo boxes is 12x150 leading to 2250, that x2 would be 4500. Given how fast you'd go through mags in a fight you'd sooner lose them anyway.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: There's now a Big Ammo Box for 10x20mm SMG caliber. 4500 rounds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
