### PR TITLE
Fixes weed landmark icon

### DIFF
--- a/code/game/objects/effects/landmarks/landmarks.dm
+++ b/code/game/objects/effects/landmarks/landmarks.dm
@@ -124,7 +124,7 @@
 /obj/effect/landmark/weed_node
 	name = "xeno weed node spawn landmark"
 	icon = 'icons/Xeno/weeds.dmi'
-	icon_state = "weednode"
+	icon_state = "weednode0"
 
 /obj/effect/landmark/weed_node/Initialize()
 	GLOB.xeno_weed_node_turfs += loc


### PR DESCRIPTION

## About The Pull Request

Title.

## Why It's Good For The Game

While https://github.com/tgstation/TerraGov-Marine-Corps/pull/11496 was a fantastic PR, it also broke the weed landmark icon so if you open up a map you'll see endless fields of this
![example9](https://user-images.githubusercontent.com/49290523/201436302-54429223-39c3-4692-859e-85948ff7f292.png)
As one of my guiding principles as map maintainer has been clear readability when it comes to mapping, they need to be fixed so as to be instantly understandable by mappers both new and old.


## Changelog
:cl:
fix: Fixed the weed landmark icon to properly display while mapping
/:cl:
