### PR TITLE
Buff pizza

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1725,7 +1725,7 @@ FACTORY
 /datum/supply_packs/factory/pizzarefill
 	name = "Nanotrasen \"Eat healthy!\" margerita pizza kit refill"
 	contains = list(/obj/item/factory_refill/pizza_refill)
-	cost = 29 //allows a one point profit if all pizzas are processed and sold back to ASRS
+	cost = 28 //allows a two point profit if all pizzas are processed and sold back to ASRS
 
 /datum/supply_packs/factory/smartgun_minigun_box_refill
 	name = "Smart minigun bullet bin parts refill"


### PR DESCRIPTION

## About The Pull Request
Pizza refill pack cost change.
## Why It's Good For The Game
Currently with pizza refills costing 29 and each pack making 30 pizzas you make 1 point per pack. Making it mostly a gimmick and a very unrealistic point generation method especially considering you need to do this process 15 times to pay off equipment for a second pizza set up. This lowers cost from 29 to 28 thus giving you 2 points per pack(also slightly lowers the startup for pizza)
## Changelog
:cl:
balance: pizza refill pack cost from 29 to 28
/:cl:
