### PR TITLE
TL127 can now fit magnetic harness and motion sensor. Scope moved to barrel attachment.

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -656,7 +656,6 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 /obj/item/attachable/scope/unremovable
 	flags_attach_features = ATTACH_ACTIVATION
 
-
 /obj/item/attachable/scope/unremovable/flaregun
 	name = "long range ironsights"
 	desc = "An unremovable set of long range ironsights for a flaregun."
@@ -674,6 +673,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	wield_delay_mod = 0
 	desc = "A rail mounted zoom sight scope specialized for the AR-127 sniper rifle. Allows zoom by activating the attachment. Use F12 if your HUD doesn't come back."
 	flags_attach_features = ATTACH_ACTIVATION
+	slot = ATTACHMENT_BARREL_MOD
 
 /obj/item/attachable/scope/unremovable/heavymachinegun
 	name = "HMG-08 long range ironsights"

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -672,7 +672,6 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	aim_speed_mod = 0
 	wield_delay_mod = 0
 	desc = "A rail mounted zoom sight scope specialized for the AR-127 sniper rifle. Allows zoom by activating the attachment. Use F12 if your HUD doesn't come back."
-	flags_attach_features = ATTACH_ACTIVATION
 	slot = ATTACHMENT_BARREL_MOD
 
 /obj/item/attachable/scope/unremovable/heavymachinegun

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1181,6 +1181,14 @@
 		/obj/item/attachable/stock/tl127stock,
 	)
 
+	attachments_by_slot = list(
+		ATTACHMENT_SLOT_MUZZLE,
+		ATTACHMENT_SLOT_RAIL,
+		ATTACHMENT_SLOT_STOCK,
+		ATTACHMENT_SLOT_UNDER,
+		ATTACHMENT_BARREL_MOD,
+	)
+
 	burst_amount = 0
 	fire_delay = 1.35 SECONDS
 	accuracy_mult = 1.15

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1164,13 +1164,15 @@
 		/obj/item/attachable/bayonetknife,
 		/obj/item/attachable/compensator,
 		/obj/item/attachable/bipod,
+		/obj/item/attachable/magnetic_harness,
+		/obj/item/attachable/motiondetector,
 	)
 
 	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER
 	reciever_flags = AMMO_RECIEVER_REQUIRES_UNIQUE_ACTION|AMMO_RECIEVER_MAGAZINES|AMMO_RECIEVER_UNIQUE_ACTION_LOCKS|AMMO_RECIEVER_AUTO_EJECT
 	cocked_message = "You rack the bolt!"
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO)
-	attachable_offset = list("muzzle_x" = 41, "muzzle_y" = 19,"rail_x" = 8, "rail_y" = 21, "under_x" = 37, "under_y" = 16, "stock_x" = 9, "stock_y" = 12)
+	attachable_offset = list("muzzle_x" = 41, "muzzle_y" = 19,"rail_x" = 8, "rail_y" = 24, "under_x" = 37, "under_y" = 16, "stock_x" = 9, "stock_y" = 12, "barrel_x" = 8, "barrel_y" = 21)
 	actions_types = list(/datum/action/item_action/aim_mode)
 	aim_fire_delay = 1 SECONDS
 


### PR DESCRIPTION

## About The Pull Request
![image](https://user-images.githubusercontent.com/46353991/201513207-95ab4f88-6399-4d94-9532-96a9fda111cf.png)
![image](https://user-images.githubusercontent.com/46353991/201513214-5669dd68-22ce-4e45-ad32-fd26b4ab95f7.png)
TL-127 now can fit Magh and Tac sensor.
Technically, the scope is now a "barrel attachement" and by doing this PR I discovered barrel attachments don't fit on anything, not even the *Mateba* which was the last thing to use them. I might just remove snubnose Mateba.
## Why It's Good For The Game
Makes TL-127 more useable overall, in my opinion and gives it a gimmick, considering its bad in CQC, this makes sense as a change.
## Changelog
:cl:
balance: SR-127 can now fit a magnetic harness and motion detector.
/:cl:
