### PR TITLE
Makes limb replacement surgery respect radial choice

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -11,25 +11,25 @@
 	name = "robot left arm"
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
 	icon_state = "l_arm"
-	part = list(ARM_LEFT, HAND_LEFT)
+	part = list(BODY_ZONE_L_ARM, BODY_ZONE_PRECISE_L_HAND)
 
 /obj/item/robot_parts/r_arm
 	name = "robot right arm"
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
 	icon_state = "r_arm"
-	part = list(ARM_RIGHT, HAND_RIGHT)
+	part = list(BODY_ZONE_R_ARM, BODY_ZONE_PRECISE_R_HAND)
 
 /obj/item/robot_parts/l_leg
 	name = "robot left leg"
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
 	icon_state = "l_leg"
-	part = list(LEG_LEFT, FOOT_LEFT)
+	part = list(BODY_ZONE_L_LEG, BODY_ZONE_PRECISE_L_FOOT)
 
 /obj/item/robot_parts/r_leg
 	name = "robot right leg"
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
 	icon_state = "r_leg"
-	part = list(LEG_RIGHT, FOOT_RIGHT)
+	part = list(BODY_ZONE_R_LEG, BODY_ZONE_PRECISE_R_FOOT)
 
 /obj/item/robot_parts/chest
 	name = "robot torso"

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -11,25 +11,25 @@
 	name = "robot left arm"
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
 	icon_state = "l_arm"
-	part = list("l_arm", "l_hand")
+	part = list(ARM_LEFT, HAND_LEFT)
 
 /obj/item/robot_parts/r_arm
 	name = "robot right arm"
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
 	icon_state = "r_arm"
-	part = list("r_arm", "r_hand")
+	part = list(ARM_RIGHT, HAND_RIGHT)
 
 /obj/item/robot_parts/l_leg
 	name = "robot left leg"
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
 	icon_state = "l_leg"
-	part = list("l_leg", "l_foot")
+	part = list(LEG_LEFT, FOOT_LEFT)
 
 /obj/item/robot_parts/r_leg
 	name = "robot right leg"
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
 	icon_state = "r_leg"
-	part = list("r_leg", "r_foot")
+	part = list(LEG_RIGHT, FOOT_RIGHT)
 
 /obj/item/robot_parts/chest
 	name = "robot torso"

--- a/code/modules/surgery/robolimbs.dm
+++ b/code/modules/surgery/robolimbs.dm
@@ -132,7 +132,7 @@
 	if(..())
 		var/obj/item/robot_parts/p = tool
 		if(p.part)
-			if(!(affected.body_part in p.part))
+			if(!(affected.name in p.part))
 				return SURGERY_CANNOT_USE
 		if(affected.limb_status & LIMB_AMPUTATED)
 			return SURGERY_CAN_USE

--- a/code/modules/surgery/robolimbs.dm
+++ b/code/modules/surgery/robolimbs.dm
@@ -132,7 +132,7 @@
 	if(..())
 		var/obj/item/robot_parts/p = tool
 		if(p.part)
-			if(!(target_zone in p.part))
+			if(!(affected.body_part in p.part))
 				return SURGERY_CANNOT_USE
 		if(affected.limb_status & LIMB_AMPUTATED)
 			return SURGERY_CAN_USE


### PR DESCRIPTION
## About The Pull Request
Currently, the limb replacement surgery does not work with radial - you need to both select the right part on the radial AND select the right part on the targeting doll with the prosthetic. This corrects that, you now only need to select the correct radial part if using radial.

## Changelog

:cl:
fix: Limb replacement surgery's attach prosthetic step now works with the radial menu.
/:cl:
