### PR TITLE
Explosive pouches maximum item size increased

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -312,7 +312,7 @@
 	desc = "It can contain grenades, plastiques, mine boxes, and other explosives."
 	icon_state = "large_explosive"
 	storage_slots = 4
-	max_w_class = 3
+	max_w_class = 4
 	can_hold = list(
 		/obj/item/explosive/plastique,
 		/obj/item/explosive/mine,


### PR DESCRIPTION
## About The Pull Request
Per title. I find it weird that explosive pouches cannot hold certain items such as recoilless rockets, so here we are.

## Why It's Good For The Game
Explosive pouches can hold recoilless rockets, giving those builds an alternative in storage options.
Also, explosive pouches are grossly underused. This'll give them an edge.

## Changelog
:cl: Lewdcifer
balance: Explosive pouches can now hold larger items (such as recoilless rockets).
/:cl: