### PR TITLE
Spitter can evolve to defiler

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -4535,7 +4535,13 @@
 /area/mainship/shipboard/firing_range)
 "nj" = (
 /obj/structure/table/mainship/nometal,
-/obj/item/folder/white,
+/obj/machinery/reagentgrinder,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
 /obj/machinery/light/mainship{
 	dir = 1
 	},
@@ -8075,6 +8081,7 @@
 /area/mainship/hallways/hangar)
 "xm" = (
 /obj/structure/table/mainship/nometal,
+/obj/item/folder/white,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "xn" = (

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -28,6 +28,7 @@
 	evolves_to = list(
 		/mob/living/carbon/xenomorph/boiler,
 		/mob/living/carbon/xenomorph/praetorian,
+		/mob/living/carbon/xenomorph/defiler,
 	)
 	deevolves_to = /mob/living/carbon/xenomorph/sentinel
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

1) Both spitter and defiler are chem based castes, and sent is practically defiler lite.
2) The sent caste is limited to its own castes compare to the drone, runner, and now defender castes. You can evolve from sent to spitter then defiler and choose to devolve to drone or runner castes. This enables flexbility for sent and defiler players.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Spitter can evolve to defiler
balance: xenomorph players can change move from sent caste to other caste to adapt to situation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
