### PR TITLE
feat: replace send order with TGUI window

### DIFF
--- a/code/modules/screen_alert/command_alert.dm
+++ b/code/modules/screen_alert/command_alert.dm
@@ -26,27 +26,31 @@
 /datum/action/innate/message_squad/should_show()
 	return owner.skills.getRating(skill_name) >= skill_min
 
-/datum/action/innate/message_squad/can_use_action()
+/datum/action/innate/message_squad/can_use_action(silent = FALSE)
 	. = ..()
+	if(!.)
+		return
 	if(owner.stat)
-		to_chat(owner, span_warning("You cannot give orders in your current state."))
+		if(!silent)
+			owner.balloon_alert(owner, "You can't send orders right now")
 		return FALSE
 	if(TIMER_COOLDOWN_CHECK(owner, COOLDOWN_HUD_ORDER))
-		to_chat(owner, span_warning("Your last order was too recent."))
+		if(!silent)
+			owner.balloon_alert(owner, "Your last order was too recent")
 		return FALSE
 
 /datum/action/innate/message_squad/action_activate()
-	var/mob/living/carbon/human/human_owner = owner
 	if(!can_use_action())
 		return
-	var/text = stripped_input(human_owner, "Maximum message length [MAX_COMMAND_MESSAGE_LEN]", "Send message to squad", max_length = MAX_COMMAND_MESSAGE_LEN)
+	var/mob/living/carbon/human/human_owner = owner
+	var/text = tgui_input_text(human_owner, "Maximum message length [MAX_COMMAND_MESSAGE_LEN]", "Send message to squad",  max_length = MAX_COMMAND_MESSAGE_LEN, multiline = TRUE)
 	if(!text)
 		return
 	if(CHAT_FILTER_CHECK(text))
 		to_chat(human_owner, span_warning("That message contained a word prohibited in IC chat! Consider reviewing the server rules.\n<span replaceRegex='show_filtered_ic_chat'>\"[text]\"</span>"))
 		SSblackbox.record_feedback(FEEDBACK_TALLY, "ic_blocked_words", 1, lowertext(config.ic_filter_regex.match))
 		return
-	if(!can_use_action())
+	if(!can_use_action(TRUE))
 		return
 	human_owner.playsound_local(owner, "sound/effects/CIC_order.ogg", 10, 1)
 	TIMER_COOLDOWN_START(owner, COOLDOWN_HUD_ORDER, ORDER_COOLDOWN)


### PR DESCRIPTION
## About The Pull Request
Just replaces the input with a TGUI input, if the player has them enabled.

## Why It's Good For The Game
It allows for the player to preformat their text a little with line breaks making for nicer orders.

## Demo
https://user-images.githubusercontent.com/1134201/204362870-798e3456-0f82-40af-b545-6612db47da87.mp4


## Changelog

:cl:
code: send order now uses a TGUI input if the player has them enabled
/:cl:
