### PR TITLE
Makes mechs take damage from lava

### DIFF
--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -391,7 +391,7 @@
 		if(ismecha(thing))
 			var/mechdamage = (rand(40, 120))
 			var/obj/vehicle/sealed/mecha/burned_mech = thing
-			burned_mech.take_damage(mechdamage , BURN)
+			burned_mech.take_damage(mechdamage, BURN)
 			log_message("Received [mechdamage] burn damage from lava", LOG_MECHA, color="orange")
 			. = 1
 

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -382,7 +382,7 @@
 		STOP_PROCESSING(SSobj, src)
 
 /turf/open/lavaland/lava/proc/burn_stuff(AM)
-	. = 0
+	. = FALSE
 
 	var/thing_to_check = src
 	if (AM)
@@ -391,7 +391,7 @@
 		if(ismecha(thing))
 			var/obj/vehicle/sealed/mecha/burned_mech = thing
 			burned_mech.take_damage(rand(40, 120), BURN)
-			. = 1
+			. = TRUE
 
 		else if(isobj(thing))
 			var/obj/O = thing
@@ -408,7 +408,7 @@
 				if(!CHECK_BITFIELD(L.flags_pass, PASSFIRE))//Pass fire allow to cross lava without igniting
 					L.adjust_fire_stacks(20)
 					L.IgniteMob()
-				. = 1
+				. = TRUE
 
 /turf/open/lavaland/lava/attackby(obj/item/C, mob/user, params)
 	..()

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -389,6 +389,7 @@
 		thing_to_check = list(AM)
 	for(var/thing in thing_to_check)
 		if(ismecha(thing))
+			///simple holder to determine damage and output it for logging
 			var/mechdamage = (rand(40, 120))
 			var/obj/vehicle/sealed/mecha/burned_mech = thing
 			burned_mech.take_damage(mechdamage, BURN)

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -392,7 +392,8 @@
 			var/obj/vehicle/sealed/mecha/burned_mech = thing
 			burned_mech.take_damage(rand(40, 120), BURN)
 			. = 1
-		if(isobj(thing))
+
+		else if(isobj(thing))
 			var/obj/O = thing
 			O.fire_act(10000, 1000)
 

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -389,8 +389,10 @@
 		thing_to_check = list(AM)
 	for(var/thing in thing_to_check)
 		if(ismecha(thing))
+			var/mechdamage = (rand(40, 120))
 			var/obj/vehicle/sealed/mecha/burned_mech = thing
-			burned_mech.take_damage(rand(40, 120), BURN)
+			burned_mech.take_damage(mechdamage , BURN)
+			log_message("Received [mechdamage] burn damage from lava", LOG_MECHA, color="orange")
 			. = 1
 
 		else if(isobj(thing))

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -388,6 +388,10 @@
 	if (AM)
 		thing_to_check = list(AM)
 	for(var/thing in thing_to_check)
+		if(ismecha(thing))
+			var/obj/vehicle/sealed/mecha/burned_mech = thing
+			burned_mech.take_damage(rand(40, 120), BURN)
+			. = 1
 		if(isobj(thing))
 			var/obj/O = thing
 			O.fire_act(10000, 1000)

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -389,11 +389,8 @@
 		thing_to_check = list(AM)
 	for(var/thing in thing_to_check)
 		if(ismecha(thing))
-			///simple holder to determine damage and output it for logging
-			var/mechdamage = (rand(40, 120))
 			var/obj/vehicle/sealed/mecha/burned_mech = thing
-			burned_mech.take_damage(mechdamage, BURN)
-			log_message("Received [mechdamage] burn damage from lava", LOG_MECHA, color="orange")
+			burned_mech.take_damage(rand(40, 120), BURN)
 			. = 1
 
 		else if(isobj(thing))


### PR DESCRIPTION
## About The Pull Request

Title.
Mechs now take damage from standing in or entering lava. The exact damage numbers are up to change if maintainers think they're too strong/weak. The intent is just to discourage mechs sitting in lava more or less invulnerable to counter attack, not make mechs unable to cross a lava river.

## Why It's Good For The Game

Currently mechs can just sit in the middle of a lava pool indefinitely, as long as team xeno doesn't have an acid based caste there's nothing that can be really done about it. For that matter, even if team xeno does have an acid based caste, there's a number of alcoves in the rock surrounding lava that the mech can just hide in and pop out to snipe boilers aiming at them.

This PR imposes a marginal penalty for just sitting in the middle of a lava pool, they can potentially do it for quite some time but they take damage doing so and can't hold out in the middle of a lava river forever. As I stated above, I'm open to adjusting the numbers depending on maintainer feedback.

EDIT: During testing the current damage numbers allow for a fully healed mech to wade around in lava for around 2-3 minutes.

## Changelog
:cl:
balance: Mechs now take damage from standing in lava.
/:cl:
