### PR TITLE
Flick overlay view/item pickup/drop animation optimization

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -129,14 +129,13 @@
 		C.images += I
 	addtimer(CALLBACK(GLOBAL_PROC, /proc/remove_images_from_clients, I, show_to), duration, TIMER_CLIENT_TIME)
 
-
-/proc/flick_overlay_view(image/I, atom/target, duration) //wrapper for the above, flicks to everyone who can see the target atom
+///wrapper for flick_overlay(), flicks to everyone who can see the target atom
+/proc/flick_overlay_view(image/image_to_show, atom/target, duration)
 	var/list/viewing = list()
-	for(var/m in viewers(target))
-		var/mob/M = m
-		if(M.client)
-			viewing += M.client
-	flick_overlay(I, viewing, duration)
+	for(var/mob/viewer as anything in viewers(target))
+		if(viewer.client)
+			viewing += viewer.client
+	flick_overlay(image_to_show, viewing, duration)
 
 
 /proc/window_flash(client/C, ignorepref = FALSE)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -682,7 +682,7 @@
 	if(!I)
 		return
 
-	flick_overlay(I, GLOB.clients, 0.5 SECONDS)
+	flick_overlay_view(I, src, 0.5 SECONDS)
 
 	// And animate the attack!
 	animate(I, alpha = 175, pixel_x = 0, pixel_y = 0, pixel_z = 0, time = 3)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -682,7 +682,7 @@
 	if(!I)
 		return
 
-	flick_overlay_view(I, src, 0.5 SECONDS)
+	flick_overlay_view(I, A, 0.5 SECONDS)
 
 	// And animate the attack!
 	animate(I, alpha = 175, pixel_x = 0, pixel_y = 0, pixel_z = 0, time = 3)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -732,7 +732,7 @@ GLOBAL_DATUM_INIT(welding_sparks_prepdoor, /mutable_appearance, mutable_appearan
 		to_y += 10
 		pickup_animation.pixel_x += 6 * (prob(50) ? 1 : -1) //6 to the right or left, helps break up the straight upward move
 
-	flick_overlay(pickup_animation, GLOB.clients, 4)
+	flick_overlay_view(pickup_animation, src, 4)
 	var/matrix/animation_matrix = new(pickup_animation.transform)
 	animation_matrix.Turn(pick(-30, 30))
 	animation_matrix.Scale(0.65)


### PR DESCRIPTION
believe it or not, using GLOB.clients in a for loop for something that absolutely does not need it scales horribly