### PR TITLE
Cleans the server

### DIFF
--- a/code/game/blood.dm
+++ b/code/game/blood.dm
@@ -135,11 +135,11 @@
 
 /mob/living/carbon/human/clean_mob()
 	. = ..()
-	var/washgloves = 1
-	var/washshoes = 1
-	var/washmask = 1
-	var/washears = 1
-	var/washglasses = 1
+	var/washgloves = TRUE
+	var/washshoes = TRUE
+	var/washmask = TRUE
+	var/washears = TRUE
+	var/washglasses = TRUE
 	if(wear_suit)
 		washgloves = !(wear_suit.flags_inv_hide & HIDEGLOVES)
 		washshoes = !(wear_suit.flags_inv_hide & HIDESHOES)

--- a/code/game/blood.dm
+++ b/code/game/blood.dm
@@ -115,6 +115,65 @@
 		update_inv_shoes()
 		return TRUE
 
+///Washes the blood and such off a mob
+/mob/living/proc/clean_mob()
+	clean_blood()
 
+/mob/living/carbon/clean_mob()
+	. = ..()
+	if(r_hand)
+		r_hand.clean_blood()
+	if(l_hand)
+		l_hand.clean_blood()
+	if(back)
+		if(back.clean_blood())
+			update_inv_back(0)
+	if(!ishuman(src))
+		if(wear_mask)//if the mob is not human, it cleans the mask without asking for bitflags
+			if(wear_mask.clean_blood())
+				update_inv_wear_mask()
 
-
+/mob/living/carbon/human/clean_mob()
+	. = ..()
+	var/washgloves = 1
+	var/washshoes = 1
+	var/washmask = 1
+	var/washears = 1
+	var/washglasses = 1
+	if(wear_suit)
+		washgloves = !(wear_suit.flags_inv_hide & HIDEGLOVES)
+		washshoes = !(wear_suit.flags_inv_hide & HIDESHOES)
+		if(wear_suit.clean_blood())
+			update_inv_wear_suit()
+	else if(w_uniform)
+		if(w_uniform.clean_blood())
+			update_inv_w_uniform()
+	if(head)
+		washmask = !(head.flags_inv_hide & HIDEMASK)
+		washglasses = !(head.flags_inv_hide & HIDEEYES)
+		washears = !(head.flags_inv_hide & HIDEEARS)
+		if(head.clean_blood())
+			update_inv_head()
+	if(wear_mask)
+		if(washears)
+			washears = !(wear_mask.flags_inv_hide & HIDEEARS)
+		if(washglasses)
+			washglasses = !(wear_mask.flags_inv_hide & HIDEEYES)
+		if(washmask && wear_mask.clean_blood())
+			update_inv_wear_mask()
+	if(gloves && washgloves)
+		if(gloves.clean_blood())
+			update_inv_gloves()
+	if(shoes && washshoes)
+		if(shoes.clean_blood())
+			update_inv_shoes()
+	if(glasses && washglasses)
+		if(glasses.clean_blood())
+			update_inv_glasses()
+	if(wear_ear && washears)
+		if(wear_ear.clean_blood())
+			update_inv_ears()
+	if(belt)
+		if(belt.clean_blood())
+			update_inv_belt()
+	clean_blood(washshoes)

--- a/code/game/objects/items/tools/cleaning_tools.dm
+++ b/code/game/objects/items/tools/cleaning_tools.dm
@@ -107,6 +107,10 @@
 	//So this is a workaround. This also makes more sense from an IC standpoint. ~Carn
 	if(user.client && (target in user.client.screen))
 		to_chat(user, span_notice("You need to take that [target.name] off before cleaning it."))
+	else if(isturf(target))
+		to_chat(user, span_notice("You scrub \the [target.name]."))
+		var/turf/target_turf = target
+		target_turf.clean_turf()
 	else if(istype(target,/obj/effect/decal/cleanable))
 		to_chat(user, span_notice("You scrub \the [target.name] out."))
 		qdel(target)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -269,73 +269,7 @@
 		L.ExtinguishMob()
 		L.fire_stacks = -20 //Douse ourselves with water to avoid fire more easily
 		to_chat(L, span_warning("You've been drenched in water!"))
-		if(iscarbon(O))
-			var/mob/living/carbon/M = O
-			if(M.r_hand)
-				M.r_hand.clean_blood()
-			if(M.l_hand)
-				M.l_hand.clean_blood()
-			if(M.back)
-				if(M.back.clean_blood())
-					M.update_inv_back(0)
-			if(ishuman(M))
-				var/mob/living/carbon/human/H = M
-				var/washgloves = 1
-				var/washshoes = 1
-				var/washmask = 1
-				var/washears = 1
-				var/washglasses = 1
-
-				if(H.wear_suit)
-					washgloves = !(H.wear_suit.flags_inv_hide & HIDEGLOVES)
-					washshoes = !(H.wear_suit.flags_inv_hide & HIDESHOES)
-
-				if(H.head)
-					washmask = !(H.head.flags_inv_hide & HIDEMASK)
-					washglasses = !(H.head.flags_inv_hide & HIDEEYES)
-					washears = !(H.head.flags_inv_hide & HIDEEARS)
-
-				if(H.wear_mask)
-					if (washears)
-						washears = !(H.wear_mask.flags_inv_hide & HIDEEARS)
-					if (washglasses)
-						washglasses = !(H.wear_mask.flags_inv_hide & HIDEEYES)
-
-				if(H.head)
-					if(H.head.clean_blood())
-						H.update_inv_head()
-				if(H.wear_suit)
-					if(H.wear_suit.clean_blood())
-						H.update_inv_wear_suit()
-				else if(H.w_uniform)
-					if(H.w_uniform.clean_blood())
-						H.update_inv_w_uniform()
-				if(H.gloves && washgloves)
-					if(H.gloves.clean_blood())
-						H.update_inv_gloves()
-				if(H.shoes && washshoes)
-					if(H.shoes.clean_blood())
-						H.update_inv_shoes()
-				if(H.wear_mask && washmask)
-					if(H.wear_mask.clean_blood())
-						H.update_inv_wear_mask()
-				if(H.glasses && washglasses)
-					if(H.glasses.clean_blood())
-						H.update_inv_glasses()
-				if(H.wear_ear && washears)
-					if(H.wear_ear.clean_blood())
-						H.update_inv_ears()
-				if(H.belt)
-					if(H.belt.clean_blood())
-						H.update_inv_belt()
-				H.clean_blood(washshoes)
-			else
-				if(M.wear_mask)						//if the mob is not human, it cleans the mask without asking for bitflags
-					if(M.wear_mask.clean_blood())
-						M.update_inv_wear_mask()
-				M.clean_blood()
-		else
-			O.clean_blood()
+		L.clean_mob()
 
 	if(isturf(loc))
 		var/turf/tile = loc

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -270,13 +270,8 @@
 		L.fire_stacks = -20 //Douse ourselves with water to avoid fire more easily
 		to_chat(L, span_warning("You've been drenched in water!"))
 		L.clean_mob()
-
-	if(isturf(loc))
-		var/turf/tile = loc
-		loc.clean_blood()
-		for(var/obj/effect/E in tile)
-			if(istype(E,/obj/effect/rune) || istype(E,/obj/effect/decal/cleanable) || istype(E,/obj/effect/overlay))
-				qdel(E)
+	else
+		O.clean_blood()
 
 /obj/machinery/shower/process()
 	if(!on)
@@ -293,7 +288,7 @@
 	is_washing = TRUE
 	addtimer(VARSET_CALLBACK(src, is_washing, FALSE), 10 SECONDS)
 	var/turf/T = get_turf(src)
-	T.clean(src)
+	T.clean_turf()
 
 /obj/machinery/shower/proc/check_heat(mob/M)
 	if(!on || watertemp == WATER_TEMP_NORMAL)

--- a/code/game/turfs/open_ground.dm
+++ b/code/game/turfs/open_ground.dm
@@ -51,12 +51,9 @@
 	if(iscarbon(arrived))
 		var/mob/living/carbon/C = arrived
 		var/river_slowdown = 1.75
+		C.clean_mob()
 
-		if(ishuman(C))
-			var/mob/living/carbon/human/H = C
-			cleanup(H)
-
-		else if(isxeno(C))
+		if(isxeno(C))
 			if(!isxenoboiler(C))
 				river_slowdown = 1.3
 			else
@@ -66,21 +63,6 @@
 			C.ExtinguishMob()
 
 		C.next_move_slowdown += river_slowdown
-
-
-/turf/open/ground/river/proc/cleanup(mob/living/carbon/human/H)
-	if(H.back?.clean_blood())
-		H.update_inv_back()
-	if(H.wear_suit?.clean_blood())
-		H.update_inv_wear_suit()
-	if(H.w_uniform?.clean_blood())
-		H.update_inv_w_uniform()
-	if(H.gloves?.clean_blood())
-		H.update_inv_gloves()
-	if(H.shoes?.clean_blood())
-		H.update_inv_shoes()
-	H.clean_blood()
-
 
 /turf/open/ground/river/poison/Initialize()
 	. = ..()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -933,3 +933,8 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	// Balloon alerts occuring on turf objects result in mass spam of alerts.
 	// Thus, no more balloon alerts for turfs.
 	return
+
+///cleans any cleanable decals from the turf
+/turf/proc/clean_turf()
+	for(var/obj/effect/decal/cleanable/filth in src)
+		qdel(filth) //dirty, filthy floor


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Soap REFACTORED
Showers REFACTORED
Rivers FRESH
Server CLEANER THAN EVER

Adds a clean_mob() and clean_turf() proc to mobs and turfs respectively. Maybe I should have just added this at the atom level but eh.

Made shower code a little bit less guh, and means RIP's rain pr can just reference this proc instead of copy pasting shower code, like I've done with river code.
Soap can now actually target a turf to clean all the crap off it instead of targeting one decal at a time.

Fixes a pretty funny bug where showers can be used to qdel ANY effect/overlay, for example OB/CAS laser indicators, certain effects like timestop and gib animations. Also palmtrees.
Also stops showers from runtiming constantly as they clean decals in the most bizarre way possible.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cleaner cleaning code
bugfix good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Buffed soap. You can now directly clean turfs
fix: fixed some shower exploits/bugs
refactor: refactored soap, showers and rivers slightly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
