### PR TITLE
Rocket Storage Box QoL

### DIFF
--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -737,9 +737,6 @@
 	new /obj/item/storage/box/mlrs_rockets(src)
 	new /obj/item/storage/box/mlrs_rockets(src)
 	new /obj/item/storage/box/mlrs_rockets(src)
-	new /obj/item/storage/box/mlrs_rockets(src)
-	new /obj/item/storage/box/mlrs_rockets(src)
-	new /obj/item/storage/box/mlrs_rockets(src)
 	new /obj/item/encryptionkey/engi(src)
 	new /obj/item/encryptionkey/engi(src)
 	new /obj/item/binoculars/tactical/range(src)
@@ -752,10 +749,18 @@
 /obj/item/storage/box/mlrs_rockets
 	name = "\improper TA-40L rocket crate"
 	desc = "A large case containing rockets in a compressed setting for the TA-40L MLRS. Drag this sprite into you to open it up!\nNOTE: You cannot put items back inside this case."
-	storage_slots = 8
+	storage_slots = 16
 
 /obj/item/storage/box/mlrs_rockets/Initialize()
 	. = ..()
+	new /obj/item/mortal_shell/rocket/mlrs(src)
+	new /obj/item/mortal_shell/rocket/mlrs(src)
+	new /obj/item/mortal_shell/rocket/mlrs(src)
+	new /obj/item/mortal_shell/rocket/mlrs(src)
+	new /obj/item/mortal_shell/rocket/mlrs(src)
+	new /obj/item/mortal_shell/rocket/mlrs(src)
+	new /obj/item/mortal_shell/rocket/mlrs(src)
+	new /obj/item/mortal_shell/rocket/mlrs(src)
 	new /obj/item/mortal_shell/rocket/mlrs(src)
 	new /obj/item/mortal_shell/rocket/mlrs(src)
 	new /obj/item/mortal_shell/rocket/mlrs(src)

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -680,7 +680,7 @@ EXPLOSIVES
 /datum/supply_packs/explosives/mlrs_rockets
 	name = "TA-40L MLRS Rocket Pack (x8)"
 	contains = list(/obj/item/storage/box/mlrs_rockets)
-	cost = 3
+	cost = 6
 
 /datum/supply_packs/explosives/howitzer
 	name = "MG-100Y howitzer"


### PR DESCRIPTION

## About The Pull Request
TA-40L (MLRS) rocket boxes now carry 16 rockets instead of 8, req orders adjusted to balance for this
## Why It's Good For The Game
Just a QoL thing, instead of having to ask for 2 boxes for every 'volley', it is just a 1 box per volley.
## Changelog
:cl:
qol: TA-40L Rocket Boxes now carry 16 rockets instead of 8. Requisition adjusted to compensate.
/:cl:
