### PR TITLE
APC prop QOL change

### DIFF
--- a/code/game/objects/structures/prop.dm
+++ b/code/game/objects/structures/prop.dm
@@ -1150,6 +1150,15 @@
 	resistance_flags = RESIST_ALL
 	layer = ABOVE_MOB_LAYER
 
+/obj/structure/prop/vehicle/apc/Initialize()
+	. = ..()
+	if(dir == EAST || dir == WEST)
+		bound_height = 64
+		pixel_y = -20
+	else
+		bound_width = 64
+		pixel_x = -34
+
 /obj/structure/prop/vehicle/apc/med
 	icon_state = "apc_base_med"
 


### PR DESCRIPTION
## About The Pull Request
Have you ever tried to walk past an APC prop only to reee in agony as you get blocked by an invisible wall?
No more.

Changed the position of the sprite and its hit box to actually reflect the amount of space it visually takes up.
![image](https://user-images.githubusercontent.com/7869430/201058935-9b40baad-784a-401a-b414-57c626b61b10.png)
## Why It's Good For The Game
Invisible walls obstructing movement when they don't appear like they should is bad.
## Changelog
:cl:
qol: Changed APC prop hitboxes to accurate reflect the amount of space they visually take up.
/:cl:
