### PR TITLE
Emergency chem tweaks

### DIFF
--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -165,7 +165,7 @@
 
 /obj/item/reagent_containers/pill/inaprovaline
 	pill_desc = "An inaprovaline pill. Used to stabilize patients."
-	list_reagents = list(/datum/reagent/medicine/inaprovaline = 30)
+	list_reagents = list(/datum/reagent/medicine/inaprovaline = 15)
 	pill_id = 10
 
 /obj/item/reagent_containers/pill/dexalin

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -26,11 +26,6 @@
 		L.adjustBruteLoss(-L.getBruteLoss(TRUE) * 0.30)
 		L.adjustFireLoss(-L.getFireLoss(TRUE) * 0.30)
 		L.jitter(5)
-		for(var/datum/internal_organ/I AS in H.internal_organs)
-			if(I.damage)
-				if(I.damage < 29)
-					return
-				I.heal_organ_damage((I.damage-29) *effect_str)
 		TIMER_COOLDOWN_START(L, name, 300 SECONDS)
 
 /datum/reagent/medicine/inaprovaline/on_mob_delete(mob/living/L, metabolism)
@@ -473,11 +468,6 @@
 		L.adjustBruteLoss(-L.getBruteLoss(TRUE) * 0.20)
 		L.adjustFireLoss(-L.getFireLoss(TRUE) * 0.20)
 		L.jitter(10)
-		for(var/datum/internal_organ/I AS in H.internal_organs)
-			if(I.damage)
-				if(I.damage < 29)
-					return
-				I.heal_organ_damage((I.damage-29) *effect_str)
 		TIMER_COOLDOWN_START(L, name, 300 SECONDS)
 
 /datum/reagent/medicine/neuraline/on_mob_life(mob/living/L)
@@ -566,11 +556,6 @@
 		L.adjustBruteLoss(-L.getBruteLoss(TRUE) * 0.20)
 		L.adjustFireLoss(-L.getFireLoss(TRUE) * 0.20)
 		L.jitter(10)
-		for(var/datum/internal_organ/I AS in H.internal_organs)
-			if(I.damage)
-				if(I.damage < 29)
-					return
-				I.heal_organ_damage((I.damage-29) *effect_str)
 		TIMER_COOLDOWN_START(L, name, 300 SECONDS)
 
 /datum/reagent/medicine/russian_red/on_mob_life(mob/living/L, metabolism)
@@ -1288,7 +1273,7 @@
 			if(volume < 35) //allows 10 ticks of healing for 20 points of free heal to lower scratch damage bloodloss amounts.
 				L.reagents.add_reagent(/datum/reagent/medicine/research/medicalnanites, 0.1)
 
-			if (volume >5 && L.getBruteLoss(organic_only = TRUE))
+			if (volume > 5 && L.getBruteLoss(organic_only = TRUE))
 				L.heal_limb_damage(2*effect_str, 0)
 				L.adjustToxLoss(0.1*effect_str)
 				holder.remove_reagent(/datum/reagent/medicine/research/medicalnanites, 0.5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the organ healing from emergency chems (rr, neura, inaprov)
Reduces inaprov pill from 30u to 15u

## Why It's Good For The Game
The organ damage changes meant that e.g. having broken lungs is no longer hugely crippling, and the raw healing provided by the three is strong as is. Organ damage is supposed to be hard to remove, too.
Inaprov has fairly limited benefit after the initial application's heal, just minor pain relief and denying certain forms of oxloss. Reduces the dosage a: keeps it consistent with most other mainstay pills and b: lets it leave the body earlier to open chem slots back up.

## Changelog

:cl:
balance: Inaprov pills changed to 15u
balance: Inaprov, RR, and neuraline don't unbreak organs
/:cl:
