### PR TITLE
Removes recoil from masterkey

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -131,7 +131,7 @@
 	fire_delay = 20 // Base shotgun fire delay.
 	pixel_shift_x = 14
 	pixel_shift_y = 18
-
+	recoil = 0
 	wield_delay_mod	= 0.2 SECONDS
 
 //-------------------------------------------------------


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
Normal shotguns don't have recoil when wielded and masterkey can only be fired when wielded.
Makes sense to remove the recoil.
## Changelog
:cl:
balance: removes recoil from the masterkey.
/:cl:
