### PR TITLE
Kills shotgun juggling

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -126,6 +126,9 @@
 #define SLOWDOWN_ARMOR_HEAVY 1
 #define SLOWDOWN_ARMOR_VERY_HEAVY 1.15
 
+//Fire delay groups.
+#define FIRE_DELAY_GROUP_SHOTGUN (1<<0)
+
 
 //=================================================
 

--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -127,7 +127,7 @@
 #define SLOWDOWN_ARMOR_VERY_HEAVY 1.15
 
 //Fire delay groups.
-#define FIRE_DELAY_GROUP_SHOTGUN (1<<0)
+#define FIRE_DELAY_GROUP_SHOTGUN "fire_delay_group_shotgun"
 
 
 //=================================================

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -29,6 +29,7 @@
 	var/track_blood = 0
 	var/feet_blood_color
 	var/datum/skills/skills
+	var/list/fire_delay_next_fire
 
 
 	//Movement

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -58,6 +58,11 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 /obj/item/weapon/gun/dropped(mob/user)
 	. = ..()
 
+	var/delay_left = (last_fired + fire_delay + fire_group_delay_time) - world.time
+	if(fire_delay_group && delay_left > 0)
+		for(var/group in fire_delay_group)
+			LAZYSET(user.fire_delay_next_fire, group, world.time + delay_left)
+
 	unwield(user)
 	harness_check(user)
 

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -70,6 +70,11 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 /obj/item/weapon/gun/pickup(mob/user)
 	..()
 
+	var/delay_left = (last_fired + fire_delay + fire_group_delay_time) - world.time
+	if(fire_delay_group && delay_left > 0)
+		for(var/group in fire_delay_group)
+			LAZYSET(user.fire_delay_next_fire, group, world.time + delay_left)
+
 	unwield(user)
 
 

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -262,9 +262,8 @@
 	var/ammo_diff = null
 
 	///Fire delay is applied to a gun group when a gun of that group was dropped
-	var/list/fire_delay_group = null
+	var/list/fire_delay_group
 	var/fire_group_delay_time = 0
-	var/list/fire_delay_next_fire = null
 
 /*
  *  extra icon and item states or overlays

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -261,6 +261,11 @@
 	///what ammo to use for overcharge
 	var/ammo_diff = null
 
+	///Fire delay is applied to a gun group when a gun of that group was dropped
+	var/list/fire_delay_group = null
+	var/fire_group_delay_time = 0
+	var/list/fire_delay_next_fire = null
+
 /*
  *  extra icon and item states or overlays
 */
@@ -1550,6 +1555,11 @@
 	if(CHECK_BITFIELD(flags_gun_features, GUN_IS_ATTACHMENT) && !master_gun && CHECK_BITFIELD(flags_gun_features, GUN_ATTACHMENT_FIRE_ONLY))
 		to_chat(user, span_notice("You cannot fire [src] without it attached to a gun!"))
 		return FALSE
+	if(fire_delay_group)
+		for(var/group in fire_delay_group)
+			var/group_next_fire = LAZYACCESS(user.fire_delay_next_fire, group)
+			if(!isnull(group_next_fire) && world.time < group_next_fire)
+				return FALSE
 	return TRUE
 
 /obj/item/weapon/gun/proc/gun_on_cooldown(mob/user)

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -17,7 +17,7 @@
 	aim_slowdown = 0.35
 	wield_delay = 0.6 SECONDS //Shotguns are really easy to put up to fire, since they are designed for CQC (at least compared to a rifle)
 	fire_delay_group = list(FIRE_DELAY_GROUP_SHOTGUN)
-	fire_group_delay_time = 2 SECONDS
+	fire_group_delay_time = 2 SECONDS + cock_delay
 	gun_skill_category = GUN_SKILL_SHOTGUNS
 	flags_item_map_variant = NONE
 

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -17,7 +17,7 @@
 	aim_slowdown = 0.35
 	wield_delay = 0.6 SECONDS //Shotguns are really easy to put up to fire, since they are designed for CQC (at least compared to a rifle)
 	fire_delay_group = list(FIRE_DELAY_GROUP_SHOTGUN)
-	fire_group_delay_time = 2 SECONDS + cock_delay
+	fire_group_delay_time = 3 SECONDS
 	gun_skill_category = GUN_SKILL_SHOTGUNS
 	flags_item_map_variant = NONE
 

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -16,6 +16,8 @@
 	allowed_ammo_types = list()
 	aim_slowdown = 0.35
 	wield_delay = 0.6 SECONDS //Shotguns are really easy to put up to fire, since they are designed for CQC (at least compared to a rifle)
+	fire_delay_group = list(FIRE_DELAY_GROUP_SHOTGUN)
+	fire_group_delay_time = 2 SECONDS
 	gun_skill_category = GUN_SKILL_SHOTGUNS
 	flags_item_map_variant = NONE
 


### PR DESCRIPTION
## About The Pull Request

This PR kills shotgun juggling. If you drop a shotgun on the ground you won't be able to fire another shotgun for 3 seconds.

## Why It's Good For The Game

Shotgun juggling is bad.

## Changelog

:cl:
balance: If you drop a shotgun on the ground you won't be able to fire another shotgun for 3 seconds
/:cl:
