### PR TITLE
Combat canteen has more possible transfer amounts

### DIFF
--- a/code/game/objects/items/reagent_containers/food/drinks.dm
+++ b/code/game/objects/items/reagent_containers/food/drinks.dm
@@ -8,7 +8,7 @@
 	icon_state = null
 	init_reagent_flags = OPENCONTAINER_NOUNIT
 	var/gulp_size = 5 //This is now officially broken ... need to think of a nice way to fix it.
-	possible_transfer_amounts = list(5,10,25)
+	possible_transfer_amounts = list(5,10,15,20,30,60)
 	volume = 50
 
 /obj/item/reagent_containers/food/drinks/on_reagent_change()


### PR DESCRIPTION

## About The Pull Request

Combat canteen has more possible transfer amounts from inheriting /obj/item/reagent_containers/food/drinks .

## Why It's Good For The Game

Sometimes, marines want to have more measured transfer amount when drinking out of their canteen. possible_transfer_amounts is the same as /obj/item/reagent_containers/glass, which is what beaker inherits from. I would not be surprised if marines make some cocktail of a canteen with this PR.

## Changelog

:cl:
add: Combat canteen has more possible transfer amounts
balance: More options on transfer amounts for combat canteen will inevitably change how marine consume from combat canteen
/:cl:

