### PR TITLE
Corrects Sulaco having regular tables/chairs

### DIFF
--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -100,7 +100,7 @@
 /turf/open/floor/plating/mainship,
 /area/sulaco/engineering/engine)
 "aaq" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/mass_spectrometer,
 /obj/item/reagent_scanner,
 /obj/item/tool/hand_labeler,
@@ -119,7 +119,7 @@
 	},
 /area/sulaco/medbay/west)
 "aas" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/box/beakers{
 	pixel_x = -7;
 	pixel_y = 7
@@ -155,7 +155,7 @@
 	},
 /area/sulaco/medbay/west)
 "aav" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/reagentgrinder,
 /obj/item/stack/sheet/mineral/phoron,
 /obj/item/reagent_containers/dropper,
@@ -196,7 +196,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
 "aaG" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/stack/cable_coil,
 /obj/item/toy/deck,
 /obj/machinery/light/mainship{
@@ -245,7 +245,7 @@
 	},
 /area/sulaco/medbay/west)
 "aaS" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/firstaid/adv{
 	pixel_x = 4;
 	pixel_y = 4
@@ -303,7 +303,7 @@
 /turf/open/floor/plating/mainship,
 /area/sulaco/engineering/engine)
 "aba" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/pizzabox/meat,
 /obj/item/tool/soap/deluxe,
 /obj/item/tool/soap/deluxe,
@@ -443,7 +443,7 @@
 /turf/open/floor/prison/arrow/clean,
 /area/sulaco/cafeteria)
 "abB" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/firstaid/o2{
 	layer = 2.8;
 	pixel_x = 4;
@@ -679,7 +679,7 @@
 	},
 /area/sulaco/medbay/west)
 "acs" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/defibrillator,
 /obj/item/defibrillator,
 /turf/open/floor/prison/whitegreen/corner{
@@ -936,7 +936,7 @@
 /obj/machinery/light/mainship{
 	dir = 8
 	},
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/recharger,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 8
@@ -1145,7 +1145,7 @@
 	},
 /area/sulaco/medbay)
 "adP" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
@@ -1208,7 +1208,7 @@
 	},
 /area/sulaco/medbay)
 "adW" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/reagent_containers/glass/beaker/cryomix,
 /obj/item/reagent_containers/glass/beaker/cryomix,
 /turf/open/floor/prison/whitegreen/corner{
@@ -1216,13 +1216,13 @@
 	},
 /area/sulaco/medbay)
 "adZ" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 4
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
 "aec" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/microwave,
 /obj/machinery/light/mainship{
 	dir = 4
@@ -1305,7 +1305,7 @@
 /obj/machinery/alarm{
 	dir = 1
 	},
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/recharger,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
@@ -1319,7 +1319,7 @@
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay/west)
 "aew" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/box/quickclot{
 	pixel_x = 2;
 	pixel_y = 2
@@ -1337,7 +1337,7 @@
 	},
 /area/sulaco/medbay/storage)
 "aex" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/box/masks{
 	pixel_x = -4
 	},
@@ -1367,7 +1367,7 @@
 	},
 /area/sulaco/medbay/storage)
 "aey" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/pill_bottle/packet/paracetamol{
 	pixel_y = 7
 	},
@@ -1403,7 +1403,7 @@
 	},
 /area/sulaco/medbay/storage)
 "aeA" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/clothing/glasses/hud/health,
 /obj/item/healthanalyzer,
 /obj/item/healthanalyzer,
@@ -1418,7 +1418,7 @@
 	},
 /area/sulaco/medbay/storage)
 "aeB" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/box/bodybags,
 /obj/item/storage/box/bodybags,
 /obj/item/storage/box/bodybags,
@@ -1457,7 +1457,7 @@
 	},
 /area/sulaco/medbay/storage)
 "aeG" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/effect/spawner/random/toolbox,
 /obj/item/lightreplacer,
 /turf/open/floor/prison/whitegreen/corner{
@@ -1579,7 +1579,7 @@
 /turf/open/floor/engine,
 /area/sulaco/engineering/atmos)
 "afc" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 1
 	},
 /turf/open/floor/prison/whitegreen/corner,
@@ -1619,7 +1619,7 @@
 	},
 /area/sulaco/engineering/atmos)
 "afk" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 1
 	},
 /turf/open/floor/prison/whitegreen/corner{
@@ -1644,7 +1644,7 @@
 	},
 /area/sulaco/medbay/storage)
 "afG" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 8
 	},
 /turf/open/floor/prison/sterilewhite,
@@ -1656,7 +1656,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
 "afQ" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/fancy/cigar,
 /obj/item/tool/lighter/zippo,
 /turf/open/floor/prison/darkyellow/full,
@@ -1768,7 +1768,7 @@
 /area/sulaco/engineering/ce)
 "agZ" = (
 /obj/machinery/light/mainship,
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/book/manual/marine_law,
 /obj/item/storage/box/tgmc_mre,
 /obj/structure/sign/prop2,
@@ -1993,7 +1993,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/cargo)
 "ajj" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/briefcase/inflatable,
 /obj/item/storage/briefcase/inflatable,
 /obj/item/storage/briefcase/inflatable,
@@ -2142,7 +2142,7 @@
 /turf/open/floor/prison,
 /area/sulaco/engineering)
 "ako" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/cell_charger,
 /obj/machinery/cell_charger,
 /obj/item/flashlight,
@@ -2209,7 +2209,7 @@
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay)
 "akM" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/clothing/glasses/hud/health,
 /obj/structure/paper_bin,
 /obj/item/tool/pen,
@@ -2282,7 +2282,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall2)
 "alq" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/power/apc/mainship{
 	dir = 4
 	},
@@ -2583,7 +2583,7 @@
 /turf/closed/wall/mainship/gray,
 /area/sulaco/hallway/central_hall2)
 "anq" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/alarm{
 	dir = 4
@@ -2599,7 +2599,7 @@
 /turf/open/floor/prison,
 /area/sulaco/briefing)
 "ans" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/box/lights/mixed,
 /obj/item/tool/crowbar,
 /obj/item/tool/crowbar,
@@ -2649,7 +2649,7 @@
 /turf/open/floor/prison/red,
 /area/sulaco/hallway/central_hall)
 "anJ" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/tool/crowbar,
 /obj/item/tool/crowbar,
 /obj/item/tool/crowbar,
@@ -2911,7 +2911,7 @@
 	},
 /area/sulaco/bridge)
 "apn" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/structure/flora/pottedplant{
 	icon_state = "plant-15";
 	pixel_y = 10
@@ -2976,12 +2976,12 @@
 /turf/open/floor/prison,
 /area/sulaco/bridge)
 "apz" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/computer/squad_changer,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/bridge)
 "apB" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/computer/security,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/bridge)
@@ -3026,7 +3026,7 @@
 	},
 /area/sulaco/hallway/central_hall2)
 "apI" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 8
 	},
 /turf/open/floor/prison,
@@ -3046,66 +3046,66 @@
 /turf/open/floor/prison,
 /area/sulaco/briefing)
 "apO" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/red{
 	dir = 5
 	},
 /area/sulaco/briefing)
 "apP" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/red,
 /area/sulaco/briefing)
 "apQ" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/red{
 	dir = 9
 	},
 /area/sulaco/briefing)
 "apR" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/darkyellow{
 	dir = 5
 	},
 /area/sulaco/briefing)
 "apS" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/darkyellow,
 /area/sulaco/briefing)
 "apT" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/darkyellow{
 	dir = 9
 	},
 /area/sulaco/briefing)
 "apV" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/darkpurple{
 	dir = 5
 	},
 /area/sulaco/briefing)
 "apW" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/darkpurple,
 /area/sulaco/briefing)
 "apX" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/prison/darkpurple{
 	dir = 9
 	},
 /area/sulaco/briefing)
 "apY" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/blue{
 	dir = 5
 	},
 /area/sulaco/briefing)
 "apZ" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/blue,
 /area/sulaco/briefing)
 "aqa" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/blue{
 	dir = 9
 	},
@@ -3124,7 +3124,7 @@
 /turf/open/floor/prison,
 /area/sulaco/cargo/office)
 "aqi" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/structure/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
@@ -3140,7 +3140,7 @@
 /turf/open/floor/prison,
 /area/sulaco/briefing)
 "aql" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 8
 	},
 /obj/item/radio/intercom/general{
@@ -3153,7 +3153,7 @@
 /turf/closed/wall/mainship/gray,
 /area/sulaco/cargo/office)
 "aqt" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/structure/window/reinforced/toughened{
 	dir = 8
 	},
@@ -3167,7 +3167,7 @@
 /area/sulaco/bridge)
 "aqu" = (
 /obj/machinery/photocopier,
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
@@ -3341,13 +3341,13 @@
 /turf/open/floor/prison,
 /area/sulaco/briefing)
 "arn" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/red{
 	dir = 4
 	},
 /area/sulaco/briefing)
 "aro" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
@@ -3359,38 +3359,38 @@
 /turf/open/floor/prison/red,
 /area/sulaco/briefing)
 "arq" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/darkyellow{
 	dir = 4
 	},
 /area/sulaco/briefing)
 "ars" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/darkyellow{
 	dir = 8
 	},
 /area/sulaco/briefing)
 "aru" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/darkpurple{
 	dir = 4
 	},
 /area/sulaco/briefing)
 "arv" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/prison/darkpurple{
 	dir = 8
 	},
 /area/sulaco/briefing)
 "arw" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/blue{
 	dir = 4
 	},
 /area/sulaco/briefing)
 "arx" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/blue{
 	dir = 8
 	},
@@ -3449,7 +3449,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/bridge)
 "arC" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/structure/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
@@ -3636,7 +3636,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/bridge)
 "asv" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/weapon/gun/smg/m25,
 /obj/item/ammo_magazine/smg/m25,
 /obj/item/ammo_magazine/smg/m25,
@@ -3700,7 +3700,7 @@
 /area/sulaco/engineering)
 "asJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/red,
 /area/sulaco/briefing)
 "asP" = (
@@ -3734,7 +3734,7 @@
 	},
 /area/sulaco/bridge)
 "asV" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/structure/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
@@ -3814,7 +3814,7 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_north_maint)
 "atp" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/structure/window/reinforced/toughened{
 	dir = 8
 	},
@@ -3836,7 +3836,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/bridge)
 "ats" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
@@ -3852,7 +3852,7 @@
 	},
 /area/sulaco/bridge)
 "att" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
@@ -3937,7 +3937,7 @@
 /turf/open/floor/prison,
 /area/sulaco/bridge/office)
 "atG" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -4041,7 +4041,7 @@
 	},
 /area/sulaco/briefing)
 "aua" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/flasher{
 	id = "brief";
 	last_flash = 100;
@@ -4062,7 +4062,7 @@
 /turf/open/floor/prison,
 /area/sulaco/briefing)
 "aue" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/flasher{
 	id = "brief";
 	last_flash = 100;
@@ -4090,7 +4090,7 @@
 /turf/open/floor/prison,
 /area/sulaco/briefing)
 "auh" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
@@ -4102,7 +4102,7 @@
 	},
 /area/sulaco/briefing)
 "aui" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/flasher{
 	id = "brief";
 	last_flash = 100;
@@ -4119,7 +4119,7 @@
 /turf/open/floor/prison/darkpurple,
 /area/sulaco/briefing)
 "auj" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
@@ -4129,7 +4129,7 @@
 	},
 /area/sulaco/briefing)
 "auk" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
@@ -4141,7 +4141,7 @@
 	},
 /area/sulaco/briefing)
 "aul" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/flasher{
 	id = "brief";
 	last_flash = 100;
@@ -4158,7 +4158,7 @@
 /turf/open/floor/prison/blue,
 /area/sulaco/briefing)
 "aum" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
 	dir = 1
 	},
@@ -4328,7 +4328,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/bridge)
 "ava" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
@@ -4340,13 +4340,13 @@
 	},
 /area/sulaco/bridge)
 "avb" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /turf/open/floor/mainship/terragov{
 	dir = 8
 	},
 /area/sulaco/bridge)
 "avc" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 8
 	},
 /turf/open/floor/mainship/terragov/west{
@@ -4491,7 +4491,7 @@
 	},
 /area/sulaco/briefing)
 "avE" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
@@ -4507,7 +4507,7 @@
 	},
 /area/sulaco/briefing)
 "avF" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
@@ -4534,7 +4534,7 @@
 /turf/open/floor/prison,
 /area/sulaco/briefing)
 "avI" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -4606,7 +4606,7 @@
 	},
 /area/sulaco/engineering)
 "awb" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/red{
 	dir = 8
 	},
@@ -4734,7 +4734,7 @@
 /turf/open/floor/wood,
 /area/sulaco/bridge/office)
 "awx" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
@@ -4743,11 +4743,11 @@
 	},
 /area/sulaco/bridge)
 "awy" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /turf/open/floor/mainship/terragov/west,
 /area/sulaco/bridge)
 "awz" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 8
 	},
 /turf/open/floor/mainship/terragov/west{
@@ -4855,7 +4855,7 @@
 /turf/open/floor/prison,
 /area/sulaco/engineering)
 "axv" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
@@ -4880,7 +4880,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/hallway/central_hall3)
 "axE" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 1
 	},
 /obj/structure/platform{
@@ -5051,7 +5051,7 @@
 /area/sulaco/bridge/office)
 "ayx" = (
 /obj/machinery/light/mainship,
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/computer/secure_data,
 /turf/open/floor/prison/red/full{
 	dir = 1
@@ -5079,7 +5079,7 @@
 /turf/open/floor/tile/dark2,
 /area/mainship/living/basketball)
 "ayA" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/computer/station_alert,
 /turf/open/floor/prison/red{
 	dir = 10
@@ -5130,7 +5130,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall2)
 "ayN" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/red{
 	dir = 6
 	},
@@ -5139,17 +5139,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/red,
 /area/sulaco/briefing)
 "ayP" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/red{
 	dir = 10
 	},
 /area/sulaco/briefing)
 "ayQ" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/darkyellow{
 	dir = 6
 	},
@@ -5169,19 +5169,19 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/bridge)
 "ayT" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/darkpurple{
 	dir = 10
 	},
 /area/sulaco/briefing)
 "ayU" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/blue{
 	dir = 6
 	},
 /area/sulaco/briefing)
 "ayV" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/blue{
 	dir = 10
 	},
@@ -5679,24 +5679,24 @@
 /turf/open/floor/prison,
 /area/sulaco/briefing)
 "aBz" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 1
 	},
 /turf/open/floor/prison,
 /area/sulaco/briefing)
 "aBB" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/effect/spawner/random/plushie/nospawnninetyfive,
 /turf/open/floor/prison,
 /area/sulaco/briefing)
 "aBC" = (
 /obj/machinery/light/mainship,
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/fancy/cigarettes/dromedaryco,
 /turf/open/floor/prison,
 /area/sulaco/briefing)
 "aBD" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/prison,
 /area/sulaco/briefing)
@@ -5829,7 +5829,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/weapon/gun/energy/taser,
 /turf/open/floor/prison/red/full{
 	dir = 1
@@ -5967,7 +5967,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/sulaco/disposal)
 "aCI" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/tool/pen,
 /obj/machinery/power/apc/mainship{
 	dir = 1
@@ -5982,7 +5982,7 @@
 /turf/open/floor/prison,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
 "aCJ" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /turf/open/floor/prison,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
 "aCK" = (
@@ -6410,7 +6410,7 @@
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
 "aEF" = (
 /obj/machinery/reagentgrinder,
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
 "aEH" = (
@@ -6574,7 +6574,7 @@
 /turf/open/floor/prison,
 /area/sulaco/engineering/lower_engineering)
 "aFs" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/reagentgrinder,
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
@@ -6850,7 +6850,7 @@
 /turf/open/floor/wood,
 /area/sulaco/marine/chapel)
 "aHx" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/structure/paper_bin,
 /turf/open/floor/prison,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
@@ -6950,7 +6950,7 @@
 	},
 /area/sulaco/command/eva)
 "aIb" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 4
 	},
 /turf/open/floor/prison,
@@ -6989,7 +6989,7 @@
 	},
 /area/sulaco/disposal)
 "aIp" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison,
 /area/sulaco/hallway/evac)
 "aIr" = (
@@ -7001,7 +7001,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/evac)
 "aIt" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7011,7 +7011,7 @@
 	},
 /area/sulaco/briefing)
 "aIv" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 1
 	},
 /turf/open/floor/prison,
@@ -7107,12 +7107,12 @@
 /turf/open/floor/prison/plate,
 /area/shuttle/distress/arrive_1)
 "aJd" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/vending/nanomed,
 /turf/open/floor/prison,
 /area/sulaco/hallway/evac)
 "aJe" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/light/mainship{
 	dir = 1
 	},
@@ -7226,7 +7226,7 @@
 /turf/closed/wall/mainship/gray,
 /area/sulaco/liaison)
 "aJL" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/wood,
 /area/sulaco/liaison)
 "aJM" = (
@@ -7391,7 +7391,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
 "aKH" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/disk/botany,
 /obj/item/radio,
 /obj/machinery/door_control/old/unmeltable{
@@ -7412,7 +7412,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hydro)
 "aKK" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/computer/atmos_alert,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hydro)
@@ -7705,7 +7705,7 @@
 /turf/open/floor/mainship/research/containment/corner1,
 /area/sulaco/research)
 "aMc" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 1
 	},
 /turf/open/floor/prison/sterilewhite,
@@ -7728,11 +7728,11 @@
 /turf/open/floor/prison/green,
 /area/sulaco/marine)
 "aMg" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
 "aMh" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/stack/sheet/mineral/phoron,
 /obj/item/stack/sheet/mineral/phoron,
 /obj/machinery/light/mainship{
@@ -8076,18 +8076,18 @@
 /turf/open/floor/prison/red,
 /area/sulaco/command/eva)
 "aOp" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/tool/extinguisher,
 /obj/item/tool/crowbar,
 /turf/open/floor/prison/red,
 /area/sulaco/command/eva)
 "aOq" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/toolbox/electrical,
 /turf/open/floor/prison/red,
 /area/sulaco/command/eva)
 "aOr" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/toolbox/mechanical,
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -8095,7 +8095,7 @@
 /turf/open/floor/prison/red,
 /area/sulaco/command/eva)
 "aOs" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/effect/spawner/random/tech_supply,
 /obj/effect/spawner/random/tech_supply,
 /turf/open/floor/prison/red,
@@ -8194,7 +8194,7 @@
 /turf/open/floor/prison,
 /area/mainship/shipboard/weapon_room)
 "aPd" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8337,12 +8337,12 @@
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
 "aQl" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/box/beakers,
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
 "aQm" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/box/syringes,
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
@@ -8471,7 +8471,7 @@
 /turf/open/floor/wood,
 /area/sulaco/liaison)
 "aQY" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/power/apc/mainship{
 	dir = 4
 	},
@@ -8590,7 +8590,7 @@
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
 "aRH" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/box/monkeycubes,
 /obj/item/tool/extinguisher,
 /obj/effect/decal/warning_stripes/thin{
@@ -8742,11 +8742,11 @@
 /obj/item/storage/box/pillbottles,
 /obj/item/storage/box/pillbottles,
 /obj/item/storage/box/pillbottles,
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
 "aSq" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/stack/sheet/mineral/phoron,
 /obj/item/stack/sheet/mineral/phoron,
 /obj/item/stack/sheet/mineral/phoron,
@@ -8907,7 +8907,7 @@
 	pixel_y = 3
 	},
 /obj/item/storage/firstaid/adv,
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/firstaid/o2{
 	layer = 2.8;
 	pixel_x = 4;
@@ -8958,7 +8958,7 @@
 /turf/open/floor/carpet,
 /area/sulaco/liaison)
 "aTy" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -9085,7 +9085,7 @@
 /turf/open/floor/prison/marked,
 /area/sulaco/hallway/lower_main_hall)
 "aUG" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker,
@@ -9179,7 +9179,7 @@
 	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
 	name = "Chemistry Cleaner"
 	},
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/tool/hand_labeler,
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
@@ -9194,7 +9194,7 @@
 /turf/open/floor/cult,
 /area/sulaco/morgue)
 "aVl" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/box/bodybags,
 /obj/item/storage/box/bodybags,
 /turf/open/floor/cult,
@@ -9611,7 +9611,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "aYH" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/reagent_containers/glass/bucket,
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -9787,7 +9787,7 @@
 /turf/open/floor/wood,
 /area/sulaco/liaison)
 "baa" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/light/mainship{
 	dir = 1
 	},
@@ -9860,7 +9860,7 @@
 "baH" = (
 /obj/machinery/computer/operating,
 /obj/machinery/camera/autoname,
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/surgical_tray,
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/medbay/hangar)
@@ -10331,7 +10331,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_foreship)
 "bjj" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/lightreplacer,
 /obj/machinery/vending/nanomed,
 /turf/open/floor/prison/bright_clean,
@@ -10465,7 +10465,7 @@
 /area/sulaco/cargo/office)
 "bvu" = (
 /obj/machinery/computer/droppod_control,
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/structure/sign/pods,
 /turf/open/floor/mainship/sterile/plain,
 /area/sulaco/hangar/droppod)
@@ -10568,7 +10568,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
 	},
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /turf/open/floor/prison/whitegreen{
 	dir = 9
 	},
@@ -10955,7 +10955,7 @@
 /turf/open/floor/mainship/tcomms,
 /area/sulaco/command/ai)
 "chQ" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/flashlight/flare,
 /obj/item/cane,
 /obj/machinery/firealarm{
@@ -10990,7 +10990,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
 "cls" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/tool/mop,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
@@ -11078,7 +11078,7 @@
 /turf/open/floor/prison,
 /area/sulaco/cargo)
 "csJ" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/electrical,
@@ -11132,7 +11132,7 @@
 	},
 /area/sulaco/medbay)
 "cvJ" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/cell_charger,
 /obj/item/lightreplacer,
 /obj/item/clothing/glasses/welding,
@@ -11163,7 +11163,7 @@
 /turf/open/floor/cult,
 /area/sulaco/morgue)
 "cyg" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/computer/security/marinemainship{
 	dir = 4;
 	pixel_x = 17
@@ -11378,7 +11378,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/dropshipprep)
 "cID" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11415,14 +11415,14 @@
 /turf/open/floor/prison,
 /area/sulaco/marine)
 "cKW" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
 "cMp" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/reagent_containers/food/snacks/monkeyburger,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
@@ -11489,7 +11489,7 @@
 /turf/open/floor/tile/darkgreen/darkgreen2,
 /area/mainship/living/basketball)
 "cOP" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 6
 	},
@@ -11604,7 +11604,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/evac)
 "cVn" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
@@ -11689,7 +11689,7 @@
 /area/sulaco/cargo)
 "cZo" = (
 /obj/machinery/light/mainship/small,
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/tool/crowbar,
 /obj/item/clothing/head/hardhat/rugged,
 /turf/open/floor/plating,
@@ -12287,7 +12287,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "dZI" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/folder/yellow,
 /obj/item/tool/pen{
 	pixel_x = 4;
@@ -12313,7 +12313,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/evac)
 "ear" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/effect/spawner/random/tech_supply,
 /obj/effect/spawner/random/tech_supply,
 /obj/effect/spawner/random/tech_supply,
@@ -12429,7 +12429,7 @@
 /turf/open/floor/wood,
 /area/mainship/living/basketball)
 "ejF" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/tool/kitchen/tray,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
@@ -12666,7 +12666,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall2)
 "eAP" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/flashlight/flare,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
@@ -12783,7 +12783,7 @@
 /obj/machinery/light/mainship{
 	dir = 8
 	},
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 4
 	},
 /turf/open/floor/tile/darkgreen/darkgreen2{
@@ -12835,7 +12835,7 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/faxmachine/research,
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
@@ -13125,7 +13125,7 @@
 /turf/open/floor/mainship/black,
 /area/sulaco/mechpilotquarters)
 "fkQ" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/taperecorder,
 /obj/item/taperecorder,
 /obj/machinery/recharger,
@@ -13208,7 +13208,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 8
 	},
 /turf/open/floor/tile/darkgreen/darkgreen2{
@@ -13249,7 +13249,7 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
 "fqG" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/weapon/gun/shotgun/pump,
 /obj/item/ammo_magazine/shotgun,
 /obj/item/ammo_magazine/shotgun/buckshot,
@@ -13276,7 +13276,7 @@
 /turf/open/floor/prison,
 /area/sulaco/bar)
 "fsL" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_foreship)
 "fsW" = (
@@ -13306,7 +13306,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "fuV" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
@@ -13359,7 +13359,7 @@
 /turf/open/floor/prison,
 /area/sulaco/engineering/atmos)
 "fyW" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
@@ -13519,7 +13519,7 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
 "fKJ" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/reagent_containers/food/condiment/saltshaker,
 /obj/item/reagent_containers/food/condiment/peppermill,
 /obj/machinery/camera/autoname{
@@ -13551,7 +13551,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_main_hall)
 "fOA" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/firstaid/adv,
 /turf/open/floor/prison,
 /area/sulaco/security)
@@ -13799,12 +13799,12 @@
 	},
 /area/sulaco/bridge)
 "ghD" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/prison/red,
 /area/sulaco/briefing)
 "gim" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/light/mainship{
 	dir = 8
 	},
@@ -14169,7 +14169,7 @@
 /turf/open/floor/freezer,
 /area/sulaco/showers)
 "gKQ" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/flashlight/flare,
 /obj/item/facepaint/brown,
 /turf/open/floor/prison/sterilewhite,
@@ -14212,7 +14212,7 @@
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/bridge)
 "gNX" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/tile/chapel,
 /area/sulaco/marine/chapel)
 "gNZ" = (
@@ -14321,7 +14321,7 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/book/manual/medical_diagnostics_manual,
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay/cmo)
@@ -14345,7 +14345,7 @@
 /turf/open/floor/prison,
 /area/mainship/living/pilotbunks)
 "gWJ" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 4
 	},
 /turf/open/floor/tile/darkgreen/darkgreen2{
@@ -14780,7 +14780,7 @@
 	},
 /area/sulaco/marine)
 "hBC" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/roller,
 /obj/item/roller,
 /obj/item/roller,
@@ -14966,7 +14966,7 @@
 /turf/open/floor/prison,
 /area/sulaco/cargo)
 "hNw" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 9
 	},
@@ -15047,13 +15047,13 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/briefcase/inflatable,
 /obj/item/reagent_containers/spray,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "hTK" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/structure/cable,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
@@ -15076,7 +15076,7 @@
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
 "hUr" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/light/mainship/small{
 	dir = 1
 	},
@@ -15089,7 +15089,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "hVY" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -15172,7 +15172,7 @@
 	},
 /area/mainship/living/basketball)
 "ibZ" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 4
 	},
 /obj/machinery/alarm,
@@ -15248,7 +15248,7 @@
 /turf/open/floor/prison,
 /area/sulaco/bridge/office)
 "ihO" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
@@ -15431,7 +15431,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/computer/emails,
 /turf/open/floor/wood,
 /area/sulaco/marine/chapel/chapel_office)
@@ -15590,7 +15590,7 @@
 	},
 /area/sulaco/engineering)
 "iGB" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /turf/open/floor/prison/red/full{
 	dir = 8
 	},
@@ -15602,7 +15602,7 @@
 /turf/open/floor/prison/cleanmarked,
 /area/sulaco/hangar/droppod)
 "iHn" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/lightreplacer,
 /turf/open/floor/plating,
 /area/mainship/command/self_destruct)
@@ -15615,7 +15615,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/computer/med_data/laptop,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
@@ -15780,7 +15780,7 @@
 /turf/closed/wall/mainship/gray,
 /area/sulaco/engineering)
 "iSd" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15883,12 +15883,12 @@
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "iWH" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/firstaid,
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_foreship)
 "iWV" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 1
 	},
 /turf/open/floor/prison/red{
@@ -15930,7 +15930,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/sulaco/hangar/storage)
 "iZY" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /turf/open/floor/tile/darkgreen/darkgreen2{
 	dir = 5
 	},
@@ -16058,7 +16058,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/mainship/command/self_destruct)
 "jhf" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/reagent_containers/glass/beaker/biomass,
 /obj/item/reagent_containers/glass/beaker/biomass,
 /turf/open/floor/prison/whitegreen/corner{
@@ -16293,7 +16293,7 @@
 /turf/open/floor/prison,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
 "jCo" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/belt/utility/full,
 /obj/item/storage/belt/utility/full,
 /obj/machinery/light/mainship{
@@ -16377,7 +16377,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/mainship/command/self_destruct)
 "jGq" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/microwave,
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/wood,
@@ -16586,7 +16586,7 @@
 /turf/open/floor/prison,
 /area/sulaco/marine)
 "jUS" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16835,7 +16835,7 @@
 /area/sulaco/marine)
 "knu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 4
 	},
 /turf/open/floor/prison,
@@ -16854,7 +16854,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/hallway/lower_foreship)
 "knZ" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
@@ -17244,7 +17244,7 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/light/mainship{
 	dir = 8
 	},
@@ -17259,7 +17259,7 @@
 /area/sulaco/bridge)
 "kNF" = (
 /obj/structure/cable,
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/fancy/cigarettes/luckystars,
 /turf/open/floor/prison,
 /area/sulaco/bar)
@@ -17304,7 +17304,7 @@
 /obj/effect/decal/warning_stripes/thick{
 	dir = 1
 	},
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/lightreplacer,
 /obj/item/flashlight/flare,
 /turf/open/floor/prison/sterilewhite,
@@ -17794,7 +17794,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall2)
 "lDs" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/camera,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
@@ -17832,7 +17832,7 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/mainship,
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/wood,
 /area/sulaco/marine/chapel/chapel_office)
 "lEr" = (
@@ -17870,7 +17870,7 @@
 /turf/open/floor/prison,
 /area/sulaco/marine)
 "lHY" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/darkpurple{
 	dir = 8
 	},
@@ -18141,7 +18141,7 @@
 /turf/open/floor/wood,
 /area/sulaco/marine/chapel/chapel_office)
 "mbL" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -18158,7 +18158,7 @@
 /obj/structure/closet/walllocker/emerglocker{
 	dir = 4
 	},
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/facepaint/green,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
@@ -18187,7 +18187,7 @@
 /obj/machinery/light/mainship{
 	dir = 4
 	},
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 8
 	},
 /turf/open/floor/tile/darkgreen/darkgreen2{
@@ -18300,7 +18300,7 @@
 /turf/open/floor/mainship_hull/gray,
 /area/space)
 "mnO" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
@@ -18647,7 +18647,7 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
 "mMU" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
@@ -18746,7 +18746,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "mRD" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/explosive/grenade/chem_grenade/cleaner,
 /obj/item/explosive/grenade/chem_grenade/cleaner,
 /obj/item/explosive/grenade/chem_grenade/cleaner,
@@ -18776,7 +18776,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "mUF" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/tile/chapel{
@@ -18906,7 +18906,7 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint2)
 "ncn" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
@@ -18916,7 +18916,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/flashlight/lamp,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
@@ -19382,7 +19382,7 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 4
 	},
 /turf/open/floor/prison,
@@ -19436,7 +19436,7 @@
 /obj/machinery/firealarm{
 	dir = 8
 	},
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /turf/open/floor/cult,
 /area/sulaco/morgue)
 "nVS" = (
@@ -19612,7 +19612,7 @@
 /turf/open/floor/prison,
 /area/sulaco/engineering/lower_engineering)
 "oiG" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/vending/nanomed,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
@@ -19759,7 +19759,7 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/tile/darkgreen/darkgreen2{
 	dir = 1
 	},
@@ -19815,13 +19815,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/tile/chapel{
 	dir = 8
 	},
 /area/sulaco/marine/chapel)
 "oux" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/healthanalyzer,
 /turf/open/floor/prison/sterilewhite,
@@ -19921,7 +19921,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/sulaco/command/ai)
 "oBg" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/clothing/ears/earmuffs,
 /turf/open/floor/prison/cellstripe{
 	dir = 1
@@ -20185,7 +20185,7 @@
 /turf/open/floor/prison/darkyellow/corner,
 /area/sulaco/engineering)
 "oPl" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 5
 	},
@@ -20244,7 +20244,7 @@
 /turf/open/floor/prison,
 /area/sulaco/marine)
 "oTn" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
@@ -20322,7 +20322,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/robot_parts/chest,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
@@ -20471,7 +20471,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_foreship)
 "pig" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/vending/nanomed,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20494,7 +20494,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/dropshipprep)
 "pjA" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/reagent_containers/food/snacks/protein_pack,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
@@ -20578,7 +20578,7 @@
 	},
 /area/sulaco/medbay/cmo)
 "pmB" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/radio,
 /obj/item/radio,
 /obj/item/stack/cable_coil{
@@ -20699,7 +20699,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "ptE" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/reagent_containers/food/snacks/monkeyburger,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
@@ -21196,7 +21196,7 @@
 /turf/open/floor/plating/mainship,
 /area/sulaco/engineering/engine)
 "qjQ" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/defibrillator,
 /obj/item/defibrillator,
 /turf/open/floor/prison/whitegreen/corner{
@@ -21250,7 +21250,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/tile/chapel{
 	dir = 1
 	},
@@ -21264,7 +21264,7 @@
 	},
 /area/sulaco/hallway/central_hall)
 "qoV" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/tile/darkgreen/darkgreen2{
 	dir = 1
 	},
@@ -21456,7 +21456,7 @@
 /turf/open/floor/mainship_hull/gray/dir,
 /area/space)
 "qDX" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/effect/spawner/random/plushie/nospawnninetyfive,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
@@ -21469,7 +21469,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_main_hall)
 "qGm" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
 	dir = 8
@@ -21535,7 +21535,7 @@
 /turf/open/floor/prison,
 /area/sulaco/engineering/lower_engineering)
 "qJY" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/faxmachine/cic,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/bridge)
@@ -21646,7 +21646,7 @@
 /turf/open/floor/prison,
 /area/mainship/shipboard/weapon_room)
 "qSR" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/structure/paper_bin,
 /obj/item/clipboard,
 /obj/item/tool/pen,
@@ -22352,7 +22352,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "rIv" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/tool/stamp{
 	name = "Quartermaster's stamp"
 	},
@@ -22372,11 +22372,11 @@
 /obj/machinery/firealarm{
 	dir = 4
 	},
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /turf/open/floor/wood,
 /area/sulaco/medbay/west)
 "rIx" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison/darkyellow,
 /area/sulaco/briefing)
@@ -22433,7 +22433,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/oil,
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/clothing/head/helmet/marine/robot/heavy,
 /obj/machinery/light/mainship/small,
 /turf/open/floor/prison,
@@ -22496,7 +22496,7 @@
 	},
 /area/sulaco/marine)
 "rSi" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/ashtray/glass,
 /turf/open/floor/prison,
 /area/sulaco/bar)
@@ -22563,7 +22563,7 @@
 	},
 /area/sulaco/research)
 "saZ" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/tile/chapel{
 	dir = 8
 	},
@@ -22774,7 +22774,7 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
 "shz" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/prop/mainship/computer{
 	dir = 4
 	},
@@ -22813,7 +22813,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "sjY" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
@@ -22922,7 +22922,7 @@
 /turf/open/floor/cult,
 /area/sulaco/morgue)
 "srT" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 1
 	},
 /obj/machinery/light/mainship,
@@ -23139,7 +23139,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_foreship)
 "sId" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/tool/hand_labeler,
 /obj/item/tool/hand_labeler,
 /turf/open/floor/prison,
@@ -23162,7 +23162,7 @@
 	},
 /area/sulaco/hangar)
 "sIy" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/computer/supplydrop_console,
 /obj/machinery/light/mainship{
 	dir = 8
@@ -23488,7 +23488,7 @@
 /turf/closed/wall/mainship/gray,
 /area/sulaco/bridge)
 "tbN" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
@@ -23576,7 +23576,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/hallway/lower_main_hall)
 "tfx" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 4
 	},
 /obj/item/radio/intercom/general{
@@ -23609,7 +23609,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/hallway/lower_foreship)
 "tiD" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/prop/mainship/computer{
 	dir = 8
 	},
@@ -23677,7 +23677,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "tlQ" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/effect/spawner/random/toolbox,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
@@ -24032,7 +24032,7 @@
 /turf/open/floor/prison/kitchen,
 /area/sulaco/cafeteria)
 "tJx" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/clothing/glasses/meson,
 /obj/item/paper,
 /obj/item/tool/pen,
@@ -24109,7 +24109,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "tOk" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/flashlight/lamp,
 /obj/machinery/firealarm{
 	dir = 8
@@ -24146,7 +24146,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_foreship)
 "tPL" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/clothing/glasses/hud/health,
 /obj/item/tool/pen,
 /obj/structure/paper_bin,
@@ -24169,7 +24169,7 @@
 /turf/open/floor/prison,
 /area/sulaco/marine/chapel)
 "tRg" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /turf/open/floor/prison,
 /area/sulaco/bar)
 "tRW" = (
@@ -24381,7 +24381,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar/droppod)
 "uhf" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/light/mainship,
 /obj/item/reagent_containers/food/snacks/hotdog,
 /turf/open/floor/prison/sterilewhite,
@@ -24414,7 +24414,7 @@
 /turf/open/floor/prison,
 /area/sulaco/cargo/prep)
 "uiN" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/weapon/gun/rifle/m412,
 /obj/item/ammo_magazine/rifle,
 /obj/item/ammo_magazine/rifle,
@@ -24434,7 +24434,7 @@
 /turf/open/floor/prison,
 /area/mainship/living/pilotbunks)
 "ujW" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 4
 	},
 /turf/open/floor/prison,
@@ -24567,7 +24567,7 @@
 /turf/open/floor/plating,
 /area/sulaco/engineering/engine_monitoring)
 "uwG" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/light/mainship,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
@@ -24678,7 +24678,7 @@
 /turf/open/floor/prison/darkyellow/corner,
 /area/sulaco/engineering)
 "uDh" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/stack/sheet/cardboard{
 	amount = 50
 	},
@@ -25426,7 +25426,7 @@
 /turf/closed/wall/mainship/white/outer,
 /area/sulaco/medbay/west)
 "vIy" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/door_control/old/req{
 	id = "Reqshutters";
 	name = "Req Lockdown";
@@ -25625,7 +25625,7 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 4
 	},
 /turf/open/floor/tile/darkgreen/darkgreen2{
@@ -25733,7 +25733,7 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
 "wco" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/clothing/head/warning_cone,
 /obj/item/clothing/head/warning_cone,
 /obj/item/clothing/head/warning_cone,
@@ -25767,7 +25767,7 @@
 /turf/open/floor/tile/hydro,
 /area/sulaco/hydro)
 "wfn" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 8
 	},
 /turf/open/floor/tile/darkgreen/darkgreen2{
@@ -26005,7 +26005,7 @@
 /turf/open/floor/prison/darkyellow/corner,
 /area/sulaco/engineering/ce)
 "wyw" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/reagent_containers/food/snacks/grilledcheese{
 	desc = "'The best grilled cheese this side of Uranus!' (tm)";
 	name = "Sandwich Joe's Grilled Cheese";
@@ -26022,7 +26022,7 @@
 	},
 /area/space)
 "wAj" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/door/window{
 	dir = 8
 	},
@@ -26131,7 +26131,7 @@
 /turf/open/floor/mainship_hull/gray,
 /area/space)
 "wJH" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
 "wJL" = (
@@ -26199,7 +26199,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
 "wNN" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/nometal{
 	dir = 8
 	},
 /obj/item/radio/intercom/general{
@@ -26666,7 +26666,7 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/machinery/computer/shuttle/shuttle_control/dropship,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26720,7 +26720,7 @@
 /turf/open/floor/mainship/ai,
 /area/sulaco/command/ai)
 "xzB" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/clipboard,
 /obj/item/tool/stamp/cmo,
 /obj/machinery/camera/autoname,
@@ -26803,7 +26803,7 @@
 /turf/open/floor/wood,
 /area/mainship/living/basketball)
 "xFO" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil{
 	pixel_x = 3;
@@ -26985,7 +26985,7 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/nometal,
 /turf/open/floor/tile/hydro,
 /area/sulaco/hydro)
 "xPO" = (
@@ -27041,7 +27041,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
 "xWb" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
@@ -27068,11 +27068,11 @@
 /turf/open/floor/prison/plate,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
 "xXD" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /turf/open/floor/prison,
 /area/sulaco/marine)
 "xXL" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
 "xXS" = (
@@ -27098,7 +27098,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_main_hall)
 "xZq" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/reagent_containers/food/snacks/cookie,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
@@ -27137,7 +27137,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "yfM" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/item/storage/box/nt_mre,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
@@ -27262,7 +27262,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "yjH" = (
-/obj/structure/table/mainship,
+/obj/structure/table/mainship/nometal.
 /obj/structure/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -100,7 +100,7 @@
 /turf/open/floor/plating/mainship,
 /area/sulaco/engineering/engine)
 "aaq" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/mass_spectrometer,
 /obj/item/reagent_scanner,
 /obj/item/tool/hand_labeler,
@@ -119,7 +119,7 @@
 	},
 /area/sulaco/medbay/west)
 "aas" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/box/beakers{
 	pixel_x = -7;
 	pixel_y = 7
@@ -155,7 +155,7 @@
 	},
 /area/sulaco/medbay/west)
 "aav" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/reagentgrinder,
 /obj/item/stack/sheet/mineral/phoron,
 /obj/item/reagent_containers/dropper,
@@ -196,7 +196,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
 "aaG" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/stack/cable_coil,
 /obj/item/toy/deck,
 /obj/machinery/light/mainship{
@@ -245,7 +245,7 @@
 	},
 /area/sulaco/medbay/west)
 "aaS" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/firstaid/adv{
 	pixel_x = 4;
 	pixel_y = 4
@@ -303,7 +303,7 @@
 /turf/open/floor/plating/mainship,
 /area/sulaco/engineering/engine)
 "aba" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/pizzabox/meat,
 /obj/item/tool/soap/deluxe,
 /obj/item/tool/soap/deluxe,
@@ -443,7 +443,7 @@
 /turf/open/floor/prison/arrow/clean,
 /area/sulaco/cafeteria)
 "abB" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/firstaid/o2{
 	layer = 2.8;
 	pixel_x = 4;
@@ -679,7 +679,7 @@
 	},
 /area/sulaco/medbay/west)
 "acs" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/defibrillator,
 /obj/item/defibrillator,
 /turf/open/floor/prison/whitegreen/corner{
@@ -936,7 +936,7 @@
 /obj/machinery/light/mainship{
 	dir = 8
 	},
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/recharger,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 8
@@ -1145,7 +1145,7 @@
 	},
 /area/sulaco/medbay)
 "adP" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
@@ -1208,7 +1208,7 @@
 	},
 /area/sulaco/medbay)
 "adW" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/reagent_containers/glass/beaker/cryomix,
 /obj/item/reagent_containers/glass/beaker/cryomix,
 /turf/open/floor/prison/whitegreen/corner{
@@ -1222,7 +1222,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
 "aec" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/microwave,
 /obj/machinery/light/mainship{
 	dir = 4
@@ -1305,7 +1305,7 @@
 /obj/machinery/alarm{
 	dir = 1
 	},
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/recharger,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
@@ -1319,7 +1319,7 @@
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay/west)
 "aew" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/box/quickclot{
 	pixel_x = 2;
 	pixel_y = 2
@@ -1337,7 +1337,7 @@
 	},
 /area/sulaco/medbay/storage)
 "aex" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/box/masks{
 	pixel_x = -4
 	},
@@ -1367,7 +1367,7 @@
 	},
 /area/sulaco/medbay/storage)
 "aey" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/pill_bottle/packet/paracetamol{
 	pixel_y = 7
 	},
@@ -1403,7 +1403,7 @@
 	},
 /area/sulaco/medbay/storage)
 "aeA" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/healthanalyzer,
 /obj/item/healthanalyzer,
@@ -1418,7 +1418,7 @@
 	},
 /area/sulaco/medbay/storage)
 "aeB" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/box/bodybags,
 /obj/item/storage/box/bodybags,
 /obj/item/storage/box/bodybags,
@@ -1457,7 +1457,7 @@
 	},
 /area/sulaco/medbay/storage)
 "aeG" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/effect/spawner/random/toolbox,
 /obj/item/lightreplacer,
 /turf/open/floor/prison/whitegreen/corner{
@@ -1656,7 +1656,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
 "afQ" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/fancy/cigar,
 /obj/item/tool/lighter/zippo,
 /turf/open/floor/prison/darkyellow/full,
@@ -1768,7 +1768,7 @@
 /area/sulaco/engineering/ce)
 "agZ" = (
 /obj/machinery/light/mainship,
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/book/manual/marine_law,
 /obj/item/storage/box/tgmc_mre,
 /obj/structure/sign/prop2,
@@ -1993,7 +1993,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/cargo)
 "ajj" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/briefcase/inflatable,
 /obj/item/storage/briefcase/inflatable,
 /obj/item/storage/briefcase/inflatable,
@@ -2142,7 +2142,7 @@
 /turf/open/floor/prison,
 /area/sulaco/engineering)
 "ako" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/cell_charger,
 /obj/machinery/cell_charger,
 /obj/item/flashlight,
@@ -2209,7 +2209,7 @@
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay)
 "akM" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/clothing/glasses/hud/health,
 /obj/structure/paper_bin,
 /obj/item/tool/pen,
@@ -2282,7 +2282,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall2)
 "alq" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/power/apc/mainship{
 	dir = 4
 	},
@@ -2583,7 +2583,7 @@
 /turf/closed/wall/mainship/gray,
 /area/sulaco/hallway/central_hall2)
 "anq" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/alarm{
 	dir = 4
@@ -2599,7 +2599,7 @@
 /turf/open/floor/prison,
 /area/sulaco/briefing)
 "ans" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/box/lights/mixed,
 /obj/item/tool/crowbar,
 /obj/item/tool/crowbar,
@@ -2649,7 +2649,7 @@
 /turf/open/floor/prison/red,
 /area/sulaco/hallway/central_hall)
 "anJ" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/tool/crowbar,
 /obj/item/tool/crowbar,
 /obj/item/tool/crowbar,
@@ -2911,7 +2911,7 @@
 	},
 /area/sulaco/bridge)
 "apn" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/structure/flora/pottedplant{
 	icon_state = "plant-15";
 	pixel_y = 10
@@ -2976,12 +2976,12 @@
 /turf/open/floor/prison,
 /area/sulaco/bridge)
 "apz" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/computer/squad_changer,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/bridge)
 "apB" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/computer/security,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/bridge)
@@ -3124,7 +3124,7 @@
 /turf/open/floor/prison,
 /area/sulaco/cargo/office)
 "aqi" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/structure/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
@@ -3153,7 +3153,7 @@
 /turf/closed/wall/mainship/gray,
 /area/sulaco/cargo/office)
 "aqt" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/structure/window/reinforced/toughened{
 	dir = 8
 	},
@@ -3167,7 +3167,7 @@
 /area/sulaco/bridge)
 "aqu" = (
 /obj/machinery/photocopier,
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
@@ -3449,7 +3449,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/bridge)
 "arC" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/structure/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
@@ -3636,7 +3636,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/bridge)
 "asv" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/weapon/gun/smg/m25,
 /obj/item/ammo_magazine/smg/m25,
 /obj/item/ammo_magazine/smg/m25,
@@ -3734,7 +3734,7 @@
 	},
 /area/sulaco/bridge)
 "asV" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/structure/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
@@ -3814,7 +3814,7 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_north_maint)
 "atp" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/structure/window/reinforced/toughened{
 	dir = 8
 	},
@@ -3852,7 +3852,7 @@
 	},
 /area/sulaco/bridge)
 "att" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
@@ -4340,7 +4340,7 @@
 	},
 /area/sulaco/bridge)
 "avb" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /turf/open/floor/mainship/terragov{
 	dir = 8
 	},
@@ -4743,7 +4743,7 @@
 	},
 /area/sulaco/bridge)
 "awy" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /turf/open/floor/mainship/terragov/west,
 /area/sulaco/bridge)
 "awz" = (
@@ -5051,7 +5051,7 @@
 /area/sulaco/bridge/office)
 "ayx" = (
 /obj/machinery/light/mainship,
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/computer/secure_data,
 /turf/open/floor/prison/red/full{
 	dir = 1
@@ -5079,7 +5079,7 @@
 /turf/open/floor/tile/dark2,
 /area/mainship/living/basketball)
 "ayA" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/computer/station_alert,
 /turf/open/floor/prison/red{
 	dir = 10
@@ -5685,18 +5685,18 @@
 /turf/open/floor/prison,
 /area/sulaco/briefing)
 "aBB" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/effect/spawner/random/plushie/nospawnninetyfive,
 /turf/open/floor/prison,
 /area/sulaco/briefing)
 "aBC" = (
 /obj/machinery/light/mainship,
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/fancy/cigarettes/dromedaryco,
 /turf/open/floor/prison,
 /area/sulaco/briefing)
 "aBD" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/prison,
 /area/sulaco/briefing)
@@ -5829,7 +5829,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/weapon/gun/energy/taser,
 /turf/open/floor/prison/red/full{
 	dir = 1
@@ -5967,7 +5967,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/sulaco/disposal)
 "aCI" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/tool/pen,
 /obj/machinery/power/apc/mainship{
 	dir = 1
@@ -5982,7 +5982,7 @@
 /turf/open/floor/prison,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
 "aCJ" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /turf/open/floor/prison,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
 "aCK" = (
@@ -6410,7 +6410,7 @@
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
 "aEF" = (
 /obj/machinery/reagentgrinder,
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
 "aEH" = (
@@ -6574,7 +6574,7 @@
 /turf/open/floor/prison,
 /area/sulaco/engineering/lower_engineering)
 "aFs" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
@@ -6850,7 +6850,7 @@
 /turf/open/floor/wood,
 /area/sulaco/marine/chapel)
 "aHx" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/structure/paper_bin,
 /turf/open/floor/prison,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
@@ -7391,7 +7391,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
 "aKH" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/disk/botany,
 /obj/item/radio,
 /obj/machinery/door_control/old/unmeltable{
@@ -7412,7 +7412,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hydro)
 "aKK" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/computer/atmos_alert,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hydro)
@@ -7728,11 +7728,11 @@
 /turf/open/floor/prison/green,
 /area/sulaco/marine)
 "aMg" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
 "aMh" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/stack/sheet/mineral/phoron,
 /obj/item/stack/sheet/mineral/phoron,
 /obj/machinery/light/mainship{
@@ -8076,18 +8076,18 @@
 /turf/open/floor/prison/red,
 /area/sulaco/command/eva)
 "aOp" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/tool/extinguisher,
 /obj/item/tool/crowbar,
 /turf/open/floor/prison/red,
 /area/sulaco/command/eva)
 "aOq" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/toolbox/electrical,
 /turf/open/floor/prison/red,
 /area/sulaco/command/eva)
 "aOr" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/toolbox/mechanical,
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -8095,7 +8095,7 @@
 /turf/open/floor/prison/red,
 /area/sulaco/command/eva)
 "aOs" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/effect/spawner/random/tech_supply,
 /obj/effect/spawner/random/tech_supply,
 /turf/open/floor/prison/red,
@@ -8337,12 +8337,12 @@
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
 "aQl" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/box/beakers,
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
 "aQm" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/box/syringes,
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
@@ -8471,7 +8471,7 @@
 /turf/open/floor/wood,
 /area/sulaco/liaison)
 "aQY" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/power/apc/mainship{
 	dir = 4
 	},
@@ -8590,7 +8590,7 @@
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
 "aRH" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/box/monkeycubes,
 /obj/item/tool/extinguisher,
 /obj/effect/decal/warning_stripes/thin{
@@ -8742,11 +8742,11 @@
 /obj/item/storage/box/pillbottles,
 /obj/item/storage/box/pillbottles,
 /obj/item/storage/box/pillbottles,
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
 "aSq" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/stack/sheet/mineral/phoron,
 /obj/item/stack/sheet/mineral/phoron,
 /obj/item/stack/sheet/mineral/phoron,
@@ -8907,7 +8907,7 @@
 	pixel_y = 3
 	},
 /obj/item/storage/firstaid/adv,
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/firstaid/o2{
 	layer = 2.8;
 	pixel_x = 4;
@@ -9085,7 +9085,7 @@
 /turf/open/floor/prison/marked,
 /area/sulaco/hallway/lower_main_hall)
 "aUG" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker,
@@ -9179,7 +9179,7 @@
 	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
 	name = "Chemistry Cleaner"
 	},
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/tool/hand_labeler,
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
@@ -9194,7 +9194,7 @@
 /turf/open/floor/cult,
 /area/sulaco/morgue)
 "aVl" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/box/bodybags,
 /obj/item/storage/box/bodybags,
 /turf/open/floor/cult,
@@ -9611,7 +9611,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "aYH" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/reagent_containers/glass/bucket,
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -9860,7 +9860,7 @@
 "baH" = (
 /obj/machinery/computer/operating,
 /obj/machinery/camera/autoname,
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/surgical_tray,
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/medbay/hangar)
@@ -10331,7 +10331,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_foreship)
 "bjj" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/lightreplacer,
 /obj/machinery/vending/nanomed,
 /turf/open/floor/prison/bright_clean,
@@ -10465,7 +10465,7 @@
 /area/sulaco/cargo/office)
 "bvu" = (
 /obj/machinery/computer/droppod_control,
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/structure/sign/pods,
 /turf/open/floor/mainship/sterile/plain,
 /area/sulaco/hangar/droppod)
@@ -10568,7 +10568,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
 	},
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /turf/open/floor/prison/whitegreen{
 	dir = 9
 	},
@@ -10955,7 +10955,7 @@
 /turf/open/floor/mainship/tcomms,
 /area/sulaco/command/ai)
 "chQ" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/flashlight/flare,
 /obj/item/cane,
 /obj/machinery/firealarm{
@@ -10990,7 +10990,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
 "cls" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/tool/mop,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
@@ -11078,7 +11078,7 @@
 /turf/open/floor/prison,
 /area/sulaco/cargo)
 "csJ" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/electrical,
@@ -11132,7 +11132,7 @@
 	},
 /area/sulaco/medbay)
 "cvJ" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/cell_charger,
 /obj/item/lightreplacer,
 /obj/item/clothing/glasses/welding,
@@ -11163,7 +11163,7 @@
 /turf/open/floor/cult,
 /area/sulaco/morgue)
 "cyg" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/computer/security/marinemainship{
 	dir = 4;
 	pixel_x = 17
@@ -11422,7 +11422,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
 "cMp" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/reagent_containers/food/snacks/monkeyburger,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
@@ -11689,7 +11689,7 @@
 /area/sulaco/cargo)
 "cZo" = (
 /obj/machinery/light/mainship/small,
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/tool/crowbar,
 /obj/item/clothing/head/hardhat/rugged,
 /turf/open/floor/plating,
@@ -12287,7 +12287,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "dZI" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/folder/yellow,
 /obj/item/tool/pen{
 	pixel_x = 4;
@@ -12313,7 +12313,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/evac)
 "ear" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/effect/spawner/random/tech_supply,
 /obj/effect/spawner/random/tech_supply,
 /obj/effect/spawner/random/tech_supply,
@@ -12429,7 +12429,7 @@
 /turf/open/floor/wood,
 /area/mainship/living/basketball)
 "ejF" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/tool/kitchen/tray,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
@@ -12666,7 +12666,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall2)
 "eAP" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/flashlight/flare,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
@@ -12835,7 +12835,7 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/faxmachine/research,
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
@@ -13125,7 +13125,7 @@
 /turf/open/floor/mainship/black,
 /area/sulaco/mechpilotquarters)
 "fkQ" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/taperecorder,
 /obj/item/taperecorder,
 /obj/machinery/recharger,
@@ -13249,7 +13249,7 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
 "fqG" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/weapon/gun/shotgun/pump,
 /obj/item/ammo_magazine/shotgun,
 /obj/item/ammo_magazine/shotgun/buckshot,
@@ -13276,7 +13276,7 @@
 /turf/open/floor/prison,
 /area/sulaco/bar)
 "fsL" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_foreship)
 "fsW" = (
@@ -13519,7 +13519,7 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
 "fKJ" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/reagent_containers/food/condiment/saltshaker,
 /obj/item/reagent_containers/food/condiment/peppermill,
 /obj/machinery/camera/autoname{
@@ -13551,7 +13551,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_main_hall)
 "fOA" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/firstaid/adv,
 /turf/open/floor/prison,
 /area/sulaco/security)
@@ -13804,7 +13804,7 @@
 /turf/open/floor/prison/red,
 /area/sulaco/briefing)
 "gim" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/light/mainship{
 	dir = 8
 	},
@@ -14169,7 +14169,7 @@
 /turf/open/floor/freezer,
 /area/sulaco/showers)
 "gKQ" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/flashlight/flare,
 /obj/item/facepaint/brown,
 /turf/open/floor/prison/sterilewhite,
@@ -14321,7 +14321,7 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/book/manual/medical_diagnostics_manual,
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay/cmo)
@@ -14780,7 +14780,7 @@
 	},
 /area/sulaco/marine)
 "hBC" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/roller,
 /obj/item/roller,
 /obj/item/roller,
@@ -15047,7 +15047,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/briefcase/inflatable,
 /obj/item/reagent_containers/spray,
 /turf/open/floor/prison,
@@ -15076,7 +15076,7 @@
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
 "hUr" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/light/mainship/small{
 	dir = 1
 	},
@@ -15431,7 +15431,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/computer/emails,
 /turf/open/floor/wood,
 /area/sulaco/marine/chapel/chapel_office)
@@ -15590,7 +15590,7 @@
 	},
 /area/sulaco/engineering)
 "iGB" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /turf/open/floor/prison/red/full{
 	dir = 8
 	},
@@ -15602,7 +15602,7 @@
 /turf/open/floor/prison/cleanmarked,
 /area/sulaco/hangar/droppod)
 "iHn" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/lightreplacer,
 /turf/open/floor/plating,
 /area/mainship/command/self_destruct)
@@ -15615,7 +15615,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/computer/med_data/laptop,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
@@ -15883,7 +15883,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "iWH" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/firstaid,
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_foreship)
@@ -15930,7 +15930,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/sulaco/hangar/storage)
 "iZY" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /turf/open/floor/tile/darkgreen/darkgreen2{
 	dir = 5
 	},
@@ -16058,7 +16058,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/mainship/command/self_destruct)
 "jhf" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/reagent_containers/glass/beaker/biomass,
 /obj/item/reagent_containers/glass/beaker/biomass,
 /turf/open/floor/prison/whitegreen/corner{
@@ -16293,7 +16293,7 @@
 /turf/open/floor/prison,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
 "jCo" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/belt/utility/full,
 /obj/item/storage/belt/utility/full,
 /obj/machinery/light/mainship{
@@ -16377,7 +16377,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/mainship/command/self_destruct)
 "jGq" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/microwave,
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/wood,
@@ -17244,7 +17244,7 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/light/mainship{
 	dir = 8
 	},
@@ -17259,7 +17259,7 @@
 /area/sulaco/bridge)
 "kNF" = (
 /obj/structure/cable,
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/fancy/cigarettes/luckystars,
 /turf/open/floor/prison,
 /area/sulaco/bar)
@@ -17304,7 +17304,7 @@
 /obj/effect/decal/warning_stripes/thick{
 	dir = 1
 	},
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/lightreplacer,
 /obj/item/flashlight/flare,
 /turf/open/floor/prison/sterilewhite,
@@ -17794,7 +17794,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall2)
 "lDs" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/camera,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
@@ -18158,7 +18158,7 @@
 /obj/structure/closet/walllocker/emerglocker{
 	dir = 4
 	},
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/facepaint/green,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
@@ -18300,7 +18300,7 @@
 /turf/open/floor/mainship_hull/gray,
 /area/space)
 "mnO" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
@@ -18746,7 +18746,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "mRD" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/explosive/grenade/chem_grenade/cleaner,
 /obj/item/explosive/grenade/chem_grenade/cleaner,
 /obj/item/explosive/grenade/chem_grenade/cleaner,
@@ -18916,7 +18916,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/flashlight/lamp,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
@@ -19436,7 +19436,7 @@
 /obj/machinery/firealarm{
 	dir = 8
 	},
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /turf/open/floor/cult,
 /area/sulaco/morgue)
 "nVS" = (
@@ -19821,7 +19821,7 @@
 	},
 /area/sulaco/marine/chapel)
 "oux" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/healthanalyzer,
 /turf/open/floor/prison/sterilewhite,
@@ -19921,7 +19921,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/sulaco/command/ai)
 "oBg" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/clothing/ears/earmuffs,
 /turf/open/floor/prison/cellstripe{
 	dir = 1
@@ -20322,7 +20322,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/robot_parts/chest,
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
@@ -20494,7 +20494,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/dropshipprep)
 "pjA" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/reagent_containers/food/snacks/protein_pack,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
@@ -20578,7 +20578,7 @@
 	},
 /area/sulaco/medbay/cmo)
 "pmB" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/radio,
 /obj/item/radio,
 /obj/item/stack/cable_coil{
@@ -20699,7 +20699,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "ptE" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/reagent_containers/food/snacks/monkeyburger,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
@@ -21196,7 +21196,7 @@
 /turf/open/floor/plating/mainship,
 /area/sulaco/engineering/engine)
 "qjQ" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/defibrillator,
 /obj/item/defibrillator,
 /turf/open/floor/prison/whitegreen/corner{
@@ -21456,7 +21456,7 @@
 /turf/open/floor/mainship_hull/gray/dir,
 /area/space)
 "qDX" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/effect/spawner/random/plushie/nospawnninetyfive,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
@@ -21535,7 +21535,7 @@
 /turf/open/floor/prison,
 /area/sulaco/engineering/lower_engineering)
 "qJY" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/faxmachine/cic,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/bridge)
@@ -21646,7 +21646,7 @@
 /turf/open/floor/prison,
 /area/mainship/shipboard/weapon_room)
 "qSR" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/structure/paper_bin,
 /obj/item/clipboard,
 /obj/item/tool/pen,
@@ -22352,7 +22352,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "rIv" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/tool/stamp{
 	name = "Quartermaster's stamp"
 	},
@@ -22372,7 +22372,7 @@
 /obj/machinery/firealarm{
 	dir = 4
 	},
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /turf/open/floor/wood,
 /area/sulaco/medbay/west)
 "rIx" = (
@@ -22433,7 +22433,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/oil,
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/clothing/head/helmet/marine/robot/heavy,
 /obj/machinery/light/mainship/small,
 /turf/open/floor/prison,
@@ -22496,7 +22496,7 @@
 	},
 /area/sulaco/marine)
 "rSi" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/ashtray/glass,
 /turf/open/floor/prison,
 /area/sulaco/bar)
@@ -22774,7 +22774,7 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
 "shz" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/prop/mainship/computer{
 	dir = 4
 	},
@@ -23139,7 +23139,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_foreship)
 "sId" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/tool/hand_labeler,
 /obj/item/tool/hand_labeler,
 /turf/open/floor/prison,
@@ -23162,7 +23162,7 @@
 	},
 /area/sulaco/hangar)
 "sIy" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/computer/supplydrop_console,
 /obj/machinery/light/mainship{
 	dir = 8
@@ -23488,7 +23488,7 @@
 /turf/closed/wall/mainship/gray,
 /area/sulaco/bridge)
 "tbN" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
@@ -23609,7 +23609,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/hallway/lower_foreship)
 "tiD" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/prop/mainship/computer{
 	dir = 8
 	},
@@ -23677,7 +23677,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "tlQ" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/effect/spawner/random/toolbox,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
@@ -24032,7 +24032,7 @@
 /turf/open/floor/prison/kitchen,
 /area/sulaco/cafeteria)
 "tJx" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/clothing/glasses/meson,
 /obj/item/paper,
 /obj/item/tool/pen,
@@ -24109,7 +24109,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hangar/cas)
 "tOk" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/flashlight/lamp,
 /obj/machinery/firealarm{
 	dir = 8
@@ -24146,7 +24146,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_foreship)
 "tPL" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/tool/pen,
 /obj/structure/paper_bin,
@@ -24169,7 +24169,7 @@
 /turf/open/floor/prison,
 /area/sulaco/marine/chapel)
 "tRg" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /turf/open/floor/prison,
 /area/sulaco/bar)
 "tRW" = (
@@ -24381,7 +24381,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar/droppod)
 "uhf" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/light/mainship,
 /obj/item/reagent_containers/food/snacks/hotdog,
 /turf/open/floor/prison/sterilewhite,
@@ -24414,7 +24414,7 @@
 /turf/open/floor/prison,
 /area/sulaco/cargo/prep)
 "uiN" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/weapon/gun/rifle/m412,
 /obj/item/ammo_magazine/rifle,
 /obj/item/ammo_magazine/rifle,
@@ -24567,7 +24567,7 @@
 /turf/open/floor/plating,
 /area/sulaco/engineering/engine_monitoring)
 "uwG" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/light/mainship,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
@@ -24678,7 +24678,7 @@
 /turf/open/floor/prison/darkyellow/corner,
 /area/sulaco/engineering)
 "uDh" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/stack/sheet/cardboard{
 	amount = 50
 	},
@@ -25426,7 +25426,7 @@
 /turf/closed/wall/mainship/white/outer,
 /area/sulaco/medbay/west)
 "vIy" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/door_control/old/req{
 	id = "Reqshutters";
 	name = "Req Lockdown";
@@ -25733,7 +25733,7 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
 "wco" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/clothing/head/warning_cone,
 /obj/item/clothing/head/warning_cone,
 /obj/item/clothing/head/warning_cone,
@@ -26005,7 +26005,7 @@
 /turf/open/floor/prison/darkyellow/corner,
 /area/sulaco/engineering/ce)
 "wyw" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/reagent_containers/food/snacks/grilledcheese{
 	desc = "'The best grilled cheese this side of Uranus!' (tm)";
 	name = "Sandwich Joe's Grilled Cheese";
@@ -26022,7 +26022,7 @@
 	},
 /area/space)
 "wAj" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/door/window{
 	dir = 8
 	},
@@ -26666,7 +26666,7 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/machinery/computer/shuttle/shuttle_control/dropship,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26720,7 +26720,7 @@
 /turf/open/floor/mainship/ai,
 /area/sulaco/command/ai)
 "xzB" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/clipboard,
 /obj/item/tool/stamp/cmo,
 /obj/machinery/camera/autoname,
@@ -26803,7 +26803,7 @@
 /turf/open/floor/wood,
 /area/mainship/living/basketball)
 "xFO" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil{
 	pixel_x = 3;
@@ -27041,7 +27041,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
 "xWb" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
@@ -27068,11 +27068,11 @@
 /turf/open/floor/prison/plate,
 /area/sulaco/maintenance/upperdeck_AIcore_maint)
 "xXD" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /turf/open/floor/prison,
 /area/sulaco/marine)
 "xXL" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
 "xXS" = (
@@ -27098,7 +27098,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_main_hall)
 "xZq" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/reagent_containers/food/snacks/cookie,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
@@ -27137,7 +27137,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hangar/storage)
 "yfM" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/item/storage/box/nt_mre,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
@@ -27262,7 +27262,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "yjH" = (
-/obj/structure/table/mainship/nometal.
+/obj/structure/table/mainship/nometal,
 /obj/structure/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7

--- a/code/game/objects/items/frames/table_rack.dm
+++ b/code/game/objects/items/frames/table_rack.dm
@@ -21,7 +21,7 @@
 /obj/item/frame/table/attackby(obj/item/I, mob/user, params)
 	. = ..()
 
-	if(iswrench(I) && deconstruct_type))
+	if(iswrench(I) && deconstruct_type)
 		new deconstruct_type(loc)
 		qdel(src)
 

--- a/code/game/objects/items/frames/table_rack.dm
+++ b/code/game/objects/items/frames/table_rack.dm
@@ -17,11 +17,12 @@
 	attack_verb = list("slammed", "bashed", "battered", "bludgeoned", "thrashed", "whacked")
 	var/table_type = /obj/structure/table //what type of table it creates when assembled
 	var/deconstruct_type = /obj/item/stack/sheet/metal
+	var/dropmetal_on_deconstruct = TRUE
 
 /obj/item/frame/table/attackby(obj/item/I, mob/user, params)
 	. = ..()
 
-	if(iswrench(I))
+	if(iswrench(I) && dropmetal_on_deconstruct)
 		new deconstruct_type(loc)
 		qdel(src)
 
@@ -53,13 +54,13 @@
 	if(locate(/obj/structure/table) in get_turf(user))
 		to_chat(user, span_warning("There is another table built in here already."))
 		return
-	if(istype(get_area(loc), /area/shuttle))  //HANGAR/SHUTTLE BUILDING
-		to_chat(user, span_warning("No. This area is needed for the dropship."))
-		return
 
 	new table_type(user.loc)
 	user.drop_held_item()
 	qdel(src)
+
+/obj/item/frame/table/nometal
+	dropmetal_on_deconstruct = FALSE
 
 /*
 * Reinforced Table Parts

--- a/code/game/objects/items/frames/table_rack.dm
+++ b/code/game/objects/items/frames/table_rack.dm
@@ -17,6 +17,7 @@
 	attack_verb = list("slammed", "bashed", "battered", "bludgeoned", "thrashed", "whacked")
 	var/table_type = /obj/structure/table //what type of table it creates when assembled
 	var/deconstruct_type = /obj/item/stack/sheet/metal
+	//do we drop metal when deconstructing parts?
 	var/dropmetal_on_deconstruct = TRUE
 
 /obj/item/frame/table/attackby(obj/item/I, mob/user, params)

--- a/code/game/objects/items/frames/table_rack.dm
+++ b/code/game/objects/items/frames/table_rack.dm
@@ -54,6 +54,9 @@
 	if(locate(/obj/structure/table) in get_turf(user))
 		to_chat(user, span_warning("There is another table built in here already."))
 		return
+	if(istype(get_area(loc), /area/shuttle))  //HANGAR/SHUTTLE BUILDING
+		to_chat(user, span_warning("No. This area is needed for the dropship."))
+		return
 
 	new table_type(user.loc)
 	user.drop_held_item()

--- a/code/game/objects/items/frames/table_rack.dm
+++ b/code/game/objects/items/frames/table_rack.dm
@@ -21,7 +21,7 @@
 /obj/item/frame/table/attackby(obj/item/I, mob/user, params)
 	. = ..()
 
-	if(iswrench(I) && !(deconstruct_type == null))
+	if(iswrench(I) && deconstruct_type))
 		new deconstruct_type(loc)
 		qdel(src)
 

--- a/code/game/objects/items/frames/table_rack.dm
+++ b/code/game/objects/items/frames/table_rack.dm
@@ -62,7 +62,7 @@
 	qdel(src)
 
 /obj/item/frame/table/nometal
-	dropmetal_on_deconstruct = null
+	deconstruct_type = null
 
 /*
 * Reinforced Table Parts

--- a/code/game/objects/items/frames/table_rack.dm
+++ b/code/game/objects/items/frames/table_rack.dm
@@ -17,13 +17,11 @@
 	attack_verb = list("slammed", "bashed", "battered", "bludgeoned", "thrashed", "whacked")
 	var/table_type = /obj/structure/table //what type of table it creates when assembled
 	var/deconstruct_type = /obj/item/stack/sheet/metal
-	//do we drop metal when deconstructing parts?
-	var/dropmetal_on_deconstruct = TRUE
 
 /obj/item/frame/table/attackby(obj/item/I, mob/user, params)
 	. = ..()
 
-	if(iswrench(I) && dropmetal_on_deconstruct)
+	if(iswrench(I) && !(deconstruct_type == null))
 		new deconstruct_type(loc)
 		qdel(src)
 
@@ -64,7 +62,7 @@
 	qdel(src)
 
 /obj/item/frame/table/nometal
-	dropmetal_on_deconstruct = FALSE
+	dropmetal_on_deconstruct = null
 
 /*
 * Reinforced Table Parts

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -50,10 +50,6 @@
 
 	if(!istype(user.loc,/turf)) return 0
 
-	if(istype(get_area(usr.loc),/area/sulaco/hangar))  //HANGER BUILDING
-		to_chat(usr, span_warning("No. This area is needed for the dropships and personnel."))
-		return
-
 	if (locate(/obj/structure/grille, usr.loc))
 		for(var/obj/structure/grille/G in usr.loc)
 			if (G.obj_integrity <= G.integrity_failure)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -26,6 +26,7 @@
 	max_integrity = 40
 
 /obj/structure/table/mainship/nometal
+	parts = /obj/item/frame/table/nometal
 	dropmetal = FALSE
 
 /obj/structure/table/deconstruct(disassembled)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Apparently I missed this map when doing https://github.com/tgstation/TerraGov-Marine-Corps/pull/10248, while I was fixing that oversight I also changed tables so you can't game them by deconstructing them into parts and then turning the parts into metal.

I also removed a random check that existed to prevent building in a hangar.

## Why It's Good For The Game

Oversights bad, it needs done because apparently it's becoming an issue again.

## Changelog
:cl:
balance: You can no longer deconstruct Sulaco's tables and chairs for metal.
fix: Fixed an oversight where you could deconstruct tables for parts, then parts for metal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
