### PR TITLE
increase widow leash ball hp

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
@@ -56,7 +56,7 @@
 	icon_state = "aoe_leash"
 	desc = "Sticky and icky. Destroy it when you are stuck!"
 	destroy_sound = "alien_resin_break"
-	max_integrity = 25
+	max_integrity = 75
 	layer = ABOVE_ALL_MOB_LAYER
 	anchored = TRUE
 	throwpass = FALSE


### PR DESCRIPTION

## About The Pull Request
leash ball hp 25->75
## Why It's Good For The Game

Currently leash ball is very situational, you need other xenos to be occupying marines so that the leash ball can do its job.
This should hopefully still make the leash ball easy to destroy for marines but also not vanish from getting hit once.
## Changelog
:cl:
balance: leash ball hp 25->75
/:cl:
