### PR TITLE
Adds MP bay to Minerva

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -1723,9 +1723,7 @@
 	},
 /area/mainship/medical/lounge)
 "eT" = (
-/obj/machinery/door/airlock/mainship/marine/general{
-	dir = 8
-	},
+/obj/machinery/door/airlock/mainship/generic/mech_pilot/bunk,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/tankerbunks)
 "eU" = (
@@ -2516,12 +2514,12 @@
 /turf/closed/wall/mainship,
 /area/mainship/hallways/hangar)
 "gW" = (
-/obj/machinery/door/airlock/mainship/marine/general{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/poddoor/mainship/mech{
+	dir = 1
+	},
+/obj/machinery/door/airlock/mainship/generic/mech_pilot/bunk{
 	dir = 1
 	},
 /turf/open/floor/mainship/mono,
@@ -5887,13 +5885,13 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/shipboard/firing_range)
 "ro" = (
-/obj/machinery/door/airlock/mainship/marine/general{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/poddoor/mainship/mech{
+	dir = 1
+	},
+/obj/machinery/door/airlock/mainship/generic/mech_pilot{
 	dir = 1
 	},
 /turf/open/floor/mainship/mono,

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -5182,7 +5182,7 @@
 "oY" = (
 /obj/machinery/door_control/mainship{
 	dir = 8;
-	id = mechbay;
+	id = "mechbay";
 	name = "Mech Bay Shutters"
 	},
 /turf/open/floor/mainship/mono,
@@ -9086,7 +9086,7 @@
 "AD" = (
 /obj/machinery/door_control/mainship{
 	dir = 4;
-	id = mechbay;
+	id = "mechbay";
 	name = "Mech Bay Shutters"
 	},
 /turf/open/floor/mainship/mono,
@@ -9787,7 +9787,7 @@
 /area/mainship/hallways/hangar)
 "CI" = (
 /obj/machinery/door/poddoor/shutters{
-	id = mechbay;
+	id = "mechbay";
 	name = "Mech Bay Shutters"
 	},
 /turf/open/floor/mainship/mono,

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -15,6 +15,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
+"ad" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "ae" = (
 /obj/structure/droppod,
 /obj/structure/dropprop,
@@ -52,6 +58,13 @@
 /obj/machinery/door/airlock/multi_tile/mainship/generic/noglass,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/starboard_hull)
+"al" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "an" = (
 /obj/effect/decal/warning_stripes/thick/corner,
 /obj/item/ammo_casing/bullet{
@@ -64,6 +77,11 @@
 /obj/effect/decal/warning_stripes/thick/corner,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"ap" = (
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
 "aq" = (
 /obj/structure/rack,
 /obj/item/tool/wrench,
@@ -73,6 +91,20 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"ar" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/port_garden)
+"as" = (
+/obj/item/ammo_casing/bullet{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/mainship/living/briefing)
 "at" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /obj/structure/cable,
@@ -87,11 +119,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "aw" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/open/floor/mainship/green{
-	dir = 4
-	},
-/area/mainship/living/port_garden)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "ax" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -156,6 +186,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
+"aG" = (
+/obj/structure/closet/cabinet,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "aH" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/tcomms,
@@ -352,8 +389,27 @@
 /obj/structure/sign/poster,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"bd" = (
+/obj/machinery/autodoc_console,
+/turf/open/floor/mainship/sterile,
+/area/mainship/medical/lower_medical)
 "be" = (
-/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
+"bf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -361,14 +417,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar)
-"bf" = (
 /obj/machinery/door/airlock/mainship/maint,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
 "bg" = (
@@ -404,16 +453,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
 "bj" = (
-/obj/machinery/door/airlock/mainship/maint,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/starboard_hull)
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "bk" = (
 /obj/effect/decal/warning_stripes/thick{
 	dir = 8
@@ -424,16 +466,18 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "bl" = (
-/obj/machinery/door/airlock/mainship/maint,
-/obj/structure/cable,
+/obj/machinery/door/airlock/mainship/medical/glass{
+	name = "Medical Lounge"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar/droppod)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lounge)
 "bm" = (
 /turf/open/floor/mainship/red{
 	dir = 5
@@ -540,6 +584,16 @@
 "bE" = (
 /turf/closed/wall/mainship,
 /area/mainship/command/corporateliaison)
+"bF" = (
+/obj/machinery/door/airlock/mainship/command/officer,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/bridgebunks)
 "bG" = (
 /obj/structure/bed/fancy,
 /obj/item/bedsheet/hos,
@@ -555,6 +609,15 @@
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct,
 /turf/closed/wall/mainship/outer,
 /area/mainship/command/self_destruct)
+"bI" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/obj/structure/bed/chair/nometal{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "bJ" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/drinks/cans/aspen{
@@ -633,6 +696,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
+"bS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "bT" = (
 /obj/machinery/dropship_part_fabricator,
 /turf/open/floor/mainship/cargo,
@@ -682,6 +759,14 @@
 	dir = 9
 	},
 /area/mainship/hallways/hangar)
+"ca" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/mainship/red{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "cb" = (
 /obj/effect/decal/warning_stripes/thick{
 	dir = 1
@@ -703,6 +788,16 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/starboard_hallway)
+"ce" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/living/tankerbunks)
 "cf" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/gas,
@@ -941,6 +1036,11 @@
 /obj/structure/cable,
 /turf/open/floor/grass,
 /area/mainship/living/port_garden)
+"cR" = (
+/obj/structure/table/mainship/nometal,
+/obj/machinery/chem_dispenser/beer,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lounge)
 "cS" = (
 /obj/effect/ai_node,
 /obj/item/paper/memorial,
@@ -1008,13 +1108,13 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "dc" = (
-/obj/machinery/camera/autoname/mainship{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 8
-	},
-/area/mainship/medical/chemistry)
+/area/mainship/medical/lower_medical)
 "dd" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
@@ -1034,6 +1134,16 @@
 	dir = 6
 	},
 /area/mainship/hallways/hangar)
+"di" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "dj" = (
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/floor,
@@ -1072,6 +1182,12 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/mainship/red,
 /area/mainship/command/cic)
+"dp" = (
+/obj/structure/bed/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "dq" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/camera/autoname/mainship{
@@ -1123,6 +1239,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"dy" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/cable,
+/turf/open/floor/mainship/silver/corner{
+	dir = 1
+	},
+/area/mainship/medical/medical_science)
 "dz" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -1134,12 +1258,9 @@
 /turf/open/floor/plating,
 /area/mainship/squads/req)
 "dB" = (
-/obj/machinery/door/airlock/mainship/command/CPToffice{
-	dir = 2
-	},
-/obj/structure/cable,
+/obj/machinery/vending/tool,
 /turf/open/floor/mainship/mono,
-/area/mainship/living/commandbunks)
+/area/mainship/living/tankerbunks)
 "dC" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -1176,8 +1297,8 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "dH" = (
-/obj/structure/window/framed/mainship/white,
-/turf/open/floor/mainship/sterile/dark,
+/mob/living/simple_animal/cat/Runtime,
+/turf/closed/wall/mainship/white,
 /area/mainship/medical/operating_room_one)
 "dI" = (
 /turf/open/floor/mainship/orange{
@@ -1199,6 +1320,10 @@
 /obj/structure/bed/chair/sofa/left,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
+"dM" = (
+/obj/machinery/light/mainship,
+/turf/open/floor/mainship/black,
+/area/mainship/hallways/hangar)
 "dO" = (
 /obj/docking_port/stationary/marine_dropship/minidropship,
 /turf/open/floor/plating,
@@ -1282,16 +1407,35 @@
 	dir = 4
 	},
 /area/mainship/hallways/hangar)
+"dW" = (
+/obj/machinery/vending/medical/shipside,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
 "dX" = (
 /obj/structure/dropship_equipment/weapon/minirocket_pod,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "dY" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/mainship/orange{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/area/mainship/hallways/hangar)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/squads/req)
 "dZ" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -1373,10 +1517,22 @@
 	dir = 10
 	},
 /area/mainship/living/evacuation)
+"em" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/mainship/hallways/hangar)
 "en" = (
 /obj/structure/janitorialcart,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
+"eo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "ep" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating/plating_catwalk,
@@ -1468,22 +1624,22 @@
 	},
 /area/mainship/hallways/hangar)
 "eD" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/mainship/orange{
+/obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
-/area/mainship/hallways/hangar)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "eE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
 "eF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/disposalpipe/segment,
-/mob/living/simple_animal/cat/martin,
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/squads/req)
+/obj/structure/table/mainship/nometal,
+/obj/machinery/chem_dispenser/soda{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "eG" = (
 /obj/machinery/telecomms/server/presets/common,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -1551,16 +1707,40 @@
 	},
 /area/mainship/hallways/hangar)
 "eS" = (
-/obj/machinery/light/mainship/small{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/port_hull)
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lounge)
+"eT" = (
+/obj/machinery/door/airlock/mainship/marine/general{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "eU" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/autodoc,
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/lower_medical)
+/obj/machinery/bioprinter/stocked,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
+"eV" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
 "eW" = (
 /obj/machinery/computer/skills,
 /obj/machinery/light/mainship{
@@ -1639,6 +1819,22 @@
 /obj/structure/ship_ammo/rocket/widowmaker,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"fg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/living/tankerbunks)
+"fh" = (
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/bridgebunks)
 "fj" = (
 /obj/structure/sign/electricshock{
 	name = "Engineer Preparations"
@@ -1672,6 +1868,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"fn" = (
+/obj/machinery/vending/marineFood,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "fo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -1767,6 +1967,20 @@
 /obj/item/stack/conveyor/thirty,
 /turf/open/floor/plating,
 /area/mainship/squads/req)
+"fC" = (
+/obj/structure/table/mainship/nometal,
+/obj/item/clothing/head/welding,
+/obj/item/tool/weldingtool/largetank,
+/obj/item/tool/weldingtool/largetank,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/tool/weldingtool/largetank,
+/obj/item/tool/weldingtool/largetank,
+/obj/item/tool/weldpack/marinestandard,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "fD" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/hull/port_hull)
@@ -1808,12 +2022,15 @@
 /obj/structure/sign/poster,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"fJ" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research,
+/turf/open/floor/mainship/silver/full,
+/area/mainship/medical/medical_science)
 "fK" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/mainship/orange{
-	dir = 8
-	},
-/area/mainship/hallways/hangar)
+/obj/structure/rack,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "fM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -2025,17 +2242,16 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "gp" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/jerrycan,
-/obj/item/reagent_containers/jerrycan,
-/obj/machinery/light/mainship{
-	dir = 4
+/obj/effect/decal/warning_stripes/thin,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
-/obj/item/reagent_containers/jerrycan,
-/turf/open/floor/mainship/orange{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
-/area/mainship/hallways/hangar)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "gq" = (
 /obj/effect/decal/warning_stripes/thick,
 /obj/machinery/light/mainship{
@@ -2043,6 +2259,16 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/squads/req)
+"gr" = (
+/obj/machinery/disposal,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/port_garden)
 "gs" = (
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
@@ -2050,6 +2276,27 @@
 /obj/effect/decal/warning_stripes/thick,
 /turf/open/floor/plating,
 /area/mainship/squads/req)
+"gu" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/bridgebunks)
+"gv" = (
+/obj/structure/table/mainship/nometal,
+/obj/structure/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/tool/stamp/ce,
+/obj/item/tool/pen,
+/obj/structure/cable,
+/obj/item/blueprints,
+/obj/effect/ai_node,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/turf/open/floor/wood,
+/area/mainship/engineering/ce_room)
 "gw" = (
 /obj/machinery/door/airlock/mainship/marine/requisitions{
 	dir = 2;
@@ -2069,6 +2316,22 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/port_atmos)
+"gy" = (
+/obj/machinery/door/airlock/mainship/generic/glass{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "gz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -2193,6 +2456,16 @@
 "gN" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/evacuation)
+"gO" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "gP" = (
 /obj/structure/window/framed/mainship/requisitions,
 /turf/open/floor/plating,
@@ -2242,14 +2515,13 @@
 /turf/closed/wall/mainship,
 /area/mainship/hallways/hangar)
 "gW" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/jerrycan,
-/obj/item/reagent_containers/jerrycan,
-/obj/item/reagent_containers/jerrycan,
-/turf/open/floor/mainship/orange{
-	dir = 10
+/obj/machinery/door/airlock/mainship/marine/general{
+	dir = 1
 	},
-/area/mainship/hallways/hangar)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "gX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -2270,6 +2542,20 @@
 /obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
+"ha" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/port_hallway)
 "hc" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/cell_charger,
@@ -2322,10 +2608,14 @@
 /turf/open/floor/plating,
 /area/mainship/squads/req)
 "hj" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/mainship/research,
-/area/mainship/medical/medical_science)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 1
+	},
+/area/mainship/medical/chemistry)
 "hk" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/hull/starboard_hull)
@@ -2349,9 +2639,19 @@
 /turf/closed/wall/mainship,
 /area/mainship/living/cryo_cells)
 "hp" = (
-/mob/living/simple_animal/corgi/ranger,
-/turf/open/floor/mainship/floor,
-/area/mainship/living/cafeteria_starboard)
+/obj/structure/table/mainship/nometal,
+/obj/machinery/reagentgrinder,
+/obj/item/stack/sheet/mineral/phoron{
+	amount = 10;
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/mainship/research,
+/area/mainship/medical/medical_science)
 "hq" = (
 /obj/structure/window/framed/mainship/requisitions,
 /turf/open/floor/plating,
@@ -2369,13 +2669,8 @@
 /turf/open/floor/plating,
 /area/mainship/living/evacuation)
 "hu" = (
-/obj/effect/decal/cleanable/blood/oil{
-	name = "grease";
-	pixel_x = -2;
-	pixel_y = -6
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/briefing)
+/turf/open/floor/wood,
+/area/mainship/hallways/hangar)
 "hv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
@@ -2417,6 +2712,52 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/port_hallway)
+"hE" = (
+/obj/item/storage/firstaid/fire{
+	pixel_x = 7
+	},
+/obj/item/storage/firstaid/fire{
+	pixel_x = 7
+	},
+/obj/item/storage/firstaid/o2{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/storage/firstaid/rad{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/storage/firstaid/adv{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/firstaid/adv{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/storage/firstaid/adv{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/structure/table/mainship/nometal,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "hF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
@@ -2431,6 +2772,22 @@
 	dir = 1
 	},
 /area/mainship/hallways/port_hallway)
+"hH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/holopad,
+/turf/open/floor/mainship/sterile,
+/area/mainship/medical/lower_medical)
+"hJ" = (
+/obj/structure/table/mainship/nometal,
+/obj/item/megaphone,
+/obj/item/book/manual/medical_diagnostics_manual,
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lounge)
 "hK" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -2453,6 +2810,11 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"hN" = (
+/turf/open/floor/mainship/silver{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "hO" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -2460,9 +2822,10 @@
 /turf/closed/wall/mainship,
 /area/mainship/hallways/hangar)
 "hP" = (
-/obj/vehicle/ridden/powerloader,
-/turf/open/floor/mainship/cargo,
-/area/mainship/squads/req)
+/obj/structure/table/woodentable,
+/obj/item/newspaper,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "hQ" = (
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 4
@@ -2497,24 +2860,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "hU" = (
-/obj/item/frame/table,
-/obj/item/frame/table,
-/obj/item/frame/table,
-/obj/structure/rack,
-/obj/machinery/door_control{
-	dir = 8;
-	id = "reqaccess";
-	name = "Requisitions Access"
-	},
-/obj/item/stack/sheet/cardboard,
-/obj/item/stack/sheet/glass/reinforced{
-	amount = 30
-	},
-/obj/item/stack/sheet/wood/large_stack,
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/autolathe,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "hV" = (
 /obj/structure/table/gamblingtable,
@@ -2619,6 +2966,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/port_atmos)
+"io" = (
+/obj/structure/bed/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/mainship/medical/lounge)
 "ip" = (
 /turf/open/floor/mainship/silver/corner{
 	dir = 1
@@ -2650,18 +3003,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "it" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/wood,
+/area/mainship/engineering/ce_room)
 "iu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -2805,25 +3149,33 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "iO" = (
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/tool/extinguisher,
-/obj/item/tool/extinguisher/mini,
-/obj/structure/rack,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/lightreplacer,
-/obj/machinery/light/mainship{
+/obj/structure/platform{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/squads/req)
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "iP" = (
 /obj/structure/table,
 /turf/open/floor/mainship/green{
 	dir = 10
 	},
 /area/mainship/hull/starboard_hull)
+"iQ" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
 "iR" = (
 /obj/structure/table,
 /obj/item/newspaper,
@@ -2854,6 +3206,10 @@
 /obj/effect/landmark/start/job/squadmarine,
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/living/cryo_cells)
+"ja" = (
+/obj/machinery/marine_selector/clothes/synth,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/command/cic)
 "jb" = (
 /obj/effect/soundplayer,
 /turf/closed/wall/mainship,
@@ -2865,14 +3221,11 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "jd" = (
-/obj/item/ammo_casing/bullet{
-	pixel_x = 5;
-	pixel_y = -5
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
 	},
-/turf/open/floor/mainship/red{
-	dir = 4
-	},
-/area/mainship/living/briefing)
+/turf/open/floor/mainship/mono,
+/area/mainship/command/cic)
 "je" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -2887,6 +3240,35 @@
 	},
 /turf/closed/wall/mainship,
 /area/mainship/living/evacuation)
+"jh" = (
+/obj/machinery/door/airlock/mainship/medical/glass{
+	name = "Medical Lounge"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lounge)
+"ji" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/port_hallway)
 "jj" = (
 /turf/open/floor/mainship/silver/corner,
 /area/mainship/hallways/port_hallway)
@@ -2913,6 +3295,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"jp" = (
+/obj/structure/closet/secure_closet/CMO,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lounge)
 "jq" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/mono,
@@ -3011,6 +3397,10 @@
 /obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"jE" = (
+/obj/machinery/holopad,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "jF" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -3084,10 +3474,14 @@
 	},
 /area/mainship/hallways/starboard_hallway)
 "jO" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 6
+/obj/structure/table/reinforced,
+/obj/machinery/microwave,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/area/mainship/hallways/starboard_hallway)
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "jP" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/bulletproof,
@@ -3206,7 +3600,7 @@
 	},
 /obj/item/stack/sheet/mineral/phoron/medium_stack,
 /turf/open/floor/mainship/cargo,
-/area/mainship/command/self_destruct)
+/area/mainship/hallways/hangar)
 "kd" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 8
@@ -3224,6 +3618,16 @@
 /obj/effect/decal/siding,
 /turf/open/floor/mainship/terragov/north,
 /area/space)
+"kh" = (
+/obj/machinery/door/airlock/mainship/medical/free_access{
+	dir = 2;
+	name = "Chemistry"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
 "ki" = (
 /turf/open/floor/mainship/silver{
 	dir = 8
@@ -3235,10 +3639,9 @@
 	},
 /area/mainship/hallways/port_hallway)
 "km" = (
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 1
-	},
-/area/mainship/command/self_destruct)
+/obj/machinery/holopad,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/briefing)
 "kn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -3259,15 +3662,15 @@
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/medical_science)
 "kr" = (
-/obj/machinery/door/airlock/multi_tile/mainship/research,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/turf/open/floor/mainship/silver/full,
-/area/mainship/medical/medical_science)
+/turf/open/floor/mainship/sterile,
+/area/mainship/medical/lower_medical)
 "ks" = (
-/turf/open/floor/mainship/silver/full,
-/area/mainship/medical/medical_science)
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 4
+	},
+/area/mainship/medical/chemistry)
 "kt" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/lower_medical)
@@ -3310,11 +3713,29 @@
 /obj/structure/supply_drop,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"kF" = (
+/obj/machinery/door/airlock/multi_tile/mainship/research,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/turf/open/floor/mainship/silver/full,
+/area/mainship/medical/medical_science)
 "kI" = (
 /turf/open/floor/mainship_hull/dir{
 	dir = 10
 	},
 /area/space)
+"kJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "kK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3331,8 +3752,15 @@
 	},
 /obj/structure/cable,
 /obj/machinery/light/mainship,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"kN" = (
+/obj/machinery/holopad,
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
+/area/mainship/living/briefing)
 "kO" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -3389,36 +3817,71 @@
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
 "kZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lounge)
+"la" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/mainship/silver{
+/obj/structure/bed/chair/comfy/beige{
 	dir = 8
 	},
-/area/mainship/medical/medical_science)
-"la" = (
-/turf/open/floor/mainship/silver{
+/obj/effect/landmark/start/job/staffofficer,
+/turf/open/floor/carpet/side{
 	dir = 4
 	},
-/area/mainship/medical/medical_science)
+/area/mainship/living/bridgebunks)
 "lb" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/reagentgrinder,
-/obj/item/stack/sheet/mineral/phoron{
-	amount = 10;
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/light/mainship,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
 	},
-/obj/item/storage/box/beakers{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/mainship/research,
-/area/mainship/medical/medical_science)
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "lc" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/port_atmos)
 "ld" = (
+/obj/machinery/power/apc/mainship{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/port_garden)
+"le" = (
+/obj/machinery/computer/camera_advanced/overwatch/bravo{
+	name = "Charlie Overwatch Console"
+	},
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/obj/structure/table/mainship/nometal,
+/turf/open/floor/mainship/mono,
+/area/mainship/command/cic)
+"lg" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/surgical_tray,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/light/mainship{
+	light_color = "#da2f1b"
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
+"lh" = (
+/obj/structure/morgue,
+/turf/open/floor/mainship/silver/full,
+/area/mainship/medical/lower_medical)
+"li" = (
+/obj/structure/bed/chair/comfy/black,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
+"lj" = (
 /obj/machinery/chem_master,
 /obj/machinery/light/mainship{
 	dir = 1
@@ -3426,26 +3889,6 @@
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
-"lg" = (
-/obj/machinery/computer/pandemic,
-/turf/open/floor/mainship/research,
-/area/mainship/medical/medical_science)
-"lh" = (
-/obj/structure/morgue,
-/turf/open/floor/mainship/silver/full,
-/area/mainship/medical/lower_medical)
-"li" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/plain,
-/area/mainship/medical/lower_medical)
-"lj" = (
-/obj/structure/morgue{
-	dir = 8
-	},
-/turf/open/floor/mainship/silver/full,
-/area/mainship/medical/lower_medical)
 "lk" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/trash/cheesie,
@@ -3454,23 +3897,16 @@
 	},
 /area/mainship/living/evacuation)
 "ll" = (
-/obj/structure/morgue/crematorium,
-/obj/machinery/crema_switch{
-	pixel_x = 24
+/turf/open/floor/mainship/sterile/purple/corner{
+	dir = 1
 	},
-/turf/open/floor/mainship/silver{
-	dir = 8
-	},
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/chemistry)
 "lm" = (
-/obj/machinery/door/airlock/multi_tile/mainship/marine/requisitions{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1
+/obj/structure/flora/pottedplant/twentyone{
+	icon_state = "plant-12"
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/area/mainship/living/tankerbunks)
 "lo" = (
 /obj/machinery/computer/supplydrop_console,
 /obj/structure/table/mainship/nometal,
@@ -3600,7 +4036,7 @@
 /obj/machinery/computer/general_air_control/large_tank_control{
 	name = "Nitrogen Control Console";
 	output_tag = "nit_out";
-	sensors = list("nit_sensor" = "Tank")
+	sensors = list("nit_sensor"="Tank")
 	},
 /turf/open/floor/mainship/black{
 	dir = 1
@@ -3639,6 +4075,10 @@
 	dir = 9
 	},
 /area/mainship/living/bridgebunks)
+"lL" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "lM" = (
 /turf/open/floor/mainship/red{
 	dir = 1
@@ -3668,16 +4108,39 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/self_destruct)
+"lR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/mainship/medical/lounge)
 "lS" = (
 /obj/effect/soundplayer,
 /turf/closed/wall/mainship,
 /area/mainship/command/cic)
+"lU" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/obj/structure/flora/pottedplant/twentyone{
+	icon_state = "plant-09"
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "lV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/mob/living/simple_animal/corgi/walten,
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
+	dir = 1;
+	name = "Chemistry";
+	req_one_access = list(2,8,40)
+	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/chemistry)
 "lW" = (
 /turf/open/floor/mainship_hull/dir{
 	dir = 6
@@ -3695,6 +4158,16 @@
 	},
 /turf/open/floor/mainship_hull,
 /area/mainship/powered)
+"lZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/living/briefing)
 "ma" = (
 /obj/structure/window/framed/mainship/canterbury,
 /turf/open/floor/mainship/mono,
@@ -3756,44 +4229,38 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "ml" = (
-/obj/structure/bed/stool{
-	pixel_y = 8
-	},
-/obj/effect/landmark/start/job/researcher,
-/turf/open/floor/mainship/research,
-/area/mainship/medical/medical_science)
+/obj/machinery/vending/cola,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "mm" = (
-/obj/machinery/alarm{
-	dir = 8
-	},
-/turf/open/floor/mainship/research,
-/area/mainship/medical/medical_science)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/hallways/hangar)
 "mn" = (
 /turf/open/floor/mainship/sterile/plain,
 /area/mainship/medical/lower_medical)
 "mo" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
+/obj/machinery/light/mainship{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/ash,
-/turf/open/floor/mainship/silver{
-	dir = 10
-	},
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/bridgebunks)
 "mp" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"mr" = (
+/obj/machinery/vending/snack,
+/obj/machinery/light/mainship,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "ms" = (
-/obj/machinery/computer/camera_advanced/overwatch/bravo{
-	name = "Delta Overwatch Console"
+/obj/structure/bed/chair/wood/normal{
+	dir = 4
 	},
-/obj/structure/table/reinforced,
-/obj/structure/table/mainship/nometal,
-/turf/open/floor/mainship/mono,
-/area/mainship/command/cic)
+/turf/open/floor/wood,
+/area/mainship/hallways/hangar)
 "mv" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
@@ -3806,6 +4273,18 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
+"mx" = (
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/side{
+	dir = 5
+	},
+/area/mainship/living/commandbunks)
 "my" = (
 /obj/machinery/computer/supplycomp,
 /obj/machinery/light/mainship{
@@ -3813,15 +4292,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"mz" = (
+/obj/structure/sign/chemistry2,
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/lower_medical)
 "mA" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/squads/req)
+/turf/closed/wall/mainship,
+/area/mainship/living/tankerbunks)
 "mB" = (
 /obj/structure/flora/pottedplant/twentyone{
 	icon_state = "plant-12"
@@ -4004,6 +4481,9 @@
 /obj/machinery/vending/medical,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/general)
+"ne" = (
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/operating_room_two)
 "nf" = (
 /obj/structure/lattice,
 /turf/closed/shuttle/ert{
@@ -4083,9 +4563,10 @@
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
 "nt" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/mainship/research,
-/area/mainship/medical/medical_science)
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/port_garden)
 "nu" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/mainship{
@@ -4108,15 +4589,36 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "nx" = (
-/obj/machinery/vending/medical/shipside,
-/turf/open/floor/mainship/research,
-/area/mainship/medical/medical_science)
-"nz" = (
-/obj/machinery/light/mainship{
+/obj/structure/rack,
+/obj/item/defibrillator,
+/obj/item/defibrillator,
+/obj/item/defibrillator,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
+"ny" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
+"nz" = (
+/obj/effect/decal/warning_stripes/thin,
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/area/mainship/living/tankerbunks)
 "nA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -4185,9 +4687,8 @@
 /turf/open/floor/mainship/red,
 /area/mainship/shipboard/firing_range)
 "nJ" = (
-/obj/structure/disposalpipe/segment/corner,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/squads/req)
+/turf/open/floor/mainship/black,
+/area/mainship/hallways/hangar)
 "nK" = (
 /obj/effect/landmark/start/job/squadcorpsman,
 /turf/open/floor/mainship/cargo/arrow{
@@ -4255,6 +4756,18 @@
 	dir = 4
 	},
 /area/mainship/shipboard/weapon_room)
+"nU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/purple/side,
+/area/mainship/medical/chemistry)
+"nV" = (
+/obj/machinery/light/mainship{
+	light_color = "#da2f1b"
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "nX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/ai_node,
@@ -4290,9 +4803,8 @@
 /area/mainship/living/pilotbunks)
 "ob" = (
 /obj/structure/table/mainship/nometal,
-/obj/effect/spawner/random/plushie/nospawnninety,
 /turf/open/floor/mainship/floor,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/living/briefing)
 "oc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -4348,6 +4860,11 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
+"ok" = (
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 1
+	},
+/area/mainship/medical/chemistry)
 "ol" = (
 /turf/open/floor/mainship/research/containment/floor1,
 /area/mainship/medical/medical_science)
@@ -4445,26 +4962,84 @@
 	},
 /area/mainship/medical/medical_science)
 "ox" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable,
-/turf/open/floor/mainship/silver/corner{
-	dir = 1
+/obj/structure/bed/chair/office/dark{
+	dir = 8
 	},
-/area/mainship/medical/medical_science)
+/obj/effect/landmark/start/job/cmo,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lounge)
 "oy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
 	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/bridgebunks)
+"oz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/obj/structure/disposalpipe/segment/corner,
 /obj/structure/cable,
-/turf/open/floor/mainship/silver/corner{
+/turf/open/floor/mainship/silver{
 	dir = 4
 	},
 /area/mainship/medical/medical_science)
-"oz" = (
+"oA" = (
+/obj/structure/closet/firecloset,
+/obj/item/clothing/mask/gas,
+/obj/effect/decal/warning_stripes/thin,
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/hangar)
+"oB" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/silver{
+	dir = 4
+	},
+/area/mainship/hallways/port_hallway)
+"oC" = (
+/obj/item/frame/table,
+/obj/item/frame/table,
+/obj/item/frame/table,
+/obj/structure/rack,
+/obj/machinery/door_control{
+	dir = 8;
+	id = "reqaccess";
+	name = "Requisitions Access"
+	},
+/obj/item/stack/sheet/cardboard,
+/obj/item/stack/sheet/glass/reinforced{
+	amount = 30
+	},
+/obj/item/stack/sheet/wood/large_stack,
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/squads/req)
+"oD" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/plain,
+/area/mainship/medical/lower_medical)
+"oE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -4477,7 +5052,7 @@
 	dir = 1
 	},
 /area/mainship/medical/medical_science)
-"oA" = (
+"oF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -4490,7 +5065,11 @@
 	dir = 1
 	},
 /area/mainship/medical/medical_science)
-"oB" = (
+"oG" = (
+/obj/machinery/vending/weapon,
+/turf/open/floor/mainship/red,
+/area/mainship/command/cic)
+"oH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
@@ -4502,49 +5081,9 @@
 	dir = 5
 	},
 /area/mainship/medical/medical_science)
-"oD" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/plain,
-/area/mainship/medical/lower_medical)
-"oE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 4;
-	on = 1
-	},
-/turf/open/floor/mainship/sterile/plain,
-/area/mainship/medical/lower_medical)
-"oF" = (
-/obj/structure/disposalpipe/segment/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/mainship/sterile/plain,
-/area/mainship/medical/lower_medical)
-"oG" = (
-/obj/machinery/vending/weapon,
-/turf/open/floor/mainship/red,
-/area/mainship/command/cic)
-"oH" = (
-/obj/machinery/light/mainship,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/plain,
-/area/mainship/medical/lower_medical)
 "oI" = (
-/obj/machinery/autolathe,
-/obj/structure/sign/poster,
 /turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/area/mainship/living/tankerbunks)
 "oK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -4561,9 +5100,23 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "oM" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/machinery/light/mainship,
+/turf/open/floor/mainship/sterile/purple/corner{
+	dir = 4
+	},
+/area/mainship/medical/chemistry)
+"oN" = (
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
+"oP" = (
+/obj/structure/bed,
+/obj/item/bedsheet/hop,
+/obj/effect/landmark/start/job/fieldcommander,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "oQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -4616,6 +5169,24 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/starboard_hull)
+"oX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/mainship/sterile/plain,
+/area/mainship/medical/lower_medical)
+"oY" = (
+/obj/machinery/door_control/mainship{
+	dir = 8;
+	id = mechbay;
+	name = "Mech Bay Shutters"
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "oZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -4627,6 +5198,10 @@
 /obj/machinery/light/mainship,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/port_atmos)
+"pa" = (
+/obj/machinery/computer/arcade,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "pb" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/mainship/sterile/corner,
@@ -4661,6 +5236,12 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/port_hallway)
+"pi" = (
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship/red{
+	dir = 9
+	},
+/area/mainship/living/briefing)
 "pj" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
@@ -4675,6 +5256,15 @@
 	dir = 4
 	},
 /area/mainship/medical/lower_medical)
+"pm" = (
+/obj/structure/window/reinforced/extratoughened{
+	dir = 4
+	},
+/obj/structure/window/reinforced/extratoughened{
+	dir = 1
+	},
+/turf/open/floor/mainship/tcomms,
+/area/mainship/command/airoom)
 "pn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -4687,6 +5277,12 @@
 	dir = 10
 	},
 /area/mainship/medical/medical_science)
+"pp" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "pq" = (
 /obj/machinery/light/mainship/small,
 /turf/open/floor/mainship/research/containment/floor2,
@@ -4751,26 +5347,17 @@
 /turf/open/floor/mainship/silver,
 /area/mainship/medical/medical_science)
 "pB" = (
-/obj/structure/closet/toolcloset,
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/cargo,
-/area/mainship/command/self_destruct)
+/obj/machinery/light/mainship,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "pC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/silver,
-/area/mainship/medical/medical_science)
+/obj/structure/table/mainship/nometal,
+/obj/item/storage/box/cups,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "pD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/silver/corner{
-	dir = 8
-	},
+/obj/machinery/computer/pandemic,
+/turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
 "pE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -4782,27 +5369,26 @@
 /turf/open/floor/mainship/silver/full,
 /area/mainship/medical/medical_science)
 "pF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
 	},
-/obj/effect/ai_node,
-/obj/structure/disposalpipe/segment/corner,
-/obj/structure/cable,
-/turf/open/floor/mainship/silver{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/area/mainship/medical/medical_science)
-"pG" = (
-/obj/machinery/door/airlock/mainship/medical/morgue{
-	dir = 2
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
-/area/mainship/medical/lower_medical)
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
+"pG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/silver/corner{
+	dir = 8
+	},
+/area/mainship/medical/medical_science)
 "pH" = (
 /obj/item/radio/intercom/general{
 	dir = 4
@@ -4814,6 +5400,12 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"pJ" = (
+/obj/structure/bed/chair/wood/wings{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "pK" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -4844,14 +5436,13 @@
 /area/mainship/hallways/hangar)
 "pN" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/junction/flipped{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/turf/open/floor/mainship/sterile/side{
+	dir = 10
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar)
+/area/mainship/medical/lower_medical)
 "pO" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -4863,10 +5454,33 @@
 /obj/structure/window/framed/mainship,
 /turf/open/floor/plating,
 /area/mainship/command/self_destruct)
+"pQ" = (
+/obj/machinery/marine_selector/clothes/commander,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
+"pR" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/obj/machinery/light/mainship,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
+"pS" = (
+/obj/structure/table/woodentable,
+/obj/item/storage/fancy/cigarettes,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "pT" = (
 /obj/docking_port/stationary/supply,
 /turf/open/floor/mainship/empty,
 /area/mainship/squads/req)
+"pU" = (
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship/silver{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "pV" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/mainship/black{
@@ -4916,6 +5530,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/shipboard/firing_range)
+"qc" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/hallways/hangar)
 "qd" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -4929,6 +5549,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/shipboard/firing_range)
+"qf" = (
+/turf/open/floor/mainship/silver{
+	dir = 6
+	},
+/area/mainship/hallways/hangar)
 "qg" = (
 /obj/structure/closet/crate,
 /obj/item/target/syndicate,
@@ -4939,6 +5564,32 @@
 /obj/item/healthanalyzer,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
+"qi" = (
+/obj/structure/bed/chair/sofa/right{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
+"qj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
+"qk" = (
+/obj/structure/bed/chair/sofa{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
+"ql" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/purple/corner{
+	dir = 8
+	},
+/area/mainship/medical/chemistry)
 "qm" = (
 /obj/structure/sign/prop1{
 	name = "Smartgunner Preparations"
@@ -4964,6 +5615,31 @@
 	},
 /turf/open/floor/mainship_hull,
 /area/space)
+"qr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/living/briefing)
+"qs" = (
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/mainship/sterile/side{
+	dir = 10
+	},
+/area/mainship/medical/lounge)
+"qt" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "qu" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 2;
@@ -5011,14 +5687,20 @@
 	},
 /area/mainship/medical/medical_science)
 "qB" = (
-/obj/machinery/camera/autoname/mainship{
+/obj/structure/table/mainship/nometal,
+/obj/machinery/computer/shuttle/shuttle_control/dropship,
+/turf/open/floor/mainship/black{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/command/self_destruct)
+/area/mainship/hallways/hangar)
 "qC" = (
 /turf/closed/wall/mainship/research/containment/wall/south,
 /area/mainship/medical/medical_science)
+"qD" = (
+/turf/open/floor/mainship/black/corner{
+	dir = 4
+	},
+/area/mainship/hallways/hangar)
 "qE" = (
 /turf/closed/wall/mainship/research/containment/wall/corner,
 /area/mainship/medical/medical_science)
@@ -5039,23 +5721,24 @@
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
 "qI" = (
-/obj/structure/bed/chair/office/dark,
-/turf/open/floor/mainship/research,
-/area/mainship/medical/medical_science)
-"qJ" = (
-/turf/open/floor/mainship/silver{
-	dir = 8
-	},
-/area/mainship/medical/medical_science)
-"qK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/mainship/silver{
+/turf/open/floor/carpet/side{
 	dir = 4
 	},
-/area/mainship/medical/medical_science)
+/area/mainship/living/grunt_rnr)
+"qJ" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
+"qK" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/ai_node,
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/plain,
+/area/mainship/medical/lower_medical)
 "qL" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -5071,30 +5754,29 @@
 	},
 /area/mainship/medical/lower_medical)
 "qN" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/bed/chair/office/dark,
+/turf/open/floor/mainship/research,
+/area/mainship/medical/medical_science)
+"qO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/alarm{
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/mainship/silver{
+	dir = 4
+	},
+/area/mainship/medical/medical_science)
+"qP" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/purple/side{
 	dir = 8
 	},
-/turf/open/floor/mainship/sterile/corner,
-/area/mainship/medical/lower_medical)
-"qO" = (
-/obj/structure/sign/custodian,
-/turf/closed/wall/mainship/white,
-/area/mainship/medical/lower_medical)
-"qP" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/mainship/sterile/plain,
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/chemistry)
 "qQ" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/glass/bucket/janibucket,
-/obj/item/tool/mop,
-/turf/open/floor/mainship/sterile/plain,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship_hull,
+/area/mainship/powered)
 "qR" = (
 /obj/structure/ship_ammo/heavygun,
 /obj/machinery/light/mainship{
@@ -5123,21 +5805,36 @@
 /obj/vehicle/ridden/motorbike,
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
+"qW" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
+"qY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/structure/disposalpipe/junction,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/port_hallway)
+"ra" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/command/cic)
 "rb" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "rg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/computer/crew,
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/squads/req)
+/area/mainship/medical/lounge)
 "rh" = (
 /obj/effect/decal/siding{
 	dir = 10
@@ -5187,6 +5884,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/shipboard/firing_range)
+"ro" = (
+/obj/machinery/door/airlock/mainship/marine/general{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "rp" = (
 /obj/structure/sign/securearea/firingrange,
 /turf/open/floor/mainship/mono,
@@ -5207,11 +5913,12 @@
 	},
 /area/mainship/living/cryo_cells)
 "rv" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 4
-	},
-/area/mainship/medical/chemistry)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/port_hallway)
 "rw" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -5233,6 +5940,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"rz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
+"rB" = (
+/obj/structure/table/mainship/nometal,
+/obj/machinery/recharger,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "rC" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/gas,
@@ -5263,6 +5979,13 @@
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
+"rI" = (
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "rJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -5288,11 +6011,17 @@
 	},
 /area/mainship/hallways/starboard_hallway)
 "rM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
 "rN" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -5331,16 +6060,26 @@
 /obj/item/assembly/infra,
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
+"rS" = (
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
+/obj/effect/landmark/start/job/researcher,
+/turf/open/floor/mainship/research,
+/area/mainship/medical/medical_science)
 "rT" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/faxmachine/research,
-/turf/open/floor/mainship/research,
-/area/mainship/medical/medical_science)
+/obj/structure/morgue{
+	dir = 8
+	},
+/turf/open/floor/mainship/silver/full,
+/area/mainship/medical/lower_medical)
 "rU" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/light/mainship,
-/turf/open/floor/mainship/research,
-/area/mainship/medical/medical_science)
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 1;
+	on = 1
+	},
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "rV" = (
 /obj/item/ammo_casing/bullet{
 	pixel_x = -7;
@@ -5349,16 +6088,12 @@
 /turf/open/floor/mainship/purple,
 /area/mainship/living/briefing)
 "rW" = (
-/obj/structure/table/mainship/nometal,
-/obj/structure/paper_bin,
-/obj/item/tool/pen,
-/obj/item/clipboard{
-	pixel_x = -6;
-	pixel_y = 1
+/obj/machinery/loadout_vendor,
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
 	},
-/obj/structure/sign/science,
-/turf/open/floor/mainship/research,
-/area/mainship/medical/medical_science)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "rX" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -5381,13 +6116,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
 "sa" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
+/turf/open/floor/mainship/silver{
+	dir = 8
 	},
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/medical_science)
 "sb" = (
 /obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/mono,
@@ -5399,18 +6131,21 @@
 	},
 /area/mainship/medical/chemistry)
 "sd" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -9
-	},
-/turf/open/floor/mainship/sterile/plain,
-/area/mainship/medical/lower_medical)
+/obj/structure/table/woodentable,
+/obj/item/storage/donut_box,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "sf" = (
-/obj/machinery/light/mainship{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/turf/open/floor/mainship/sterile/plain,
-/area/mainship/medical/lower_medical)
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lounge)
 "sg" = (
 /obj/structure/cable,
 /obj/effect/decal/warning_stripes/thin{
@@ -5448,10 +6183,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "sk" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 10
-	},
-/area/mainship/hallways/starboard_hallway)
+/turf/open/floor/mainship/terragov/north,
+/area/mainship/living/briefing)
 "sl" = (
 /obj/machinery/door/poddoor/mainship/ammo,
 /turf/open/floor/mainship/mono,
@@ -5466,6 +6199,12 @@
 	dir = 8
 	},
 /area/mainship/squads/general)
+"sp" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/mainship/orange{
+	dir = 9
+	},
+/area/mainship/hallways/hangar)
 "sq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -5503,10 +6242,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cryo_cells)
 "sy" = (
-/obj/structure/table/woodentable,
-/obj/item/reagent_containers/food/snacks/limecakeslice,
+/obj/structure/closet/secure_closet/engineering_chief,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/ears/earmuffs,
 /turf/open/floor/wood,
-/area/mainship/medical/lounge)
+/area/mainship/engineering/ce_room)
 "sz" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic/noglass{
 	dir = 1
@@ -5536,16 +6276,17 @@
 	},
 /area/mainship/living/evacuation)
 "sE" = (
-/obj/machinery/door/airlock/multi_tile/mainship/research,
-/turf/open/floor/mainship/silver/full,
-/area/mainship/medical/medical_science)
-"sF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/mainship/silver/full,
-/area/mainship/medical/medical_science)
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/squads/req)
+"sF" = (
+/obj/machinery/light/mainship,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lounge)
 "sG" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
@@ -5555,11 +6296,12 @@
 	},
 /area/mainship/medical/lower_medical)
 "sH" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/mainship/silver/full,
+/area/mainship/medical/medical_science)
 "sI" = (
 /obj/machinery/floodlight/landing,
 /turf/open/floor/plating,
@@ -5578,40 +6320,32 @@
 	},
 /area/mainship/living/briefing)
 "sL" = (
-/obj/machinery/door_control/mainship/req{
-	dir = 1;
-	id = "qm_warehouse";
-	name = "Requisition Warehouse Shutters"
-	},
+/obj/effect/ai_node,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/disposalpipe/junction/flipped{
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
 "sM" = (
-/obj/structure/disposalpipe/junction,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
 	},
+/obj/machinery/camera/autoname/mainship,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+	dir = 6
 	},
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/squads/req)
-"sO" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/stack/cable_coil/twentyfive,
-/obj/item/lightreplacer,
 /turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/area/mainship/living/tankerbunks)
+"sO" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "sP" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 1;
@@ -5623,6 +6357,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
+"sR" = (
+/obj/machinery/door/airlock/mainship/maint,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/starboard_hull)
 "sT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -5702,6 +6447,13 @@
 	},
 /turf/open/floor/mainship_hull,
 /area/space)
+"th" = (
+/obj/machinery/power/apc/mainship{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "ti" = (
 /obj/machinery/door/airlock/mainship/evacuation{
 	dir = 8
@@ -5763,23 +6515,17 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "tq" = (
-/obj/machinery/vending/snack,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lounge)
+"tr" = (
 /obj/machinery/light/mainship{
-	dir = 1
+	dir = 8
+	},
+/obj/structure/bed/chair/nometal{
+	dir = 4
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
-"tr" = (
-/obj/structure/closet/firecloset,
-/obj/item/clothing/mask/gas,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/cargo,
-/area/mainship/hallways/port_hallway)
+/area/mainship/hallways/hangar)
 "ts" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/secure/req{
@@ -5795,38 +6541,38 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "tt" = (
-/obj/structure/bed/chair/comfy/black{
+/obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
-/turf/open/floor/mainship/red{
-	dir = 8
-	},
-/area/mainship/living/briefing)
+/obj/item/tool/wet_sign,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/hallways/hangar)
 "tu" = (
-/obj/structure/closet/emcloset,
-/obj/item/clothing/mask/gas,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/mainship/cargo,
-/area/mainship/hallways/port_hallway)
-"tw" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
-"tx" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
+/area/mainship/medical/lower_medical)
+"tv" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/purple/side{
 	dir = 8
 	},
+/area/mainship/medical/chemistry)
+"tw" = (
+/turf/open/floor/carpet,
+/area/mainship/living/bridgebunks)
+"tx" = (
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/turf/open/floor/mainship/sterile/plain,
+/area/mainship/medical/lower_medical)
 "ty" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/lounge)
@@ -5844,10 +6590,12 @@
 	},
 /area/mainship/medical/lounge)
 "tB" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/chem_dispenser/beer,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lounge)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "tD" = (
 /obj/effect/attach_point/electronics/dropship1,
 /turf/open/floor/plating,
@@ -5864,35 +6612,47 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/telecomms)
 "tF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lounge)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/poster{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "tG" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lounge)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "tH" = (
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lounge)
+/obj/machinery/computer/camera_advanced/remote_fob,
+/turf/open/floor/mainship/red{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "tI" = (
-/obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
+/obj/machinery/computer/mech_builder{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/mainship/living/tankerbunks)
 "tJ" = (
 /obj/effect/landmark/start/job/squadmarine,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/cryo_cells)
 "tL" = (
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/mainship/sterile/side{
-	dir = 10
+/obj/machinery/power/apc/mainship,
+/obj/structure/cable,
+/turf/open/floor/mainship/silver{
+	dir = 1
 	},
-/area/mainship/medical/lounge)
+/area/mainship/hallways/hangar)
 "tM" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/glass/beaker/biomass,
@@ -5931,6 +6691,16 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
+"tR" = (
+/obj/structure/table/woodentable,
+/obj/item/paper,
+/obj/item/folder{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/tool/pen,
+/turf/open/floor/carpet,
+/area/mainship/living/bridgebunks)
 "tS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -5955,17 +6725,10 @@
 	},
 /area/mainship/medical/lower_medical)
 "tV" = (
-/obj/machinery/vending/medical/shipside,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light/mainship{
+/turf/open/floor/mainship/sterile/purple/side{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/chemistry)
 "tW" = (
 /obj/structure/dropship_equipment/sentry_holder,
 /turf/open/floor/mainship/cargo,
@@ -5994,29 +6757,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "uc" = (
-/turf/open/floor/mainship/terragov{
-	dir = 1
+/turf/open/floor/mainship/terragov/north{
+	dir = 4
 	},
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/living/briefing)
 "ue" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/squads/req)
+/obj/structure/window/framed/mainship,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "uf" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 8;
@@ -6032,6 +6780,10 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/port_hull)
+"uj" = (
+/obj/machinery/vending/medical/shipside,
+/turf/open/floor/mainship/research,
+/area/mainship/medical/medical_science)
 "uk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -6039,6 +6791,16 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
+"ul" = (
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
+"um" = (
+/obj/structure/mirror,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/hallways/hangar)
 "un" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -6109,6 +6871,11 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
+"uz" = (
+/turf/open/floor/carpet/side{
+	dir = 10
+	},
+/area/mainship/living/grunt_rnr)
 "uA" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -6173,13 +6940,17 @@
 	},
 /area/mainship/hallways/port_hallway)
 "uF" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
-/obj/structure/disposalpipe/junction,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/silver{
+	dir = 4
+	},
 /area/mainship/hallways/port_hallway)
 "uG" = (
 /turf/open/floor/plating,
@@ -6189,10 +6960,13 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/silver{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/door/airlock/multi_tile/mainship/personalglass{
+	dir = 2
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "uI" = (
 /obj/machinery/cic_maptable/droppod_maptable,
@@ -6210,94 +6984,77 @@
 /turf/open/floor/plating,
 /area/mainship/command/self_destruct)
 "uL" = (
-/obj/structure/bed/chair/sofa/right,
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile,
+/area/mainship/medical/lower_medical)
+"uN" = (
+/obj/machinery/vending/cola,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
+"uO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
-"uN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/lounge)
+"uP" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/mainship/green{
+	dir = 10
+	},
+/area/mainship/living/port_garden)
+"uQ" = (
 /obj/structure/bed/chair/sofa/corner,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
-"uO" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "Medical Lounge"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lounge)
-"uP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lounge)
-"uQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/wood,
-/area/mainship/medical/lounge)
 "uS" = (
-/obj/structure/bed/chair/wood/wings,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /obj/structure/cable,
-/turf/open/floor/wood,
-/area/mainship/medical/lounge)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "uT" = (
-/obj/structure/bed/chair/wood/wings,
+/obj/structure/bed/chair/sofa/right,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/wood,
-/area/mainship/medical/lounge)
-"uU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/medical/lounge)
-"uV" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "Medical Lounge"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
 /obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
+"uU" = (
+/obj/structure/cable,
+/obj/machinery/holopad,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lounge)
+/area/mainship/medical/lower_medical)
+"uV" = (
+/turf/open/floor/mainship/terragov/north{
+	dir = 10
+	},
+/area/mainship/living/briefing)
 "uW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -6336,66 +7093,45 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "uZ" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/dark,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
 /area/mainship/medical/lower_medical)
 "va" = (
 /obj/structure/window/framed/mainship/hull,
 /turf/open/floor/plating,
 /area/mainship/hull/port_hull)
 "vb" = (
-/obj/machinery/vending/MarineMed/Blood,
-/obj/structure/disposalpipe/junction,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
+/obj/effect/landmark/start/job/medicalofficer,
+/turf/open/floor/wood,
+/area/mainship/medical/lounge)
 "vc" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/clothing/head/welding,
-/obj/item/tool/weldingtool/largetank,
-/obj/item/tool/weldingtool/largetank,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/tool/weldingtool/largetank,
-/obj/item/tool/weldingtool/largetank,
-/obj/item/tool/weldpack/marinestandard,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
-"vd" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/storage/box/masks,
-/obj/item/storage/box/masks,
-/obj/item/storage/box/gloves{
-	pixel_x = -5;
-	pixel_y = -5
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
 	},
-/obj/item/storage/box/gloves{
-	pixel_x = -5;
-	pixel_y = -5
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
-/obj/machinery/light/mainship{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/port_garden)
+"vd" = (
+/obj/structure/bed/chair/wood/wings{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/mainship/medical/lounge)
 "ve" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -6403,22 +7139,20 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "vf" = (
-/obj/effect/ai_node,
-/obj/machinery/light/mainship,
+/obj/machinery/door/airlock/mainship/medical/free_access{
+	dir = 2;
+	name = "Chemistry"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/squads/req)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
 "vg" = (
 /obj/structure/bed/chair/comfy/black,
 /turf/open/floor/mainship/silver/full,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/living/briefing)
 "vh" = (
 /obj/effect/decal/siding{
 	dir = 9
@@ -6447,7 +7181,7 @@
 "vm" = (
 /obj/structure/largecrate/supply/ammo/standard_ammo,
 /turf/open/floor/mainship/cargo,
-/area/mainship/command/self_destruct)
+/area/mainship/hallways/hangar)
 "vn" = (
 /obj/effect/landmark/start/latejoin,
 /turf/open/floor/mainship/cargo/arrow{
@@ -6466,6 +7200,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"vp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/squads/req)
 "vq" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/silver{
@@ -6505,21 +7246,49 @@
 "vw" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
-"vy" = (
-/obj/structure/table,
-/obj/item/trash/cheesie,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
-"vz" = (
-/obj/structure/bed/chair/sofa{
+"vx" = (
+/obj/structure/flora/pottedplant/twentyone,
+/obj/machinery/light/mainship{
 	dir = 8
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/area/mainship/living/briefing)
+"vy" = (
+/obj/structure/disposalpipe/segment/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/mainship/sterile/plain,
+/area/mainship/medical/lower_medical)
+"vz" = (
+/obj/structure/table/mainship/nometal,
+/obj/item/storage/box/masks,
+/obj/item/storage/box/masks,
+/obj/item/storage/box/gloves{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/obj/item/storage/box/gloves{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "vA" = (
-/obj/machinery/vending/cola,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/area/mainship/living/tankerbunks)
 "vB" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/mono,
@@ -6534,37 +7303,45 @@
 	},
 /area/mainship/medical/lounge)
 "vD" = (
-/obj/structure/bed/chair/wood/wings{
-	dir = 4
+/obj/structure/bed/chair/sofa{
+	dir = 8
 	},
-/turf/open/floor/wood,
-/area/mainship/medical/lounge)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "vE" = (
-/obj/structure/table/woodentable,
-/obj/effect/spawner/random/plushie/nospawnninety,
-/turf/open/floor/wood,
-/area/mainship/medical/lounge)
+/obj/machinery/door/airlock/multi_tile/mainship/personalglass{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "vF" = (
-/obj/structure/bed/chair/wood/wings{
+/obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/turf/open/floor/wood,
-/area/mainship/medical/lounge)
-"vG" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/ai_node,
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/plain,
-/area/mainship/medical/lower_medical)
-"vH" = (
+/obj/structure/platform_decoration,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
+"vG" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
 /area/mainship/medical/lounge)
+"vH" = (
+/obj/structure/toilet,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
+"vI" = (
+/obj/structure/closet/toolcloset,
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/hangar)
 "vJ" = (
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
@@ -6596,9 +7373,8 @@
 	},
 /area/mainship/medical/lower_medical)
 "vN" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/sterile/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mainship/sterile/plain,
 /area/mainship/medical/lower_medical)
 "vP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -6613,21 +7389,15 @@
 	},
 /area/mainship/living/evacuation)
 "vQ" = (
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
-	dir = 1;
-	name = "Medical Storage"
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
-"vR" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/machinery/camera/autoname/mainship{
+/obj/machinery/alarm{
 	dir = 8
 	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/research,
+/area/mainship/medical/medical_science)
+"vR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/port_garden)
 "vS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6661,17 +7431,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "vU" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
+/obj/effect/ai_node,
+/turf/open/floor/mainship/silver,
+/area/mainship/medical/medical_science)
 "vV" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
@@ -6680,6 +7445,16 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"vW" = (
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
+"vX" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/hallways/hangar)
 "vY" = (
 /obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/door/poddoor/shutters/mainship/req/ro{
@@ -6688,9 +7463,26 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "wb" = (
-/obj/machinery/holopad,
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/starboard_hallway)
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	pixel_y = 5
+	},
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
+"wc" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "wd" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/purple/side{
@@ -6735,32 +7527,54 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
+"wk" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "wl" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "wm" = (
-/obj/structure/bed/chair/sofa/right{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
-"wn" = (
-/obj/structure/bed/chair/sofa{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
-"wp" = (
-/obj/structure/bed/chair/sofa/corner{
+/obj/machinery/door/airlock/mainship/maint{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/turf/open/floor/plating,
+/area/mainship/living/bridgebunks)
+"wn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile,
+/area/mainship/medical/lower_medical)
+"wo" = (
+/obj/machinery/light,
+/turf/open/floor/mainship_hull,
+/area/space)
+"wp" = (
+/obj/item/tool/kitchen/tray,
+/obj/item/clothing/suit/chef/classic,
+/obj/item/clothing/head/chefhat,
+/obj/structure/table/reinforced,
+/obj/item/tool/kitchen/rollingpin,
+/obj/item/clothing/gloves/latex,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "wq" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/turf/open/floor/mainship/silver/full,
+/area/mainship/medical/medical_science)
 "wr" = (
 /obj/structure/flora/pottedplant/twentyone,
 /turf/open/floor/mainship/sterile/side{
@@ -6768,49 +7582,49 @@
 	},
 /area/mainship/medical/lounge)
 "ws" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/machinery/holopad,
-/turf/open/floor/wood,
-/area/mainship/medical/lounge)
-"wt" = (
-/obj/structure/bed/chair/wood/wings{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/mainship/medical/lounge)
-"wv" = (
-/obj/structure/bed/chair/wood/wings{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/mainship/medical/lounge)
-"ww" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/start/job/medicalofficer,
-/turf/open/floor/wood,
-/area/mainship/medical/lounge)
-"wx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/side{
+/obj/structure/bed/chair/sofa/corner{
 	dir = 8
 	},
-/area/mainship/medical/lounge)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
+"wt" = (
+/obj/structure/sink/bathroom{
+	pixel_y = 14
+	},
+/obj/item/tool/soap/nanotrasen,
+/obj/structure/mirror,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/hallways/hangar)
+"wu" = (
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/multi_tile/mainship/marine/requisitions{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/squads/req)
+"wv" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
+"ww" = (
+/obj/machinery/light/mainship,
+/turf/open/floor/mainship/black,
+/area/mainship/living/briefing)
+"wx" = (
+/obj/structure/bed/chair/nometal{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "wy" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -6843,68 +7657,37 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "wD" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/mainship/sterile/plain,
-/area/mainship/medical/lower_medical)
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/mainship/research,
+/area/mainship/medical/medical_science)
 "wE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mainship/sterile/plain,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/red{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "wF" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/machinery/holopad,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/carpet/side{
+	dir = 5
+	},
+/area/mainship/living/bridgebunks)
 "wG" = (
-/obj/effect/landmark/start/job/medicalofficer,
+/obj/structure/window/framed/mainship/white,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/operating_room_one)
 "wH" = (
-/obj/item/storage/firstaid/fire{
-	pixel_x = 7
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/item/storage/firstaid/fire{
-	pixel_x = 7
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/item/storage/firstaid/o2{
-	pixel_x = 4;
-	pixel_y = 7
-	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/storage/firstaid/rad{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/storage/firstaid/adv{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/storage/firstaid/adv{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/obj/item/storage/firstaid/adv{
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = 1
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/structure/table/mainship/nometal,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "wI" = (
 /obj/machinery/door_control/mainship/ammo{
 	dir = 1
@@ -6912,12 +7695,26 @@
 /obj/structure/ship_ammo/heavygun,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
-"wK" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
+"wJ" = (
+/turf/open/floor/mainship/silver{
+	dir = 5
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/command/self_destruct)
+/area/mainship/hallways/hangar)
+"wK" = (
+/obj/structure/flora/pottedplant/twentyone{
+	icon_state = "plant-09"
+	},
+/turf/open/floor/mainship/black,
+/area/mainship/hallways/hangar)
+"wL" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "wM" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/pilotbunks)
@@ -6930,9 +7727,10 @@
 	},
 /area/space)
 "wP" = (
-/obj/machinery/holopad,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/obj/structure/table/woodentable,
+/obj/effect/spawner/random/plushie/nospawnninety,
+/turf/open/floor/wood,
+/area/mainship/medical/lounge)
 "wQ" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 8;
@@ -7078,27 +7876,19 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/command/self_destruct)
 "xl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/structure/bed/chair/wood/normal{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
+/turf/open/floor/carpet/side{
+	dir = 8
+	},
+/area/mainship/living/grunt_rnr)
 "xm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/silver{
-	dir = 4
-	},
+/obj/structure/window/framed/mainship,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "xn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/sign/hydro,
+/obj/machinery/light/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "xo" = (
@@ -7108,53 +7898,50 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
 "xp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/light/mainship{
+	dir = 1
 	},
-/obj/machinery/light/mainship,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lounge)
 "xq" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine,
 /area/mainship/engineering/port_atmos)
 "xr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/structure/sign/hydro,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "xs" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "Medical Lounge"
+/turf/open/floor/mainship/sterile/side{
+	dir = 5
+	},
+/area/mainship/medical/lounge)
+"xu" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/beer{
+	dir = 8
+	},
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
+"xv" = (
+/obj/structure/closet/secure_closet/medical2,
+/obj/item/limb/l_hand,
+/obj/item/limb/l_arm,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
+"xw" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lounge)
-"xu" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
-"xv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 5
-	},
-/area/mainship/medical/lounge)
-"xw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/lounge)
+/area/mainship/medical/lower_medical)
 "xz" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -7164,16 +7951,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/starboard_hull)
 "xA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/lounge)
+/obj/structure/window/framed/mainship/requisitions,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "xB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -7188,22 +7968,22 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
 "xC" = (
-/obj/machinery/light/mainship,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
+/obj/machinery/light/mainship{
+	dir = 4
 	},
-/area/mainship/medical/lounge)
+/turf/open/floor/mainship/sterile/plain,
+/area/mainship/medical/lower_medical)
 "xD" = (
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
+/obj/machinery/door/airlock/mainship/medical/glass{
+	name = "Medical Lounge"
 	},
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lounge)
 "xE" = (
-/obj/machinery/vending/marineFood,
-/turf/open/floor/mainship/sterile/side{
-	dir = 9
-	},
-/area/mainship/medical/lounge)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/autodoc,
+/turf/open/floor/mainship/sterile,
+/area/mainship/medical/lower_medical)
 "xF" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/red,
@@ -7237,12 +8017,17 @@
 	},
 /area/mainship/medical/lower_medical)
 "xK" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
+/obj/structure/rack,
+/obj/item/reagent_containers/jerrycan,
+/obj/item/reagent_containers/jerrycan,
+/obj/machinery/light/mainship{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/item/reagent_containers/jerrycan,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/hallways/hangar)
 "xL" = (
 /obj/machinery/iv_drip,
 /obj/structure/disposalpipe/junction,
@@ -7253,17 +8038,22 @@
 	},
 /area/mainship/medical/lower_medical)
 "xM" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/recharger,
-/turf/open/floor/mainship/sterile/dark,
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/mainship/silver{
+	dir = 10
+	},
 /area/mainship/medical/lower_medical)
 "xO" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/healthanalyzer,
-/obj/machinery/light/mainship,
-/obj/item/healthanalyzer,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/structure/closet/firecloset,
+/obj/item/clothing/mask/gas,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/port_hallway)
 "xP" = (
 /obj/machinery/door_control/mainship/ammo{
 	dir = 4
@@ -7297,7 +8087,7 @@
 	dir = 1
 	},
 /turf/open/floor/mainship/red/full,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/living/briefing)
 "xT" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
@@ -7363,8 +8153,14 @@
 /area/mainship/living/cryo_cells)
 "ye" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/command/self_destruct)
+/area/mainship/living/briefing)
 "yf" = (
 /turf/open/floor/mainship/black,
 /area/mainship/living/cafeteria_starboard)
@@ -7469,11 +8265,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
 "yp" = (
-/obj/machinery/door/airlock/mainship/medical/glass/CMO{
-	dir = 2
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lounge)
+/obj/effect/ai_node,
+/turf/open/floor/carpet,
+/area/mainship/living/grunt_rnr)
 "yr" = (
 /obj/effect/decal/cleanable/blood/oil{
 	name = "grease";
@@ -7484,11 +8278,19 @@
 	},
 /area/mainship/living/briefing)
 "ys" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
-	dir = 2
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lounge)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "yt" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -7532,20 +8334,21 @@
 	},
 /area/mainship/medical/lower_medical)
 "yz" = (
-/obj/machinery/iv_drip,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/bridgebunks)
 "yA" = (
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/starboard_hallway)
+/obj/structure/bed/chair/nometal{
+	dir = 1
+	},
+/turf/open/floor/mainship/blue/full,
+/area/mainship/living/briefing)
 "yB" = (
 /obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/door/poddoor/shutters{
@@ -7561,6 +8364,10 @@
 	dir = 5
 	},
 /area/mainship/living/briefing)
+"yE" = (
+/obj/structure/closet/secure_closet/engineering_welding,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "yF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -7576,18 +8383,20 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/general)
 "yH" = (
-/obj/structure/bed/chair/comfy/beige{
+/obj/effect/decal/warning_stripes/thin,
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/start/job/staffofficer,
-/turf/open/floor/carpet,
-/area/mainship/living/bridgebunks)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "yI" = (
 /obj/machinery/light/mainship{
 	dir = 1
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/living/briefing)
 "yJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -7628,7 +8437,7 @@
 "yN" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/mainship/cargo,
-/area/mainship/command/self_destruct)
+/area/mainship/hallways/hangar)
 "yO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -7771,26 +8580,20 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "zk" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/ai_node,
+/obj/machinery/vending/snack,
+/obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/mono,
-/area/mainship/living/evacuation)
+/area/mainship/hallways/hangar)
 "zl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
+/obj/structure/disposalpipe/junction/flipped,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "zm" = (
@@ -7802,41 +8605,86 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
-"zp" = (
-/obj/machinery/door/airlock/mainship/generic,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/living/port_garden)
+/area/mainship/hallways/port_hallway)
+"zp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "zq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/port_garden)
 "zr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 8;
-	on = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/mainship,
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
+"zs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/bridgebunks)
+"zt" = (
+/obj/machinery/door/airlock/mainship/generic,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/port_garden)
-"zs" = (
-/obj/structure/flora/pottedplant/twentyone,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/port_garden)
-"zt" = (
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/port_garden)
 "zu" = (
-/obj/structure/closet/secure_closet/CMO,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lounge)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/port_garden)
 "zv" = (
 /obj/effect/step_trigger/teleporter/random{
 	affect_ghosts = 1;
@@ -7861,18 +8709,24 @@
 /turf/open/space/basic,
 /area/space)
 "zw" = (
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lounge)
-"zx" = (
-/obj/structure/closet/secure_closet/medical1,
-/turf/open/floor/mainship/sterile/side{
+/obj/structure/flora/pottedplant/twentyone,
+/obj/effect/ai_node,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/area/mainship/medical/lounge)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/port_garden)
+"zx" = (
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/port_garden)
 "zy" = (
-/obj/machinery/holopad,
-/turf/open/floor/carpet,
-/area/mainship/living/bridgebunks)
+/obj/machinery/door/airlock/multi_tile/mainship/personalglass{
+	dir = 2
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "zz" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -7914,48 +8768,37 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "zF" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "zG" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 5
-	},
-/area/mainship/medical/lower_medical)
-"zH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/vending/nanomed,
-/obj/machinery/computer/crew,
-/turf/open/floor/mainship/sterile/side{
+/obj/structure/bed/chair/wood/wings{
 	dir = 1
 	},
-/area/mainship/medical/lower_medical)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood,
+/area/mainship/medical/lounge)
+"zH" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "zI" = (
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
 /area/mainship/living/briefing)
 "zK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/machinery/vending/nanomed,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/lower_medical)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "zL" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine,
@@ -7965,11 +8808,19 @@
 /turf/closed/wall/mainship,
 /area/mainship/living/grunt_rnr)
 "zN" = (
-/turf/open/floor/mainship/sterile/corner,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lounge)
 "zO" = (
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/lower_medical)
+/obj/structure/rack,
+/obj/item/reagent_containers/jerrycan,
+/obj/item/reagent_containers/jerrycan,
+/obj/item/reagent_containers/jerrycan,
+/turf/open/floor/mainship/orange{
+	dir = 10
+	},
+/area/mainship/hallways/hangar)
 "zP" = (
 /obj/docking_port/stationary/marine_dropship/cas,
 /turf/open/floor/plating,
@@ -7979,13 +8830,23 @@
 	dir = 1
 	},
 /turf/open/floor/mainship/orange/full,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/living/briefing)
 "zR" = (
 /obj/structure/bed/chair/nometal{
 	dir = 1
 	},
 /turf/open/floor/mainship/purple/full,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/living/briefing)
+"zS" = (
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
 "zU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -8060,6 +8921,14 @@
 /obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"Ad" = (
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/turf/open/floor/carpet/side{
+	dir = 8
+	},
+/area/mainship/living/grunt_rnr)
 "Ae" = (
 /obj/machinery/marine_selector/clothes,
 /obj/structure/window/reinforced{
@@ -8170,104 +9039,77 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
 "Av" = (
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/obj/machinery/seed_extractor,
-/turf/open/floor/mainship/green{
-	dir = 5
-	},
-/area/mainship/living/port_garden)
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "Aw" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
+"Ax" = (
+/obj/structure/table/woodentable,
+/obj/item/storage/fancy/cigar,
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
+"Ay" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/open/floor/mainship/green{
 	dir = 9
 	},
 /area/mainship/living/port_garden)
-"Ax" = (
-/obj/machinery/vending/hydroseeds,
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/port_garden)
-"Ay" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/megaphone,
-/obj/item/book/manual/medical_diagnostics_manual,
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lounge)
 "Az" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/mainship/green{
+	dir = 5
 	},
-/obj/effect/landmark/start/job/cmo,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lounge)
+/area/mainship/living/port_garden)
 "AA" = (
-/obj/machinery/computer/crew,
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/side{
+/obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
-/area/mainship/medical/lounge)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/living/briefing)
 "AB" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lounge)
+/obj/structure/table/mainship/nometal,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/clothing/suit/storage/hazardvest/lime,
+/obj/item/clothing/suit/storage/hazardvest/blue,
+/obj/item/tool/shovel/etool,
+/obj/item/storage/pouch/medkit/firstaid,
+/obj/item/tool/taperoll/engineering,
+/turf/open/floor/mainship/mono,
+/area/mainship/command/cic)
 "AC" = (
 /obj/structure/sign/nosmoking_2,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "AD" = (
-/obj/structure/closet/secure_closet/medical2,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_one)
-"AE" = (
-/obj/structure/sink{
-	pixel_y = 20
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+/obj/machinery/door_control/mainship{
 	dir = 4;
-	on = 1
+	id = mechbay;
+	name = "Mech Bay Shutters"
 	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_one)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
+"AE" = (
+/obj/machinery/vending/MarineMed,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
 "AF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_one)
+/area/mainship/medical/lounge)
 "AG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/structure/closet/secure_closet/medical3,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_one)
+/area/mainship/medical/lounge)
 "AH" = (
 /obj/machinery/gear{
 	id = "supply_elevator_gear"
@@ -8287,6 +9129,40 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "AJ" = (
+/obj/structure/table/mainship/nometal,
+/obj/machinery/light/mainship,
+/turf/open/floor/mainship/research,
+/area/mainship/medical/medical_science)
+"AK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
+"AL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
+"AM" = (
 /obj/machinery/door/airlock/mainship/medical/or/or1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -8300,53 +9176,17 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_one)
-"AK" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
-"AL" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/junction,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
-"AM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "AN" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "AO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/table/mainship/nometal,
+/obj/machinery/chem_dispenser/beer{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "AP" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/closed/wall/mainship/white,
@@ -8372,12 +9212,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "AS" = (
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
-	dir = 1
+/obj/machinery/door/airlock/mainship/command/FCDRquarters{
+	dir = 2
 	},
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "AT" = (
 /obj/effect/soundplayer,
 /turf/closed/wall/mainship,
@@ -8469,16 +9309,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/self_destruct)
 "Bf" = (
-/obj/machinery/door/poddoor/railing{
-	id = "supply_elevator_railing"
-	},
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
-/area/mainship/squads/req)
+/turf/open/floor/plating,
+/area/mainship/living/tankerbunks)
 "Bg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8511,18 +9343,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "Bk" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/squads/req)
+/area/mainship/living/tankerbunks)
 "Bm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8530,6 +9355,16 @@
 /obj/machinery/holopad,
 /turf/open/floor/mainship/silver,
 /area/mainship/medical/medical_science)
+"Bn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/vending/nanomed,
+/obj/machinery/computer/crew,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "Bo" = (
 /obj/structure/table/mainship/nometal,
 /turf/open/floor/freezer,
@@ -8591,6 +9426,12 @@
 /obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/port_hull)
+"BC" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/light/mainship,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "BD" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -8633,23 +9474,45 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/briefing)
 "BH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
+/obj/structure/closet/emcloset,
+/obj/item/clothing/mask/gas,
+/obj/effect/decal/warning_stripes/thin,
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/hangar)
 "BI" = (
+/turf/open/floor/mainship/silver,
+/area/mainship/hallways/hangar)
+"BJ" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/mainship/cargo,
+/area/mainship/command/cic)
+"BK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
+"BM" = (
+/obj/machinery/light/mainship,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/plain,
+/area/mainship/medical/lower_medical)
+"BN" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/open/floor/mainship/green{
-	dir = 5
+	dir = 8
 	},
 /area/mainship/living/port_garden)
-"BJ" = (
+"BO" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/mainship/green{
+	dir = 4
+	},
+/area/mainship/living/port_garden)
+"BP" = (
 /obj/item/reagent_containers/glass/fertilizer/ez,
 /obj/item/reagent_containers/glass/fertilizer/ez,
 /obj/item/tool/minihoe,
@@ -8663,65 +9526,28 @@
 /obj/item/paper/hydroponics,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/port_garden)
-"BK" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar)
-"BN" = (
-/obj/structure/table/mainship/nometal,
-/obj/structure/paper_bin,
-/obj/item/tool/pen,
-/obj/item/clipboard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lounge)
-"BO" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/mob/living/simple_animal/cat/Runtime,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lounge)
-"BP" = (
-/obj/machinery/computer/med_data,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lounge)
 "BQ" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lounge)
+/obj/docking_port/stationary/marine_dropship/crash_target,
+/turf/closed/wall/mainship,
+/area/mainship/living/commandbunks)
 "BR" = (
-/obj/structure/closet/secure_closet/medical3,
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
+/obj/structure/bed/chair/comfy{
+	dir = 4
 	},
-/area/mainship/medical/lounge)
+/turf/open/floor/carpet/side,
+/area/mainship/living/grunt_rnr)
 "BS" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
+/turf/open/floor/carpet/side{
+	dir = 10
 	},
-/obj/machinery/power/apc/mainship{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_one)
+/area/mainship/living/commandbunks)
 "BT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/processor{
+	pixel_y = 5
 	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_one)
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "BU" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -8730,6 +9556,18 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
 "BV" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lounge)
+"BW" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/hallways/hangar)
+"BX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -8739,33 +9577,16 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_one)
-"BW" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/spray/surgery{
-	pixel_x = 12;
-	pixel_y = 2
-	},
-/obj/item/storage/firstaid/adv{
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/item/storage/box/gloves{
-	pixel_x = -5;
-	pixel_y = -5
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_one)
-"BX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "BY" = (
 /obj/structure/window/framed/mainship/requisitions,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
+"BZ" = (
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/purple/corner,
+/area/mainship/medical/chemistry)
 "Ca" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/tool/extinguisher/mini,
@@ -8799,19 +9620,20 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "Cc" = (
+/obj/structure/table/mainship/nometal,
+/obj/item/folder/white,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/chemistry)
 "Cd" = (
-/obj/machinery/vending/MarineMed,
-/obj/machinery/light/mainship{
-	dir = 4
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
 	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/port_hull)
 "Cf" = (
 /turf/open/floor/plating{
 	icon_state = "warnplatecorner"
@@ -8831,30 +9653,25 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "Cj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+/turf/open/floor/mainship/black{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/area/mainship/hallways/hangar)
+"Ck" = (
+/obj/structure/closet/cabinet,
+/obj/effect/ai_node,
+/obj/machinery/light/mainship{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/living/briefing)
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "Cl" = (
 /obj/structure/window/framed/mainship/requisitions,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "Cm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/living/briefing)
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "Cn" = (
 /obj/structure/flora/pottedplant/twentyone,
 /obj/machinery/light/mainship{
@@ -8878,6 +9695,10 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/command/self_destruct)
+"Cq" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "Cr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
@@ -8965,29 +9786,38 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "CI" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/light/mainship{
-	dir = 4
+/obj/machinery/door/poddoor/shutters{
+	id = mechbay;
+	name = "Mech Bay Shutters"
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/living/port_garden)
-"CK" = (
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/command/self_destruct)
-"CL" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal,
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
+/area/mainship/living/tankerbunks)
+"CJ" = (
+/obj/structure/table/mainship/nometal,
+/obj/structure/paper_bin,
+/obj/item/tool/pen,
+/obj/item/clipboard{
+	pixel_x = -6;
+	pixel_y = 2
 	},
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_one)
+/area/mainship/medical/lounge)
+"CK" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
+"CL" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/obj/structure/bed/chair,
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "CM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -9004,21 +9834,21 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/telecomms)
 "CN" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/surgical_tray,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/light/mainship,
+/obj/structure/table/mainship/nometal,
+/obj/item/paper,
+/obj/item/tool/pen,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_one)
+/area/mainship/medical/chemistry)
 "CO" = (
-/obj/machinery/optable,
-/obj/item/tank/anesthetic,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_one)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lounge)
 "CP" = (
-/obj/machinery/bioprinter/stocked,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_one)
+/obj/structure/bed/chair/wood/wings,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "CQ" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -9026,12 +9856,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/self_destruct)
 "CS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/obj/machinery/holopad,
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/lower_medical)
+/obj/machinery/optable,
+/obj/item/tank/anesthetic,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
 "CT" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/purple{
@@ -9039,28 +9867,39 @@
 	},
 /area/mainship/squads/general)
 "CU" = (
-/obj/machinery/autodoc_console,
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/lower_medical)
-"CV" = (
-/obj/structure/rack,
-/obj/item/defibrillator,
-/obj/item/defibrillator,
-/obj/item/defibrillator,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = -14
 	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
+"CV" = (
+/obj/structure/morgue/crematorium,
+/obj/machinery/crema_switch{
+	pixel_x = 24
+	},
+/turf/open/floor/mainship/silver{
+	dir = 8
 	},
 /area/mainship/medical/lower_medical)
 "CX" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
+"CZ" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/mainship/hallways/hangar)
+"Db" = (
+/obj/effect/decal/cleanable/flour,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "Dc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -9079,6 +9918,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/black,
 /area/mainship/living/briefing)
+"Df" = (
+/obj/effect/landmark/start/job/captain,
+/obj/structure/bed/fancy,
+/obj/item/bedsheet/captain,
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "Dg" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -9090,6 +9935,11 @@
 	dir = 4
 	},
 /area/mainship/command/self_destruct)
+"Dj" = (
+/obj/machinery/holopad,
+/obj/effect/ai_node,
+/turf/open/floor/carpet,
+/area/mainship/living/bridgebunks)
 "Dk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/black,
@@ -9160,6 +10010,12 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
+"Dw" = (
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "Dx" = (
 /obj/structure/dropship_equipment/operatingtable,
 /obj/machinery/light/mainship{
@@ -9172,17 +10028,9 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "Dz" = (
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/obj/item/ammo_casing/bullet{
-	pixel_x = 9;
-	pixel_y = 5
-	},
-/turf/open/floor/mainship/purple{
-	dir = 8
-	},
-/area/mainship/living/briefing)
+/obj/structure/table/mainship/nometal,
+/turf/open/floor/wood,
+/area/mainship/hallways/hangar)
 "DA" = (
 /obj/effect/ai_node,
 /obj/structure/disposalpipe/segment,
@@ -9266,9 +10114,14 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/cafeteria_starboard)
 "DJ" = (
-/obj/effect/soundplayer,
-/turf/closed/wall/mainship,
-/area/mainship/hallways/starboard_hallway)
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/green{
+	dir = 6
+	},
+/area/mainship/living/port_garden)
 "DK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -9295,6 +10148,10 @@
 	},
 /turf/open/floor/freezer,
 /area/mainship/living/cafeteria_starboard)
+"DN" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "DO" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/pizzabox,
@@ -9330,25 +10187,21 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "DV" = (
-/obj/structure/cable,
+/obj/machinery/iv_drip,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light/mainship{
+	dir = 4
 	},
-/obj/structure/disposalpipe/junction/flipped,
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
 "DW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/obj/effect/landmark/start/job/medicalofficer,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "DX" = (
 /obj/machinery/door/airlock/mainship/generic,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -9367,29 +10220,18 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/command/self_destruct)
 "DZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/port_garden)
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "Ea" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = -14
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/port_garden)
+/obj/structure/table/mainship/nometal,
+/obj/item/healthanalyzer,
+/obj/machinery/light/mainship,
+/obj/item/healthanalyzer,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "Eb" = (
 /obj/structure/window/framed/mainship/hull,
 /obj/machinery/door/poddoor/mainship/ai/exterior{
@@ -9404,15 +10246,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "Ed" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/vending/marineFood,
+/turf/open/floor/mainship/sterile/side{
+	dir = 9
 	},
-/obj/structure/cable,
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/port_garden)
+/area/mainship/medical/lounge)
 "Ef" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -9420,29 +10258,26 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cryo_cells)
 "Eg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/port_garden)
+/obj/structure/rack,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/mainship/sterile/plain,
+/area/mainship/medical/lower_medical)
 "Eh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/power/apc/mainship{
-	dir = 1
-	},
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/port_garden)
-"Ei" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
+/obj/structure/disposalpipe/junction,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
+"Ei" = (
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/mainship/mono,
-/area/mainship/living/port_garden)
+/area/mainship/living/grunt_rnr)
 "Ej" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 8
@@ -9450,14 +10285,20 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
 "Ek" = (
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/port_hull)
-"El" = (
-/obj/machinery/light/mainship/small{
-	dir = 1
+/obj/machinery/door/airlock/mainship/medical/morgue{
+	dir = 2
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/port_hull)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/mono,
+/area/mainship/medical/lower_medical)
+"El" = (
+/obj/structure/closet/secure_closet/captain,
+/turf/open/floor/carpet/side{
+	dir = 9
+	},
+/area/mainship/living/commandbunks)
 "En" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -9465,13 +10306,17 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "Eo" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 4
+/obj/machinery/door/airlock/mainship/generic{
+	dir = 1
 	},
-/area/mainship/hallways/starboard_hallway)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "Ep" = (
-/turf/closed/wall/mainship/white,
-/area/mainship/medical/operating_room_two)
+/obj/machinery/light/mainship/small{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/port_hull)
 "Eq" = (
 /obj/machinery/sleeper,
 /obj/machinery/light/mainship{
@@ -9486,19 +10331,39 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "Es" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/lower_medical)
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/spray/surgery{
+	pixel_x = 12;
+	pixel_y = 2
+	},
+/obj/item/storage/firstaid/adv{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/item/storage/box/gloves{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
 "Et" = (
-/obj/structure/closet/firecloset,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/mainship/cargo,
-/area/mainship/squads/req)
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
 "Eu" = (
-/obj/structure/closet/emcloset,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/mainship/cargo,
-/area/mainship/squads/req)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "Ev" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
@@ -9530,10 +10395,18 @@
 /turf/open/floor/freezer,
 /area/mainship/living/cafeteria_starboard)
 "EA" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/obj/machinery/vending/MarineMed/Blood,
+/obj/structure/disposalpipe/junction,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
 "EB" = (
 /obj/item/radio/intercom/general{
 	dir = 8
@@ -9565,6 +10438,13 @@
 	dir = 9
 	},
 /area/mainship/hull/port_hull)
+"EH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/starboard_hull)
 "EI" = (
 /turf/open/floor/mainship/orange{
 	dir = 1
@@ -9620,12 +10500,42 @@
 /turf/closed/wall/mainship,
 /area/mainship/living/numbertwobunks)
 "ES" = (
-/obj/structure/closet/secure_closet/medical2,
-/obj/item/limb/l_hand,
-/obj/item/limb/l_arm,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/obj/machinery/seed_extractor,
+/turf/open/floor/mainship/green{
+	dir = 5
+	},
+/area/mainship/living/port_garden)
 "ET" = (
+/obj/structure/table/mainship/nometal,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
+"EU" = (
+/obj/machinery/computer/general_air_control/large_tank_control{
+	input_tag = "waste_in";
+	name = "Waste Tank Control";
+	output_tag = "waste_out";
+	sensors = list("waste_sensor"="Tank")
+	},
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
+/area/mainship/engineering/port_atmos)
+"EV" = (
+/obj/machinery/smartfridge/chemistry,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
+"EW" = (
 /obj/structure/sink{
 	pixel_y = 20
 	},
@@ -9636,63 +10546,13 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
-"EU" = (
-/obj/machinery/computer/general_air_control/large_tank_control{
-	input_tag = "waste_in";
-	name = "Waste Tank Control";
-	output_tag = "waste_out";
-	sensors = list("waste_sensor" = "Tank")
-	},
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
-/area/mainship/engineering/port_atmos)
-"EV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
-"EW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
 "EX" = (
-/obj/machinery/door/airlock/mainship/medical/or/or2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
 "EY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -9723,85 +10583,68 @@
 /area/mainship/medical/lower_medical)
 "Fa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+	dir = 6
 	},
-/obj/structure/cable,
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/obj/effect/ai_node,
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lower_medical)
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
 "Fb" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/vending/hydroseeds,
+/obj/machinery/light/mainship{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/port_garden)
 "Fc" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/junction/flipped{
-	dir = 4
+/obj/effect/decal/cleanable/blood/oil{
+	name = "grease";
+	pixel_x = -2;
+	pixel_y = -6
 	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 10
-	},
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
 "Fd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 4;
-	on = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "Fe" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/junction{
+/obj/machinery/door/airlock/mainship/medical/or/or2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "Ff" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/mainship/sterile/side{
-	dir = 4
+	dir = 5
 	},
 /area/mainship/medical/lower_medical)
 "Fg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/structure/bed/chair/comfy,
+/turf/open/floor/carpet/side{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/lower_medical)
+/area/mainship/living/grunt_rnr)
 "Fi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -9897,6 +10740,12 @@
 	dir = 4
 	},
 /area/mainship/living/cafeteria_starboard)
+"Fu" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/port_garden)
 "Fv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -10012,10 +10861,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
 "FL" = (
-/obj/structure/table/woodentable,
-/obj/item/storage/fancy/cigar,
-/turf/open/floor/wood,
-/area/mainship/living/commandbunks)
+/obj/effect/ai_node,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
+"FM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "FN" = (
 /turf/open/floor/mainship/purple{
 	dir = 4
@@ -10025,18 +10877,38 @@
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "FP" = (
-/obj/structure/bed/chair/comfy{
-	dir = 4
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
+"FQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
-/obj/machinery/light/mainship{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
 /obj/structure/cable,
-/turf/open/floor/carpet/side{
-	dir = 5
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
 	},
-/area/mainship/living/commandbunks)
-"FQ" = (
+/obj/effect/ai_node,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
+"FS" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/port_garden)
+"FT" = (
+/obj/machinery/bioprinter/stocked,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
+"FU" = (
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
+"FV" = (
 /obj/structure/table/mainship/nometal,
 /obj/structure/paper_bin{
 	pixel_y = 5
@@ -10048,31 +10920,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
-"FS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/poster{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
-"FT" = (
-/obj/structure/bed,
-/obj/item/bedsheet/hop,
-/obj/effect/landmark/start/job/fieldcommander,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
-"FU" = (
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
-"FV" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "FW" = (
 /obj/effect/step_trigger/teleporter/random{
 	affect_ghosts = 1;
@@ -10087,6 +10934,27 @@
 /turf/open/space/basic,
 /area/space)
 "FX" = (
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 9
+	},
+/area/mainship/medical/chemistry)
+"FY" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/mainship/squads/req)
+"FZ" = (
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
+"Ga" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/storage/briefcase,
 /obj/item/clipboard{
@@ -10100,74 +10968,19 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
-"FY" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 8;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
-/area/mainship/squads/req)
-"FZ" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
-/obj/machinery/power/apc/mainship{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/blood/drip{
-	pixel_x = 6;
-	pixel_y = 22
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
-"Ga" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/blood/drip{
-	pixel_x = -15;
-	pixel_y = 18
-	},
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
 "Gb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/turf/open/floor/mainship/silver{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
+/area/mainship/hallways/hangar)
 "Gd" = (
 /obj/vehicle/ridden/powerloader,
 /turf/open/floor/mainship/cargo,
-/area/mainship/command/self_destruct)
+/area/mainship/hallways/hangar)
 "Ge" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/spray/surgery{
-	pixel_x = 12;
-	pixel_y = 2
-	},
-/obj/item/storage/firstaid/adv{
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/item/storage/box/gloves{
-	pixel_x = -5;
-	pixel_y = -5
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
+/obj/effect/ai_node,
+/turf/open/floor/plating/mainship,
+/area/mainship/living/evacuation)
 "Gf" = (
 /obj/structure/window/framed/mainship/white,
 /turf/open/floor/mainship/sterile/dark,
@@ -10192,37 +11005,45 @@
 	},
 /area/space)
 "Gj" = (
-/obj/machinery/power/apc/mainship{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/spray/surgery{
+	pixel_x = 12;
+	pixel_y = 2
 	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
+/obj/item/storage/firstaid/adv{
+	pixel_x = 6;
+	pixel_y = -2
 	},
-/area/mainship/medical/lower_medical)
-"Gk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
+/obj/item/storage/box/gloves{
+	pixel_x = -5;
+	pixel_y = -5
+	},
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/operating_room_two)
+"Gk" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/port_hull)
 "Gl" = (
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
+/obj/item/bedsheet/captain,
+/obj/structure/bed,
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "Gm" = (
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
+/obj/structure/bed/chair{
 	dir = 1
 	},
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "Gn" = (
-/turf/open/floor/mainship/red{
-	dir = 8
+/obj/machinery/computer/camera_advanced/overwatch/bravo,
+/obj/machinery/light/mainship{
+	dir = 1
 	},
-/area/mainship/living/briefing)
+/obj/structure/table/mainship/nometal,
+/turf/open/floor/mainship/mono,
+/area/mainship/command/cic)
 "Go" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -10351,34 +11172,61 @@
 /turf/open/floor/wood,
 /area/mainship/living/bridgebunks)
 "GH" = (
+/obj/structure/table/woodentable,
+/obj/item/reagent_containers/food/snacks/limecakeslice,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood,
+/area/mainship/medical/lounge)
+"GI" = (
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
+"GJ" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/multi_tile/mainship/engineering{
+	dir = 2
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/engineering/engineering_workshop)
+"GK" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/evacuation)
+"GM" = (
 /obj/structure/cable,
 /turf/open/floor/carpet/side{
 	dir = 6
 	},
 /area/mainship/living/commandbunks)
-"GI" = (
+"GN" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
-"GJ" = (
-/obj/machinery/power/apc/mainship{
-	dir = 4
+"GO" = (
+/obj/structure/bed/chair/wood/wings{
+	dir = 1
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar)
-"GK" = (
-/obj/machinery/marine_selector/clothes/commander,
 /turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
-"GM" = (
-/obj/machinery/vending/uniform_supply,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
-"GN" = (
+/area/mainship/living/grunt_rnr)
+"GP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/briefing)
+"GQ" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
-"GO" = (
+"GR" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/clothing/head/bowlerhat{
 	pixel_x = -4;
@@ -10394,38 +11242,17 @@
 /obj/item/megaphone,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
-"GP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/briefing)
-"GQ" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal,
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
-"GR" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/surgical_tray,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/light/mainship{
-	light_color = "#da2f1b"
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
 "GS" = (
-/obj/machinery/optable,
-/obj/item/tank/anesthetic,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
+/turf/open/floor/carpet/side{
+	dir = 1
+	},
+/area/mainship/living/grunt_rnr)
 "GT" = (
-/obj/machinery/bioprinter/stocked,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
+/obj/machinery/light/mainship/small{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/port_hull)
 "GU" = (
 /obj/machinery/cryopod/right,
 /turf/open/floor/mainship/sterile/dark,
@@ -10440,22 +11267,17 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "GX" = (
-/obj/item/radio/intercom/general{
+/obj/structure/bed/chair/sofa/right{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
+"GZ" = (
+/obj/structure/disposalpipe/junction/flipped{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/corner{
-	dir = 8
-	},
-/area/mainship/medical/lower_medical)
-"GZ" = (
-/obj/machinery/light/mainship,
-/obj/structure/rack,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/silver,
+/area/mainship/medical/medical_science)
 "Ha" = (
 /obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -10473,18 +11295,17 @@
 /turf/open/floor/mainship/black,
 /area/mainship/engineering/port_atmos)
 "Hc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lower_medical)
-"Hd" = (
-/obj/machinery/vending/medical/shipside,
-/turf/open/floor/mainship/sterile/corner{
+/obj/machinery/power/apc/mainship{
 	dir = 4
 	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
 /area/mainship/medical/lower_medical)
+"Hd" = (
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lounge)
 "Hf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -10497,6 +11318,11 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/telecomms)
+"Hg" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/port_garden)
 "Hh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/item/ammo_casing/bullet{
@@ -10535,6 +11361,16 @@
 	dir = 8
 	},
 /area/mainship/living/briefing)
+"Hl" = (
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = -14
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/port_garden)
 "Hm" = (
 /obj/effect/decal/cleanable/blood/oil{
 	name = "grease";
@@ -10598,9 +11434,9 @@
 /area/mainship/squads/general)
 "Hw" = (
 /turf/open/floor/mainship/terragov/north{
-	dir = 9
+	dir = 1
 	},
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/living/briefing)
 "Hx" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -10655,6 +11491,16 @@
 	dir = 6
 	},
 /area/mainship/living/cafeteria_starboard)
+"HE" = (
+/obj/effect/ai_node,
+/turf/open/floor/mech_bay_recharge_floor,
+/area/mainship/living/tankerbunks)
+"HF" = (
+/obj/structure/table/woodentable,
+/obj/item/storage/fancy/cigar,
+/obj/item/toy/deck,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "HG" = (
 /turf/open/floor/mainship/orange{
 	dir = 10
@@ -10699,6 +11545,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
+"HM" = (
+/obj/machinery/door/airlock/mainship/medical/glass{
+	dir = 2
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lounge)
 "HN" = (
 /obj/machinery/door/airlock/mainship/command/officer{
 	dir = 2
@@ -10712,36 +11564,42 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
 "HP" = (
-/obj/machinery/door/airlock/mainship/command/FCDRquarters{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
+/turf/open/floor/mainship/silver{
+	dir = 8
+	},
+/area/mainship/medical/medical_science)
 "HQ" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/chemistry)
 "HR" = (
-/obj/machinery/smartfridge/chemistry,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/obj/machinery/chem_dispenser,
+/turf/open/floor/mainship/research,
+/area/mainship/medical/medical_science)
 "HS" = (
-/obj/machinery/door/airlock/mainship/medical/free_access{
-	dir = 2;
-	name = "Chemistry"
+/obj/structure/bed/chair/wood/wings,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
-"HU" = (
-/obj/machinery/computer/camera_advanced/remote_fob,
-/turf/open/floor/mainship/red{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/mainship/medical/lounge)
+"HT" = (
+/turf/open/floor/mainship/terragov/north{
+	dir = 9
 	},
 /area/mainship/living/briefing)
+"HU" = (
+/obj/structure/flora/pottedplant/twentyone{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "HV" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/mono,
@@ -10773,15 +11631,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "Ib" = (
-/obj/structure/table/woodentable,
-/obj/item/paper,
-/obj/item/folder{
-	pixel_x = 6;
-	pixel_y = 7
+/obj/item/radio/intercom/general{
+	dir = 4
 	},
-/obj/item/tool/pen,
-/turf/open/floor/carpet,
-/area/mainship/living/bridgebunks)
+/turf/open/floor/mainship/sterile/corner{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "Ic" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -10812,24 +11668,19 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "Ih" = (
-/obj/structure/disposalpipe/segment/corner{
+/obj/machinery/vending/armor_supply,
+/obj/machinery/light/mainship{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/carpet/side{
-	dir = 5
-	},
-/area/mainship/living/bridgebunks)
-"Ii" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
 /turf/open/floor/mainship/mono,
-/area/mainship/living/bridgebunks)
+/area/mainship/living/tankerbunks)
+"Ii" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "Ij" = (
 /obj/structure/table/mainship/nometal,
 /turf/open/floor/mainship/sterile/purple/corner{
@@ -10924,37 +11775,46 @@
 	},
 /area/mainship/medical/chemistry)
 "Iw" = (
-/turf/open/floor/mainship/sterile/purple/corner{
-	dir = 1
+/obj/machinery/vending/snack,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/mainship/medical/chemistry)
-"Ix" = (
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 1
-	},
-/area/mainship/medical/chemistry)
-"Iz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 1
-	},
-/area/mainship/medical/chemistry)
-"IA" = (
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/turf/open/floor/mainship/sterile/purple/corner,
-/area/mainship/medical/chemistry)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
+"Ix" = (
+/obj/structure/sign/custodian,
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/lower_medical)
+"Iy" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
+"Iz" = (
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
+"IA" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/open/floor/mainship/green{
+	dir = 6
+	},
+/area/mainship/living/port_garden)
 "IB" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/general)
 "IC" = (
 /obj/structure/closet/crate/construction,
 /turf/open/floor/mainship/cargo,
-/area/mainship/command/self_destruct)
+/area/mainship/hallways/hangar)
 "ID" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -11011,6 +11871,10 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mainship/cargo,
 /area/mainship/living/grunt_rnr)
+"IP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "IQ" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/grunt_rnr)
@@ -11064,12 +11928,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "IW" = (
-/obj/machinery/door/airlock/mainship/command/officer,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/bed/chair/sofa/corner{
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/living/bridgebunks)
+/area/mainship/hallways/port_hallway)
 "IX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -11088,8 +11951,11 @@
 	},
 /area/mainship/living/bridgebunks)
 "IZ" = (
-/turf/open/floor/carpet,
-/area/mainship/living/bridgebunks)
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket/janibucket,
+/obj/item/tool/mop,
+/turf/open/floor/mainship/sterile/plain,
+/area/mainship/medical/lower_medical)
 "Ja" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 4
@@ -11121,12 +11987,22 @@
 	dir = 9
 	},
 /area/mainship/command/cic)
+"Jd" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/flour,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "Je" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/fancy/cigar,
 /obj/item/tool/lighter/zippo,
 /turf/open/floor/carpet,
 /area/mainship/living/bridgebunks)
+"Jf" = (
+/obj/structure/table/mainship/nometal,
+/obj/item/toy/dice,
+/turf/open/floor/wood,
+/area/mainship/hallways/hangar)
 "Ji" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 8
@@ -11134,33 +12010,38 @@
 /obj/effect/landmark/start/job/staffofficer,
 /turf/open/floor/carpet,
 /area/mainship/living/bridgebunks)
+"Jj" = (
+/mob/living/simple_animal/corgi/ranger,
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
+/area/mainship/living/cafeteria_starboard)
 "Jk" = (
 /obj/structure/window/framed/mainship/hull,
 /obj/effect/soundplayer,
 /turf/open/floor/plating,
 /area/mainship/hull/port_hull)
 "Jl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/structure/bed/chair/comfy/beige{
+/obj/structure/bed/chair/comfy{
 	dir = 8
 	},
-/obj/effect/landmark/start/job/staffofficer,
 /turf/open/floor/carpet/side{
 	dir = 4
 	},
-/area/mainship/living/bridgebunks)
+/area/mainship/living/grunt_rnr)
 "Jm" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/bridgebunks)
-"Jn" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 8
+/obj/structure/closet/emcloset,
+/obj/item/clothing/mask/gas,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/mainship/living/bridgebunks)
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/port_hallway)
+"Jn" = (
+/obj/structure/table,
+/obj/item/trash/cheesie,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "Jo" = (
 /turf/open/floor/mainship/black,
 /area/mainship/hallways/starboard_hallway)
@@ -11203,18 +12084,16 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "Ju" = (
-/obj/structure/bed/chair/comfy/black,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
-"Jv" = (
-/turf/open/floor/mainship/sterile/purple/side{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/area/mainship/medical/chemistry)
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
+"Jv" = (
+/obj/machinery/vending/weapon,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "Jw" = (
 /obj/effect/decal/warning_stripes/thick{
 	dir = 1
@@ -11222,20 +12101,22 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "Jx" = (
-/obj/structure/disposalpipe/segment/corner{
+/turf/open/floor/mainship/black{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/living/briefing)
+/area/mainship/hallways/hangar)
 "Jy" = (
-/obj/structure/window/reinforced/extratoughened{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/machinery/vending/nanomed,
+/turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
-/obj/structure/window/reinforced/extratoughened{
-	dir = 4
-	},
-/turf/open/floor/mainship/tcomms,
-/area/mainship/command/airoom)
+/area/mainship/medical/lower_medical)
 "JA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11261,6 +12142,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
+"JD" = (
+/obj/effect/landmark/start/job/synthetic,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/command/cic)
 "JE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11356,11 +12241,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/grunt_rnr)
 "JT" = (
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/command/self_destruct)
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar)
 "JU" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 8
@@ -11450,9 +12332,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "Ke" = (
-/obj/docking_port/stationary/marine_dropship/crash_target,
-/turf/closed/wall/mainship,
-/area/mainship/living/commandbunks)
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "Kf" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
@@ -11472,24 +12355,14 @@
 	},
 /area/mainship/command/cic)
 "Kh" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/carpet/side{
-	dir = 6
-	},
-/area/mainship/living/bridgebunks)
+/obj/structure/sign/chemistry2,
+/turf/open/floor/mainship/sterile/purple/side,
+/area/mainship/medical/chemistry)
 "Ki" = (
-/obj/machinery/power/apc/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/bridgebunks)
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "Kj" = (
 /obj/machinery/door/airlock/mainship/maint{
 	name = "\improper Core Hatch"
@@ -11497,6 +12370,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/medical/chemistry)
+"Kk" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/black,
+/area/mainship/command/self_destruct)
 "Kl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /obj/machinery/camera/autoname/mainship,
@@ -11505,62 +12384,68 @@
 	},
 /area/mainship/medical/chemistry)
 "Km" = (
-/obj/structure/bed/chair/nometal{
-	dir = 1
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/orange/full,
-/area/mainship/hallways/starboard_hallway)
+/turf/open/floor/mainship/floor,
+/area/mainship/living/briefing)
 "Ko" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	name = "Oxygen Supply Console";
 	output_tag = "oxyvent";
-	sensors = list("oxy_sensor" = "Tank")
+	sensors = list("oxy_sensor"="Tank")
 	},
 /turf/open/floor/mainship/black{
 	dir = 5
 	},
 /area/mainship/engineering/port_atmos)
 "Kp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 1
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
 	},
-/area/mainship/medical/chemistry)
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "Kr" = (
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "Ks" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/paper,
-/obj/item/tool/pen,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
+"Kt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/purple/side,
 /area/mainship/medical/chemistry)
 "Ku" = (
 /obj/structure/table/mainship/nometal,
-/obj/item/folder/white,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/obj/machinery/faxmachine/research,
+/turf/open/floor/mainship/research,
+/area/mainship/medical/medical_science)
 "Kv" = (
-/obj/structure/closet/secure_closet/captain,
-/turf/open/floor/carpet/side{
-	dir = 9
-	},
-/area/mainship/living/commandbunks)
-"Kw" = (
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
-	dir = 1;
-	name = "Chemistry";
-	req_one_access = list(2,8,40)
+/obj/machinery/door/airlock/mainship/generic{
+	dir = 1
 	},
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/area/mainship/hallways/hangar)
+"Kw" = (
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/silver{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "Kx" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -11568,17 +12453,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Ky" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/red{
-	dir = 10
-	},
-/area/mainship/living/briefing)
+/obj/machinery/vending/cola,
+/obj/effect/decal/warning_stripes/thin,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "Kz" = (
 /obj/effect/attach_point/weapon/dropship1,
 /turf/open/floor/plating,
@@ -11661,10 +12539,11 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "KO" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/open/floor/mainship/green{
-	dir = 10
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
 	},
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
 /area/mainship/living/port_garden)
 "KP" = (
 /obj/machinery/disposal,
@@ -11738,18 +12617,30 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
 "KZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/bridgebunks)
-"La" = (
-/obj/machinery/light/mainship{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/carpet/side{
+	dir = 6
+	},
 /area/mainship/living/bridgebunks)
+"La" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/silver/corner{
+	dir = 4
+	},
+/area/mainship/medical/medical_science)
 "Lc" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -11758,8 +12649,9 @@
 /area/mainship/command/self_destruct)
 "Ld" = (
 /obj/structure/table/mainship/nometal,
+/obj/item/megaphone,
 /turf/open/floor/mainship/floor,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/living/briefing)
 "Le" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -11801,15 +12693,11 @@
 	},
 /area/mainship/medical/chemistry)
 "Lk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/purple/side,
-/area/mainship/medical/chemistry)
+/turf/open/floor/mainship/sterile,
+/area/mainship/medical/lower_medical)
 "Ll" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -11823,18 +12711,12 @@
 	},
 /area/mainship/medical/chemistry)
 "Lm" = (
-/obj/structure/bed/chair/comfy/black{
+/obj/structure/bed/chair/nometal{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/obj/effect/ai_node,
+/turf/open/floor/mainship/purple/full,
+/area/mainship/living/briefing)
 "Ln" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector{
 	id = "waste_lower_in";
@@ -11846,23 +12728,20 @@
 /turf/open/floor/engine,
 /area/mainship/engineering/port_atmos)
 "Lo" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/area/mainship/medical/operating_room_one)
 "Lp" = (
-/obj/structure/flora/pottedplant/twentyone,
-/obj/machinery/light/mainship{
+/obj/item/ammo_casing/bullet{
+	pixel_x = 9;
+	pixel_y = 5
+	},
+/turf/open/floor/mainship/purple{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "Lq" = (
 /obj/structure/window/framed/mainship/requisitions,
@@ -11919,13 +12798,9 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "Lz" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 8
-	},
-/area/mainship/medical/chemistry)
+/obj/machinery/loadout_vendor,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "LB" = (
 /obj/effect/attach_point/weapon/dropship1{
 	dir = 8;
@@ -11936,20 +12811,21 @@
 	},
 /area/mainship/hallways/hangar)
 "LC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/mainship/medical/lounge)
 "LD" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/red{
+	dir = 10
+	},
+/area/mainship/living/briefing)
 "LE" = (
 /obj/machinery/alarm,
 /turf/open/floor/mainship/black{
@@ -11969,6 +12845,30 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
+"LH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_x = -15;
+	pixel_y = 18
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
+"LI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/living/briefing)
 "LK" = (
 /obj/machinery/bodyscanner{
 	dir = 8
@@ -11980,6 +12880,11 @@
 	dir = 8
 	},
 /area/mainship/medical/lower_medical)
+"LL" = (
+/obj/structure/table/mainship/nometal,
+/obj/item/toy/deck,
+/turf/open/floor/wood,
+/area/mainship/hallways/hangar)
 "LM" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -11994,14 +12899,11 @@
 	},
 /area/mainship/hallways/starboard_hallway)
 "LO" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
+/obj/structure/closet/secure_closet/medical1,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
 	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/command/self_destruct)
+/area/mainship/medical/lounge)
 "LP" = (
 /obj/effect/soundplayer,
 /turf/closed/wall/mainship/outer,
@@ -12087,9 +12989,9 @@
 /area/mainship/medical/chemistry)
 "Me" = (
 /obj/structure/table/mainship/nometal,
-/obj/item/megaphone,
+/obj/effect/spawner/random/plushie/nospawnninety,
 /turf/open/floor/mainship/floor,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/living/briefing)
 "Mf" = (
 /obj/machinery/light/mainship,
 /obj/structure/table/mainship/nometal,
@@ -12101,14 +13003,10 @@
 /turf/open/floor/mainship/sterile/purple/side,
 /area/mainship/medical/chemistry)
 "Mi" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/purple/corner{
-	dir = 8
-	},
-/area/mainship/medical/chemistry)
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "Mj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -12116,23 +13014,28 @@
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 8
 	},
-/area/mainship/command/self_destruct)
+/area/mainship/hallways/hangar)
 "Mk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/purple/side,
-/area/mainship/medical/chemistry)
-"Ml" = (
-/obj/structure/sign/chemistry2,
-/turf/open/floor/mainship/sterile/purple/side,
-/area/mainship/medical/chemistry)
-"Mm" = (
 /obj/machinery/light/mainship,
-/turf/open/floor/mainship/sterile/purple/corner{
-	dir = 4
+/obj/structure/rack,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
+"Ml" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/rag,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
+"Mm" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/mainship/silver{
+	dir = 1
 	},
-/area/mainship/medical/chemistry)
+/area/mainship/hallways/hangar)
 "Mn" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner{
@@ -12176,12 +13079,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "Mq" = (
-/obj/structure/bed/chair/nometal{
-	dir = 1
+/turf/open/floor/carpet/side{
+	dir = 9
 	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/purple/full,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/living/grunt_rnr)
 "Mr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -12294,6 +13195,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
+"ME" = (
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
+"MF" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/port_hull)
 "MH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -12339,19 +13247,29 @@
 /area/mainship/shipboard/weapon_room)
 "MP" = (
 /turf/open/floor/mainship/terragov/north{
-	dir = 1
+	dir = 5
 	},
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/living/briefing)
 "MQ" = (
 /obj/machinery/alarm,
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/weapon_room)
 "MR" = (
-/obj/structure/disposalpipe/junction/flipped{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/silver,
-/area/mainship/medical/medical_science)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/multi_tile/mainship/marine/requisitions{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/living/tankerbunks)
 "MS" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -12361,25 +13279,24 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/weapon_room)
 "MT" = (
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
+/obj/structure/bed/chair/wood/wings,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/bridgebunks)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/mainship/medical/lounge)
 "MU" = (
-/obj/machinery/door/airlock/mainship/medical/free_access{
-	dir = 2;
-	name = "Chemistry"
+/turf/open/floor/mainship/sterile/corner,
+/area/mainship/medical/lower_medical)
+"MV" = (
+/obj/vehicle/ridden/powerloader,
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/turf/open/floor/mainship/cargo,
+/area/mainship/squads/req)
 "MW" = (
 /obj/machinery/light/mainship,
 /obj/effect/decal/warning_stripes/thin{
@@ -12427,17 +13344,27 @@
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
+"Nf" = (
+/turf/open/floor/mainship/black/corner,
+/area/mainship/hallways/hangar)
+"Nh" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -9
+	},
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "Ni" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
 "Nj" = (
-/obj/effect/landmark/start/job/captain,
-/obj/structure/bed/fancy,
-/obj/item/bedsheet/captain,
-/turf/open/floor/wood,
-/area/mainship/living/commandbunks)
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/tool/kitchen/knife/butcher,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "Nk" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 8
@@ -12476,11 +13403,11 @@
 /turf/closed/wall/mainship/outer,
 /area/mainship/hull/port_hull)
 "Np" = (
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/red{
-	dir = 9
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 8
 	},
-/area/mainship/living/briefing)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "Nq" = (
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/weapon_room)
@@ -12532,6 +13459,17 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"Nx" = (
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/tool/extinguisher,
+/obj/item/tool/extinguisher/mini,
+/obj/structure/rack,
+/obj/item/flashlight,
+/obj/item/flashlight,
+/obj/item/lightreplacer,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/squads/req)
 "Nz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /obj/machinery/camera/autoname/mainship,
@@ -12562,18 +13500,26 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/port_hallway)
 "NF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/mainship/silver{
-	dir = 1
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
 	},
-/area/mainship/hallways/port_hallway)
-"NG" = (
-/obj/machinery/power/apc/mainship,
+/obj/machinery/power/apc/mainship{
+	dir = 4
+	},
 /obj/structure/cable,
-/turf/open/floor/mainship/silver{
-	dir = 1
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_x = 6;
+	pixel_y = 22
 	},
-/area/mainship/hallways/port_hallway)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
+"NG" = (
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
+	dir = 1;
+	name = "Medical Storage"
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "NH" = (
 /turf/closed/wall/mainship,
 /area/mainship/engineering/engineering_workshop)
@@ -12603,11 +13549,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engineering_workshop)
 "NM" = (
-/obj/machinery/holopad,
 /turf/open/floor/mainship/black{
 	dir = 1
 	},
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/living/briefing)
 "NN" = (
 /turf/open/floor/mainship/black/corner{
 	dir = 4
@@ -12745,16 +13690,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "Oc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
+/area/mainship/medical/chemistry)
 "Od" = (
 /obj/machinery/telecomms/server/presets/alpha,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -12766,23 +13706,20 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "Oe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "Of" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 5
-	},
-/area/mainship/hallways/starboard_hallway)
+/obj/structure/table/mainship/nometal,
+/turf/open/floor/carpet,
+/area/mainship/living/grunt_rnr)
 "Og" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction,
@@ -12940,6 +13877,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/engineering_workshop)
+"OE" = (
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "OF" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -12992,6 +13935,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/telecomms)
+"OM" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
 "ON" = (
 /turf/open/floor/mainship/orange{
 	dir = 1
@@ -13130,10 +14082,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "Ph" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/bed/chair/sofa/corner,
+/turf/open/floor/plating,
 /area/mainship/engineering/engineering_workshop)
 "Pi" = (
 /obj/machinery/chem_master,
@@ -13142,14 +14092,10 @@
 /area/mainship/medical/chemistry)
 "Pj" = (
 /obj/structure/table/mainship/nometal,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/clothing/suit/storage/hazardvest/lime,
-/obj/item/clothing/suit/storage/hazardvest/blue,
-/obj/item/tool/shovel/etool,
-/obj/item/storage/pouch/medkit/firstaid,
-/obj/item/tool/taperoll/engineering,
-/turf/open/floor/mainship/mono,
-/area/mainship/engineering/engineering_workshop)
+/turf/open/floor/carpet/side{
+	dir = 6
+	},
+/area/mainship/living/grunt_rnr)
 "Pk" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -13221,11 +14167,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "Px" = (
-/obj/structure/bed/chair/nometal{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/soda{
+	dir = 8
 	},
-/turf/open/floor/mainship/blue/full,
-/area/mainship/hallways/starboard_hallway)
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "Py" = (
 /obj/structure/dropship_equipment/operatingtable,
 /turf/open/floor/mainship/cargo,
@@ -13256,23 +14203,23 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "PD" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/machinery/door/airlock/multi_tile/mainship/engineering{
-	dir = 2
+/turf/open/floor/carpet/side{
+	dir = 5
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/engineering/engineering_workshop)
+/area/mainship/living/grunt_rnr)
+"PE" = (
+/obj/effect/soundplayer,
+/turf/closed/wall/mainship,
+/area/mainship/living/tankerbunks)
 "PF" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/engineering_workshop)
 "PG" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
+/obj/structure/table,
+/obj/item/trash/boonie,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/hallways/port_hallway)
 "PH" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -13296,6 +14243,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/engineering_workshop)
+"PK" = (
+/mob/living/simple_animal/cat/martin,
+/turf/closed/wall/mainship,
+/area/mainship/squads/req)
 "PL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -13332,6 +14283,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/engineering_workshop)
+"PP" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/hallways/hangar)
 "PQ" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -13343,6 +14303,17 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engineering_workshop)
+"PR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
 "PS" = (
 /obj/structure/window/framed/mainship/hull,
 /turf/open/floor/mainship/mono,
@@ -13371,7 +14342,7 @@
 "PV" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/squads/req)
 "PW" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -13391,20 +14362,23 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "PZ" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
+/obj/structure/table/woodentable,
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/obj/item/newspaper,
+/obj/item/key,
+/turf/open/floor/plating,
 /area/mainship/engineering/engineering_workshop)
 "Qa" = (
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/bed/chair/sofa/left{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/mainship/engineering/engineering_workshop)
 "Qb" = (
-/obj/machinery/marine_selector/clothes/synth,
-/turf/open/floor/mainship/mono,
-/area/mainship/engineering/engineering_workshop)
+/turf/open/floor/carpet/side{
+	dir = 8
+	},
+/area/mainship/living/grunt_rnr)
 "Qc" = (
 /obj/structure/cable,
 /obj/machinery/light/mainship{
@@ -13577,7 +14551,7 @@
 "Qz" = (
 /obj/structure/largecrate/supply/supplies/water,
 /turf/open/floor/mainship/cargo,
-/area/mainship/command/self_destruct)
+/area/mainship/hallways/hangar)
 "QA" = (
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 9
@@ -13749,13 +14723,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "Re" = (
-/obj/effect/landmark/start/job/synthetic,
-/turf/open/floor/mainship/cargo,
+/turf/open/floor/plating,
 /area/mainship/engineering/engineering_workshop)
 "Rf" = (
-/obj/machinery/recharge_station,
+/obj/structure/musician/piano,
 /turf/open/floor/mainship/mono,
-/area/mainship/engineering/engineering_workshop)
+/area/mainship/living/grunt_rnr)
 "Rg" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/ai,
@@ -13808,6 +14781,12 @@
 /obj/structure/ob_ammo/warhead/incendiary,
 /turf/open/floor/mainship/cargo,
 /area/mainship/shipboard/weapon_room)
+"Rp" = (
+/obj/structure/bed/chair/wood/wings{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/mainship/medical/lounge)
 "Rq" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/radio,
@@ -13880,20 +14859,18 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "RB" = (
-/obj/machinery/computer/camera_advanced/overwatch/bravo,
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/structure/table/mainship/nometal,
-/turf/open/floor/mainship/mono,
-/area/mainship/command/cic)
+/turf/open/floor/carpet,
+/area/mainship/living/grunt_rnr)
 "RC" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/mainship_hull,
 /area/mainship/powered)
+"RD" = (
+/obj/machinery/light/mainship,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "RE" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -13972,6 +14949,12 @@
 	dir = 1
 	},
 /area/mainship/living/evacuation)
+"RP" = (
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "RQ" = (
 /turf/open/floor/plating{
 	dir = 4;
@@ -13988,6 +14971,13 @@
 	dir = 4
 	},
 /area/mainship/hallways/hangar)
+"RT" = (
+/obj/machinery/computer/arcade,
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "RU" = (
 /turf/open/floor/plating{
 	dir = 8;
@@ -14012,6 +15002,10 @@
 	dir = 10
 	},
 /area/mainship/engineering/engineering_workshop)
+"Sa" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/mainship/sterile/plain,
+/area/mainship/medical/lower_medical)
 "Sb" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/tool/taperoll/engineering,
@@ -14020,9 +15014,10 @@
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
 "Sd" = (
-/obj/structure/sign/chemistry2,
-/turf/closed/wall/mainship/white,
-/area/mainship/medical/lower_medical)
+/obj/machinery/optable,
+/obj/item/tank/anesthetic,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
 "Se" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/lightreplacer,
@@ -14031,19 +15026,23 @@
 	},
 /area/mainship/engineering/engineering_workshop)
 "Sf" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/green{
-	dir = 6
-	},
-/area/mainship/living/port_garden)
+/obj/effect/decal/cleanable/flour,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "Sg" = (
 /turf/open/floor/mainship/red{
 	dir = 4
 	},
 /area/mainship/living/briefing)
+"Sh" = (
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/obj/structure/table/woodentable,
+/obj/item/storage/box/cups,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "Si" = (
 /obj/item/radio/intercom/general{
 	dir = 1
@@ -14070,10 +15069,8 @@
 	},
 /area/mainship/engineering/engineering_workshop)
 "Sl" = (
-/turf/open/floor/carpet/side{
-	dir = 10
-	},
-/area/mainship/living/commandbunks)
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "Sm" = (
 /obj/structure/rack,
 /obj/item/stack/rods{
@@ -14114,10 +15111,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/airoom)
 "Sr" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/command/self_destruct)
+/obj/machinery/vending/nanomed,
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "Ss" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/mainship/mono,
@@ -14152,8 +15150,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "Sy" = (
-/turf/open/floor/mainship/terragov/north,
-/area/mainship/hallways/starboard_hallway)
+/turf/open/floor/mainship/terragov/north{
+	dir = 6
+	},
+/area/mainship/living/briefing)
 "Sz" = (
 /obj/structure/prop/mainship/sensor_computer2,
 /turf/open/floor/mainship/mono,
@@ -14184,6 +15184,23 @@
 	dir = 1
 	},
 /area/mainship/shipboard/weapon_room)
+"SF" = (
+/obj/machinery/computer/med_data,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/lounge)
+"SG" = (
+/obj/structure/table/mainship/nometal,
+/obj/structure/paper_bin,
+/obj/item/tool/pen,
+/obj/item/clipboard{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/structure/sign/science,
+/turf/open/floor/mainship/research,
+/area/mainship/medical/medical_science)
 "SH" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -14263,6 +15280,12 @@
 	dir = 10
 	},
 /area/mainship/command/cic)
+"ST" = (
+/obj/machinery/door/airlock/mainship/medical/glass/CMO{
+	dir = 2
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lounge)
 "SU" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -14368,6 +15391,25 @@
 	dir = 8
 	},
 /area/mainship/living/cafeteria_starboard)
+"Th" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
+"Ti" = (
+/turf/open/floor/mainship/terragov/north{
+	dir = 8
+	},
+/area/mainship/living/briefing)
 "Tj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -14413,7 +15455,7 @@
 	input_tag = "mix_in";
 	name = "Mixed Air Control";
 	output_tag = "mix_out";
-	sensors = list("mix_sensor" = "Tank")
+	sensors = list("mix_sensor"="Tank")
 	},
 /turf/open/floor/mainship/black{
 	dir = 1
@@ -14428,19 +15470,12 @@
 /turf/open/floor/plating,
 /area/mainship/living/port_garden)
 "Tp" = (
+/obj/machinery/door/airlock/mainship/command/CPToffice{
+	dir = 2
+	},
 /obj/structure/cable,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/commandbunks)
 "Tr" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -14520,21 +15555,12 @@
 /turf/open/floor/wood,
 /area/mainship/engineering/ce_room)
 "Tz" = (
-/obj/structure/table/mainship/nometal,
-/obj/structure/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/structure/bed/chair/nometal{
+	dir = 1
 	},
-/obj/item/tool/stamp/ce,
-/obj/item/tool/pen,
-/obj/structure/cable,
-/obj/item/blueprints,
 /obj/effect/ai_node,
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/mainship/engineering/ce_room)
+/turf/open/floor/mainship/orange/full,
+/area/mainship/living/briefing)
 "TA" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -14647,6 +15673,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
+"TS" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "TT" = (
 /turf/closed/wall/mainship,
 /area/mainship/engineering/engine_core)
@@ -14659,9 +15690,7 @@
 /area/mainship/command/airoom)
 "TV" = (
 /obj/structure/cable,
-/obj/machinery/door_control/ai/exterior{
-	pixel_y = 25
-	},
+/obj/machinery/door_control/ai/exterior,
 /turf/open/floor/mainship/red{
 	dir = 4
 	},
@@ -14672,6 +15701,13 @@
 	dir = 1
 	},
 /area/mainship/hallways/hangar)
+"TX" = (
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/obj/structure/bed/chair/sofa/right,
+/turf/open/floor/plating,
+/area/mainship/engineering/engineering_workshop)
 "TY" = (
 /obj/structure/droppod,
 /obj/structure/dropprop,
@@ -14692,9 +15728,7 @@
 /area/mainship/medical/chemistry)
 "Ub" = (
 /obj/structure/cable,
-/obj/machinery/door_control/ai/exterior{
-	pixel_y = 25
-	},
+/obj/machinery/door_control/ai/exterior,
 /turf/open/floor/mainship/red{
 	dir = 8
 	},
@@ -14750,6 +15784,10 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/powered)
+"Uk" = (
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "Ul" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -14844,9 +15882,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Uz" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/command/self_destruct)
+/obj/structure/table/woodentable,
+/obj/item/clipboard{
+	pixel_x = 5
+	},
+/obj/item/paper,
+/obj/item/tool/pen,
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "UA" = (
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/mainship/tcomms,
@@ -14877,6 +15920,12 @@
 "UF" = (
 /obj/machinery/self_destruct/rod,
 /turf/open/floor/mainship/tcomms,
+/area/mainship/command/self_destruct)
+"UG" = (
+/obj/machinery/alarm{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/mainship/command/self_destruct)
 "UH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -14934,16 +15983,24 @@
 	},
 /area/mainship/living/cryo_cells)
 "UM" = (
-/obj/machinery/computer/camera_advanced/overwatch/bravo{
-	name = "Charlie Overwatch Console"
+/obj/machinery/door_control/mainship/req{
+	dir = 1;
+	id = "qm_warehouse";
+	name = "Requisition Warehouse Shutters"
 	},
-/obj/machinery/light/mainship{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/structure/table/reinforced,
-/obj/structure/table/mainship/nometal,
-/turf/open/floor/mainship/mono,
-/area/mainship/command/cic)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/mainship,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/squads/req)
 "UN" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -14981,6 +16038,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/cic)
+"UQ" = (
+/obj/machinery/door/airlock/multi_tile/mainship/personalglass{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "UR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -15131,6 +16200,13 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/engineering/ce_room)
+"Vl" = (
+/obj/machinery/computer/camera_advanced/overwatch/bravo{
+	name = "Delta Overwatch Console"
+	},
+/obj/structure/table/mainship/nometal,
+/turf/open/floor/mainship/mono,
+/area/mainship/command/cic)
 "Vm" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -15140,12 +16216,9 @@
 /turf/open/floor/wood,
 /area/mainship/engineering/ce_room)
 "Vn" = (
-/obj/structure/closet/secure_closet/engineering_chief,
-/obj/item/clothing/glasses/welding,
-/obj/item/clothing/ears/earmuffs,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/mainship/engineering/ce_room)
+/obj/structure/window/framed/mainship/canterbury,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "Vo" = (
 /turf/closed/wall/mainship,
 /area/mainship/hallways/hangar/droppod)
@@ -15205,6 +16278,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
+"VA" = (
+/obj/structure/table/reinforced,
+/obj/item/tool/hand_labeler,
+/obj/item/facepaint/green,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/tankerbunks)
 "VB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -15254,6 +16333,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engine_core)
+"VI" = (
+/obj/structure/bed/chair/sofa/left,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "VJ" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable,
@@ -15343,9 +16426,11 @@
 	},
 /area/mainship/living/cryo_cells)
 "VW" = (
-/obj/machinery/loadout_vendor,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lounge)
 "VX" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -15503,6 +16588,13 @@
 /obj/machinery/door/airlock/multi_tile/mainship/engineering,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"Wy" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "Wz" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/engineering/engineering_workshop)
@@ -15523,6 +16615,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
+"WF" = (
+/obj/structure/table/mainship/nometal,
+/obj/item/storage/box/matches,
+/obj/item/storage/fancy/cigar,
+/turf/open/floor/wood,
+/area/mainship/hallways/hangar)
 "WG" = (
 /obj/structure/sign/science,
 /turf/open/floor/mainship/mono,
@@ -15590,6 +16688,12 @@
 /obj/structure/window/framed/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/airoom)
+"WR" = (
+/obj/machinery/door/airlock/mainship/generic/glass{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/grunt_rnr)
 "WS" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
@@ -15670,6 +16774,17 @@
 /obj/machinery/telecomms/bus/preset_four,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
+"Xf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "Xg" = (
 /obj/structure/window/framed/mainship/requisitions,
 /turf/open/floor/mainship/mono,
@@ -15679,9 +16794,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "Xi" = (
-/obj/machinery/door_control/mainship/tcomms{
-	pixel_y = 25
-	},
+/obj/machinery/door_control/mainship/tcomms,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "Xj" = (
@@ -15711,6 +16824,12 @@
 /obj/structure/table/mainship/nometal,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/command/cic)
+"Xn" = (
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/port_hull)
 "Xo" = (
 /obj/machinery/computer/shuttle/shuttle_control/dropship,
 /obj/structure/table/mainship/nometal,
@@ -15807,10 +16926,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/port_atmos)
 "XD" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 8
+/turf/open/floor/mainship/terragov{
+	dir = 1
 	},
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/living/briefing)
 "XE" = (
 /turf/open/floor/mainship_hull,
 /area/space)
@@ -15913,10 +17032,10 @@
 /area/mainship/command/cic)
 "XV" = (
 /obj/structure/window/reinforced/extratoughened{
-	dir = 8
+	dir = 1
 	},
 /obj/structure/window/reinforced/extratoughened{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
@@ -16055,6 +17174,12 @@
 "Yr" = (
 /turf/closed/wall/mainship,
 /area/mainship/command/self_destruct)
+"Ys" = (
+/obj/machinery/vending/medical/shipside,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
 "Yt" = (
 /obj/machinery/vending/lasgun,
 /obj/machinery/door_control/unmeltable{
@@ -16062,7 +17187,7 @@
 	name = "Dropship Prep door control"
 	},
 /turf/open/floor/mainship/cargo,
-/area/mainship/command/self_destruct)
+/area/mainship/hallways/hangar)
 "Yu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -16071,11 +17196,11 @@
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 4
 	},
-/area/mainship/command/self_destruct)
+/area/mainship/hallways/hangar)
 "Yv" = (
 /obj/structure/largecrate/supply/supplies/flares,
 /turf/open/floor/mainship/cargo,
-/area/mainship/command/self_destruct)
+/area/mainship/hallways/hangar)
 "Yw" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -16127,11 +17252,9 @@
 	},
 /area/space)
 "YC" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/open/floor/mainship/green{
-	dir = 8
-	},
-/area/mainship/living/port_garden)
+/obj/machinery/light/mainship,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "YD" = (
 /obj/machinery/vending/weapon,
 /obj/machinery/camera/autoname/mainship{
@@ -16185,6 +17308,16 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engine_core)
+"YL" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/obj/machinery/power/apc/mainship{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
 "YM" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -16259,9 +17392,6 @@
 /area/mainship/command/airoom)
 "YX" = (
 /obj/effect/landmark/start/job/ai,
-/obj/machinery/door/window/secure/bridge{
-	dir = 2
-	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
 "YZ" = (
@@ -16305,6 +17435,15 @@
 /obj/machinery/computer/telecomms/server/preset,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
+"Zi" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/alarm{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/corner,
+/area/mainship/medical/lower_medical)
 "Zj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -16381,12 +17520,16 @@
 /turf/closed/wall/mainship,
 /area/mainship/command/self_destruct)
 "Zw" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/port_hull)
+/obj/structure/bed/chair/comfy/beige{
+	dir = 4
+	},
+/obj/effect/landmark/start/job/staffofficer,
+/turf/open/floor/carpet,
+/area/mainship/living/bridgebunks)
 "Zx" = (
-/turf/open/floor/mainship/mono,
-/area/mainship/command/self_destruct)
+/obj/machinery/griddle,
+/turf/open/floor/prison/kitchen,
+/area/mainship/living/grunt_rnr)
 "Zy" = (
 /turf/open/floor/plating/mainship,
 /area/mainship/hull/starboard_hull)
@@ -16396,7 +17539,7 @@
 	},
 /obj/structure/largecrate/supply/supplies/mre,
 /turf/open/floor/mainship/cargo,
-/area/mainship/command/self_destruct)
+/area/mainship/hallways/hangar)
 "ZA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -16413,7 +17556,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/cargo,
-/area/mainship/command/self_destruct)
+/area/mainship/hallways/hangar)
 "ZD" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/camera/autoname/mainship{
@@ -16440,9 +17583,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/starboard_hull)
 "ZH" = (
-/obj/machinery/holopad,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/port_garden)
+/turf/open/floor/mainship/silver{
+	dir = 4
+	},
+/area/mainship/medical/medical_science)
 "ZI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -16469,28 +17613,34 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "ZN" = (
-/obj/machinery/light/mainship{
-	dir = 4
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -9
 	},
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
-/area/mainship/living/briefing)
+/turf/open/floor/mainship/sterile/plain,
+/area/mainship/medical/lower_medical)
 "ZO" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"ZP" = (
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "ZQ" = (
 /obj/structure/closet/radiation,
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
 "ZR" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/open/floor/mainship/green{
-	dir = 6
-	},
-/area/mainship/living/port_garden)
+/obj/structure/table/reinforced,
+/obj/item/storage/surgical_tray,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/light/mainship,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
 "ZS" = (
 /obj/structure/closet/radiation,
 /obj/structure/sign/poster,
@@ -16867,13 +18017,13 @@ ZK
 ZK
 ZK
 ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
+Ri
+Wm
+Wm
+Wm
+Wm
+Wm
+kI
 ZK
 ZK
 ZK
@@ -16965,20 +18115,20 @@ ZK
 ZK
 ZK
 ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
+YB
+XE
+XE
+XE
+XE
+XE
+XE
+Wm
+Wm
+Wm
+Wm
+Wm
+Wm
+kI
 ZK
 ZK
 ZK
@@ -17063,27 +18213,27 @@ ZK
 ZK
 ZK
 ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
+YB
+XE
+XE
+XE
+XE
+XE
+XE
+XE
+XE
+XE
+XE
+XE
+XE
+XE
+Wm
+Wm
+Wm
+Wm
+Wm
+Wm
+kI
 ZK
 ZK
 ZK
@@ -17136,692 +18286,6 @@ FW
 ZK
 "}
 (7,1,1) = {"
-ZK
-FW
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-FW
-ZK
-"}
-(8,1,1) = {"
-ZK
-FW
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-FW
-ZK
-"}
-(9,1,1) = {"
-ZK
-FW
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-FW
-ZK
-"}
-(10,1,1) = {"
-ZK
-FW
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-FW
-ZK
-"}
-(11,1,1) = {"
-ZK
-FW
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-Ri
-Wm
-Wm
-Wm
-Wm
-Wm
-kI
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-FW
-ZK
-"}
-(12,1,1) = {"
-ZK
-FW
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-YB
-XE
-XE
-XE
-XE
-XE
-XE
-Wm
-Wm
-Wm
-Wm
-Wm
-Wm
-kI
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-FW
-ZK
-"}
-(13,1,1) = {"
-ZK
-FW
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-YB
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-Wm
-Wm
-Wm
-Wm
-Wm
-Wm
-kI
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-FW
-ZK
-"}
-(14,1,1) = {"
 ZK
 FW
 ZK
@@ -17919,7 +18383,7 @@ ZK
 FW
 ZK
 "}
-(15,1,1) = {"
+(8,1,1) = {"
 ZK
 FW
 ZK
@@ -18017,7 +18481,7 @@ ZK
 FW
 ZK
 "}
-(16,1,1) = {"
+(9,1,1) = {"
 ZK
 FW
 ZK
@@ -18115,7 +18579,7 @@ ZK
 FW
 ZK
 "}
-(17,1,1) = {"
+(10,1,1) = {"
 ZK
 FW
 ZK
@@ -18213,7 +18677,7 @@ ZK
 FW
 ZK
 "}
-(18,1,1) = {"
+(11,1,1) = {"
 ZK
 FW
 ZK
@@ -18311,7 +18775,7 @@ ZK
 FW
 ZK
 "}
-(19,1,1) = {"
+(12,1,1) = {"
 ZK
 FW
 ZK
@@ -18409,7 +18873,7 @@ ZK
 FW
 ZK
 "}
-(20,1,1) = {"
+(13,1,1) = {"
 ZK
 FW
 ZK
@@ -18507,7 +18971,7 @@ ZK
 FW
 ZK
 "}
-(21,1,1) = {"
+(14,1,1) = {"
 ZK
 FW
 ZK
@@ -18605,7 +19069,7 @@ ZK
 FW
 ZK
 "}
-(22,1,1) = {"
+(15,1,1) = {"
 ZK
 FW
 ZK
@@ -18703,7 +19167,7 @@ ZK
 FW
 ZK
 "}
-(23,1,1) = {"
+(16,1,1) = {"
 ZK
 FW
 ZK
@@ -18801,7 +19265,7 @@ ZK
 FW
 ZK
 "}
-(24,1,1) = {"
+(17,1,1) = {"
 ZK
 FW
 ZK
@@ -18899,7 +19363,7 @@ ZK
 FW
 ZK
 "}
-(25,1,1) = {"
+(18,1,1) = {"
 ZK
 FW
 ZK
@@ -18997,7 +19461,7 @@ ZK
 FW
 ZK
 "}
-(26,1,1) = {"
+(19,1,1) = {"
 ZK
 FW
 ZK
@@ -19095,7 +19559,7 @@ ZK
 FW
 ZK
 "}
-(27,1,1) = {"
+(20,1,1) = {"
 ZK
 FW
 ZK
@@ -19193,7 +19657,7 @@ ZK
 FW
 ZK
 "}
-(28,1,1) = {"
+(21,1,1) = {"
 ZK
 FW
 ZK
@@ -19291,7 +19755,7 @@ ZK
 FW
 ZK
 "}
-(29,1,1) = {"
+(22,1,1) = {"
 ZK
 FW
 ZK
@@ -19389,7 +19853,7 @@ ZK
 FW
 ZK
 "}
-(30,1,1) = {"
+(23,1,1) = {"
 ZK
 FW
 ZK
@@ -19487,7 +19951,7 @@ ZK
 FW
 ZK
 "}
-(31,1,1) = {"
+(24,1,1) = {"
 ZK
 FW
 ZK
@@ -19534,7 +19998,7 @@ hw
 xi
 yS
 zc
-zf
+Ge
 zf
 zf
 zf
@@ -19585,7 +20049,7 @@ ZK
 FW
 ZK
 "}
-(32,1,1) = {"
+(25,1,1) = {"
 ZK
 FW
 ZK
@@ -19631,7 +20095,7 @@ vr
 hw
 dd
 yo
-zk
+GK
 Au
 BD
 CG
@@ -19683,7 +20147,7 @@ ZK
 FW
 ZK
 "}
-(33,1,1) = {"
+(26,1,1) = {"
 ZK
 FW
 ZK
@@ -19781,7 +20245,7 @@ ZK
 FW
 ZK
 "}
-(34,1,1) = {"
+(27,1,1) = {"
 ZK
 FW
 ZK
@@ -19825,9 +20289,9 @@ tl
 uE
 vu
 tl
-kl
-kl
-kl
+hA
+NC
+hD
 kl
 BF
 kl
@@ -19879,7 +20343,7 @@ ZK
 FW
 ZK
 "}
-(35,1,1) = {"
+(28,1,1) = {"
 ZK
 FW
 ZK
@@ -19920,16 +20384,16 @@ kn
 kn
 kn
 tm
-uF
+qY
 vv
 wj
-xl
+rv
 wj
 zl
 wj
-BH
+ji
 wj
-DV
+rv
 wj
 wj
 wj
@@ -19977,7 +20441,7 @@ ZK
 FW
 ZK
 "}
-(36,1,1) = {"
+(29,1,1) = {"
 ZK
 FW
 ZK
@@ -20018,27 +20482,27 @@ mb
 kO
 ko
 to
-uH
+uF
 ko
 ko
-xm
+ko
 kO
 zo
 ko
 ko
 ko
-DW
+ko
 kO
 ko
 ko
 mb
-ko
+vw
 IV
-ko
-kO
 mb
-ko
-ko
+oB
+vw
+vw
+mb
 Nv
 iw
 jk
@@ -20075,7 +20539,7 @@ ZK
 FW
 ZK
 "}
-(37,1,1) = {"
+(30,1,1) = {"
 ZK
 FW
 ZK
@@ -20106,38 +20570,38 @@ gQ
 hz
 ir
 jk
-kq
-kq
-kq
-kq
-kq
-kq
-kq
-kq
-kq
+IQ
+IQ
+IQ
+Vn
+Vn
+Vn
+IQ
+IQ
+IQ
 tp
-uJ
-vw
-wl
-xn
-Hn
-zp
-co
-co
-co
-DX
-EO
-EO
-EO
-EO
-EM
-IW
-EM
-EM
-EM
-EM
-EM
-hy
+uH
+Qs
+xm
+xm
+IQ
+gy
+ue
+ue
+ue
+ue
+IQ
+ue
+ue
+IQ
+JR
+UQ
+IQ
+IQ
+JR
+zy
+IQ
+hz
 iw
 jk
 Qq
@@ -20173,7 +20637,7 @@ ZK
 FW
 ZK
 "}
-(38,1,1) = {"
+(31,1,1) = {"
 ZK
 FW
 ZK
@@ -20204,37 +20668,37 @@ gQ
 hA
 ir
 jk
-kq
-kP
-kT
-kT
-kT
-kT
-kT
-kT
-kq
-tq
-uJ
-wP
+IQ
+Ei
+pC
+JR
+Rf
+pC
+AO
+eF
+IQ
+tp
+uS
 vw
-xp
-Hn
-zq
-Av
-aw
-Sf
-DZ
-EO
-FL
-Nj
-EO
-Ia
-IX
-JY
-EM
-GF
-LZ
-EM
+vw
+vw
+IQ
+zp
+Cq
+jO
+wb
+BT
+IQ
+Nh
+wp
+ZP
+ul
+wH
+AN
+lL
+ul
+YC
+IQ
 hz
 iw
 jk
@@ -20271,7 +20735,7 @@ ZK
 FW
 ZK
 "}
-(39,1,1) = {"
+(32,1,1) = {"
 ZK
 FW
 ZK
@@ -20301,40 +20765,40 @@ Le
 gQ
 hB
 ir
-jl
-kq
-kT
-mc
-nh
-nh
-nh
-qA
-kT
-kq
-tr
-uJ
-EA
-wm
-xr
-co
-zr
-cs
-ZH
-cs
-Ea
-Ke
-FO
-FO
-EO
-lK
-IY
-Ka
-HN
-GG
-Ma
-EM
-hK
-iw
+jk
+vE
+JR
+Mq
+Ad
+xl
+Qb
+uz
+JR
+vE
+tp
+uS
+vw
+vw
+vw
+IQ
+ys
+aw
+aw
+Sf
+DZ
+WR
+FL
+Nj
+ul
+ul
+Iz
+Ii
+rU
+ul
+ul
+vE
+hz
+us
 jl
 Qq
 Rr
@@ -20369,7 +20833,7 @@ ZK
 FW
 ZK
 "}
-(40,1,1) = {"
+(33,1,1) = {"
 ZK
 FW
 ZK
@@ -20398,39 +20862,39 @@ fD
 aT
 gQ
 hD
-it
+ha
 jk
-kq
-kT
-me
-nj
-oh
-po
-qC
-kT
-kq
-tu
-uL
-vy
-wn
-xr
-co
-cs
-Aw
-YC
-KO
-Ed
-EO
-Kv
-Sl
-EO
-Ic
-zy
-Kb
-EM
-EM
-EM
-EM
+JR
+JR
+GS
+Of
+yp
+RB
+BR
+JR
+JR
+tp
+kJ
+IW
+qi
+vw
+IQ
+zr
+Jd
+Ki
+Ke
+lb
+IQ
+FP
+Ml
+ul
+dp
+wH
+CP
+sd
+GO
+ul
+JR
 hz
 iw
 jk
@@ -20467,7 +20931,7 @@ ZK
 FW
 ZK
 "}
-(41,1,1) = {"
+(34,1,1) = {"
 ZK
 FW
 ZK
@@ -20498,38 +20962,38 @@ gR
 hF
 iu
 jk
-kq
-kT
-me
-nk
-ol
-pq
-qC
-kT
-kq
-tw
+IQ
+GI
+PD
+Jl
+qI
+Fg
+Pj
+RD
+IQ
+tp
+uS
+VI
+PG
+vw
+IQ
+Th
+Db
+FM
+FM
+CU
+IQ
+Sl
+Sl
+ul
+pS
+wH
+CP
+HF
+GO
 uN
-vz
-wp
-xr
-co
-zs
-BI
-aw
-ZR
-Eg
-EO
-FP
-GH
-dB
-qv
-Ja
-Kc
-EM
-GF
-LZ
-EM
-hG
+IQ
+hz
 iw
 jk
 Qq
@@ -20565,7 +21029,7 @@ ZK
 FW
 ZK
 "}
-(42,1,1) = {"
+(35,1,1) = {"
 ZK
 FW
 ZK
@@ -20596,37 +21060,37 @@ bE
 hG
 ir
 jk
-kq
-kT
-me
-nl
-on
-pr
-qC
-kT
-kq
-FS
-uJ
+IQ
+pa
+JR
+JR
+RT
+JR
+JR
+JR
+IQ
+tp
+uS
 vw
 vw
-xr
-co
-cs
-cs
-cs
-cs
-Eh
-EO
-FQ
-GI
-EO
-Ie
-Je
-Kc
-HN
-GG
-Ma
-EM
+vw
+IQ
+zp
+Aw
+Aw
+Zx
+Sl
+IQ
+xu
+Px
+oN
+pJ
+wH
+qW
+ul
+ul
+mr
+IQ
 hz
 iw
 jk
@@ -20663,7 +21127,7 @@ ZK
 FW
 ZK
 "}
-(43,1,1) = {"
+(36,1,1) = {"
 ZK
 FW
 ZK
@@ -20695,37 +21159,37 @@ hy
 ir
 jk
 kq
-kT
-mf
-nm
-oo
-ps
-qE
-kT
 kq
-tx
-uJ
-vA
-wq
-xp
+kq
+kq
+kq
+kq
+kq
+kq
+kq
+tp
+uS
+vw
+wl
+xr
 Hn
 zt
-Ax
-BJ
-CI
-Ei
+co
+co
+co
+DX
 EO
 EO
 EO
 EO
-Ie
-Ji
-Kc
+EM
+bF
 EM
 EM
 EM
 EM
-hK
+EM
+hy
 iw
 jl
 Qq
@@ -20761,7 +21225,7 @@ ZK
 FW
 ZK
 "}
-(44,1,1) = {"
+(37,1,1) = {"
 ZK
 FW
 ZK
@@ -20793,32 +21257,32 @@ hz
 ir
 jk
 kq
+kP
+kT
+kT
+kT
+kT
+kT
+kT
 kq
-mg
-no
-mi
-pu
-qF
-kq
-kq
-ty
-uO
-ty
-ty
-xs
-ty
-ty
-ty
-ty
-ty
-Ej
-ER
-FT
-GK
-ER
-Ic
-IZ
-Kc
+Iw
+uS
+jE
+vw
+xn
+Hn
+zq
+ES
+BO
+DJ
+cs
+EO
+Ax
+Df
+EO
+Ia
+IX
+JY
 EM
 GF
 LZ
@@ -20859,7 +21323,7 @@ ZK
 FW
 ZK
 "}
-(45,1,1) = {"
+(38,1,1) = {"
 ZK
 FW
 ZK
@@ -20891,37 +21355,37 @@ hz
 ir
 jl
 kq
-kU
-mh
-np
-op
-pv
-qG
-rH
+kT
+mc
+nh
+nh
+nh
+qA
+kT
 kq
-tA
-uP
-vC
-wr
-xv
-ty
-zu
-Ay
-BN
-ty
-Ek
-ER
-FU
-VW
-ER
-Ie
-yH
-Kc
+xO
+uS
+Mi
+GX
+vw
+co
+vc
+vR
+nt
+vR
+Hl
+BQ
+FO
+FO
+EO
+lK
+IY
+Ka
 HN
 GG
 Ma
 EM
-hy
+hK
 iw
 jk
 Qq
@@ -20957,7 +21421,7 @@ ZK
 FW
 ZK
 "}
-(46,1,1) = {"
+(39,1,1) = {"
 ZK
 FW
 ZK
@@ -20989,32 +21453,32 @@ hz
 ir
 jk
 kq
-kV
-mi
-nq
-oq
-pw
-mi
-rK
+kT
+me
+nj
+oh
+po
+qC
+kT
 kq
-tB
-uQ
-vD
-ws
-xw
-yp
-zw
-Az
-BO
-ty
+Jm
+uT
+Jn
+qk
+vw
+co
+zu
+Ay
+BN
+uP
+Fu
+EO
 El
-ER
-FU
-GM
-ER
-Ie
-Ib
-Kc
+BS
+EO
+Ic
+Dj
+Kb
 EM
 EM
 EM
@@ -21055,7 +21519,7 @@ ZK
 FW
 ZK
 "}
-(47,1,1) = {"
+(40,1,1) = {"
 ZK
 FW
 ZK
@@ -21087,38 +21551,38 @@ hz
 ir
 jk
 kq
+kT
+me
+nk
+ol
+pq
+qC
+kT
 kq
-kq
-kq
-pE
-px
-kq
-kq
-kq
-tF
-uS
-sy
-wt
-xA
-ty
-ty
-ty
-ty
-ty
-Ek
-ER
-FV
-GN
-HP
-Ih
-Jl
-Kh
-KZ
-KZ
-KZ
-MT
-Pw
-NZ
+tB
+uQ
+vD
+ws
+vw
+co
+zw
+Az
+BO
+IA
+FS
+EO
+mx
+GM
+Tp
+qv
+Ja
+Kc
+EM
+GF
+LZ
+EM
+hG
+iw
 vw
 Qt
 Pv
@@ -21153,7 +21617,7 @@ ZK
 FW
 ZK
 "}
-(48,1,1) = {"
+(41,1,1) = {"
 ZK
 FW
 ZK
@@ -21185,37 +21649,37 @@ SM
 iv
 jk
 kq
-kW
-kW
-nr
-or
-py
-qG
-rO
+kT
+me
+nl
+on
+pr
+qC
+kT
 kq
-tG
-uT
-vE
-wv
-xC
-ty
-zx
-AA
-BP
-ty
-El
-ER
-FX
-GO
-ER
-Ii
-Jm
-Ki
-La
-Ig
-Ig
-Ig
+tF
+uS
 vw
+vw
+vw
+co
+Hg
+ar
+ar
+KO
+ld
+EO
+FV
+GN
+EO
+Ie
+Je
+Kc
+HN
+GG
+Ma
+EM
+hz
 Oa
 Pw
 Qv
@@ -21251,7 +21715,7 @@ ZK
 FW
 ZK
 "}
-(49,1,1) = {"
+(42,1,1) = {"
 ZK
 FW
 ZK
@@ -21281,34 +21745,34 @@ gm
 bE
 hK
 iw
-vw
-ns
-kX
-mi
-ns
-ot
-EP
-PA
-rQ
+jk
 kq
-tH
-uQ
-vF
-ww
-xD
-ys
-xD
-AB
-BQ
-ty
-Ek
+kT
+mf
+nm
+oo
+ps
+qE
+kT
+kq
+tG
+uS
+ml
+wv
+xn
+Hn
+zx
+Fb
+BP
+gr
+cs
 ER
 ER
 ER
 ER
-EM
-Jn
-EM
+Ie
+Ji
+Kc
 EM
 EM
 EM
@@ -21349,7 +21813,7 @@ ZK
 FW
 ZK
 "}
-(50,1,1) = {"
+(43,1,1) = {"
 ZK
 FW
 ZK
@@ -21381,36 +21845,36 @@ hy
 iw
 jk
 kq
-kY
-mj
-nr
-ov
-pz
-qH
-rR
 kq
-tL
-uU
-vH
-wx
-xE
+mg
+no
+mi
+pu
+qF
+kq
+kq
 ty
-BR
-BR
-BR
+bl
 ty
-Zw
-Ek
-eS
-Ek
-Ek
-eS
-Zw
-Ek
-Ek
-eS
-Ek
-fx
+ty
+xD
+ty
+ty
+ty
+ty
+ty
+Ej
+ER
+oP
+pQ
+ER
+Ic
+tw
+Kc
+EM
+GF
+LZ
+EM
 hz
 us
 jk
@@ -21447,7 +21911,7 @@ ZK
 FW
 ZK
 "}
-(51,1,1) = {"
+(44,1,1) = {"
 ZK
 FW
 ZK
@@ -21479,37 +21943,37 @@ VC
 iy
 jm
 kq
+kU
+mh
+np
+op
+pv
+qG
+rH
 kq
-kq
-kq
-ow
-pz
-kq
-kq
-kq
+tA
+uO
+vC
+wr
+xs
 ty
-uV
+jp
+hJ
+CJ
 ty
-ty
-ty
-ty
-zB
-zB
-zB
-zB
-Ep
-Ep
-Ep
-Ep
-HQ
-HQ
-HQ
-Kj
-HQ
-HQ
-HQ
-HQ
-hz
+MF
+ER
+FU
+Lz
+ER
+Ie
+Zw
+Kc
+HN
+GG
+Ma
+EM
+hy
 iw
 jk
 Wg
@@ -21545,7 +22009,7 @@ ZK
 FW
 ZK
 "}
-(52,1,1) = {"
+(45,1,1) = {"
 ZK
 FW
 ZK
@@ -21574,39 +22038,39 @@ NA
 NA
 NA
 NA
-iA
-jn
-kr
-kZ
-kZ
-kZ
-ox
-pC
-mi
-rT
+bS
+BI
 kq
-tM
-uW
-vM
-wy
-vJ
-yt
-zB
-AD
-BS
-CL
+kV
+mi
+nq
+oq
+pw
+mi
+rK
+kq
+cR
+lR
+io
+LC
+zN
+ST
+tq
+ox
+VW
+ty
 Ep
-ES
-FZ
-GQ
-HQ
-YV
-Jp
-Js
-Lf
-Jp
-Md
-HQ
+ER
+FU
+ME
+ER
+Ie
+tR
+Kc
+EM
+EM
+EM
+EM
 hz
 iw
 jk
@@ -21643,7 +22107,7 @@ ZK
 FW
 ZK
 "}
-(53,1,1) = {"
+(46,1,1) = {"
 ZK
 FW
 ZK
@@ -21673,43 +22137,43 @@ VC
 dz
 VC
 iy
-VC
-ks
-la
-la
-la
-oy
-Bm
-qI
-rU
+BI
 kq
-tN
-uX
-jc
-wz
-rY
-yu
-zB
-AE
-BT
-CN
-Ep
-ET
-Ga
-GR
-HQ
-Im
-Jq
-Jt
-Lg
-Jq
-Mf
-HQ
-hK
-iw
+kq
+kq
+kq
+pE
+px
+kq
+kq
+kq
+kZ
+MT
+GH
+zG
+sf
+ty
+ty
+ty
+ty
+ty
+MF
+ER
+FZ
+GQ
+AS
+wF
+la
+KZ
+zs
+zs
+zs
+yz
+Pw
+NZ
 jl
 Wg
-RB
+Gn
 SW
 UN
 Wj
@@ -21741,7 +22205,7 @@ ZK
 FW
 ZK
 "}
-(54,1,1) = {"
+(47,1,1) = {"
 ZK
 FW
 ZK
@@ -21771,46 +22235,46 @@ OS
 OS
 VC
 iy
-WG
+BI
 kq
-lb
-mi
-hj
-oz
-MR
-mi
-rW
+kW
+kW
+nr
+or
+py
+qG
+rO
 kq
-tO
-uX
-jc
-nA
-rY
-yv
-zB
-AF
-BV
-CO
+xp
+HS
+wP
+Rp
+sF
+ty
+LO
+rg
+SF
+ty
 Ep
-EV
-Gb
-GS
-HQ
-Iq
-Vb
-eK
-wd
-sc
-Ij
-HQ
-hz
+ER
+Ga
+GR
+ER
+oy
+gu
+fh
+mo
+Ig
+Ig
+Ig
+vw
 iw
 jk
 Wg
 RE
 SX
 UO
-UU
+Wk
 Xp
 Ym
 UU
@@ -21839,7 +22303,7 @@ ZK
 FW
 ZK
 "}
-(55,1,1) = {"
+(48,1,1) = {"
 ZK
 FW
 ZK
@@ -21860,55 +22324,55 @@ VC
 VC
 VC
 NA
-jq
+VC
 OS
-ff
-ff
-go
-go
+wt
+mm
+mm
+mm
 OS
-bO
+VC
 iy
 VC
+ns
+kX
+mi
+ns
+ot
+EP
+PA
+rQ
 kq
-ld
-ml
-nt
-oA
-pD
-qJ
-qJ
-sE
-qM
-un
-vK
-wB
-xG
-yw
-zB
-AG
-BW
-CP
-Ep
-EW
-Ge
-GT
-HQ
-Is
-HQ
-Kl
-Lh
-HQ
-Is
-HQ
-Nz
-Ob
+Hd
+lR
+vd
+vb
+zN
+HM
+zN
+AF
+BV
+ty
+MF
+ER
+ER
+ER
+ER
+EM
+wm
+EM
+EM
+EM
+EM
+EM
+hK
+iw
 jk
 Wg
 RG
 SZ
 UK
-Wk
+UU
 Xq
 Yo
 Zr
@@ -21937,7 +22401,7 @@ ZK
 FW
 ZK
 "}
-(56,1,1) = {"
+(49,1,1) = {"
 ZK
 FW
 ZK
@@ -21958,52 +22422,52 @@ NA
 NA
 NA
 NA
-VC
+NA
 OS
-mR
-mR
-mR
-mR
 OS
-VC
+OS
+um
+vX
+Kv
+NA
 iy
-VC
+BI
 kq
-lg
-mm
-nx
-oB
-pF
-qK
-qK
-sF
-tS
-uY
-vL
-wC
-xH
-yx
-zB
-AJ
-dH
-dH
-Ep
-EX
-Ep
-Ep
-HQ
-gU
-Jp
-fR
-Lj
-Jp
-It
-HQ
-NC
+kY
+mj
+nr
+ov
+pz
+qH
+rR
+kq
+qs
+eS
+CO
+vG
+Ed
+ty
+AG
+AG
+AG
+ty
+Gk
+MF
+GT
+MF
+MF
+GT
+Gk
+MF
+MF
+GT
+MF
+fx
+hz
 iw
 jk
 Wg
-UM
+le
 Tb
 UP
 Wl
@@ -22035,7 +22499,7 @@ ZK
 FW
 ZK
 "}
-(57,1,1) = {"
+(50,1,1) = {"
 ZK
 FW
 ZK
@@ -22056,6 +22520,594 @@ bw
 bw
 bw
 fS
+VC
+OS
+vH
+Eo
+mm
+tt
+OS
+VC
+iy
+jm
+kq
+kq
+kq
+kq
+ow
+pz
+kq
+kq
+kq
+ty
+jh
+ty
+ty
+ty
+ty
+zB
+zB
+dH
+zB
+ne
+ne
+ne
+ne
+HQ
+HQ
+HQ
+Kj
+HQ
+HQ
+HQ
+HQ
+hz
+iw
+jk
+Wg
+Vl
+Tc
+UR
+Wn
+Xr
+UU
+Zs
+Wg
+XU
+UU
+do
+Qw
+XE
+XE
+JZ
+nf
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+FW
+ZK
+"}
+(51,1,1) = {"
+ZK
+FW
+ZK
+ZK
+ZK
+ZK
+YB
+XE
+VS
+Uh
+ao
+dP
+dP
+dT
+aD
+aZ
+VC
+VC
+VC
+aW
+VC
+OS
+OS
+OS
+OS
+OS
+OS
+VC
+iA
+jn
+kF
+HP
+HP
+HP
+dy
+vU
+mi
+Ku
+kq
+tM
+uW
+vM
+wy
+vJ
+yt
+zB
+Et
+YL
+iQ
+ne
+xv
+NF
+eV
+HQ
+YV
+Jp
+Js
+Lf
+Jp
+Md
+HQ
+hz
+iw
+jl
+Wg
+RI
+Td
+UT
+UU
+Xt
+Yp
+Zt
+Wg
+bB
+UU
+oe
+Qw
+XE
+hr
+cP
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+FW
+ZK
+"}
+(52,1,1) = {"
+ZK
+FW
+ZK
+ZK
+ZK
+ZK
+YB
+XE
+VS
+aq
+ag
+dV
+dV
+VC
+aW
+aZ
+VC
+VC
+VC
+aW
+VC
+Cd
+MF
+MF
+Xn
+MF
+Cd
+VC
+iy
+VC
+wq
+ZH
+ZH
+ZH
+La
+Bm
+qN
+AJ
+kq
+tN
+uX
+jc
+wz
+rY
+yu
+zB
+zS
+Lo
+ZR
+ne
+EW
+LH
+lg
+HQ
+Im
+Jq
+Jt
+Lg
+Jq
+Mf
+HQ
+hK
+iw
+jk
+lS
+RJ
+Tk
+UU
+Wo
+Xu
+Yq
+Zu
+Wg
+fN
+YD
+zA
+Qw
+XE
+hr
+cP
+ZK
+VU
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+FW
+ZK
+"}
+(53,1,1) = {"
+ZK
+FW
+ZK
+ZK
+ZK
+ZK
+YB
+XE
+VS
+aa
+AR
+mR
+ct
+eC
+aI
+OS
+OS
+bP
+cC
+aW
+VC
+OS
+OS
+OS
+OS
+OS
+OS
+VC
+iy
+WG
+kq
+hp
+mi
+wD
+oE
+GZ
+mi
+SG
+kq
+tO
+uX
+jc
+nA
+rY
+yv
+zB
+AK
+BX
+CS
+ne
+Fa
+PR
+Sd
+HQ
+Iq
+Vb
+eK
+wd
+sc
+Ij
+HQ
+hz
+iw
+jk
+Wg
+Wg
+Tj
+UV
+Wg
+Wg
+Wg
+Wg
+Wg
+Wg
+Wg
+Wg
+Qw
+aU
+aU
+aU
+aU
+aU
+aU
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+FW
+ZK
+"}
+(54,1,1) = {"
+ZK
+FW
+ZK
+ZK
+ZK
+ZK
+YB
+XE
+VS
+ay
+AR
+mR
+dX
+eC
+aJ
+bc
+OS
+bQ
+cD
+aW
+jq
+OS
+ff
+ff
+go
+go
+OS
+bO
+iy
+VC
+kq
+lj
+rS
+HR
+oF
+pG
+sa
+sa
+fJ
+qM
+un
+vK
+wB
+xG
+yw
+zB
+AL
+Es
+FT
+ne
+be
+Gj
+eU
+HQ
+Is
+HQ
+Kl
+Lh
+HQ
+Is
+HQ
+Nz
+Ob
+jk
+Qx
+RL
+Tk
+Kd
+jd
+ra
+AB
+Wg
+Xx
+Xx
+Xv
+Xx
+Xv
+Xx
+Xx
+Xv
+Xx
+Xx
+aU
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+FW
+ZK
+"}
+(55,1,1) = {"
+ZK
+FW
+ZK
+ZK
+ZK
+ZK
+YB
+XE
+VS
+bk
+Ta
+dP
+Pm
+ax
+ua
+hT
+OS
+bT
+Ss
+aW
+VC
+OS
+mR
+mR
+mR
+mR
+OS
+VC
+iy
+VC
+kq
+pD
+vQ
+uj
+oH
+oz
+qO
+qO
+sH
+tS
+uY
+vL
+wC
+xH
+yx
+zB
+AM
+wG
+wG
+ne
+Fe
+kt
+kt
+HQ
+gU
+Jp
+FX
+Lj
+Jp
+It
+HQ
+NC
+iw
+jk
+Qx
+RM
+Tl
+Vc
+Wg
+ra
+JD
+Wg
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+aU
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+FW
+ZK
+"}
+(56,1,1) = {"
+ZK
+FW
+ZK
+ZK
+ZK
+ZK
+YB
+XE
+VS
+VS
+VS
+VS
+VS
+VS
+Hr
+sR
+QM
+bU
+VC
+aW
 VC
 OS
 iE
@@ -22100,25 +23152,25 @@ HQ
 hD
 iw
 jk
+Qx
+RN
+Tk
+UZ
 Wg
-ms
-Tc
-UR
-Wn
-Xr
-UU
-Zs
+ja
+BJ
 Wg
-XU
-UU
-do
-Qw
-XE
-XE
-JZ
-nf
-ZK
-ZK
+Xv
+Xv
+Xv
+YS
+Xv
+Xv
+Xv
+Xv
+YS
+YS
+aU
 ZK
 ZK
 ZK
@@ -22133,7 +23185,7 @@ ZK
 FW
 ZK
 "}
-(58,1,1) = {"
+(57,1,1) = {"
 ZK
 FW
 ZK
@@ -22142,17 +23194,17 @@ ZK
 ZK
 YB
 XE
-VS
-Uh
-ao
-dP
-dP
-dT
-aD
-aZ
-VC
-VC
-VC
+XE
+XE
+XE
+XE
+XE
+XE
+Hr
+ID
+QM
+eR
+cD
 aW
 VC
 OS
@@ -22197,28 +23249,126 @@ Iv
 HQ
 NE
 iw
-jl
+jk
 Wg
-RI
-Td
-UT
-UU
-Xt
-Yp
-Zt
 Wg
-bB
-UU
-oe
-Qw
+Tj
+UV
+Wg
+Wg
+Wg
+Wg
+Xv
+Xv
+Yr
+Yr
+Yr
+Yr
+Yr
+Xv
+Xv
+Xv
+aU
+aU
+aU
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+FW
+ZK
+"}
+(58,1,1) = {"
+ZK
+FW
+ZK
+ZK
+ZK
+ZK
+Gi
+Zl
+Zl
+Zl
+Zl
 XE
-hr
-cP
-ZK
-ZK
-ZK
-ZK
-ZK
+XE
+XE
+Hr
+EH
+QM
+bW
+cE
+aW
+VC
+OS
+jw
+dP
+dP
+Dy
+OS
+VC
+iy
+VC
+kt
+tx
+mn
+Sa
+oX
+kt
+qM
+rY
+Fd
+rY
+xw
+TS
+uU
+Wy
+Av
+Av
+wc
+ny
+hH
+ny
+FQ
+kt
+mz
+HQ
+Is
+HQ
+Oc
+Kt
+HQ
+Is
+HQ
+Mm
+Oe
+VC
+dt
+mp
+iy
+VC
+Yr
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+YS
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xx
+aU
 ZK
 ZK
 ZK
@@ -22238,85 +23388,85 @@ ZK
 ZK
 ZK
 ZK
+ZK
+ZK
+ZK
+ZK
+ZK
 YB
 XE
-VS
-aq
-ag
-dV
-dV
-VC
-aW
-aZ
-VC
+XE
+Hr
+ID
+Hr
 VC
 VC
 aW
 VC
 OS
-jw
-dP
-dP
+Dy
+eC
+cD
 Dy
 OS
 VC
-iy
+aW
 VC
 kt
-li
+rT
 mn
-wD
-oE
-kt
-qM
-rY
-oM
-rY
-uZ
-vN
-wF
-xK
+rT
+vy
+Ek
+Zi
+dc
+dc
+dW
+EA
+dc
+dc
+xL
+DV
+Ff
+Eh
 zF
+xE
 zF
-AK
-BX
-CS
-BX
-Fa
-kt
-Sd
+pN
+Hc
+Ib
+EV
+ll
+tv
+fR
+Ll
+qP
+ql
 HQ
-Is
-HQ
-Kp
-Lk
-HQ
-Is
-HQ
-NF
-Oc
-jk
-lS
-RJ
-Tk
-UU
-Wo
-Xu
-Yq
-Zu
-Wg
-fN
-YD
-zA
-Qw
-XE
-hr
-cP
-ZK
-VU
-ZK
-ZK
-ZK
+hN
+iy
+VC
+VC
+VC
+iy
+VC
+Yr
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+aU
 ZK
 ZK
 ZK
@@ -22336,85 +23486,85 @@ ZK
 ZK
 ZK
 ZK
+ZK
+ZK
+ZK
+ZK
+ZK
 YB
 XE
-VS
-aa
-AR
-mR
-ct
-eC
-aI
-OS
-OS
-bP
-cC
+XE
+Hr
+ID
+Hr
+VC
+VC
 aW
 VC
 OS
-Dy
+pe
 eC
 cD
-Dy
+pe
 OS
+VC
+aW
+VC
+kt
+lh
+mn
+lh
+BM
+kt
+Ix
+kt
+Np
+kt
+kt
+rY
+NG
+kt
+kt
+Bn
+Ju
+DW
+bd
+DW
+Xf
+rY
+Mk
+HQ
+ok
+Jt
+CN
+pF
+Kr
+Kh
+HQ
+Kw
+iy
+VC
+VC
 VC
 iy
 VC
-kt
-lj
-mn
-lj
-oF
-pG
-qN
-sa
-sa
-tV
-vb
-sa
-sa
-xL
-yz
-zG
-AL
-Es
-eU
-Es
-Fc
-Gj
-GX
-HR
-Iw
-dc
-Kr
-Ll
-Lz
-Mi
-HQ
-hz
-iw
-jk
-Wg
-Wg
-Tj
-UV
-Wg
-Wg
-Wg
-Wg
-Wg
-Wg
-Wg
-Wg
-Qw
+Yr
+Xv
+Xv
+Xx
+Xv
+Xx
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xx
 aU
-aU
-aU
-aU
-aU
-aU
-ZK
-ZK
 ZK
 ZK
 ZK
@@ -22434,85 +23584,85 @@ ZK
 ZK
 ZK
 ZK
+ZK
+ZK
+ZK
+ZK
+ZK
 YB
 XE
-VS
-ay
-AR
-mR
-dX
-eC
-aJ
-bc
-OS
-bQ
-cD
+XE
+Hr
+ID
+Hr
+VC
+VC
 aW
 VC
 OS
-pe
-eC
-cD
-pe
+qR
+VC
+VC
+tZ
 OS
 VC
-iy
+aW
 VC
 kt
-lh
+tx
 mn
-lh
-oH
+mn
+mn
 kt
-qO
+Eg
+ZN
+vN
 kt
-sH
-kt
-kt
+fC
 rY
-vQ
+DW
+rB
 kt
-kt
-zH
-AM
-wG
-CU
-wG
-Fd
-rY
-GZ
-HQ
-Ix
-Jt
+Jy
+qJ
 Ks
-Lm
-LC
-Ml
-HQ
-hK
-iw
-jk
-Qx
-RL
-Tk
-Kd
-Wg
+Ks
+Ks
+wL
+al
+EX
+vf
+hj
+li
+Cc
+rM
+OM
+nU
+kh
+zK
+gO
+VC
+VC
+VC
+iy
+nV
+Yr
+Yr
+Yr
+Yr
+Yr
+Yr
+Yr
+Yr
 Xv
 Xv
 Xv
-Xx
-Xx
 Xv
-Xx
 Xv
-Xx
-Xx
 Xv
-Xx
-Xx
+Xv
+Xv
 aU
-ZK
-ZK
 ZK
 ZK
 ZK
@@ -22532,85 +23682,85 @@ ZK
 ZK
 ZK
 ZK
+ZK
+ZK
+ZK
+ZK
+ZK
 YB
 XE
-VS
-bk
-Ta
-dP
-Pm
-ax
-ua
-hT
-OS
-bT
-Ss
+XE
+Hr
+ID
+Hr
+VC
+VC
 aW
-VC
+jq
 OS
-qR
+pe
 VC
 VC
-tZ
+wI
 OS
+bO
+aW
+jo
+kt
+CV
+xM
+mn
+mn
+kt
+IZ
+xC
+qK
+kt
+vz
+ET
+hE
+Ea
+kt
+MU
+tu
+AE
+nx
+AE
+uZ
+ap
+Ys
+HQ
+BZ
+tV
+ks
+tV
+tV
+oM
+HQ
+tL
+iy
+VC
+VC
 VC
 iy
 VC
-kt
-li
-mn
-mn
-mn
-kt
-qP
-sd
-wE
-kt
-vc
-rY
-wG
-xM
-kt
-zK
-AN
-Cc
-lV
-Cc
-Fe
-Gk
-Hc
-HS
-Iz
-Ju
-Ku
-Lo
-LD
-Mk
-MU
-rM
-Fb
-jk
-Qx
-RM
-Tl
-Vc
-Wg
+VC
+hN
+wx
+bI
+wx
+tr
+BI
+Yr
+Xv
 Xx
 Xv
 Xv
 Xv
+Xx
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+YS
 aU
-ZK
-ZK
 ZK
 ZK
 ZK
@@ -22630,86 +23780,86 @@ ZK
 ZK
 ZK
 ZK
+ZK
+ZK
+ZK
+ZK
+ZK
 YB
 XE
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-be
+XE
+Hr
+ID
+Hr
+VC
+VC
+aW
+iB
 OS
-bU
+sl
+sl
+sl
+sl
+OS
 VC
 aW
 jq
-OS
-pe
-VC
-VC
-wI
-OS
-bO
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kr
+uL
+kt
+kt
+kt
+wn
+Lk
+kt
+HQ
+EV
+Jt
+lV
+HQ
+Is
+Is
+HQ
+pU
 iy
-jo
-kt
-ll
-mo
-mn
-mn
-kt
-qQ
-sf
-vG
-kt
-vd
-vR
-wH
-xO
-kt
-zN
-AO
-Cd
-CV
-Cd
-Ff
-Gl
-Hd
-HQ
-IA
-Jv
-rv
-Jv
-Jv
-Mm
-HQ
-NG
-iw
-jk
-Qx
-RN
-Tk
-UZ
-Wg
-Xx
-Xv
-Xv
-Xv
-Xv
-Xv
-YS
-Xv
-Xv
-Xv
-Xv
-YS
-YS
-aU
-ZK
-ZK
-ZK
+VC
+VC
+VC
+iy
+VC
+VC
+wJ
+Gb
+Gb
+Gb
+Gb
+qf
+Zv
+Zv
+Zv
+Zv
+Zv
+Zv
+Zv
+Zv
+Zv
+bH
+bH
 ZK
 ZK
 ZK
@@ -22728,117 +23878,19 @@ ZK
 ZK
 ZK
 ZK
+ZK
+ZK
+ZK
+ZK
+ZK
 YB
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-Hr
-ID
-QM
-eR
-cD
-aW
-iB
-OS
-sl
-sl
-sl
-sl
-OS
-VC
-iy
-jq
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-zO
-AS
-kt
-kt
-kt
-Fg
-Gm
-kt
-HQ
-HR
-Jt
-Kw
-HQ
-Is
-Is
-HQ
-hy
-iw
-jk
-Wg
-Wg
-Tj
-UV
-Wg
-OS
-OS
-Yr
-Yr
-Yr
-Yr
-Zv
-Zv
-Zv
-Zv
-Zv
-Zv
-Zv
-bH
-bH
-bH
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-FW
-ZK
-"}
-(65,1,1) = {"
-ZK
-FW
-ZK
-ZK
-ZK
-ZK
-Gi
-Zl
-Zl
-Zl
-Zl
-XE
 XE
 XE
 Hr
 bf
-QM
-bW
-cE
+Hr
+VC
+VC
 aW
 VC
 VC
@@ -22848,7 +23900,7 @@ VC
 VC
 xP
 VC
-iy
+aW
 VC
 dt
 VC
@@ -22856,7 +23908,7 @@ mp
 dt
 VC
 pH
-GJ
+th
 dt
 VC
 VC
@@ -22876,30 +23928,31 @@ mp
 dt
 VC
 VC
-NA
+PC
 dt
 VC
 VC
 QB
 VC
-Oe
-VC
-dt
-mp
-Tp
-VC
-dt
+iy
 VC
 VC
-qB
-Zx
-JT
-Zx
+VC
+iy
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+VC
 tn
 UB
 qn
-ZB
-ZB
+qn
+qn
+qn
 qn
 qn
 qn
@@ -22913,11 +23966,10 @@ ZK
 ZK
 ZK
 ZK
-ZK
 FW
 ZK
 "}
-(66,1,1) = {"
+(65,1,1) = {"
 ZK
 FW
 ZK
@@ -22989,11 +24041,12 @@ VC
 VC
 VC
 VC
-Zx
-ye
-ye
-ye
+VC
+PC
+PC
+PC
 JC
+ZB
 ZB
 ZB
 ZB
@@ -23011,11 +24064,10 @@ ZK
 ZK
 ZK
 ZK
-ZK
 FW
 ZK
 "}
-(67,1,1) = {"
+(66,1,1) = {"
 ZK
 FW
 ZK
@@ -23087,10 +24139,10 @@ Bi
 PC
 Bi
 PC
-ye
-Sr
-Zx
-wK
+PC
+Bi
+VC
+jo
 tn
 Ap
 sv
@@ -23100,8 +24152,8 @@ ZB
 DY
 Yr
 Cp
+gl
 uK
-ZK
 ZK
 ZK
 ZK
@@ -23113,7 +24165,7 @@ ZK
 FW
 ZK
 "}
-(68,1,1) = {"
+(67,1,1) = {"
 ZK
 FW
 ZK
@@ -23152,7 +24204,7 @@ ez
 Kx
 iF
 aW
-Pu
+VC
 tW
 tW
 VC
@@ -23185,10 +24237,10 @@ VC
 VC
 VC
 VC
-Zx
-ye
-Sr
-ye
+VC
+PC
+Bi
+PC
 JC
 YH
 Ht
@@ -23198,6 +24250,7 @@ gs
 Dr
 lQ
 xR
+gl
 uK
 Wm
 Wm
@@ -23207,11 +24260,10 @@ ZK
 ZK
 ZK
 ZK
-ZK
 FW
 ZK
 "}
-(69,1,1) = {"
+(68,1,1) = {"
 ZK
 FW
 ZK
@@ -23283,10 +24335,10 @@ VC
 VC
 Ch
 tW
-Zx
-Zx
-CK
-Zx
+VC
+VC
+dz
+VC
 tn
 Ap
 bV
@@ -23295,7 +24347,8 @@ Lc
 gs
 Bt
 UF
-LO
+Dg
+Kk
 aU
 lY
 XE
@@ -23305,11 +24358,10 @@ Wm
 ZK
 ZK
 ZK
-ZK
 FW
 ZK
 "}
-(70,1,1) = {"
+(69,1,1) = {"
 ZK
 FW
 ZK
@@ -23380,9 +24432,9 @@ Tw
 VC
 jq
 OS
-Yr
-Yr
-Yr
+OS
+OS
+OS
 Yr
 If
 If
@@ -23394,6 +24446,7 @@ gs
 mw
 CQ
 mv
+gl
 aU
 aU
 aU
@@ -23403,11 +24456,10 @@ lY
 ZK
 ZK
 ZK
-ZK
 FW
 ZK
 "}
-(71,1,1) = {"
+(70,1,1) = {"
 ZK
 FW
 ZK
@@ -23492,6 +24544,7 @@ AW
 AW
 lx
 ZB
+ZB
 yV
 gs
 BU
@@ -23501,11 +24554,10 @@ XE
 ZK
 ZK
 ZK
-ZK
 FW
 ZK
 "}
-(72,1,1) = {"
+(71,1,1) = {"
 ZK
 FW
 ZK
@@ -23577,7 +24629,7 @@ Wt
 Wt
 AI
 Yu
-ZB
+JT
 Qz
 Yr
 Wb
@@ -23590,6 +24642,7 @@ gs
 Dr
 tz
 xR
+gl
 pP
 gs
 gs
@@ -23599,11 +24652,10 @@ XE
 ZK
 ZK
 ZK
-ZK
 FW
 ZK
 "}
-(73,1,1) = {"
+(72,1,1) = {"
 ZK
 FW
 ZK
@@ -23674,8 +24726,8 @@ sU
 Ac
 VC
 Gz
-ZB
-km
+JT
+eC
 yN
 Yr
 Wb
@@ -23688,6 +24740,7 @@ ur
 Bt
 UF
 Dg
+gl
 pP
 gs
 ZW
@@ -23697,11 +24750,10 @@ lY
 ZK
 ZK
 ZK
-ZK
 FW
 ZK
 "}
-(74,1,1) = {"
+(73,1,1) = {"
 ZK
 FW
 ZK
@@ -23773,7 +24825,7 @@ Wu
 Wu
 ry
 Mj
-ZB
+JT
 kc
 Yr
 Wb
@@ -23786,6 +24838,7 @@ gs
 mw
 CQ
 mv
+gl
 pP
 gs
 gs
@@ -23795,11 +24848,10 @@ XE
 ZK
 ZK
 ZK
-ZK
 FW
 ZK
 "}
-(75,1,1) = {"
+(74,1,1) = {"
 ZK
 FW
 ZK
@@ -23884,6 +24936,7 @@ AW
 AW
 lx
 ZB
+ZB
 yV
 gs
 jB
@@ -23893,11 +24946,10 @@ XE
 ZK
 ZK
 ZK
-ZK
 FW
 ZK
 "}
-(76,1,1) = {"
+(75,1,1) = {"
 ZK
 FW
 ZK
@@ -23968,9 +25020,9 @@ Tw
 VC
 jq
 OS
-Yr
-Yr
-Yr
+OS
+OS
+OS
 Yr
 If
 If
@@ -23982,6 +25034,7 @@ gs
 Dr
 tz
 xR
+gl
 aU
 aU
 aU
@@ -23991,11 +25044,10 @@ lY
 ZK
 ZK
 ZK
-ZK
 FW
 ZK
 "}
-(77,1,1) = {"
+(76,1,1) = {"
 ZK
 FW
 ZK
@@ -24035,8 +25087,8 @@ MW
 OS
 Ou
 VC
-VC
-VC
+Py
+PB
 VC
 CH
 OS
@@ -24068,9 +25120,9 @@ VC
 Dx
 PB
 Gd
-Zx
-JT
-Zx
+VC
+dt
+VC
 tn
 Ap
 bV
@@ -24079,7 +25131,8 @@ Lc
 gs
 Bt
 UF
-LO
+Dg
+Kk
 aU
 lY
 XE
@@ -24089,11 +25142,10 @@ Zl
 ZK
 ZK
 ZK
-ZK
 FW
 ZK
 "}
-(78,1,1) = {"
+(77,1,1) = {"
 ZK
 FW
 ZK
@@ -24133,8 +25185,8 @@ Kx
 mp
 aW
 VC
-Py
-PB
+Pu
+VC
 VC
 aW
 mp
@@ -24165,10 +25217,10 @@ VC
 VC
 VC
 VC
-Uz
-ye
-ye
-ye
+av
+PC
+PC
+PC
 JC
 YH
 Su
@@ -24178,6 +25230,7 @@ gs
 mw
 Be
 mv
+gl
 uK
 Zl
 Zl
@@ -24187,11 +25240,10 @@ ZK
 ZK
 ZK
 ZK
-ZK
 FW
 ZK
 "}
-(79,1,1) = {"
+(78,1,1) = {"
 ZK
 FW
 ZK
@@ -24263,10 +25315,10 @@ Bi
 PC
 PC
 Bi
-ye
-ye
-Zx
-wK
+PC
+PC
+VC
+jo
 tn
 Ap
 vB
@@ -24276,8 +25328,8 @@ ZB
 DY
 Yr
 Cp
+gl
 uK
-ZK
 ZK
 ZK
 ZK
@@ -24289,7 +25341,7 @@ ZK
 FW
 ZK
 "}
-(80,1,1) = {"
+(79,1,1) = {"
 ZK
 FW
 ZK
@@ -24361,11 +25413,12 @@ VC
 VC
 VC
 VC
-Zx
-ye
-ye
-ye
+VC
+PC
+PC
+PC
 JC
+ZB
 ZB
 ZB
 ZB
@@ -24383,11 +25436,696 @@ VU
 ZK
 ZK
 ZK
+FW
+ZK
+"}
+(80,1,1) = {"
+ZK
+FW
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+YB
+XE
+XE
+Hr
+bf
+Hr
+VC
+iy
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+aW
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+oY
+VC
+Vi
+ey
+ey
+ey
+ey
+Hq
+Cj
+aW
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+iy
+VC
+VC
+VC
+PC
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+tn
+Nl
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+ZB
+AX
+aU
+Du
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
 ZK
 FW
 ZK
 "}
 (81,1,1) = {"
+ZK
+FW
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+YB
+XE
+XE
+Hr
+ID
+Hr
+VC
+iy
+VC
+VC
+sp
+PP
+BW
+qc
+xK
+zO
+mA
+xA
+oI
+MR
+xA
+mA
+mA
+CI
+CI
+CI
+CI
+mA
+mA
+Vj
+hu
+ms
+hu
+hu
+Kx
+Cj
+aW
+Nf
+qB
+Jx
+Jx
+Jx
+Jx
+Jx
+Jx
+Jx
+Jx
+qD
+iy
+VC
+VC
+VC
+PC
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+VC
+Zv
+Zv
+Zv
+Zv
+Zv
+Zv
+Zv
+Zv
+Zv
+bH
+bH
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+FW
+ZK
+"}
+(82,1,1) = {"
+ZK
+FW
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+YB
+XE
+XE
+Hr
+ID
+Hr
+VC
+iy
+VC
+VC
+mA
+mA
+mA
+mA
+mA
+mA
+mA
+lm
+oI
+fg
+HU
+mA
+sM
+sO
+sO
+sO
+vA
+AD
+mA
+oA
+hu
+Dz
+WF
+hu
+Kx
+Cj
+aW
+wK
+Cg
+pi
+wE
+wE
+tH
+ca
+AA
+LD
+Cg
+Cj
+iy
+VC
+VC
+VC
+PC
+VC
+VC
+VC
+VC
+VC
+pI
+qS
+vI
+VC
+dz
+VC
+Yr
+Xv
+Xv
+Xy
+Xv
+Xv
+YS
+Xv
+YS
+aU
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+FW
+ZK
+"}
+(83,1,1) = {"
+ZK
+FW
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+YB
+XE
+XE
+Hr
+ID
+Hr
+VC
+iy
+VC
+VC
+mA
+Iy
+fn
+CL
+hP
+Gm
+mA
+rI
+oI
+fg
+pB
+mA
+nz
+Bf
+Bf
+Bf
+di
+BC
+mA
+BH
+hu
+hu
+em
+hu
+Kx
+Cj
+aW
+dM
+Cg
+zD
+Ci
+xb
+FI
+Gp
+UJ
+KA
+Cg
+Sr
+iy
+VC
+VC
+VC
+PC
+VC
+VC
+VC
+VC
+aU
+Yr
+Yr
+Yr
+Yr
+Yr
+Yr
+Yr
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+aU
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+FW
+ZK
+"}
+(84,1,1) = {"
+ZK
+FW
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+YB
+XE
+XE
+Hr
+ID
+Hr
+VC
+iy
+VC
+VC
+mA
+DN
+IP
+rz
+Dw
+qj
+gW
+qj
+qj
+Bk
+eo
+ro
+gp
+Bf
+HE
+Bf
+ad
+yE
+mA
+zk
+hu
+ms
+hu
+hu
+Kx
+Cj
+aW
+nJ
+vx
+bm
+as
+Sg
+fT
+Vp
+OT
+KB
+vx
+Cj
+iy
+VC
+VC
+VC
+PC
+VC
+VC
+VC
+VC
+aU
+Xv
+Xv
+YS
+YS
+Xv
+Xv
+Xy
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+aU
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+FW
+ZK
+"}
+(85,1,1) = {"
+ZK
+FW
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+YB
+XE
+XE
+Hr
+ID
+Hr
+VC
+bS
+VC
+VC
+mA
+eT
+mA
+mA
+eT
+mA
+mA
+bj
+oI
+fg
+oI
+mA
+yH
+Bf
+tI
+Bf
+qt
+fK
+mA
+Ky
+hu
+LL
+Jf
+CZ
+Kx
+Cj
+aW
+nJ
+Ci
+Ci
+Ci
+Ci
+Ci
+Ci
+OT
+Ci
+Ci
+Cj
+iy
+VC
+VC
+VC
+PC
+iF
+dz
+VC
+VC
+aU
+Xy
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xy
+aU
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+FW
+ZK
+"}
+(86,1,1) = {"
+ZK
+FW
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+YB
+XE
+XE
+Hr
+ID
+Hr
+VC
+iy
+VC
+VC
+mA
+Cm
+Gl
+mA
+Uk
+Gl
+mA
+Sh
+oI
+fg
+pB
+mA
+iO
+zH
+Kp
+vF
+wk
+CK
+mA
+Vj
+hu
+em
+hu
+hu
+Kx
+Cj
+aW
+nJ
+Ci
+Fc
+xT
+Gs
+HV
+pt
+kK
+Ci
+Ci
+Cj
+iy
+VC
+VC
+VC
+PC
+aE
+QD
+QD
+QD
+Ww
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+aU
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+ZK
+FW
+ZK
+"}
+(87,1,1) = {"
 ZK
 FW
 ZK
@@ -24403,77 +26141,77 @@ XE
 XE
 XE
 Hr
-bj
+ID
 QM
 bO
-hT
-VC
-dz
-dY
-eD
-eD
-fK
-gp
-gW
-iF
-VC
-VC
-pN
-VC
-VC
-dz
-VC
-VC
-VC
-VC
-VC
-VC
-VC
-VC
-VC
-VC
-VC
-VC
-VC
 aW
 VC
-Wv
-VC
-VC
-VC
-VC
-VC
-VC
-VC
-VC
-VC
+dz
+mA
+Ck
+Uz
+mA
+aG
+Uz
+mA
+HU
+oI
+ce
+lU
+mA
+vW
+oI
+OE
+OE
+oI
+dB
+mA
+Wr
+eA
+eA
+eA
+eA
+Oi
+Cj
+aW
+nJ
+Ci
+Ci
+Ci
+Ci
+Ci
+Ci
+OT
+Ci
+Ci
+Cj
 pM
 VC
 dz
-NA
+VC
 PC
-iF
-dz
-VC
-VC
-dz
-pI
-qS
-pB
-Zx
-CK
-Zx
-tn
-Nl
-Dh
-ZB
-ZB
-Dh
-Dh
-Dh
-AX
+QD
+sy
+RW
+Vk
+Ww
+Xv
+Xv
+Xv
+Xv
+Xv
+YS
+Xv
+YS
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+UG
 aU
-Du
+ZK
 ZK
 ZK
 ZK
@@ -24485,7 +26223,7 @@ ZK
 FW
 ZK
 "}
-(82,1,1) = {"
+(88,1,1) = {"
 ZK
 FW
 ZK
@@ -24515,62 +26253,62 @@ SA
 SA
 SA
 ug
-ug
-rg
-lm
-SA
-SA
-SA
-SA
 gY
-gY
-WS
-PG
-WS
-WS
+wu
+SA
+SA
+VA
+oI
+oI
+oI
+oI
+rW
+mA
+Ci
+Ci
 xS
 xS
 zQ
 zQ
-Ot
-BG
-Dn
-Cg
-Np
-Gn
-Gn
-HU
-tt
-Jx
-Ky
-Cg
+NM
+ye
+De
+GP
+QJ
+hg
+Hh
+fP
+Hk
+OT
+KC
+Ci
 Ot
 zU
 MX
 NH
 QZ
-PD
-aE
+GJ
 QD
-QD
-QD
+it
+RW
+RX
 Ww
-OS
-OS
+Xv
+Xv
+Xv
+Xv
+Xv
 Yr
 Yr
 Yr
 Yr
-Zv
-Zv
-Zv
-Zv
-Zv
-Zv
-Zv
-bH
-bH
-bH
+Yr
+Xv
+Xv
+Xv
+aU
+aU
+aU
 ZK
 ZK
 ZK
@@ -24583,7 +26321,7 @@ ZK
 FW
 ZK
 "}
-(83,1,1) = {"
+(89,1,1) = {"
 ZK
 FW
 ZK
@@ -24598,9 +26336,9 @@ UY
 UY
 UY
 UY
-UY
-bl
-Vo
+Hr
+sR
+QM
 cf
 Io
 Jo
@@ -24610,38 +26348,38 @@ ea
 ea
 ea
 gq
-gY
-hP
+hU
+MV
 jH
-Ir
-Bk
 gY
-sO
-nz
-oI
+dY
+pR
 SA
-Et
-gY
-PV
-DJ
-yI
-WS
+Ih
+oI
+oI
+RP
+oI
+Jv
+PE
+Ci
+Ci
 xS
 xS
 zQ
 zQ
-Ot
+NM
 BG
 NB
-Cg
-zD
 Ci
-xb
-FI
+Nr
+Ci
 Gp
-UJ
-KA
-Cg
+FI
+xb
+OT
+gG
+Ci
 Ot
 zU
 Jo
@@ -24651,7 +26389,7 @@ PF
 QF
 RW
 RW
-Vk
+RX
 QD
 Xy
 Xv
@@ -24681,7 +26419,7 @@ ZK
 FW
 ZK
 "}
-(84,1,1) = {"
+(90,1,1) = {"
 ZK
 FW
 ZK
@@ -24713,33 +26451,33 @@ hQ
 gY
 gY
 jz
-gY
-gY
-gY
-Bc
 SA
-Eu
-gY
-PV
-MI
+SA
+mA
+mA
+mA
+mA
+mA
+mA
+mA
 yI
-WS
+Ci
 xS
 xS
 zQ
 zQ
-Ot
+NM
 BG
 NB
-Lp
-bm
-jd
-Sg
-fT
-Vp
+aF
+Bd
+jK
+Hi
+zI
+zI
 OT
-KB
-Lp
+KD
+Ci
 Ot
 zU
 Jo
@@ -24779,7 +26517,7 @@ ZK
 FW
 ZK
 "}
-(85,1,1) = {"
+(91,1,1) = {"
 ZK
 FW
 ZK
@@ -24812,32 +26550,32 @@ gY
 gY
 jA
 SA
-ug
-ug
-SA
-SA
 qV
 gY
-WS
-xu
-WS
-WS
+gY
+gY
+gY
+gY
+gY
+pp
+Ci
+Ci
 xS
 xS
 zQ
 zQ
-Ot
+NM
 BG
-NB
-Ci
-hu
-xT
-Gs
-HV
-pt
-kK
+ww
+Cg
 Ci
 Ci
+Ci
+aF
+Ci
+OT
+Ci
+Cg
 Ot
 zU
 Jo
@@ -24846,8 +26584,8 @@ NQ
 PH
 QG
 RX
-Tz
-Vn
+gv
+RX
 QD
 Xv
 Xv
@@ -24877,7 +26615,7 @@ ZK
 FW
 ZK
 "}
-(86,1,1) = {"
+(92,1,1) = {"
 ZK
 FW
 ZK
@@ -24912,30 +26650,30 @@ sT
 SA
 jF
 Fp
-Bf
+EN
 Fp
 EN
 Fp
 qy
-yA
-yA
-yA
-xS
-xS
 Km
+Km
+Km
+xS
+xS
+Tz
 zQ
-Ot
-Cj
-De
-GP
-QJ
-hg
-Hh
-fP
-Hk
-OT
-KC
+NM
+qr
+NB
+Cl
 Ci
+Ci
+sb
+Cg
+sb
+OT
+Ci
+Cl
 Ot
 zU
 MX
@@ -24975,7 +26713,7 @@ ZK
 FW
 ZK
 "}
-(87,1,1) = {"
+(93,1,1) = {"
 ZK
 FW
 ZK
@@ -25002,7 +26740,7 @@ ea
 ea
 ea
 gt
-gY
+Bc
 gY
 gY
 iK
@@ -25016,24 +26754,24 @@ vi
 vi
 sV
 vg
-Ld
-yA
-yA
-yA
-yA
-yA
-Ot
+ob
+Km
+Km
+Km
+Km
+Km
+NM
 BG
-NB
-aF
-Nr
+ww
+Cg
 Ci
-Gp
-FI
-xb
+Ci
+Ci
+dJ
+Ci
 OT
-gG
 Ci
+Cg
 Ot
 zU
 Te
@@ -25073,7 +26811,7 @@ ZK
 FW
 ZK
 "}
-(88,1,1) = {"
+(94,1,1) = {"
 ZK
 FW
 ZK
@@ -25114,24 +26852,24 @@ vi
 vi
 sP
 vg
-Ld
-yA
-Hw
-XD
-sk
-yA
-Ot
+ob
+Km
+HT
+Ti
+uV
+Km
+NM
 BG
 NB
-Cg
-Bd
-jK
-Hi
-ZN
-zI
+dJ
+sK
+SN
+Hm
+Lp
+SN
 OT
-KD
-Cg
+KE
+Ci
 Ot
 Mo
 En
@@ -25171,7 +26909,7 @@ ZK
 FW
 ZK
 "}
-(89,1,1) = {"
+(95,1,1) = {"
 ZK
 FW
 ZK
@@ -25212,24 +26950,24 @@ vi
 vi
 MZ
 vg
-Me
-wb
-MP
-uc
-Sy
-yA
-NM
+Ld
+km
+Hw
+XD
+sk
+Km
+kN
 jT
 NB
-Cl
 Ci
+Us
+Gr
+Gp
+xb
+FI
+Ba
+rV
 Ci
-sb
-Cg
-sb
-OT
-Ci
-Cl
 Ot
 zU
 by
@@ -25269,7 +27007,7 @@ ZK
 FW
 ZK
 "}
-(90,1,1) = {"
+(96,1,1) = {"
 ZK
 FW
 ZK
@@ -25310,24 +27048,24 @@ vi
 vi
 sP
 vg
-ob
-yA
-Of
-Eo
-jO
-yA
-Ot
-BG
-NB
-Cg
-sK
-SN
-Hm
-Dz
-SN
+Me
+Km
+MP
+uc
+Sy
+Km
+NM
+lZ
+Dk
+Ev
+yD
+nX
+Ho
+XL
+Mb
 OT
-KE
-Cg
+KG
+Ci
 Ot
 zU
 MX
@@ -25367,7 +27105,7 @@ ZK
 FW
 ZK
 "}
-(91,1,1) = {"
+(97,1,1) = {"
 ZK
 FW
 ZK
@@ -25408,23 +27146,23 @@ vi
 vi
 sV
 vg
-Ld
-yA
-yA
-yA
-yA
-yA
-Ot
+ob
+Km
+Km
+Km
+Km
+Km
+NM
 BG
 NB
-dJ
-Us
-Gr
-Gp
-xb
-FI
-Ba
-rV
+Ci
+Ci
+Ci
+Ci
+Ci
+Ci
+OT
+Ci
 Ci
 Ot
 Mp
@@ -25465,7 +27203,7 @@ ZK
 FW
 ZK
 "}
-(92,1,1) = {"
+(98,1,1) = {"
 ZK
 FW
 ZK
@@ -25482,13 +27220,13 @@ TY
 TY
 SP
 bo
-Am
+by
 WS
 Io
 Jo
 SA
 SA
-SA
+PK
 SA
 SA
 SA
@@ -25496,7 +27234,7 @@ dZ
 gY
 gY
 gY
-sL
+UM
 SA
 AH
 uf
@@ -25505,24 +27243,24 @@ uf
 FY
 uf
 Kf
+Km
+Km
+Km
 yA
 yA
-yA
-Px
-Px
-Mq
+Lm
 zR
-Ot
-Cm
-Dk
-Ev
-yD
-nX
-Ho
-XL
-Mb
-OT
-KG
+NM
+LI
+NB
+Ci
+Ci
+xT
+Gs
+HV
+pt
+kK
+Ci
 Ci
 Ot
 VB
@@ -25563,7 +27301,7 @@ ZK
 FW
 ZK
 "}
-(93,1,1) = {"
+(99,1,1) = {"
 ZK
 FW
 ZK
@@ -25586,40 +27324,40 @@ Io
 dk
 SA
 Ir
-eF
+sE
 fl
 fO
 gw
 iG
 iN
 iN
-mA
-vf
-SA
+vp
+sL
 ug
 ug
 SA
 SA
 Gq
 gY
-WS
-PG
-WS
-WS
-Px
-Px
+gY
+gY
+eD
+Ci
+Ci
+yA
+yA
 zR
 zR
-Ot
+NM
 BG
 NB
 Ci
 Ci
-xT
-Gs
-HV
-pt
-kK
+Ci
+Ci
+Ci
+Ci
+OT
 Ci
 Ci
 Ot
@@ -25661,7 +27399,7 @@ ZK
 FW
 ZK
 "}
-(94,1,1) = {"
+(100,1,1) = {"
 ZK
 FW
 ZK
@@ -25691,24 +27429,24 @@ ug
 gY
 gY
 gY
-nJ
-sM
-ue
+gY
+gX
 gY
 AZ
 ts
 DF
 gY
 gY
+gY
 PV
-MI
+Cg
 yI
-WS
-Px
-Px
+Ci
+yA
+yA
 zR
 zR
-Ot
+NM
 BG
 NB
 Cn
@@ -25759,7 +27497,7 @@ ZK
 FW
 ZK
 "}
-(95,1,1) = {"
+(101,1,1) = {"
 ZK
 FW
 ZK
@@ -25787,9 +27525,8 @@ fo
 KW
 ug
 hc
-hU
-iO
-gY
+oC
+Nx
 gY
 lv
 my
@@ -25798,17 +27535,18 @@ vY
 Do
 gY
 gY
+gY
 PV
-MI
+Cg
 yI
-WS
-Px
-Px
+Ci
+yA
+yA
 zR
 zR
-Ot
+NM
 BG
-NB
+ww
 Cg
 YM
 Gt
@@ -25857,7 +27595,7 @@ ZK
 FW
 ZK
 "}
-(96,1,1) = {"
+(102,1,1) = {"
 ZK
 FW
 ZK
@@ -25886,7 +27624,6 @@ ug
 SA
 SA
 SA
-SA
 ug
 gY
 vS
@@ -25896,15 +27633,16 @@ vY
 Do
 gY
 gY
-WS
-xu
-WS
-WS
-Px
-Px
+gY
+gY
+pp
+Ci
+Ci
+yA
+yA
 zR
 zR
-Ot
+NM
 BG
 Dn
 Cg
@@ -25916,7 +27654,7 @@ Tt
 JB
 KL
 Cg
-Ot
+cn
 zU
 Jo
 NH
@@ -25955,7 +27693,7 @@ ZK
 FW
 ZK
 "}
-(97,1,1) = {"
+(103,1,1) = {"
 ZK
 FW
 ZK
@@ -25986,8 +27724,8 @@ eg
 jM
 jM
 jM
-jM
 vT
+jM
 jM
 jM
 jM
@@ -26053,7 +27791,7 @@ ZK
 FW
 ZK
 "}
-(98,1,1) = {"
+(104,1,1) = {"
 ZK
 FW
 ZK
@@ -26084,8 +27822,8 @@ En
 En
 En
 En
-tI
-vU
+Eu
+zV
 zV
 Bj
 Bp
@@ -26151,7 +27889,7 @@ ZK
 FW
 ZK
 "}
-(99,1,1) = {"
+(105,1,1) = {"
 ZK
 FW
 ZK
@@ -26249,7 +27987,7 @@ ZK
 FW
 ZK
 "}
-(100,1,1) = {"
+(106,1,1) = {"
 ZK
 FW
 ZK
@@ -26263,7 +28001,7 @@ ZK
 ZK
 YB
 XE
-ie
+wo
 Hr
 tX
 Hn
@@ -26347,7 +28085,7 @@ ZK
 FW
 ZK
 "}
-(101,1,1) = {"
+(107,1,1) = {"
 ZK
 FW
 ZK
@@ -26361,7 +28099,7 @@ ZK
 ZK
 Gi
 XE
-XE
+qQ
 aO
 ID
 To
@@ -26445,7 +28183,7 @@ ZK
 FW
 ZK
 "}
-(102,1,1) = {"
+(108,1,1) = {"
 ZK
 FW
 ZK
@@ -26543,7 +28281,7 @@ ZK
 FW
 ZK
 "}
-(103,1,1) = {"
+(109,1,1) = {"
 ZK
 FW
 ZK
@@ -26641,7 +28379,7 @@ ZK
 FW
 ZK
 "}
-(104,1,1) = {"
+(110,1,1) = {"
 ZK
 FW
 ZK
@@ -26655,7 +28393,7 @@ ZK
 ZK
 ZK
 YB
-ie
+wo
 Hr
 tX
 Hn
@@ -26739,7 +28477,7 @@ ZK
 FW
 ZK
 "}
-(105,1,1) = {"
+(111,1,1) = {"
 ZK
 FW
 ZK
@@ -26753,7 +28491,7 @@ ZK
 ZK
 ZK
 Gi
-XE
+qQ
 Hr
 br
 bA
@@ -26837,7 +28575,7 @@ ZK
 FW
 ZK
 "}
-(106,1,1) = {"
+(112,1,1) = {"
 ZK
 FW
 ZK
@@ -26935,7 +28673,7 @@ ZK
 FW
 ZK
 "}
-(107,1,1) = {"
+(113,1,1) = {"
 ZK
 FW
 ZK
@@ -27033,7 +28771,7 @@ ZK
 FW
 ZK
 "}
-(108,1,1) = {"
+(114,1,1) = {"
 ZK
 FW
 ZK
@@ -27131,7 +28869,7 @@ ZK
 FW
 ZK
 "}
-(109,1,1) = {"
+(115,1,1) = {"
 ZK
 FW
 ZK
@@ -27229,7 +28967,7 @@ ZK
 FW
 ZK
 "}
-(110,1,1) = {"
+(116,1,1) = {"
 ZK
 FW
 ZK
@@ -27293,7 +29031,7 @@ zU
 Te
 NH
 NH
-PZ
+NH
 NH
 NH
 TP
@@ -27327,7 +29065,7 @@ ZK
 FW
 ZK
 "}
-(111,1,1) = {"
+(117,1,1) = {"
 ZK
 FW
 ZK
@@ -27390,8 +29128,8 @@ cj
 zU
 MX
 NH
-Ph
-Qa
+TX
+PZ
 Re
 NH
 TQ
@@ -27425,7 +29163,7 @@ ZK
 FW
 ZK
 "}
-(112,1,1) = {"
+(118,1,1) = {"
 ZK
 FW
 ZK
@@ -27484,13 +29222,13 @@ IH
 JP
 KR
 sr
-Ot
+cn
 zU
 Jo
 NH
-Pj
-Qb
-Rf
+Ph
+Qa
+Re
 NH
 TP
 VL
@@ -27523,7 +29261,7 @@ ZK
 FW
 ZK
 "}
-(113,1,1) = {"
+(119,1,1) = {"
 ZK
 FW
 ZK
@@ -27621,7 +29359,7 @@ ZK
 FW
 ZK
 "}
-(114,1,1) = {"
+(120,1,1) = {"
 ZK
 FW
 ZK
@@ -27667,7 +29405,7 @@ ho
 wX
 Yw
 yO
-Ai
+Jj
 Tg
 Yw
 DG
@@ -27719,7 +29457,7 @@ ZK
 FW
 ZK
 "}
-(115,1,1) = {"
+(121,1,1) = {"
 ZK
 FW
 ZK
@@ -27765,7 +29503,7 @@ ho
 wZ
 yb
 yP
-hp
+yb
 yb
 yb
 DI
@@ -27817,7 +29555,7 @@ ZK
 FW
 ZK
 "}
-(116,1,1) = {"
+(122,1,1) = {"
 ZK
 FW
 ZK
@@ -27915,7 +29653,7 @@ ZK
 FW
 ZK
 "}
-(117,1,1) = {"
+(123,1,1) = {"
 ZK
 FW
 ZK
@@ -28013,7 +29751,7 @@ ZK
 FW
 ZK
 "}
-(118,1,1) = {"
+(124,1,1) = {"
 ZK
 FW
 ZK
@@ -28111,7 +29849,7 @@ ZK
 FW
 ZK
 "}
-(119,1,1) = {"
+(125,1,1) = {"
 ZK
 FW
 ZK
@@ -28181,7 +29919,7 @@ Sp
 TZ
 VR
 WQ
-Jy
+pm
 YZ
 NO
 xB
@@ -28209,7 +29947,7 @@ ZK
 FW
 ZK
 "}
-(120,1,1) = {"
+(126,1,1) = {"
 ZK
 FW
 ZK
@@ -28307,7 +30045,7 @@ ZK
 FW
 ZK
 "}
-(121,1,1) = {"
+(127,1,1) = {"
 ZK
 FW
 ZK
@@ -28405,7 +30143,7 @@ ZK
 FW
 ZK
 "}
-(122,1,1) = {"
+(128,1,1) = {"
 ZK
 FW
 ZK
@@ -28503,7 +30241,7 @@ ZK
 FW
 ZK
 "}
-(123,1,1) = {"
+(129,1,1) = {"
 ZK
 FW
 ZK
@@ -28601,7 +30339,7 @@ ZK
 FW
 ZK
 "}
-(124,1,1) = {"
+(130,1,1) = {"
 ZK
 FW
 ZK
@@ -28699,7 +30437,7 @@ ZK
 FW
 ZK
 "}
-(125,1,1) = {"
+(131,1,1) = {"
 ZK
 FW
 ZK
@@ -28797,7 +30535,7 @@ ZK
 FW
 ZK
 "}
-(126,1,1) = {"
+(132,1,1) = {"
 ZK
 FW
 ZK
@@ -28895,7 +30633,7 @@ ZK
 FW
 ZK
 "}
-(127,1,1) = {"
+(133,1,1) = {"
 ZK
 FW
 ZK
@@ -28993,7 +30731,7 @@ ZK
 FW
 ZK
 "}
-(128,1,1) = {"
+(134,1,1) = {"
 ZK
 FW
 ZK
@@ -29091,7 +30829,7 @@ ZK
 FW
 ZK
 "}
-(129,1,1) = {"
+(135,1,1) = {"
 ZK
 FW
 ZK
@@ -29189,7 +30927,7 @@ ZK
 FW
 ZK
 "}
-(130,1,1) = {"
+(136,1,1) = {"
 ZK
 FW
 ZK
@@ -29287,7 +31025,7 @@ ZK
 FW
 ZK
 "}
-(131,1,1) = {"
+(137,1,1) = {"
 ZK
 FW
 ZK
@@ -29385,594 +31123,6 @@ ZK
 FW
 ZK
 "}
-(132,1,1) = {"
-ZK
-FW
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-YB
-Hr
-Hr
-Hr
-Hr
-Hr
-Hr
-aO
-aO
-aO
-Hr
-Hr
-Hr
-Hr
-Hr
-Hr
-Hr
-Hr
-XE
-XE
-XE
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-lW
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-FW
-ZK
-"}
-(133,1,1) = {"
-ZK
-FW
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-YB
-XE
-XE
-XE
-XE
-XE
-RC
-XE
-XE
-XE
-RC
-XE
-XE
-XE
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-lW
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-FW
-ZK
-"}
-(134,1,1) = {"
-ZK
-FW
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-YB
-XE
-XE
-XE
-XE
-XE
-XE
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-lW
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-FW
-ZK
-"}
-(135,1,1) = {"
-ZK
-FW
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-Gi
-Zl
-Zl
-Zl
-Zl
-Zl
-lW
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-FW
-ZK
-"}
-(136,1,1) = {"
-ZK
-FW
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-FW
-ZK
-"}
-(137,1,1) = {"
-ZK
-FW
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-FW
-ZK
-"}
 (138,1,1) = {"
 ZK
 FW
@@ -29999,34 +31149,34 @@ ZK
 ZK
 ZK
 ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
+YB
+Hr
+Hr
+Hr
+Hr
+Hr
+Hr
+aO
+aO
+aO
+Hr
+Hr
+Hr
+Hr
+Hr
+Hr
+Hr
+Hr
+XE
+XE
+XE
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+lW
 ZK
 ZK
 ZK
@@ -30097,27 +31247,27 @@ ZK
 ZK
 ZK
 ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
+YB
+XE
+XE
+XE
+XE
+XE
+RC
+XE
+XE
+XE
+RC
+XE
+XE
+XE
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+lW
 ZK
 ZK
 ZK
@@ -30195,20 +31345,20 @@ ZK
 ZK
 ZK
 ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
+YB
+XE
+XE
+XE
+XE
+XE
+XE
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+lW
 ZK
 ZK
 ZK
@@ -30293,13 +31443,13 @@ ZK
 ZK
 ZK
 ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
-ZK
+Gi
+Zl
+Zl
+Zl
+Zl
+Zl
+lW
 ZK
 ZK
 ZK

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -454,6 +454,7 @@
 /area/mainship/hull/starboard_hull)
 "bj" = (
 /obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/door_control/mainship/mech,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/tankerbunks)
 "bk" = (
@@ -2520,6 +2521,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/poddoor/mainship/mech{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/tankerbunks)
 "gX" = (
@@ -5180,10 +5184,8 @@
 /turf/open/floor/mainship/sterile/plain,
 /area/mainship/medical/lower_medical)
 "oY" = (
-/obj/machinery/door_control/mainship{
-	dir = 8;
-	id = "mechbay";
-	name = "Mech Bay Shutters"
+/obj/machinery/door_control/mainship/mech{
+	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -5891,6 +5893,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/poddoor/mainship/mech{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/tankerbunks)
 "rp" = (
@@ -9084,10 +9089,8 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "AD" = (
-/obj/machinery/door_control/mainship{
-	dir = 4;
-	id = "mechbay";
-	name = "Mech Bay Shutters"
+/obj/machinery/door_control/mainship/mech{
+	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/tankerbunks)
@@ -9786,10 +9789,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "CI" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "mechbay";
-	name = "Mech Bay Shutters"
-	},
+/obj/machinery/door/poddoor/mainship/mech,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/tankerbunks)
 "CJ" = (
@@ -10150,6 +10150,7 @@
 /area/mainship/living/cafeteria_starboard)
 "DN" = (
 /obj/effect/ai_node,
+/obj/machinery/door_control/mainship/mech,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/tankerbunks)
 "DO" = (

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -11028,6 +11028,7 @@
 "Gl" = (
 /obj/item/bedsheet/captain,
 /obj/structure/bed,
+/obj/effect/landmark/start/job/mechpilot,
 /turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
 "Gm" = (


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Implements Azon's PR here, https://github.com/tgstation/TerraGov-Marine-Corps/pull/11215. I have permission to do this.
EDIT: I've given this the high priority label due to the fact that Tivi's mechs won't work on Minerva without the PR being merged.

## Why It's Good For The Game

With https://github.com/tgstation/TerraGov-Marine-Corps/pull/11393 live only Minerva lacks an MP bay, without one mechs and pilots cannot spawn in normal gameplay.

## Changelog
:cl:
add: Added a mechbay and MP spawners to Minerva.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
