### PR TITLE
Remove a tree south of LV-624 hydro bridge

### DIFF
--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -45964,7 +45964,7 @@ ajz
 aZu
 aOj
 aWM
-mOs
+arW
 mOs
 mOs
 atX
@@ -46141,7 +46141,7 @@ vCy
 vCy
 cbi
 ksD
-jeR
+bnF
 mOs
 atX
 arW


### PR DESCRIPTION
## About The Pull Request

before

![image](https://user-images.githubusercontent.com/6610922/206819470-d8e00acb-7790-49e7-8fde-095ce4de3514.png)

after

![image](https://user-images.githubusercontent.com/6610922/206819499-dfc8d0d6-ace5-4833-956a-186b19e78086.png)


## Why It's Good For The Game

I've seen many players WASD into this weird chokepoint, look at it, then waggle their way out (me included). It's such a weird chokepoint that I think deserve to be open up. Yes, it is a one tile chokepoint, but now the flow is better.

## Changelog

:cl:
del: Remove a tree south of LV-624 hydro bridge
/:cl:

