### PR TITLE
Renames metal barricade upgrades

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -426,8 +426,8 @@
 #define BARRICADE_METAL_ANCHORED 1
 #define BARRICADE_METAL_FIRM 2
 
-#define CADE_TYPE_BOMB "concussive armor"
-#define CADE_TYPE_MELEE "ballistic armor"
+#define CADE_TYPE_BOMB "explosive armor"
+#define CADE_TYPE_MELEE "strengthened armor"
 #define CADE_TYPE_ACID "caustic armor"
 
 #define CADE_UPGRADE_REQUIRED_SHEETS 1


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes barricade upgrade naming from "concussive" to "explosive", and "ballistic" to "strengthened".
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
My single braincell thought ballistic armor meant purely bullet armor and concussive would help vs crusher and punching. Turns out the latter is only bomb armor and the former is bullet AND melee armor.

![image](https://user-images.githubusercontent.com/72712909/197364659-b0a6c311-d562-4d5b-9a52-a87366603492.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Metal barricade armor upgrades are named more clearly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
