### PR TITLE
Tiny perf improvement for guncode

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -470,8 +470,8 @@
 		new_state = base_gun_icon + "_l"
 
 	if(icon_state == new_state)
-		return
-	icon_state = new_state //apparently this helps with performance
+		return //small perf benefit
+	icon_state = new_state
 
 //manages the overlays for the gun - separate from attachment overlays
 /obj/item/weapon/gun/update_overlays()

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -459,16 +459,19 @@
 
 /obj/item/weapon/gun/update_icon_state()
 	. = ..()
+	var/new_state = base_gun_icon
 	if(CHECK_BITFIELD(reciever_flags, AMMO_RECIEVER_TOGGLES_OPEN) && !CHECK_BITFIELD(reciever_flags, AMMO_RECIEVER_CLOSED))
-		icon_state = base_gun_icon + "_o"
+		new_state = base_gun_icon + "_o"
 	else if(CHECK_BITFIELD(reciever_flags, AMMO_RECIEVER_REQUIRES_UNIQUE_ACTION) && !in_chamber && length(chamber_items))
-		icon_state = base_gun_icon + "_u"
+		new_state = base_gun_icon + "_u"
 	else if((!length(chamber_items) && max_chamber_items) || !rounds)
-		icon_state = base_gun_icon + "_e"
+		new_state = base_gun_icon + "_e"
 	else if(current_chamber_position <= length(chamber_items) && chamber_items[current_chamber_position] && chamber_items[current_chamber_position].loc != src)
-		icon_state = base_gun_icon + "_l"
-	else
-		icon_state = base_gun_icon
+		new_state = base_gun_icon + "_l"
+
+	if(icon_state == new_state)
+		return
+	icon_state = new_state //apparently this helps with performance
 
 //manages the overlays for the gun - separate from attachment overlays
 /obj/item/weapon/gun/update_overlays()


### PR DESCRIPTION
## About The Pull Request
Guns won't update their icon unless the icon state is actually changing. There is a slight performance benefit for doing it this way, and since gun are used by 50 people spamming update_icon multiple times per second, it can't hurt. May also further help with returning hyperscale guns.

Ideally byond would automatically do this but uh, byond.
## Why It's Good For The Game
Micro improvement good
## Changelog
:cl:
code: slightly improved gun icon updates
/:cl:
