### PR TITLE
TAT is now Acidable. All Mortars (artillery) can be slashed.

### DIFF
--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -419,6 +419,7 @@
 	deployable_item = /obj/machinery/deployable/mortar/double
 
 /obj/machinery/deployable/mortar/double
+	resistance_flags = XENO_DAMAGEABLE
 	tally_type = TALLY_MORTAR
 	reload_time = 1 SECONDS
 	fire_amount = 2
@@ -438,6 +439,7 @@
 	deployable_item = /obj/machinery/deployable/mortar/howitzer
 
 /obj/machinery/deployable/mortar/howitzer
+	resistance_flags = XENO_DAMAGEABLE
 	pixel_x = -16
 	anchored = FALSE // You can move this.
 	offset_per_turfs = 25
@@ -481,6 +483,7 @@
 	deployable_item = /obj/machinery/deployable/mortar/howitzer/rocket_arty
 
 /obj/machinery/deployable/mortar/howitzer/rocket_arty
+	resistance_flags = XENO_DAMAGEABLE
 	pixel_x = -16
 	anchored = FALSE // You can move this.
 	fire_sound = 'sound/weapons/guns/fire/rocket_arty.ogg'
@@ -510,6 +513,7 @@
 	deployable_item = /obj/machinery/deployable/mortar/howitzer/mlrs
 
 /obj/machinery/deployable/mortar/howitzer/mlrs
+	resistance_flags = XENO_DAMAGEABLE
 	pixel_x = 0
 	anchored = FALSE // You can move this.
 	fire_sound = 'sound/weapons/guns/fire/rocket_arty.ogg'

--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -414,7 +414,7 @@
 
 /obj/machinery/deployable/mounted/moveable/atgun
 	var/obj/item/storage/internal/ammo_rack/sponson = /obj/item/storage/internal/ammo_rack
-	resistance_flags = XENO_DAMAGEABLE|UNACIDABLE
+	resistance_flags = XENO_DAMAGEABLE
 	coverage = 75 //has a shield
 
 /obj/item/storage/internal/ammo_rack


### PR DESCRIPTION
## About The Pull Request
Title.
## Why It's Good For The Game
<s>Seems like an oversight that TAT couldn't be acided but slashed and vice versa for the Mortars. Better consistency.</s>
Artillery and hard hitting weapons should be defended better.
## Changelog
:cl:
balance: TAT can be acided.
balance: Mortars can be slashed.
/:cl:
