### PR TITLE
Improve AI shutdown verb

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai_verbs.dm
+++ b/code/modules/mob/living/silicon/ai/ai_verbs.dm
@@ -309,7 +309,15 @@
 	if(tgui_alert(src, "Do you want to shutdown your systems? WARNING: This will permanently put you out of your mob.", "Shutdown Systems", list("Yes", "No")) != "Yes")
 		return
 
-	to_chat(src, span_notice("Systems shutting down..."))
+	if(tgui_alert(src, "Are you sure you want to shutdown your systems? You won't be able to return to your body. You can't change your mind so choose wisely!", "Shutdown systems confirm", list("Yes", "No")) != "Yes")
+		return
 
+	to_chat(src, span_notice("Systems shutting down..."))
+	icon_state = "ai"
+
+	log_game("[key_name(src)] has ghosted at [AREACOORD(src)].")
+	message_admins("[ADMIN_TPMONTY(src)] has ghosted.")
+
+	priority_announce("[src] has suffered an unexpected NTOS failure over its Logarithmic silicon backhaul functions and has been taken offline. An attempt to load a backup personality core will proceed shortly.", "AI NT-OS Critical Failure")
 	ghostize(FALSE)
 	offer_mob()


### PR DESCRIPTION
## About The Pull Request
The AI has a shutdown systems verb, which is just a fancy ghost button. I don't know why that thing exists, but I improved it a little. 

This PR : 
- Added another confirm to prevent accidental ghosting
- Added icon reset for core, so you go back to default AI looks
- Added Announcement for whenever that happens, so people know you shutdown for some reason
- Added Admin message, so they know the AI ghosted. 

I tested the PR and had no significant issues.

## Why It's Good For The Game
Just makes the game plain better.

## Changelog

:cl:
qol: made AI ghosting harder to do accidentally, look better, and notify marines of the fact
admin: made AI ghosting notify admins
/:cl:
