### PR TITLE
Removes dupe TGMC uniform from Clothing vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1239,7 +1239,6 @@
 	products = list(
 		"Standard" = list(
 			/obj/item/clothing/under/marine/robotic = -1,
-			/obj/item/clothing/under/marine = -1,
 			/obj/item/clothing/under/marine/standard = -1,
 			/obj/item/clothing/under/marine/camo = -1,
 			/obj/item/clothing/under/marine/camo/desert = -1,


### PR DESCRIPTION

## About The Pull Request
Title.
![image](https://user-images.githubusercontent.com/73274515/203811574-839c22a7-d152-49ec-adf0-31a4bbaaa928.png)
## Why It's Good For The Game
Less bloat.
## Changelog
:cl:
del: Removed dupe of TGMC uniform.
/:cl:
