### PR TITLE
King Cost Significantly Reduced

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -305,7 +305,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	desc = "Places a Psychic Echo chamber that tallhosts can detect, then after a summon time selects a random sister to take over the mind of the gravity manipulating King."
 	icon = "king"
 	flags_gamemode = ABILITY_DISTRESS
-	psypoint_cost = 1800
+	psypoint_cost = 800
 
 /datum/hive_upgrade/xenos/king/can_buy(mob/living/carbon/xenomorph/buyer, silent = TRUE)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
King psypoint cost reduced from 1800 to 800.
## Why It's Good For The Game
While according to Tivi a king rework will come someday, until that day comes, having the current king be at a cost that better reflects its value is a good measure to do to make king less of a meme pick.

MJP approved! 
![image](https://user-images.githubusercontent.com/91219575/200632091-4f21358f-731a-4db4-a630-aa471671a5ee.png)
## Changelog
:cl:
balance: King psypoint cost reduced to 800
/:cl:
