### PR TITLE
Removes Infinite flamerfuel source by setting avaliable welderpacks to 20

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1338,7 +1338,7 @@
 		"Backpacks" = list(
 			/obj/item/storage/backpack/marine/standard = -1,
 			/obj/item/storage/backpack/marine/satchel = -1,
-			/obj/item/tool/weldpack/marinestandard = -1,
+			/obj/item/tool/weldpack/marinestandard = 20,
 		),
 		"Instruments" = list(
 			/obj/item/instrument/violin = -1,


### PR DESCRIPTION

## About The Pull Request
This PR sets the amount of welderpacks available within in clothing vendor from infinite to 20. 

This PR does not change the avaliable amount of welderpacks from other vendors such as engi base equipment vendor.

## Why It's Good For The Game
Right now, being a xeno, mazing is extremely unenjoyable but it is absolutely vital to winning. The main factor of it being unenjoyable is the fact that flamer fuel is functionally infinite, meaning people can spray extended nozzle as much as they like clearing huge swaths of mazes, refuel from their backpack until it is empty, then go get another backpack/have a backpack sent down to them for absolutely free and no drawbacks, instead of having to use a gas tank which can be found around the map/bought by RO. 

This PR seeks to limit infinite flamer fuel by cutting the amount of available welder packs from infinite to 20, while this doesn't make it a viable choice for engi's to take from their equipment vendor, it does solve the infinite flamer fuel issue.

## Changelog
:cl:
balance: Sets the amount of welderpacks in the clothing vendor to 20
/:cl:
