### PR TITLE
Neuraline Buff

### DIFF
--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -457,7 +457,7 @@
 	name = "Neuraline"
 	description = "A chemical cocktail tailored to enhance or dampen specific neural processes."
 	color = "#C8A5DC" // rgb: 200, 165, 220
-	custom_metabolism = REAGENTS_METABOLISM * 2
+	custom_metabolism = REAGENTS_METABOLISM
 	overdose_threshold = 5
 	overdose_crit_threshold = 6
 	scannable = FALSE
@@ -494,7 +494,7 @@
 	L.AdjustSleeping(-40)
 	L.adjustStaminaLoss(-30*effect_str)
 	L.heal_limb_damage(7.5*effect_str, 7.5*effect_str)
-	L.adjustToxLoss(3.75*effect_str)
+	L.adjustToxLoss(2.75*effect_str)
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
 		C.setShock_Stage(min(C.shock_stage - volume*effect_str, 150)) //will pull a target out of deep paincrit instantly, if he's in it


### PR DESCRIPTION
## Why It's Good For The Game

## The Current State of Neuraline

Neuraline at the moment sees next to no use. It is extremely costly to make, and only is craftable in batches of 1 (one) dose. 4u per batch. It requires 2 ingredients that already consume lemoline to make, on top of the lemoline catalyst required for the final chemical reaction to form neuraline. On top of that, you require prepared larval jelly. One dead larvae can create one, (1), unit of prepared larval jelly. At the moment, one dose of neuraline, (4u), lasts 10 ticks, and deals a total of 38 toxin damage.

## The Changes This Would Implement

1. Neuraline would go from 10 ticks to metabolize per dose (4u), to 20 ticks per dose (4u). This would increase its effectiveness as a combat stimulant.
2. Toxin damage dealt over time reduced from 3.75 per tick, to 2.75 per tick. This would result in a net toxin damage total of 55, which is roughly 20 more damage total than before.


## Changelog
:cl:
balance: Increased how long it takes for Neuraline to metabolize. 
balance: decreased neuraline toxin damage per tick from 3.75 to 2.75
/:cl:
