### PR TITLE
Carrier can switch huggers while resting

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -251,6 +251,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_CHOOSE_HUGGER,
 		KEYBINDING_ALTERNATE = COMSIG_XENOABILITY_SWITCH_HUGGER,
 	)
+	use_state_flags = XACT_USE_LYING
 
 /datum/action/xeno_action/choose_hugger_type/give_action(mob/living/L)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Carrier can switch type of hugger to use while resting
## Why It's Good For The Game
Quality of life, shouldn't affect any balance, just allows the carrier to change the hugger type they want while resting.
## Changelog
:cl:
qol: Carrier can switch hugger type while resting
/:cl:
