### PR TITLE
Mech minigun buff

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1256,8 +1256,8 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 /datum/ammo/bullet/minigun/mech
 	name = "vulcan bullet"
-	damage = 20
-	penetration = 20
+	damage = 30
+	penetration = 10
 	sundering = 0.5
 
 /datum/ammo/bullet/dual_cannon


### PR DESCRIPTION
## About The Pull Request

Buff mech minigun damage, nerfs AP

## Why It's Good For The Game

I might have made the minigun just straight up worse than the LMG in the last nerf pr, oops

## Changelog

:cl:
balance: Mech minigun damage buffed to 30, AP nerfed to 10
/:cl:
