### PR TITLE
Fixes 10x20mm ammo box not working

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -535,6 +535,7 @@ Turn() or Shift() as there is virtually no overhead. ~N
 	default_ammo = /datum/ammo/bullet/smg
 	bullet_amount = 4500
 	max_bullet_amount = 4500
+	caliber = CALIBER_10X20_CASELESS
 
 /obj/item/shotgunbox/buckshot
 	name = "Buckshot Ammo Box"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Big Ammo Box (10x20mm) couldn't actually refill mags because it still inherited the parent caliber of rifle ammo. Apparently nobody uses big ammo boxes to realize they could be using the 4500 round box to refill 10x24mm rifle mags.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugs bad

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Big Ammo Box (10x20mm) will actually fill mags of its caliber now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
