### PR TITLE
Fixes beer not being dispensable

### DIFF
--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -328,22 +328,6 @@
 	L.reagent_pain_modifier = volume
 	return ..()
 
-/datum/reagent/toxin/beer2	//disguised as normal beer
-	name = "Beer"
-	description = "An alcoholic beverage made from malted grains, hops, yeast, and water. The fermentation appears to be incomplete." //If the players manage to analyze this, they deserve to know something is wrong.
-	color = "#664300" // rgb: 102, 67, 0
-	custom_metabolism = REAGENTS_METABOLISM * 2.5
-	taste_description = "piss water"
-
-/datum/reagent/toxin/beer2/on_mob_life(mob/living/L, metabolism)
-	switch(current_cycle)
-		if(1 to 50)
-			L.Sleeping(10 SECONDS)
-		if(51 to INFINITY)
-			L.Sleeping(10 SECONDS)
-			L.adjustToxLoss((current_cycle/2 - 25)*effect_str)
-	return ..()
-
 /datum/reagent/toxin/plasticide
 	name = "Plasticide"
 	description = "Liquid plastic, do not eat."


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/11244.
There's a mixup in the beer datum with beer2, causing a check to fail and the beer to not be dispensed. Because beer2 is a toxic knockout drink that has no place in TGMC I removed it entirely.

## Why It's Good For The Game

Bugs bad fixes good.

## Changelog
:cl:
fix: The booze dispenser can dispense beer again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
