### PR TITLE
Tad weaponpoint fix

### DIFF
--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -44,6 +44,10 @@
 		return TRUE
 	if(installed_equipment)
 		return TRUE
+	for(var/atom/thing_to_check AS in loc)
+		if(thing_to_check.density)
+			balloon_alert(user, "Blocked by [thing_to_check]")
+			return TRUE
 	playsound(loc, 'sound/machines/hydraulics_1.ogg', 40, 1)
 	if(!do_after(user, 7 SECONDS, FALSE, src))
 		return TRUE


### PR DESCRIPTION

## About The Pull Request
Yo can no longer deploy a mounted gun on top of other dense atoms, i.e. howies or sentries.
## Why It's Good For The Game
Exploit bad.
## Changelog
:cl:
fix: Tadpole weapons can no longer be deployed on top of other dense objects
/:cl:
