### PR TITLE
Hivemind now passes through all mobs.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
@@ -125,7 +125,7 @@
 	if(status_flags & INCORPOREAL)
 		status_flags = NONE
 		resistance_flags = BANISH_IMMUNE
-		flags_pass = NONE
+		flags_pass = PASSTABLE | PASSMOB | PASSXENO
 		density = TRUE
 		throwpass = FALSE
 		hive.xenos_by_upgrade[upgrade] -= src


### PR DESCRIPTION

## About The Pull Request
Title.
## Why It's Good For The Game
Prevents Hivemind shuffle cheese.
Hivemind can now pass through Xenos as well, preventing shuffling of castes (that can result in death occasionally <s>skill issues</s>) and can also heal more easily as hivemind itself cannot be shuffled.

Yes it can stand on a mob to block bullets or stand on marines, but hivemind has negligible HP and its rarely worth it if it actually wants to contribute to the hive.
## Changelog
:cl:
balance: Hivemind can pass through all mobs.
/:cl:
