### PR TITLE
Fixes tier 2 xeno calculation

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -1060,7 +1060,7 @@ to_chat will check for valid clients itself already so no need to double check f
 	var/fours = length(xenos_by_tier[XENO_TIER_FOUR])
 
 	tier3_xeno_limit = max(threes, FLOOR(((zeros + ones + twos + fours) * (evotowers.len * 0.2 + 1)) / 3 + 1, 1))
-	tier2_xeno_limit = max((twos + zeros + ones + fours) * (evotowers.len * 0.2 + 1) + 1 - threes)
+	tier2_xeno_limit = max(twos, (zeros + ones + fours) * (evotowers.len * 0.2 + 1) + 1 - threes)
 
 // ***************************************
 // *********** Corrupted Xenos


### PR DESCRIPTION

## About The Pull Request
Tier 2 slots will now be calculated correctly.

It was adding the existing t2 xenos to the calculation, so you'd never run out.
## Why It's Good For The Game
Bug fix good.
## Changelog
:cl:
fix: T2 xeno slots being calculated incorrectly
/:cl:
