### PR TITLE
Removes juggling NO MOB VARS edition

### DIFF
--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -65,7 +65,7 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 /obj/item/weapon/gun/pickup(mob/user)
 	..()
 
-	last_fired = world.time
+	last_fired = world.time + pickup_fire_delay
 
 	unwield(user)
 

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -65,6 +65,8 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 /obj/item/weapon/gun/pickup(mob/user)
 	..()
 
+	last_fired = world.time
+
 	unwield(user)
 
 

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -232,6 +232,8 @@
 	var/aim_speed_modifier = 6
 	/// Time to enter aim mode, generally one second.
 	var/aim_time = 1 SECONDS
+	///Additional time to fire a weapon from pickup
+	var/pickup_fire_delay = 0
 
 	///How many shots can the weapon shoot in burst? Anything less than 2 and you cannot toggle burst.
 	var/burst_amount = 1

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -167,7 +167,7 @@
 	recoil = 2
 	recoil_unwielded = 4
 	aim_slowdown = 0.6
-	pickup_fire_delay = 10
+	pickup_fire_delay = 20
 
 /obj/item/weapon/gun/shotgun/double/sawn
 	name = "sawn-off shotgun"

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -167,6 +167,7 @@
 	recoil = 2
 	recoil_unwielded = 4
 	aim_slowdown = 0.6
+	pickup_fire_delay = 10
 
 /obj/item/weapon/gun/shotgun/double/sawn
 	name = "sawn-off shotgun"


### PR DESCRIPTION

## About The Pull Request

Title. You wont be able to fire a weapon for its fire_delay when you pick it up.

## Why It's Good For The Game

removes juggling without touching mob vars

## Changelog
:cl:
balance: removed juggling
/:cl:
