### PR TITLE
Fixes being able to pod into BR containment tanks

### DIFF
--- a/_maps/modularmaps/big_red/bigredatmosvar1.dmm
+++ b/_maps/modularmaps/big_red/bigredatmosvar1.dmm
@@ -186,7 +186,7 @@
 /area/bigredv2/outside/s)
 "rg" = (
 /turf/open/ground/river,
-/area/bigredv2/outside/s)
+/area/bigredv2/caves/rock)
 "rC" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 1

--- a/_maps/modularmaps/big_red/bigredatmosvar3.dmm
+++ b/_maps/modularmaps/big_red/bigredatmosvar3.dmm
@@ -257,9 +257,6 @@
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/filtration_plant)
-"nS" = (
-/turf/closed/mineral/smooth/bigred,
-/area/bigredv2/outside/filtration_plant)
 "ok" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor,
@@ -921,8 +918,8 @@ jX
 HM
 pY
 Ff
-nS
-nS
+Jl
+Jl
 Ff
 eH
 eH

--- a/_maps/modularmaps/big_red/bigredatmosvar4.dmm
+++ b/_maps/modularmaps/big_red/bigredatmosvar4.dmm
@@ -499,7 +499,7 @@
 /area/bigredv2/outside/se)
 "Uj" = (
 /turf/open/ground/river,
-/area/bigredv2/outside/s)
+/area/bigredv2/caves/rock)
 "Uu" = (
 /obj/machinery/computer/nuke_disk_generator/red,
 /turf/open/floor,

--- a/_maps/modularmaps/big_red/bigredatmosvar6.dmm
+++ b/_maps/modularmaps/big_red/bigredatmosvar6.dmm
@@ -383,7 +383,7 @@
 /area/bigredv2/outside/se)
 "zz" = (
 /turf/open/ground/river,
-/area/bigredv2/outside/s)
+/area/bigredv2/caves/rock)
 "zI" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can pod into the tank on BR if you're insane enough, the walls are invincible so nobody can get at you. It wasn't really a consideration because you're intentionally locking yourself out of the game and most people don't want to do that, but Franklin Ramis isn't most people apparently and I have to do something about it.

## Why It's Good For The Game

Bugs bad, fixes good. Also it keeps wind from affecting the interior of the tank area.

## Changelog
:cl:
fix: You can no longer pod inside of the water tanks in BR.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
