### PR TITLE
CL shutters now start open on Theseus

### DIFF
--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -9703,11 +9703,13 @@
 /area/mainship/command/corporateliaison)
 "etF" = (
 /obj/structure/window/framed/mainship,
-/obj/machinery/door/poddoor/shutters/mainship/corporate{
-	dir = 2
-	},
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
+	},
+/obj/machinery/door/poddoor/shutters/mainship/open{
+	dir = 2;
+	id = "cl_shutters";
+	name = "\improper Privacy Shutters"
 	},
 /turf/open/floor/plating,
 /area/mainship/command/corporateliaison)
@@ -16586,8 +16588,10 @@
 /obj/machinery/door/airlock/mainship/generic/corporate{
 	dir = 2
 	},
-/obj/machinery/door/poddoor/shutters/mainship/corporate{
-	dir = 2
+/obj/machinery/door/poddoor/shutters/mainship/open{
+	dir = 2;
+	id = "cl_shutters";
+	name = "\improper Privacy Shutters"
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.
CLs were getting locked out of their office roundstart, in an earlier PR I gave an extra button to the CL in the CIC as an override, but the button isn't noticeable and the area near the CL office is cluttered so there's no easy place to relocate the button.

I've opted to just start the doors open at roundstart, if the CL needs to close the shutters he has a button inside his quarters.

## Why It's Good For The Game

It should lead to less locked out CLs.

## Changelog
:cl:
balance: The CL office on Theseus now starts open on roundstart.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
