### PR TITLE
Queen Hive Message now uses TGUI textbox

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -29,8 +29,7 @@
 	var/mob/living/carbon/xenomorph/queen/Q = owner
 
 	//Preferring the use of multiline input as the message box is larger and easier to quickly proofread before sending to hive.
-	var/input = stripped_multiline_input(Q, "Maximum message length: [MAX_BROADCAST_LEN]", "Hive Message", "", MAX_BROADCAST_LEN, TRUE)
-	//Newlines are of course stripped and replaced with a space.
+	var/input = tgui_input_text(usr, "Hive Message", multiline = TRUE, encode = FALSE)
 	input = capitalize(trim(replacetext(input, "\n", " ")))
 	if(!input)
 		return


### PR DESCRIPTION

## About The Pull Request

Queen Hive Message now uses TGUI textbox.
## Why It's Good For The Game

Prettier, in line with other text inputs, smoother.

![image](https://user-images.githubusercontent.com/78281369/202198885-a3971827-3d5d-4f38-af6f-ef89c6703b36.png)
## Changelog
:cl:
qol: Queen Hive Message now uses TGUI textbox.
/:cl:
