### PR TITLE
Mech Pilots are now worth STRONG Larva points, and have HIGH smartgunner point value

### DIFF
--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -375,8 +375,8 @@ Though you are a warrant officer, your authority is limited to the dropship and 
 	job_points_needed = 40
 	job_points = 15
 	jobworth = list(
-		/datum/job/xenomorph = LARVA_POINTS_SHIPSIDE,
-		/datum/job/terragov/squad/smartgunner = SMARTIE_POINTS_REGULAR,
+		/datum/job/xenomorph = LARVA_POINTS_STRONG,
+		/datum/job/terragov/squad/smartgunner = SMARTIE_POINTS_MEDIUM,
 	)
 	html_description = {"
 		<b>Difficulty</b>:Very Hard<br /><br />


### PR DESCRIPTION

## About The Pull Request
Title, literaly. They went from shipside larva point cost (1) to STRONG (6) and up a level in smartgunner point value (1 to 2)
## Why It's Good For The Game
Mech pilot is clearly a role with a decent amount of power in the game, so it should be worth quite a bit of larva and smartgunner points.
## Changelog
:cl:
balance: Mech pilot is now worth 6 larva points from 1, and 1 more smartgunner spawn point.
/:cl:
