### PR TITLE
Grav crush is actually effective against mechs

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -86,11 +86,6 @@
 	SEND_SIGNAL(src, COMSIG_OBJ_SETANCHORED, anchorvalue)
 	anchored = anchorvalue
 
-/obj/ex_act()
-	if(CHECK_BITFIELD(resistance_flags, INDESTRUCTIBLE))
-		return
-	return ..()
-
 /obj/item/proc/is_used_on(obj/O, mob/user)
 	return
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
@@ -112,6 +112,9 @@
 						continue
 				mob_crushed.ex_act(EXPLODE_LIGHT)
 				continue
+			else if(ismecha(item))
+				var/obj/vehicle/sealed/mecha/mech_crushed = item
+				mech_crushed.take_damage(rand(500, 800), BRUTE, "bomb", 0)
 			item.ex_act(EXPLODE_HEAVY)	//crushing without damaging the nearby area
 
 /datum/action/xeno_action/activable/gravity_crush/ai_should_start_consider()


### PR DESCRIPTION
## About The Pull Request
Grav crush does a sad 50-125 damage to mechs which can have over 3k hp.
Made grav crush do bonus 250-400 damage (after armour) against mechs, because they're big heavy robits so grav crush should have an outsized effect on them.

Also gives kings something to do other than crush cades and cope about being UP I guess.

And removed some random code, obj has two ex_acts so this did nothing as far as I could tell.
## Why It's Good For The Game
Makes grav crush a useful mechanic against mechs.
## Changelog
:cl:
balance: Gravcrush does bonus damage against mechs
/:cl:
