### PR TITLE
Improves engi teleporters slightly

### DIFF
--- a/code/game/objects/structures/teleporter.dm
+++ b/code/game/objects/structures/teleporter.dm
@@ -15,6 +15,18 @@
 		/obj/machinery/nuclearbomb
 	)
 
+/obj/machinery/deployable/teleporter/examine(mob/user)
+	. = ..()
+	var/obj/item/teleporter_kit/kit = internal_item
+	if(!istype(kit))
+		CRASH("A teleporter didn't have an internal item, or it was of the wrong type.")
+	if(kit.linked_teleporter)
+		. += "It is currently linked to [kit.linked_teleporter] at [kit.linked_teleporter.loc]"
+	if(!kit.linked_teleporter)
+		. += "It is not linked to any other teleporter."
+	if(!kit.cell)
+		. += "It is currently lacking a power cell."
+
 /obj/machinery/deployable/teleporter/Initialize()
 	. = ..()
 	SSminimaps.add_marker(src, z, MINIMAP_FLAG_MARINE, "teleporter")
@@ -26,16 +38,16 @@
 		CRASH("A teleporter didn't have an internal item, or it was of the wrong type.")
 
 	if (!powered() && (!kit.cell || kit.cell.charge < TELEPORTING_COST))
-		to_chat(user, span_warning("A red light flashes on the [src]. It seems it doesn't have enough power."))
+		to_chat(user, span_warning("A red light flashes on [src]. It seems it doesn't have enough power."))
 		playsound(loc,'sound/machines/buzz-two.ogg', 25, FALSE)
 		return
 
 	if(!COOLDOWN_CHECK(kit, teleport_cooldown))
-		to_chat(user, span_warning("The [src] is still recharging! It will be ready in [round(COOLDOWN_TIMELEFT(kit, teleport_cooldown) / 10)] seconds."))
+		to_chat(user, span_warning("[src] is still recharging! It will be ready in [round(COOLDOWN_TIMELEFT(kit, teleport_cooldown) / 10)] seconds."))
 		return
 
 	if(!kit.linked_teleporter)
-		to_chat(user, span_warning("The [src] is not linked to any other teleporter."))
+		to_chat(user, span_warning("[src] is not linked to any other teleporter."))
 		return
 
 	if(!istype(kit.linked_teleporter.loc, /obj/machinery/deployable/teleporter))
@@ -151,6 +163,13 @@
 	linked_teleporter = null
 	QDEL_NULL(cell)
 	return ..()
+
+/obj/item/teleporter_kit/examine(mob/user)
+	. = ..()
+	if(linked_teleporter)
+		. += "It is currently linked to [linked_teleporter] at [linked_teleporter.loc]"
+	else
+		. += "It is currently not linked to any other teleporter."
 
 ///Link the two teleporters
 /obj/item/teleporter_kit/proc/set_linked_teleporter(obj/item/teleporter_kit/linked_teleporter)

--- a/code/game/objects/structures/teleporter.dm
+++ b/code/game/objects/structures/teleporter.dm
@@ -18,14 +18,13 @@
 /obj/machinery/deployable/teleporter/examine(mob/user)
 	. = ..()
 	var/obj/item/teleporter_kit/kit = internal_item
-	if(!istype(kit))
-		CRASH("A teleporter didn't have an internal item, or it was of the wrong type.")
-	if(kit.linked_teleporter)
-		. += "It is currently linked to [kit.linked_teleporter] at [kit.linked_teleporter.loc]"
-	if(!kit.linked_teleporter)
-		. += "It is not linked to any other teleporter."
 	if(!kit.cell)
 		. += "It is currently lacking a power cell."
+	if(kit.linked_teleporter)
+		. += "It is currently linked to another teleporter at [kit.linked_teleporter.loc]"
+	else
+		. += "It is not linked to any other teleporter."
+
 
 /obj/machinery/deployable/teleporter/Initialize()
 	. = ..()
@@ -164,12 +163,6 @@
 	QDEL_NULL(cell)
 	return ..()
 
-/obj/item/teleporter_kit/examine(mob/user)
-	. = ..()
-	if(linked_teleporter)
-		. += "It is currently linked to [linked_teleporter] at [linked_teleporter.loc]"
-	else
-		. += "It is currently not linked to any other teleporter."
 
 ///Link the two teleporters
 /obj/item/teleporter_kit/proc/set_linked_teleporter(obj/item/teleporter_kit/linked_teleporter)

--- a/code/game/objects/structures/teleporter.dm
+++ b/code/game/objects/structures/teleporter.dm
@@ -179,6 +179,25 @@
 		CRASH("A teleporter was linked with itself!")
 	src.linked_teleporter = linked_teleporter
 
+/obj/item/teleporter_kit/attackby(obj/item/I, mob/user, params)
+	if(!ishuman(user))
+		return FALSE
+	if(istype(I, /obj/item/teleporter_kit))
+		var/obj/item/teleporter_kit/gadget = I
+		if(src.linked_teleporter)
+			to_chat(user , span_warning("The teleporter is already linked with another!"))
+			return
+		if(linked_teleporter == src)
+			to_chat(user , span_warning("You can't link the teleporter with itself!"))
+			return
+		src.linked_teleporter = linked_teleporter
+		to_chat(user , span_notice("You link both teleporters to each others."))
+
+		src.set_linked_teleporter(gadget)
+		gadget.set_linked_teleporter(src)
+		return
+	return
+
 /obj/item/teleporter_kit/attack_self(mob/user)
 	do_unique_action(user)
 

--- a/code/game/objects/structures/teleporter.dm
+++ b/code/game/objects/structures/teleporter.dm
@@ -30,13 +30,6 @@
 	. = ..()
 	SSminimaps.add_marker(src, z, MINIMAP_FLAG_MARINE, "teleporter")
 
-/obj/machinery/deployable/teleporter/Destroy()
-	var/obj/item/teleporter_kit/kit = internal_item
-
-	if(kit && kit.linked_teleporter)
-		kit.linked_teleporter.linked_teleporter = null
-		QDEL_NULL(kit.cell)
-	return ..()
 
 /obj/machinery/deployable/teleporter/attack_hand(mob/living/user)
 	. = ..()
@@ -173,10 +166,11 @@
 	
 
 /obj/item/teleporter_kit/Destroy()
-	linked_teleporter.linked_teleporter = null
-	linked_teleporter = null
-	QDEL_NULL(cell)
-	return ..()
+	if(linked_teleporter)
+		linked_teleporter.linked_teleporter = null
+		linked_teleporter = null
+		QDEL_NULL(cell)
+		return ..()
 
 
 ///Link the two teleporters

--- a/code/game/objects/structures/teleporter.dm
+++ b/code/game/objects/structures/teleporter.dm
@@ -21,7 +21,7 @@
 	if(!kit.cell)
 		. += "It is currently lacking a power cell."
 	if(kit.linked_teleporter)
-		. += "It is currently linked to Teleporter #[kit.linked_teleporter.tele_tag] at [get_area(kit.linked_teleporter)]"
+		. += "It is currently linked to Teleporter #[kit.linked_teleporter.self_tele_tag] at [get_area(kit.linked_teleporter)]"
 	else
 		. += "It is not linked to any other teleporter."
 
@@ -155,13 +155,16 @@
 	COOLDOWN_DECLARE(teleport_cooldown)
 	
 	///tag to avoid mixups. Purely for players, not for systems.
-	var/tele_tag
+	var/static/tele_tag = 78
+	///Easier reference to the correct number.
+	var/self_tele_tag
 
 /obj/item/teleporter_kit/Initialize()
 	. = ..()
 	AddElement(/datum/element/deployable_item, /obj/machinery/deployable/teleporter, type, 2 SECONDS)
 	cell = new /obj/item/cell/high(src)
-	tele_tag = rand(1, 999)
+	tele_tag++
+	self_tele_tag = tele_tag
 	name = "\improper ASRS Bluespace teleporter #[tele_tag]"
 	
 
@@ -214,13 +217,5 @@
 	var/obj/item/teleporter_kit/teleporter_b = new(loc)
 	teleporter_a.set_linked_teleporter(teleporter_b)
 	teleporter_b.set_linked_teleporter(teleporter_a)
-	var/created_tele_tag = rand(1, 999)
-	var/teleport_name_a = "\improper ASRS Bluespace teleporter #[created_tele_tag]"
-	var/teleport_name_b = "\improper ASRS Bluespace teleporter #[created_tele_tag + 1]"
-
-	teleporter_a.name = teleport_name_a
-	teleporter_b.name = teleport_name_b
-	teleporter_a.tele_tag = created_tele_tag
-	teleporter_b.tele_tag = created_tele_tag + 1
 	qdel(src)
 

--- a/code/game/objects/structures/teleporter.dm
+++ b/code/game/objects/structures/teleporter.dm
@@ -192,13 +192,13 @@
 	
 	var/obj/item/teleporter_kit/gadget = I
 	if(src.linked_teleporter)
-		to_chat(user , span_warning("The teleporter is already linked with another!"))
+		balloon_alert(user, "The teleporter is already linked with another!")
 		return
 	if(linked_teleporter == src)
-		to_chat(user , span_warning("You can't link the teleporter with itself!"))
+		balloon_alert(user, "You can't link the teleporter with itself!")
 		return
 	src.linked_teleporter = linked_teleporter
-	to_chat(user , span_notice("You link both teleporters to each others."))
+	balloon_alert(user, "You link both teleporters to each others.")
 
 	src.set_linked_teleporter(gadget)
 	gadget.set_linked_teleporter(src)

--- a/code/game/objects/structures/teleporter.dm
+++ b/code/game/objects/structures/teleporter.dm
@@ -38,16 +38,16 @@
 		CRASH("A teleporter didn't have an internal item, or it was of the wrong type.")
 
 	if (!powered() && (!kit.cell || kit.cell.charge < TELEPORTING_COST))
-		to_chat(user, span_warning("A red light flashes on [src]. It seems it doesn't have enough power."))
+		to_chat(user, span_warning("A red light flashes on \the [src]. It seems it doesn't have enough power."))
 		playsound(loc,'sound/machines/buzz-two.ogg', 25, FALSE)
 		return
 
 	if(!COOLDOWN_CHECK(kit, teleport_cooldown))
-		to_chat(user, span_warning("[src] is still recharging! It will be ready in [round(COOLDOWN_TIMELEFT(kit, teleport_cooldown) / 10)] seconds."))
+		to_chat(user, span_warning("\The [src] is still recharging! It will be ready in [round(COOLDOWN_TIMELEFT(kit, teleport_cooldown) / 10)] seconds."))
 		return
 
 	if(!kit.linked_teleporter)
-		to_chat(user, span_warning("[src] is not linked to any other teleporter."))
+		to_chat(user, span_warning("\The [src] is not linked to any other teleporter."))
 		return
 
 	if(!istype(kit.linked_teleporter.loc, /obj/machinery/deployable/teleporter))

--- a/code/game/objects/structures/teleporter.dm
+++ b/code/game/objects/structures/teleporter.dm
@@ -184,20 +184,21 @@
 /obj/item/teleporter_kit/attackby(obj/item/I, mob/user, params)
 	if(!ishuman(user))
 		return FALSE
-	if(istype(I, /obj/item/teleporter_kit))
-		var/obj/item/teleporter_kit/gadget = I
-		if(src.linked_teleporter)
-			to_chat(user , span_warning("The teleporter is already linked with another!"))
-			return
-		if(linked_teleporter == src)
-			to_chat(user , span_warning("You can't link the teleporter with itself!"))
-			return
-		src.linked_teleporter = linked_teleporter
-		to_chat(user , span_notice("You link both teleporters to each others."))
-
-		src.set_linked_teleporter(gadget)
-		gadget.set_linked_teleporter(src)
+	if(!istype(I, /obj/item/teleporter_kit))
 		return
+	
+	var/obj/item/teleporter_kit/gadget = I
+	if(src.linked_teleporter)
+		to_chat(user , span_warning("The teleporter is already linked with another!"))
+		return
+	if(linked_teleporter == src)
+		to_chat(user , span_warning("You can't link the teleporter with itself!"))
+		return
+	src.linked_teleporter = linked_teleporter
+	to_chat(user , span_notice("You link both teleporters to each others."))
+
+	src.set_linked_teleporter(gadget)
+	gadget.set_linked_teleporter(src)
 	return
 
 /obj/item/teleporter_kit/attack_self(mob/user)

--- a/code/game/objects/structures/teleporter.dm
+++ b/code/game/objects/structures/teleporter.dm
@@ -177,12 +177,12 @@
 
 
 ///Link the two teleporters
-/obj/item/teleporter_kit/proc/set_linked_teleporter(obj/item/teleporter_kit/linked_teleporter)
-	if(src.linked_teleporter)
+/obj/item/teleporter_kit/proc/set_linked_teleporter(obj/item/teleporter_kit/link_teleport)
+	if(linked_teleporter)
 		CRASH("A teleporter was linked with another teleporter even though it already has a twin!")
-	if(linked_teleporter == src)
+	if(link_teleport == src)
 		CRASH("A teleporter was linked with itself!")
-	src.linked_teleporter = linked_teleporter
+	linked_teleporter = link_teleport
 
 /obj/item/teleporter_kit/attackby(obj/item/I, mob/user, params)
 	if(!ishuman(user))
@@ -191,16 +191,16 @@
 		return
 	
 	var/obj/item/teleporter_kit/gadget = I
-	if(src.linked_teleporter)
+	if(linked_teleporter)
 		balloon_alert(user, "The teleporter is already linked with another!")
 		return
 	if(linked_teleporter == src)
 		balloon_alert(user, "You can't link the teleporter with itself!")
 		return
-	src.linked_teleporter = linked_teleporter
+	linked_teleporter = linked_teleporter
 	balloon_alert(user, "You link both teleporters to each others.")
 
-	src.set_linked_teleporter(gadget)
+	set_linked_teleporter(gadget)
 	gadget.set_linked_teleporter(src)
 	return
 

--- a/code/game/objects/structures/teleporter.dm
+++ b/code/game/objects/structures/teleporter.dm
@@ -154,9 +154,9 @@
 	var/obj/item/cell/cell
 	COOLDOWN_DECLARE(teleport_cooldown)
 	
-	///tag to avoid mixups. Purely for players, not for systems.
+	///Tag for teleporters number. Exists for fluff reasons. Shared variable. 
 	var/static/tele_tag = 78
-	///Easier reference to the correct number.
+	///References to the number of the teleporter.
 	var/self_tele_tag
 
 /obj/item/teleporter_kit/Initialize()

--- a/code/game/objects/structures/teleporter.dm
+++ b/code/game/objects/structures/teleporter.dm
@@ -172,8 +172,8 @@
 	if(linked_teleporter)
 		linked_teleporter.linked_teleporter = null
 		linked_teleporter = null
-		QDEL_NULL(cell)
-		return ..()
+	QDEL_NULL(cell)
+	return ..()
 
 
 ///Link the two teleporters


### PR DESCRIPTION
## About The Pull Request
Improved the engineer teleporter's description
Fixed some 'The the' issues
Made it possible to link 2 teleporters.

## Why It's Good For The Game
QoL and better info. 
Paving the way for buying single teleporters.

## Changelog

:cl:
qol: Created the possibility to link 2 engineer teleporters
qol: Removed 'The the' issues on engineer teleporters
qol: Made examining engineer teleporters with no cell tell you that fact
qol: Engineer teleporters now have unique #123 names. 
fix: Made engineer teleporters properly unlink when one is destroyed


/:cl:
