### PR TITLE
Nerfs MP-19 akimbo delay

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -69,7 +69,7 @@
 	aim_slowdown = 0.15
 	burst_amount = 5
 	movement_acc_penalty_mult = 2
-	akimbo_additional_delay = 1.0
+	akimbo_additional_delay = 1.2
 	upper_akimbo_accuracy = 5
 	lower_akimbo_accuracy = 3
 

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -69,7 +69,7 @@
 	aim_slowdown = 0.15
 	burst_amount = 5
 	movement_acc_penalty_mult = 2
-	akimbo_additional_delay = 1.2
+	akimbo_additional_delay = 1.3
 	upper_akimbo_accuracy = 5
 	lower_akimbo_accuracy = 3
 

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -69,7 +69,7 @@
 	aim_slowdown = 0.15
 	burst_amount = 5
 	movement_acc_penalty_mult = 2
-	akimbo_additional_delay = 0.5
+	akimbo_additional_delay = 1.0
 	upper_akimbo_accuracy = 5
 	lower_akimbo_accuracy = 3
 


### PR DESCRIPTION
## About The Pull Request
Per title. Akimbo delay increased from 0.5 to 1.3.

## Why It's Good For The Game
Funny double MP-19 man shouldn't be almost instantly shredding through xeno health like a HOT (thank you mr. @revelation-8468) knife through butter.

## Changelog
:cl: Lewdcifer
balance: MP-19 akimbo delay 0.5 > 1.3.
/:cl: