### PR TITLE
Remove autosplint break from warrior punch

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -505,10 +505,6 @@
 			target_zone = BODY_ZONE_CHEST
 			L =  carbon_victim.get_limb(target_zone)
 
-		if(L.limb_status & LIMB_SPLINTED) //If they have it splinted, the splint won't hold.
-			L.remove_limb_flags(LIMB_SPLINTED)
-			to_chat(src, span_danger("The splint on your [L.display_name] comes apart!"))
-
 		L.take_damage_limb(damage, 0, FALSE, FALSE, get_soft_armor("melee", target_zone))
 	else
 		apply_damage(damage, BRUTE, target_zone, get_soft_armor("melee", target_zone))


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Warrior's punch ability is currently hardcoded to break your splint no matter what, which is super cringe.
Even without this it's still likely to break your splint, just not 100% guaranteed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
autobreak is cringe.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Warrior punch is no longer 100% guaranteed to always break splints
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
