### PR TITLE
Runtime fix when linking telecomms machinery

### DIFF
--- a/code/game/objects/machinery/telecomms/machine_interactions.dm
+++ b/code/game/objects/machinery/telecomms/machine_interactions.dm
@@ -195,8 +195,8 @@
 				temp = "<font color = #efef88>-% Removed [REF(T)] [T.name] from linked entities. %-</font>"
 				// Remove link entries from both T and src.
 				if(T.links)
-					LAZYREMOVE(T.links, src)
-				LAZYREMOVE(links, T)
+					T.links.Remove(src)
+				links.Remove(T)
 
 			else
 				temp = "<font color = #efef88>-% Unable to locate machine to unlink from, try again. %-</font>"


### PR DESCRIPTION
Copypaste fix from TG that should fix linking telecomms machinery resulting in UI errors and runtimes.
Tested locally and didn't have issues with it, no clue why it works though, perhaps something about removing laziness.

Should have someone who can understand it take a look and ensure this doesn't harm anything though.

Credit to KacperRaid for digging up this code from TG.
### Why It's Good For The Game
Because telecomms shouldn't become a game of "How long does it take multiple admins and Pit Boss to fix" or "How one AI stole the airwaves."

### Changelog

:cl:
Linking telecomms machinery together should now function properly
/:cl:
