### PR TITLE
Fixes smoothing when mining turfs

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -316,7 +316,7 @@
 	if(thisarea.lighting_effect)
 		W.add_overlay(thisarea.lighting_effect)
 
-	if(W.smoothing_behavior == NO_SMOOTHING)
+	if(!W.smoothing_behavior == NO_SMOOTHING)
 		return W
 	else
 		for(var/dirn in GLOB.alldirs)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -316,6 +316,13 @@
 	if(thisarea.lighting_effect)
 		W.add_overlay(thisarea.lighting_effect)
 
+	if(W.smoothing_behavior == NO_SMOOTHING)
+		return W
+	else
+		for(var/dirn in GLOB.alldirs)
+			var/turf/D = get_step(W,dirn)
+			D.smooth_self()
+			D.smooth_neighbors()
 	return W
 
 /// Take off the top layer turf and replace it with the next baseturf down


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.
The new smoothing system doesn't really understand the concept of ChangeTurf() that well and so you get ugly black voids or weird missing walls if you plasma cut a wall.
This PR fixes that by integrating a smoothing check into ChangeTurf itself so the walls behave properly.

## Why It's Good For The Game

I have really needed to do this for a while, it's a small consistency fix that makes mining more bearable.

## Changelog
:cl:
fix: Walls will now properly smooth when destroyed via plasma cutter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
