### PR TITLE
Make bookcases slashable by xenos

### DIFF
--- a/code/game/objects/structures/bookcase.dm
+++ b/code/game/objects/structures/bookcase.dm
@@ -3,6 +3,7 @@
 	name = "bookcase"
 	icon = 'icons/obj/structures/structures.dmi'
 	icon_state = "book-0"
+	resistance_flags = XENO_DAMAGEABLE
 	anchored = TRUE
 	density = TRUE
 	opacity = TRUE


### PR DESCRIPTION
## About The Pull Request

Title.

## Why It's Good For The Game

QOL.

Continuing on my last object update PRs to fix the overwhelming amount of objects that can only be destroyed by crusher or acid.

## Changelog
:cl:
qol: Xenos can now destroy bookshelves by slashing.
/:cl:
