### PR TITLE
Bull Headbutt Adjustments (Primo Nerf Non Nuclear Edition)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -547,7 +547,9 @@
 		if(CHARGE_CRUSH)
 			Paralyze(CHARGE_SPEED(charge_datum) * 20)
 		if(CHARGE_BULL_HEADBUTT)
-			Paralyze(CHARGE_SPEED(charge_datum) * 25)
+			Paralyze(1) //Token paralyze to drop stuff etc...
+			adjust_stagger(CHARGE_SPEED(charge_datum) * 25)
+			add_slowdown(CHARGE_SPEED(charge_datum) * 10)
 
 	if(anchored)
 		charge_datum.do_stop_momentum(FALSE)


### PR DESCRIPTION
For the record I personally don't see the need for any changes, but if it helps the overall health of the game I am for it.

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the *still* far too long stun from bull headbutt charge, but keeps it as a viable tool both with and without primo.

## Why It's Good For The Game

The current state of headbutt especially with primo is unfun to face as a marine and boring to play as a xeno.

Better than the alternative of nerfing the primo gimmick into the ground when the real issue is the perma stun from headbutt, and maybe keeps primo bull a powerhouse of 1v1s.

## Changelog
:cl:
balance: Bull headbutt charge now staggers and slows instead of stunning.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
