### PR TITLE
[Discussion Needed] Lower cost of x fuel in req

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -480,7 +480,7 @@ WEAPONS
 /datum/supply_packs/weapons/napalm_X
 	name = "FL-84 X fuel tank"
 	contains = list(/obj/item/ammo_magazine/flamer_tank/large/X)
-	cost = 8
+	cost = 10
 
 /datum/supply_packs/weapons/back_fuel_tank
 	name = "Standard back fuel tank"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -475,12 +475,12 @@ WEAPONS
 /datum/supply_packs/weapons/napalm
 	name = "FL-84 normal fuel tank"
 	contains = list(/obj/item/ammo_magazine/flamer_tank/large)
-	cost = 6
+	cost = 5
 
 /datum/supply_packs/weapons/napalm_X
 	name = "FL-84 X fuel tank"
 	contains = list(/obj/item/ammo_magazine/flamer_tank/large/X)
-	cost = 30
+	cost = 8
 
 /datum/supply_packs/weapons/back_fuel_tank
 	name = "Standard back fuel tank"
@@ -490,7 +490,7 @@ WEAPONS
 /datum/supply_packs/weapons/back_fuel_tank_x
 	name = "Type X back fuel tank"
 	contains = list(/obj/item/ammo_magazine/flamer_tank/backtank/X)
-	cost = 60
+	cost = 30
 
 /datum/supply_packs/weapons/rpgoneuse
 	name = "RL-72 Disposable RPG"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The idea was thrown around a bunch of times without anyone committing to it, so I did it. Back tank cost 60 -> 30, 72-round large tank 30 (lmao) -> 10, and normal large tank 6->5, both to be in line with most other mags in req and to have a large point spread between that and the x fuel tank (half as much).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
X fuel cannot be refueled anymore. while the 60 point cost was fine when you could, right now its an excessive cost. Not just that, but the 30-point tanks @Naaanii added were also single use, and I am not sure why you would spend 60 points for 140 x fuel vs 60 points for the back tank and 500 fuel. Now priced at 10, if you spend 60 points you get almos 100 less fuel than a back tank's worth.

_**This PR was marked with "discussion needed" because I wanted to indicate the price nerf is negotiable and I set them to something I personally viewed as fair**_. Maybe the back tank could be priced at 40, so both the single magazines and the back tank are double the cost of the normal equivalent (5 and 20 points vs 10 and 40, in this case). Though 40 is a lot for being disposable.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added new mechanics or gameplay changes
add: Added more mechanics or gameplay changes
expansion: Expands content of an existing feature
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
