### PR TITLE
Bull remastered: The rebullening: The bull within

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
@@ -147,6 +147,8 @@
 	// *** Defense *** //
 	soft_armor = list(MELEE = 40, BULLET = 50, LASER = 40, ENERGY = 40, BOMB = 0, BIO = 33, FIRE = 50, ACID = 33)
 
+	stomp_damage = 30
+
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
 		/datum/action/xeno_action/watch_xeno,

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
@@ -147,3 +147,14 @@
 	// *** Defense *** //
 	soft_armor = list(MELEE = 40, BULLET = 50, LASER = 40, ENERGY = 40, BOMB = 0, BIO = 33, FIRE = 50, ACID = 33)
 
+	actions = list(
+		/datum/action/xeno_action/xeno_resting,
+		/datum/action/xeno_action/watch_xeno,
+		/datum/action/xeno_action/activable/psydrain,
+		/datum/action/xeno_action/activable/stomp,
+		/datum/action/xeno_action/ready_charge/bull_charge,
+		/datum/action/xeno_action/activable/bull_charge,
+		/datum/action/xeno_action/activable/bull_charge/headbutt,
+		/datum/action/xeno_action/activable/bull_charge/gore,
+	)
+

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -97,9 +97,9 @@
 		do_stop_momentum()
 		return
 	var/turn_rate = 16
-		if(agile_charge)
-			turn_rate = 8
-	if(last_dir_change > world.time - 10)
+	if(agile_charge)
+		turn_rate = 8
+	if(last_dir_change > world.time - turn_rate)
 		do_stop_momentum()
 	last_dir_change = world.time
 

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -36,6 +36,8 @@
 	var/plasma_use_multiplier = 1
 	///If this charge should keep momentum on dir change and if it can charge diagonally
 	var/agile_charge = FALSE
+	///the time we last changed direction. Used for agile charging
+	var/last_dir_change
 
 
 /datum/action/xeno_action/ready_charge/give_action(mob/living/L)
@@ -89,9 +91,14 @@
 	var/mob/living/carbon/xenomorph/charger = owner
 	if(charger.is_charging == CHARGE_OFF)
 		return
-	if(!old_dir || !new_dir || old_dir == new_dir || agile_charge) //Check for null direction from help shuffle signals
+	if(!old_dir || !new_dir || old_dir == new_dir) //Check for null direction from help shuffle signals
 		return
-	do_stop_momentum()
+	if(!agile_charge || new_dir == REVERSE_DIR(old_dir)) //we can't just go back and forth
+		do_stop_momentum()
+		return
+	if(last_dir_change > world.time - 10)
+		do_stop_momentum()
+	last_dir_change = world.time
 
 
 /datum/action/xeno_action/ready_charge/proc/update_charging(datum/source, atom/oldloc, direction, Forced, old_locs)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -34,7 +34,7 @@
 	var/crush_living_damage = 20
 	var/next_special_attack = 0 //Little var to keep track on special attack timers.
 	var/plasma_use_multiplier = 1
-	///If this charge should keep momentum on dir change and if it can charge diagonally
+	///If this charge should keep momentum on dir change
 	var/agile_charge = 0
 	///the time we last changed direction
 	var/last_dir_change
@@ -93,7 +93,7 @@
 		return
 	if(!old_dir || !new_dir || old_dir == new_dir) //Check for null direction from help shuffle signals
 		return
-	if((new_dir != old_dir && !agile_charge) || new_dir == REVERSE_DIR(old_dir))
+	if((!agile_charge) || new_dir == REVERSE_DIR(old_dir)) //No doubling back
 		do_stop_momentum()
 		return
 	var/turn_rate = 16
@@ -165,7 +165,7 @@
 	var/mob/living/carbon/xenomorph/charger = owner
 	if(!newdir)
 		return
-	if(ISDIAGONALDIR(newdir) && !agile_charge) //broken due to mob dir being cardinals, will see if fixable...
+	if(ISDIAGONALDIR(newdir)
 		return
 
 	if(next_move_limit && world.time > next_move_limit)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -36,7 +36,7 @@
 	var/plasma_use_multiplier = 1
 	///If this charge should keep momentum on dir change and if it can charge diagonally
 	var/agile_charge = FALSE
-	///the time we last changed direction. Used for agile charging
+	///the time we last changed direction
 	var/last_dir_change
 
 
@@ -93,13 +93,15 @@
 		return
 	if(!old_dir || !new_dir || old_dir == new_dir) //Check for null direction from help shuffle signals
 		return
-	if(!agile_charge || new_dir == REVERSE_DIR(old_dir)) //we can't just go back and forth
+	if(new_dir == REVERSE_DIR(old_dir))//we can't just 180 back the way we came
 		do_stop_momentum()
 		return
+	var/turn_rate = 16
+		if(agile_charge)
+			turn_rate = 8
 	if(last_dir_change > world.time - 10)
 		do_stop_momentum()
 	last_dir_change = world.time
-
 
 /datum/action/xeno_action/ready_charge/proc/update_charging(datum/source, atom/oldloc, direction, Forced, old_locs)
 	SIGNAL_HANDLER_DOES_SLEEP

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -165,7 +165,7 @@
 	var/mob/living/carbon/xenomorph/charger = owner
 	if(!newdir)
 		return
-	if(ISDIAGONALDIR(newdir)
+	if(ISDIAGONALDIR(newdir))
 		return
 
 	if(next_move_limit && world.time > next_move_limit)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -163,8 +163,10 @@
 
 /datum/action/xeno_action/ready_charge/proc/check_momentum(newdir)
 	var/mob/living/carbon/xenomorph/charger = owner
-	if((newdir && ISDIAGONALDIR(newdir) || charge_dir != newdir) && !agile_charge) //Check for null direction from help shuffle signals
-		return FALSE
+	if(!newdir)
+		return
+	if(ISDIAGONALDIR(newdir) && !agile_charge)
+		return
 
 	if(next_move_limit && world.time > next_move_limit)
 		return FALSE
@@ -173,9 +175,6 @@
 		return FALSE
 
 	if(charger.incapacitated())
-		return FALSE
-
-	if(charge_dir != charger.dir && !agile_charge)
 		return FALSE
 
 	if(charger.pulledby)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -35,7 +35,7 @@
 	var/next_special_attack = 0 //Little var to keep track on special attack timers.
 	var/plasma_use_multiplier = 1
 	///If this charge should keep momentum on dir change and if it can charge diagonally
-	var/agile_charge = FALSE
+	var/agile_charge = 0
 	///the time we last changed direction
 	var/last_dir_change
 
@@ -93,11 +93,11 @@
 		return
 	if(!old_dir || !new_dir || old_dir == new_dir) //Check for null direction from help shuffle signals
 		return
-	if(new_dir == REVERSE_DIR(old_dir))//we can't just 180 back the way we came
+	if((new_dir != old_dir && !agile_charge) || new_dir == REVERSE_DIR(old_dir))
 		do_stop_momentum()
 		return
 	var/turn_rate = 16
-	if(agile_charge)
+	if(agile_charge == 2)
 		turn_rate = 8
 	if(last_dir_change > world.time - turn_rate)
 		do_stop_momentum()
@@ -165,7 +165,7 @@
 	var/mob/living/carbon/xenomorph/charger = owner
 	if(!newdir)
 		return
-	if(ISDIAGONALDIR(newdir) && !agile_charge)
+	if(ISDIAGONALDIR(newdir) && !agile_charge) //broken due to mob dir being cardinals, will see if fixable...
 		return
 
 	if(next_move_limit && world.time > next_move_limit)
@@ -342,6 +342,7 @@
 	max_steps_buildup = 10
 	crush_living_damage = 15
 	plasma_use_multiplier = 2
+	agile_charge = 1
 
 
 /datum/action/xeno_action/ready_charge/bull_charge/give_action(mob/living/L)
@@ -378,7 +379,8 @@
 
 /datum/action/xeno_action/ready_charge/bull_charge/on_xeno_upgrade()
 	var/mob/living/carbon/xenomorph/X = owner
-	agile_charge = (X.upgrade == XENO_UPGRADE_FOUR)
+	if(X.upgrade == XENO_UPGRADE_FOUR)
+		agile_charge = 2
 
 /datum/action/xeno_action/ready_charge/queen_charge
 	action_icon_state = "queen_ready_charge"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removing Bull is lame.

Bull can now change direction while charging without primo.
Changing direction mid charge now has a cooldown, so you can change direction, but you can't do so repeatedly in a short period.
 Primo reduces this cool down to make you more agile, so is now far less overwhelming.
Note: You cannot double back on yourself without losing charge, so no more going back and forth to endlessly charge a poor unga.

Primo bull now also gets the stomp ability, since it's going to be notably weaker than before. It also means it can do something other that literally charge and nothing else.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Primobull is bullshit, non primo is bullbad
Addresses both of these points somewhat
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Bulls can now natively change direction when charging except for 180 degrees, on a cooldown
add: Primo bull reduces charge direction change cooldown and has the stomp ability
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
