### PR TITLE
Nerfs Warrior Lunge bonus modifier for Punch from x2.0 to x1.5

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -490,7 +490,7 @@
 
 /mob/living/punch_act(mob/living/carbon/xenomorph/warrior/X, damage, target_zone, push = TRUE, punch_description = "powerful", stagger_stacks = 3, slowdown_stacks = 3)
 	if(pulledby == X) //If we're being grappled by the Warrior punching us, it's gonna do extra damage and debuffs; combolicious
-		damage *= 2
+		damage *= 1.5
 		slowdown_stacks *= 2
 		stagger_stacks *= 2
 		ParalyzeNoChain(0.5 SECONDS)


### PR DESCRIPTION
## About The Pull Request
Per title. Meant to go together with the Lunge range nerf PR here: #11387.
It is published separately since maintainers don't like unatomized nerfs.
**If a choice must be made between either, prioritize this one.**

### As of currently
Punch's base damage is equal to the Warrior's **slash damage**. At Ancient, this is **23** damage.

Primordial's **Empower bonus** to Punch is **x1.5**, applied **BEFORE** the Lunge into Punch bonus.
23 x 1.5 = **34.5** damage.

The **Lunge into Punch bonus** is **x2.0**.
23 x 2.0 = **46** damage.
Including the **Empower bonus**, 34.5 x 2.0 = **69** damage.

### After nerfs
Base damage remains untouched. This is **23** damage.

Primordial's **Empower bonus** untouched.
23 x 1.5 = **34.5** damage.

Lunge into Punch bonus **decreased** to **x1.5**.
23 x 1.5 = **34.5** damage.
Including the **Empower bonus**, 34.5 x 1.5 = **51.75** damage.

## Why It's Good For The Game
Warrior's Punch damage could get out of hand easily due to stacking multipliers. Though some would argue the problem lies in its Primordial bonus, I'd say Warrior's base kit has always been too good, outdoing several castes between damage and stuff such as Lunge's grab-stun, the stagger and slowdown applied by Punch, etc.
As such, I've decided to nerf a part of its base kit, which does extend into the Primordial bonus.

## Changelog
:cl: Lewdcifer
balance: Warrior's Lunge into Punch damage modifier reduced from x2.0 to x1.5.
/:cl: