### PR TITLE
Resin Doors have custom ex_acts now

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -185,6 +185,15 @@
 /obj/structure/mineral_door/resin/flamer_fire_act(burnlevel)
 	take_damage(burnlevel * 2, BURN, "fire")
 
+/obj/structure/mineral_door/resin/ex_act(severity)
+	switch(severity)
+		if(EXPLODE_DEVASTATE)
+			qdel()
+		if(EXPLODE_HEAVY)
+			qdel()
+		if(EXPLODE_LIGHT)
+			take_damage((rand(50, 60)))
+
 /turf/closed/wall/resin/fire_act()
 	take_damage(50, BURN, "fire")
 


### PR DESCRIPTION
## About The Pull Request
Doors have custom ex_acts now. 2 light explosions to kill them, anything heavier qdel's them.
## Why It's Good For The Game
Resin doors are supposed to be fragile, they have low health on purpose to make them worse than walls at defending a position but allow  for better xeno mobility. Them not dying to explosions properly is an oversight to me. But it is a change of balance compared to how it previously was.
## Changelog
:cl:
balance: Resin Doors have proper custom Ex_Acts now, and die to 2 light explosions, heavy and devastation explosions delete them off the face of the universe.
/:cl:
