### PR TITLE
BR-8 scout rifle magazine assembly refill Cost Fix

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1702,7 +1702,7 @@ FACTORY
 /datum/supply_packs/factory/scout_rifle_magazine_refill
 	name = "BR-8 scout rifle magazine assembly refill"
 	contains = list(/obj/item/factory_refill/scout_rifle_magazine_refill)
-	cost = 50
+	cost = 20
 
 /datum/supply_packs/factory/claymorerefill
 	name = "Claymore parts refill"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
refill used to give 20 mag for 50 points. Now Buying 20 mag  is now cheaper than refilling.
Fix: cost before 5 points per magazine( if you buy 20 mag separately for 100 points) refill gives 20 mag for half the price (50 points for 20 mag)
Before: 5x20=100 (100\2=50)
Now: 2x20=40 (40\2 = 20 - refill price)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
![Screenshot_99](https://user-images.githubusercontent.com/116975250/199898239-f3024f95-9f76-4a66-9f7d-87d177cedf81.png)
![Screenshot_102](https://user-images.githubusercontent.com/116975250/199898266-6e28e21b-a57f-414a-b68d-c349ad5a42c0.png)
![Screenshot_100](https://user-images.githubusercontent.com/116975250/199898334-928e559c-8588-4249-a0dd-ada4b570a0a7.png)

:cl:
fix: Reqtorio refill Cost for scout  rifle decreased to reasonable levels
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
