### PR TITLE
Flamer particle colors

### DIFF
--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -481,7 +481,7 @@
 
 
 
-GLOBAL_DATUM_INIT(flamer_particles, /particles/flamer_fire, new)
+GLOBAL_LIST_EMPTY(flamer_particles)
 /particles/flamer_fire
 	icon = 'icons/effects/particles/fire.dmi'
 	icon_state = "bonfire"
@@ -499,6 +499,11 @@ GLOBAL_DATUM_INIT(flamer_particles, /particles/flamer_fire, new)
 	scale = generator("vector", list(0.3, 0.3), list(1,1), NORMAL_RAND)
 	rotation = 30
 	spin = generator("num", -20, 20)
+
+/particles/flamer_fire/New(set_color)
+	..()
+	if(set_color != "red") // we're already red colored by default
+		color = set_color
 
 /obj/flamer_fire
 	name = "fire"
@@ -520,7 +525,10 @@ GLOBAL_DATUM_INIT(flamer_particles, /particles/flamer_fire, new)
 
 /obj/flamer_fire/Initialize(mapload, fire_lvl, burn_lvl, f_color, fire_stacks = 0, fire_damage = 0)
 	. = ..()
-	particles = GLOB.flamer_particles
+
+	if(!GLOB.flamer_particles[f_color])
+		GLOB.flamer_particles[f_color] = new /particles/flamer_fire(f_color)
+	particles = GLOB.flamer_particles[f_color]
 
 	if(f_color)
 		flame_color = f_color


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

https://user-images.githubusercontent.com/57223640/200179538-42cf0f28-7ca2-41e0-a72c-d740137e8ebd.mp4

## Why It's Good For The Game

Blue fire is now dark blue instead of orange
## Changelog
:cl:
qol: flamer particles are now colored for blue/green fire
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
