### PR TITLE
Large Flamethrower Tank buff.

### DIFF
--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -59,8 +59,8 @@
 	name = "large flamerthrower tank"
 	desc = "A large fuel tank of ultra thick napthal, a sticky combustable liquid chemical, for use in the FL-84 flamethrower."
 	icon_state = "flametank_large"
-	max_rounds = 75
-	current_rounds = 75
+	max_rounds = 100
+	current_rounds = 100
 	reload_delay = 3 SECONDS
 	icon_state_mini = "tank_orange"
 
@@ -68,8 +68,8 @@
 	name = "large flamerthrower tank"
 	desc = "A large fuel tank of ultra thick napthal, a sticky combustable liquid chemical, for use in the V-62 flamethrower."
 	icon_state = "flametank_som"
-	max_rounds = 75
-	current_rounds = 75
+	max_rounds = 100
+	current_rounds = 100
 	reload_delay = 3 SECONDS
 	icon_state_mini = "tank_orange"
 


### PR DESCRIPTION

## About The Pull Request
Increases the ammo for the large flamethrower tank from 75 to 100.
## Why It's Good For The Game
The large tank, while refillable also terribly pales in comparison to the 500 ammo backtank and even the 50 ammo incinerator tank.
This should keep it a bit closer in line with the backtank while also not being a strictly better/worse option. 
## Changelog
:cl:
balance: Increases Large flamethrower tank's capacity from 75 to 100. (76 to 101)
/:cl:
