### PR TITLE
Fixes SADAR gun flags being defined twice

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -601,7 +601,6 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	desc = "The RL-152 is the primary anti-armor weapon of the TGMC. Used to take out light-tanks and enemy structures, the RL-152 rocket launcher is a dangerous weapon with a variety of combat uses. Uses a variety of 84mm rockets."
 	icon_state = "m5"
 	item_state = "m5"
-	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_WIELDED_STABLE_FIRING_ONLY
 	max_shells = 1 //codex
 	caliber = CALIBER_84MM //codex
 	load_method = SINGLE_CASING //codex
@@ -624,7 +623,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 		/obj/item/attachable/buildasentry,
 	)
 
-	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER
+	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_WIELDED_STABLE_FIRING_ONLY|GUN_AMMO_COUNTER
 	gun_skill_category = GUN_SKILL_FIREARMS
 	dry_fire_sound = 'sound/weapons/guns/fire/launcher_empty.ogg'
 	reload_sound = 'sound/weapons/guns/interact/launcher_reload.ogg'


### PR DESCRIPTION
## About The Pull Request
Fixes an issue where the SADAR had two lines defining gun flags each, which means that SADAR has always been able to fire without full wielding. This was my mistake. Hee hoo.

## Why It's Good For The Game
Bug fix good. Bug-free game good. Bug bad. Squash bug.

## Changelog
:cl: Lewdcifer
fix: Fixes an issue where SADAR gun flags were defined twice.
/:cl: