### PR TITLE
xenos no longer pay back for free slots on crash

### DIFF
--- a/code/datums/jobs/job/xenomorph.dm
+++ b/code/datums/jobs/job/xenomorph.dm
@@ -39,9 +39,10 @@
 	return TRUE
 
 /datum/job/xenomorph/add_job_positions(amount)
-	if(free_xeno_at_start > 0)
-		free_xeno_at_start--
-		return
+	if(!(SSticker.mode.flags_round_type & MODE_XENO_SPAWN_PROTECT))
+		if(free_xeno_at_start > 0)
+			free_xeno_at_start--
+			return
 	. = ..()
 	if(!.)
 		return


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Crash xeno to marine ratios feel weird and I think its because xenos have to pay back for free slots, this PR should hopefully make those free slots, actually free.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Low-pop should be fun for both sides too, this should hopefully even out the playing field.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: xenos dont pay back for roundstart slots
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
