### PR TITLE
Rebalances Paracetamol bonuses granted by Vali boost

### DIFF
--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -79,7 +79,7 @@
 	var/static/list/reagent_stats = list(
 		/datum/reagent/medicine/bicaridine = list(NAME = "Bicaridine", REQ = 5, BRUTE_AMP = 0.1, BURN_AMP = 0, TOX_HEAL = 0, STAM_REG_AMP = 0, SPEED_BOOST = 0),
 		/datum/reagent/medicine/kelotane = list(NAME = "Kelotane", REQ = 5, BRUTE_AMP = 0, BURN_AMP = 0.1, TOX_HEAL = 0, STAM_REG_AMP = 0, SPEED_BOOST = 0),
-		/datum/reagent/medicine/paracetamol = list(NAME = "Paracetamol", REQ = 5, BRUTE_AMP = 0, BURN_AMP = 0, TOX_HEAL = 0, STAM_REG_AMP = 0.2, SPEED_BOOST = -0.1),
+		/datum/reagent/medicine/paracetamol = list(NAME = "Paracetamol", REQ = 5, BRUTE_AMP = 0.1, BURN_AMP = 0.1, TOX_HEAL = 0, STAM_REG_AMP = 0.2, SPEED_BOOST = 0),
 		/datum/reagent/medicine/meralyne = list(NAME = "Meralyne", REQ = 5, BRUTE_AMP = 0.2, BURN_AMP = 0, TOX_HEAL = 0, STAM_REG_AMP = 0, SPEED_BOOST = 0),
 		/datum/reagent/medicine/dermaline = list(NAME = "Dermaline", REQ = 5, BRUTE_AMP = 0, BURN_AMP = 0.2, TOX_HEAL = 0, STAM_REG_AMP = 0, SPEED_BOOST = 0),
 		/datum/reagent/medicine/dylovene = list(NAME = "Dylovene", REQ = 5, BRUTE_AMP = 0, BURN_AMP = 0, TOX_HEAL = 0.5, STAM_REG_AMP = 0, SPEED_BOOST = 0),


### PR DESCRIPTION
## About The Pull Request
The following changes aim to rebalance Paracetamol to be a more viable alternative to bica/kelo/tram, and should be considered an overall buff, since it was quite underwhelming.
These changes are as follows:
- Movement speed bonus removed.
- Brute and burn healing are now increased by 10%.
- Stamina regen bonus unchanged.

## Why It's Good For The Game
- Paracetamol now fulfills the role of Bicaridine and Kelotane in Vali boosts, by increasing brute and burn healing. This further enables a certain variety in Vali builds.
- Paracetamol's speed bonus amounted to nothing, practically speaking. Felt better to remove it in favor of the above, especially since we don't really need faster ungas.

## Changelog
:cl: Lewdcifer
balance: Paracetamol bonuses granted by Vali boosts changed. Movement speed bonus removed, but brute and burn healing are now increased by 10%.
/:cl: