### PR TITLE
Increases tyr helmet module armor to Hod level

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -117,7 +117,7 @@
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "tyr_head"
 	item_state = "tyr_head_a"
-	soft_armor = list(MELEE = 15, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 10, BIO = 10, FIRE = 10, ACID = 10)
+	soft_armor = list(MELEE = 15, BULLET = 40, LASER = 10, ENERGY = 10, BOMB = 10, BIO = 10, FIRE = 10, ACID = 10)
 	slot = ATTACHMENT_SLOT_HEAD_MODULE
 	variants_by_parent_type = list(/obj/item/clothing/head/modular/marine/m10x = "tyr_head_xn", /obj/item/clothing/head/modular/marine/m10x/leader = "tyr_head_xn")
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Increases tyr helmet system bullet armor value from 10 to 40.

## Why It's Good For The Game
Brings it up to par with Hod module armor so that bullets hitting your head doesn't invalidate the body armor value, which is a big deal given that's the entire purpose of Hod as it already offers considerably slowdown and no direct benefit vs xenos. Same issue that caused the tyr helmet system to appear, IE helmet having less armor than body with the module. Ideally there'd be a separate helmet module entirely but I lack the ability to code it and have no sprite to go with it.

Ideally has little to no impact for xenos. Still competes with antenna module. Worst case scenario every marine might go with it and aim head to invalidate it, but that'd require levels of coordination unheard of on top of being very reckless on a marine just aiming head and mindlessly spraying into marines even more than some currently do.

If there's anyone able to code a separate module, I'll vouch for your pr to get merged rather than this one. Otherwise, this'll have to do.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Tyr helmet module now offers bullet armor comparable to Hod module.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
