### PR TITLE
SG-85 Magazine Typo Fix

### DIFF
--- a/code/modules/projectiles/magazines/misc.dm
+++ b/code/modules/projectiles/magazines/misc.dm
@@ -62,7 +62,7 @@
 
 /obj/item/ammo_magazine/packet/smart_minigun
 	name = "SG-85 ammo bin"
-	desc = "A hefty container stuffed to the absolute brim with 1000 rounds for the SG-85 powerpack."
+	desc = "A hefty container stuffed to the absolute brim with 500 rounds for the SG-85 powerpack."
 	icon_state = "box_smartminigun"
 	default_ammo = /datum/ammo/bullet/smart_minigun
 	caliber = CALIBER_10x26_CASELESS


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

SG-85 ammo bin now states 500 rounds instead of the incorrect 1000.

## Changelog
:cl:
spellcheck: SG-85 Ammo Bin now shows correct number of rounds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
