### PR TITLE
Fixes mech component damage and weapon integrity

### DIFF
--- a/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
@@ -24,7 +24,7 @@
 	)
 	mech_flags = EXOSUIT_MODULE_GREYSCALE
 	ammotype = /datum/ammo/bullet/pistol/mech
-	obj_integrity = 500
+	max_integrity = 500
 	projectiles = 20
 	projectiles_cache = 400
 	projectiles_cache_max = 400
@@ -49,7 +49,7 @@
 		MECHA_L_ARM = list("N" = list(-4,30), "S" = list(32,8), "E" = list(52,28), "W" = list(-20,8)),
 	)
 	ammotype = /datum/ammo/bullet/pistol/mech/burst
-	obj_integrity = 450
+	max_integrity = 450
 	projectiles = 42
 	projectiles_cache = 840
 	projectiles_cache_max = 840
@@ -76,7 +76,7 @@
 		MECHA_L_ARM = list("N" = list(-4,30), "S" = list(32,12), "E" = list(52,34), "W" = list(-22,14)),
 	)
 	ammotype = /datum/ammo/bullet/smg/mech
-	obj_integrity = 400
+	max_integrity = 400
 	projectiles = 60
 	projectiles_cache = 900
 	projectiles_cache_max = 900
@@ -100,7 +100,7 @@
 		MECHA_L_ARM = list("N" = list(-4,30), "S" = list(32,-6), "E" = list(63,37), "W" = list(-34,17)),
 	)
 	ammotype = /datum/ammo/bullet/rifle/mech/burst
-	obj_integrity = 400
+	max_integrity = 400
 	projectiles = 72
 	projectiles_cache = 720
 	projectiles_cache_max = 720
@@ -126,7 +126,7 @@
 		MECHA_L_ARM = list("N" = list(-4,30), "S" = list(32,-6), "E" = list(64,37), "W" = list(-34,17)),
 	)
 	ammotype = /datum/ammo/bullet/rifle/mech
-	obj_integrity = 400
+	max_integrity = 400
 	projectiles = 80
 	projectiles_cache = 960
 	projectiles_cache_max = 960
@@ -150,7 +150,7 @@
 		MECHA_L_ARM = list("N" = list(-4,30), "S" = list(32,-4), "E" = list(61,36), "W" = list(-31,16)),
 	)
 	ammotype = /datum/ammo/bullet/shotgun/mech
-	obj_integrity = 350
+	max_integrity = 350
 	projectiles = 10
 	projectiles_cache = 120
 	projectiles_cache_max = 120
@@ -174,7 +174,7 @@
 		MECHA_L_ARM = list("N" = list(-4,30), "S" = list(32,-6), "E" = list(64,37), "W" = list(-34,17)),
 	)
 	ammotype = /datum/ammo/bullet/rifle/mech/lmg
-	obj_integrity = 400
+	max_integrity = 400
 	projectiles = 120
 	projectiles_cache = 1200
 	projectiles_cache_max = 1200
@@ -198,7 +198,7 @@
 		MECHA_L_ARM = list("N" = list(-4,30), "S" = list(32,-15), "E" = list(80,24), "W" = list(-50,4)),
 	)
 	ammotype = /datum/ammo/tx54/mech
-	obj_integrity = 400
+	max_integrity = 400
 	projectiles = 30
 	projectiles_cache = 300
 	projectiles_cache_max = 300
@@ -222,7 +222,7 @@
 		MECHA_L_ARM = list("N" = list(0,68), "S" = list(32,-6), "E" = list(80,33), "W" = list(-50,13)),
 	)
 	ammotype = /datum/ammo/energy/lasgun/marine/mech
-	obj_integrity = 400
+	max_integrity = 400
 	energy_drain = 10
 	variance = 0
 	projectile_delay = 0.4 SECONDS
@@ -242,7 +242,7 @@
 		MECHA_L_ARM = list("N" = list(0,52), "S" = list(32,-6), "E" = list(75,31), "W" = list(-45,11)),
 	)
 	ammotype = /datum/ammo/energy/lasgun/marine/mech/burst
-	obj_integrity = 400
+	max_integrity = 400
 	energy_drain = 5
 	variance = 0
 	projectile_delay = 0.6 SECONDS
@@ -264,7 +264,7 @@
 	)
 	mech_flags = EXOSUIT_MODULE_GREYSCALE
 	ammotype = /datum/ammo/energy/lasgun/marine/mech/smg
-	obj_integrity = 400
+	max_integrity = 400
 	energy_drain = 5
 	variance = 0
 	projectile_delay = 0.2 SECONDS
@@ -284,7 +284,7 @@
 	)
 	mech_flags = EXOSUIT_MODULE_GREYSCALE
 	ammotype = /datum/ammo/bullet/apfsds
-	obj_integrity = 400
+	max_integrity = 400
 	projectiles = 1
 	projectiles_cache = 15
 	projectiles_cache_max = 15
@@ -309,7 +309,7 @@
 	)
 	mech_flags = EXOSUIT_MODULE_GREYSCALE
 	ammotype = /datum/ammo/bullet/minigun/mech
-	obj_integrity = 400
+	max_integrity = 400
 	projectiles = 200
 	projectiles_cache = 800
 	projectiles_cache_max = 800
@@ -334,7 +334,7 @@
 	)
 	mech_flags = EXOSUIT_MODULE_GREYSCALE
 	ammotype = /datum/ammo/bullet/sniper/mech
-	obj_integrity = 200
+	max_integrity = 200
 	projectiles = 15
 	projectiles_cache = 90
 	projectiles_cache_max = 90
@@ -354,7 +354,7 @@
 	fire_sound = 'sound/weapons/guns/fire/grenadelauncher.ogg'
 	mech_flags = EXOSUIT_MODULE_GREYSCALE
 	ammotype = /obj/item/explosive/grenade
-	obj_integrity = 350
+	max_integrity = 350
 	projectiles = 10
 	projectiles_cache = 40
 	projectiles_cache_max = 40
@@ -386,7 +386,7 @@
 	)
 	mech_flags = EXOSUIT_MODULE_GREYSCALE
 	ammotype = /datum/ammo/flamethrower/mech_flamer
-	obj_integrity = 250
+	max_integrity = 250
 	projectiles = 20
 	projectiles_cache = 20 // low ammo counts so player cant just spam fire while rushing infinitely
 	projectiles_cache_max = 20
@@ -410,7 +410,7 @@
 	)
 	mech_flags = EXOSUIT_MODULE_GREYSCALE
 	ammotype = /datum/ammo/rocket/mech
-	obj_integrity = 400
+	max_integrity = 400
 	projectiles = 1
 	projectiles_cache = 1
 	projectiles_cache_max = 1
@@ -435,7 +435,7 @@
 	desc = "A specialized mech laser blade made out of compressed energy with unimaginable power. Its compact size allows fast, short-ranged attacks. When activated, overloads the leg actuators to dash forward, before cutting with a superheated plasma beam. Melee core increases area cut and distance dashed. Heavy, but it is the top-of-the-line melee weapon of TGMC's fine line of mecha close-range offensive capability."
 	icon_state = "moonlight"
 	mech_flags = EXOSUIT_MODULE_GREYSCALE
-	obj_integrity = 400
+	max_integrity = 400
 	slowdown = 0
 	harmful = TRUE
 	equip_cooldown = 3 SECONDS

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -217,6 +217,11 @@
 	log_combat(user, src, "attacked", attacking_item)
 	log_message("Attacked by [user]. Item - [attacking_item], Damage - [damage_taken]", LOG_MECHA)
 
+/obj/vehicle/sealed/mecha/attack_generic(mob/user, damage_amount, damage_type, damage_flag, effects, armor_penetration)
+	. = ..()
+	if(.)
+		try_damage_component(., user.zone_selected)
+
 /obj/vehicle/sealed/mecha/wrench_act(mob/living/user, obj/item/I)
 	..()
 	. = TRUE


### PR DESCRIPTION
## About The Pull Request

Title, oversight

## Changelog
:cl:
fix: Fixes mech arm weapons not taking damage from xeno slashes when targetted and fixes their integrity being set to 400 regardless of intended HP(usually 300 or lower)
/:cl:
