### PR TITLE
Autoexpanding weeds

### DIFF
--- a/code/controllers/subsystem/weeds.dm
+++ b/code/controllers/subsystem/weeds.dm
@@ -56,6 +56,8 @@ SUBSYSTEM_DEF(weeds)
 			return
 		// Adds a bit of jitter to the spawning weeds.
 		addtimer(CALLBACK(src, .proc/create_weed, T, creating[T]), rand(1, 3 SECONDS))
+		if(prob(25) && !locate(/obj/alien/weeds/node) in range(1, T))
+			addtimer(CALLBACK(src, .proc/create_node, T, creating[T]), rand(4, 5 SECONDS))
 		pending -= T
 		spawn_attempts_by_node -= T
 		creating -= T
@@ -100,3 +102,27 @@ SUBSYSTEM_DEF(weeds)
 			swapped = TRUE
 			qdel(O)
 	new weed_to_spawn(T, node, swapped)
+
+/datum/controller/subsystem/weeds/proc/create_node(turf/T, obj/alien/weeds/node/node)
+	if(QDELETED(node))
+		return
+	var/obj/alien/weeds/node/node_to_spawn = /obj/alien/weeds/node
+	switch(node.name)
+		if(WEED)
+			node_to_spawn = /obj/alien/weeds/node
+		if(STICKY_WEED)
+			node_to_spawn = /obj/alien/weeds/node/sticky
+		if(RESTING_WEED)
+			node_to_spawn = /obj/alien/weeds/node/resting
+	if(!T.is_weedable() || iswallturf(T))
+		return
+	for (var/obj/O in T)
+		if(O.density)
+			return
+		else if(istype(O, /obj/alien/weeds))
+			if(istype(O, /obj/alien/weeds/node))
+				return
+			var/obj/alien/weeds/weed = O
+			weed.swapped = TRUE
+			qdel(O)
+	new node_to_spawn(T)

--- a/code/controllers/subsystem/weeds.dm
+++ b/code/controllers/subsystem/weeds.dm
@@ -56,7 +56,7 @@ SUBSYSTEM_DEF(weeds)
 			return
 		// Adds a bit of jitter to the spawning weeds.
 		addtimer(CALLBACK(src, .proc/create_weed, T, creating[T]), rand(1, 3 SECONDS))
-		if(prob(20))
+		if(prob(20) && !(locate(/obj/alien/weeds/node) in range(1, T)))
 			addtimer(CALLBACK(src, .proc/create_node, T, creating[T]), rand(8, 10 SECONDS))
 		pending -= T
 		spawn_attempts_by_node -= T

--- a/code/controllers/subsystem/weeds.dm
+++ b/code/controllers/subsystem/weeds.dm
@@ -56,7 +56,7 @@ SUBSYSTEM_DEF(weeds)
 			return
 		// Adds a bit of jitter to the spawning weeds.
 		addtimer(CALLBACK(src, .proc/create_weed, T, creating[T]), rand(1, 3 SECONDS))
-		if(prob(33))
+		if(prob(20))
 			addtimer(CALLBACK(src, .proc/create_node, T, creating[T]), rand(8, 10 SECONDS))
 		pending -= T
 		spawn_attempts_by_node -= T
@@ -104,18 +104,9 @@ SUBSYSTEM_DEF(weeds)
 	new weed_to_spawn(T, node, swapped)
 
 /datum/controller/subsystem/weeds/proc/create_node(turf/T, obj/alien/weeds/node/node)
-	if(QDELETED(node))
+	if(QDELETED(node) || (node.name != WEED) || !T.is_weedable() || iswallturf(T) || (locate(/obj/alien/weeds/node) in range(1, T)))
 		return
 	var/obj/alien/weeds/node/node_to_spawn = /obj/alien/weeds/node
-	switch(node.name)
-		if(WEED)
-			node_to_spawn = /obj/alien/weeds/node
-		if(STICKY_WEED)
-			node_to_spawn = /obj/alien/weeds/node/sticky
-		if(RESTING_WEED)
-			node_to_spawn = /obj/alien/weeds/node/resting
-	if(!T.is_weedable() || iswallturf(T) || (locate(/obj/alien/weeds/node) in range(1, T)))
-		return
 	for (var/obj/O in T)
 		if(O.density)
 			return

--- a/code/controllers/subsystem/weeds.dm
+++ b/code/controllers/subsystem/weeds.dm
@@ -56,8 +56,8 @@ SUBSYSTEM_DEF(weeds)
 			return
 		// Adds a bit of jitter to the spawning weeds.
 		addtimer(CALLBACK(src, .proc/create_weed, T, creating[T]), rand(1, 3 SECONDS))
-		if(prob(25) && !locate(/obj/alien/weeds/node) in range(1, T))
-			addtimer(CALLBACK(src, .proc/create_node, T, creating[T]), rand(4, 5 SECONDS))
+		if(prob(33))
+			addtimer(CALLBACK(src, .proc/create_node, T, creating[T]), rand(8, 10 SECONDS))
 		pending -= T
 		spawn_attempts_by_node -= T
 		creating -= T
@@ -114,7 +114,7 @@ SUBSYSTEM_DEF(weeds)
 			node_to_spawn = /obj/alien/weeds/node/sticky
 		if(RESTING_WEED)
 			node_to_spawn = /obj/alien/weeds/node/resting
-	if(!T.is_weedable() || iswallturf(T))
+	if(!T.is_weedable() || iswallturf(T) || (locate(/obj/alien/weeds/node) in range(1, T)))
 		return
 	for (var/obj/O in T)
 		if(O.density)


### PR DESCRIPTION
## About The Pull Request

Normal weeds now have a chance to spawn a new weed node while spreading.

https://user-images.githubusercontent.com/69199543/208481646-51549ec6-e81c-4a82-8d58-955eb961e5a6.mp4

## Why It's Good For The Game

I think this is huge qol feature for xenos that suffer from lack of builder castes, and also makes maps preweed to be more consistent.

## Changelog
:cl:
add: normal weeds can now spawn a new node while spreading
/:cl:
