### PR TITLE
Dispenser nerfed to 48 max storage size from 63.

### DIFF
--- a/code/game/objects/items/storage/dispenser.dm
+++ b/code/game/objects/items/storage/dispenser.dm
@@ -114,7 +114,7 @@
 	icon_state = "dispenser"
 	flags_equip_slot = ITEM_SLOT_BACK
 	max_w_class = 6
-	max_storage_space = 63
+	max_storage_space = 48
 	max_integrity = 250
 
 /obj/item/storage/backpack/dispenser/Initialize(mapload, ...)


### PR DESCRIPTION

## About The Pull Request
Dispenser storage size 63->48.
## Why It's Good For The Game
Backpacks are 24, you're telling me dispenser is about 2.3 times as big as a normal backpack, fits bulky items and fits on your back?

Thats absurd considering the only trade off is that you have to buy and deploy it to me. Should be more balanced being twice as big as a backpack overall.
## Changelog
:cl:
balance: Dispenser storage amount nerfed from being about two and a half times bigger than a normal backpack to only being twice as big as a backpack in storage amount.
/:cl:
