### PR TITLE
Give soldering tool to corpsman instead of engineers

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -660,7 +660,6 @@ GLOBAL_LIST_INIT(loadout_role_essential_set, list(
 		/obj/item/lightreplacer = 1,
 		/obj/item/circuitboard/apc = 1,
 		/obj/item/clothing/under/marine/engineer = 1,
-		/obj/item/tool/surgery/solderingtool = 1,
 	),
 	SQUAD_CORPSMAN = list(
 		/obj/item/bodybag/cryobag = 1,
@@ -674,6 +673,7 @@ GLOBAL_LIST_INIT(loadout_role_essential_set, list(
 		/obj/item/storage/firstaid/adv = 1,
 		/obj/item/clothing/glasses/hud/health = 1,
 		/obj/item/clothing/under/marine/corpsman = 1,
+		/obj/item/tool/surgery/solderingtool = 1,
 	),
 	SQUAD_SMARTGUNNER = list(
 		/obj/item/clothing/glasses/night/m56_goggles = 1,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Give soldering tool to corpsman instead of engineers

## Why It's Good For The Game

While it makes sense lore wise that engineers would know better how to fix robots. Right now its kinda useless on them because.

1. its corpsman job to heal, engineer is buzy with other things
2. engineer has welder and cable coils, so the soldering tool is redundent
3. it uses medical skill, so engineer is way slower with using it then a corpsman
4. engineers do not have a defib, so they cannot revive the robot even IF they heal them. meaning corpsman gets a patiant anyawy

when im engi I pass mine to them usualy anyhow. I dont quiet understand why it was decided like this other then being thematic

## Changelog
:cl:
qol: The corpsman now start with soldering tool instead of the engineers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
