### PR TITLE
req consoles can be rebuilt

### DIFF
--- a/code/game/objects/items/circuitboards/computer.dm
+++ b/code/game/objects/items/circuitboards/computer.dm
@@ -59,6 +59,26 @@
 	name = "Circuit board (ID Computer)"
 	build_path = /obj/machinery/computer/marine_card
 
+/obj/item/circuitboard/computer/supplycomp
+	name = "Circuit board (Requisitions ASRS Computer)"
+	build_path = /obj/machinery/computer/supplycomp
+
+/obj/item/circuitboard/computer/rebelsupplycomp
+	name = "Circuit board (Rebel Requisitions ASRS Computer)"
+	build_path = /obj/machinery/computer/supplycomp/rebel
+
+/obj/item/circuitboard/computer/ordercomp
+	name = "Circuit board (Requisitions Ordering Computer)"
+	build_path = /obj/machinery/computer/ordercomp
+
+/obj/item/circuitboard/computer/supplyoverwatch
+	name = "Circuit board (Requisitions Overwatch Computer)"
+	build_path = /obj/machinery/computer/camera_advanced/overwatch/req
+
+/obj/item/circuitboard/computer/supplydrop
+	name = "Circuit board (Requisitions Targeting Computer)"
+	build_path = /obj/machinery/computer/supplydrop_console
+
 /obj/item/circuitboard/computer/marine_card/centcom
 	name = "Circuit board (CentCom ID Computer)"
 	build_path = /obj/machinery/computer/marine_card/centcom

--- a/code/game/objects/machinery/overwatch.dm
+++ b/code/game/objects/machinery/overwatch.dm
@@ -96,6 +96,7 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 	icon_state = "overwatch_req"
 	name = "Requisition Overwatch Console"
 	desc = "Big Brother Requisition demands to see money flowing into the void that is greed."
+	circuit = /obj/item/circuitboard/computer/supplyoverwatch
 
 /obj/machinery/computer/camera_advanced/overwatch/rebel
 	faction = FACTION_TERRAGOV_REBEL
@@ -117,10 +118,6 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 
 /obj/machinery/computer/camera_advanced/overwatch/rebel/delta
 	name = "Delta Overwatch Console"
-
-
-/obj/machinery/computer/camera_advanced/overwatch/attackby(obj/item/I, mob/user, params)
-	return
 
 
 /obj/machinery/computer/camera_advanced/overwatch/CreateEye()

--- a/code/game/objects/machinery/squad_supply/supply_console.dm
+++ b/code/game/objects/machinery/squad_supply/supply_console.dm
@@ -5,6 +5,7 @@
 	desc = "used by shipside staff to issue supply drops to squad beacons"
 	icon_state = "supplydrop"
 	interaction_flags = INTERACT_MACHINE_TGUI
+	circuit = /obj/item/circuitboard/computer/supplydrop
 	///Time between two supply drops
 	var/launch_cooldown = 30 SECONDS
 	///The beacon we will send the supplies

--- a/code/modules/reqs/supply.dm
+++ b/code/modules/reqs/supply.dm
@@ -263,7 +263,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	icon = 'icons/obj/machines/computer.dmi'
 	icon_state = SHUTTLE_SUPPLY
 	req_access = list(ACCESS_MARINE_CARGO)
-	circuit = null
+	circuit = /obj/item/circuitboard/computer/supplycomp
 	var/datum/supply_ui/SU
 	///Id of the shuttle controlled
 	var/shuttle_id = SHUTTLE_SUPPLY
@@ -277,6 +277,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	shuttle_id = "supply_rebel"
 	home_id = "supply_home_rebel"
 	faction = FACTION_TERRAGOV_REBEL
+	circuit = /obj/item/circuitboard/computer/rebelsupplycomp
 
 /obj/machinery/computer/supplycomp/interact(mob/user)
 	. = ..()
@@ -611,7 +612,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	name = "Supply ordering console"
 	icon = 'icons/obj/machines/computer.dmi'
 	icon_state = "request"
-	circuit = null
+	circuit = /obj/item/circuitboard/computer/ordercomp
 	var/datum/supply_ui/requests/SU
 
 /obj/machinery/computer/ordercomp/interact(mob/user)


### PR DESCRIPTION

## About The Pull Request
All req computers were given circuit boards so they can be rebuilt if an unga ever blows them up. This is not a balance change since xenos cannot use grenades. Slashes can already be repaired with a blowtorch.

Split from #11729

## Why It's Good For The Game
I don't want to ask admins to fix the req computers whenever they are hit by a grenade.

## Changelog
:cl:
add: Req consoles can be repaired after friendly fire.
/:cl:
