### PR TITLE
Normal resin walls start with 50 less health, hivelord walls start with 100 less health, minor heavy explosion changes.

### DIFF
--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -72,7 +72,7 @@
 		if(EXPLODE_DEVASTATE)
 			take_damage(600) // Heavy and devastate instakill walls.
 		if(EXPLODE_HEAVY)
-			take_damage(rand(400))
+			take_damage(600)
 		if(EXPLODE_LIGHT)
 			take_damage(rand(75, 100))
 
@@ -150,7 +150,7 @@
  * Regenerating walls that start with lower health, but grow to a much higher hp over time
  */
 /turf/closed/wall/resin/regenerating
-	max_integrity = 150
+	max_integrity = 100
 
 	/// Total health possible for a wall after regenerating at max health
 	var/max_upgradable_health = 300
@@ -200,4 +200,4 @@
 
 /* Hivelord walls, they start off stronger */
 /turf/closed/wall/resin/regenerating/thick
-	max_integrity = 250
+	max_integrity = 150


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Stops you from making a maze infront of the entire marine horde.
Heavy explosions now just do the same damage as devastation and no longer rand consider its always a set amount of damage, and heavy is supposed to instakill resin walls, so the difference from devastation is pretty much cosmetic.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Normal Resin walls start with 50 less HP. Hivelord thick walls start with 100 less HP.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
