### PR TITLE
Help intent clicking starts removing huggers 

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -28,6 +28,7 @@
 
 			if(istype(src.wear_mask, /obj/item/clothing/mask/facehugger) && H != src)
 				H.stripPanelUnequip(src.wear_mask, src, SLOT_WEAR_MASK)
+				return TRUE
 
 			if(health >= get_crit_threshold())
 				help_shake_act(H)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -26,7 +26,7 @@
 					ExtinguishMob()
 				return TRUE
 
-			if(istype(src.wear_mask, /obj/item/clothing/mask/facehugger) && H != src)
+			if(istype(wear_mask, /obj/item/clothing/mask/facehugger) && H != src)
 				H.stripPanelUnequip(src.wear_mask, src, SLOT_WEAR_MASK)
 				return TRUE
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -26,6 +26,9 @@
 					ExtinguishMob()
 				return TRUE
 
+			if(istype(src.wear_mask, /obj/item/clothing/mask/facehugger) && H != src)
+				H.stripPanelUnequip(src.wear_mask, src, SLOT_WEAR_MASK)
+
 			if(health >= get_crit_threshold())
 				help_shake_act(H)
 				return TRUE

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -27,7 +27,7 @@
 				return TRUE
 
 			if(istype(wear_mask, /obj/item/clothing/mask/facehugger) && H != src)
-				H.stripPanelUnequip(src.wear_mask, src, SLOT_WEAR_MASK)
+				H.stripPanelUnequip(wear_mask, src, SLOT_WEAR_MASK)
 				return TRUE
 
 			if(health >= get_crit_threshold())


### PR DESCRIPTION
## About The Pull Request
Clicking on human with empty hand will now start removing hugger from their face if they have one. This has lower priority than putting out fire so hilarity ensues.
## Why It's Good For The Game
Removing huggers is a pain in ass. You need to drag victim's sprite onto yourself then click the corresponding item slot and THEN you start removing it. I do not consider it to be a balance change for two main reasons
1. Removing huggers with hands is a noob trap that puts two marines out of combat for at least 4 seconds and will not work out if anybody shuffles them. Removing huggers with fire is the most reliable option to deal with them.
2. Abilities should not be balanced by janky, user unfriendly interfaces. Hugger removal time can be increased if needed, but not the complexity of controls.
## Changelog
:cl:
qol: huggers can now be removed without using equip menu
/:cl: