### PR TITLE
Add beeping & explosion noises to C4

### DIFF
--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -115,7 +115,7 @@
 		qdel(src)
 		return
 	explosion(plant_target, 0, 0, 1, 0, 0, 1, 0, 1)
-	playsound(loc, pick('sound/effects/explosion_small1.ogg','sound/effects/explosion_small2.ogg','sound/effects/explosion_small3.ogg' ), 200, FALSE)
+	playsound(loc, pick('sound/effects/explosion_small1.ogg','sound/effects/explosion_small2.ogg','sound/effects/explosion_small3.ogg'), 200, FALSE)
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
 	smoke.set_up(smokeradius, loc, 2)
 	smoke.start()

--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -115,6 +115,7 @@
 		qdel(src)
 		return
 	explosion(plant_target, 0, 0, 1, 0, 0, 1, 0, 1)
+	playsound(loc, pick('sound/effects/explosion_small1.ogg','sound/effects/explosion_small2.ogg','sound/effects/explosion_small3.ogg' ), 200, FALSE)
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
 	smoke.set_up(smokeradius, loc, 2)
 	smoke.start()

--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -69,6 +69,9 @@
 			var/atom/movable/T = plant_target
 			T.vis_contents += src
 		detonation_pending = addtimer(CALLBACK(src, .proc/detonate), timer*10, TIMER_STOPPABLE)
+		var/beeping_timer = ((timer*10) - 27)
+		addtimer(CALLBACK(GLOBAL_PROC, .proc/playsound, get_turf(target), 'sound/items/countdown.ogg', 40, TRUE), beeping_timer)
+
 
 /obj/item/explosive/plastique/attack(mob/M as mob, mob/user as mob, def_zone)
 	return


### PR DESCRIPTION
## About The Pull Request
I was waiting for someone to answer my mails, so I did this in the meantime.

This PR adds a little beeping noise before the C4 blows up. 
It also adds explosion noises, which weren't present. It picks randomly from 3 different ones. 

I tested it, but I forgot to test the longer cooldowns. I don't think this should be an issue.

## Why It's Good For The Game
C4 was kind of underwhelming before. This gives it a bit more fluff, and hopefully makes people more interested in using it.

## Changelog
:cl:
soundadd: Add a beeping noise to C4
soundadd: Add an explosion noise to C4
/:cl:


