### PR TITLE
Update the SAS ERT Gear

### DIFF
--- a/code/datums/jobs/job/special_forces.dm
+++ b/code/datums/jobs/job/special_forces.dm
@@ -19,7 +19,7 @@
 	id = /obj/item/card/id/silver
 	belt = /obj/item/storage/belt/marine
 	ears = /obj/item/radio/headset/distress/dutch
-	mask = /obj/item/clothing/mask/balaclava
+	mask = /obj/item/clothing/mask/gas/swat
 	w_uniform = /obj/item/clothing/under/syndicate/tacticool
 	shoes = /obj/item/clothing/shoes/combat
 	wear_suit = /obj/item/clothing/suit/armor/bulletproof
@@ -70,13 +70,13 @@
 	id = /obj/item/card/id/silver
 	belt = /obj/item/storage/belt/gun/pistol/standard_pistol
 	ears = /obj/item/radio/headset/distress/dutch
-	mask = /obj/item/clothing/mask/balaclava
+	mask = /obj/item/clothing/mask/gas/swat
 	w_uniform = /obj/item/clothing/under/syndicate/tacticool
 	shoes = /obj/item/clothing/shoes/combat
 	wear_suit = /obj/item/clothing/suit/armor/bulletproof
 	gloves = /obj/item/clothing/gloves/marine/veteran/PMC
 	head = /obj/item/clothing/head/helmet/marine/tech
-	suit_store = /obj/item/weapon/gun/pistol/standard_heavypistol/suppressed
+	suit_store = /obj/item/weapon/gun/pistol/standard_heavypistol/tacticool
 	r_store = /obj/item/storage/pouch/medical_injectors/firstaid
 	l_store = /obj/item/storage/pouch/medkit/firstaid
 	back = /obj/item/storage/backpack/lightpack
@@ -117,7 +117,7 @@
 	id = /obj/item/card/id/silver
 	belt = /obj/item/storage/belt/marine
 	ears = /obj/item/radio/headset/distress/dutch
-	mask = /obj/item/clothing/mask/balaclava
+	mask = /obj/item/clothing/mask/gas/swat
 	w_uniform = /obj/item/clothing/under/syndicate/tacticool
 	glasses = /obj/item/clothing/glasses/night
 	shoes = /obj/item/clothing/shoes/combat

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -207,6 +207,9 @@
 /obj/item/weapon/gun/pistol/standard_heavypistol/suppressed
 	starting_attachment_types = list(/obj/item/attachable/suppressor, /obj/item/attachable/flashlight) //Tacticool
 
+/obj/item/weapon/gun/pistol/standard_heavypistol/tacticool
+	starting_attachment_types = list(/obj/item/attachable/lace, /obj/item/attachable/flashlight) //Tacticool
+
 /obj/item/weapon/gun/pistol/standard_heavypistol/tactical
 	starting_attachment_types = list(/obj/item/attachable/reddot)
 //-------------------------------------------------------

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -236,7 +236,7 @@
 /obj/item/weapon/gun/smg/m25/elite/suppressed
 	icon_state = "m25"
 	item_state = "m25"
-	starting_attachment_types = list(/obj/item/attachable/suppressor) //Tacticool
+	starting_attachment_types = list(/obj/item/attachable/suppressor, /obj/item/attachable/magnetic_harness) //Tacticool
 
 //-------------------------------------------------------
 //SMG-27, based on the grease gun


### PR DESCRIPTION
## About The Pull Request
- Replace their baclava with SWAT masks
- Gave them mag harnesses
- Gave them pistol laces where applicable.

## Why It's Good For The Game
SAS ERT has not kept up with other ERT's
Their armor is really weak right now, and the guns are pretty unwieldly without any mag harness. This PR should make them survive longer than a single stun, defiler, or other sources of gas. 

## Changelog
:cl:
balance: Gave SAS ERT Mag Harness
balance: Gave SAS ERT Pistol Lace for breacher
balance: Gave SAS ERT Gas masks instead of baclavas
/:cl: