### PR TITLE
fix: maptable for observers

### DIFF
--- a/code/game/objects/machinery/cic_maptable.dm
+++ b/code/game/objects/machinery/cic_maptable.dm
@@ -13,7 +13,6 @@
 	var/targetted_zlevel = 2
 	///minimap obj ref that we will display to users
 	var/atom/movable/screen/minimap/map
-	///timer to check if we're in range of the map table still.
 
 /obj/machinery/cic_maptable/Destroy()
 	map = null

--- a/code/game/objects/machinery/cic_maptable.dm
+++ b/code/game/objects/machinery/cic_maptable.dm
@@ -13,6 +13,7 @@
 	var/targetted_zlevel = 2
 	///minimap obj ref that we will display to users
 	var/atom/movable/screen/minimap/map
+	///timer to check if we're in range of the map table still.
 
 /obj/machinery/cic_maptable/Destroy()
 	map = null
@@ -27,6 +28,19 @@
 	if(!map)
 		map = SSminimaps.fetch_minimap_object(targetted_zlevel, allowed_flags)
 	user.client.screen += map
+	if(isobserver(user))
+		RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/on_move)
+
+
+//Bugfix to handle cases for ghosts/observers that dont automatically close uis on move.
+/obj/machinery/cic_maptable/proc/on_move(mob/dead/observer/source, oldloc)
+	SIGNAL_HANDLER
+	if(!istype(source))
+		CRASH("on_move called by non observer")
+	if(Adjacent(source))
+		return
+	UnregisterSignal(source, COMSIG_MOVABLE_MOVED)
+	source.unset_interaction()
 
 /obj/machinery/cic_maptable/on_unset_interaction(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Registers an `on_move` signal for observers.
This allows us to close the map when they move too far away.

## Why It's Good For The Game
Fixes broken observer gameplay

## Changelog

:cl:
fix: maptable closes when observers move away.
/:cl:
