### PR TITLE
Minor fix to the damage refactor fix

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -182,8 +182,8 @@
 		visible_message(span_danger("[M] [M.attacktext] [src]!"))
 		log_combat(M, src, "attacked")
 		var/dam_zone = pick("chest", "l_hand", "r_hand", "l_leg", "r_leg")
-		var/datum/limb/affecting = get_limb(ran_zone(dam_zone))
-		apply_damage(M.melee_damage, BRUTE, affecting, MELEE, updating_health = TRUE)
+		dam_zone = ran_zone(dam_zone)
+		apply_damage(M.melee_damage, BRUTE, dam_zone, MELEE, updating_health = TRUE)
 
 /mob/living/carbon/human/show_inv(mob/living/user)
 	var/obj/item/clothing/under/suit

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -110,8 +110,8 @@
 			var/max_dmg = H.melee_damage + H.skills.getRating("cqc")
 			var/damage = rand(1, max_dmg)
 
-			var/datum/limb/affecting = get_limb(ran_zone(H.zone_selected))
-			var/armor_block = get_soft_armor("melee", affecting)
+			var/target_zone = ran_zone(H.zone_selected)
+			var/armor_block = get_soft_armor("melee", target_zone)
 
 			playsound(loc, attack.attack_sound, 25, TRUE)
 
@@ -123,7 +123,7 @@
 				hit_report += "(KO)"
 
 			damage += attack.damage
-			apply_damage(damage, BRUTE, affecting, MELEE, attack.sharp, attack.edge, updating_health = TRUE)
+			apply_damage(damage, BRUTE, target_zone, MELEE, attack.sharp, attack.edge, updating_health = TRUE)
 
 			hit_report += "(RAW DMG: [damage])"
 
@@ -138,7 +138,7 @@
 
 			H.do_attack_animation(src, ATTACK_EFFECT_DISARM)
 
-			var/datum/limb/affecting = get_limb(ran_zone(H.zone_selected))
+			var/target_zone = ran_zone(H.zone_selected)
 
 			//Accidental gun discharge
 			if(user.skills.getRating("cqc") < SKILL_CQC_MP)
@@ -166,7 +166,7 @@
 			var/randn = rand(1, 100) + skills.getRating("cqc") * 5 - H.skills.getRating("cqc") * 5
 
 			if (randn <= 25)
-				apply_effect(3, WEAKEN, get_soft_armor("melee", affecting))
+				apply_effect(3, WEAKEN, get_soft_armor("melee", target_zone))
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
 				visible_message(span_danger("[H] has pushed [src]!"), null, null, 5)
 				log_combat(user, src, "pushed")

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -148,7 +148,7 @@ Contains most of the procs that are called when a mob is attacked by something
 			log_combat(user, src, "attacked", I, "(FAILED: shield blocked) (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(I.damtype)])")
 			return TRUE
 
-	var/applied_damage = modify_by_armor(damage, MELEE, I.penetration, def_zone)
+	var/applied_damage = modify_by_armor(damage, MELEE, I.penetration, target_zone)
 	var/percentage_penetration = applied_damage / damage * 100
 	var/attack_verb = LAZYLEN(I.attack_verb) ? pick(I.attack_verb) : "attacked"
 	var/armor_verb

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -177,7 +177,7 @@ Contains most of the procs that are called when a mob is attacked by something
 
 	user.do_attack_animation(src, used_item = I)
 
-	apply_damage(applied_damage, I.damtype, affecting, 0, weapon_sharp, weapon_edge, updating_health = TRUE)
+	apply_damage(applied_damage, I.damtype, target_zone, 0, weapon_sharp, weapon_edge, updating_health = TRUE)
 
 	var/list/hit_report = list("(RAW DMG: [damage])")
 
@@ -300,7 +300,7 @@ Contains most of the procs that are called when a mob is attacked by something
 		return
 
 	thrown_item.set_throwing(FALSE) // Hit the limb.
-	var/applied_damage = modify_by_armor(throw_damage, MELEE, thrown_item.penetration, affecting)
+	var/applied_damage = modify_by_armor(throw_damage, MELEE, thrown_item.penetration, zone)
 
 	if(applied_damage <= 0)
 		visible_message(span_notice("\The [thrown_item] bounces on [src]'s armor!"), null, null, 5)
@@ -309,7 +309,7 @@ Contains most of the procs that are called when a mob is attacked by something
 
 	visible_message(span_warning("[src] has been hit in the [affecting.display_name] by \the [thrown_item]."), null, null, 5)
 
-	apply_damage(applied_damage, thrown_item.damtype, affecting, 0, is_sharp(thrown_item), has_edge(thrown_item), updating_health = TRUE)
+	apply_damage(applied_damage, thrown_item.damtype, zone, 0, is_sharp(thrown_item), has_edge(thrown_item), updating_health = TRUE)
 
 	var/list/hit_report = list("(RAW DMG: [throw_damage])")
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -888,6 +888,8 @@ GLOBAL_VAR_INIT(join_as_robot_allowed, TRUE)
 
 ///damage override at the species level, called by /mob/living/proc/apply_damage
 /datum/species/proc/apply_damage(damage = 0, damagetype = BRUTE, def_zone, blocked = 0, sharp = FALSE, edge = FALSE, updating_health = FALSE, penetration, mob/living/carbon/human/victim)
+	if(isorgan(def_zone)) //Got sent a limb datum, convert to a zone define
+		def_zone = def_zone.name
 	if(isnum(blocked))
 		damage -= clamp(damage * (blocked - penetration) * 0.01, 0, damage)
 	else
@@ -900,12 +902,9 @@ GLOBAL_VAR_INIT(join_as_robot_allowed, TRUE)
 		return 0
 
 	var/datum/limb/organ = null
-	if(isorgan(def_zone))
-		organ = def_zone
-	else
-		if(!def_zone)
-			def_zone = ran_zone(def_zone)
-		organ = victim.get_limb(check_zone(def_zone))
+	if(!def_zone)
+		def_zone = ran_zone(def_zone)
+	organ = victim.get_limb(check_zone(def_zone))
 	if(!organ)
 		return FALSE
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -888,8 +888,10 @@ GLOBAL_VAR_INIT(join_as_robot_allowed, TRUE)
 
 ///damage override at the species level, called by /mob/living/proc/apply_damage
 /datum/species/proc/apply_damage(damage = 0, damagetype = BRUTE, def_zone, blocked = 0, sharp = FALSE, edge = FALSE, updating_health = FALSE, penetration, mob/living/carbon/human/victim)
+	var/datum/limb/organ = null
 	if(isorgan(def_zone)) //Got sent a limb datum, convert to a zone define
-		def_zone = def_zone.name
+		organ = def_zone
+		def_zone = organ.name
 	if(isnum(blocked))
 		damage -= clamp(damage * (blocked - penetration) * 0.01, 0, damage)
 	else
@@ -901,7 +903,6 @@ GLOBAL_VAR_INIT(join_as_robot_allowed, TRUE)
 	if(!damage)
 		return 0
 
-	var/datum/limb/organ = null
 	if(!def_zone)
 		def_zone = ran_zone(def_zone)
 	organ = victim.get_limb(check_zone(def_zone))

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -892,6 +892,14 @@ GLOBAL_VAR_INIT(join_as_robot_allowed, TRUE)
 	if(isorgan(def_zone)) //Got sent a limb datum, convert to a zone define
 		organ = def_zone
 		def_zone = organ.name
+
+	if(!def_zone)
+		def_zone = ran_zone(def_zone)
+	if(!organ)
+		organ = victim.get_limb(check_zone(def_zone))
+	if(!organ)
+		return FALSE
+
 	if(isnum(blocked))
 		damage -= clamp(damage * (blocked - penetration) * 0.01, 0, damage)
 	else
@@ -903,11 +911,6 @@ GLOBAL_VAR_INIT(join_as_robot_allowed, TRUE)
 	if(!damage)
 		return 0
 
-	if(!def_zone)
-		def_zone = ran_zone(def_zone)
-	organ = victim.get_limb(check_zone(def_zone))
-	if(!organ)
-		return FALSE
 
 	switch(damagetype)
 		if(BRUTE)

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -53,19 +53,18 @@
 /mob/living/proc/get_xeno_slash_zone(mob/living/carbon/xenomorph/X, set_location = FALSE, random_location = FALSE, no_head = FALSE)
 	return
 
-///Returns a zone define
 /mob/living/carbon/get_xeno_slash_zone(mob/living/carbon/xenomorph/X, set_location = FALSE, random_location = FALSE, no_head = FALSE, ignore_destroyed = TRUE)
-	var/affecting
+	var/datum/limb/affecting
 	if(set_location)
-		affecting = set_location
+		affecting = get_limb(set_location)
 	else if(SEND_SIGNAL(X, COMSIG_XENOMORPH_ZONE_SELECT) & COMSIG_ACCURATE_ZONE)
-		affecting = X.zone_selected
+		affecting = get_limb(X.zone_selected)
 	else
-		affecting = ran_zone(X.zone_selected, 70)
-	if(!affecting || (random_location && !set_location) || (ignore_destroyed && !get_limb(affecting).is_usable())) //No organ or it's destroyed, just get a random one
-		affecting = ran_zone(null, 0)
-	if(!affecting || (no_head && affecting == "head") || (ignore_destroyed && !get_limb(affecting).is_usable()))
-		affecting = "chest"
+		affecting = get_limb(ran_zone(X.zone_selected, 70))
+	if(!affecting || (random_location && !set_location) || (ignore_destroyed && !affecting.is_usable())) //No organ or it's destroyed, just get a random one
+		affecting = get_limb(ran_zone(null, 0))
+	if(!affecting || (no_head && affecting == get_limb("head")) || (ignore_destroyed && !affecting.is_usable()))
+		affecting = get_limb("chest")
 	return affecting
 
 /mob/living/proc/attack_alien_harm(mob/living/carbon/xenomorph/X, dam_bonus, set_location = FALSE, random_location = FALSE, no_head = FALSE, no_crit = FALSE, force_intent = null)
@@ -77,7 +76,7 @@
 	if(!damage)
 		return FALSE
 
-	var/target_zone = get_xeno_slash_zone(X, set_location, random_location, no_head)
+	var/datum/limb/affecting = get_xeno_slash_zone(X, set_location, random_location, no_head)
 	var/armor_block = 0
 
 	var/list/damage_mod = list()
@@ -128,7 +127,7 @@
 	else //Normal xenomorph friendship with benefits
 		log_combat(X, src, log)
 
-	apply_damage(damage, BRUTE, target_zone, armor_block, TRUE, TRUE, TRUE, armor_pen) //This should slicey dicey
+	apply_damage(damage, BRUTE, affecting, armor_block, TRUE, TRUE, TRUE, armor_pen) //This should slicey dicey
 
 	return TRUE
 

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -53,18 +53,19 @@
 /mob/living/proc/get_xeno_slash_zone(mob/living/carbon/xenomorph/X, set_location = FALSE, random_location = FALSE, no_head = FALSE)
 	return
 
+///Returns a zone define
 /mob/living/carbon/get_xeno_slash_zone(mob/living/carbon/xenomorph/X, set_location = FALSE, random_location = FALSE, no_head = FALSE, ignore_destroyed = TRUE)
-	var/datum/limb/affecting
+	var/affecting
 	if(set_location)
-		affecting = get_limb(set_location)
+		affecting = set_location
 	else if(SEND_SIGNAL(X, COMSIG_XENOMORPH_ZONE_SELECT) & COMSIG_ACCURATE_ZONE)
-		affecting = get_limb(X.zone_selected)
+		affecting = X.zone_selected
 	else
-		affecting = get_limb(ran_zone(X.zone_selected, 70))
-	if(!affecting || (random_location && !set_location) || (ignore_destroyed && !affecting.is_usable())) //No organ or it's destroyed, just get a random one
-		affecting = get_limb(ran_zone(null, 0))
-	if(!affecting || (no_head && affecting == get_limb("head")) || (ignore_destroyed && !affecting.is_usable()))
-		affecting = get_limb("chest")
+		affecting = ran_zone(X.zone_selected, 70)
+	if(!affecting || (random_location && !set_location) || (ignore_destroyed && !get_limb(affecting).is_usable())) //No organ or it's destroyed, just get a random one
+		affecting = ran_zone(null, 0)
+	if(!affecting || (no_head && affecting == "head") || (ignore_destroyed && !get_limb(affecting).is_usable()))
+		affecting = "chest"
 	return affecting
 
 /mob/living/proc/attack_alien_harm(mob/living/carbon/xenomorph/X, dam_bonus, set_location = FALSE, random_location = FALSE, no_head = FALSE, no_crit = FALSE, force_intent = null)
@@ -76,7 +77,7 @@
 	if(!damage)
 		return FALSE
 
-	var/datum/limb/affecting = get_xeno_slash_zone(X, set_location, random_location, no_head)
+	var/target_zone = get_xeno_slash_zone(X, set_location, random_location, no_head)
 	var/armor_block = 0
 
 	var/list/damage_mod = list()
@@ -127,7 +128,7 @@
 	else //Normal xenomorph friendship with benefits
 		log_combat(X, src, log)
 
-	apply_damage(damage, BRUTE, affecting, armor_block, TRUE, TRUE, TRUE, armor_pen) //This should slicey dicey
+	apply_damage(damage, BRUTE, target_zone, armor_block, TRUE, TRUE, TRUE, armor_pen) //This should slicey dicey
 
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request
Marine item attack uses the final target zone for armor calculation instead of the starting zone
Species apply_damage properly handles being sent a limb datum instead of a zone define

## Why It's Good For The Game
Doesn't really matter in the standard usecase since humans don't actually have random limb miss chance but prevents issues in a nonstandard but possible situation (null defzone).
Stops runtiming when species tries to check armor with a zone that isn't actually a zone

## Changelog
:cl:
fix: Marine on marine violence more fully uses the correct armor
/:cl:
