### PR TITLE
Mech Pilots are no longer a selectable job

### DIFF
--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -17,7 +17,6 @@
 		/datum/job/terragov/medical/researcher = 2,
 		/datum/job/terragov/civilian/liaison = 1,
 		/datum/job/terragov/silicon/synthetic = 1,
-		/datum/job/terragov/command/mech_pilot = 0,
 		/datum/job/terragov/silicon/ai = 1,
 		/datum/job/terragov/squad/engineer = 8,
 		/datum/job/terragov/squad/corpsman = 8,

--- a/code/datums/gamemodes/extended.dm
+++ b/code/datums/gamemodes/extended.dm
@@ -7,7 +7,6 @@
 		/datum/job/terragov/command/fieldcommander = 1,
 		/datum/job/terragov/command/staffofficer = 4,
 		/datum/job/terragov/command/pilot = 2,
-		/datum/job/terragov/command/mech_pilot = 0,
 		/datum/job/terragov/engineering/chief = 1,
 		/datum/job/terragov/engineering/tech = 1,
 		/datum/job/terragov/requisitions/officer = 1,


### PR DESCRIPTION
## About The Pull Request
Per title. Mech Pilots are no longer available in normal gameplay.

## Why It's Good For The Game
- You introduced a broken mess with little to no bugfixes that has been wrecking balance completely for the last few months.
- There's so many broken guns, and you can akimbo them. Akimbo was an unintended feature, mind you, which loops back to a lack of bug fixes.
- You completely prevent other contributors from doing anything about its balance state because Kuro will not accept any balance changes not made by himself, something which he's said multiple times in case you haven't read most dev channels in the past few months.

At that point, I believe it a healthy choice for all involved to remove access to mechs for normal gameplay until the issues are solved.
It's been far too many weeks worth of unfun for xenos. Enough of it.

## Changelog
:cl: Lewdcifer
del: Mech Pilots have been removed from normal gameplay temporarily.
/:cl: