### PR TITLE
Adds a hotkey for place acid well

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -637,6 +637,7 @@
 #define COMSIG_XENOABILITY_DROP_PLANT "xenoability_drop_plant"
 #define COMSIG_XENOABILITY_CHOOSE_PLANT "xenoability_choose_plant"
 #define COMSIG_XENOABILITY_SECRETE_RESIN "xenoability_secrete_resin"
+#define COMSIG_XENOABILITY_PLACE_ACID_WELL "place_acid_well"
 #define COMSIG_XENOABILITY_EMIT_RECOVERY "xenoability_emit_recovery"
 #define COMSIG_XENOABILITY_EMIT_WARDING "xenoability_emit_warding"
 #define COMSIG_XENOABILITY_EMIT_FRENZY "xenoability_emit_frenzy"

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -45,6 +45,7 @@
 	full_name = "Place acid well"
 	description = "Builds acid well on your tile."
 	keybind_signal = COMSIG_XENOABILITY_PLACE_ACID_WELL
+	hotkey_keys = list("G")
 
 /datum/keybinding/xeno/emit_recovery
 	name = "emit_recovery"

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -40,6 +40,12 @@
 	description = "Builds whatever you’ve selected with (choose resin structure) on your tile."
 	keybind_signal = COMSIG_XENOABILITY_SECRETE_RESIN
 
+/datum/keybinding/xeno/place_acid_well
+	name = "place_acid_well"
+	full_name = "Place acid well"
+	description = "Builds acid well on your tile."
+	keybind_signal = COMSIG_XENOABILITY_PLACE_ACID_WELL
+
 /datum/keybinding/xeno/emit_recovery
 	name = "emit_recovery"
 	full_name = "Emit Recovery Pheromones"

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -214,7 +214,6 @@
 			FH.kill_hugger()
 
 
-
 // ***************************************
 // *********** Psychic Cure
 // ***************************************
@@ -297,6 +296,7 @@
 	succeed_activate()
 	add_cooldown()
 
+
 // ***************************************
 // *********** Construct Acid Well
 // ***************************************
@@ -307,7 +307,7 @@
 	plasma_cost = 400
 	cooldown_timer = 2 MINUTES
 	keybinding_signals = list(
-	KEYBINDING_NORMAL = COMSIG_XENOABILITY_PSYCHIC_CURE,
+	KEYBINDING_NORMAL = COMSIG_XENOABILITY_PLACE_ACID_WELL,
 	)
 
 /datum/action/xeno_action/place_acidwell/can_use_action(silent = FALSE, override_flags)

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -307,7 +307,7 @@
 	plasma_cost = 400
 	cooldown_timer = 2 MINUTES
 	keybinding_signals = list(
-	KEYBINDING_NORMAL = COMSIG_XENOABILITY_PLACE_ACID_WELL,
+	    KEYBINDING_NORMAL = COMSIG_XENOABILITY_PLACE_ACID_WELL,
 	)
 
 /datum/action/xeno_action/place_acidwell/can_use_action(silent = FALSE, override_flags)

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -306,6 +306,9 @@
 	mechanics_text = "Place an acid well that can put out fires."
 	plasma_cost = 400
 	cooldown_timer = 2 MINUTES
+	keybinding_signals = list(
+	KEYBINDING_NORMAL = COMSIG_XENOABILITY_PSYCHIC_CURE,
+	)
 
 /datum/action/xeno_action/place_acidwell/can_use_action(silent = FALSE, override_flags)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Adds a hotkey for "Place acid well" - xeno 's ability

## Why It's Good For The Game

Easy access to the use of the ability 
Improving the quality of the game

## Changelog

:cl:
add: Xenomorphs can quickly build acid wells, as well as collapse the top panel with abilities (since all abilities can be used using keyboard shortcuts).
/:cl:
