### PR TITLE
Actual lever action guns, assorted gun improvements and fixes

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -454,8 +454,6 @@
 	RegisterSignal(gun_user, COMSIG_KB_UNLOADGUN, .proc/unload_gun)
 	RegisterSignal(gun_user, COMSIG_KB_FIREMODE, .proc/do_toggle_firemode)
 	RegisterSignal(gun_user, COMSIG_KB_GUN_SAFETY, .proc/toggle_gun_safety_keybind)
-	scatter = min_scatter
-	scatter_unwielded = min_scatter_unwielded
 
 
 ///Null out gun user to prevent hard del
@@ -1491,7 +1489,9 @@
 	for(var/obj/chamber_item in chamber_items)
 		total_rounds += get_current_rounds(chamber_item)
 		total_max_rounds += get_max_rounds(chamber_item)
-	rounds = total_rounds + (in_chamber ? rounds_per_shot : 0)
+	rounds = total_rounds
+	if(!CHECK_BITFIELD(reciever_flags, AMMO_RECIEVER_DO_NOT_EMPTY_ROUNDS_AFTER_FIRE))
+		rounds += in_chamber ? rounds_per_shot : 0
 	max_rounds = total_max_rounds
 	gun_user?.hud_used.update_ammo_hud(src, get_ammo_list(), get_display_ammo_count())
 
@@ -1546,7 +1546,7 @@
 	if(!user || user.incapacitated()  || user.lying_angle || !isturf(user.loc))
 		return
 	if(rounds - rounds_per_shot < 0 && rounds)
-		to_chat(user, span_warning("Theres not enough rounds left to fire."))
+		to_chat(user, span_warning("There's not enough rounds left to fire."))
 		return FALSE
 	if(!CHECK_BITFIELD(reciever_flags, AMMO_RECIEVER_CLOSED) && CHECK_BITFIELD(reciever_flags, AMMO_RECIEVER_TOGGLES_OPEN))
 		to_chat(user, span_warning("The chamber is open! Close it first."))
@@ -1651,11 +1651,11 @@
 
 	if(((flags_item & WIELDED) && wielded_stable()) || CHECK_BITFIELD(flags_item, IS_DEPLOYED) || (master_gun && CHECK_BITFIELD(master_gun.flags_item, WIELDED) && master_gun.wielded_stable()))
 		gun_accuracy_mult = accuracy_mult
-		scatter = max(max(min_scatter, 0), min((scatter + scatter_increase) - ((world.time - last_fired - 1) * scatter_decay), max_scatter))
+		scatter = clamp((scatter + scatter_increase) - ((world.time - last_fired - 1) * scatter_decay), min_scatter, max_scatter)
 		gun_scatter = scatter
 		wielded_fire = TRUE
 	else
-		scatter_unwielded = max(min_scatter_unwielded, min((scatter + scatter_increase_unwielded) - ((world.time - last_fired - 1) * scatter_decay_unwielded), max_scatter_unwielded))
+		scatter_unwielded = clamp((scatter_unwielded + scatter_increase_unwielded) - ((world.time - last_fired - 1) * scatter_decay_unwielded), min_scatter_unwielded, max_scatter_unwielded)
 		gun_scatter = scatter_unwielded
 
 	if(user && world.time - user.last_move_time < 5) //if you moved during the last half second, you have some penalties to accuracy and scatter


### PR DESCRIPTION
## About The Pull Request

"Lever action" gun code implemented. No changes made to existing guns.
- Unique action opens and closes the receiver.
- Close receiver to fire, open it after firing, repeat
- Opening the receiver will eject the current bullet in the chamber, or a casing if fired
- Gun can only be un/loaded when the receiver is open.
- Gun can be cycled as fast as the user wants to. Still limited by the fire delay though.

Bug fixes & improvements:
- You can eject the last bullet in a gun through unique action
- gun/rifle/ had an incorrectly set `flags_gun_features`, removed duplications in children
- Fixed bug where shell ejections stopped occurring when there were less than 3 rounds left
- Cycling code changes to account for different scenarios of how a gun is or is not loaded

## Why It's Good For The Game

Proper yee-haw guns can be made.

## Changelog
:cl:
qol: Last bullet in a chamber can be ejected.
fix: Casing ejection fixes.
refactor: True lever action guns. Unique action key opens and closes receiver. Must be cycled after every shot.
/:cl:
