### PR TITLE
Railing smoothing removal

### DIFF
--- a/code/game/objects/machinery/doors/railing.dm
+++ b/code/game/objects/machinery/doors/railing.dm
@@ -7,6 +7,8 @@
 	opacity = FALSE
 	open_layer = CATWALK_LAYER
 	closed_layer = WINDOW_LAYER
+	smoothing_behavior = null
+	smoothing_groups = null
 
 	var/obj/docking_port/mobile/supply/linked_pad
 

--- a/code/game/objects/machinery/doors/railing.dm
+++ b/code/game/objects/machinery/doors/railing.dm
@@ -7,8 +7,8 @@
 	opacity = FALSE
 	open_layer = CATWALK_LAYER
 	closed_layer = WINDOW_LAYER
-	smoothing_behavior = null
-	smoothing_groups = null
+	smoothing_behavior = NO_SMOOTHING
+	smoothing_groups = NONE
 
 	var/obj/docking_port/mobile/supply/linked_pad
 


### PR DESCRIPTION

## About The Pull Request
In some req areas, we get ugly smoothing like this:
![image](https://user-images.githubusercontent.com/7869430/203642024-3d907e1f-ce23-4a84-b948-32a61505e728.png)

Removes this.
## Why It's Good For The Game
Uggo smoothing be gone.
## Changelog
:cl:
fix: Req railing will not longer smooth with walls nearby
/:cl:
