### PR TITLE
Xenomorph pheromones update when maturing

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
@@ -73,6 +73,10 @@
 	client.perspective = EYE_PERSPECTIVE
 	client.eye = loc
 
+/mob/living/carbon/xenomorph/queen/upgrade_xeno(newlevel, silent = FALSE)
+	. = ..()
+	hive?.update_leader_pheromones()
+
 // ***************************************
 // *********** Name
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/xenoupgrade.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoupgrade.dm
@@ -46,8 +46,6 @@
 	if(current_aura) //Updates pheromone strength
 		current_aura.range = 6 + xeno_caste.aura_strength * 2
 		current_aura.strength = xeno_caste.aura_strength
-		if(isxenoqueen(src))
-			hive?.update_leader_pheromones()
 
 	switch(upgrade)
 		//FIRST UPGRADE

--- a/code/modules/mob/living/carbon/xenomorph/xenoupgrade.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoupgrade.dm
@@ -43,6 +43,12 @@
 	if(queen_chosen_lead)
 		give_rally_abilities() //Give them back their rally hive ability
 
+	if(current_aura) //Updates pheromone strength
+		current_aura.range = 6 + xeno_caste.aura_strength * 2
+		current_aura.strength = xeno_caste.aura_strength
+		if(isxenoqueen(src))
+			hive?.update_leader_pheromones()
+
 	switch(upgrade)
 		//FIRST UPGRADE
 		if(XENO_UPGRADE_ONE)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When maturing pheromone strength changes are applied without having to turn them off and on again.
Tested it, both auras of single xenos and leader auras from queen both update properly.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's how people expect it to work considering the ammount of poor clueless benos running around with unupdated pheromones
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Xenomorph pheromones update when maturing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
