### PR TITLE
Guns burst fire nerf

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -238,7 +238,7 @@
 	///The delay in between shots. Lower = less delay = faster.
 	var/burst_delay = 0.1 SECONDS
 	///When burst-firing, this number is extra time before the weapon can fire again. Depends on number of rounds fired.
-	var/extra_delay	= 0
+	var/extra_delay	= 0.3 SECONDS
 	///when autobursting, this is the total amount of time before the weapon fires again. If no amount is specified, defaults to fire_delay + extra_delay
 	var/autoburst_delay = 0
 

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -238,7 +238,7 @@
 	///The delay in between shots. Lower = less delay = faster.
 	var/burst_delay = 0.1 SECONDS
 	///When burst-firing, this number is extra time before the weapon can fire again. Depends on number of rounds fired.
-	var/extra_delay	= 0.3 SECONDS
+	var/extra_delay	= 0.15 SECONDS
 	///when autobursting, this is the total amount of time before the weapon fires again. If no amount is specified, defaults to fire_delay + extra_delay
 	var/autoburst_delay = 0
 

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -513,6 +513,7 @@
 
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.1 SECONDS
+	extra_delay = 0.2 SECONDS
 	burst_amount = 3
 	accuracy_mult = 1.2
 	accuracy_mult_unwielded = 0.95

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -78,7 +78,6 @@
 
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.1 SECONDS
-	extra_delay = 0.3 SECONDS
 	accuracy_mult = 1.05
 	scatter = 0
 	burst_scatter_mult = 0.25
@@ -158,7 +157,6 @@
 
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.15 SECONDS
-	extra_delay = 0.15 SECONDS
 	accuracy_mult = 1.1
 	scatter = -2
 	wield_delay = 0.7 SECONDS
@@ -305,7 +303,6 @@
 	fire_delay = 0.3 SECONDS
 	burst_amount = 3
 	burst_delay = 0.10 SECONDS
-	extra_delay = 0.25 SECONDS
 	accuracy_mult = 0.9
 	scatter = 0
 
@@ -1584,7 +1581,6 @@
 	aim_speed_modifier = 2
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.15 SECONDS
-	extra_delay = 0.05 SECONDS
 	accuracy_mult_unwielded = 0.5
 	scatter = 1
 	scatter_unwielded = 15

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -158,7 +158,7 @@
 
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.15 SECONDS
-	extra_delay = 0.15 SECONDS
+	extra_delay = 0.1 SECONDS
 	accuracy_mult = 1.1
 	scatter = -2
 	wield_delay = 0.7 SECONDS

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1278,7 +1278,7 @@
 	fire_delay = 0.2 SECONDS
 	burst_amount = 3
 	burst_delay = 0.05 SECONDS
-	extra_delay = 0.2 SECONDS
+	extra_delay = 0.3 SECONDS
 	accuracy_mult_unwielded = 0.5
 	accuracy_mult = 1.15
 	scatter = -1

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -78,7 +78,7 @@
 
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.1 SECONDS
-	extra_delay = 0.2 SECONDS
+	extra_delay = 0.3 SECONDS
 	accuracy_mult = 1.05
 	scatter = 0
 	burst_scatter_mult = 0.25

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -78,7 +78,7 @@
 
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.1 SECONDS
-	extra_delay = 0.05 SECONDS
+	extra_delay = 0.15 SECONDS
 	accuracy_mult = 1.05
 	scatter = 0
 	burst_scatter_mult = 0.25
@@ -158,7 +158,7 @@
 
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.15 SECONDS
-	extra_delay = 0.05 SECONDS
+	extra_delay = 0.15 SECONDS
 	accuracy_mult = 1.1
 	scatter = -2
 	wield_delay = 0.7 SECONDS
@@ -1279,7 +1279,7 @@
 	fire_delay = 0.25 SECONDS
 	burst_amount = 3
 	burst_delay = 0.05 SECONDS
-	extra_delay = 0.1 SECONDS
+	extra_delay = 0.15 SECONDS
 	accuracy_mult_unwielded = 0.5
 	accuracy_mult = 1.15
 	scatter = -1

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -78,7 +78,7 @@
 
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.1 SECONDS
-	extra_delay = 0.15 SECONDS
+	extra_delay = 0.2 SECONDS
 	accuracy_mult = 1.05
 	scatter = 0
 	burst_scatter_mult = 0.25

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -78,6 +78,7 @@
 
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.1 SECONDS
+	extra_delay = 0.3 SECONDS
 	accuracy_mult = 1.05
 	scatter = 0
 	burst_scatter_mult = 0.25
@@ -157,6 +158,7 @@
 
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.15 SECONDS
+	extra_delay = 0.1 SECONDS
 	accuracy_mult = 1.1
 	scatter = -2
 	wield_delay = 0.7 SECONDS
@@ -299,10 +301,10 @@
 	aim_fire_delay = 0.2 SECONDS
 	aim_speed_modifier = 3
 
-	autoburst_delay = 0.60 SECONDS
 	fire_delay = 0.3 SECONDS
 	burst_amount = 3
 	burst_delay = 0.10 SECONDS
+	extra_delay = 0.4 SECONDS
 	accuracy_mult = 0.9
 	scatter = 0
 
@@ -1273,10 +1275,10 @@
 	actions_types = list(/datum/action/item_action/aim_mode)
 	aim_fire_delay = 0.15 SECONDS
 
-	fire_delay = 0.25 SECONDS
+	fire_delay = 0.2 SECONDS
 	burst_amount = 3
 	burst_delay = 0.05 SECONDS
-	extra_delay = 0.15 SECONDS
+	extra_delay = 0.2 SECONDS
 	accuracy_mult_unwielded = 0.5
 	accuracy_mult = 1.15
 	scatter = -1

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -158,7 +158,7 @@
 
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.15 SECONDS
-	extra_delay = 0.1 SECONDS
+	extra_delay = 0.15 SECONDS
 	accuracy_mult = 1.1
 	scatter = -2
 	wield_delay = 0.7 SECONDS

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -65,6 +65,7 @@
 	recoil_unwielded = 0
 	scatter = 0
 	fire_delay = 0.15 SECONDS
+	extra_delay = 0.1 SECONDS
 	scatter_unwielded = 4
 	aim_slowdown = 0.15
 	burst_amount = 5
@@ -343,6 +344,7 @@
 	)
 
 	fire_delay = 0.15 SECONDS
+	extra_delay = 0.25 SECONDS
 	burst_amount = 6
 	accuracy_mult = 1.05
 	accuracy_mult_unwielded = 0.8

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -65,7 +65,6 @@
 	recoil_unwielded = 0
 	scatter = 0
 	fire_delay = 0.15 SECONDS
-	extra_delay = 0.15 SECONDS
 	scatter_unwielded = 4
 	aim_slowdown = 0.15
 	burst_amount = 5
@@ -344,7 +343,6 @@
 	)
 
 	fire_delay = 0.15 SECONDS
-	extra_delay = 0.15 SECONDS
 	burst_amount = 6
 	accuracy_mult = 1.05
 	accuracy_mult_unwielded = 0.8

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -65,7 +65,7 @@
 	recoil_unwielded = 0
 	scatter = 0
 	fire_delay = 0.15 SECONDS
-	extra_delay = 0.1 SECONDS
+	extra_delay = 0.2 SECONDS
 	scatter_unwielded = 4
 	aim_slowdown = 0.15
 	burst_amount = 5

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -65,6 +65,7 @@
 	recoil_unwielded = 0
 	scatter = 0
 	fire_delay = 0.15 SECONDS
+	extra_delay = 0.15 SECONDS
 	scatter_unwielded = 4
 	aim_slowdown = 0.15
 	burst_amount = 5
@@ -343,6 +344,7 @@
 	)
 
 	fire_delay = 0.15 SECONDS
+	extra_delay = 0.15 SECONDS
 	burst_amount = 6
 	accuracy_mult = 1.05
 	accuracy_mult_unwielded = 0.8


### PR DESCRIPTION
## About The Pull Request

Adds a base 0.15 extra_delay between burstfire, and finetunes most weapons burstfire to have the same DPS as autofire.

![изображение](https://user-images.githubusercontent.com/69199543/208218827-5e77332c-214e-47af-bd3c-dd6bdc590117.png)

## Why It's Good For The Game

Fixes several guns burst fire having more DPS than autofire.

## Changelog
:cl:
balance: added 0.15 second base extra_delay, adjusted some weapons burstfire.
/:cl:
