### PR TITLE
Minor mapping bugfixes

### DIFF
--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -4177,8 +4177,10 @@
 /area/lv624/ground/sand8)
 "czI" = (
 /obj/docking_port/stationary/crashmode,
-/turf/closed/wall,
-/area/lv624/lazarus/hydroponics)
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
 "czL" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor,
@@ -10406,7 +10408,7 @@
 /area/lv624/ground/jungle1)
 "jRU" = (
 /obj/effect/attach_point/weapon/dropship1{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
@@ -47235,7 +47237,7 @@ wgH
 xGM
 wgH
 wgH
-wgH
+czI
 wgH
 wgH
 wgH
@@ -48098,7 +48100,7 @@ bcA
 rcz
 rcz
 brD
-czI
+eUY
 biS
 bqx
 bqx

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -8375,7 +8375,6 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
-/obj/docking_port/stationary/marine_dropship/crash_target,
 /obj/structure/cable,
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -18038,6 +18037,22 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"YH" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/vending/weapon,
+/obj/docking_port/stationary/marine_dropship/crash_target,
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
+/area/mainship/squads/general)
 "YI" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
@@ -55657,7 +55672,7 @@ Eo
 Eo
 xT
 zh
-WN
+YH
 IQ
 IQ
 xT

--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -275,17 +275,15 @@
 /turf/open/floor/mainship/tcomms,
 /area/shuttle/canterbury)
 "bi" = (
+/obj/structure/barricade/plasteel{
+	dir = 8
+	},
 /obj/machinery/door_control{
-	id = "port_umbilical_outer";
+	id = "starboard_umbilical_outer";
 	name = "outer door-control";
 	pixel_y = 32
 	},
-/obj/machinery/door/poddoor/mainship{
-	id = "port_umbilical_outer";
-	name = "\improper Umbillical Airlock"
-	},
-/obj/machinery/door/poddoor/shutters/transit,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/stripesquare,
 /area/shuttle/canterbury)
 "bj" = (
 /obj/structure/cable,
@@ -401,17 +399,15 @@
 /turf/open/floor/mainship,
 /area/shuttle/canterbury)
 "bC" = (
+/obj/structure/barricade/plasteel{
+	dir = 4
+	},
 /obj/machinery/door_control{
 	id = "starboard_umbilical_outer";
 	name = "outer door-control";
 	pixel_y = 32
 	},
-/obj/machinery/door/poddoor/mainship{
-	id = "starboard_umbilical_outer";
-	name = "\improper Umbillical Airlock"
-	},
-/obj/machinery/door/poddoor/shutters/transit,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/stripesquare,
 /area/shuttle/canterbury)
 "bD" = (
 /obj/structure/cable,
@@ -1163,7 +1159,7 @@ al
 Mj
 Kk
 ab
-bi
+bU
 bU
 bU
 bU
@@ -1196,7 +1192,7 @@ al
 Ui
 Xp
 ab
-DH
+bi
 DH
 DH
 DH
@@ -1658,7 +1654,7 @@ al
 vW
 cR
 ab
-hc
+bC
 hc
 hc
 hc
@@ -1691,7 +1687,7 @@ al
 ql
 te
 ab
-bC
+bV
 bV
 bV
 bV

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -133,6 +133,11 @@
 /obj/item/binoculars,
 /obj/item/facepaint/sniper,
 /obj/machinery/alarm,
+/obj/machinery/door_control{
+	dir = 4;
+	id = "port_umbilical_outer";
+	name = "outer door-control"
+	},
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "av" = (
@@ -172,20 +177,12 @@
 "ay" = (
 /obj/structure/largecrate/supply/supplies/sandbags,
 /obj/machinery/alarm,
-/turf/open/floor/mainship/cargo,
-/area/shuttle/canterbury)
-"az" = (
-/obj/machinery/door/poddoor/mainship{
-	id = "port_umbilical_outer";
-	name = "\improper Umbillical Airlock"
-	},
-/obj/machinery/door/poddoor/shutters/transit,
 /obj/machinery/door_control{
+	dir = 4;
 	id = "port_umbilical_outer";
-	name = "outer door-control";
-	pixel_y = 32
+	name = "outer door-control"
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "aA" = (
 /obj/structure/barricade/plasteel{
@@ -210,19 +207,6 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/stripesquare,
-/area/shuttle/canterbury)
-"aG" = (
-/obj/machinery/door/poddoor/mainship{
-	id = "starboard_umbilical_outer";
-	name = "\improper Umbillical Airlock"
-	},
-/obj/machinery/door/poddoor/shutters/transit,
-/obj/machinery/door_control{
-	id = "starboard_umbilical_outer";
-	name = "outer door-control";
-	pixel_y = 32
-	},
-/turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "aH" = (
 /obj/machinery/door/poddoor/mainship{
@@ -902,7 +886,7 @@ aa
 aa
 an
 an
-az
+aH
 aH
 aH
 an
@@ -1178,7 +1162,7 @@ aa
 aa
 an
 an
-aG
+aK
 aK
 aK
 an


### PR DESCRIPTION

## About The Pull Request

Patches a handful of known problems, mostly with the Canterbury and its crash locations.

## Why It's Good For The Game

Bugs bad.

## Changelog
:cl:
fix: Adjusted a crash location on LV624 that could crush the green disk generator
fix: Adjusted a crash location on the Pillar of Spring that could destroy the hull of the ship and lead to space.
fix: Changed the button locations on both Canterbury variations so they can't be melted from the outside.
/:cl:
