### PR TITLE
Facehugger Impregnates Faster

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -1,7 +1,7 @@
 ///After how much time of being active we die
 #define FACEHUGGER_DEATH 10 SECONDS
 ///Time it takes to impregnate someone
-#define IMPREGNATION_TIME 12 SECONDS
+#define IMPREGNATION_TIME 10 SECONDS
 
 /**
  *Facehuggers


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Impregnate timer shortened to 10 seconds from 12.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As it stands, with the facehugger being easier to remove with just help intent, marines can reliably have the hugger removed as long as they are in a group. This change should not change that dynamic, just adjusts the window of time the marine has to take into account the ease of removal. This does not affect gestation period, only how long until an infection begins.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Hugger impregnate timer shortened from 12 seconds to 10.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
