### PR TITLE
Mech Balance changes 2.0

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2450,21 +2450,21 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/energy/lasgun/marine/mech
 	name = "superheated laser bolt"
-	damage = 50
+	damage = 45
 	penetration = 20
 	sundering = 1
 	damage_falloff = 0.5
 
 /datum/ammo/energy/lasgun/marine/mech/burst
-	damage = 50
+	damage = 40
 	penetration = 20
 	sundering = 0.75
 	damage_falloff = 0.6
 
 /datum/ammo/energy/lasgun/marine/mech/smg
 	name = "superheated pulsed laser bolt"
-	damage = 25
-	penetration = 15
+	damage = 20
+	penetration = 10
 
 // Plasma //
 /datum/ammo/energy/plasma

--- a/code/modules/vehicles/mecha/combat/greyscale/greyscale_limbs.dm
+++ b/code/modules/vehicles/mecha/combat/greyscale/greyscale_limbs.dm
@@ -126,6 +126,7 @@ GLOBAL_LIST_INIT(mech_bodytypes, list(MECH_RECON, MECH_ASSAULT, MECH_VANGUARD))
 	health_mod = 500
 	accuracy_mod = 1.4
 	slowdown_mod = 0.3
+	light_range = 6
 	greyscale_type = /datum/greyscale_config/mech_assault/head
 	visor_config = /datum/greyscale_config/mech_assault/visor
 
@@ -133,6 +134,7 @@ GLOBAL_LIST_INIT(mech_bodytypes, list(MECH_RECON, MECH_ASSAULT, MECH_VANGUARD))
 	health_mod = 750
 	accuracy_mod = 1.5
 	slowdown_mod = 0.4
+	light_range = 5
 	greyscale_type = /datum/greyscale_config/mech_vanguard/head
 	visor_config = /datum/greyscale_config/mech_vanguard/visor
 

--- a/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
@@ -51,8 +51,8 @@
 	ammotype = /datum/ammo/bullet/pistol/mech/burst
 	obj_integrity = 450
 	projectiles = 42
-	projectiles_cache = 820
-	projectiles_cache_max = 820
+	projectiles_cache = 840
+	projectiles_cache_max = 840
 	variance = 15
 	slowdown = 0.1
 	projectile_delay = 0.6 SECONDS
@@ -78,8 +78,8 @@
 	ammotype = /datum/ammo/bullet/smg/mech
 	obj_integrity = 400
 	projectiles = 60
-	projectiles_cache = 420
-	projectiles_cache_max = 420
+	projectiles_cache = 900
+	projectiles_cache_max = 900
 	variance = 20
 	projectile_delay = 0.15 SECONDS
 	slowdown = 0.15
@@ -102,8 +102,8 @@
 	ammotype = /datum/ammo/bullet/rifle/mech/burst
 	obj_integrity = 400
 	projectiles = 72
-	projectiles_cache = 360
-	projectiles_cache_max = 360
+	projectiles_cache = 720
+	projectiles_cache_max = 720
 	variance = 15
 	projectile_delay = 0.6 SECONDS
 	burst_amount = 3
@@ -127,9 +127,9 @@
 	)
 	ammotype = /datum/ammo/bullet/rifle/mech
 	obj_integrity = 400
-	projectiles = 50
-	projectiles_cache = 300
-	projectiles_cache_max = 300
+	projectiles = 80
+	projectiles_cache = 960
+	projectiles_cache_max = 960
 	variance = 15
 	projectile_delay = 0.2 SECONDS
 	slowdown = 0.2
@@ -152,8 +152,8 @@
 	ammotype = /datum/ammo/bullet/shotgun/mech
 	obj_integrity = 350
 	projectiles = 10
-	projectiles_cache = 50
-	projectiles_cache_max = 50
+	projectiles_cache = 120
+	projectiles_cache_max = 120
 	variance = 6
 	projectile_delay = 1.5 SECONDS
 	slowdown = 0.3
@@ -175,9 +175,9 @@
 	)
 	ammotype = /datum/ammo/bullet/rifle/mech/lmg
 	obj_integrity = 400
-	projectiles = 80
-	projectiles_cache = 400
-	projectiles_cache_max = 400
+	projectiles = 120
+	projectiles_cache = 1200
+	projectiles_cache_max = 1200
 	variance = 25
 	projectile_delay = 0.15 SECONDS
 	slowdown = 0.3
@@ -286,8 +286,8 @@
 	ammotype = /datum/ammo/bullet/apfsds
 	obj_integrity = 400
 	projectiles = 1
-	projectiles_cache = 10
-	projectiles_cache_max = 10
+	projectiles_cache = 15
+	projectiles_cache_max = 15
 	variance = 0
 	projectile_delay = 1 SECONDS
 	slowdown = 1.2
@@ -311,8 +311,8 @@
 	ammotype = /datum/ammo/bullet/minigun/mech
 	obj_integrity = 400
 	projectiles = 200
-	projectiles_cache = 600
-	projectiles_cache_max = 600
+	projectiles_cache = 800
+	projectiles_cache_max = 800
 	variance = 35
 	projectile_delay = 1.5
 	slowdown = 0.7
@@ -336,8 +336,8 @@
 	ammotype = /datum/ammo/bullet/sniper/mech
 	obj_integrity = 200
 	projectiles = 15
-	projectiles_cache = 60
-	projectiles_cache_max = 60
+	projectiles_cache = 90
+	projectiles_cache_max = 90
 	variance = -15
 	projectile_delay = 1 SECONDS
 	slowdown = 0.6
@@ -356,8 +356,8 @@
 	ammotype = /obj/item/explosive/grenade
 	obj_integrity = 350
 	projectiles = 10
-	projectiles_cache = 20
-	projectiles_cache_max = 20
+	projectiles_cache = 40
+	projectiles_cache_max = 40
 	projectile_delay = 1.5 SECONDS
 	missile_speed = 1.5
 	equip_cooldown = 2 SECONDS


### PR DESCRIPTION
## About The Pull Request

Final balance adjustments before release:

-All laser guns nerfed, they were too strong considering they didn't have to worry about ammo at all, and mech ammo logistics is painful, with that in mind~

-Most weapons max ammo count, and magazine count, got buffed, majority of these weapons had pitiful ammounts of ammo and reloading a mech is absolute hell, and that's even if marines actually bother carrying your ammo crate for you, this should give them more staying power and make them more desirable when compared to energy weapons.

-Mech medium and heavy head did not have a light range var so they were stuck with shitty lights, now they do.


## Why It's Good For The Game

Walance

## Changelog
:cl:
balance: Lasers nerfed, ammo count on most guns buffed, medium and heavy head have better lights
/:cl:
