### PR TITLE
Tadpole Rotation Bugfix

### DIFF
--- a/code/game/objects/machinery/computer/camera_advanced.dm
+++ b/code/game/objects/machinery/computer/camera_advanced.dm
@@ -211,6 +211,8 @@
 	var/tiles_moved = 0
 	/// Limits tiles_moved to this value.
 	var/max_tile_acceleration = 8
+	/// last direction moved
+	var/direction_moved = 0
 	var/cooldown = 0
 	var/acceleration = TRUE
 	var/mob/living/eye_user = null
@@ -247,7 +249,7 @@
 		return
 	if(T.z != z && use_static)
 		GLOB.cameranet.visibility(src, GetViewerClient(), null, use_static)
-	dir = get_dir(src, target)
+	direction_moved = get_dir(src, target)
 	abstract_move(T)
 	if(use_static)
 		GLOB.cameranet.visibility(src, GetViewerClient(), null, use_static)
@@ -278,7 +280,7 @@
 	cooldown = world.time + move_delay * (1 - acceleration * tiles_moved / 10)
 	var/turf/T = get_turf(get_step(src, direct))
 	// check for dir change , if we changed then remove all acceleration
-	if(get_dir(src, T) != dir)
+	if(get_dir(src, T) != direction_moved)
 		tiles_moved = 0
 	tiles_moved = min(tiles_moved++, max_tile_acceleration)
 	setLoc(T)

--- a/code/game/objects/machinery/computer/camera_advanced.dm
+++ b/code/game/objects/machinery/computer/camera_advanced.dm
@@ -212,7 +212,7 @@
 	/// Limits tiles_moved to this value.
 	var/max_tile_acceleration = 8
 	/// last direction moved
-	var/direction_moved = 0
+	var/direction_moved
 	var/cooldown = 0
 	var/acceleration = TRUE
 	var/mob/living/eye_user = null


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes issue #11067 caused by bug introduced in #11002. Tad now lands in the direction expected.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Funny tad spin is not a feature and I don't like it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Tadpole now lands in the correct direction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
