### PR TITLE
Runners and Spiderlings will now bump UAVs instead of going over them

### DIFF
--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -41,7 +41,7 @@
 	/// If something is already controlling the vehicle
 	var/controlled = FALSE
 	/// Flags for unmanned vehicules
-	var/unmanned_flags = OVERLAY_TURRET|HAS_LIGHTS
+	var/unmanned_flags = OVERLAY_TURRET|HAS_LIGHTS|UNDERCARRIAGE
 	/// Iff flags, to prevent friendly fire from sg and aiming marines
 	var/iff_signal = TGMC_LOYALIST_IFF
 	/// muzzleflash stuff
@@ -120,7 +120,7 @@
 
 /obj/vehicle/unmanned/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()
-	if((unmanned_flags & UNDERCARRIAGE) && istype(mover) && CHECK_BITFIELD(mover.flags_pass, PASSTABLE))
+	if((unmanned_flags & UNDERCARRIAGE) && istype(mover) && !ismob(mover) && CHECK_BITFIELD(mover.flags_pass, PASSTABLE))
 		return TRUE
 
 /obj/vehicle/unmanned/relaymove(mob/living/user, direction)

--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -41,7 +41,7 @@
 	/// If something is already controlling the vehicle
 	var/controlled = FALSE
 	/// Flags for unmanned vehicules
-	var/unmanned_flags = OVERLAY_TURRET|HAS_LIGHTS|UNDERCARRIAGE
+	var/unmanned_flags = OVERLAY_TURRET|HAS_LIGHTS
 	/// Iff flags, to prevent friendly fire from sg and aiming marines
 	var/iff_signal = TGMC_LOYALIST_IFF
 	/// muzzleflash stuff


### PR DESCRIPTION
## About The Pull Request
Per title. Fixes #11211, even though it's not strictly a fix and also a balance change.

## Why It's Good For The Game
Allows these specific castes to contest UAVs instead of being screwed over.
 
## Changelog
:cl: Lewdcifer
balance: Xenos such as the Runner and the Spiderling will now bump into UAVs instead of going over them.
/:cl: