### PR TITLE
Evo towers now provide 1 T3 slot and 2 T2 slots

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -1059,8 +1059,8 @@ to_chat will check for valid clients itself already so no need to double check f
 	var/threes = length(xenos_by_tier[XENO_TIER_THREE])
 	var/fours = length(xenos_by_tier[XENO_TIER_FOUR])
 
-	tier3_xeno_limit = max(threes, FLOOR(((zeros + ones + twos + fours) * (evotowers.len * 0.2 + 1)) / 3 + 1, 1))
-	tier2_xeno_limit = max(twos, (zeros + ones + fours) * (evotowers.len * 0.2 + 1) + 1 - threes)
+	tier3_xeno_limit = max(threes, FLOOR((zeros + ones + twos + fours) / 3 + length(evotowers) + 1, 1))
+	tier2_xeno_limit = max(twos, (zeros + ones + fours) + length(evotowers) * 2 + 1 - threes)
 
 // ***************************************
 // *********** Corrupted Xenos


### PR DESCRIPTION

## About The Pull Request
Initially in my september PR , a maintainer has raised concerns when using quantitized quantities instead of multipliers on total xeno pop
After a few months of gameplay , the evo tower is still not a good choice , even with big hives they were not used due to the buff being simply too small (20% of 15-20 xenos was still not enough)
## Why It's Good For The Game
I believe not using multipliers is  a better choice , as multipliers can easily get out of control at high-population ,  but remain nigh useless at low-pop
This change aims to make them decent at any pop .

## Changelog
:cl:
balance: Evotowers no longer provide 20% more slots , and instead provide 1 T3 slot and 2 T2 slots for each.
/:cl:
