### PR TITLE
Can no longer pack up deployables covered in acid

### DIFF
--- a/code/game/objects/machinery/deployable.dm
+++ b/code/game/objects/machinery/deployable.dm
@@ -97,6 +97,10 @@
 
 ///Dissassembles the device
 /obj/machinery/deployable/proc/disassemble(mob/user)
+	for(var/obj/effect/xenomorph/acid/A in loc)
+		if(A.acid_t == src)
+			to_chat(user, "You can't get near that, it's melting!")
+			return
 	var/obj/item/item = internal_item
 	if(CHECK_BITFIELD(item.flags_item, DEPLOYED_NO_PICKUP))
 		to_chat(user, span_notice("The [src] is anchored in place and cannot be disassembled."))


### PR DESCRIPTION
### About The Pull Request
Deployables objects (telepads, dispensers, etc) can no longer be picked up/undeployed if they're covered in acid.

### Why It's Good For The Game
Fixes oversight where deployables covered in acid can be picked up and redeployed to remove the acid on them.

### Changelog

:cl:
fix: Deployables covered in acid can no longer be picked up
/:cl:
