### PR TITLE
Ally export prevention

### DIFF
--- a/code/modules/requisitions/supply_export.dm
+++ b/code/modules/requisitions/supply_export.dm
@@ -29,6 +29,8 @@
 
 
 /mob/living/carbon/human/supply_export(faction_selling)
+	if(!can_sell_human_body(src, faction_selling))
+		return new /datum/export_report(0, name, faction_selling)
 	switch(job.job_category)
 		if(JOB_CAT_ENGINEERING, JOB_CAT_MEDICAL, JOB_CAT_REQUISITIONS)
 			. = 20


### PR DESCRIPTION
## About The Pull Request
Quick fix to prevent selling marines in hvx by putting them on the cargo elevator after you've started lowering it.

## Why It's Good For The Game
bugfix

## Changelog
:cl:
fix: Trying to sell humans you shouldn't be able to sell will not let you collect 200 dollars
/:cl:
