### PR TITLE
Pillar of Spring Winter Edition Part 2: Captain and FC's Presents

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -18,6 +18,11 @@
 /obj/item/tool/pen,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
+"ad" = (
+/turf/open/floor/carpet/side{
+	dir = 9
+	},
+/area/mainship/living/commandbunks)
 "ae" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -75,8 +80,13 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"an" = (
+/obj/effect/ai_node,
+/turf/open/floor/carpet/side{
+	dir = 10
+	},
+/area/mainship/living/commandbunks)
 "ao" = (
-/obj/structure/disposalpipe/segment/corner,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
@@ -184,12 +194,6 @@
 /obj/item/megaphone,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/briefing)
-"aC" = (
-/obj/structure/bed/chair/wood/wings{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/mainship/living/commandbunks)
 "aD" = (
 /obj/structure/window/reinforced/toughened{
 	dir = 1
@@ -200,6 +204,17 @@
 /obj/machinery/computer/camera_advanced/overwatch/main,
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
+"aE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "aF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -252,13 +267,25 @@
 	dir = 10
 	},
 /area/mainship/hallways/hangar)
-"aM" = (
+"aL" = (
+/obj/machinery/door/airlock/mainship/command/CPToffice,
+/obj/machinery/door/firedoor/mainship,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/wood,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/commandbunks)
+"aM" = (
+/turf/open/floor/carpet/side{
+	dir = 5
+	},
 /area/mainship/living/commandbunks)
 "aN" = (
 /obj/structure/bed/chair/wood/wings{
@@ -412,9 +439,8 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "bk" = (
-/obj/machinery/light/mainship,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/commandbunks)
+/turf/open/floor/mainship_hull,
+/area/mainship/hull/lower_hull)
 "bl" = (
 /obj/machinery/firealarm,
 /turf/open/floor/mainship/mono,
@@ -474,11 +500,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
 "bu" = (
-/obj/structure/paper_bin{
-	pixel_x = 7;
-	pixel_y = 6
+/obj/machinery/light/mainship,
+/obj/machinery/door_control/old/ai{
+	id = "cl_shutters";
+	name = "Privacy Shutters"
 	},
-/obj/item/tool/pen,
 /obj/structure/table/fancywoodentable,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
@@ -603,7 +629,10 @@
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
 "bI" = (
-/turf/open/floor/mainship/mono,
+/obj/structure/bookcase,
+/obj/item/binoculars,
+/obj/item/megaphone,
+/turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "bJ" = (
 /obj/structure/bed/chair/sofa,
@@ -626,10 +655,12 @@
 /turf/open/floor/wood,
 /area/mainship/living/chapel)
 "bM" = (
-/obj/machinery/computer/security/marinemainship_network,
-/obj/structure/table/fancywoodentable,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/area/mainship/living/commandbunks)
 "bN" = (
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct,
 /turf/open/floor/mainship/stripesquare,
@@ -643,11 +674,6 @@
 	dir = 5
 	},
 /area/mainship/medical/lower_medical)
-"bP" = (
-/turf/open/floor/carpet/side{
-	dir = 5
-	},
-/area/mainship/living/numbertwobunks)
 "bQ" = (
 /turf/open/space,
 /area/space)
@@ -740,25 +766,20 @@
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "cd" = (
-/turf/open/floor/mainship/black,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/plain,
 /area/mainship/living/tankerbunks)
 "ce" = (
 /obj/structure/disposalpipe/segment/corner,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "cf" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/area/mainship/living/commandbunks)
 "cg" = (
 /obj/structure/table/reinforced,
 /obj/item/tool/hand_labeler,
@@ -824,6 +845,9 @@
 /obj/machinery/vending/cola,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
+"cp" = (
+/turf/open/floor/mainship/mono,
+/area/mainship/shipboard/firing_range)
 "cq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -846,23 +870,21 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/engineering/engineering_workshop)
 "ct" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/tool/minihoe,
-/obj/item/tool/plantspray/weeds,
-/obj/item/tool/plantspray/weeds,
-/obj/item/reagent_containers/glass/fertilizer/ez,
-/obj/item/reagent_containers/glass/fertilizer/ez,
-/turf/open/floor/mainship/mono,
-/area/mainship/command/corporateliaison)
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/mainship/black,
+/area/mainship/living/tankerbunks)
 "cu" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "cv" = (
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/plating/mainship,
-/area/mainship/shipboard/firing_range)
+/turf/open/floor/carpet/side{
+	dir = 9
+	},
+/area/mainship/living/numbertwobunks)
 "cw" = (
 /obj/machinery/telecomms/receiver/preset_right,
 /turf/open/floor/mainship/tcomms,
@@ -897,33 +919,18 @@
 "cB" = (
 /turf/closed/wall/mainship,
 /area/mainship/hallways/hangar/droppod)
-"cC" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "cD" = (
 /turf/open/floor/mainship/black{
 	dir = 5
 	},
 /area/mainship/squads/general)
 "cE" = (
-/obj/item/clipboard{
-	pixel_x = 5
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/item/newspaper,
-/obj/structure/table/fancywoodentable,
+/obj/effect/ai_node,
 /turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/area/mainship/living/commandbunks)
 "cF" = (
 /obj/machinery/marine_selector/clothes/engi,
 /turf/open/floor/mainship,
@@ -932,13 +939,6 @@
 /obj/structure/window/framed/mainship,
 /turf/open/floor/plating,
 /area/mainship/living/starboard_garden)
-"cH" = (
-/obj/machinery/marine_selector/clothes/commander,
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "cI" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/mainship/maint,
@@ -966,6 +966,14 @@
 	dir = 8
 	},
 /area/mainship/squads/general)
+"cM" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/mainship/red{
+	dir = 5
+	},
+/area/mainship/shipboard/firing_range)
 "cN" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/item/storage/surgical_tray,
@@ -977,25 +985,18 @@
 	},
 /area/mainship/medical/operating_room_two)
 "cO" = (
+/obj/structure/table/mainship,
+/obj/item/clothing/mask/cigarette/pipe{
+	pixel_y = 5
+	},
+/obj/item/storage/box/matches,
+/obj/item/storage/fancy/cigar,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "cP" = (
 /obj/structure/window/framed/mainship/hull,
 /turf/open/floor/plating,
 /area/mainship/command/cic)
-"cQ" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "cR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/loadout_vendor,
@@ -1010,10 +1011,6 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
-"cT" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/grass,
-/area/mainship/shipboard/firing_range)
 "cU" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
@@ -1078,11 +1075,8 @@
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/lower_medical)
 "dd" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/machinery/vending/nanomed,
-/turf/open/floor/plating/mainship,
+/obj/structure/target_stake,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/shipboard/firing_range)
 "de" = (
 /obj/effect/ai_node,
@@ -1276,14 +1270,6 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
-"dF" = (
-/obj/machinery/computer/mech_builder{
-	dir = 8
-	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 6
-	},
-/area/mainship/living/tankerbunks)
 "dG" = (
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 4
@@ -1294,19 +1280,29 @@
 	dir = 4
 	},
 /area/mainship/living/pilotbunks)
+"dI" = (
+/obj/structure/table/mainship,
+/obj/item/ashtray/bronze,
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "dJ" = (
 /obj/structure/dropship_equipment/flare_launcher,
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
 /area/mainship/hallways/hangar)
-"dL" = (
-/obj/structure/sign/securearea/firingrange,
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
+"dK" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 8
 	},
-/turf/open/floor/mainship/red/full,
-/area/mainship/shipboard/firing_range)
+/turf/open/floor/mainship/floor,
+/area/mainship/living/numbertwobunks)
+"dL" = (
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "dN" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -1460,9 +1456,6 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/command/cic)
-"en" = (
-/turf/open/floor/grass,
-/area/mainship/shipboard/firing_range)
 "eo" = (
 /obj/structure/closet/secure_closet/staff_officer,
 /turf/open/floor/mainship/red/full,
@@ -1547,9 +1540,15 @@
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/hull/lower_hull)
 "eC" = (
-/obj/structure/target_stake,
+/obj/machinery/shower{
+	dir = 4;
+	pixel_y = -3
+	},
+/obj/machinery/door/window,
+/obj/structure/window/reinforced/tinted,
+/obj/item/tool/soap/nanotrasen,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/shipboard/firing_range)
+/area/mainship/living/numbertwobunks)
 "eD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -1656,10 +1655,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/tankerbunks)
-"eR" = (
-/obj/structure/closet/secure_closet/bar/captain,
-/turf/open/floor/wood,
-/area/mainship/living/commandbunks)
 "eS" = (
 /obj/machinery/computer/mech_bay_power_console,
 /turf/open/floor/mainship/floor,
@@ -1684,6 +1679,15 @@
 "eV" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
 /turf/open/floor/mainship/black{
 	dir = 4
 	},
@@ -1711,21 +1715,14 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "eZ" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/explosive/grenade/training,
-/obj/item/explosive/grenade/training,
-/obj/item/explosive/grenade/training,
-/obj/item/tool/extinguisher/mini,
-/obj/item/tool/extinguisher/mini,
-/obj/item/tool/extinguisher/mini,
-/obj/item/tool/extinguisher/mini,
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
 /obj/structure/sign/securearea/firingrange,
-/obj/machinery/firealarm{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
 /turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/firing_range)
 "fa" = (
@@ -1816,10 +1813,13 @@
 /area/mainship/living/pilotbunks)
 "fn" = (
 /obj/machinery/light/mainship{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/mainship/living/commandbunks)
+/obj/structure/prop/mainship/halfbuilt_mech/vanguard,
+/turf/open/floor/mainship/black{
+	dir = 6
+	},
+/area/mainship/living/tankerbunks)
 "fo" = (
 /turf/open/floor/plating,
 /area/mainship/squads/req)
@@ -1909,18 +1909,6 @@
 "fB" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/hallways/port_hallway)
-"fC" = (
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/door/airlock/multi_tile/mainship/blackgeneric/glass{
-	name = "\improper Firing Range Airlock"
-	},
-/turf/open/floor/mainship/red{
-	dir = 8
-	},
-/area/mainship/shipboard/firing_range)
 "fD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -1952,6 +1940,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/structure/disposalpipe/segment/corner,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "fG" = (
@@ -1960,10 +1949,6 @@
 	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
-"fH" = (
-/obj/machinery/photocopier,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "fI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -1986,9 +1971,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/turf/open/floor/mainship/red{
-	dir = 5
-	},
+/turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/firing_range)
 "fL" = (
 /obj/machinery/computer/med_data,
@@ -2019,6 +2002,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"fP" = (
+/obj/structure/cable,
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
+/area/mainship/squads/general)
 "fQ" = (
 /obj/item/radio/intercom/general{
 	dir = 1
@@ -2039,14 +2031,14 @@
 	},
 /area/mainship/squads/general)
 "fU" = (
-/obj/machinery/firealarm{
-	dir = 8
-	},
 /obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/machinery/vending/nanomed{
 	dir = 4
 	},
 /turf/open/floor/mainship/red{
-	dir = 4
+	dir = 8
 	},
 /area/mainship/shipboard/firing_range)
 "fV" = (
@@ -2057,14 +2049,6 @@
 	dir = 9
 	},
 /area/mainship/squads/general)
-"fW" = (
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/carpet/side{
-	dir = 6
-	},
-/area/mainship/living/numbertwobunks)
 "fX" = (
 /obj/structure/morgue{
 	dir = 2
@@ -2088,10 +2072,25 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "ga" = (
-/turf/open/floor/plating/mainship/striped{
+/obj/structure/bed/fancy,
+/obj/effect/landmark/start/job/fieldcommander,
+/obj/item/bedsheet/captain,
+/turf/open/floor/carpet/side{
+	dir = 1
+	},
+/area/mainship/living/numbertwobunks)
+"gb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/area/mainship/shipboard/firing_range)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/bed/chair/nometal{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/command/corporateliaison)
 "gc" = (
 /turf/closed/wall/mainship,
 /area/mainship/hallways/starboard_hallway)
@@ -2163,12 +2162,23 @@
 	dir = 1
 	},
 /area/mainship/medical/operating_room_two)
-"gq" = (
-/obj/machinery/light/mainship{
-	dir = 8
+"gp" = (
+/obj/machinery/door/airlock/multi_tile/mainship/maint{
+	dir = 1
 	},
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/mainship/shipboard/firing_range)
+"gq" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "gr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/floor,
@@ -2189,10 +2199,6 @@
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"gu" = (
-/obj/machinery/holopad,
-/turf/open/floor/mainship/red/full,
-/area/mainship/shipboard/firing_range)
 "gv" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/machinery/landinglight/ds1/delayone,
@@ -2201,14 +2207,10 @@
 /area/mainship/hallways/hangar)
 "gw" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "gx" = (
@@ -2261,6 +2263,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
 /turf/open/floor/mainship/black{
 	dir = 8
 	},
@@ -2295,10 +2300,10 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "gJ" = (
-/obj/structure/table/reinforced,
-/obj/effect/soundplayer,
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/shipboard/firing_range)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "gK" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/book/manual/engineering_construction,
@@ -2315,11 +2320,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "gM" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "gN" = (
 /obj/machinery/door/airlock/mainship/engineering/CSEoffice{
 	dir = 2
@@ -2585,6 +2589,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "hy" = (
@@ -2739,8 +2749,9 @@
 	},
 /area/mainship/medical/medical_science)
 "hV" = (
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/shipboard/firing_range)
+/obj/machinery/photocopier,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/numbertwobunks)
 "hW" = (
 /turf/closed/wall/mainship/research/containment/wall/corner,
 /area/mainship/medical/medical_science)
@@ -2819,6 +2830,14 @@
 	dir = 4
 	},
 /area/mainship/squads/general)
+"ij" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "ik" = (
 /obj/machinery/light/mainship,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2859,18 +2878,17 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "iq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/door/airlock/mainship/command/CPTstudy{
+	dir = 1
 	},
-/turf/open/floor/carpet/side{
-	dir = 10
-	},
+/turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "ir" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/obj/structure/table/fancywoodentable,
+/obj/item/storage/bible/booze,
+/obj/item/reagent_containers/food/drinks/britcup,
+/turf/open/floor/carpet,
+/area/mainship/living/commandbunks)
 "is" = (
 /obj/machinery/power/smes/preset,
 /obj/structure/cable,
@@ -2885,9 +2903,14 @@
 "iu" = (
 /turf/open/floor/mainship/ntlogo,
 /area/mainship/squads/general)
-"iw" = (
-/turf/closed/wall/mainship/outer,
-/area/mainship/shipboard/firing_range)
+"iv" = (
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/obj/structure/table/mainship,
+/obj/machinery/photocopier,
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "ix" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -2904,6 +2927,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "iA" = (
@@ -2931,6 +2955,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"iE" = (
+/obj/structure/sink,
+/turf/open/floor/mainship/mono,
+/area/space)
 "iF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -2985,11 +3013,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "iM" = (
-/obj/structure/bed/chair/comfy{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/area/mainship/living/commandbunks)
 "iO" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction{
@@ -3047,11 +3075,9 @@
 /turf/open/floor/mainship/green,
 /area/mainship/squads/req)
 "iX" = (
-/obj/machinery/firealarm{
-	dir = 1
-	},
+/obj/structure/filingcabinet,
 /turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/area/mainship/living/commandbunks)
 "iY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -3230,9 +3256,9 @@
 	},
 /area/mainship/hallways/hangar/droppod)
 "jt" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/shipboard/firing_range)
+/obj/structure/bed/chair/comfy,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/numbertwobunks)
 "ju" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -3411,10 +3437,12 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "jX" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/faxmachine,
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/obj/structure/flora/pottedplant/twentytwo,
 /turf/open/floor/wood,
-/area/mainship/command/corporateliaison)
+/area/mainship/living/numbertwobunks)
 "jY" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -3440,11 +3468,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "kb" = (
-/obj/structure/bed/chair/nometal{
-	dir = 8
+/turf/open/floor/carpet/side{
+	dir = 5
 	},
-/turf/open/floor/wood,
-/area/mainship/command/corporateliaison)
+/area/mainship/living/numbertwobunks)
 "kc" = (
 /obj/machinery/cic_maptable,
 /turf/open/floor/mainship/mono,
@@ -3486,11 +3513,10 @@
 	},
 /area/mainship/engineering/engineering_workshop)
 "kh" = (
-/obj/machinery/light/mainship,
-/obj/machinery/computer/marine_card,
-/obj/structure/table/fancywoodentable,
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/food/drinks/golden_cup,
 /turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/area/mainship/living/commandbunks)
 "ki" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -3561,14 +3587,13 @@
 /turf/open/floor/plating,
 /area/mainship/hull/lower_hull)
 "kt" = (
-/obj/structure/table/woodentable,
-/obj/item/storage/bible,
-/obj/item/reagent_containers/food/drinks/flask/barflask,
-/obj/effect/spawner/random/plushie/nospawnninetynine,
-/turf/open/floor/carpet/side{
-	dir = 5
+/obj/machinery/light/mainship{
+	dir = 1
 	},
-/area/mainship/living/commandbunks)
+/turf/open/floor/plating/mainship/striped{
+	dir = 8
+	},
+/area/mainship/shipboard/firing_range)
 "ku" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -3657,10 +3682,6 @@
 	},
 /turf/open/shuttle/escapepod/zero,
 /area/mainship/command/self_destruct)
-"kJ" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/shipboard/firing_range)
 "kK" = (
 /obj/machinery/light/mainship,
 /obj/structure/closet/emcloset,
@@ -3720,12 +3741,6 @@
 	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
-"kR" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/mainship/living/commandbunks)
 "kS" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/structure/cable,
@@ -3778,15 +3793,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "kZ" = (
-/obj/machinery/door/airlock/mainship/generic/bathroom{
-	dir = 1
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/commandbunks)
+/obj/structure/punching_bag,
+/turf/open/floor/plating/mainship,
+/area/mainship/shipboard/firing_range)
 "la" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
@@ -3906,24 +3918,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"lw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1
-	},
-/obj/machinery/door/airlock/multi_tile/mainship/blackgeneric{
-	dir = 1;
-	name = "\improper Firing Range Airlock"
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
-/area/mainship/shipboard/firing_range)
 "lx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -4039,6 +4033,22 @@
 /obj/machinery/computer/supplydrop_console,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"lP" = (
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/hallways/port_hallway)
 "lQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -4062,6 +4072,13 @@
 	dir = 8
 	},
 /area/mainship/engineering/ce_room)
+"lT" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/shipboard/firing_range)
 "lU" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -4110,8 +4127,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/command/corporateliaison)
 "mc" = (
@@ -4239,10 +4258,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "mt" = (
-/obj/structure/closet/boxinggloves,
 /obj/machinery/light/mainship{
 	dir = 8
 	},
+/obj/structure/punching_bag,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "mu" = (
@@ -4263,15 +4282,17 @@
 	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
-"mx" = (
-/obj/structure/paper_bin{
-	pixel_y = 5
-	},
-/obj/machinery/light/mainship{
+"mw" = (
+/obj/machinery/light/mainship,
+/turf/open/floor/mainship/red{
 	dir = 4
 	},
-/obj/item/tool/pen,
-/obj/structure/table/fancywoodentable,
+/area/mainship/shipboard/firing_range)
+"mx" = (
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/food/drinks/bottle/patron,
+/obj/item/reagent_containers/food/drinks/bottle/cognac,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "my" = (
@@ -4298,11 +4319,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "mB" = (
-/obj/machinery/door/airlock/mainship/marine/general,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
-/area/mainship/shipboard/firing_range)
+/obj/structure/table/fancywoodentable,
+/obj/item/newspaper,
+/obj/item/reagent_containers/food/drinks/britcup,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "mC" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -4321,6 +4342,10 @@
 	dir = 8
 	},
 /area/mainship/engineering/engine_core)
+"mF" = (
+/obj/structure/bed/chair/sofa,
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "mG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -4444,11 +4469,16 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "mY" = (
-/obj/structure/window/reinforced/windowstake{
-	dir = 8
+/obj/structure/table/fancywoodentable,
+/obj/item/clipboard{
+	pixel_x = 5
 	},
-/turf/open/floor/mainship/cargo,
-/area/mainship/shipboard/firing_range)
+/obj/structure/paper_bin{
+	pixel_y = 5
+	},
+/obj/item/tool/pen,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/numbertwobunks)
 "mZ" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/storage/box/gloves{
@@ -4474,6 +4504,20 @@
 	dir = 4
 	},
 /area/mainship/medical/lower_medical)
+"na" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "nb" = (
 /obj/structure/ob_ammo/warhead/plasmaloss,
 /obj/structure/ob_ammo/warhead/plasmaloss,
@@ -4508,15 +4552,10 @@
 	},
 /area/mainship/medical/lower_medical)
 "ng" = (
-/obj/machinery/light/mainship{
-	dir = 4
+/turf/open/floor/carpet/side{
+	dir = 10
 	},
-/obj/structure/bed/fancy,
-/obj/item/bedsheet/blue,
-/obj/effect/landmark/start/job/corporateliaison,
-/obj/item/toy/plush/farwa,
-/turf/open/floor/wood,
-/area/mainship/command/corporateliaison)
+/area/mainship/living/numbertwobunks)
 "nh" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -4528,16 +4567,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "ni" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 8;
-	on = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/shipboard/firing_range)
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "nj" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/reagentgrinder,
@@ -4634,6 +4666,21 @@
 "nw" = (
 /turf/closed/wall/mainship,
 /area/mainship/command/airoom)
+"nx" = (
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/hallways/port_hallway)
 "ny" = (
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/mainship/tcomms,
@@ -4646,9 +4693,15 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "nA" = (
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/obj/structure/table/fancywoodentable,
+/obj/structure/paper_bin{
+	pixel_y = 5
+	},
+/obj/item/tool/pen,
+/obj/item/tool/pen/red,
+/obj/item/tool/pen/blue,
+/turf/open/floor/carpet,
+/area/mainship/living/commandbunks)
 "nB" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -4678,15 +4731,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "nF" = (
-/obj/machinery/shower{
-	dir = 4;
-	pixel_y = -3
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
 	},
-/obj/machinery/door/window,
-/obj/structure/window/reinforced/tinted,
-/obj/item/tool/soap/nanotrasen,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/living/numbertwobunks)
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "nG" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/mainship/mono,
@@ -4848,9 +4898,14 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/stern_hallway)
 "of" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/mainship,
-/area/mainship/shipboard/firing_range)
+/obj/structure/table/fancywoodentable,
+/obj/item/storage/fancy/cigar,
+/obj/item/clothing/mask/cigarette/pipe{
+	pixel_y = 5
+	},
+/obj/item/storage/box/matches,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "og" = (
 /obj/structure/rack,
 /obj/structure/ob_ammo/ob_fuel,
@@ -4863,6 +4918,11 @@
 	dir = 4
 	},
 /area/mainship/shipboard/weapon_room)
+"oh" = (
+/turf/open/floor/mainship/red{
+	dir = 8
+	},
+/area/mainship/shipboard/firing_range)
 "oi" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/machinery/landinglight/ds1/delaythree,
@@ -4924,6 +4984,11 @@
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
+"oq" = (
+/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/commandbunks)
 "or" = (
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/floor,
@@ -4988,11 +5053,9 @@
 	},
 /area/mainship/medical/lower_medical)
 "oD" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/red{
-	dir = 8
-	},
-/area/mainship/shipboard/firing_range)
+/obj/machinery/light/mainship,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "oE" = (
 /turf/open/floor/mainship/red,
 /area/mainship/command/airoom)
@@ -5006,19 +5069,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "oG" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/reagent_containers/food/drinks/bottle/sake{
-	pixel_x = -4
+/turf/open/floor/carpet/side{
+	dir = 6
 	},
-/obj/item/reagent_containers/food/drinks/bottle/sake{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/storage/box/drinkingglasses,
-/obj/item/portable_vendor/corporate,
-/obj/machinery/computer/emails,
-/turf/open/floor/wood,
-/area/mainship/command/corporateliaison)
+/area/mainship/living/numbertwobunks)
 "oH" = (
 /obj/structure/dropship_equipment/weapon/minirocket_pod,
 /turf/open/floor/mainship/mono,
@@ -5075,9 +5129,7 @@
 /area/mainship/squads/general)
 "oP" = (
 /obj/effect/decal/cleanable/blood/gibs/robot,
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 9
-	},
+/turf/open/floor/plating,
 /area/mainship/living/tankerbunks)
 "oQ" = (
 /obj/effect/spawner/random/plushie/nospawnninetyfive,
@@ -5094,10 +5146,12 @@
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
 "oS" = (
-/turf/open/floor/plating/mainship/striped{
-	dir = 8
+/obj/machinery/light/mainship{
+	light_color = "#da2f1b"
 	},
-/area/mainship/shipboard/firing_range)
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "oT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -5131,9 +5185,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "oZ" = (
-/obj/structure/target_stake/occupied/alien,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/grass,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
 "pa" = (
 /obj/machinery/camera/autoname/mainship{
@@ -5187,6 +5242,16 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
+"pj" = (
+/obj/machinery/door/airlock/mainship/generic/bathroom{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/mono,
+/area/space)
 "pk" = (
 /obj/structure/closet/crate/ammo,
 /obj/structure/cable,
@@ -5214,12 +5279,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "pp" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/firealarm{
-	dir = 1
-	},
-/obj/item/binoculars,
-/obj/item/megaphone,
+/obj/machinery/vending/uniform_supply,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "pq" = (
@@ -5274,14 +5334,10 @@
 	},
 /area/mainship/medical/lower_medical)
 "py" = (
-/obj/machinery/light/mainship,
-/obj/machinery/door_control/old/ai{
-	id = "cl_shutters";
-	name = "Privacy Shutters"
+/turf/open/floor/plating/mainship/striped{
+	dir = 8
 	},
-/obj/structure/table/fancywoodentable,
-/turf/open/floor/wood,
-/area/mainship/command/corporateliaison)
+/area/mainship/shipboard/firing_range)
 "pz" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
@@ -5378,21 +5434,20 @@
 	},
 /area/mainship/squads/general)
 "pR" = (
-/obj/item/binoculars,
-/obj/item/storage/briefcase,
-/obj/structure/closet/cabinet,
-/obj/item/clothing/head/bowlerhat{
-	pixel_x = -4;
-	pixel_y = 8
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/staff/gentcane{
-	pixel_x = 5
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/light/mainship{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/turf/open/floor/carpet/side{
+	dir = 4
+	},
+/area/mainship/living/commandbunks)
 "pS" = (
 /obj/structure/window/reinforced/toughened{
 	dir = 1
@@ -5416,19 +5471,6 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "pU" = (
-/obj/item/weapon/gun/pistol/vp70,
-/obj/item/ammo_magazine/pistol/vp70,
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/liaison_suit/formal,
-/obj/item/clothing/under/liaison_suit,
-/obj/item/clothing/under/liaison_suit/outing,
-/obj/item/clothing/under/liaison_suit/suspenders,
-/obj/item/clipboard{
-	pixel_x = 5
-	},
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/attachable/suppressor,
-/obj/item/armor_module/storage/uniform/holster,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
@@ -5439,8 +5481,9 @@
 /turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
 "pW" = (
-/obj/structure/disposalpipe/segment/corner,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "pX" = (
@@ -5520,24 +5563,14 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/engineering/engineering_workshop)
 "qf" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/door/airlock/mainship/command/FCDRoffice,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
+/obj/structure/target_stake,
+/obj/item/target,
+/obj/item/clothing/suit/storage/faction/militia,
+/turf/open/floor/plating/mainship,
+/area/mainship/shipboard/firing_range)
 "qg" = (
-/obj/machinery/loadout_vendor,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/turf/open/floor/carpet,
+/area/mainship/living/commandbunks)
 "qh" = (
 /obj/structure/bed/bunkbed,
 /obj/effect/landmark/start/job/squadleader,
@@ -5551,21 +5584,10 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hull/lower_hull)
 "qj" = (
-/obj/structure/flora/pottedplant/twentytwo,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/turf/open/floor/carpet/side,
+/area/mainship/living/commandbunks)
 "qk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "ql" = (
@@ -5612,8 +5634,9 @@
 	},
 /area/mainship/hallways/hangar)
 "qr" = (
-/obj/effect/ai_node,
-/turf/open/floor/grass,
+/turf/open/floor/plating/mainship/striped{
+	dir = 4
+	},
 /area/mainship/shipboard/firing_range)
 "qs" = (
 /obj/machinery/light/mainship{
@@ -5739,14 +5762,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/tankerbunks)
 "qK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	on = 1
+/obj/structure/bed/chair/comfy{
+	dir = 8
 	},
-/obj/structure/bed/chair/wood/wings{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/obj/effect/ai_node,
+/turf/open/floor/carpet,
+/area/mainship/living/commandbunks)
 "qL" = (
 /obj/machinery/marine_selector/gear/medic,
 /obj/machinery/camera/autoname/mainship,
@@ -5770,7 +5791,18 @@
 /area/mainship/medical/medical_science)
 "qO" = (
 /obj/structure/table/mainship/nometal,
-/obj/machinery/computer/emails,
+/obj/item/folder/black_random{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/machinery/computer/security/marinemainship{
+	dir = 8;
+	pixel_x = -17
+	},
+/obj/item/clipboard{
+	pixel_x = 5
+	},
+/obj/item/tool/pen,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "qP" = (
@@ -5786,6 +5818,16 @@
 	dir = 1
 	},
 /area/mainship/living/chapel)
+"qQ" = (
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "qR" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/mono,
@@ -5878,15 +5920,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "rd" = (
-/obj/structure/table/mainship/nometal,
-/turf/open/floor/plating/mainship,
-/area/mainship/shipboard/firing_range)
-"re" = (
-/obj/machinery/camera/autoname/mainship{
+/obj/structure/table/fancywoodentable,
+/obj/item/megaphone,
+/obj/machinery/light/mainship{
 	dir = 4
 	},
-/turf/open/floor/grass,
-/area/mainship/shipboard/firing_range)
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "rf" = (
 /obj/effect/soundplayer,
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
@@ -6054,7 +6094,6 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
 "ry" = (
-/obj/structure/cable,
 /obj/machinery/alarm,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -6062,16 +6101,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "rz" = (
-/turf/open/floor/plating/icefloor/warnplate{
+/obj/machinery/light/mainship{
 	dir = 4
 	},
-/area/mainship/living/tankerbunks)
+/obj/structure/target_stake,
+/obj/item/target,
+/obj/item/clothing/suit/storage/faction/militia,
+/turf/open/floor/plating/mainship/striped{
+	dir = 4
+	},
+/area/mainship/shipboard/firing_range)
 "rA" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/computer/station_alert,
@@ -6118,6 +6160,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/sterile/plain,
 /area/mainship/living/tankerbunks)
 "rI" = (
@@ -6127,9 +6170,6 @@
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
@@ -6168,15 +6208,15 @@
 	dir = 8
 	},
 /area/mainship/hallways/aft_hallway)
-"rP" = (
-/obj/structure/closet/crate,
-/obj/item/target/syndicate,
-/obj/item/target/syndicate,
-/obj/item/target/syndicate,
-/obj/item/target/syndicate,
-/obj/item/target/syndicate,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/shipboard/firing_range)
+"rQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "rR" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 2;
@@ -6270,15 +6310,6 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
-"sf" = (
-/obj/structure/window/framed/mainship/requisitions,
-/turf/open/floor/plating,
-/area/mainship/shipboard/firing_range)
-"sg" = (
-/obj/effect/decal/cleanable/blood,
-/obj/item/clothing/shoes/jackboots,
-/turf/open/floor/grass,
-/area/mainship/shipboard/firing_range)
 "sh" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	frequency = 1443;
@@ -6339,6 +6370,19 @@
 	},
 /area/mainship/command/self_destruct)
 "sq" = (
+/obj/item/weapon/gun/pistol/vp70,
+/obj/item/ammo_magazine/pistol/vp70,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/liaison_suit/formal,
+/obj/item/clothing/under/liaison_suit,
+/obj/item/clothing/under/liaison_suit/outing,
+/obj/item/clothing/under/liaison_suit/suspenders,
+/obj/item/clipboard{
+	pixel_x = 5
+	},
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/attachable/suppressor,
+/obj/item/armor_module/storage/uniform/holster,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
@@ -6416,11 +6460,7 @@
 	},
 /area/mainship/hull/lower_hull)
 "sA" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "plant-18"
-	},
-/obj/structure/cable,
-/obj/effect/ai_node,
+/obj/machinery/vending/armor_supply,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "sB" = (
@@ -6446,11 +6486,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "sF" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/floor/mainship/red/full,
-/area/mainship/shipboard/firing_range)
+/obj/structure/table/fancywoodentable,
+/obj/machinery/computer/marine_card,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/numbertwobunks)
 "sG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -6486,15 +6525,11 @@
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
 "sK" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/microwave{
-	pixel_y = 5
+/obj/machinery/light/mainship/small{
+	dir = 8
 	},
-/obj/machinery/light/mainship,
-/obj/item/storage/box/donkpockets,
-/obj/docking_port/stationary/marine_dropship/crash_target,
-/turf/open/floor/wood,
-/area/mainship/command/corporateliaison)
+/turf/open/floor/plating/mainship,
+/area/mainship/shipboard/firing_range)
 "sL" = (
 /obj/structure/window/framed/mainship,
 /turf/open/floor/mainship/mono,
@@ -6530,6 +6565,10 @@
 /area/mainship/hallways/aft_hallway)
 "sS" = (
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/black{
 	dir = 5
 	},
@@ -6627,13 +6666,13 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "tg" = (
-/obj/structure/bed/chair/nometal{
-	dir = 1
+/obj/machinery/light/mainship{
+	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = -2
-	},
+/obj/structure/bed/fancy,
+/obj/item/bedsheet/blue,
+/obj/effect/landmark/start/job/corporateliaison,
+/obj/item/toy/plush/farwa,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "ti" = (
@@ -6712,8 +6751,13 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
 "tt" = (
-/obj/structure/target_stake/occupied/alien,
-/turf/open/floor/grass,
+/obj/structure/target_stake,
+/obj/item/target,
+/obj/item/clothing/suit/storage/faction/militia,
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
 "tu" = (
 /obj/machinery/chem_master,
@@ -6742,6 +6786,12 @@
 	dir = 8
 	},
 /area/mainship/command/self_destruct)
+"tx" = (
+/mob/living/simple_animal/cat/Jones,
+/turf/open/floor/carpet/side{
+	dir = 9
+	},
+/area/mainship/living/commandbunks)
 "ty" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -6749,17 +6799,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "tz" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/structure/bed/chair/comfy{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/shipboard/firing_range)
+/turf/open/floor/mainship/floor,
+/area/mainship/living/numbertwobunks)
 "tA" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/mainship/mono,
@@ -6785,12 +6829,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
-"tE" = (
-/obj/item/weapon/gun/rifle/m412{
-	desc = "The PR-412 rifle is a Pulse Industries rifle, billed as a pulse rifle due to its use of electronic firing for faster velocity. A rather common sight in most systems. Uses 10x24mm caseless ammunition. There is a worn inscription of a moth on it."
-	},
-/turf/open/floor/grass,
-/area/mainship/shipboard/firing_range)
 "tF" = (
 /turf/open/floor/cult,
 /area/medical/morgue)
@@ -6833,6 +6871,14 @@
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
+"tM" = (
+/obj/structure/table/mainship/nometal,
+/obj/item/ammo_magazine/rifle/standard_carbine,
+/obj/item/ammo_magazine/rifle/standard_carbine,
+/obj/item/ammo_magazine/rifle/standard_carbine,
+/obj/item/weapon/gun/rifle/standard_carbine,
+/turf/open/floor/mainship/red/full,
+/area/mainship/shipboard/firing_range)
 "tN" = (
 /obj/machinery/power/monitor/core,
 /obj/structure/cable,
@@ -6909,6 +6955,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "tY" = (
@@ -7016,6 +7068,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/hangar/droppod)
+"ul" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/mainship/mono,
+/area/space)
 "um" = (
 /obj/structure/rack,
 /turf/open/floor/mainship/blue/full,
@@ -7050,12 +7106,8 @@
 	},
 /area/mainship/hallways/hangar/droppod)
 "up" = (
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/obj/structure/prop/mainship/halfbuilt_mech/vanguard,
 /turf/open/floor/mainship/black{
-	dir = 6
+	dir = 4
 	},
 /area/mainship/living/tankerbunks)
 "uq" = (
@@ -7070,9 +7122,10 @@
 	},
 /area/mainship/hallways/hangar)
 "ur" = (
-/obj/structure/filingcabinet,
+/obj/structure/table/mainship,
+/obj/machinery/faxmachine,
 /turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/area/mainship/living/commandbunks)
 "us" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -7096,11 +7149,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/aft_hallway)
 "uu" = (
-/obj/machinery/computer/marine_card,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/table/fancywoodentable,
+/obj/machinery/vending/weapon,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "uv" = (
@@ -7113,11 +7162,20 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "uw" = (
+/obj/structure/closet/secure_closet/freezer,
+/obj/item/reagent_containers/food/snacks/sandwich,
+/obj/item/reagent_containers/food/snacks/sandwich,
+/obj/item/reagent_containers/food/snacks/sandwich,
+/obj/item/reagent_containers/food/snacks/sandwich,
+/obj/item/reagent_containers/food/drinks/bottle/sake,
+/obj/item/reagent_containers/food/drinks/bottle/sake,
+/obj/item/reagent_containers/food/drinks/bottle/wine,
+/obj/item/reagent_containers/food/drinks/bottle/wine,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/light/mainship{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/ntlogo/nt3,
 /area/mainship/command/corporateliaison)
 "ux" = (
@@ -7147,12 +7205,22 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"uB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/mainship/shipboard/firing_range)
 "uC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/dropship_equipment/operatingtable,
 /turf/open/floor/mainship/office,
 /area/mainship/hallways/hangar)
+"uD" = (
+/turf/open/floor/mainship/mono,
+/area/space)
 "uE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -7241,16 +7309,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
+/obj/machinery/light/mainship/small{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "uR" = (
-/obj/structure/safe,
-/obj/item/moneybag,
-/obj/item/clothing/glasses/monocle,
-/obj/item/weapon/telebaton,
-/obj/item/book/codebook,
-/obj/item/weapon/chainofcommand,
-/obj/item/cane,
+/obj/structure/closet/secure_closet/captain,
+/obj/item/reagent_containers/food/snacks/bearmeat,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "uS" = (
@@ -7261,9 +7327,9 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "uT" = (
-/obj/structure/cable,
-/obj/machinery/holopad,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/side{
+	dir = 4
+	},
 /area/mainship/living/commandbunks)
 "uU" = (
 /mob/living/simple_animal/catslug/newt,
@@ -7428,14 +7494,12 @@
 /turf/open/floor/mainship/floor,
 /area/sulaco/showers)
 "vt" = (
-/obj/machinery/door/airlock/mainship/generic/bathroom{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/carpet/side{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
+/area/mainship/living/commandbunks)
 "vu" = (
 /obj/structure/bed/bunkbed,
 /obj/effect/landmark/start/job/squadengineer,
@@ -7513,9 +7577,11 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/starboard_hallway)
 "vC" = (
-/obj/machinery/vending/uniform_supply,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/mainship/living/commandbunks)
 "vD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
@@ -7527,6 +7593,14 @@
 /area/mainship/squads/req)
 "vF" = (
 /obj/structure/reagent_dispensers/water_cooler,
+/obj/item/storage/box/cups{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/storage/box/cups{
+	pixel_x = 5;
+	pixel_y = 2
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "vH" = (
@@ -7745,6 +7819,10 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
+"wm" = (
+/obj/structure/sign/prop4,
+/turf/closed/wall/mainship,
+/area/mainship/living/commandbunks)
 "wn" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/storage/backpack/marine/engineerpack,
@@ -7766,9 +7844,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "wq" = (
-/obj/effect/decal/cleanable/blood,
-/obj/item/clothing/head/helmet/marine/standard,
-/turf/open/floor/grass,
+/obj/machinery/camera/autoname/mainship,
+/turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
 "wr" = (
 /obj/structure/cable,
@@ -7783,7 +7860,7 @@
 "ws" = (
 /obj/structure/noticeboard,
 /turf/closed/wall/mainship,
-/area/mainship/command/corporateliaison)
+/area/mainship/living/commandbunks)
 "wt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/prison/kitchen,
@@ -7816,18 +7893,19 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "wy" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "wz" = (
 /obj/machinery/light/mainship{
 	dir = 8
 	},
+/obj/structure/closet/boxinggloves,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "wA" = (
@@ -7868,15 +7946,10 @@
 	},
 /area/mainship/command/self_destruct)
 "wF" = (
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/obj/structure/table/fancywoodentable,
+/obj/machinery/computer/security/marinemainship_network,
+/turf/open/floor/carpet/side,
+/area/mainship/living/commandbunks)
 "wG" = (
 /obj/effect/landmark/start/job/researcher,
 /obj/structure/cable,
@@ -7919,14 +7992,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "wN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/light/mainship/small{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/turf/open/floor/plating/mainship,
+/area/mainship/shipboard/firing_range)
 "wO" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
@@ -7937,7 +8010,6 @@
 	},
 /area/mainship/engineering/engineering_workshop)
 "wQ" = (
-/obj/effect/ai_node,
 /obj/structure/cable,
 /turf/open/floor/mainship/black{
 	dir = 9
@@ -8155,10 +8227,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "xv" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/mainship/command/CPTstudy,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "xw" = (
@@ -8213,21 +8282,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "xF" = (
-/obj/item/storage/fancy/cigar,
-/obj/item/clothing/mask/cigarette/pipe{
-	pixel_y = 5
+/turf/open/floor/carpet/side{
+	dir = 8
 	},
-/obj/item/newspaper,
-/obj/item/reagent_containers/food/drinks/britcup,
-/obj/item/storage/box/matches,
-/obj/structure/table/fancywoodentable,
-/turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "xG" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -8246,6 +8306,16 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
+"xI" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/docking_port/stationary/marine_dropship/crash_target,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/mainship/mono,
+/area/mainship/shipboard/firing_range)
 "xJ" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/stock_parts/matter_bin,
@@ -8385,6 +8455,12 @@
 	dir = 1
 	},
 /area/mainship/squads/general)
+"ya" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "yb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -8426,6 +8502,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "yh" = (
@@ -8536,6 +8613,16 @@
 /obj/structure/sign/poster,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
+"yx" = (
+/obj/structure/bed/chair/sofa/left,
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
+"yy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/mainship/command/corporateliaison)
 "yz" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
@@ -8562,14 +8649,12 @@
 /obj/machinery/portable_atmospherics/canister/empty,
 /turf/open/floor/engine,
 /area/mainship/engineering/port_atmos)
-"yF" = (
-/obj/structure/bed/fancy,
-/obj/item/bedsheet/captain,
-/obj/effect/landmark/start/job/fieldcommander,
-/turf/open/floor/carpet/side{
-	dir = 9
+"yG" = (
+/obj/structure/window/reinforced/windowstake{
+	dir = 8
 	},
-/area/mainship/living/numbertwobunks)
+/turf/open/floor/mainship/cargo,
+/area/mainship/shipboard/firing_range)
 "yH" = (
 /obj/machinery/vending/cargo_supply,
 /turf/open/floor/mainship/mono,
@@ -8580,9 +8665,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/ai_node,
@@ -8600,6 +8682,19 @@
 "yL" = (
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
+"yM" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/machinery/door/window{
+	dir = 2
+	},
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/item/tool/soap/nanotrasen,
+/turf/open/floor/plating/plating_catwalk,
+/area/space)
 "yN" = (
 /turf/closed/wall/mainship,
 /area/mainship/engineering/upper_engineering)
@@ -8650,15 +8745,18 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
 "yT" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/structure/bed/chair/comfy{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/shipboard/firing_range)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/living/numbertwobunks)
 "yU" = (
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/mono,
@@ -8837,6 +8935,11 @@
 "zs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table/mainship/nometal,
+/obj/machinery/microwave{
+	pixel_y = 5
+	},
+/obj/item/storage/box/donkpockets,
 /turf/open/floor/mainship/floor,
 /area/mainship/command/corporateliaison)
 "zt" = (
@@ -8897,11 +9000,10 @@
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "zC" = (
-/obj/structure/target_stake,
-/obj/item/target,
-/obj/item/clothing/suit/storage/faction/militia,
-/turf/open/floor/plating/mainship,
-/area/mainship/shipboard/firing_range)
+/obj/machinery/door/airlock/mainship/generic/bathroom,
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "zD" = (
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/red/full,
@@ -9008,10 +9110,10 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
 "zS" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
 	},
-/turf/open/floor/grass,
+/turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
 "zT" = (
 /turf/open/floor/plating/icefloor/warnplate{
@@ -9024,12 +9126,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
-"zV" = (
-/obj/structure/bed/chair/comfy{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "zW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -9121,6 +9217,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
+/obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/sterile/plain,
 /area/mainship/living/tankerbunks)
 "Aj" = (
@@ -9160,12 +9257,11 @@
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/squads/req)
 "Ao" = (
-/obj/structure/bed/chair/comfy{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/effect/ai_node,
 /turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/area/mainship/living/commandbunks)
 "Ap" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -9231,19 +9327,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
-"Ax" = (
-/obj/structure/mirror,
-/obj/structure/sink,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "Ay" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "Az" = (
 /obj/machinery/landinglight/ds1/delayone,
 /turf/open/floor/mainship/mono,
@@ -9256,8 +9343,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "AB" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/mainship/mono,
+/obj/machinery/atm,
+/turf/closed/wall/mainship,
 /area/mainship/command/corporateliaison)
 "AC" = (
 /obj/structure/mirror,
@@ -9410,9 +9497,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "AU" = (
@@ -9546,17 +9630,9 @@
 	},
 /area/mainship/command/self_destruct)
 "Bo" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/obj/structure/disposalpipe/junction,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
+/obj/structure/bed/chair/wood/wings,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "Bp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -9602,6 +9678,9 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/tankerbunks)
+"Bx" = (
+/turf/closed/wall/mainship,
+/area/space)
 "By" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -9716,16 +9795,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "BR" = (
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/obj/structure/target_stake,
-/obj/item/target,
-/obj/item/clothing/suit/storage/faction/militia,
-/turf/open/floor/plating/mainship/striped{
-	dir = 4
-	},
-/area/mainship/shipboard/firing_range)
+/obj/effect/ai_node,
+/turf/open/floor/carpet/side,
+/area/mainship/living/numbertwobunks)
 "BS" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/storage/backpack/marine/engineerpack,
@@ -9762,6 +9834,10 @@
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
+"BX" = (
+/obj/machinery/holopad,
+/turf/open/floor/mainship/red/full,
+/area/mainship/shipboard/firing_range)
 "BY" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/mainship/sterile/side{
@@ -9886,14 +9962,6 @@
 /obj/structure/flora/pottedplant,
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
-"Ct" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/weapon/gun/revolver/standard_revolver,
-/obj/item/ammo_magazine/revolver/standard_revolver,
-/obj/item/ammo_magazine/revolver/standard_revolver,
-/obj/item/ammo_magazine/revolver/standard_revolver,
-/turf/open/floor/mainship/red/full,
-/area/mainship/shipboard/firing_range)
 "Cu" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -9973,20 +10041,29 @@
 	dir = 9
 	},
 /area/mainship/command/cic)
-"CE" = (
+"CD" = (
+/obj/structure/table/mainship/nometal,
+/obj/item/explosive/grenade/training,
+/obj/item/explosive/grenade/training,
+/obj/item/explosive/grenade/training,
+/obj/item/tool/extinguisher/mini,
+/obj/item/tool/extinguisher/mini,
+/obj/item/tool/extinguisher/mini,
+/obj/item/tool/extinguisher/mini,
+/obj/machinery/firealarm{
+	dir = 1
+	},
 /obj/effect/decal/warning_stripes/thin{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/red{
-	dir = 8
-	},
+/turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/firing_range)
+"CE" = (
+/obj/machinery/alarm{
+	dir = 4
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/living/numbertwobunks)
 "CF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/wood,
@@ -10013,6 +10090,17 @@
 	dir = 8
 	},
 /area/mainship/squads/general)
+"CJ" = (
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/mainship/shipboard/firing_range)
 "CK" = (
 /obj/structure/cable,
 /obj/structure/window/framed/mainship,
@@ -10023,15 +10111,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
-"CM" = (
-/obj/structure/target_stake,
-/obj/item/target,
-/obj/item/clothing/suit/storage/faction/militia,
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/plating/mainship,
-/area/mainship/shipboard/firing_range)
 "CN" = (
 /turf/open/floor/mainship/sterile/purple/side{
 	dir = 4
@@ -10043,9 +10122,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
@@ -10122,12 +10198,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/sulaco/showers)
-"CZ" = (
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/numbertwobunks)
 "Da" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -10144,6 +10214,9 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
 /turf/open/floor/mainship/black/corner{
 	dir = 1
 	},
@@ -10292,6 +10365,9 @@
 "Dx" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/structure/bed/chair/nometal{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "Dy" = (
@@ -10363,12 +10439,10 @@
 	},
 /area/space)
 "DI" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/structure/cable,
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "DJ" = (
@@ -10498,13 +10572,13 @@
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
 "Eb" = (
-/obj/machinery/door/airlock/mainship/maint,
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/target_stake,
+/obj/item/target,
+/obj/item/clothing/suit/storage/faction/militia,
+/turf/open/floor/plating/mainship/striped{
+	dir = 8
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/commandbunks)
+/area/mainship/shipboard/firing_range)
 "Ec" = (
 /turf/open/floor/prison/kitchen,
 /area/mainship/living/grunt_rnr)
@@ -10527,6 +10601,19 @@
 	},
 /turf/open/floor/grass,
 /area/mainship/living/starboard_garden)
+"Eg" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "Eh" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -10568,6 +10655,19 @@
 /obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
+"Em" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/command/corporateliaison)
 "En" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -10620,15 +10720,16 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "Eu" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/docking_port/stationary/marine_dropship/crash_target,
-/turf/open/floor/mainship/mono,
-/area/mainship/shipboard/firing_range)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/living/numbertwobunks)
 "Ev" = (
 /obj/machinery/firealarm{
 	dir = 4
@@ -10645,16 +10746,16 @@
 /turf/closed/wall/mainship,
 /area/mainship/living/cryo_cells)
 "Ey" = (
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 8
+/obj/machinery/door/airlock/mainship/command/FCDRoffice{
+	dir = 1
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/blackgeneric/glass{
-	name = "\improper Firing Range Airlock"
-	},
-/turf/open/floor/mainship/red{
-	dir = 8
-	},
-/area/mainship/shipboard/firing_range)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/space/basic,
+/area/mainship/living/numbertwobunks)
 "Ez" = (
 /obj/item/clothing/gloves/marine/som,
 /turf/open/floor/mainship/mono,
@@ -10720,6 +10821,15 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"EJ" = (
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/obj/item/reagent_containers/food/snacks/carpmeat,
+/turf/open/floor/carpet/side{
+	dir = 5
+	},
+/area/mainship/living/commandbunks)
 "EK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -10857,11 +10967,11 @@
 	},
 /area/mainship/living/briefing)
 "Fe" = (
-/obj/structure/target_stake,
-/turf/open/floor/mainship/red{
+/obj/structure/toilet{
 	dir = 4
 	},
-/area/mainship/shipboard/firing_range)
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "Ff" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -10872,6 +10982,11 @@
 "Fg" = (
 /turf/closed/wall/mainship,
 /area/mainship/squads/general)
+"Fh" = (
+/obj/structure/bed/chair/sofa,
+/obj/machinery/vending/nanomed,
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "Fi" = (
 /obj/machinery/optable,
 /obj/item/tank/anesthetic,
@@ -10894,8 +11009,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Fl" = (
-/obj/machinery/light/mainship{
-	dir = 8
+/obj/structure/bed/chair/comfy{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
@@ -10929,14 +11044,15 @@
 	},
 /area/mainship/medical/lower_medical)
 "Fp" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
+/obj/machinery/door/airlock/mainship/command/FCDRquarters,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
-/area/mainship/shipboard/firing_range)
+/area/mainship/living/numbertwobunks)
 "Fq" = (
 /obj/structure/bed/chair/wood/wings{
 	dir = 8
@@ -10986,15 +11102,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
-"Fy" = (
-/obj/machinery/door/window{
-	dir = 2
-	},
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/shipboard/firing_range)
 "Fz" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
@@ -11028,11 +11135,10 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "FE" = (
-/obj/machinery/light/mainship/small{
-	dir = 8
-	},
-/turf/open/floor/plating/mainship,
-/area/mainship/shipboard/firing_range)
+/obj/structure/table/fancywoodentable,
+/obj/item/book/codebook,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "FF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
@@ -11117,10 +11223,6 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/port_hallway)
-"FO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/commandbunks)
 "FP" = (
 /obj/machinery/door/firedoor/mainship,
 /obj/machinery/door/poddoor/mainship/open/cic,
@@ -11143,6 +11245,14 @@
 /obj/item/radio,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
+"FR" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/mainship/shipboard/firing_range)
 "FS" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
@@ -11173,6 +11283,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
+"FX" = (
+/obj/machinery/alarm{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "FY" = (
 /obj/structure/dropship_equipment/weapon/rocket_pod,
 /turf/open/floor/mainship/floor,
@@ -11368,6 +11484,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_umbilical)
+"GA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/command/corporateliaison)
 "GB" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -11397,6 +11522,12 @@
 	dir = 5
 	},
 /area/mainship/engineering/engine_core)
+"GE" = (
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/commandbunks)
 "GF" = (
 /obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/mono,
@@ -11437,14 +11568,11 @@
 /turf/open/floor/mainship/black/full,
 /area/mainship/command/self_destruct)
 "GN" = (
-/obj/machinery/light/mainship{
-	dir = 8
-	},
+/obj/structure/table/woodentable,
+/obj/effect/spawner/random/plushie/nospawnninetynine,
+/obj/item/weapon/gun/energy/taser,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
-"GO" = (
-/turf/open/floor/mainship/mono,
-/area/mainship/shipboard/firing_range)
 "GP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11518,9 +11646,12 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "Hc" = (
-/obj/machinery/holopad,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
 /turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/area/mainship/living/commandbunks)
 "Hd" = (
 /obj/machinery/computer/ordercomp,
 /turf/open/floor/mainship/mono,
@@ -11543,12 +11674,12 @@
 /turf/open/floor/wood,
 /area/mainship/medical/medical_science)
 "Hh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 4;
-	on = 1
+/obj/structure/bed/chair/comfy{
+	dir = 8
 	},
-/obj/effect/ai_node,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/side{
+	dir = 9
+	},
 /area/mainship/living/commandbunks)
 "Hi" = (
 /obj/machinery/door/firedoor/multi_tile{
@@ -11669,19 +11800,6 @@
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
-"HC" = (
-/obj/item/clothing/under/redpyjamas{
-	pixel_y = 5
-	},
-/obj/structure/bed/fancy,
-/obj/item/bedsheet/captain,
-/obj/effect/landmark/start/job/captain,
-/obj/machinery/vending/nanomed,
-/mob/living/simple_animal/cat/Jones,
-/turf/open/floor/carpet/side{
-	dir = 1
-	},
-/area/mainship/living/commandbunks)
 "HD" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
@@ -11730,10 +11848,11 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "HJ" = (
-/turf/open/floor/mainship/red{
-	dir = 1
+/obj/machinery/light/mainship{
+	dir = 4
 	},
-/area/mainship/shipboard/firing_range)
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "HK" = (
 /obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/mono,
@@ -11785,9 +11904,8 @@
 /turf/open/floor/plating,
 /area/mainship/command/telecomms)
 "HQ" = (
-/obj/structure/closet/secure_closet/captain,
 /turf/open/floor/carpet/side{
-	dir = 9
+	dir = 10
 	},
 /area/mainship/living/commandbunks)
 "HR" = (
@@ -11866,12 +11984,6 @@
 "Id" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/pilotbunks)
-"Ie" = (
-/obj/structure/target_stake,
-/obj/item/target,
-/obj/item/clothing/suit/replica,
-/turf/open/floor/plating/mainship,
-/area/mainship/shipboard/firing_range)
 "If" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -11881,11 +11993,11 @@
 /area/mainship/command/self_destruct)
 "Ig" = (
 /obj/structure/cable,
-/obj/machinery/power/apc,
-/turf/open/floor/carpet/side{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/area/mainship/living/numbertwobunks)
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "Ih" = (
 /obj/machinery/door/airlock/mainship/secure/tcomms,
 /obj/machinery/door/poddoor/mainship/open/cic,
@@ -11929,8 +12041,9 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "In" = (
-/obj/machinery/computer/security/marinemainship_network,
-/obj/structure/table/fancywoodentable,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "Io" = (
@@ -11989,17 +12102,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "Iv" = (
-/obj/structure/table/mainship/nometal,
-/obj/structure/paper_bin{
-	pixel_x = 7;
-	pixel_y = 6
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = -2
 	},
-/obj/item/tool/pen,
-/obj/item/camera,
-/obj/item/reagent_containers/food/drinks/cans/aspen{
-	pixel_x = 8
-	},
-/obj/item/camera_film,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "Iw" = (
@@ -12067,6 +12173,9 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
+"IE" = (
+/turf/open/floor/mainship/red/full,
+/area/mainship/shipboard/firing_range)
 "IF" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/bed/stool{
@@ -12191,20 +12300,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
-"IZ" = (
-/obj/item/storage/fancy/cigar,
-/obj/item/clothing/mask/cigarette/pipe{
-	pixel_y = 5
-	},
-/obj/item/newspaper,
-/obj/item/reagent_containers/food/drinks/britcup,
-/obj/item/storage/box/matches,
-/obj/structure/table/fancywoodentable,
-/obj/machinery/alarm{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
 "Ja" = (
 /obj/machinery/marine_selector/clothes,
 /obj/structure/window/reinforced,
@@ -12374,6 +12469,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
+"Ju" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/shipboard/firing_range)
 "Jv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window{
@@ -12493,6 +12595,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
+"JL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "JM" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
@@ -12585,11 +12692,10 @@
 	},
 /area/mainship/command/airoom)
 "JZ" = (
-/obj/structure/mirror{
-	dir = 8
+/turf/open/floor/carpet/side{
+	dir = 6
 	},
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/area/mainship/living/commandbunks)
 "Ka" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -12597,9 +12703,7 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "Kb" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 1
-	},
+/turf/open/floor/mech_bay_recharge_floor,
 /area/mainship/living/tankerbunks)
 "Kc" = (
 /turf/open/floor/wood,
@@ -12681,8 +12785,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
 "Kq" = (
-/obj/machinery/computer/skills,
+/obj/structure/paper_bin{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/tool/pen,
 /obj/structure/table/fancywoodentable,
+/obj/item/book/manual/security_space_law,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "Kr" = (
@@ -12775,25 +12884,25 @@
 	},
 /area/mainship/hallways/hangar)
 "KE" = (
-/obj/structure/table/mainship/nometal,
-/obj/structure/window/reinforced/toughened{
-	dir = 1
-	},
-/obj/structure/window/reinforced/toughened,
-/obj/machinery/door/window{
-	dir = 8
-	},
-/obj/item/weapon/claymore/mercsword/captain,
-/turf/open/floor/wood,
-/area/mainship/living/commandbunks)
+/obj/structure/target_stake,
+/obj/item/target,
+/obj/item/clothing/suit/replica,
+/turf/open/floor/plating/mainship,
+/area/mainship/shipboard/firing_range)
 "KF" = (
 /obj/structure/cable,
 /obj/machinery/light/mainship/small,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/self_destruct)
 "KG" = (
-/obj/structure/bed/chair/wood/wings{
-	dir = 4
+/obj/structure/bed/fancy,
+/obj/effect/landmark/start/job/captain,
+/obj/item/bedsheet/captain,
+/obj/item/clothing/under/redpyjamas{
+	pixel_y = 5
+	},
+/obj/machinery/light/mainship{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
@@ -12820,9 +12929,6 @@
 "KJ" = (
 /obj/machinery/light/mainship{
 	dir = 1
-	},
-/obj/structure/bed/chair/nometal{
-	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
@@ -12860,6 +12966,14 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/medical/lower_medical)
+"KQ" = (
+/obj/structure/table/mainship/nometal,
+/obj/item/weapon/gun/revolver/standard_revolver,
+/obj/item/ammo_magazine/revolver/standard_revolver,
+/obj/item/ammo_magazine/revolver/standard_revolver,
+/obj/item/ammo_magazine/revolver/standard_revolver,
+/turf/open/floor/mainship/red/full,
+/area/mainship/shipboard/firing_range)
 "KS" = (
 /obj/structure/closet/bodybag,
 /turf/open/floor/plating/plating_catwalk,
@@ -12873,6 +12987,18 @@
 	dir = 1
 	},
 /area/mainship/command/airoom)
+"KV" = (
+/obj/structure/safe,
+/obj/item/moneybag,
+/obj/item/clothing/glasses/monocle,
+/obj/item/weapon/telebaton,
+/obj/item/book/codebook,
+/obj/item/weapon/chainofcommand,
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "KW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -12897,7 +13023,7 @@
 "KY" = (
 /obj/structure/window/framed/mainship,
 /turf/open/floor/plating,
-/area/mainship/shipboard/firing_range)
+/area/mainship/living/numbertwobunks)
 "KZ" = (
 /obj/structure/sign/nosmoking_2,
 /turf/closed/wall/mainship/white,
@@ -12932,16 +13058,10 @@
 /turf/closed/wall/mainship,
 /area/sulaco/showers)
 "Lf" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/effect/ai_node,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/obj/structure/table/fancywoodentable,
+/obj/item/newspaper,
+/turf/open/floor/carpet/side,
+/area/mainship/living/commandbunks)
 "Lg" = (
 /obj/machinery/door/airlock/multi_tile/mainship/engineering/glass,
 /obj/machinery/door/firedoor/multi_tile,
@@ -12981,7 +13101,6 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
 "Lk" = (
-/obj/structure/bed/chair/nometal,
 /obj/machinery/firealarm{
 	dir = 8
 	},
@@ -13047,15 +13166,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Lv" = (
-/obj/structure/closet/secure_closet/freezer,
-/obj/item/reagent_containers/food/snacks/sandwich,
-/obj/item/reagent_containers/food/snacks/sandwich,
-/obj/item/reagent_containers/food/snacks/sandwich,
-/obj/item/reagent_containers/food/snacks/sandwich,
-/obj/item/reagent_containers/food/drinks/bottle/sake,
-/obj/item/reagent_containers/food/drinks/bottle/sake,
-/obj/item/reagent_containers/food/drinks/bottle/wine,
-/obj/item/reagent_containers/food/drinks/bottle/wine,
+/obj/structure/table/mainship/nometal,
+/obj/machinery/computer/emails,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "Lw" = (
@@ -13112,8 +13224,8 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "LE" = (
-/turf/open/floor/plating/mainship,
-/area/mainship/shipboard/firing_range)
+/turf/closed/wall/mainship/outer,
+/area/mainship/living/numbertwobunks)
 "LF" = (
 /obj/structure/table/mainship/nometal,
 /turf/open/floor/mainship/white{
@@ -13138,9 +13250,7 @@
 /obj/machinery/computer/mech_builder{
 	dir = 8
 	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 5
-	},
+/turf/open/floor/plating,
 /area/mainship/living/tankerbunks)
 "LJ" = (
 /obj/machinery/door/airlock/mainship/maint{
@@ -13190,8 +13300,8 @@
 	},
 /area/mainship/squads/req)
 "LR" = (
-/obj/item/ammo_magazine/rifle,
-/turf/open/floor/grass,
+/obj/structure/table/mainship/nometal,
+/turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
 "LS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13246,18 +13356,13 @@
 "Ma" = (
 /obj/effect/soundplayer,
 /turf/closed/wall/mainship,
-/area/mainship/living/numbertwobunks)
+/area/mainship/living/commandbunks)
 "Mb" = (
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/structure/sign/securearea/firingrange,
-/turf/open/floor/mainship/red/full,
-/area/mainship/shipboard/firing_range)
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/living/numbertwobunks)
 "Mc" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
 /turf/open/floor/mainship/tcomms,
@@ -13312,10 +13417,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Ml" = (
-/obj/machinery/photocopier,
-/obj/machinery/light/mainship,
-/turf/open/floor/mainship/mono,
-/area/mainship/command/corporateliaison)
+/obj/structure/filingcabinet,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/numbertwobunks)
 "Mm" = (
 /obj/machinery/fuelcell_recycler,
 /obj/machinery/light/mainship,
@@ -13327,6 +13431,22 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/stern_hallway)
+"Mo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/table/mainship/nometal,
+/obj/item/camera_film,
+/obj/item/reagent_containers/food/drinks/cans/aspen{
+	pixel_x = 8
+	},
+/obj/item/camera,
+/obj/item/tool/pen,
+/turf/open/floor/mainship/mono,
+/area/mainship/command/corporateliaison)
 "Mp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -13347,7 +13467,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Mr" = (
-/obj/machinery/photocopier,
+/obj/structure/table/woodentable,
+/obj/item/reagent_containers/food/drinks/flask/barflask,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "Ms" = (
@@ -13360,9 +13481,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Mt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/structure/table/woodentable,
+/obj/structure/paper_bin{
+	pixel_y = 5
 	},
+/obj/item/tool/pen/sleepypen,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "Mu" = (
@@ -13401,15 +13524,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"Mz" = (
-/obj/structure/flora/pottedplant/ten,
-/obj/machinery/power/apc/mainship,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/mainship/living/commandbunks)
 "MA" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
@@ -13441,6 +13555,10 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
+"ME" = (
+/obj/machinery/loadout_vendor,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "MF" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -13487,6 +13605,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/cic)
 "MK" = (
@@ -13530,6 +13649,17 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"MQ" = (
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 8
+	},
+/obj/machinery/door/airlock/multi_tile/mainship/blackgeneric/glass{
+	name = "\improper Firing Range Airlock"
+	},
+/turf/open/floor/mainship/red{
+	dir = 8
+	},
+/area/mainship/shipboard/firing_range)
 "MR" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -13548,6 +13678,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"MT" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/carpet/side,
+/area/mainship/living/commandbunks)
 "MU" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -13578,22 +13713,18 @@
 /turf/open/floor/cult,
 /area/medical/morgue)
 "MY" = (
-/obj/machinery/power/apc/mainship,
-/obj/structure/cable,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/turf/open/floor/mainship/red{
-	dir = 1
-	},
-/area/mainship/shipboard/firing_range)
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "MZ" = (
 /obj/machinery/floodlight/landing,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
+"Na" = (
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/mainship/command/corporateliaison)
 "Nb" = (
 /obj/structure/bed/chair/nometal{
 	dir = 1
@@ -13645,10 +13776,12 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
 "Ni" = (
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 8
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/area/mainship/living/tankerbunks)
+/turf/open/floor/mainship/floor,
+/area/mainship/living/numbertwobunks)
 "Nj" = (
 /turf/closed/wall/mainship,
 /area/mainship/engineering/port_atmos)
@@ -13688,16 +13821,16 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Np" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
+/obj/machinery/computer/skills,
+/obj/structure/table/fancywoodentable,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "Nq" = (
-/obj/machinery/atm,
-/turf/closed/wall/mainship,
-/area/mainship/command/corporateliaison)
+/obj/machinery/power/apc,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/numbertwobunks)
 "Nr" = (
 /obj/structure/cable,
 /obj/machinery/camera/autoname/mainship{
@@ -13784,6 +13917,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/bed/chair/nometal{
+	dir = 4
+	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "NE" = (
@@ -13827,20 +13964,31 @@
 	},
 /area/mainship/engineering/engineering_workshop)
 "NJ" = (
-/obj/machinery/door/airlock/mainship/command/CPToffice{
-	dir = 2
+/obj/structure/closet/cabinet,
+/obj/item/storage/briefcase,
+/obj/item/clothing/head/bowlerhat{
+	pixel_x = -4;
+	pixel_y = 8
 	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
+/obj/item/staff/gentcane{
+	pixel_x = 5
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/commandbunks)
-"NK" = (
+/obj/item/binoculars,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
+"NK" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/carpet,
+/area/mainship/living/commandbunks)
 "NL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -13863,8 +14011,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "NN" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/storage/donut_box,
+/obj/machinery/loadout_vendor,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "NO" = (
@@ -13876,13 +14023,8 @@
 /turf/open/floor/wood,
 /area/mainship/medical/lower_medical)
 "NQ" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/ammo_magazine/rifle/standard_carbine,
-/obj/item/ammo_magazine/rifle/standard_carbine,
-/obj/item/ammo_magazine/rifle/standard_carbine,
-/obj/item/weapon/gun/rifle/standard_carbine,
-/turf/open/floor/mainship/red/full,
-/area/mainship/shipboard/firing_range)
+/turf/open/floor/mainship/floor,
+/area/mainship/living/numbertwobunks)
 "NR" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -13893,6 +14035,10 @@
 "NS" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/hull/lower_hull)
+"NT" = (
+/obj/structure/window/framed/mainship,
+/turf/open/floor/plating,
+/area/mainship/shipboard/firing_range)
 "NU" = (
 /obj/vehicle/ridden/motorbike{
 	dir = 4
@@ -13972,17 +14118,9 @@
 /turf/open/floor/mainship/red,
 /area/mainship/command/airoom)
 "Oh" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/obj/machinery/door/window{
-	dir = 2
-	},
-/obj/machinery/shower{
-	pixel_y = 16
-	},
-/obj/item/tool/soap/nanotrasen,
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/power/apc/mainship,
+/obj/structure/cable,
+/turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "Oi" = (
 /obj/structure/cable,
@@ -14149,11 +14287,12 @@
 	},
 /area/mainship/medical/medical_science)
 "OI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	on = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/command/cic)
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "OJ" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/black{
@@ -14214,16 +14353,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
 "OU" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/structure/flora/pottedplant/ten,
+/obj/machinery/light/mainship{
+	dir = 4
 	},
 /turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/area/mainship/living/commandbunks)
 "OV" = (
 /obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -14245,13 +14380,8 @@
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "OY" = (
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/carpet/side{
-	dir = 6
-	},
-/area/mainship/living/commandbunks)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/shipboard/firing_range)
 "Pa" = (
 /mob/living/simple_animal/corgi/ranger,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -14323,16 +14453,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/self_destruct)
 "Pm" = (
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/obj/item/book/codebook,
-/obj/item/megaphone,
 /obj/structure/table/fancywoodentable,
+/obj/machinery/computer/marine_card,
 /turf/open/floor/carpet/side{
-	dir = 10
+	dir = 1
 	},
-/area/mainship/living/numbertwobunks)
+/area/mainship/living/commandbunks)
 "Pn" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/mainship/mono,
@@ -14370,23 +14496,21 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Pt" = (
-/obj/item/ashtray/glass,
-/obj/item/clipboard{
-	pixel_x = 5
+/obj/machinery/door/airlock/mainship/marine/general,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/item/newspaper,
-/obj/structure/table/fancywoodentable,
-/turf/open/floor/wood,
-/area/mainship/living/commandbunks)
+/area/mainship/shipboard/firing_range)
 "Pu" = (
 /turf/open/floor/mainship/black/corner{
 	dir = 4
 	},
 /area/mainship/command/self_destruct)
 "Pv" = (
-/turf/open/floor/mainship/cargo,
-/area/mainship/shipboard/firing_range)
+/obj/structure/table/fancywoodentable,
+/obj/machinery/computer/security/marinemainship_network,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/numbertwobunks)
 "Pw" = (
 /obj/effect/ai_node,
 /obj/machinery/light/mainship,
@@ -14402,12 +14526,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "Pz" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/mainship/living/commandbunks)
+/obj/effect/ai_node,
+/turf/open/floor/plating/mainship,
+/area/mainship/shipboard/firing_range)
 "PA" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -14519,15 +14640,12 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "PN" = (
-/obj/machinery/light/mainship/small{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
-"PO" = (
-/obj/machinery/vending/weapon,
-/turf/open/floor/mainship/red/full,
+/turf/open/floor/plating,
 /area/mainship/shipboard/firing_range)
+"PO" = (
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "PP" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/storage/firstaid/o2{
@@ -14585,9 +14703,7 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/starboard_hallway)
 "PV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/machinery/light/mainship,
 /turf/open/floor/mainship/floor,
 /area/mainship/command/corporateliaison)
 "PW" = (
@@ -14619,9 +14735,12 @@
 /turf/open/floor/wood,
 /area/mainship/living/chapel)
 "Qa" = (
-/obj/effect/decal/cleanable/blood,
-/obj/item/clothing/gloves/black,
-/turf/open/floor/grass,
+/obj/structure/sign/securearea/firingrange,
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/obj/machinery/vending/weapon,
+/turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/firing_range)
 "Qb" = (
 /obj/machinery/light/mainship{
@@ -14686,13 +14805,13 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "Qi" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/light/mainship{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/mainship/black{
-	dir = 1
-	},
-/area/mainship/squads/general)
+/turf/open/floor/mainship/floor,
+/area/mainship/living/numbertwobunks)
 "Qj" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -14725,9 +14844,9 @@
 /turf/open/floor/grass,
 /area/mainship/living/starboard_garden)
 "Qo" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/floor,
-/area/mainship/command/corporateliaison)
+/obj/machinery/marine_selector/clothes/commander,
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "Qp" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -14755,11 +14874,8 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
-/obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "Qu" = (
@@ -14888,9 +15004,9 @@
 	},
 /area/mainship/squads/general)
 "QM" = (
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/obj/machinery/holopad,
+/turf/open/floor/carpet,
+/area/mainship/living/commandbunks)
 "QN" = (
 /obj/machinery/suit_storage_unit/carbon_unit,
 /turf/open/floor/mainship/mono,
@@ -14948,7 +15064,13 @@
 /area/mainship/hallways/port_hallway)
 "QX" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
 	},
 /turf/open/floor/mainship/black{
@@ -14966,12 +15088,6 @@
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/chemistry)
 "Ra" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/book/manual/security_space_law,
-/obj/item/storage/box/cups{
-	pixel_x = 5;
-	pixel_y = 2
-	},
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -14988,6 +15104,10 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
+"Rc" = (
+/obj/machinery/light/mainship,
+/turf/closed/wall/mainship,
 /area/mainship/hull/lower_hull)
 "Rd" = (
 /obj/structure/cable,
@@ -15064,6 +15184,11 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
+"Ro" = (
+/obj/structure/sink,
+/obj/structure/mirror,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/commandbunks)
 "Rp" = (
 /obj/machinery/light/mainship/small{
 	dir = 8
@@ -15253,10 +15378,14 @@
 /turf/open/floor/plating,
 /area/mainship/engineering/upper_engineering)
 "RS" = (
-/turf/open/floor/mainship/red{
-	dir = 8
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
 	},
-/area/mainship/shipboard/firing_range)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/numbertwobunks)
 "RT" = (
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
@@ -15265,6 +15394,11 @@
 "RU" = (
 /turf/open/floor/plating/mainship,
 /area/mainship/command/self_destruct)
+"RV" = (
+/obj/structure/toilet,
+/obj/structure/mirror,
+/turf/open/floor/mainship/mono,
+/area/space)
 "RW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
@@ -15293,6 +15427,12 @@
 	dir = 1
 	},
 /area/mainship/command/cic)
+"RZ" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/commandbunks)
 "Sa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15345,11 +15485,6 @@
 "Sf" = (
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
-"Sg" = (
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
-/area/mainship/shipboard/firing_range)
 "Sh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/mainship{
@@ -15409,10 +15544,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
 "Sp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/turf/open/floor/carpet/side{
+	dir = 1
 	},
-/turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "Sq" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -15612,9 +15746,12 @@
 /turf/open/floor/cult,
 /area/medical/morgue)
 "SQ" = (
-/obj/structure/cable,
-/turf/open/floor/carpet/side,
-/area/mainship/living/numbertwobunks)
+/obj/structure/table/fancywoodentable,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/carpet/side{
+	dir = 1
+	},
+/area/mainship/living/commandbunks)
 "SR" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -15624,10 +15761,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "SS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/obj/structure/table/fancywoodentable,
+/obj/item/ashtray/glass,
+/turf/open/floor/carpet,
+/area/mainship/living/commandbunks)
 "ST" = (
 /obj/structure/table/woodentable,
 /obj/item/flashlight/lamp,
@@ -15667,9 +15804,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
@@ -15763,7 +15897,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_umbilical)
 "Tn" = (
-/obj/structure/filingcabinet,
+/obj/structure/window/reinforced/toughened{
+	dir = 1
+	},
+/obj/structure/window/reinforced/toughened,
+/obj/structure/table/fancywoodentable,
+/obj/machinery/door/window,
+/obj/item/weapon/claymore/mercsword/captain,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "To" = (
@@ -15779,11 +15919,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "Tq" = (
-/obj/effect/ai_node,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/carpet/side,
+/obj/structure/window/framed/mainship/hull,
+/turf/open/floor/plating,
 /area/mainship/living/commandbunks)
 "Tr" = (
 /obj/machinery/mech_bay_recharge_port,
@@ -15935,19 +16072,14 @@
 	},
 /area/mainship/medical/lower_medical)
 "TK" = (
-/obj/structure/target_stake,
-/obj/item/target,
-/obj/item/clothing/suit/storage/faction/militia,
-/turf/open/floor/plating/mainship/striped{
-	dir = 8
-	},
-/area/mainship/shipboard/firing_range)
+/turf/closed/wall/mainship,
+/area/mainship/living/numbertwobunks)
 "TL" = (
 /obj/effect/decal/cleanable/blood/gibs/robot/limb,
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},
-/turf/open/floor/plating/icefloor/warnplate,
+/turf/open/floor/mech_bay_recharge_floor,
 /area/mainship/living/tankerbunks)
 "TM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -15962,9 +16094,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "TO" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
+/obj/structure/table/mainship/nometal,
+/obj/item/tool/minihoe,
+/obj/item/tool/plantspray/weeds,
+/obj/item/tool/plantspray/weeds,
+/obj/item/reagent_containers/glass/fertilizer/ez,
+/obj/item/reagent_containers/glass/fertilizer/ez,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "TP" = (
@@ -15993,7 +16128,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/holopad,
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
@@ -16021,6 +16155,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
+"TX" = (
+/obj/machinery/light/mainship,
+/turf/open/floor/mainship/mono,
+/area/space)
 "TY" = (
 /turf/open/floor/mainship/research/containment/floor2{
 	dir = 5
@@ -16034,11 +16172,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "Ua" = (
-/obj/machinery/door/airlock/multi_tile/mainship/blackgeneric{
-	dir = 1;
-	name = "\improper Firing Range Airlock"
-	},
-/turf/open/floor/grass,
+/obj/structure/table/reinforced,
+/turf/open/floor/mainship/stripesquare,
 /area/mainship/shipboard/firing_range)
 "Ub" = (
 /obj/structure/cable,
@@ -16051,7 +16186,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "Uc" = (
-/obj/structure/sink,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/commandbunks)
 "Ud" = (
@@ -16096,9 +16230,6 @@
 	},
 /area/mainship/medical/medical_science)
 "Ug" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "Uh" = (
@@ -16128,9 +16259,7 @@
 /obj/machinery/firealarm{
 	dir = 1
 	},
-/turf/open/floor/plating/icefloor/warnplate{
-	dir = 10
-	},
+/turf/open/floor/plating,
 /area/mainship/living/tankerbunks)
 "Ul" = (
 /obj/structure/disposalpipe/segment,
@@ -16172,10 +16301,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "Ur" = (
-/obj/effect/decal/cleanable/blood,
-/obj/item/clothing/head/helmet/marine/standard,
-/obj/item/ammo_casing,
-/turf/open/floor/grass,
+/turf/open/floor/mainship/red{
+	dir = 1
+	},
 /area/mainship/shipboard/firing_range)
 "Us" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -16265,13 +16393,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/firealarm,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
@@ -16339,6 +16463,12 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
+"UL" = (
+/obj/structure/bookcase,
+/obj/item/folder/white,
+/obj/item/book/manual/marine_law,
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "UM" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -16438,8 +16568,8 @@
 /turf/closed/wall/mainship,
 /area/mainship/hallways/hangar)
 "Vd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
 	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
@@ -16475,46 +16605,53 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
 /turf/open/floor/mainship/sterile/plain,
 /area/mainship/living/tankerbunks)
 "Vi" = (
 /obj/structure/table/mainship/nometal,
-/obj/item/folder/black_random{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/item/reagent_containers/food/drinks/bottle/sake{
+	pixel_x = -4
 	},
-/obj/machinery/computer/security/marinemainship{
-	dir = 8;
-	pixel_x = -17
+/obj/item/reagent_containers/food/drinks/bottle/sake{
+	pixel_x = 5;
+	pixel_y = 5
 	},
-/obj/item/clipboard{
-	pixel_x = 5
-	},
-/obj/item/tool/pen,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/portable_vendor/corporate,
+/obj/machinery/computer/emails,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "Vj" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"Vk" = (
+/obj/machinery/power/apc/mainship,
+/obj/structure/cable,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/mainship/red{
+	dir = 1
+	},
+/area/mainship/shipboard/firing_range)
 "Vl" = (
 /obj/machinery/cryopod/right,
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship,
 /area/mainship/living/cryo_cells)
 "Vm" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/bed/chair/wood/wings{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/turf/open/floor/wood,
+/area/mainship/living/numbertwobunks)
 "Vn" = (
 /obj/machinery/door/firedoor/mainship,
 /obj/structure/cable,
@@ -16524,6 +16661,9 @@
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"Vo" = (
+/turf/open/floor/mainship/cargo,
+/area/mainship/shipboard/firing_range)
 "Vp" = (
 /turf/open/floor/mainship/ntlogo/nt2,
 /area/mainship/squads/general)
@@ -16550,12 +16690,14 @@
 	},
 /area/mainship/shipboard/weapon_room)
 "Vu" = (
-/obj/structure/bed/chair/comfy,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+/obj/machinery/door/window{
+	dir = 2
 	},
-/turf/open/floor/wood,
-/area/mainship/living/commandbunks)
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/shipboard/firing_range)
 "Vv" = (
 /obj/structure/rack,
 /obj/item/storage/belt/utility/full,
@@ -16662,8 +16804,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
 "VJ" = (
-/turf/closed/wall/mainship,
-/area/mainship/living/numbertwobunks)
+/obj/structure/bed/chair/sofa/right,
+/obj/machinery/firealarm,
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "VK" = (
 /obj/machinery/door/firedoor/mainship,
 /obj/structure/cable,
@@ -16720,6 +16864,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "VR" = (
@@ -16740,6 +16885,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
 	on = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
 	},
 /turf/open/floor/mainship/sterile/plain,
 /area/mainship/living/tankerbunks)
@@ -16782,18 +16930,18 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/sulaco/showers)
 "VZ" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/plating/mainship/striped{
-	dir = 8
-	},
-/area/mainship/shipboard/firing_range)
+/obj/structure/mirror,
+/obj/structure/sink,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "Wa" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/floor/plating/mainship,
+/obj/structure/closet/crate,
+/obj/item/target/syndicate,
+/obj/item/target/syndicate,
+/obj/item/target/syndicate,
+/obj/item/target/syndicate,
+/obj/item/target/syndicate,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/shipboard/firing_range)
 "Wb" = (
 /obj/structure/table/mainship/nometal,
@@ -16823,9 +16971,8 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/engineering/lower_engineering)
 "We" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
+/obj/structure/table/mainship/nometal,
+/obj/machinery/faxmachine,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "Wf" = (
@@ -16998,8 +17145,7 @@
 	},
 /area/mainship/living/cryo_cells)
 "WB" = (
-/obj/structure/toilet,
-/obj/structure/mirror,
+/obj/machinery/door/airlock/mainship/generic/bathroom,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/commandbunks)
 "WC" = (
@@ -17191,8 +17337,7 @@
 	},
 /area/mainship/squads/req)
 "Xd" = (
-/obj/item/ammo_casing,
-/turf/open/floor/grass,
+/turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
 "Xe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -17201,9 +17346,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "Xf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/mainship/living/commandbunks)
 "Xg" = (
 /turf/open/floor/mainship/green/corner{
 	dir = 4
@@ -17270,11 +17417,20 @@
 	dir = 8
 	},
 /area/mainship/squads/general)
+"Xr" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/shipboard/firing_range)
 "Xs" = (
-/turf/open/floor/mainship/red{
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/obj/machinery/light/mainship{
 	dir = 4
 	},
-/area/mainship/shipboard/firing_range)
+/turf/open/floor/mainship/floor,
+/area/mainship/living/numbertwobunks)
 "Xt" = (
 /obj/item/folder/black_random,
 /obj/item/tool/hand_labeler,
@@ -17498,6 +17654,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"XV" = (
+/obj/machinery/photocopier,
+/turf/open/floor/mainship/floor,
+/area/mainship/command/corporateliaison)
 "XW" = (
 /obj/structure/bed/stool{
 	pixel_y = 8
@@ -17522,12 +17682,28 @@
 	dir = 8
 	},
 /area/mainship/medical/medical_science)
+"XZ" = (
+/obj/structure/table/mainship,
+/obj/item/whistle,
+/turf/open/floor/wood,
+/area/mainship/living/commandbunks)
 "Ya" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/mainship/maint,
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"Yc" = (
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 1
+	},
+/obj/machinery/door/window,
+/obj/item/tool/soap/deluxe,
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/living/commandbunks)
 "Yd" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner{
@@ -17592,9 +17768,8 @@
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "Yn" = (
-/obj/machinery/alarm{
-	dir = 4
-	},
+/obj/structure/table/woodentable,
+/obj/item/flashlight/lamp/green,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "Yo" = (
@@ -17741,8 +17916,8 @@
 /turf/closed/wall/mainship,
 /area/mainship/living/tankerbunks)
 "YK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/light/mainship{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
@@ -17869,6 +18044,9 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
 /turf/open/floor/mainship/sterile/plain,
 /area/mainship/living/tankerbunks)
 "Zb" = (
@@ -17896,6 +18074,9 @@
 "Ze" = (
 /obj/machinery/door_control/mainship/mech{
 	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
 	},
 /turf/open/floor/mainship/black,
 /area/mainship/living/tankerbunks)
@@ -18014,7 +18195,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
 "Zw" = (
-/obj/structure/cable,
+/obj/structure/closet/secure_closet/bar/captain,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "Zx" = (
@@ -18049,14 +18230,18 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "ZC" = (
-/obj/effect/decal/warning_stripes/thin{
+/obj/structure/target_stake,
+/turf/open/floor/mainship/red{
 	dir = 4
 	},
-/obj/machinery/light/mainship/small{
-	dir = 4
-	},
-/turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
+"ZD" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/mainship/command/corporateliaison)
 "ZE" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/bible,
@@ -18075,9 +18260,7 @@
 /turf/open/floor/wood,
 /area/mainship/living/chapel)
 "ZH" = (
-/obj/structure/bed/chair/comfy{
-	dir = 4
-	},
+/obj/structure/filingcabinet,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "ZI" = (
@@ -18087,14 +18270,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "ZJ" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/wood,
-/area/mainship/living/commandbunks)
+/obj/structure/table/reinforced,
+/obj/effect/soundplayer,
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/shipboard/firing_range)
 "ZK" = (
 /obj/structure/cable,
 /obj/structure/sink,
@@ -18120,9 +18299,11 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/command/cic)
 "ZO" = (
-/obj/machinery/light/mainship,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
 /turf/open/floor/wood,
-/area/mainship/living/numbertwobunks)
+/area/mainship/living/commandbunks)
 "ZP" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/mono,
@@ -40736,9 +40917,9 @@ lR
 lR
 lR
 lR
-lR
-lR
-lR
+Bx
+Bx
+Bx
 lR
 lR
 bQ
@@ -40993,9 +41174,9 @@ lR
 lR
 lR
 lR
-lR
-lR
-lR
+iE
+ul
+pj
 lR
 lR
 bQ
@@ -41250,9 +41431,9 @@ lR
 lR
 lR
 lR
-lR
-lR
-lR
+RV
+TX
+Bx
 lR
 lR
 bQ
@@ -41507,9 +41688,9 @@ lR
 lR
 lR
 lR
-lR
-lR
-lR
+yM
+uD
+Bx
 lR
 lR
 bQ
@@ -41764,9 +41945,9 @@ lR
 lR
 lR
 lR
-lR
-lR
-lR
+Bx
+Bx
+Bx
 lR
 lR
 bQ
@@ -42241,7 +42422,7 @@ JA
 JA
 JA
 JA
-JA
+Rc
 JA
 JA
 JA
@@ -42495,7 +42676,7 @@ OB
 DB
 RD
 Qt
-RD
+SR
 RD
 MS
 RD
@@ -42748,11 +42929,11 @@ JA
 JA
 JA
 gC
-Qu
 QQ
 QQ
-Eb
 QQ
+QQ
+oq
 QQ
 QQ
 QQ
@@ -43005,11 +43186,11 @@ DB
 RD
 RD
 uQ
-PN
 QQ
+tx
 HQ
 iq
-eR
+Ug
 uR
 Yn
 KG
@@ -43262,15 +43443,15 @@ WZ
 WZ
 WZ
 WZ
-WZ
 QQ
-HC
+EJ
+JZ
 Tq
 qk
 Ug
 Hh
 xF
-cO
+an
 pp
 QQ
 Fx
@@ -43516,18 +43697,18 @@ zW
 Lv
 qO
 Vi
-oG
 WZ
 PB
 PB
 QQ
-kt
-OY
-KE
+QQ
+QQ
+QQ
+QQ
 YK
 Sp
-aC
-cO
+qg
+qj
 NN
 QQ
 Xe
@@ -43771,20 +43952,20 @@ UE
 WZ
 ND
 Mw
-Mw
+ZD
 We
-jX
 WZ
 wO
 wO
 QQ
+RZ
+GE
+Yc
 QQ
-QQ
-QQ
-Mz
+Ug
 aM
 uT
-cO
+JZ
 sA
 QQ
 ho
@@ -44026,22 +44207,22 @@ dS
 al
 JR
 WZ
-zW
-Qo
-hz
+Mo
 SY
-Ml
+hz
+XV
 WZ
+KJ
 TO
-ct
 QQ
+Ro
 Uc
-FO
-kZ
+Uc
+QQ
 Mt
 uu
 In
-kR
+Ug
 Zw
 QQ
 rD
@@ -44283,24 +44464,24 @@ dS
 al
 JR
 WZ
-zW
+gb
 SY
 jc
 PV
 AB
-Nq
+wO
 ql
-WZ
+QQ
 QQ
 WB
-bk
 QQ
-fn
-Vu
-Pt
+wm
+QQ
+QQ
+QQ
 xv
-ZJ
-NJ
+QQ
+QQ
 DI
 kX
 BF
@@ -44547,16 +44728,16 @@ mb
 sq
 pU
 VQ
-sK
+QQ
 QQ
 Oh
 bI
-QQ
+UL
 Tn
 cO
 mx
-kR
-Pz
+FX
+QQ
 QQ
 UD
 wR
@@ -44800,20 +44981,20 @@ WZ
 Hr
 WZ
 WZ
-Ap
+GA
+yy
 Mw
-Mw
-Mw
-Mw
+ZH
 QQ
-QQ
-QQ
-QQ
-QQ
-QQ
-QQ
-QQ
-QQ
+KV
+ij
+ad
+xF
+xF
+xF
+HQ
+ya
+iv
 QQ
 ry
 RW
@@ -45061,17 +45242,17 @@ Ap
 Lk
 Iv
 tg
-ng
+QQ
 VJ
-yF
+Ig
 Pm
 QM
 vC
 qg
 wF
-fH
+Ao
 ur
-VJ
+QQ
 rI
 kX
 BF
@@ -45318,17 +45499,17 @@ jd
 WZ
 WZ
 WZ
-WZ
-VJ
+QQ
+Fh
 Ig
 SQ
 nA
 ir
 SS
 Lf
-zV
+Ao
 kh
-VJ
+QQ
 AT
 kX
 BF
@@ -45572,14 +45753,14 @@ sO
 Zl
 wO
 Ap
-Mw
+Na
 Fl
 ZH
-Mw
-VJ
-bP
-fW
-IZ
+QQ
+mF
+Ig
+Sp
+Xf
 qK
 Xf
 qj
@@ -45828,21 +46009,21 @@ zu
 Jb
 WZ
 KJ
-Ap
+Em
 Np
 Kq
 bu
-py
-VJ
-VJ
-VJ
-VJ
-cH
-NK
-cC
+QQ
+yx
+Ig
+aM
+qg
+qg
+qg
+JZ
 Ao
 iM
-VJ
+QQ
 xE
 BF
 BF
@@ -46089,17 +46270,17 @@ fF
 pW
 Dx
 TS
-kb
-VJ
+QQ
+dI
 nF
 gM
 vt
 NK
-NK
+MT
 cf
 Hc
 ZO
-VJ
+QQ
 CO
 ye
 qE
@@ -46346,17 +46527,17 @@ xP
 vr
 iI
 ch
-AB
-VJ
-Ax
-CZ
-VJ
+QQ
+XZ
+Ug
+OU
+aM
 pR
 JZ
 OU
-cQ
 iX
-VJ
+iX
+QQ
 yI
 ww
 Qp
@@ -46604,16 +46785,16 @@ vg
 zv
 It
 ws
-VJ
-VJ
-VJ
-VJ
-VJ
-VJ
-VJ
-qf
-VJ
-VJ
+QQ
+QQ
+QQ
+QQ
+aL
+QQ
+QQ
+QQ
+QQ
+QQ
 ao
 wy
 ye
@@ -46865,10 +47046,10 @@ qE
 lj
 ye
 ye
-Cn
+lP
 ye
 ye
-Vm
+ye
 Cn
 Wj
 ye
@@ -47122,10 +47303,10 @@ Qp
 Qp
 Qp
 Qp
-Bl
+nx
 Qp
 iy
-Bo
+Qp
 Zu
 Qp
 QW
@@ -49695,7 +49876,7 @@ Rg
 gc
 HS
 MJ
-OI
+RK
 Oj
 RK
 oc
@@ -51750,7 +51931,7 @@ tb
 JW
 Cp
 tb
-Gs
+aE
 tb
 Cp
 tb
@@ -53015,7 +53196,7 @@ gw
 qV
 AY
 MB
-Mp
+na
 mA
 AY
 AY
@@ -53268,7 +53449,7 @@ BA
 BA
 BA
 BA
-wN
+BA
 tb
 gi
 mM
@@ -53518,16 +53699,16 @@ Id
 pN
 eu
 pN
-Qx
-Qx
-sf
-sf
-sf
-Qx
-Sg
-lw
-Qx
-Qx
+TK
+TK
+TK
+TK
+TK
+TK
+TK
+TK
+TK
+TK
 Fg
 hx
 ea
@@ -53775,16 +53956,16 @@ Id
 gB
 aS
 UW
-iw
+LE
 eC
 Fe
-rP
+TK
 hV
-Fy
+Mb
 sF
 CE
 Mb
-Qx
+TK
 Bu
 QX
 kD
@@ -54032,18 +54213,18 @@ Id
 my
 aS
 VD
-iw
+LE
 VZ
 oS
 TK
-oS
+Ml
 jt
 Pv
 tz
 NQ
 KY
-Qi
-YV
+mU
+Eg
 Hk
 fT
 IQ
@@ -54289,12 +54470,12 @@ qu
 tU
 iO
 rJ
-iw
+LE
 LE
 zC
-LE
-LE
-jt
+TK
+Ni
+NQ
 mY
 yT
 RS
@@ -54546,16 +54727,16 @@ la
 ie
 aS
 rJ
-iw
 LE
-LE
-zC
-LE
-jt
-mY
+jX
+MY
+TK
+Nq
+Qi
+dK
 Eu
 Xs
-Xs
+KY
 wQ
 Xq
 cg
@@ -54803,17 +54984,17 @@ Id
 my
 aS
 VD
-iw
-CM
 LE
-LE
-LE
-jt
-mY
+MY
+MY
+TK
+TK
+TK
+TK
 Fp
-gu
-KY
-OJ
+TK
+TK
+fP
 yL
 La
 mU
@@ -55060,16 +55241,16 @@ Id
 TR
 aS
 rJ
-iw
+LE
 cv
-LE
-Ie
-LE
-jt
-mY
-Fp
+ng
+MY
+NJ
+Qo
+ME
+rQ
 dL
-Qx
+TK
 xZ
 HI
 ec
@@ -55317,16 +55498,16 @@ Id
 rl
 fm
 rl
-iw
+LE
 ga
 BR
-ga
-ga
+Ay
+OI
 gJ
-mY
-Fp
+gJ
+qQ
 PO
-KY
+TK
 OJ
 yL
 Hk
@@ -55574,16 +55755,16 @@ gE
 Dc
 VS
 Ze
-Qx
-Qx
-Qx
-Qx
+TK
+kb
+oG
+Bo
 mB
-Qx
+Vm
 MY
 ni
 oD
-fC
+TK
 OJ
 HI
 bH
@@ -55829,18 +56010,18 @@ YJ
 dD
 rH
 oP
-Ni
+hX
 Uk
-Qx
+TK
 rd
 FE
-LE
+Bo
 of
-LE
+Vm
 HJ
-kJ
-Xs
-Xs
+MY
+MY
+TK
 MA
 si
 vl
@@ -56088,16 +56269,16 @@ rH
 Kb
 hX
 TL
-Qx
-cv
-LE
-LE
-LE
-LE
-HJ
-GO
-Ct
-KY
+TK
+TK
+TK
+TK
+TK
+TK
+TK
+TK
+TK
+TK
 Zd
 tV
 lQ
@@ -56343,14 +56524,14 @@ mN
 EG
 Ai
 LI
-rz
-dF
+hX
+LI
 Qx
 dd
 ZC
 Wa
-Wa
-Wa
+OY
+Vu
 fK
 fU
 eZ
@@ -56601,18 +56782,18 @@ gf
 Za
 Vh
 cd
-YJ
+ct
 Qx
-Qx
-Qx
-Qx
-en
+kt
+py
+Eb
+py
 Ua
-Qx
-Qx
-Qx
-Qx
-yL
+Vo
+oZ
+tM
+NT
+YV
 xO
 IQ
 IQ
@@ -56858,18 +57039,18 @@ Up
 SJ
 uY
 up
-YJ
-en
-en
-tt
-re
-en
-en
-en
-oZ
-en
+fn
 Qx
-yL
+Xd
+qf
+Xd
+Xd
+Ua
+yG
+oZ
+oh
+MQ
+YV
 xO
 IQ
 IQ
@@ -57116,19 +57297,19 @@ sd
 YJ
 YJ
 YJ
-en
-tE
-sg
-en
-en
-en
-en
-Xd
-en
 Qx
-at
-gq
-yL
+Xd
+Xd
+qf
+Xd
+Ua
+yG
+xI
+uB
+FR
+JL
+AK
+Xv
 Vd
 LD
 Xv
@@ -57371,19 +57552,19 @@ jQ
 jQ
 jQ
 jQ
-Ay
-JA
-en
+jQ
+gq
+Qx
 tt
 Xd
-en
-en
-en
-en
-en
-tt
-Qx
-yL
+Xd
+Xd
+Ua
+yG
+Ju
+BX
+NT
+tI
 yL
 yL
 kQ
@@ -57628,16 +57809,16 @@ NS
 NS
 NS
 NS
+NS
 Da
-JA
-en
+Qx
 wq
-cT
-en
-en
-en
-en
-LR
+Xd
+KE
+Xd
+Ua
+yG
+Ju
 Qa
 Qx
 co
@@ -57884,18 +58065,18 @@ Yv
 Yv
 Ci
 Ci
+bk
 NS
 Da
-JA
-tt
-en
-tt
-en
+Qx
 qr
-en
-en
-Xd
-en
+rz
+qr
+qr
+ZJ
+yG
+Ju
+IE
 Qx
 JA
 JA
@@ -58141,18 +58322,18 @@ lR
 lR
 rn
 Ci
+bk
 NS
 Da
-JA
-sg
-en
-Qa
-en
-en
-en
-Xd
-en
-tt
+Qx
+Qx
+Qx
+Qx
+Pt
+Qx
+Vk
+lT
+oh
 Qx
 vp
 Yq
@@ -58398,18 +58579,18 @@ lR
 lR
 rn
 Ci
+bk
 NS
 Da
-JA
-Xd
+Qx
 LR
-en
+sK
 Xd
-en
-tt
+Pz
+Xd
 Ur
-en
-en
+Xr
+mw
 Qx
 ER
 kF
@@ -58655,18 +58836,18 @@ lR
 lR
 rn
 Ci
+bk
 NS
 Da
-JA
-en
-tt
-en
-tt
-en
-en
-en
-LR
-tt
+Qx
+wq
+Xd
+Xd
+Xd
+Xd
+Ur
+cp
+KQ
 Qx
 ER
 MN
@@ -58912,18 +59093,18 @@ lR
 lR
 rn
 Ci
+bk
 NS
 Da
-JA
-en
-en
-en
-cT
-LR
+Qx
+kZ
+wN
 zS
-tt
-en
-en
+zS
+zS
+cM
+CJ
+CD
 Qx
 ER
 Ez
@@ -59169,15 +59350,15 @@ lR
 lR
 rn
 Ci
+bk
 NS
 Da
-JA
 Qx
 Qx
 Qx
 Qx
-Qx
-Qx
+PN
+gp
 Qx
 Qx
 Qx
@@ -59426,9 +59607,9 @@ lR
 lR
 rn
 Ci
+bk
 NS
 Lq
-jQ
 jQ
 jQ
 Eq
@@ -59683,7 +59864,7 @@ lR
 lR
 rn
 Ci
-NS
+bk
 NS
 NS
 NS


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bigger Captain office. CM inspired.

CL's office got smaller because captain is bigger.

Remove dark room simulation and put FC's room right at marine prep because FC WANTS TO SEE HIS PRIVATES!

More easter eggs.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Captain must have the bigger office. Also, remove dark room simulator because nobody uses it. Very sad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added new mechanics or gameplay changes
add: Added more mechanics or gameplay changes
expansion: Bigger Captain office. CM inspired.
add: CL's office got smaller because captain is bigger.
del: Remove dark room simulation
add: put FC's room right at marine prep because FC WANTS TO SEE HIS PRIVATES!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
