### PR TITLE
Remove multiple 1-tile chokepoints in Gelida

### DIFF
--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -42748,7 +42748,7 @@ vhV
 npU
 lmN
 yiB
-ghy
+yiB
 wLU
 oJT
 oJT

--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -19837,11 +19837,6 @@
 	},
 /turf/open/ground/river,
 /area/gelida/indoors/a_block/fitness)
-"mJY" = (
-/turf/closed/ice_rock/corners{
-	dir = 9
-	},
-/area/gelida/outdoors/w_rockies)
 "mKd" = (
 /obj/structure/fakeplatform{
 	dir = 8
@@ -42079,7 +42074,7 @@ udH
 yiB
 uXf
 dQm
-cAW
+aZV
 gEt
 lmN
 uXf
@@ -42301,7 +42296,7 @@ mFD
 qhP
 uXf
 lmN
-peB
+lmN
 daB
 lmN
 nkH
@@ -42993,7 +42988,7 @@ otX
 peB
 oJT
 ojq
-mJY
+ddP
 ddP
 bYd
 peB

--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -42296,7 +42296,7 @@ mFD
 qhP
 uXf
 lmN
-lmN
+aZV
 daB
 lmN
 nkH
@@ -42320,7 +42320,7 @@ daB
 otX
 rih
 rih
-daB
+nAJ
 ddP
 ddP
 fBJ
@@ -42547,8 +42547,8 @@ daB
 bYd
 ddP
 bYd
-ojq
-daB
+nAJ
+nAJ
 bYd
 bYd
 gNQ
@@ -42761,7 +42761,7 @@ oJT
 oJT
 oJT
 rCM
-tQg
+nAJ
 rih
 ojq
 oJT

--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -43192,7 +43192,7 @@ lmN
 lmN
 lmN
 lmN
-nkH
+lmN
 lmN
 lmN
 dQm

--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -19837,6 +19837,11 @@
 	},
 /turf/open/ground/river,
 /area/gelida/indoors/a_block/fitness)
+"mJY" = (
+/turf/closed/ice_rock/corners{
+	dir = 9
+	},
+/area/gelida/outdoors/w_rockies)
 "mKd" = (
 /obj/structure/fakeplatform{
 	dir = 8
@@ -42742,7 +42747,7 @@ kuB
 gqh
 lmN
 lby
-nff
+lmN
 nkH
 vhV
 npU
@@ -42766,9 +42771,9 @@ rih
 ojq
 oJT
 oJT
-tQg
+nAJ
 ddP
-ghy
+nAJ
 oJT
 oJT
 daB
@@ -42988,7 +42993,7 @@ otX
 peB
 oJT
 ojq
-ddP
+mJY
 ddP
 bYd
 peB
@@ -43185,8 +43190,8 @@ lmN
 uXf
 lmN
 lmN
-ojq
-tQg
+lmN
+lmN
 nkH
 lmN
 lmN
@@ -43407,7 +43412,7 @@ yiB
 uXf
 jaU
 gqh
-nff
+lmN
 lmN
 nkH
 syU

--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -42334,7 +42334,7 @@ vFl
 vFl
 ddP
 fBJ
-cAW
+fBJ
 fBJ
 fBJ
 oTB


### PR DESCRIPTION
## About The Pull Request

I cope hard as a mapper and marine player.

before
![image](https://user-images.githubusercontent.com/6610922/206876358-5a110546-8f3c-42cf-98f3-bf44dc6e1895.png)

![image](https://user-images.githubusercontent.com/6610922/206876306-0b3beb2b-eb56-45ec-9924-9b4cdf3b09af.png)

![image](https://user-images.githubusercontent.com/6610922/206876315-adfc1ab8-2e9b-44c3-b962-29db708c4942.png)

after
![image](https://user-images.githubusercontent.com/6610922/206876330-19461b83-0596-44e6-be92-e455e6b7ea3d.png)

![image](https://user-images.githubusercontent.com/6610922/206876381-3a3c63a2-88c8-4759-a5f5-6fbb9332dc5f.png)

## Why It's Good For The Game

Having walls that force a 1-tile choke which can only be destroyed by plasma cutters and C4 is not good map practice. Since these chokepoints are in the direction of the map (marines push from south to north), these chokepoints are contested very often.

Also, I'm coping hard.

## Changelog

:cl:
del: Remove multiple 1 tile chokepoints in Gelida
/:cl:

