### PR TITLE
Mechs take the same damage from crusher charge as anchored objects

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -410,6 +410,9 @@
 /obj/vehicle/unmanned/pre_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
 	return (CHARGE_SPEED(charge_datum) * 10)
 
+/obj/vehicle/sealed/mecha/pre_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
+	return (CHARGE_SPEED(charge_datum) * 240)
+
 /obj/structure/razorwire/pre_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
 	if(CHECK_BITFIELD(resistance_flags, INDESTRUCTIBLE) || charger.is_charging < CHARGE_ON)
 		charge_datum.do_stop_momentum()


### PR DESCRIPTION
## About The Pull Request

Title.

## Why It's Good For The Game

Currently it takes ~50 full speed charges to take down a 2500 HP mecha.

Crusher can delete rwalls in a single charge, yes there is some rng, but currently only does like 2 slashes worth of damage to a mech.

## Changelog
:cl:
balance: Mechs take the same damage from crusher charge as anchored objects.
/:cl:
