### PR TITLE
Mech engine rebalance

### DIFF
--- a/code/modules/vehicles/mecha/equipment/tools/greyscale_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/greyscale_tools.dm
@@ -31,17 +31,20 @@
 
 /obj/item/mecha_parts/mecha_equipment/generator/greyscale
 	name = "phoron engine"
-	desc = "An advanced Nanotrasen phoron engine core prototype designed for TGMC advanced mech exosuits. Uses solid phoron as fuel, click engine to refuel. The increased power generation comes at a cost to speed due to the weight."
+	desc = "An advanced Nanotrasen phoron engine core prototype designed for TGMC advanced mech exosuits. Uses solid phoron as fuel, click engine to refuel. The lightest engine mechs can use at a cost of recharge rate and max fuel capacity."
 	icon_state = "phoron_engine"
 	mech_flags = EXOSUIT_MODULE_GREYSCALE
-	rechargerate = 100
-	slowdown = 0.2
+	rechargerate = 5
+	slowdown = 0.3
+	max_fuel = 30000
 
 /obj/item/mecha_parts/mecha_equipment/generator/greyscale/upgraded
 	name = "fusion engine"
-	desc = "A highly experimental phoron fusion core. Generates more power at the same consumption rate, but slows you down even more than the standard phoron engine. Uses solid phoron as fuel, click engine to refuel. Nanotrasen does not take any responsibility in case of detonation."
+	desc = "A highly experimental phoron fusion core. Generates more power at the same consumption rate, but slows you down even more than the standard phoron engine. Uses solid phoron as fuel, click engine to refuel. The heaviest engine mechs can use at a cost of speed due to weight."
 	icon_state = "phoron_engine_adv"
-	slowdown = 0.4
+	rechargerate = 10
+	slowdown = 0.6
+	max_fuel = 60000
 
 /obj/item/mecha_parts/mecha_equipment/energy_optimizer
 	name = "energy optimizer"


### PR DESCRIPTION
## About The Pull Request

Rebalances the phoron and fusion engine

## Why It's Good For The Game

Makes the engines actually balanced and MPs actually have to consider which one is better for their build now, with phoron being better for lighter mechs but having less recharge rate and less capacity, and fusion being better for heavy builds but having more slowdown, also reduces max fuel capacity overall so MPs can't run around with infinite energy memes

## Changelog

:cl:
balance: Mech phoron and fusion engine have been rebalanced
/:cl:
