### PR TITLE
Plasma cutter now has the ability to nodrop toggle.

### DIFF
--- a/code/game/objects/items/tools/mining_tools.dm
+++ b/code/game/objects/items/tools/mining_tools.dm
@@ -309,3 +309,18 @@
 	cut_apart(user, O.name, O)
 	qdel(O)
 	return TRUE
+
+/obj/item/tool/pickaxe/plasmacutter/AltClick(mob/user)
+	if(!can_interact(user))
+		return ..()
+	if(!ishuman(user))
+		return ..()
+	if(!(user.l_hand == src || user.r_hand == src))
+		return ..()
+	TOGGLE_BITFIELD(flags_item, NODROP)
+	if(CHECK_BITFIELD(flags_item, NODROP))
+		to_chat(user, span_warning("You feel the [src] clamp shut around your hand!"))
+		playsound(user, 'sound/weapons/fistclamp.ogg', 25, 1, 7)
+	else
+		to_chat(user, span_notice("You feel the [src] loosen around your hand!"))
+		playsound(user, 'sound/weapons/fistunclamp.ogg', 25, 1, 7)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Works like shield and powerfist
![image](https://user-images.githubusercontent.com/46353991/198236595-943dcbab-07a1-4d66-a15a-5ae7ad72f4ce.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes plasma cutter more reliable in the age of xeno drag and makes sense anyway considering its a high value item.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Plasma cutter now has togggleable nodrop.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
