### PR TITLE
Remove t2 xeno cap

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -143,7 +143,6 @@
 		return
 
 	// used below
-	var/no_room_tier_two = length(hive.xenos_by_tier[XENO_TIER_TWO]) >= hive.tier2_xeno_limit
 	var/no_room_tier_three = length(hive.xenos_by_tier[XENO_TIER_THREE]) >= hive.tier3_xeno_limit
 
 	if(new_caste_type == /mob/living/carbon/xenomorph/queen) //Special case for dealing with queenae
@@ -217,9 +216,6 @@
 
 		if(regression)
 			//Nothing, go on as normal.
-		else if(tier == XENO_TIER_ONE && no_room_tier_two)
-			to_chat(src, span_warning("The hive cannot support another Tier 2, wait for either more aliens to be born or someone to die."))
-			return
 		else if(tier == XENO_TIER_TWO && no_room_tier_three)
 			to_chat(src, span_warning("The hive cannot support another Tier 3, wait for either more aliens to be born or someone to die."))
 			return
@@ -260,10 +256,7 @@
 			to_chat(src, span_warning("There cannot be two manifestations of the hivemind's will at once."))
 			return
 	else if(!regression) // these shouldnt be checked if trying to become a queen.
-		if(tier == XENO_TIER_ONE && no_room_tier_two)
-			to_chat(src, span_warning("Another sister evolved meanwhile. The hive cannot support another Tier 2."))
-			return
-		else if(tier == XENO_TIER_TWO && no_room_tier_three)
+		if(tier == XENO_TIER_TWO && no_room_tier_three)
 			to_chat(src, span_warning("Another sister evolved meanwhile. The hive cannot support another Tier 3."))
 			return
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -22,7 +22,6 @@
 	///list of phero towers
 	var/list/obj/structure/xeno/pherotower/pherotowers = list()
 	var/tier3_xeno_limit
-	var/tier2_xeno_limit
 	///Queue of all observer wanting to join xeno side
 	var/list/mob/dead/observer/candidate
 	///Its an int showing the count of living kings
@@ -68,7 +67,6 @@
 
 /datum/hive_status/ui_data(mob/user)
 	. = ..()
-	.["hive_max_tier_two"] = tier2_xeno_limit
 	.["hive_max_tier_three"] = tier3_xeno_limit
 	.["hive_minion_count"] = length(xenos_by_tier[XENO_TIER_MINION])
 
@@ -1060,7 +1058,6 @@ to_chat will check for valid clients itself already so no need to double check f
 	var/fours = length(xenos_by_tier[XENO_TIER_FOUR])
 
 	tier3_xeno_limit = max(threes, FLOOR(((zeros + ones + twos + fours) * (evotowers.len * 0.2 + 1)) / 3 + 1, 1))
-	tier2_xeno_limit = max(twos, (zeros + ones + fours) * (evotowers.len * 0.2 + 1) + 1 - threes)
 
 // ***************************************
 // *********** Corrupted Xenos

--- a/tgui/packages/tgui/interfaces/HiveStatus.tsx
+++ b/tgui/packages/tgui/interfaces/HiveStatus.tsx
@@ -6,7 +6,6 @@ import { round } from 'common/math';
 type InputPack = {
   // ------- Hive info --------
   hive_name: string;
-  hive_max_tier_two: number;
   hive_max_tier_three: number;
   hive_larva_current: number;
   hive_larva_threshold: number;
@@ -385,7 +384,6 @@ type PyramidCalc = {
 const PopulationPyramid = (_props, context) => {
   const { act, data } = useBackend<InputPack>(context);
   const {
-    hive_max_tier_two,
     hive_max_tier_three,
     hive_minion_count,
     hive_primos,
@@ -488,12 +486,7 @@ const PopulationPyramid = (_props, context) => {
       <Flex direction="column-reverse" align={compact_disp ? 'left' : 'center'}>
         {pyramid_data.map((tier_info, tier) => {
           // Hardcoded tier check for limited slots.
-          const max_slots =
-            tier === 2
-              ? hive_max_tier_two
-              : 0 + tier === 3
-                ? hive_max_tier_three
-                : 0;
+          const max_slots = tier === 3 ? hive_max_tier_three : 0;
           const TierSlots = (_props, _context) => {
             return (
               <Box
@@ -503,8 +496,7 @@ const PopulationPyramid = (_props, context) => {
               </Box>
             );
           };
-          const slot_text =
-            tier === 2 || tier === 3 ? <TierSlots /> : tier_info.total;
+          const slot_text = tier === 3 ? <TierSlots /> : tier_info.total;
           // Praetorian name way too long. Clips into Rav.
           const row_width = tier === 3 ? 8 : 7;
           const primordial = primos[tier] ? (


### PR DESCRIPTION
## About The Pull Request

Formally removes the cap on t2 xenos as has been the case gameplay wise since September due to a bug, and with less rounys around having seemingly negligible impacts on balance.

## Why It's Good For The Game

More options more often for fun.

## Changelog
:cl:
del: Deleted the cap on t2 xenos.
/:cl:
