### PR TITLE
remove the 3 extra sentries and hsg marines get in crash

### DIFF
--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -675,9 +675,6 @@
 /area/shuttle/canterbury)
 "ql" = (
 /obj/structure/rack,
-/obj/item/storage/box/sentry,
-/obj/item/storage/box/sentry,
-/obj/item/storage/box/sentry,
 /obj/item/tool/screwdriver,
 /obj/item/tool/wrench,
 /obj/item/storage/toolbox/mechanical,
@@ -924,7 +921,6 @@
 /area/shuttle/canterbury)
 "Mj" = (
 /obj/structure/rack,
-/obj/item/storage/box/tl102,
 /obj/item/storage/toolbox/electrical,
 /obj/item/tool/hand_labeler,
 /obj/item/stack/barbed_wire/full,

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -142,7 +142,6 @@
 	},
 /obj/item/tool/hand_labeler,
 /obj/item/storage/toolbox/electrical,
-/obj/item/storage/box/tl102,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -168,9 +167,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/item/storage/box/sentry,
-/obj/item/storage/box/sentry,
-/obj/item/storage/box/sentry,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "ay" = (


### PR DESCRIPTION
## About The Pull Request
removes the 3 extra sentries and hsg in crash
## Why It's Good For The Game
3 sentries and a hsg is a bit much to deal with especially in lowpop xeno
## Changelog
:cl:
balance: remove the extra sentries and hsg in crash
/:cl:
