### PR TITLE
Alt right click opens storage

### DIFF
--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -786,6 +786,10 @@
 /obj/item/storage/AltClick(mob/user)
 	attempt_draw_object(user)
 
+/obj/item/storage/AltRightClick(mob/user)
+	if(Adjacent(usr))
+		open(user)
+
 /obj/item/storage/attack_hand_alternate(mob/living/user)
 	attempt_draw_object(user)
 


### PR DESCRIPTION

## About The Pull Request

Alt -right-clicking a storage item will open the menu, just like if you clicked it with the item in hand or drag-and-dropped it to your sprite.

Unfortunately does not work if you have right click context menu enabled, but that does not seem to be the standard here. Just something to note.

## Why It's Good For The Game

Incredibly useful QoL addition. Instantly open any storage item on or around you.

## Changelog
:cl:
qol: Alt-right-click storage items to open them. Does not work if right click opens context menu.
/:cl:
