### PR TITLE
Limit the availability of M-22 welder kits

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1318,7 +1318,7 @@
 		"Backpacks" = list(
 			/obj/item/storage/backpack/marine/standard = -1,
 			/obj/item/storage/backpack/marine/satchel = -1,
-			/obj/item/tool/weldpack/marinestandard = -1,
+			/obj/item/tool/weldpack/marinestandard = 6,
 		),
 		"Instruments" = list(
 			/obj/item/instrument/violin = -1,

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -830,6 +830,11 @@ CLOTHING
 	contains = list(/obj/item/storage/backpack/marine/engineerpack)
 	cost = 5
 
+/datum/supply_packs/clothing/welding_kit
+	name = "M-22 welding kit"
+	contains = list(/obj/item/tool/weldpack/marinestandard)
+	cost = 5
+
 /datum/supply_packs/clothing/radio_pack
 	name = "Radio Operator Pack"
 	contains = list(/obj/item/storage/backpack/marine/radiopack)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Welding kits are no longer unlimited, but are available through req for 5 points.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's a little too easy to spam flamers forever. Now there's either a cost involved, or you have to deal with constantly reloading the small tanks.
I could be a real grinch and limit the small tanks as well, but I'll leave that for now.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: M-22 welder kits are no longer unlimited, but can now be purchased from req for 5 points
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
