### PR TITLE
Fixes Theseus SD doors

### DIFF
--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -1482,11 +1482,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "aoW" = (
-/obj/machinery/door/airlock/mainship/secure{
-	name = "Self Destruct Room"
-	},
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct,
 /obj/structure/cable,
+/obj/machinery/door/airlock/mainship/secure/free_access{
+	name = "Self Destruct Room"
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
 "aoY" = (
@@ -1800,9 +1800,9 @@
 /turf/open/floor/plating,
 /area/mainship/command/self_destruct)
 "axs" = (
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 2;
-	name = "\improper Exterior Airlock"
+	name = "Self Destruct Room"
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
@@ -1841,11 +1841,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/cryo_cells)
 "azh" = (
-/obj/machinery/door/airlock/mainship/secure{
-	name = "Self Destruct Room"
-	},
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct,
+/obj/machinery/door/airlock/mainship/secure/free_access{
+	name = "Self Destruct Room"
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
 "azj" = (
@@ -11956,7 +11956,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "iHs" = (
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	name = "\improper Self Destruct Control Room"
 	},
 /turf/open/floor/mainship/floor,
@@ -16415,9 +16415,9 @@
 	},
 /area/mainship/engineering/ce_room)
 "quo" = (
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 2;
-	name = "\improper Exterior Airlock"
+	name = "Self Destruct Room"
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/command/self_destruct)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The SD doors on Theseus aren't accessible to everyone, unlike every other ship we have. This PR corrects that oversight.

## Why It's Good For The Game

It's apparently difficult for marines to hold SD when they can't even filter in and out of the doors, ERT can't invade either apparently.

## Changelog
:cl:
fix: The Theseus' SD doors are now accessible to everyone once the shutters are lifted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
