### PR TITLE
Spawned in xenos have correct age

### DIFF
--- a/code/modules/events/hive_threat.dm
+++ b/code/modules/events/hive_threat.dm
@@ -53,7 +53,10 @@
 			receiving_xeno.evolution_stored = receiving_xeno.xeno_caste.evolution_threshold
 			if(receiving_xeno.tier == XENO_UPGRADE_FOUR || receiving_xeno.tier == XENO_UPGRADE_THREE)
 				continue
-			receiving_xeno.upgrade_xeno(XENO_UPGRADE_THREE)
+			var/datum/xeno_caste/tier_two = GLOB.xeno_caste_datums[receiving_xeno.caste_base_type][XENO_UPGRADE_TWO]
+			if(!tier_two)
+				continue
+			receiving_xeno.upgrade_stored = tier_two.upgrade_threshold
 	SEND_SOUND(GLOB.alive_xeno_list, sound(get_sfx("queen"), channel = CHANNEL_ANNOUNCEMENTS, volume = 50))
 	addtimer(CALLBACK(src, .proc/remove_blessing), 2 MINUTES)
 

--- a/code/modules/mob/living/carbon/xenomorph/xenoupgrade.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoupgrade.dm
@@ -96,15 +96,19 @@
 
 /mob/living/carbon/xenomorph/runner/mature
 	upgrade = XENO_UPGRADE_ONE
+	upgrade_stored = TIER_ONE_YOUNG_THRESHOLD
 
 /mob/living/carbon/xenomorph/runner/elder
 	upgrade = XENO_UPGRADE_TWO
+	upgrade_stored = TIER_ONE_MATURE_THRESHOLD
 
 /mob/living/carbon/xenomorph/runner/ancient
 	upgrade = XENO_UPGRADE_THREE
+	upgrade_stored = TIER_ONE_ELDER_THRESHOLD
 
 /mob/living/carbon/xenomorph/runner/primordial
 	upgrade = XENO_UPGRADE_FOUR
+	upgrade_stored = TIER_ONE_ANCIENT_THRESHOLD
 
 //-----RUNNER END-----//
 //================//
@@ -112,15 +116,19 @@
 
 /mob/living/carbon/xenomorph/bull/mature
 	upgrade = XENO_UPGRADE_ONE
+	upgrade_stored = TIER_TWO_YOUNG_THRESHOLD
 
 /mob/living/carbon/xenomorph/bull/elder
 	upgrade = XENO_UPGRADE_TWO
+	upgrade_stored = TIER_TWO_MATURE_THRESHOLD
 
 /mob/living/carbon/xenomorph/bull/ancient
 	upgrade = XENO_UPGRADE_THREE
+	upgrade_stored = TIER_TWO_ELDER_THRESHOLD
 
 /mob/living/carbon/xenomorph/bull/primordial
 	upgrade = XENO_UPGRADE_FOUR
+	upgrade_stored = TIER_TWO_ANCIENT_THRESHOLD
 
 //-----BULL END-----//
 //================//
@@ -128,15 +136,19 @@
 
 /mob/living/carbon/xenomorph/drone/mature
 	upgrade = XENO_UPGRADE_ONE
+	upgrade_stored = TIER_ONE_YOUNG_THRESHOLD
 
 /mob/living/carbon/xenomorph/drone/elder
 	upgrade = XENO_UPGRADE_TWO
+	upgrade_stored = TIER_ONE_MATURE_THRESHOLD
 
 /mob/living/carbon/xenomorph/drone/ancient
 	upgrade = XENO_UPGRADE_THREE
+	upgrade_stored = TIER_ONE_ELDER_THRESHOLD
 
 /mob/living/carbon/xenomorph/drone/primordial
 	upgrade = XENO_UPGRADE_FOUR
+	upgrade_stored = TIER_ONE_ANCIENT_THRESHOLD
 
 //-----DRONE END-----//
 //================//
@@ -162,15 +174,19 @@
 
 /mob/living/carbon/xenomorph/carrier/mature
 	upgrade = XENO_UPGRADE_ONE
+	upgrade_stored = TIER_TWO_YOUNG_THRESHOLD
 
 /mob/living/carbon/xenomorph/carrier/elder
 	upgrade = XENO_UPGRADE_TWO
+	upgrade_stored = TIER_TWO_MATURE_THRESHOLD
 
 /mob/living/carbon/xenomorph/carrier/ancient
 	upgrade = XENO_UPGRADE_THREE
+	upgrade_stored = TIER_TWO_ELDER_THRESHOLD
 
 /mob/living/carbon/xenomorph/carrier/primordial
 	upgrade = XENO_UPGRADE_FOUR
+	upgrade_stored = TIER_TWO_ANCIENT_THRESHOLD
 
 //-----CARRIER END-----//
 //================//
@@ -178,15 +194,19 @@
 
 /mob/living/carbon/xenomorph/hivelord/mature
 	upgrade = XENO_UPGRADE_ONE
+	upgrade_stored = TIER_TWO_YOUNG_THRESHOLD
 
 /mob/living/carbon/xenomorph/hivelord/elder
 	upgrade = XENO_UPGRADE_TWO
+	upgrade_stored = TIER_TWO_MATURE_THRESHOLD
 
 /mob/living/carbon/xenomorph/hivelord/ancient
 	upgrade = XENO_UPGRADE_THREE
+	upgrade_stored = TIER_TWO_ELDER_THRESHOLD
 
 /mob/living/carbon/xenomorph/hivelord/primordial
 	upgrade = XENO_UPGRADE_FOUR
+	upgrade_stored = TIER_TWO_ANCIENT_THRESHOLD
 
 //----HIVELORD END----//
 //================//
@@ -196,15 +216,19 @@
 
 /mob/living/carbon/xenomorph/praetorian/mature
 	upgrade = XENO_UPGRADE_ONE
+	upgrade_stored = TIER_THREE_YOUNG_THRESHOLD
 
 /mob/living/carbon/xenomorph/praetorian/elder
 	upgrade = XENO_UPGRADE_TWO
+	upgrade_stored = TIER_THREE_MATURE_THRESHOLD
 
 /mob/living/carbon/xenomorph/praetorian/ancient
 	upgrade = XENO_UPGRADE_THREE
+	upgrade_stored = TIER_THREE_ELDER_THRESHOLD
 
 /mob/living/carbon/xenomorph/praetorian/primordial
 	upgrade = XENO_UPGRADE_FOUR
+	upgrade_stored = TIER_THREE_ANCIENT_THRESHOLD
 
 //----PRAETORIAN END----//
 //================//
@@ -212,15 +236,19 @@
 
 /mob/living/carbon/xenomorph/ravager/mature
 	upgrade = XENO_UPGRADE_ONE
+	upgrade_stored = TIER_THREE_YOUNG_THRESHOLD
 
 /mob/living/carbon/xenomorph/ravager/elder
 	upgrade = XENO_UPGRADE_TWO
+	upgrade_stored = TIER_THREE_MATURE_THRESHOLD
 
 /mob/living/carbon/xenomorph/ravager/ancient
 	upgrade = XENO_UPGRADE_THREE
+	upgrade_stored = TIER_THREE_ELDER_THRESHOLD
 
 /mob/living/carbon/xenomorph/ravager/primordial
 	upgrade = XENO_UPGRADE_FOUR
+	upgrade_stored = TIER_THREE_ANCIENT_THRESHOLD
 
 //----RAVAGER END----//
 //================//
@@ -228,15 +256,19 @@
 
 /mob/living/carbon/xenomorph/sentinel/mature
 	upgrade = XENO_UPGRADE_ONE
+	upgrade_stored = TIER_ONE_YOUNG_THRESHOLD
 
 /mob/living/carbon/xenomorph/sentinel/elder
 	upgrade = XENO_UPGRADE_TWO
