### PR TITLE
Weyland Yutani Removal

### DIFF
--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -4366,7 +4366,6 @@
 "cIq" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atm{
-	name = "NanoTrasen Automatic Teller Machine";
 	pixel_y = 30
 	},
 /obj/item/reagent_containers/food/drinks/flask/vacuumflask,
@@ -6997,7 +6996,6 @@
 	dir = 1
 	},
 /obj/machinery/atm{
-	name = "Automatic Teller Machine";
 	pixel_y = 30
 	},
 /turf/open/floor/tile/white,
@@ -17981,7 +17979,6 @@
 /obj/item/clothing/suit/redtag,
 /obj/structure/closet/athletic_mixed,
 /obj/machinery/atm{
-	name = "Weyland Yutani Automatic Teller Machine";
 	pixel_y = 30
 	},
 /turf/open/floor/tile/purple/whitepurplecorner{

--- a/_maps/map_files/desertdam/desertdam.dmm
+++ b/_maps/map_files/desertdam/desertdam.dmm
@@ -7603,7 +7603,6 @@
 /area/desert_dam/exterior/valley/south_valley_dam)
 "aUv" = (
 /obj/machinery/atm{
-	name = "NanoTrasen Automatic Teller Machine";
 	pixel_y = 30
 	},
 /turf/open/floor/prison/red{
@@ -25382,7 +25381,6 @@
 /area/desert_dam/building/hydroponics/hydroponics_breakroom)
 "cTP" = (
 /obj/machinery/atm{
-	name = "NanoTrasen Automatic Teller Machine";
 	pixel_y = 30
 	},
 /turf/open/floor/prison/sterilewhite,
@@ -28172,7 +28170,6 @@
 /area/desert_dam/building/dorms/hallway_northwing)
 "dxj" = (
 /obj/machinery/atm{
-	name = "NanoTrasen Automatic Teller Machine";
 	pixel_y = 30
 	},
 /turf/open/floor/prison/green/corner{
@@ -29459,7 +29456,6 @@
 /area/desert_dam/building/dorms/pool)
 "dIM" = (
 /obj/machinery/atm{
-	name = "NanoTrasen Automatic Teller Machine";
 	pixel_y = 30
 	},
 /obj/structure/cable,
@@ -60326,7 +60322,6 @@
 /area/desert_dam/interior/dam_interior/south_tunnel)
 "uCR" = (
 /obj/machinery/atm{
-	name = "NanoTrasen Automatic Teller Machine";
 	pixel_y = 30
 	},
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -17712,7 +17712,6 @@
 /area/gelida/caves/west_caves)
 "lnb" = (
 /obj/machinery/atm{
-	name = "Weyland-Yutani Automatic Teller Machine";
 	pixel_y = 30
 	},
 /obj/structure/bed/chair{
@@ -28510,7 +28509,7 @@
 /area/gelida/indoors/a_block/fitness)
 "saH" = (
 /obj/structure/showcase{
-	desc = "The display model for a Weyland Yutani generation one synthetic. It almost feels like the eyes on this one follow you.";
+	desc = "The display model for a Nanotrasen generation one synthetic. It almost feels like the eyes on this one follow you.";
 	name = "Display synthetic"
 	},
 /obj/structure/window/reinforced,

--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -28509,7 +28509,7 @@
 /area/gelida/indoors/a_block/fitness)
 "saH" = (
 /obj/structure/showcase{
-	desc = "The display model for a Nanotrasen generation one synthetic. It almost feels like the eyes on this one follow you.";
+	desc = "The display model for a NanoTrasen generation one synthetic. It almost feels like the eyes on this one follow you.";
 	name = "Display synthetic"
 	},
 /obj/structure/window/reinforced,

--- a/_maps/modularmaps/big_red/operation.dmm
+++ b/_maps/modularmaps/big_red/operation.dmm
@@ -1139,7 +1139,6 @@
 "NT" = (
 /obj/structure/bed/chair,
 /obj/machinery/atm{
-	name = "Weyland Yutani Automatic Teller Machine";
 	pixel_y = 30
 	},
 /turf/open/floor,
@@ -1378,7 +1377,6 @@
 /area/bigredv2/outside/admin_building)
 "Wp" = (
 /obj/machinery/atm{
-	name = "Weyland Yutani Automatic Teller Machine";
 	pixel_y = 30
 	},
 /turf/open/floor/tile/dark/red2{

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -15,7 +15,7 @@ log transactions
 /obj/item/card/id/var/money = 2000
 
 /obj/machinery/atm
-	name = "NT Automatic Teller Machine"
+	name = "NanoTrasen Automatic Teller Machine"
 	desc = "For all your monetary needs!"
 	icon = 'icons/obj/terminals.dmi'
 	icon_state = "atm"


### PR DESCRIPTION

## About The Pull Request

Cleans up the last remaining few references to Weyland Yutani, replaces them with NanoTrasen.
Also removes all var edited ATMs and slightly changes ATM name to better standardize.

## Why It's Good For The Game

References to Weyland Yutani are bad for lore and legal. Cleaning up the last few remnants that were missed is good. Removing var edits on ATMs and standardizing their name is also good.

## Changelog
:cl:
fix: Weyland Yutani references removed
fix: ATM var edits removed
/:cl:
