### PR TITLE
Turf smoothing for shuttles

### DIFF
--- a/code/game/smoothwall.dm
+++ b/code/game/smoothwall.dm
@@ -90,22 +90,17 @@
 	icon_state = "[basestate][jun]_frame"
 	junction = jun
 
-/turf/closed/wall/handle_icon_junction(junction)
+/turf/closed/handle_icon_junction(junction)
 	icon_state = "[walltype][junction]"
 	junctiontype = junction
 
 /obj/structure/grille/mainship/handle_icon_junction(junction)
 	icon_state = "grille[junction]"
 
-
 /turf/open/floor/vault/relativewall()
 	return
 
 /turf/closed/wall/vault/relativewall()
-	return
-
-/turf/closed/shuttle/relativewall()
-	//TODO: Make something for this and make it work with shuttle rotations
 	return
 
 /turf/open/shuttle/relativewall()

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -410,6 +410,7 @@
 	icon_state = "swall0"
 	smoothing_behavior = CARDINAL_SMOOTHING
 	smoothing_groups = SMOOTH_ESCAPESHUTTLE
+	walltype = "swall"
 
 /turf/closed/banish_space //Brazil
 	plane = PLANE_SPACE

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -11,9 +11,7 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 		//rotate our direction
 		setDir(angle2dir(rotation+dir2angle(dir)))
 
-	//resmooth if need be.
-//	if(smooth && (params & ROTATE_SMOOTH))
-//		queue_smooth(src)
+		smooth_self() //resmooth if need be.
 
 	//rotate the pixel offsets too.
 	if((pixel_x || pixel_y) && (params & ROTATE_OFFSET))


### PR DESCRIPTION

## About The Pull Request
Makes smoothing work for shuttles. This will specifically be effecting the large escape shuttles, but it means it can be extended out to any shuttle including the Alamo etc if desired.

![image](https://user-images.githubusercontent.com/7869430/203667329-ba979b79-6d39-481a-9b79-cf33136a526e.png)

Notably the two shuttles are smoothing together. That's because they're actually two copies of the same shuttle, and so share a smoothing group.
Ideally a second identical shuttle should be made using a new smoothing group to resolve that, but that's a mapping change and I don't feeling like dying right now.
## Why It's Good For The Game
Makes shuttle look less jank.
## Changelog
:cl:
fix: fixed turf smoothing not working for shuttles
/:cl:
