### PR TITLE
Fixes rain giving xenos wet messages

### DIFF
--- a/code/datums/weather/weather_types/acid_rain.dm
+++ b/code/datums/weather/weather_types/acid_rain.dm
@@ -83,7 +83,7 @@
 		"As you move through the heavy rain, your clothes become completely waterlogged!",
 		)
 		if(prob(20))
-			if(isrobot(L))
+			if(isrobot(L) || isxeno(L))
 				return
 			else
 				to_chat(L, span_warning(wetmessage))


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.
I had a check to prevent this in an earlier version, forgot to re-implement it once the shower refactor was in. 
![water](https://user-images.githubusercontent.com/49290523/199305745-20cfdb02-eaf0-460f-925d-a56c9af5b791.png)
Oops.

## Why It's Good For The Game

As amusing as it is to hear the game refer to the xenos nonexistent clothing getting waterlogged, it should probably be fixed.

## Changelog
:cl:
fix: Rain no longer affects xenomorphs' nonexistent clothing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
