### PR TITLE
1984 name removal

### DIFF
--- a/strings/names/first.txt
+++ b/strings/names/first.txt
@@ -376,7 +376,6 @@ Peregrine
 Pheobe
 Phoebe
 Phyliss
-Phyllida
 Phyllis
 Porsche
 Prosper

--- a/strings/names/first_female.txt
+++ b/strings/names/first_female.txt
@@ -2567,7 +2567,6 @@ Phoebe
 Phyl
 Phylicia
 Phyliss
-Phyllida
 Phyllis
 Pihla
 Pilar


### PR DESCRIPTION
## About The Pull Request
![image](https://user-images.githubusercontent.com/46353991/203432496-be190598-0761-4fac-af4d-71a43ef1fa39.png)
As per lore master obligations of TGMC I am here to 1984 remove any reference to namescrubbed personnel
## Why It's Good For The Game
Move along citizen.
## Changelog
:cl:
grammar: 1984'd some names
/:cl:
