### PR TITLE
Nerfs laser sword energy usage and increase cooldown between uses

### DIFF
--- a/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
@@ -465,7 +465,7 @@
 		return ..()
 
 	//try dash to target
-	var/laser_dash_range = LASER_DASH_RANGE_ENHANCED
+	var/laser_dash_range = LASER_DASH_RANGE_NORMAL
 
 	chassis.add_filter("dash_blur", 1, radial_blur_filter(0.3))
 	icon_state += "_on"

--- a/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
@@ -439,7 +439,7 @@
 	slowdown = 0
 	harmful = TRUE
 	equip_cooldown = 3 SECONDS
-	energy_drain = 150 // Gives 8 slashes before running out of energy
+	energy_drain = 100 // Gives 8 slashes before running out of energy
 	range = MECHA_MELEE|MECHA_RANGED
 	force = 150
 	/// holder var for the mob that is attacking right now

--- a/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
@@ -439,7 +439,7 @@
 	slowdown = 0
 	harmful = TRUE
 	equip_cooldown = 3 SECONDS
-	energy_drain = 100 // Gives 8 slashes before running out of energy
+	energy_drain = 100
 	range = MECHA_MELEE|MECHA_RANGED
 	force = 150
 	/// holder var for the mob that is attacking right now

--- a/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
@@ -439,7 +439,7 @@
 	slowdown = 0
 	harmful = TRUE
 	equip_cooldown = 1 SECONDS
-	energy_drain = 0 // energy drain due to dashing is good enough
+	energy_drain = 150 // Gives 8 slashes before running out of energy
 	range = MECHA_MELEE|MECHA_RANGED
 	force = 150
 	/// holder var for the mob that is attacking right now

--- a/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
@@ -438,7 +438,7 @@
 	obj_integrity = 400
 	slowdown = 0
 	harmful = TRUE
-	equip_cooldown = 1 SECONDS
+	equip_cooldown = 3 SECONDS
 	energy_drain = 150 // Gives 8 slashes before running out of energy
 	range = MECHA_MELEE|MECHA_RANGED
 	force = 150


### PR DESCRIPTION
## About The Pull Request

Energy sword now uses mech energy when swinging, you have 8 slashes give or take before running out and having to go take a break in a corner

## Why It's Good For The Game

Infinite dashing with mech is fun, for the mech, actualy having to deal with it isn't very fun, this puts a max ammount to the number  of dashes you can do with it so it still retains mobility without making mechs barry alen

## Changelog
:cl:
balance: mech energy sword now uses energy to swing
/:cl: