### PR TITLE
Drones can now cancel essence links properly, essence link automatically removed on death.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
@@ -71,10 +71,11 @@
 
 /// Ends the ability, removing signals and buffs.
 /datum/action/xeno_action/activable/essence_link/proc/end_ability()
+	var/mob/living/carbon/xenomorph/X = owner
 	var/datum/action/xeno_action/enhancement/enhancement_action = X.actions_by_path[/datum/action/xeno_action/enhancement]
 	if(enhancement_action)
 		enhancement_action.end_ability()
-	remove_status_effect(STATUS_EFFECT_XENO_ESSENCE_LINK)
+	X.remove_status_effect(STATUS_EFFECT_XENO_ESSENCE_LINK)
 	QDEL_NULL(existing_link)
 	linked_target = null
 	add_cooldown()

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
@@ -73,8 +73,7 @@
 /datum/action/xeno_action/activable/essence_link/proc/end_ability()
 	var/mob/living/carbon/xenomorph/X = owner
 	var/datum/action/xeno_action/enhancement/enhancement_action = X.actions_by_path[/datum/action/xeno_action/enhancement]
-	if(enhancement_action)
-		enhancement_action.end_ability()
+	enhancement_action?.end_ability()
 	X.remove_status_effect(STATUS_EFFECT_XENO_ESSENCE_LINK)
 	QDEL_NULL(existing_link)
 	linked_target = null

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
@@ -71,11 +71,11 @@
 
 /// Ends the ability, removing signals and buffs.
 /datum/action/xeno_action/activable/essence_link/proc/end_ability()
-	var/mob/living/carbon/xenomorph/X = owner
 	var/datum/action/xeno_action/enhancement/enhancement_action = X.actions_by_path[/datum/action/xeno_action/enhancement]
-	enhancement_action.end_ability()
-	X.remove_status_effect(STATUS_EFFECT_XENO_ESSENCE_LINK)
-	existing_link = null
+	if(enhancement_action)
+		enhancement_action.end_ability()
+	remove_status_effect(STATUS_EFFECT_XENO_ESSENCE_LINK)
+	QDEL_NULL(existing_link)
 	linked_target = null
 	add_cooldown()
 
@@ -167,6 +167,5 @@
 /// Ends the ability if the Enhancement buff is removed.
 /datum/action/xeno_action/enhancement/proc/end_ability()
 	if(existing_enhancement)
-		essence_link_action.linked_target.remove_status_effect(STATUS_EFFECT_XENO_ENHANCEMENT)
-		existing_enhancement = null
+		QDEL_NULL(existing_enhancement)
 		add_cooldown()

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/drone.dm
@@ -15,4 +15,3 @@
 	inherent_verbs = list(
 		/mob/living/carbon/xenomorph/proc/vent_crawl,
 	)
-

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/drone.dm
@@ -16,8 +16,3 @@
 		/mob/living/carbon/xenomorph/proc/vent_crawl,
 	)
 
-/mob/living/carbon/xenomorph/drone/on_death()
-	var/datum/action/xeno_action/activable/essence_link/essence_link_action = actions_by_path[/datum/action/xeno_action/activable/essence_link]
-	if(essence_link_action)
-		essence_link_action.end_ability()
-	return ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/drone.dm
@@ -15,3 +15,9 @@
 	inherent_verbs = list(
 		/mob/living/carbon/xenomorph/proc/vent_crawl,
 	)
+
+/mob/living/carbon/xenomorph/drone/on_death()
+	var/datum/action/xeno_action/activable/essence_link/essence_link_action = actions_by_path[/datum/action/xeno_action/activable/essence_link]
+	if(essence_link_action)
+		essence_link_action.end_ability()
+	return ..()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
`enhancement_action.end_ability()` was causing a runtime as drones will always lack that ability unless primordial.
Replaced `remove_status_effect` with `QDEL_NULL` accomplishes the same thing but faster, no reason not to use it as we are already storing a reference to it in the action.

closes #11332
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Things should work as they are supposed to, drone link not being removed on death was also causing issue
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Drone link is now removed on death
fix: Drone link removal by alt-use of the link ability now works
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
