### PR TITLE
Replaces boot knife with the M5 survival knife

### DIFF
--- a/code/modules/clothing/shoes/marine_shoes.dm
+++ b/code/modules/clothing/shoes/marine_shoes.dm
@@ -75,7 +75,7 @@
 
 /obj/item/storage/internal/shoes/boot_knife/full/Initialize()
 	. = ..()
-	new /obj/item/attachable/bayonetknife(src)
+	new /obj/item/weapon/combat_knife(src)
 
 /obj/item/clothing/shoes/marine/pyro
 	name = "flame-resistant combat boots"


### PR DESCRIPTION


## About The Pull Request

Replaces the default boot knife to the M5 Survival knife from the M22 bayonet knife

## Why It's Good For The Game

M5s are free items and an upgrade to the old boot knife. Also, almost nobody uses boot knife to slap a bayonet on anymore.
QoL change for marines so boot knives are more useful for clearing weeds if you have a weapon that has trash melee damage. (Two hits for M5 knife as opposed to three for the bayo knife)

## Changelog


:cl:

add: Replaced M22 Bayonet knife with M5 Survival knife as the default boot knife

/:cl:

