### PR TITLE
Minor V-31/AP tweak

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -604,7 +604,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	name = "armor-piercing rifle bullet"
 	hud_state = "rifle_ap"
 	damage = 20
-	penetration = 30
+	penetration = 25
 	sundering = 3
 
 /datum/ammo/bullet/rifle/hv

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1662,7 +1662,7 @@
 	fire_delay = 0.2 SECONDS
 	aim_slowdown = 0.35
 
-	accuracy_mult = 1.05
+	accuracy_mult = 1
 	accuracy_mult_unwielded = 0.55
 	scatter = 1
 	scatter_unwielded = 15
@@ -1670,7 +1670,6 @@
 	burst_amount = 3
 	burst_delay = 0.1 SECONDS
 	extra_delay = 0.1 SECONDS
-	autoburst_delay = 0.3 SECONDS
 
 	damage_falloff_mult = 0.7
 


### PR DESCRIPTION

## About The Pull Request
Very minor tweaks I forgot to do ages ago.
Slight reduction on V-31 accuracy, and slight decrease in AP for AP rifle ammo. I guess this also effects PMC SL but they can cope, they still have mega dps due to their damage multiplier.

Reducing the AP as the actual % damage reduction is lower on rifles compared to AP smg ammo, but with the same AP gain.

Also removed an uneeded var.
## Why It's Good For The Game
More comparable scaling for rifle AP ammo.
## Changelog
:cl:
balance: Slight reduction in V-31 base accuracy
balance: Reduced AP rifle ammo AP to 25 from 30
/:cl:
