### PR TITLE
Give Warlock psychic whisper

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1002,7 +1002,7 @@
 	log_directed_talk(X, L, msg, LOG_SAY, "psychic whisper")
 	to_chat(L, span_alien("You hear a strange, alien voice in your head. <i>\"[msg]\"</i>"))
 	to_chat(X, span_xenonotice("We said: \"[msg]\" to [L]"))
-	message_admins(msg)
+	message_admins("[X] has sent [L] this psychic message: \"[msg]\" at [ADMIN_VERBOSEJMP(target)].")
 
 // ***************************************
 // *********** Lay Egg

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1002,7 +1002,7 @@
 	log_directed_talk(X, L, msg, LOG_SAY, "psychic whisper")
 	to_chat(L, span_alien("You hear a strange, alien voice in your head. <i>\"[msg]\"</i>"))
 	to_chat(X, span_xenonotice("We said: \"[msg]\" to [L]"))
-	message_admins("[X] has sent [L] this psychic message: \"[msg]\" at [ADMIN_VERBOSEJMP(target)].")
+	message_admins("[X] has sent [L] this psychic message: \"[msg]\" at [ADMIN_VERBOSEJMP(X)].")
 
 // ***************************************
 // *********** Lay Egg

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1002,7 +1002,7 @@
 	log_directed_talk(X, L, msg, LOG_SAY, "psychic whisper")
 	to_chat(L, span_alien("You hear a strange, alien voice in your head. <i>\"[msg]\"</i>"))
 	to_chat(X, span_xenonotice("We said: \"[msg]\" to [L]"))
-
+	message_admins("[msg]")
 
 // ***************************************
 // *********** Lay Egg

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1002,7 +1002,7 @@
 	log_directed_talk(X, L, msg, LOG_SAY, "psychic whisper")
 	to_chat(L, span_alien("You hear a strange, alien voice in your head. <i>\"[msg]\"</i>"))
 	to_chat(X, span_xenonotice("We said: \"[msg]\" to [L]"))
-	message_admins("[msg]")
+	message_admins(msg)
 
 // ***************************************
 // *********** Lay Egg

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/castedatum_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/castedatum_warlock.dm
@@ -28,6 +28,7 @@
 		/datum/action/xeno_action/activable/psy_blast,
 		/datum/action/xeno_action/activable/psychic_shield,
 		/datum/action/xeno_action/activable/transfer_plasma/drone,
+		/datum/action/xeno_action/psychic_whisper,
 	)
 
 	water_slowdown = 0


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

WARLOCK'S BRAIN IS SO BIG HE CAN TELEPATHICALLY TALK TO MARINES AND TELL THEM, "COPE AND SEETH!" WHEN WARLOCK BLASTS THEM WITH ITS MIND! BEAT MARINES WITH PSYCHIC POWER?! MORE LIKE CRUSH MARINES THROUGH PSYCHOLOGICAL OPERATION!!

Due to how psychic whisper bypasses admin's oversight, I gave admins the ability to see what kind of message the xenomorph is sending to a marine.

## Changelog

:cl:
add: Give Warlock psychic whisper
add: admins can now read psychic whisper
/:cl:

