### PR TITLE
Nerfs Warrior Lunge range from 6 to 4 tiles

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -77,7 +77,7 @@
 	if(!.)
 		return FALSE
 
-	if(get_dist_euclide_square(A, owner) > 36)
+	if(get_dist_euclide_square(A, owner) > 16)
 		if(!silent)
 			to_chat(owner, span_xenonotice("You are too far!"))
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -77,7 +77,7 @@
 	if(!.)
 		return FALSE
 
-	if(get_dist_euclide_square(A, owner) > 18)
+	if(get_dist_euclide_square(A, owner) > 20)
 		if(!silent)
 			to_chat(owner, span_xenonotice("You are too far!"))
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -77,7 +77,7 @@
 	if(!.)
 		return FALSE
 
-	if(get_dist_euclide_square(A, owner) > 16)
+	if(get_dist_euclide_square(A, owner) > 18)
 		if(!silent)
 			to_chat(owner, span_xenonotice("You are too far!"))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request
Per title. This PR is meant to go together with the Lunge Punch damage modifier nerf PR here: #11386.
It is published separately since maintainers don't like unatomized nerfs.
**If a choice must be made between either, prioritize #11386 before this one.**

### Old Warrior Lunge range

https://user-images.githubusercontent.com/59634950/198903302-02540db4-a6d8-4822-9a36-aea107d0c060.mp4

### New Warrior Lunge range

https://user-images.githubusercontent.com/59634950/198903315-16079228-2fd4-4c1b-972b-5eee9843eeaa.mp4

Effective range:
![image](https://user-images.githubusercontent.com/59634950/198922515-d7b53707-c8b4-4ddb-915a-110ec9cfd3b7.png)


## Why It's Good For The Game
Lunge having 6 tiles of range has contributed to the current issue of Warriors being too good at what they do, not to mention being able to easily punish from considerable distances. This PR aims to amend that.

## Changelog
:cl: Lewdcifer
balance: Warrior Lunge range reduced from 6 to 4 tiles.
/:cl: