### PR TITLE
Paracetamol no longer purges Tricordrazine

### DIFF
--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -86,7 +86,7 @@
 	color = "#cac5c5"
 	scannable = TRUE
 	custom_metabolism = REAGENTS_METABOLISM * 0.125
-	purge_list = list(/datum/reagent/medicine/kelotane, /datum/reagent/medicine/tricordrazine, /datum/reagent/medicine/bicaridine)
+	purge_list = list(/datum/reagent/medicine/kelotane, /datum/reagent/medicine/bicaridine)
 	purge_rate = 1
 	overdose_threshold = REAGENTS_OVERDOSE*2
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL*2


### PR DESCRIPTION
## About The Pull Request
Paracetamol will no longer purge Tricordrazine.

The implications of this change are as follows;
- Allows players to have a viable alternative to the usual bica/kelo/tram trinity, in the form of paracetamol / oxycodone / tricordrazine, since the latter chem can counteract oxycodone's tox loss. Dylovene cannot do this since it purges paracetamol.
- Actually enables very niche builds such as Vali paracetamol builds, by allowing them to counteract oxycodone's consequence via tricordrazine.


## Why It's Good For The Game
- Adds more variety to chem gameplay by giving players viable alternatives to the usual everyday chems.
- Enables niche Vali builds based on paracetamol, which in turn means more variety for Vali players.
- Paracetamol gains more relevance, instead of being a forgotten and unused chem that nobody cares about.

## Changelog
:cl: Lewdcifer
balance: Paracetamol no longer purges Tricordrazine.
/:cl: