### PR TITLE
Arty range fix

### DIFF
--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -225,9 +225,9 @@
 ///Start firing the gun on target and increase tally
 /obj/machinery/deployable/mortar/proc/begin_fire(atom/target, obj/item/mortal_shell/arty_shell)
 	firing = TRUE
-	for(var/mob/M in (cheap_get_humans_near(src, 7) + cheap_get_xenos_near(src,7)))
-		shake_camera(M, 1, 1)
-
+	for(var/mob/M in GLOB.player_list)
+		if(get_dist(M , src) <= 7)
+			shake_camera(M, 1, 1)
 	switch(tally_type)
 		if(TALLY_MORTAR)
 			GLOB.round_statistics.mortar_shells_fired++

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -225,9 +225,9 @@
 ///Start firing the gun on target and increase tally
 /obj/machinery/deployable/mortar/proc/begin_fire(atom/target, obj/item/mortal_shell/arty_shell)
 	firing = TRUE
-	for(var/mob/M in GLOB.player_list)
-		if(get_dist(M , src) <= 7)
-			shake_camera(M, 1, 1)
+	for(var/mob/M in (cheap_get_humans_near(src, 7) + cheap_get_xenos_near(src,7)))
+		shake_camera(M, 1, 1)
+
 	switch(tally_type)
 		if(TALLY_MORTAR)
 			GLOB.round_statistics.mortar_shells_fired++

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -223,7 +223,7 @@
 	to_chat(user, "<span class='notice'>You disconnect the [binocs] from their linked mortar.")
 
 ///Start firing the gun on target and increase tally
-/obj/machinery/deployable/mortar/proc/begin_fire(target, obj/item/mortal_shell/arty_shell)
+/obj/machinery/deployable/mortar/proc/begin_fire(atom/target, obj/item/mortal_shell/arty_shell)
 	firing = TRUE
 	for(var/mob/M in GLOB.player_list)
 		if(get_dist(M , src) <= 7)
@@ -243,8 +243,9 @@
 	var/obj/projectile/shell = new /obj/projectile(loc)
 	var/datum/ammo/ammo = GLOB.ammo_list[arty_shell.ammo_type]
 	shell.generate_bullet(ammo)
-	shell.fire_at(target, src, src, get_dist(src, target), ammo.shell_speed)
-	var/fall_time = get_dist(src, target)/ammo.shell_speed - 1 SECONDS
+	var/shell_range = min(get_dist_euclide(src,target), ammo.max_range)
+	shell.fire_at(target, src, src, shell_range, ammo.shell_speed)
+	var/fall_time = shell_range/ammo.shell_speed - 1 SECONDS
 	//prevent runtime
 	if(fall_time < 0.5 SECONDS)
 		fall_time = 0.5 SECONDS
@@ -323,7 +324,7 @@
 	location.ceiling_debris_check(2)
 	log_game("[key_name(user)] has fired the [src] at [AREACOORD(target)]")
 
-	var/max_offset = round(abs((get_dist(src,target)))/offset_per_turfs)
+	var/max_offset = round(abs((get_dist_euclide(src,target)))/offset_per_turfs)
 	var/firing_spread = max_offset + spread
 	if(firing_spread > max_spread)
 		firing_spread = max_spread

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2029,8 +2029,8 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 0
 	penetration = 0
 	sundering = 0
-	accuracy = 250
-	max_range = 250
+	accuracy = 1000
+	max_range = 1000
 	ping = null
 	bullet_color = COLOR_WHITE
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces several instances of get_dist() with get_dist_euclide() in artillery code.
Get_dist() has a cap of 127 tiles (thanks BYOND) which meant artillery shots had an effective range of 127 tiles (~63 on diagonals). Lest we forget the many pushes decimated by BYOND's cruel gaze.

Previously, the max_range on the shell datum didn't actually affect the range of the shot. It now does. The default for all shells has been set to 1000 so this doesn't actually change gameplay currently, but the code's ready if you want to.

Also alters the screenshake check to use cheap_get_humans_near/cheap_get_xenos_near instead of checking if every single mob is next to the mortar or not, which SHOULD be slightly more efficient.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Artillery shots no longer have a pitiful range of 127, exploding way before their intended target. Spread will be significantly more consistent now
fix: The max_range on shell datums is actually functional now
balance: Default shell max_range 250 -> 1000, because it's intended to be infinite. PR a change for this if you want
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
