### PR TITLE
Marine masks no longer protect against ash/sandstorms

### DIFF
--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -77,8 +77,6 @@
 	while (L && !isturf(L))
 		if(iscarbon(L))// if we're a non immune mob inside an immune mob we have to reconsider if that mob is immune to protect ourselves
 			var/mob/living/carbon/the_mob = L
-			if(the_mob.wear_mask)	//safety first
-				return TRUE
 			if(the_mob.status_flags & INCORPOREAL)
 				return TRUE
 		L = L.loc //Check parent items immunities (recurses up to the turf)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Masks no longer protect against inclement weather, meaning marines outside are at risk.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Anyone with more than two minutes of playtime will wear a mask as there is no downside to doing so, and therefore this mechanic only negatively impacts one side whilst letting the other roam free. This will hopefully force both sides into more close encounters within buildings while taking shelter from storms, whilst at the same time not removing the ability for both to quickly dart in and out of the weather outside or shore up defences with haste.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Masks no longer make marines immune to inclement weather.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
