### PR TITLE
Adds radial menu support to medical tweezers, chain-tweezing.

### DIFF
--- a/code/datums/elements/shrapnel_removal.dm
+++ b/code/datums/elements/shrapnel_removal.dm
@@ -24,7 +24,7 @@
 		M.balloon_alert(user, "You only know how to remove shrapnel from humans!")
 		return
 	var/mob/living/carbon/human/target = M
-	var/datum/limb/targetlimb = target.get_limb(user.zone_selected)
+	var/datum/limb/targetlimb = user.client.prefs.toggles_gameplay & RADIAL_MEDICAL ? radial_medical(target, user) : target.get_limb(user.zone_selected)
 	if(!length(targetlimb.implants))
 		M.balloon_alert(user, "There is nothing in limb!")
 		return
@@ -43,8 +43,8 @@
 		I.unembed_ourself(FALSE)
 		if(skill < SKILL_MEDICAL_PRACTICED)
 			user.visible_message(span_notice("[user] violently rips out [I] from [target]!"), span_notice("You violently rip out [I] from [target]!"))
-			target.apply_damage(30 * (SKILL_MEDICAL_PRACTICED - skill), def_zone = user.zone_selected)
+			targetlimb.take_damage_limb(30 * (SKILL_MEDICAL_PRACTICED - skill), 0, FALSE, FALSE)
 		else
 			user.visible_message(span_notice("[user] pulls out [I] from [target]!"), span_notice("You pull out [I] from [target]!"))
-			target.apply_damage(15, def_zone = user.zone_selected)
+			targetlimb.take_damage_limb(15, 0, FALSE_FALSE)
 		break

--- a/code/datums/elements/shrapnel_removal.dm
+++ b/code/datums/elements/shrapnel_removal.dm
@@ -46,5 +46,5 @@
 			targetlimb.take_damage_limb(30 * (SKILL_MEDICAL_PRACTICED - skill), 0, FALSE, FALSE)
 		else
 			user.visible_message(span_notice("[user] pulls out [I] from [target]!"), span_notice("You pull out [I] from [target]!"))
-			targetlimb.take_damage_limb(15, 0, FALSE_FALSE)
+			targetlimb.take_damage_limb(15, 0, FALSE, FALSE)
 		break


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds support to the corpsman's medical tweezers for the same radial menu that medkits and surgery use. This PR also makes it so you will continue attempting to remove shrapnel as long as your patient has any in them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes using the tweezers slightly less inconvenient. Also it was weird that virtually every other limb-based medical thing supported the radial menu setting but the tweezers didn't.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: The corpsman's medical tweezers now support radial menus and will continue attempting to remove shrapnel if the patient still has any.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
