### PR TITLE
Miner layer fix

### DIFF
--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -22,6 +22,7 @@
 	icon_state = "mining_drill_active"
 	anchored = TRUE
 	coverage = 30
+	layer = ABOVE_MOB_LAYER
 	resistance_flags = INDESTRUCTIBLE | DROPSHIP_IMMUNE
 	///How many sheets of material we have stored
 	var/stored_mineral = 0


### PR DESCRIPTION

## About The Pull Request
Miners now render above mobs, changing from this:
![image](https://user-images.githubusercontent.com/7869430/203209338-cd8942d5-17d3-4ede-a445-3ce96842d298.png)
To this:
![image](https://user-images.githubusercontent.com/7869430/203215105-24ba460f-8c06-4da6-b67b-352b167dd904.png)

This kinda bugged me, just a minor visual thing.
## Why It's Good For The Game
Magic man floating over miners bad.
## Changelog
:cl:
fix: Mobs no longer render over miners
/:cl:
