### PR TITLE
GUI Fix for medical analyzer's display of infections/necrosis

### DIFF
--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -176,12 +176,12 @@ REAGENT SCANNER
 						continue
 					internal_bleeding = TRUE
 					break
-			if(limb.limb_status & LIMB_NECROTIZED)
-				infection_message = "Subject's [limb.display_name] has necrotized. Surgery required."
-				necrotized = TRUE
 			if(limb.germ_level > INFECTION_LEVEL_ONE)
 				infection_message = "Infection detected in subject's [limb.display_name]. Antibiotics recommended."
 				infected = TRUE
+			if(limb.limb_status & LIMB_NECROTIZED)
+				infection_message = "Subject's [limb.display_name] has necrotized. Surgery required."
+				necrotized = TRUE
 
 			if(limb.hidden)
 				unknown_implants++

--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -163,23 +163,25 @@ REAGENT SCANNER
 	if(ishuman(patient))
 		var/mob/living/carbon/human/human_patient = patient
 		var/infection_message
-		var/infected = 0
 		var/internal_bleeding
 
 		var/unknown_implants = 0
 		for(var/datum/limb/limb AS in human_patient.limbs)
+			var/infected = FALSE
+			var/necrotized = FALSE
+
 			if(!internal_bleeding)
 				for(var/datum/wound/wound in limb.wounds)
 					if(!istype(wound, /datum/wound/internal_bleeding))
 						continue
 					internal_bleeding = TRUE
 					break
-			if(infected < 2 && limb.limb_status & LIMB_NECROTIZED)
+			if(limb.limb_status & LIMB_NECROTIZED)
 				infection_message = "Subject's [limb.display_name] has necrotized. Surgery required."
-				infected = 2
-			if(infected < 1 && limb.germ_level > INFECTION_LEVEL_ONE)
+				necrotized = TRUE
+			if(limb.germ_level > INFECTION_LEVEL_ONE)
 				infection_message = "Infection detected in subject's [limb.display_name]. Antibiotics recommended."
-				infected = 1
+				infected = TRUE
 
 			if(limb.hidden)
 				unknown_implants++
@@ -191,7 +193,7 @@ REAGENT SCANNER
 					unknown_implants++
 					implant = TRUE
 
-			if(!limb.brute_dam && !limb.burn_dam && !CHECK_BITFIELD(limb.limb_status, LIMB_DESTROYED) && !CHECK_BITFIELD(limb.limb_status, LIMB_BROKEN) && !CHECK_BITFIELD(limb.limb_status, LIMB_BLEEDING) && !implant)
+			if(!limb.brute_dam && !limb.burn_dam && !CHECK_BITFIELD(limb.limb_status, LIMB_DESTROYED) && !CHECK_BITFIELD(limb.limb_status, LIMB_BROKEN) && !CHECK_BITFIELD(limb.limb_status, LIMB_BLEEDING) && !CHECK_BITFIELD(limb.limb_status, LIMB_NECROTIZED) && !implant && !infected )
 				continue
 			var/list/current_list = list(
 				"name" = limb.display_name,
@@ -203,6 +205,7 @@ REAGENT SCANNER
 				"limb_status" = null,
 				"bleeding" = CHECK_BITFIELD(limb.limb_status, LIMB_BLEEDING),
 				"open_incision" = limb.surgery_open_stage,
+				"necrotized" = necrotized,
 				"infected" = infected,
 				"implant" = implant
 			)

--- a/tgui/packages/tgui/interfaces/MedScanner.js
+++ b/tgui/packages/tgui/interfaces/MedScanner.js
@@ -257,8 +257,7 @@ export const MedScanner = (props, context) => {
                       ) : null}
                       {limb.necrotized ? (
                         <>
-                          <Box
-                            inline color={'brown'} bold={1}>
+                          <Box inline color={'brown'} bold={1}>
                             Necrotizing
                           </Box>
                           <Box inline width={'5px'} />

--- a/tgui/packages/tgui/interfaces/MedScanner.js
+++ b/tgui/packages/tgui/interfaces/MedScanner.js
@@ -251,9 +251,20 @@ export const MedScanner = (props, context) => {
                         <>
                           <Box
                             inline
-                            color={limb.infected === 1 ? 'olive' : 'brown'}
+                            color={'olive'}
                             bold={1}>
-                            {limb.infected === 1 ? 'Infected' : 'Necrotizing'}
+                            {'Infected'}
+                          </Box>
+                          <Box inline width={'5px'} />
+                        </>
+                      ) : null}
+                      {limb.necrotized ? (
+                        <>
+                          <Box
+                            inline
+                            color={'brown'}
+                            bold={1}>
+                            {'Necrotizing'}
                           </Box>
                           <Box inline width={'5px'} />
                         </>

--- a/tgui/packages/tgui/interfaces/MedScanner.js
+++ b/tgui/packages/tgui/interfaces/MedScanner.js
@@ -249,11 +249,8 @@ export const MedScanner = (props, context) => {
                       ) : null}
                       {limb.infected ? (
                         <>
-                          <Box
-                            inline
-                            color={'olive'}
-                            bold={1}>
-                            {'Infected'}
+                          <Box inline color={'olive'} bold={1}>
+                            Infected
                           </Box>
                           <Box inline width={'5px'} />
                         </>
@@ -261,10 +258,8 @@ export const MedScanner = (props, context) => {
                       {limb.necrotized ? (
                         <>
                           <Box
-                            inline
-                            color={'brown'}
-                            bold={1}>
-                            {'Necrotizing'}
+                            inline color={'brown'} bold={1}>
+                            Necrotizing
                           </Box>
                           <Box inline width={'5px'} />
                         </>


### PR DESCRIPTION
## About The Pull Request
This PR makes changes to the GUI for healthanalyzer, to correct the following usability issues.
1. If any limb was infected, every limb was labelled as infected. Now, only the specific limb is is labelled.
2. Limbs who where infected or necrotizing were not marked as such unless they had another condition. Now, they are labelled.
3. If a limb has necrosis, it suppressed the limb being labelled with infected. Now, they are separate (This is important because limbs can have necrosis while not being infected).

## Why It's Good For The Game
Due to the above oddities with the GUI, infections seemed to exhibit strange behavior. This should make it more clear to the user what is happening. 

## Changelog
:cl:
fix: Heath analyzers are now more clear about what limbs have infections and necrosis.
/:cl:
