### PR TITLE
balance: increase cooldown on mech computer

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -49,6 +49,7 @@
 #define COOLDOWN_ITEM_TRICK "cooldown_item_trick"
 
 //Mecha cooldowns
+#define COOLDOWN_MECHA "mecha"
 #define COOLDOWN_MECHA_MESSAGE "mecha_message"
 #define COOLDOWN_MECHA_EQUIPMENT(type) ("mecha_equip_[type]")
 #define COOLDOWN_MECHA_ARMOR "mecha_armor"

--- a/code/modules/vehicles/mecha/combat/greyscale/greyscale_constructor.dm
+++ b/code/modules/vehicles/mecha/combat/greyscale/greyscale_constructor.dm
@@ -223,7 +223,7 @@ GLOBAL_LIST_INIT(greyscale_weapons_data, generate_greyscale_weapons_data())
 	if(.)
 		return
 
-	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_MECHA))
+	if(S_TIMER_COOLDOWN_TIMELEFT(src, COOLDOWN_MECHA))
 		return FALSE
 	var/selected_part = params["bodypart"]
 	if(selected_part && !(selected_part in selected_primary))
@@ -290,7 +290,7 @@ GLOBAL_LIST_INIT(greyscale_weapons_data, generate_greyscale_weapons_data())
 				return FALSE
 			addtimer(CALLBACK(src, .proc/deploy_mech), 1 SECONDS)
 			playsound(get_step(src, dir), 'sound/machines/elevator_move.ogg', 50, 0)
-			TIMER_COOLDOWN_START(src, COOLDOWN_MECHA, 5 MINUTES)
+			S_TIMER_COOLDOWN_START(src, COOLDOWN_MECHA, 5 MINUTES)
 			return TRUE
 
 		if("add_weapon")

--- a/code/modules/vehicles/mecha/combat/greyscale/greyscale_constructor.dm
+++ b/code/modules/vehicles/mecha/combat/greyscale/greyscale_constructor.dm
@@ -397,7 +397,7 @@ GLOBAL_LIST_INIT(greyscale_weapons_data, generate_greyscale_weapons_data())
 
 	currently_assembling = FALSE
 	balloon_alert_to_viewers("Beep. Machine ready for use.")
-	playsound(src, 'sound/machines/two_tones_beep.ogg', 30, 1)
+	playsound(src, 'sound/machines/chime.ogg', 30, 1)
 
 ///updates the current_stats data for the UI
 /obj/machinery/computer/mech_builder/proc/update_stats(selected_part, old_bodytype, new_bodytype)
@@ -443,7 +443,3 @@ GLOBAL_LIST_INIT(greyscale_weapons_data, generate_greyscale_weapons_data())
 		if(slot == MECH_GREY_HEAD)
 			new_overlays += icon2appearance(SSgreyscale.GetColoredIconByType(initial(typepath.visor_config), selected_visor))
 	mech_view.overlays = new_overlays
-
-///called when ready to assemble new mechs
-/obj/machinery/computer/mech_builder/proc/on_cooldown_end()
-

--- a/code/modules/vehicles/mecha/combat/greyscale/greyscale_constructor.dm
+++ b/code/modules/vehicles/mecha/combat/greyscale/greyscale_constructor.dm
@@ -130,8 +130,6 @@ GLOBAL_LIST_INIT(greyscale_weapons_data, generate_greyscale_weapons_data())
 	var/equipment_max = MECH_GREYSCALE_MAX_EQUIP
 	///reference to the mech screen object
 	var/atom/movable/screen/mech_builder_view/mech_view
-	///bool if the mech is currently assembling, stops Ui actions
-	var/currently_assembling = FALSE
 	///list of stat data that will be sent to the UI
 	var/list/current_stats
 
@@ -217,7 +215,7 @@ GLOBAL_LIST_INIT(greyscale_weapons_data, generate_greyscale_weapons_data())
 	data["selected_name"] = selected_name
 	data["selected_equipment"] = selected_equipment
 	data["current_stats"] = current_stats
-	data["currently_assembling"] = currently_assembling
+	data["cooldown_left"] = S_TIMER_COOLDOWN_TIMELEFT(src, COOLDOWN_MECHA)
 	return data
 
 /obj/machinery/computer/mech_builder/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
@@ -225,7 +223,7 @@ GLOBAL_LIST_INIT(greyscale_weapons_data, generate_greyscale_weapons_data())
 	if(.)
 		return
 
-	if(currently_assembling)
+	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_MECHA))
 		return FALSE
 	var/selected_part = params["bodypart"]
 	if(selected_part && !(selected_part in selected_primary))
@@ -290,9 +288,9 @@ GLOBAL_LIST_INIT(greyscale_weapons_data, generate_greyscale_weapons_data())
 					return FALSE
 			if(isnull(selected_visor))
 				return FALSE
-			currently_assembling = TRUE
-			addtimer(CALLBACK(src, .proc/deploy_mech), 60 SECONDS)
+			addtimer(CALLBACK(src, .proc/deploy_mech), 1 SECONDS)
 			playsound(get_step(src, dir), 'sound/machines/elevator_move.ogg', 50, 0)
+			TIMER_COOLDOWN_START(src, COOLDOWN_MECHA, 5 MINUTES)
 			return TRUE
 
 		if("add_weapon")
@@ -395,8 +393,7 @@ GLOBAL_LIST_INIT(greyscale_weapons_data, generate_greyscale_weapons_data())
 	mech.pixel_y = 240
 	animate(mech, time=4 SECONDS, pixel_y=initial(mech.pixel_y), easing=SINE_EASING|EASE_OUT)
 
-	currently_assembling = FALSE
-	balloon_alert_to_viewers("Beep. Machine ready for use.")
+	balloon_alert_to_viewers("Beep. Mecha ready for use.")
 	playsound(src, 'sound/machines/chime.ogg', 30, 1)
 
 ///updates the current_stats data for the UI

--- a/tgui/packages/tgui/interfaces/MechVendor/MechAssembly.tsx
+++ b/tgui/packages/tgui/interfaces/MechVendor/MechAssembly.tsx
@@ -219,7 +219,9 @@ export const MechAssembly = (props, context) => {
               }
             />
             <Button
-              content={!!cooldown_left ? `BUSY (${cooldown_left} seconds)` : 'ASSEMBLE'}
+              content={
+                cooldown_left ? `BUSY (${cooldown_left} seconds)` : 'ASSEMBLE'
+              }
               disabled={cooldown_left && cooldown_left > 0}
               fluid
               mt={2}

--- a/tgui/packages/tgui/interfaces/MechVendor/MechAssembly.tsx
+++ b/tgui/packages/tgui/interfaces/MechVendor/MechAssembly.tsx
@@ -1,6 +1,7 @@
 import { capitalize } from 'common/string';
 import { useBackend, useLocalState } from '../../backend';
 import { Box, Button, ByondUi, Collapsible, ColorBox, Input, Section, Stack } from '../../components';
+import { formatTime } from '../../format';
 import { BodypartPickerData, ColorDisplayData, MechVendData, partdefinetofluff } from './data';
 
 const ColorDisplayRow = (props: ColorDisplayData, context) => {
@@ -220,7 +221,9 @@ export const MechAssembly = (props, context) => {
             />
             <Button
               content={
-                cooldown_left ? `BUSY (${cooldown_left} seconds)` : 'ASSEMBLE'
+                cooldown_left
+                  ? `BUSY (${formatTime(cooldown_left, 'short')})`
+                  : 'ASSEMBLE'
               }
               disabled={cooldown_left && cooldown_left > 0}
               fluid

--- a/tgui/packages/tgui/interfaces/MechVendor/MechAssembly.tsx
+++ b/tgui/packages/tgui/interfaces/MechVendor/MechAssembly.tsx
@@ -1,7 +1,7 @@
-import { useBackend, useLocalState } from '../../backend';
 import { capitalize } from 'common/string';
-import { Button, Section, Box, Stack, ByondUi, ColorBox, Collapsible, Input } from '../../components';
-import { ColorDisplayData, BodypartPickerData, MechVendData, partdefinetofluff } from './data';
+import { useBackend, useLocalState } from '../../backend';
+import { Box, Button, ByondUi, Collapsible, ColorBox, Input, Section, Stack } from '../../components';
+import { BodypartPickerData, ColorDisplayData, MechVendData, partdefinetofluff } from './data';
 
 const ColorDisplayRow = (props: ColorDisplayData, context) => {
   const { shown_colors } = props;
@@ -68,6 +68,7 @@ export const MechAssembly = (props, context) => {
     current_stats,
     all_equipment,
     selected_equipment,
+    currently_assembling,
   } = data;
   const [selectedBodypart, setSelectedBodypart] = useLocalState(
     context,
@@ -218,7 +219,8 @@ export const MechAssembly = (props, context) => {
               }
             />
             <Button
-              content="ASSEMBLE"
+              content={currently_assembling ? 'BUSY' : 'ASSEMBLE'}
+              disabled={currently_assembling}
               fluid
               mt={2}
               color={'red'}

--- a/tgui/packages/tgui/interfaces/MechVendor/MechAssembly.tsx
+++ b/tgui/packages/tgui/interfaces/MechVendor/MechAssembly.tsx
@@ -68,7 +68,7 @@ export const MechAssembly = (props, context) => {
     current_stats,
     all_equipment,
     selected_equipment,
-    currently_assembling,
+    cooldown_left,
   } = data;
   const [selectedBodypart, setSelectedBodypart] = useLocalState(
     context,
@@ -219,8 +219,8 @@ export const MechAssembly = (props, context) => {
               }
             />
             <Button
-              content={currently_assembling ? 'BUSY' : 'ASSEMBLE'}
-              disabled={currently_assembling}
+              content={!!cooldown_left ? `BUSY (${cooldown_left} seconds)` : 'ASSEMBLE'}
+              disabled={cooldown_left && cooldown_left > 0}
               fluid
               mt={2}
               color={'red'}

--- a/tgui/packages/tgui/interfaces/MechVendor/data.ts
+++ b/tgui/packages/tgui/interfaces/MechVendor/data.ts
@@ -1,16 +1,16 @@
-export const tabs = ["Mecha Assembly", "Weapons"];
-export const equipTabs = ["Weapons", "Power", "Armor", "Utility"];
+export const tabs = ['Mecha Assembly', 'Weapons'];
+export const equipTabs = ['Weapons', 'Power', 'Armor', 'Utility'];
 
 export const partdefinetofluff = {
-  CHEST: "Torso",
-  HEAD: "Head",
-  L_ARM: "Left Arm",
-  R_ARM: "Right arm",
-  LEG: "Legs",
+  CHEST: 'Torso',
+  HEAD: 'Head',
+  L_ARM: 'Left Arm',
+  R_ARM: 'Right arm',
+  LEG: 'Legs',
 };
-export const MECHA_UTILITY = "mecha_utility";
-export const MECHA_POWER = "mecha_power";
-export const MECHA_ARMOR = "mecha_armor";
+export const MECHA_UTILITY = 'mecha_utility';
+export const MECHA_POWER = 'mecha_power';
+export const MECHA_ARMOR = 'mecha_armor';
 
 export type MechVendData = {
   mech_view: string;

--- a/tgui/packages/tgui/interfaces/MechVendor/data.ts
+++ b/tgui/packages/tgui/interfaces/MechVendor/data.ts
@@ -25,6 +25,7 @@ export type MechVendData = {
   current_stats: MechStatData;
   all_equipment: AllEquipment;
   selected_equipment: SelectedEquip;
+  currently_assembling: boolean;
 };
 
 type MaxEquip = {

--- a/tgui/packages/tgui/interfaces/MechVendor/data.ts
+++ b/tgui/packages/tgui/interfaces/MechVendor/data.ts
@@ -1,16 +1,16 @@
-export const tabs = ['Mecha Assembly', 'Weapons'];
-export const equipTabs = ['Weapons', 'Power', 'Armor', 'Utility'];
+export const tabs = ["Mecha Assembly", "Weapons"];
+export const equipTabs = ["Weapons", "Power", "Armor", "Utility"];
 
 export const partdefinetofluff = {
-  'CHEST': 'Torso',
-  'HEAD': 'Head',
-  'L_ARM': 'Left Arm',
-  'R_ARM': 'Right arm',
-  'LEG': 'Legs',
+  CHEST: "Torso",
+  HEAD: "Head",
+  L_ARM: "Left Arm",
+  R_ARM: "Right arm",
+  LEG: "Legs",
 };
-export const MECHA_UTILITY = 'mecha_utility';
-export const MECHA_POWER = 'mecha_power';
-export const MECHA_ARMOR = 'mecha_armor';
+export const MECHA_UTILITY = "mecha_utility";
+export const MECHA_POWER = "mecha_power";
+export const MECHA_ARMOR = "mecha_armor";
 
 export type MechVendData = {
   mech_view: string;
@@ -25,7 +25,7 @@ export type MechVendData = {
   current_stats: MechStatData;
   all_equipment: AllEquipment;
   selected_equipment: SelectedEquip;
-  currently_assembling: boolean;
+  cooldown_left?: number;
 };
 
 type MaxEquip = {


### PR DESCRIPTION
## About The Pull Request

Increase cooldown on crafting mechs to 1 minute each.
Additionally updates the display to show when its busy.

## Why It's Good For The Game

There is currently no limit to how many you can spam.
No external resources used or anything.

This will slow the spam of mechs, until a proper solution can be implemented.

## Changelog

:cl:
balance: mechs now take a minute to build
/:cl:
