### PR TITLE
Mateba changes, removes snubnose, and some minor scatter buffs.

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1259,20 +1259,6 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 
 	update_icon()
 
-/obj/item/attachable/mateba_longbarrel
-	name = "Mateba long barrel"
-	desc = "A longer barrel for the Mateba, makes the gun more accurate and deal more damage on impact."
-	icon_state = "mateba_barrel"
-	slot = ATTACHMENT_BARREL_MOD
-	damage_mod = 0.20
-	scatter_mod = -2
-	damage_falloff_mod = -0.5
-	pixel_shift_x = 0
-	pixel_shift_y = 0
-	size_mod = 1
-	detach_delay = 0
-	gun_attachment_offset_mod = list("muzzle_x" = 8)
-
 /obj/item/attachable/buildasentry
 	name = "\improper Build-A-Sentry Attachment System"
 	icon = 'icons/Marine/sentry.dmi'

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -160,7 +160,7 @@
 //Mateba is pretty well known. The cylinder folds up instead of to the side. This has a non-marine version and a marine version.
 
 /obj/item/weapon/gun/revolver/mateba
-	name = "\improper R-24 autorevolver"
+	name = "\improper R-24 'Mateba' autorevolver"
 	desc = "The R-24 is the rather rare autorevolver used by the TGMC issued in rather small numbers to backline personnel and officers it uses recoil to spin the cylinder. Uses heavy .454 rounds."
 	icon_state = "mateba"
 	item_state = "mateba"
@@ -180,24 +180,19 @@
 		/obj/item/attachable/heavy_barrel,
 		/obj/item/attachable/compensator,
 		/obj/item/attachable/lace,
-		/obj/item/attachable/mateba_longbarrel,
 		/obj/item/attachable/buildasentry,
 		/obj/item/attachable/shoulder_mount,
 	)
-	starting_attachment_types = list(
-		/obj/item/attachable/mateba_longbarrel,
-	)
+
 	attachable_offset = list("muzzle_x" = 20, "muzzle_y" = 18,"rail_x" = 16, "rail_y" = 21, "under_x" = 22, "under_y" = 15, "stock_x" = 22, "stock_y" = 15)
 
-	damage_mult = 0.80
-	damage_falloff_mult = 1.5
 	fire_delay = 0.2 SECONDS
 	aim_fire_delay = 0.3 SECONDS
 	recoil = 0
 	accuracy_mult = 1.1
-	scatter = 5
+	scatter = 0
 	accuracy_mult_unwielded = 0.6
-	scatter_unwielded = 20
+	scatter_unwielded = 7
 
 /obj/item/weapon/gun/revolver/mateba/notmarine
 	name = "\improper Mateba autorevolver"


### PR DESCRIPTION

## About The Pull Request
Removes snubnose Mateba, it literally doesn't matter considering longbarrel hasn't worked for probably like half a year?
Moves all the Longbarrel stats to the default Mateba.
Scatter buff. 0 scatter wielded, 7 unwielded.
## Why It's Good For The Game
Basically just reverts Mateba to the pre-snubnose nerf with some minor buffs., it was unnecessary for it to get nerfed in the first place in my opinion and this should make it more appealing to order and get.
## Changelog
:cl:
balance: Mateba buffs, now has long barrel stats, removes snubnose and just makes the longbarrel form the default with the snubnose storage size.
/:cl:
