### PR TITLE
Lowers the inventory size of thermal dampening tarps

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -371,7 +371,7 @@
 	desc = "A tarp carried by TGMC Snipers. When laying underneath the tarp, the sniper is almost indistinguishable from the landscape if utilized correctly. The tarp contains a thermal-dampening weave to hide the wearer's heat signatures, optical camoflauge, and smell dampening."
 	icon = 'icons/obj/bodybag.dmi'
 	icon_state = "jungletarp_folded"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 	unfoldedbag_path = /obj/structure/closet/bodybag/tarp
 	var/serial_number //Randomized serial number used to stop point macros and such.
 


### PR DESCRIPTION
## About The Pull Request
Per title. Tarps have had their inventory size reduced, allowing more storage options to carry them.

## Why It's Good For The Game
This thing is so underwhelming nowadays, since xenos have a lot of tools to catch people in tarps.
Tarps would see more use if more inventory storages could hold them, and would also put them in line with other similar options, such as rollerbeds.

## Changelog
:cl: Lewdcifer
balance: Thermal dampening tarp inventory size reduced. More inventory storage options can hold them now.
/:cl: