### PR TITLE
Explosion light fix

### DIFF
--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -17,9 +17,8 @@
 	set_light(radius, radius, color)
 
 	var/image/I = image('icons/effects/explosion.dmi',src,"explosion",10 , pixel_x = -16, pixel_y = -16)
-	var/angle = rand(0, 359)
 	var/matrix/rotate = matrix()
-	rotate.Turn(angle)
+	rotate.Turn(rand(0, 359))
 	I.transform = rotate
 	add_overlay(I) //we use an overlay so the explosion and light source are both in the correct location
 

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -10,13 +10,13 @@
 	duration = 8
 	light_system = STATIC_LIGHT
 	///The icon for the explosion itself
-	var/explosion_icon
+	var/explosion_icon = "explosion"
 
 /obj/effect/temp_visual/explosion/Initialize(mapload, radius, color)
 	. = ..()
 	set_light(radius, radius, color)
 
-	var/image/I = image('icons/effects/explosion.dmi',src,"explosion",10 , pixel_x = -16, pixel_y = -16)
+	var/image/I = image(icon, src, explosion_icon, 10, pixel_x = -16, pixel_y = -16)
 	var/matrix/rotate = matrix()
 	rotate.Turn(rand(0, 359))
 	I.transform = rotate

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -6,21 +6,20 @@
 /obj/effect/temp_visual/explosion
 	name = "explosion"
 	icon = 'icons/effects/explosion.dmi'
-	icon_state = ""
+	icon_state = "explosion"
 	duration = 8
 	light_system = STATIC_LIGHT
-	///The icon for the explosion itself
-	var/explosion_icon = "explosion"
 
 /obj/effect/temp_visual/explosion/Initialize(mapload, radius, color)
 	. = ..()
 	set_light(radius, radius, color)
 
-	var/image/I = image(icon, src, explosion_icon, 10, pixel_x = -16, pixel_y = -16)
+	var/image/I = image(icon, src, icon_state, 10, pixel_x = -16, pixel_y = -16)
 	var/matrix/rotate = matrix()
 	rotate.Turn(rand(0, 359))
 	I.transform = rotate
-	add_overlay(I) //we use an overlay so the explosion and light source are both in the correct location
+	overlays += I //we use an overlay so the explosion and light source are both in the correct location
+	icon_state = null
 
 //unsorted miscellaneous temporary visuals
 /obj/effect/temp_visual/dir_setting/bloodsplatter

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -6,15 +6,22 @@
 /obj/effect/temp_visual/explosion
 	name = "explosion"
 	icon = 'icons/effects/explosion.dmi'
-	icon_state = "explosion"
+	icon_state = ""
 	duration = 8
-	pixel_x = -16
-	pixel_y = -16
 	light_system = STATIC_LIGHT
+	///The icon for the explosion itself
+	var/explosion_icon
 
 /obj/effect/temp_visual/explosion/Initialize(mapload, radius, color)
 	. = ..()
 	set_light(radius, radius, color)
+
+	var/image/I = image('icons/effects/explosion.dmi',src,"explosion",10, pixel_x = -16, pixel_y = -16)
+	var/angle = rand(0, 359)
+	var/matrix/rotate = matrix()
+	rotate.Turn(angle)
+	I.transform = rotate
+	add_overlay(I) //we use an overlay so the explosion and light source are both in the correct location
 
 //unsorted miscellaneous temporary visuals
 /obj/effect/temp_visual/dir_setting/bloodsplatter

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -16,7 +16,7 @@
 	. = ..()
 	set_light(radius, radius, color)
 
-	var/image/I = image('icons/effects/explosion.dmi',src,"explosion",10, pixel_x = -16, pixel_y = -16)
+	var/image/I = image('icons/effects/explosion.dmi',src,"explosion",10 , pixel_x = -16, pixel_y = -16)
 	var/angle = rand(0, 359)
 	var/matrix/rotate = matrix()
 	rotate.Turn(angle)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The explosion visual and lighting effect are now both correctly centered on where the explosion occured.

The cool new explosion animation and lighting effect had an offset problem, where the explosion was centered but the light was not.
This is because the light source is based off where the icon is, which is offset due to being 64x64.

Making the explosion an overlay fixed this, as that can be offset separately. I also gave it a rotate, so while barely noticable, it means when you have 10 explosion go off on screen at once, they won't all be perfectly identical, which I think is visually nice.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed explosion lights not being correctly centered
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
