### PR TITLE
Makes rejuvenate and feast work even if staggered

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -244,6 +244,7 @@
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_REJUVENATE,
 	)
 	keybind_flags = XACT_KEYBIND_USE_ABILITY
+	use_state_flags = XACT_USE_STAGGERED
 
 /datum/action/xeno_action/activable/rejuvenate/can_use_ability(atom/A, silent, override_flags)
 	. = ..()
@@ -410,6 +411,7 @@
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_FEAST,
 	)
 	keybind_flags = XACT_KEYBIND_USE_ABILITY
+	use_state_flags = XACT_USE_STAGGERED
 
 /datum/action/xeno_action/activable/feast/can_use_ability(atom/target, silent, override_flags)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Allows the tank to live up to their name and continue fighting and soaking damage for their fellow xenos

## Why It's Good For The Game
I believe that a caste which is supposed to soak damage should be able to do so properly

## Changelog
:cl:
balance: made it possible for gorger to activate feast or rejuvenete while staggered
/:cl:
