### PR TITLE
Fixes the "show typing indicator" pref

### DIFF
--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -111,8 +111,5 @@
 	/// Messages currently seen by this client
 	var/list/seen_messages
 
-	/// Does this client have typing indicators enabled?
-	var/typing_indicators = TRUE
-
 	show_popup_menus = TRUE // right click menu no longer shows up
 	control_freak = CONTROL_FREAK_MACROS

--- a/code/modules/client/preferences_ui.dm
+++ b/code/modules/client/preferences_ui.dm
@@ -587,7 +587,7 @@
 			show_typing = !show_typing
 			// Need to remove any currently shown
 			if(!show_typing && istype(user))
-				user.remove_typing_indicator()
+				user.remove_all_indicators()
 
 		if("tooltips")
 			tooltips = !tooltips

--- a/code/modules/tgui_input/say_modal/modal.dm
+++ b/code/modules/tgui_input/say_modal/modal.dm
@@ -84,7 +84,7 @@
 	window_open = TRUE
 	if(payload["channel"] != OOC_CHANNEL)
 		start_thinking()
-	if(client.typing_indicators)
+	if(client.prefs.show_typing)
 		log_speech_indicators("[key_name(client)] started typing at [loc_name(client.mob)], indicators enabled.")
 	else
 		log_speech_indicators("[key_name(client)] started typing at [loc_name(client.mob)], indicators DISABLED.")
@@ -97,7 +97,7 @@
 /datum/tgui_say/proc/close()
 	window_open = FALSE
 	stop_thinking()
-	if(client.typing_indicators)
+	if(client.prefs.show_typing)
 		log_speech_indicators("[key_name(client)] stopped typing at [loc_name(client.mob)], indicators enabled.")
 	else
 		log_speech_indicators("[key_name(client)] stopped typing at [loc_name(client.mob)], indicators DISABLED.")

--- a/code/modules/tgui_input/say_modal/speech.dm
+++ b/code/modules/tgui_input/say_modal/speech.dm
@@ -70,7 +70,7 @@
 	if(stat != CONSCIOUS || !client?.tgui_say?.window_open)
 		return FALSE
 	client.tgui_say.force_say()
-	if(client.typing_indicators)
+	if(client.prefs.show_typing)
 		log_speech_indicators("[key_name(client)] FORCED to stop typing, indicators enabled.")
 	else
 		log_speech_indicators("[key_name(client)] FORCED to stop typing, indicators DISABLED.")

--- a/code/modules/tgui_input/say_modal/typing.dm
+++ b/code/modules/tgui_input/say_modal/typing.dm
@@ -29,7 +29,7 @@
 
 /** Sets the mob as "thinking" - with indicator and variable thinking_IC */
 /datum/tgui_say/proc/start_thinking()
-	if(!window_open || !client.typing_indicators)
+	if(!window_open || !client.prefs.show_typing)
 		return FALSE
 	client.mob.thinking_IC = TRUE
 	client.mob.create_thinking_indicator()
@@ -44,7 +44,7 @@
  */
 /datum/tgui_say/proc/start_typing()
 	client.mob.remove_thinking_indicator()
-	if(!window_open || !client.typing_indicators || !client.mob.thinking_IC)
+	if(!window_open || !client.prefs.show_typing || !client.mob.thinking_IC)
 		return FALSE
 	client.mob.create_typing_indicator()
 	addtimer(CALLBACK(src, .proc/stop_typing), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_STOPPABLE)
@@ -57,7 +57,7 @@
 	if(!client?.mob)
 		return FALSE
 	client.mob.remove_typing_indicator()
-	if(!window_open || !client.typing_indicators || !client.mob.thinking_IC)
+	if(!window_open || !client.prefs.show_typing || !client.mob.thinking_IC)
 		return FALSE
 	client.mob.create_thinking_indicator()
 


### PR DESCRIPTION

## About The Pull Request
Title.
Currently, typing indicators will always show up, regardless of preference settings, due to client having a var that determines whether they show up, but this var having nothing hooked into it to change it regardless of the pref existing. This removes that redundant var and hooks the checks back into preferences directly (since clients should always have preferences attached).
## Why It's Good For The Game
Preferences actually doing what they say they do tends to be a good thing.
## Changelog
:cl:
fix: The 'show typing indicator' pref should be functioning properly once again.
/:cl:
