### PR TITLE
Reduce C4 boom volume & range

### DIFF
--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -115,7 +115,7 @@
 		qdel(src)
 		return
 	explosion(plant_target, 0, 0, 1, 0, 0, 1, 0, 1)
-	playsound(loc, pick('sound/effects/explosion_small1.ogg','sound/effects/explosion_small2.ogg','sound/effects/explosion_small3.ogg'), 200, FALSE)
+	playsound(loc, pick('sound/effects/explosion_small1.ogg','sound/effects/explosion_small2.ogg','sound/effects/explosion_small3.ogg'), 100, FALSE, 25)
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
 	smoke.set_up(smokeradius, loc, 2)
 	smoke.start()


### PR DESCRIPTION
## About The Pull Request
I didn't notice the sound_range was the same as volume by default. 
Thanks, @Lumipharon, for the callout. 

## Why It's Good For The Game
It just makes sense to not hear it so far.

## Changelog
:cl:
fix: fixed C4 being hearable way too far.
/:cl:
