### PR TITLE
Dispenser tweaks

### DIFF
--- a/code/game/objects/items/storage/dispenser.dm
+++ b/code/game/objects/items/storage/dispenser.dm
@@ -127,3 +127,6 @@
 /obj/item/storage/backpack/dispenser/open(mob/user)
 	if(CHECK_BITFIELD(flags_item, IS_DEPLOYED))
 		return ..()
+
+/obj/item/storage/backpack/dispenser/attempt_draw_object(mob/living/user)
+	to_chat(usr, span_notice("You can't grab anything out of [src] while its not deployed."))

--- a/code/game/objects/items/storage/dispenser.dm
+++ b/code/game/objects/items/storage/dispenser.dm
@@ -1,9 +1,11 @@
 
 /obj/machinery/deployable/dispenser
 	name = "TX-9000 provisions dispenser"
-	desc = "The TX-9000 also known as \"Dispenser\" is a machine capable of holding a big amount of items on it, while also healing nearby synthetics. Your allies will often ask you to lay down one of those."
+	desc = "The TX-9000 also known as \"Dispenser\" is a machine capable of holding a large amount of items on it, while also healing nearby synthetics. Your allies will often ask you to lay down one of these."
 	density = TRUE
 	anchored = TRUE
+	max_integrity = 250
+	resistance_flags = XENO_DAMAGEABLE
 	///list of human mobs we're currently affecting in our area.
 	var/list/mob/living/carbon/human/affecting_list
 	///if the dispenser has finished deploying and is fully active and can be used.
@@ -111,6 +113,7 @@
 	flags_equip_slot = ITEM_SLOT_BACK
 	max_w_class = 6
 	max_storage_space = 63
+	max_integrity = 200
 
 /obj/item/storage/backpack/dispenser/Initialize(mapload, ...)
 	. = ..()

--- a/code/game/objects/structures/teleporter.dm
+++ b/code/game/objects/structures/teleporter.dm
@@ -1,7 +1,7 @@
 #define TELEPORTING_COST 250
 /obj/machinery/deployable/teleporter
 	density = FALSE
-	max_integrity = 250
+	max_integrity = 200
 	resistance_flags = XENO_DAMAGEABLE
 	idle_power_usage = 50
 	///List of all teleportable types


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the XENO_DAMAGEABLE flag to the dispenser so xenos can actually hurt it, also set its max integrity to 200, same as the teleporter.

Also fixes an exploit that allowed you to draw items from a dispenser when not deployed.
Oh and a couple of desc fixes.

Incidentally, updated a var on the teleporter that was misleading, since max integrity is actually inherited from the item it deploys from, but left it in on both items for clarity.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Marine structures hittable is good
misleading var bad
Being able to carry and wield 9 guns is bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Reduced dispenser integrity to 200. Can also now be hit by xenos
fix: Fixed an exploit that allowed for items to be drawn from a dispenser when not deployed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
