### PR TITLE
Mimir MK2 changes, less armor, less slowdown

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -150,8 +150,8 @@
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "mod_biohazard"
 	item_state = "mod_biohazard_a"
-	soft_armor = list("bio" = 40, ACID = 30)
-	slowdown = 0.2
+	soft_armor = list("bio" = 30, ACID = 25)
+	slowdown = 0.1
 	slot = ATTACHMENT_SLOT_MODULE
 	variants_by_parent_type = list(/obj/item/clothing/suit/modular/xenonauten = "mod_biohazard_xn", /obj/item/clothing/suit/modular/xenonauten/light = "mod_biohazard_xn", /obj/item/clothing/suit/modular/xenonauten/heavy = "mod_biohazard_xn")
 	///siemens coefficient mod for gas protection.


### PR DESCRIPTION

## About The Pull Request
Mimir Mark 2 (The req bought one) has .1 slowdown instead of .2, and lost a bit of armor overall, totaling up to 25 acid and 30 bio protection. (5 less acid and 10 less bio)
## Why It's Good For The Game
Makes Mimir 2 less hardcountery towards sentinels and spitters and makes it more dynamic to use
## Changelog
:cl:
balance: Mimir MK2 now has 10 less bio and 5 less acid protection, has less slowdown to compensate.
/:cl:
