### PR TITLE
Scout/Sniper Cloak Balance :)

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -782,12 +782,12 @@ ARMOR
 /datum/supply_packs/armor/scout_cloak
 	name = "Scout Cloak"
 	contains = list(/obj/item/storage/backpack/marine/satchel/scout_cloak/scout)
-	cost = 50
+	cost = 35
 
 /datum/supply_packs/armor/sniper_cloak
 	name = "Sniper Cloak"
 	contains = list(/obj/item/storage/backpack/marine/satchel/scout_cloak/sniper)
-	cost = 50
+	cost = 35
 
 /datum/supply_packs/armor/grenade_belt
 	name = "High Capacity Grenade Belt"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -787,7 +787,7 @@ ARMOR
 /datum/supply_packs/armor/sniper_cloak
 	name = "Sniper Cloak"
 	contains = list(/obj/item/storage/backpack/marine/satchel/scout_cloak/sniper)
-	cost = 35
+	cost = 30
 
 /datum/supply_packs/armor/grenade_belt
 	name = "High Capacity Grenade Belt"


### PR DESCRIPTION

## About The Pull Request

Lowers the price of both the scout cloak and the sniper cloak to 35.

## Why It's Good For The Game

Let me ask you, when's the last time you saw somebody run a scout cloak or sniper cloak? That's right. You've never seen somebody run a scout cloak or a sniper cloak. They're way too expensive to be viable, by the time you can afford 50 points for one item for one marine, the push is either dead as fuck or way too far in for a stealth unga to be viable. Now, this doesn't make them quite so viable that every marines gonna have one, but maybe you're gonna see one or two of them every few rounds.

## Changelog
:cl:
balance: Scout/Sniper cloak now 35 points from req
/:cl:
