### PR TITLE
Fixes telecomms props not having descriptions

### DIFF
--- a/code/game/objects/structures/prop.dm
+++ b/code/game/objects/structures/prop.dm
@@ -305,14 +305,47 @@
 	icon_state = "secure_wide_right_locked"
 
 /obj/structure/prop/mainship/telecomms
-	name = "\improper Command Airlock"
+	name = "subspace broadcaster"
+	desc = "A mighty piece of hardware used to broadcast processed subspace signals."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "broadcaster_send"
 
+/obj/structure/prop/mainship/telecomms/hub
+	name = "subspace broadcaster"
+	desc = "A mighty piece of hardware used to send/receive massive amounts of data."
+	icon = 'icons/obj/machines/telecomms.dmi'
+	icon_state = "hub"
+
+/obj/structure/prop/mainship/telecomms/processor
+	name = "processor unit"
+	desc = "This machine is used to process large quantities of information."
+	icon = 'icons/obj/machines/telecomms.dmi'
+	icon_state = "processor"
+
 /obj/structure/prop/mainship/telecomms/bus
-	name = "\improper Command Airlock"
-	icon = 'icons/obj/stationobjs.dmi'
+	name = "bus mainframe"
+	desc = "A mighty piece of hardware used to send massive amounts of data quickly."
+	icon = 'icons/obj/machines/telecomms.dmi'
 	icon_state = "bus"
+
+/obj/structure/prop/mainship/telecomms/broadcaster
+	name = "subspace broadcaster"
+	desc = "This machine has a dish-like shape and green lights. It is designed to detect and process subspace radio activity."
+	icon = 'icons/obj/machines/telecomms.dmi'
+	icon_state = "broadcaster"
+
+/obj/structure/prop/mainship/telecomms/receiver
+	name = "subspace receiver"
+	desc = "A dish-shaped machine used to broadcast processed subspace signals."
+	icon = 'icons/obj/machines/telecomms.dmi'
+	icon_state = "broadcast receiver"
+
+/obj/structure/prop/mainship/telecomms/relay
+	name = "telecomms relay"
+	desc = "A mighty piece of hardware used to send massive amounts of data far away."
+	icon = 'icons/obj/machines/telecomms.dmi'
+	icon_state = "relay"
+
 
 /obj/structure/prop/mainship/suit_storage_prop
 	name = "Suit Storage Unit"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.
As Skye found out, some telecomms props don't have have proper names or descriptions. I fixed that and added in extra variants to cover the spectrum of telecomms devices.

## Why It's Good For The Game

Bugs bad fixes good.

## Changelog
:cl:
fix: Some telecomms props now have proper descriptions and names.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