+	upgrade_stored = TIER_ONE_MATURE_THRESHOLD
 
 /mob/living/carbon/xenomorph/sentinel/ancient
 	upgrade = XENO_UPGRADE_THREE
+	upgrade_stored = TIER_ONE_ELDER_THRESHOLD
 
 /mob/living/carbon/xenomorph/sentinel/primordial
 	upgrade = XENO_UPGRADE_FOUR
+	upgrade_stored = TIER_ONE_ANCIENT_THRESHOLD
 
 //----SENTINEL END----//
 //================//
@@ -244,15 +276,19 @@
 
 /mob/living/carbon/xenomorph/spitter/mature
 	upgrade = XENO_UPGRADE_ONE
+	upgrade_stored = TIER_TWO_YOUNG_THRESHOLD
 
 /mob/living/carbon/xenomorph/spitter/elder
 	upgrade = XENO_UPGRADE_TWO
+	upgrade_stored = TIER_TWO_MATURE_THRESHOLD
 
 /mob/living/carbon/xenomorph/spitter/ancient
 	upgrade = XENO_UPGRADE_THREE
+	upgrade_stored = TIER_TWO_ELDER_THRESHOLD
 
 /mob/living/carbon/xenomorph/spitter/primordial
 	upgrade = XENO_UPGRADE_FOUR
+	upgrade_stored = TIER_TWO_ANCIENT_THRESHOLD
 
 //-----SPITTER END-----//
 //================//
@@ -276,15 +312,19 @@
 
 /mob/living/carbon/xenomorph/hunter/mature
 	upgrade = XENO_UPGRADE_ONE
+	upgrade_stored = TIER_TWO_YOUNG_THRESHOLD
 
 /mob/living/carbon/xenomorph/hunter/elder
 	upgrade = XENO_UPGRADE_TWO
+	upgrade_stored = TIER_TWO_MATURE_THRESHOLD
 
 /mob/living/carbon/xenomorph/hunter/ancient
 	upgrade = XENO_UPGRADE_THREE
+	upgrade_stored = TIER_TWO_ELDER_THRESHOLD
 
 /mob/living/carbon/xenomorph/hunter/primordial
 	upgrade = XENO_UPGRADE_FOUR
+	upgrade_stored = TIER_TWO_ANCIENT_THRESHOLD
 
 //----HUNTER END----//
 //================//
@@ -308,15 +348,19 @@
 
 /mob/living/carbon/xenomorph/queen/mature
 	upgrade = XENO_UPGRADE_ONE
+	upgrade_stored = TIER_THREE_YOUNG_THRESHOLD
 
 /mob/living/carbon/xenomorph/queen/elder
 	upgrade = XENO_UPGRADE_TWO
+	upgrade_stored = TIER_THREE_MATURE_THRESHOLD
 
 /mob/living/carbon/xenomorph/queen/ancient
 	upgrade = XENO_UPGRADE_THREE
+	upgrade_stored = TIER_THREE_ELDER_THRESHOLD
 
 /mob/living/carbon/xenomorph/queen/primordial
 	upgrade = XENO_UPGRADE_FOUR
+	upgrade_stored = TIER_THREE_ANCIENT_THRESHOLD
 
 //----QUEEN END----//
 //============//
@@ -324,15 +368,19 @@
 
 /mob/living/carbon/xenomorph/crusher/mature
 	upgrade = XENO_UPGRADE_ONE
+	upgrade_stored = TIER_THREE_YOUNG_THRESHOLD
 
 /mob/living/carbon/xenomorph/crusher/elder
 	upgrade = XENO_UPGRADE_TWO
+	upgrade_stored = TIER_THREE_MATURE_THRESHOLD
 
 /mob/living/carbon/xenomorph/crusher/ancient
 	upgrade = XENO_UPGRADE_THREE
+	upgrade_stored = TIER_THREE_ELDER_THRESHOLD
 
 /mob/living/carbon/xenomorph/crusher/primordial
 	upgrade = XENO_UPGRADE_FOUR
+	upgrade_stored = TIER_THREE_ANCIENT_THRESHOLD
 
 //---CRUSHER END---//
 //============//
@@ -340,15 +388,19 @@
 
 /mob/living/carbon/xenomorph/gorger/mature
 	upgrade = XENO_UPGRADE_ONE
+	upgrade_stored = TIER_THREE_YOUNG_THRESHOLD
 
 /mob/living/carbon/xenomorph/gorger/elder
 	upgrade = XENO_UPGRADE_TWO
+	upgrade_stored = TIER_THREE_MATURE_THRESHOLD
 
 /mob/living/carbon/xenomorph/gorger/ancient
 	upgrade = XENO_UPGRADE_THREE
+	upgrade_stored = TIER_THREE_ELDER_THRESHOLD
 
 /mob/living/carbon/xenomorph/gorger/primordial
 	upgrade = XENO_UPGRADE_FOUR
+	upgrade_stored = TIER_THREE_ANCIENT_THRESHOLD
 
 //---GORGER END---//
 //============//
@@ -356,15 +408,19 @@
 
 /mob/living/carbon/xenomorph/boiler/mature
 	upgrade = XENO_UPGRADE_ONE
+	upgrade_stored = TIER_THREE_YOUNG_THRESHOLD
 
 /mob/living/carbon/xenomorph/boiler/elder
 	upgrade = XENO_UPGRADE_TWO
+	upgrade_stored = TIER_THREE_MATURE_THRESHOLD
 
 /mob/living/carbon/xenomorph/boiler/ancient
 	upgrade = XENO_UPGRADE_THREE
+	upgrade_stored = TIER_THREE_ELDER_THRESHOLD
 
 /mob/living/carbon/xenomorph/boiler/primordial
 	upgrade = XENO_UPGRADE_FOUR
+	upgrade_stored = TIER_THREE_ANCIENT_THRESHOLD
 
 //---BOILER END---//
 //============//
@@ -372,15 +428,19 @@
 
 /mob/living/carbon/xenomorph/defender/mature
 	upgrade = XENO_UPGRADE_ONE
+	upgrade_stored = TIER_ONE_YOUNG_THRESHOLD
 
 /mob/living/carbon/xenomorph/defender/elder
 	upgrade = XENO_UPGRADE_TWO
+	upgrade_stored = TIER_ONE_MATURE_THRESHOLD
 
 /mob/living/carbon/xenomorph/defender/ancient
 	upgrade = XENO_UPGRADE_THREE
+	upgrade_stored = TIER_ONE_ELDER_THRESHOLD
 
 /mob/living/carbon/xenomorph/defender/primordial
 	upgrade = XENO_UPGRADE_FOUR
+	upgrade_stored = TIER_ONE_ANCIENT_THRESHOLD
 
 //---DEFENDER END---//
 //============//
@@ -388,15 +448,19 @@
 
 /mob/living/carbon/xenomorph/warrior/mature
 	upgrade = XENO_UPGRADE_ONE
+	upgrade_stored = TIER_TWO_YOUNG_THRESHOLD
 
 /mob/living/carbon/xenomorph/warrior/elder
 	upgrade = XENO_UPGRADE_TWO
+	upgrade_stored = TIER_TWO_MATURE_THRESHOLD
 
 /mob/living/carbon/xenomorph/warrior/ancient
 	upgrade = XENO_UPGRADE_THREE
+	upgrade_stored = TIER_TWO_ELDER_THRESHOLD
 
 /mob/living/carbon/xenomorph/warrior/primordial
 	upgrade = XENO_UPGRADE_FOUR
+	upgrade_stored = TIER_TWO_ANCIENT_THRESHOLD
 
 //----WARRIOR END----//
 //============//
@@ -404,15 +468,19 @@
 
 /mob/living/carbon/xenomorph/defiler/mature
 	upgrade = XENO_UPGRADE_ONE
+	upgrade_stored = TIER_THREE_YOUNG_THRESHOLD
 
 /mob/living/carbon/xenomorph/defiler/elder
 	upgrade = XENO_UPGRADE_TWO
+	upgrade_stored = TIER_THREE_MATURE_THRESHOLD
 
 /mob/living/carbon/xenomorph/defiler/ancient
 	upgrade = XENO_UPGRADE_THREE
+	upgrade_stored = TIER_THREE_ELDER_THRESHOLD
 
 /mob/living/carbon/xenomorph/defiler/primordial
 	upgrade = XENO_UPGRADE_FOUR
+	upgrade_stored = TIER_THREE_ANCIENT_THRESHOLD
 
 //----DEFILER END----//
 //============//
@@ -420,30 +488,38 @@
 
 /mob/living/carbon/xenomorph/shrike/mature
 	upgrade = XENO_UPGRADE_ONE
+	upgrade_stored = TIER_TWO_YOUNG_THRESHOLD
 
 /mob/living/carbon/xenomorph/shrike/elder
 	upgrade = XENO_UPGRADE_TWO
+	upgrade_stored = TIER_TWO_MATURE_THRESHOLD
 
 /mob/living/carbon/xenomorph/shrike/ancient
 	upgrade = XENO_UPGRADE_THREE
+	upgrade_stored = TIER_TWO_ELDER_THRESHOLD
 
 /mob/living/carbon/xenomorph/shrike/primordial
 	upgrade = XENO_UPGRADE_FOUR
+	upgrade_stored = TIER_TWO_ANCIENT_THRESHOLD
 
 //----SHRIKE END----//
 //============//
 //----WRAITH START----//
 /mob/living/carbon/xenomorph/wraith/mature
 	upgrade = XENO_UPGRADE_ONE
+	upgrade_stored = TIER_TWO_YOUNG_THRESHOLD
 
 /mob/living/carbon/xenomorph/wraith/elder
 	upgrade = XENO_UPGRADE_TWO
+	upgrade_stored = TIER_TWO_MATURE_THRESHOLD
 
 /mob/living/carbon/xenomorph/wraith/ancient
 	upgrade = XENO_UPGRADE_THREE
+	upgrade_stored = TIER_TWO_ELDER_THRESHOLD
 
 /mob/living/carbon/xenomorph/wraith/primordial
 	upgrade = XENO_UPGRADE_FOUR
+	upgrade_stored = TIER_TWO_ANCIENT_THRESHOLD
 
 //----WRAITH END----//
 //============//
@@ -451,15 +527,19 @@
 
 /mob/living/carbon/xenomorph/widow/mature
 	upgrade = XENO_UPGRADE_ONE
+	upgrade_stored = TIER_THREE_YOUNG_THRESHOLD
 
 /mob/living/carbon/xenomorph/widow/elder
 	upgrade = XENO_UPGRADE_TWO
+	upgrade_stored = TIER_THREE_MATURE_THRESHOLD
 
 /mob/living/carbon/xenomorph/widow/ancient
 	upgrade = XENO_UPGRADE_THREE
+	upgrade_stored = TIER_THREE_ELDER_THRESHOLD
 
 /mob/living/carbon/xenomorph/widow/primordial
 	upgrade = XENO_UPGRADE_FOUR
+	upgrade_stored = TIER_THREE_ANCIENT_THRESHOLD
 
 //----WIDOW END----//
 //============//


### PR DESCRIPTION
## About The Pull Request
Mature/elder/etc xenos have the correct stocked age when created by spawning directly. No gameplay changes
## Why It's Good For The Game
can be worked around by varediting/xeno panel but easier to not bother
## Changelog

:cl:
fix: Spawning in aged xenos via admin tools will give them the proper upgrade_stored for their maturity level
fix: Draining the hive threat target give you the necessary stored age for ancient instead of setting you ancient and leaving it too low
/:cl:
