### PR TITLE
Infections Give Larva Points

### DIFF
--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -467,6 +467,8 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		dat += "[GLOB.round_statistics.larva_from_silo] larvas came from silos."
 	if(GLOB.round_statistics.larva_from_cocoon)
 		dat += "[GLOB.round_statistics.larva_from_cocoon] larvas came from cocoons."
+	if(GLOB.round_statistics.larva_from_embryo)
+		dat += "[GLOB.round_statistics.larva_from_embryo] larvas came from infections."
 	if(GLOB.round_statistics.larva_from_marine_spawning)
 		dat += "[GLOB.round_statistics.larva_from_marine_spawning] larvas came from marine spawning."
 	if(GLOB.round_statistics.larva_from_siloing_body)

--- a/code/datums/round_statistics.dm
+++ b/code/datums/round_statistics.dm
@@ -85,6 +85,7 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	var/larva_from_marine_spawning = 0
 	var/larva_from_silo = 0
 	var/larva_from_cocoon = 0
+	var/larva_from_embryo = 0
 	var/larva_from_psydrain = 0
 	var/larva_from_siloing_body = 0
 	var/req_items_produced = list()

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -64,6 +64,12 @@
 
 	process_growth()
 
+/obj/item/alien_embryo/proc/process_reward(var/points)
+	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
+	xeno_job.add_job_points(points)
+	var/datum/hive_status/hive_status = GLOB.hive_datums[hivenumber]
+	hive_status.update_tier_limits()
+	GLOB.round_statistics.larva_from_embryo += points / xeno_job.job_points_needed 
 
 /obj/item/alien_embryo/proc/process_growth()
 
@@ -81,6 +87,8 @@
 		counter = 0
 		stage++
 		log_combat(affected_mob, null, "had their embryo advance to stage [stage]")
+		if(stage >= 3)
+			process_reward(0.2)
 		var/mob/living/carbon/C = affected_mob
 		C.med_hud_set_status()
 		affected_mob.jitter(stage * 5)

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -64,7 +64,7 @@
 
 	process_growth()
 
-/obj/item/alien_embryo/proc/process_reward(var/points)
+/obj/item/alien_embryo/proc/process_reward(points)
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
 	xeno_job.add_job_points(points)
 	var/datum/hive_status/hive_status = GLOB.hive_datums[hivenumber]


### PR DESCRIPTION

## About The Pull Request
When an embryo reaches stage 2, subsequent stages give 0.2 job points towards the next larva. (This means that a infection that reaches stage 5 gives 0.6 points, stage 6 doesnt give anymore since that is burst)
## Why It's Good For The Game
As it stands, when an infection occurs via huggers, it only serves as a timer for marines to get to surgery, and as such has encouraged the practice of simply ignoring the infection for awhile until around five minutes past, then medevac to get it dealt with. This results in no boon for the xeno exlcuding the marine is now not on the ground (which doesn't do too much considering how fast said marine can come back, esp with drop pod).

This change gives the xenos a small but tangeable benefit to getting the hard to acquire infection, and moves the infection dynamic from a relic of the capture loop to something more fitting of the modern TGMC.

TLDR: Current infection system accounted for the infected to be captures by xenos, current state means infections are not really worth acquiring outside of the occasional burst from the bald marine, this will make xenos get a new larva quicker if the infection gets to the later stages

It is important to note that infections are very hard to acquire in the current state of the game, with infections only occuring via xeno intervention, marine being isolated, or dumb luck.
## Changelog
:cl:
add: Embryos now give 0.2 larva points to xenos when they reach stage 3-5.
/:cl:
