### PR TITLE
Nuke Disk Gen minimap icon fix

### DIFF
--- a/code/game/objects/machinery/computer/nuke_disk_generator.dm
+++ b/code/game/objects/machinery/computer/nuke_disk_generator.dm
@@ -59,6 +59,7 @@
 
 	deltimer(current_timer)
 	current_timer = null
+	update_minimap_icon()
 	visible_message("<b>[src]</b> shuts down as it loses power. Any running programs will now exit")
 	return PROCESS_KILL
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Stop the minimap icon blinking when the console shuts down from power loss or hijack.

## Why It's Good For The Game

Fix good.

## Changelog
:cl:
fix: Fixed the Nuke Disk Gen minimap icon blinking forever in some cases.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
