### PR TITLE
Engineers can purchase TL-182 deployable shield for 3 engineering points

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -49,8 +49,9 @@ GLOBAL_LIST_INIT(marine_gear_listed_products, list())
 GLOBAL_LIST_INIT(engineer_gear_listed_products, list(
 		/obj/effect/essentials_set/engi = list(CAT_ESS, "Essential Engineer Set", 0, "white"),
 		/obj/item/stack/sheet/metal/small_stack = list(CAT_ENGSUP, "Metal x10", METAL_PRICE_IN_GEAR_VENDOR, "orange"),
-		/obj/item/stack/sheet/plasteel/small_stack = list(CAT_ENGSUP, "Plasteel x10", PLASTEEL_PRICE_IN_GEAR_VENDOR, "orange"),
+		/obj/item/stack/sheet/plasteel/small_stack = list(CAT_ENGSUP, "Plasteel x10", SANDBAG_PRICE_IN_GEAR_VENDOR, "orange"),
 		/obj/item/stack/sandbags_empty/half = list(CAT_ENGSUP, "Sandbags x25", SANDBAG_PRICE_IN_GEAR_VENDOR, "orange"),
+		/obj/item/weapon/shield/riot/marine/deployable = list(CAT_ENGSUP, "TL-182 deployable shield", 3, "orange"),
 		/obj/item/tool/weldingtool/hugetank = list(CAT_ENGSUP, "High-capacity industrial blowtorch", 5, "black"),
 		/obj/item/clothing/glasses/welding/superior = list(CAT_ENGSUP, "Superior welding goggles", 2, "black"),
 		/obj/item/armor_module/module/welding/superior = list(CAT_ENGSUP, "Superior welding module", 2, "black"),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

For the frontline engineers that want to be economical in the long run. Since marines are always pushing the frontlines, spending time to use 4*n, where n is the number of metal barricades used, forces frontline engineers to often NOT make metal barricades. Often, frontline engineers decide to make metal barricades for (1) miner, (2) a choke, (3) a small FOB, and (4) a firing lane. It is likely for frontline engineers to choose (1) and (2), (3), and (4) are up to the discretion of the player. 

With this PR, it encourages frontline engineers to use TL-182 deployable shield to enable (2) and (4). Note that TGMC is inherently a fast and dynamic TDM, meaning that holding down a spot is unlikely (unless FOB siege), which makes TL-182 deployable shield not meta. That said, since you can redeploy it, an engineer can save materials and hunker down on the move.

Remember, for 2 engineering points, an engineer can get 10 metal sheets, which is 2 metal barricade with barbed wires. Investing 3 points for a TL-182 deployable shield gives you 1 but the ability to move the shield.

It is true that there are 6 free TL-182 deployable shields, but machine gun players take them (which I haven't seen, yet, so machine gun players, use them!).

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Engineers can purchase TL-182 deployable shield for 3 engineering points
balance: frontline engineers can hunker down on locations to much of xenomorphs' dismay
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
