### PR TITLE
facehuggers no longer disable lights and headset

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -538,13 +538,6 @@
 			if(!blocked)
 				M.visible_message(span_danger("[src] smashes against [M]'s [W.name] and rips it off!"))
 				M.dropItemToGround(W)
-			if(ishuman(M)) //Check for camera; if we have one, turn it off.
-				var/mob/living/carbon/human/H = M
-				if(istype(H.wear_ear, /obj/item/radio/headset/mainship/marine))
-					var/obj/item/radio/headset/mainship/marine/R = H.wear_ear
-					if(R.camera.status)
-						R.camera.toggle_cam(null, FALSE) //Turn camera off.
-						to_chat(H, "<span class='danger'>Your headset camera flickers off; you'll need to reactivate it by rebooting your headset HUD!<span>")
 
 	if(blocked)
 		M.visible_message(span_danger("[src] smashes against [M]'s [blocked]!"))
@@ -562,7 +555,6 @@
 		var/hugsound = user.gender == FEMALE ? get_sfx("female_hugged") : get_sfx("male_hugged")
 		playsound(loc, hugsound, 25, 0)
 	if(!sterile && !issynth(user))
-		user.disable_lights(sparks = TRUE, silent = TRUE)
 		var/stamina_dmg = user.maxHealth + user.max_stamina
 		user.apply_damage(stamina_dmg, STAMINA) // complete winds the target
 		user.Unconscious(2 SECONDS)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
facehuggers no longer disable your lights and headset cam when you are hugged
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
removes a cap gameplay relic
less overwatch screaming at marines to reboot their headsets and marines having to turn their lights back on
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: facehuggers no longer disable your lights and headset cam when you are hugged
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
