### PR TITLE
Decreases jab blur

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -584,8 +584,8 @@
 	if(!target.punch_act(X, damage, target_zone, push = FALSE, punch_description = "precise", stagger_stacks = 3, slowdown_stacks = 6))
 		return fail_activate()
 	if(X.empower())
-		target.blind_eyes(3)
-		target.blur_eyes(6)
+		target.blind_eyes(1)
+		target.blur_eyes(2)
 		to_chat(target, span_highdanger("The concussion from the [X]'s blow blinds us!"))
 		target.Confused(3 SECONDS) //Does literally nothing for now, will have to re-add confusion code.
 	GLOB.round_statistics.warrior_punches++

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -584,7 +584,7 @@
 	if(!target.punch_act(X, damage, target_zone, push = FALSE, punch_description = "precise", stagger_stacks = 3, slowdown_stacks = 6))
 		return fail_activate()
 	if(X.empower())
-		target.blind_eyes(1)
+		target.blind_eyes(3)
 		target.blur_eyes(2)
 		to_chat(target, span_highdanger("The concussion from the [X]'s blow blinds us!"))
 		target.Confused(3 SECONDS) //Does literally nothing for now, will have to re-add confusion code.


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Warrior primo jab will no longer blur you for so long it can stack with itself or others

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Turns out that it lasts for long enough that it can actually stack with itself/other warrior punches and effectively blind you harder than having actual proper eye damage which is pretty absurd. Lowers it to a third of its duration so that while it still impacts the fight the warrior is in it wont last for centuries after the warrior runs. It was purely cosmetic anyway since you can tell that the big purple thing is a xeno to shoot at.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Primordial warrior's blind duration lowered.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
