### PR TITLE
Enables Psypoint Usage on Crash

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/infestation/crash
 	name = "Crash"
 	config_tag = "Crash"
-	flags_round_type = MODE_INFESTATION|MODE_XENO_SPAWN_PROTECT|MODE_DEAD_GRAB_FORBIDDEN
+	flags_round_type = MODE_INFESTATION|MODE_XENO_SPAWN_PROTECT|MODE_DEAD_GRAB_FORBIDDEN|MODE_PSY_POINTS|MODE_PSY_POINTS_ADVANCED
 	flags_xeno_abilities = ABILITY_CRASH
 	valid_job_types = list(
 		/datum/job/terragov/squad/standard = -1,
@@ -78,6 +78,8 @@
 
 /datum/game_mode/infestation/crash/post_setup()
 	. = ..()
+	SSpoints.add_psy_points(XENO_HIVE_NORMAL, 4 * XENO_TURRET_PRICE)
+
 	for(var/i in GLOB.xeno_resin_silo_turfs)
 		new /obj/structure/xeno/silo(i)
 

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -2,7 +2,7 @@
 	name = "Crash"
 	config_tag = "Crash"
 	flags_round_type = MODE_INFESTATION|MODE_XENO_SPAWN_PROTECT|MODE_DEAD_GRAB_FORBIDDEN|MODE_PSY_POINTS|MODE_PSY_POINTS_ADVANCED
-	flags_xeno_abilities = ABILITY_CRASH
+	flags_xeno_abilities = ABILITY_DISTRESS
 	valid_job_types = list(
 		/datum/job/terragov/squad/standard = -1,
 		/datum/job/terragov/squad/engineer = 8,

--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -202,7 +202,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	desc = "Constructs a tower that increases the rate of evolution point generation by 1.25 times per tower."
 	psypoint_cost = 300
 	icon = "evotower"
-	flags_upgrade = ABILITY_DISTRESS
+	flags_upgrade = ABILITY_ALL_GAMEMODE
 	building_type = /obj/structure/xeno/evotower
 
 /datum/hive_upgrade/building/maturitytower
@@ -210,7 +210,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	desc = "Constructs a tower that increases the rate of maturity point generation by 1.2 times per tower."
 	psypoint_cost = 300
 	icon = "maturitytower"
-	flags_upgrade = ABILITY_DISTRESS
+	flags_upgrade = ABILITY_ALL_GAMEMODE
 	building_type = /obj/structure/xeno/maturitytower
 
 /datum/hive_upgrade/building/pherotower
@@ -218,7 +218,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	desc = "Constructs a tower that emanates a selectable type of pheromone."
 	psypoint_cost = 150
 	icon = "pherotower"
-	flags_upgrade = ABILITY_DISTRESS
+	flags_upgrade = ABILITY_ALL_GAMEMODE
 	building_type = /obj/structure/xeno/pherotower
 	building_loc = 0 //This results in spawning the structure under the user.
 	building_time = 5 SECONDS
@@ -239,7 +239,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	desc = "Places a acid spitting resin turret under you. Must be at least 6 tiles away from other turrets, not near fog and on a weeded area."
 	icon = "acidturret"
 	psypoint_cost = XENO_TURRET_PRICE
-	flags_gamemode = ABILITY_DISTRESS
+	flags_gamemode = ABILITY_ALL_GAMEMODE
 	///How long to build one turret
 	var/build_time = 10 SECONDS
 	///What type of turret is built


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Enables passive psypoint generation on Crash, as well as draining/cocooning. Gives xenos enough psy for four acid turrets at start (400 at the point of this PR).  Also enables certain blessings to be bought, including maturation/evo towers, pheremone towers, and turrets. No silos, no spawners, no primos/smart minions.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Makes xenos more of a threat on Crash, rewards them for scoring kills against marines, enables them to mix up how they defend sites/attack the Canterbury to provide more of an engaging experience for both sides. Makes lowpop rounds more of a danger for marines with the addition of turrets. Mirrors the amount of kit marines have been provided with by giving xenos some advantages of their own.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Activates psypoint generation and usage on Crash.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
