### PR TITLE
Throwpass refactor

### DIFF
--- a/code/__DEFINES/equipment.dm
+++ b/code/__DEFINES/equipment.dm
@@ -7,6 +7,11 @@
 #define PASSSMALLSTRUCT (1<<5)
 #define PASSFIRE (1<<6)
 #define PASSXENO (1<<7)
+#define PASSTHROW (1<<8) //you can throw past
+#define PASSPROJECTILE (1<<9) //projectiles can pass
+#define PASSAIR (1<<10) //non-airtight, gas/fire can pass
+#define PASSLASER (1<<11) //lasers and the like can pass unobstructed
+#define PASSABLE (PASSTHROW|PASSPROJECTILE|PASSAIR)
 #define HOVERING (PASSTABLE|PASSMOB|PASSSMALLSTRUCT|PASSFIRE)
 
 //==========================================================================================

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -167,11 +167,12 @@ GLOBAL_REAL_VAR(list/stack_trace_storage)
 /**
  *	Returns true if the path from A to B is blocked. Checks both paths where the direction is diagonal
  *	Variables:
- *	bypass_window - whether it will go through transparent windows like lasers
- *	projectile - whether throwpass will be checked to ignore dense objects like projectiles
+ *	bypass_window - check for PASSLASER - laser like behavior
+ *	projectile - check for PASSPROJECTILE - bullet like behavior
  *	bypass_xeno - whether to bypass dense xeno structures like flamers
+ *	air_pass - whether to bypass non airtight atoms
  */
-/proc/LinkBlocked(turf/A, turf/B, bypass_window = FALSE, projectile = FALSE, bypass_xeno = FALSE)
+/proc/LinkBlocked(turf/A, turf/B, bypass_window = FALSE, projectile = FALSE, bypass_xeno = FALSE, air_pass = FALSE)
 	if(isnull(A) || isnull(B))
 		return TRUE
 	var/adir = get_dir(A, B)
@@ -180,30 +181,32 @@ GLOBAL_REAL_VAR(list/stack_trace_storage)
 		return TRUE
 	if(adir & (adir - 1))//is diagonal direction
 		var/turf/iStep = get_step(A, adir & (NORTH|SOUTH))
-		if((!iStep.density || (istype(iStep, /turf/closed/wall/resin) && bypass_xeno)) && !LinkBlocked(A, iStep, bypass_window, projectile, bypass_xeno) && !LinkBlocked(iStep, B, bypass_window, projectile, bypass_xeno))
+		if((!iStep.density || (istype(iStep, /turf/closed/wall/resin) && bypass_xeno)) && !LinkBlocked(A, iStep, bypass_window, projectile, bypass_xeno, air_pass) && !LinkBlocked(iStep, B, bypass_window, projectile, bypass_xeno, air_pass))
 			return FALSE
 
 		var/turf/pStep = get_step(A,adir & (EAST|WEST))
-		if((!pStep.density || (istype(pStep, /turf/closed/wall/resin) && bypass_xeno)) && !LinkBlocked(A, pStep, bypass_window, projectile, bypass_xeno) && !LinkBlocked(pStep, B, bypass_window, projectile, bypass_xeno))
+		if((!pStep.density || (istype(pStep, /turf/closed/wall/resin) && bypass_xeno)) && !LinkBlocked(A, pStep, bypass_window, projectile, bypass_xeno, air_pass) && !LinkBlocked(pStep, B, bypass_window, projectile, bypass_xeno, air_pass))
 			return FALSE
 		return TRUE
 
-	if(DirBlocked(A, adir, bypass_window, projectile, bypass_xeno))
+	if(DirBlocked(A, adir, bypass_window, projectile, bypass_xeno, air_pass))
 		return TRUE
-	if(DirBlocked(B, rdir, bypass_window, projectile, bypass_xeno))
+	if(DirBlocked(B, rdir, bypass_window, projectile, bypass_xeno, air_pass))
 		return TRUE
 	return FALSE
 
 ///Checks if moving in a direction is blocked
-/proc/DirBlocked(turf/loc, direction, bypass_window = FALSE, projectile = FALSE, bypass_xeno = FALSE)
+/proc/DirBlocked(turf/loc, direction, bypass_window = FALSE, projectile = FALSE, bypass_xeno = FALSE, air_pass = FALSE)
 	for(var/obj/object in loc)
 		if(!object.density)
 			continue
-		if(object.throwpass && projectile) //projectiles can bypass dense objects with throwpass
+		if((object.flags_pass & PASSPROJECTILE) && projectile)
 			continue
 		if((istype(object, /obj/structure/mineral_door/resin) || istype(object, /obj/structure/xeno)) && bypass_xeno) //xeno objects are bypassed by flamers
 			continue
-		if((istype(object, /obj/machinery/door/window) || istype(object, /obj/structure/window)) && bypass_window) //windows are bypassed energy weapons
+		if((object.flags_pass & PASSLASER) && bypass_window)
+			continue
+		if((object.flags_pass & PASSAIR) && air_pass)
 			continue
 		if(object.flags_atom & ON_BORDER && object.dir != direction)
 			continue
@@ -1228,10 +1231,11 @@ will handle it, but:
  *	cone_direction - at what angle should the cone be made, relative to the game board's orientation
  *	blocked - whether the cone should take into consideration solid walls
  *	bypass_window - whether it will go through transparent windows like lasers
- *	projectile - whether throwpass will be checked to ignore dense objects like projectiles
+ *	projectile - whether PASSPROJECTILE will be checked to ignore dense objects like projectiles
  *	bypass_xeno - whether to bypass dense xeno structures like flamers
+ *	air_pass - whether to bypass non airtight atoms
  */
-/proc/generate_true_cone(atom/center, max_row_count = 10, starting_row = 1, cone_width = 60, cone_direction = 0, blocked = TRUE, bypass_window = FALSE, projectile = FALSE, bypass_xeno = FALSE)
+/proc/generate_true_cone(atom/center, max_row_count = 10, starting_row = 1, cone_width = 60, cone_direction = 0, blocked = TRUE, bypass_window = FALSE, projectile = FALSE, bypass_xeno = FALSE, air_pass = FALSE)
 	var/right_angle = cone_direction + cone_width/2
 	var/left_angle = cone_direction - cone_width/2
 
@@ -1259,7 +1263,7 @@ will handle it, but:
 					continue
 				if(turf_angle > right_angle && turf_angle < left_angle)
 					continue
-				if(blocked && LinkBlocked(old_turf, turf_to_check, bypass_window, projectile, bypass_xeno))
+				if(blocked && LinkBlocked(old_turf, turf_to_check, bypass_window, projectile, bypass_xeno, air_pass))
 					continue
 				cone_turfs += turf_to_check
 				turfs_to_check += turf_to_check
@@ -1277,14 +1281,15 @@ GLOBAL_LIST_INIT(survivor_outfits, typecacheof(/datum/outfit/job/survivor))
  *	start -start point of the path
  *	end - end point of the path
  *	bypass_window - whether it will go through transparent windows in the same way as lasers
- *	projectile - whether throwpass will be checked to ignore dense objects in the same way as projectiles
+ *	projectile - whether PASSPROJECTILE will be checked to ignore dense objects in the same way as projectiles
  *	bypass_xeno - whether to bypass dense xeno structures in the same way as flamers
+ *	air_pass - whether to bypass non airtight atoms
  */
-/proc/check_path(atom/start, atom/end, bypass_window = FALSE, projectile = FALSE, bypass_xeno = FALSE)
+/proc/check_path(atom/start, atom/end, bypass_window = FALSE, projectile = FALSE, bypass_xeno = FALSE, air_pass = FALSE)
 	var/list/path_to_target = getline(start, end)
 	var/line_count = 1
 	while(line_count < length(path_to_target))
-		if(LinkBlocked(path_to_target[line_count], path_to_target[line_count + 1], bypass_window, projectile, bypass_xeno))
+		if(LinkBlocked(path_to_target[line_count], path_to_target[line_count + 1], bypass_window, projectile, bypass_xeno, air_pass))
 			return FALSE
 		line_count ++
 	return TRUE

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -28,7 +28,7 @@
 	* If you are in the same turf, always true
 	* If you are vertically/horizontally adjacent, ensure there are no border objects
 	* If you are diagonally adjacent, ensure you can pass through at least one of the mutually adjacent square.
-		* Passing through in this case ignores anything with the throwpass flag, such as tables, racks, and morgue trays.
+		* Passing through in this case ignores anything with the PASSPROJECTILE flag, such as tables, racks, and morgue trays.
 */
 /turf/Adjacent(atom/neighbor, atom/target, atom/movable/mover)
 	var/turf/T0 = get_turf(neighbor)
@@ -175,32 +175,23 @@
 
 /*
 	This checks if you there is uninterrupted airspace between that turf and this one.
-	This is defined as any dense ON_BORDER object, or any dense object without throwpass.
+	This is defined as any dense ON_BORDER object, or any dense object without PASSPROJECTILES.
 	The border_only flag allows you to not objects (for source and destination squares)
 */
 /turf/proc/ClickCross(target_dir, border_only, target_atom = null, atom/movable/mover = null)
 	for(var/obj/O in src)
 		if((mover && O.CanPass(mover,get_step(src, target_dir))) || (!mover && !O.density))
 			continue
-		if(O == target_atom || O == mover || O.throwpass) //check if there's a dense object present on the turf
+		if(O == target_atom || O == mover || (O.flags_pass & PASSPROJECTILE)) //check if there's a dense object present on the turf
 			continue // LETPASSTHROW is used for anything you can click through (or the firedoor special case, see above)
 
-		if(O.flags_atom & ON_BORDER) // windows have throwpass but are on border, check them first
+		if(O.flags_atom & ON_BORDER) // windows have PASSPROJECTILE but are on border, check them first
 			if(O.dir & target_dir || O.dir & (O.dir-1)) // full tile windows are just diagonals mechanically
 				return FALSE
 
 		else if(!border_only) // dense, not on border, cannot pass over
 			return FALSE
 	return TRUE
-/*
-	Aside: throwpass does not do what I thought it did originally, and is only used for checking whether or not
-	a thrown object should stop after already successfully entering a square.  Currently the throw code involved
-	only seems to affect hitting mobs, because the checks performed against objects are already performed when
-	entering or leaving the square.  Since throwpass isn't used on mobs, but only on objects, it is effectively
-	useless.  Throwpass may later need to be removed and replaced with a passcheck (bitfield on movable atom passflags).
-
-	Since I don't want to complicate the click code rework by messing with unrelated systems it won't be changed here.
-*/
 
 /atom/proc/handle_barriers(mob/living/M)
 	for(var/obj/structure/S in M.loc)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -11,9 +11,8 @@
 	var/blood_color
 	var/list/blood_DNA
 
+	///Flags to indicate whether this atom can bypass certain things, or if certain things can bypass this atom
 	var/flags_pass = NONE
-	///whether items can be thrown past, or projectiles can fire past this atom.
-	var/throwpass = FALSE
 
 	var/resistance_flags = PROJECTILE_IMMUNE
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -456,13 +456,13 @@
 			continue
 		if(isliving(A))
 			var/mob/living/L = A
-			if((!L.density || L.throwpass) && !(SEND_SIGNAL(A, COMSIG_LIVING_PRE_THROW_IMPACT, src) & COMPONENT_PRE_THROW_IMPACT_HIT))
+			if((!L.density || (L.flags_pass & PASSPROJECTILE)) && !(SEND_SIGNAL(A, COMSIG_LIVING_PRE_THROW_IMPACT, src) & COMPONENT_PRE_THROW_IMPACT_HIT))
 				continue
 			if(SEND_SIGNAL(A, COMSIG_THROW_PARRY_CHECK, src))	//If parried, do not continue checking the turf and immediately return.
 				playsound(A, 'sound/weapons/alien_claw_block.ogg', 40, TRUE, 7, 4)
 				return A
 			throw_impact(A, speed)
-		if(isobj(A) && A.density && !(A.flags_atom & ON_BORDER) && (!A.throwpass || iscarbon(src)) && !flying)
+		if(isobj(A) && A.density && !(A.flags_atom & ON_BORDER) && (!(A.flags_pass & PASSPROJECTILE) || iscarbon(src)) && !flying)
 			throw_impact(A, speed)
 
 

--- a/code/game/objects/effects/effect_system/foam.dm
+++ b/code/game/objects/effects/effect_system/foam.dm
@@ -167,7 +167,7 @@
 	density = TRUE
 	opacity = FALSE 	// changed in New()
 	anchored = TRUE
-	flags_pass = null
+	flags_pass = NONE
 	name = "foamed metal"
 	desc = "A lightweight foamed metal wall."
 	resistance_flags = XENO_DAMAGEABLE

--- a/code/game/objects/effects/effect_system/foam.dm
+++ b/code/game/objects/effects/effect_system/foam.dm
@@ -167,7 +167,7 @@
 	density = TRUE
 	opacity = FALSE 	// changed in New()
 	anchored = TRUE
-	throwpass = FALSE
+	flags_pass = null
 	name = "foamed metal"
 	desc = "A lightweight foamed metal wall."
 	resistance_flags = XENO_DAMAGEABLE

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -11,8 +11,8 @@
 	layer = FLY_LAYER
 	mouse_opacity = 0
 	var/amount = 3
-	var/spread_speed = 1 //time in decisecond for a smoke to spread one tile.
 	var/lifetime = 5
+	///time in decisecond for a smoke to spread one tile.
 	var/expansion_speed = 1
 	var/smoke_traits = NONE
 	var/strength = 1 // Effects scale with the emitter's bomb_strength upgrades.
@@ -262,7 +262,6 @@
 /obj/effect/particle_effect/smoke/satrapine
 	color = "#b02828"
 	lifetime = 6
-	spread_speed = 7
 	expansion_speed = 3
 	strength = 1.5
 	smoke_traits = SMOKE_SATRAPINE|SMOKE_GASP|SMOKE_COUGH
@@ -274,7 +273,6 @@
 //Xeno acid smoke.
 /obj/effect/particle_effect/smoke/xeno
 	lifetime = 6
-	spread_speed = 7
 	expansion_speed = 3
 	smoke_traits = SMOKE_XENO
 

--- a/code/game/objects/items/storage/dispenser.dm
+++ b/code/game/objects/items/storage/dispenser.dm
@@ -6,7 +6,7 @@
 	anchored = TRUE
 	max_integrity = 250
 	resistance_flags = XENO_DAMAGEABLE
-	throwpass = TRUE
+	flags_pass = PASSABLE
 	coverage = 60
 	///list of human mobs we're currently affecting in our area.
 	var/list/mob/living/carbon/human/affecting_list

--- a/code/game/objects/items/toys/toys.dm
+++ b/code/game/objects/items/toys/toys.dm
@@ -536,7 +536,6 @@
 	icon_state = "hoop"
 	anchored = TRUE
 	density = TRUE
-	throwpass = 1
 	var/side = ""
 	var/id = ""
 

--- a/code/game/objects/machinery.dm
+++ b/code/game/objects/machinery.dm
@@ -22,7 +22,7 @@
 	var/mob/living/carbon/human/operator
 
 	///Whether bullets can bypass the object even though it's dense
-	throwpass = TRUE
+	flags_pass = PASSABLE
 
 /obj/machinery/Initialize()
 	. = ..()

--- a/code/game/objects/machinery/computer/HolodeckControl.dm
+++ b/code/game/objects/machinery/computer/HolodeckControl.dm
@@ -5,9 +5,6 @@
 	icon_state = "table"
 	density = TRUE
 	anchored = TRUE
-	throwpass = 1	//You can throw objects over this, despite it's density.
-
-
 
 /obj/structure/table/holotable/attack_animal(mob/living/user as mob) //Removed code for larva since it doesn't work. Previous code is now a larva ability. /N
 	return attack_hand(user)
@@ -77,7 +74,6 @@
 	icon_state = "hoop"
 	anchored = TRUE
 	density = TRUE
-	throwpass = 1
 	var/side = ""
 	var/id = ""
 

--- a/code/game/objects/machinery/deployable.dm
+++ b/code/game/objects/machinery/deployable.dm
@@ -2,7 +2,7 @@
 	flags_atom = PREVENT_CONTENTS_EXPLOSION
 	hud_possible = list(MACHINE_HEALTH_HUD)
 	obj_flags = CAN_BE_HIT
-	throwpass = FALSE
+	flags_pass = PASSAIR
 	///Since /obj/machinery/deployable aquires its sprites from an item and are set in New(), initial(icon_state) would return null. This var exists as a substitute.
 	var/default_icon_state
 	///Item that is deployed to create src.

--- a/code/game/objects/machinery/doors/door.dm
+++ b/code/game/objects/machinery/doors/door.dm
@@ -6,7 +6,7 @@
 	anchored = TRUE
 	opacity = TRUE
 	density = TRUE
-	throwpass = FALSE
+	flags_pass = NULL
 	move_resist = MOVE_FORCE_VERY_STRONG
 	layer = DOOR_OPEN_LAYER
 	explosion_block = 2

--- a/code/game/objects/machinery/doors/door.dm
+++ b/code/game/objects/machinery/doors/door.dm
@@ -6,7 +6,7 @@
 	anchored = TRUE
 	opacity = TRUE
 	density = TRUE
-	flags_pass = null
+	flags_pass = NONE
 	move_resist = MOVE_FORCE_VERY_STRONG
 	layer = DOOR_OPEN_LAYER
 	explosion_block = 2

--- a/code/game/objects/machinery/doors/door.dm
+++ b/code/game/objects/machinery/doors/door.dm
@@ -6,7 +6,7 @@
 	anchored = TRUE
 	opacity = TRUE
 	density = TRUE
-	flags_pass = NULL
+	flags_pass = null
 	move_resist = MOVE_FORCE_VERY_STRONG
 	layer = DOOR_OPEN_LAYER
 	explosion_block = 2

--- a/code/game/objects/machinery/doors/windowdoor.dm
+++ b/code/game/objects/machinery/doors/windowdoor.dm
@@ -12,6 +12,7 @@
 	visible = FALSE
 	use_power = FALSE
 	flags_atom = ON_BORDER
+	flags_pass = PASSLASER
 	opacity = FALSE
 	var/obj/item/circuitboard/airlock/electronics = null
 

--- a/code/game/objects/machinery/kitchen/smartfridge.dm
+++ b/code/game/objects/machinery/kitchen/smartfridge.dm
@@ -7,7 +7,7 @@
 	layer = BELOW_OBJ_LAYER
 	density = TRUE
 	anchored = TRUE
-	throwpass = FALSE
+	flags_pass = PASSAIR
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 5
 	active_power_usage = 100

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -39,7 +39,7 @@
 	///Optimization for dynamic explosion block values, for things whose explosion block is dependent on certain conditions.
 	var/real_explosion_block
 
-	///odds of a projectile hitting the object, if throwpass is true and the object is dense
+	///Odds of a projectile hitting the object, if the object is dense and has THROWPROJECTILE
 	var/coverage = 50
 
 /obj/Initialize()

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -6,7 +6,7 @@
 	var/broken = FALSE //similar to machinery's stat BROKEN
 	obj_flags = CAN_BE_HIT
 	anchored = TRUE
-	throwpass = TRUE
+	flags_pass = PASSABLE
 	destroy_sound = 'sound/effects/meteorimpact.ogg'
 
 /obj/structure/proc/handle_barrier_chance(mob/living/M)

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -5,7 +5,6 @@
 	climbable = TRUE
 	anchored = TRUE
 	density = TRUE
-	throwpass = TRUE //You can throw objects over this, despite its density.//This comment is a lie, throwpass is for projectiles apparently
 	layer = BELOW_OBJ_LAYER
 	flags_atom = ON_BORDER
 	resistance_flags = XENO_DAMAGEABLE
@@ -373,7 +372,6 @@
 	max_integrity = 100
 	layer = OBJ_LAYER
 	climbable = FALSE
-	throwpass = FALSE
 	stack_type = /obj/item/stack/sheet/wood
 	stack_amount = 5
 	destroyed_stack_amount = 3

--- a/code/game/objects/structures/bookcase.dm
+++ b/code/game/objects/structures/bookcase.dm
@@ -7,7 +7,7 @@
 	anchored = TRUE
 	density = TRUE
 	opacity = TRUE
-	throwpass = FALSE
+	flags_pass = PASSAIR
 
 /obj/structure/bookcase/Initialize()
 	. = ..()

--- a/code/game/objects/structures/cargo_container.dm
+++ b/code/game/objects/structures/cargo_container.dm
@@ -9,7 +9,7 @@
 	max_integrity = 200
 	opacity = TRUE
 	anchored = TRUE
-	throwpass = FALSE
+	flags_pass = null
 
 /obj/structure/cargo_container/attack_hand(mob/living/user)
 	. = ..()

--- a/code/game/objects/structures/cargo_container.dm
+++ b/code/game/objects/structures/cargo_container.dm
@@ -9,7 +9,7 @@
 	max_integrity = 200
 	opacity = TRUE
 	anchored = TRUE
-	flags_pass = null
+	flags_pass = NONE
 
 /obj/structure/cargo_container/attack_hand(mob/living/user)
 	. = ..()

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -6,7 +6,7 @@
 	anchored = FALSE
 	density = TRUE
 	resistance_flags = XENO_DAMAGEABLE
-	throwpass = FALSE
+	flags_pass = PASSAIR
 	max_integrity = 50
 	var/state = 0
 	var/base_icon_state = ""

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -8,7 +8,6 @@
 	icon = 'icons/Marine/mainship_props.dmi'
 	density = TRUE
 	anchored = TRUE
-	throwpass = TRUE
 	climbable = TRUE
 	resistance_flags = XENO_DAMAGEABLE
 	coverage = 20

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/obj/structures/fence.dmi'
 	icon_state = "fence0"
 	density = TRUE
-	throwpass = TRUE //So people and xenos can shoot through!
 	anchored = TRUE //We can not be moved.
 	coverage = 5
 	layer = WINDOW_LAYER

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -37,7 +37,7 @@
 	density = TRUE
 	anchored = TRUE
 	opacity = FALSE
-	flags_pass = null
+	flags_pass = NONE
 
 	icon = 'icons/obj/inflatable.dmi'
 	icon_state = "wall"

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -37,7 +37,7 @@
 	density = TRUE
 	anchored = TRUE
 	opacity = FALSE
-	throwpass = FALSE
+	flags_pass = null
 
 	icon = 'icons/obj/inflatable.dmi'
 	icon_state = "wall"

--- a/code/game/objects/structures/memorial.dm
+++ b/code/game/objects/structures/memorial.dm
@@ -16,7 +16,7 @@ This memorial has been designed for him and any future contributors to perish.
 	icon_state = "memorial"
 	density = TRUE
 	anchored = TRUE
-	throwpass = FALSE
+	flags_pass = null
 	resistance_flags = RESIST_ALL
 
 /obj/structure/prop/mainship/valmoric
@@ -26,5 +26,5 @@ This memorial has been designed for him and any future contributors to perish.
 	icon_state = "memorial2"
 	density = TRUE
 	anchored = TRUE
-	throwpass = FALSE
+	flags_pass = null
 	resistance_flags = RESIST_ALL

--- a/code/game/objects/structures/memorial.dm
+++ b/code/game/objects/structures/memorial.dm
@@ -16,7 +16,7 @@ This memorial has been designed for him and any future contributors to perish.
 	icon_state = "memorial"
 	density = TRUE
 	anchored = TRUE
-	flags_pass = null
+	flags_pass = NONE
 	resistance_flags = RESIST_ALL
 
 /obj/structure/prop/mainship/valmoric
@@ -26,5 +26,5 @@ This memorial has been designed for him and any future contributors to perish.
 	icon_state = "memorial2"
 	density = TRUE
 	anchored = TRUE
-	flags_pass = null
+	flags_pass = NONE
 	resistance_flags = RESIST_ALL

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -9,7 +9,7 @@
 	density = TRUE
 	anchored = TRUE
 	opacity = TRUE
-	flags_pass = null
+	flags_pass = NONE
 
 	icon = 'icons/obj/doors/mineral_doors.dmi'
 	icon_state = "metal"

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -9,7 +9,7 @@
 	density = TRUE
 	anchored = TRUE
 	opacity = TRUE
-	throwpass = FALSE
+	flags_pass = null
 
 	icon = 'icons/obj/doors/mineral_doors.dmi'
 	icon_state = "metal"

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -119,7 +119,6 @@
 	layer = OBJ_LAYER
 	var/obj/structure/morgue/linked_morgue = null
 	anchored = TRUE
-	throwpass = 1
 
 /obj/structure/morgue_tray/Initialize(mapload, obj/structure/morgue/morgue_source)
 	. = ..()

--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -14,7 +14,7 @@
 	bound_height = 64
 	bound_y = 64
 	resistance_flags = RESIST_ALL
-	throwpass = FALSE
+	flags_pass = null
 	var/obj/structure/orbital_tray/tray
 	var/chambered_tray = FALSE
 	var/loaded_tray = FALSE
@@ -230,7 +230,6 @@
 	icon_state = "cannon_tray"
 	density = TRUE
 	anchored = TRUE
-	throwpass = TRUE
 	climbable = TRUE
 	layer = LADDER_LAYER + 0.01
 	bound_width = 64
@@ -325,7 +324,6 @@
 	name = "theoretical ob ammo"
 	density = TRUE
 	anchored = TRUE
-	throwpass = TRUE
 	climbable = TRUE
 	icon = 'icons/Marine/mainship_props.dmi'
 	resistance_flags = XENO_DAMAGEABLE

--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -14,7 +14,7 @@
 	bound_height = 64
 	bound_y = 64
 	resistance_flags = RESIST_ALL
-	flags_pass = null
+	flags_pass = NONE
 	var/obj/structure/orbital_tray/tray
 	var/chambered_tray = FALSE
 	var/loaded_tray = FALSE

--- a/code/game/objects/structures/platforms.dm
+++ b/code/game/objects/structures/platforms.dm
@@ -71,7 +71,6 @@
 	icon_state = "platform_deco"
 	anchored = TRUE
 	density = FALSE
-	throwpass = TRUE
 	layer = 3.5
 	flags_atom = ON_BORDER
 	resistance_flags = UNACIDABLE

--- a/code/game/objects/structures/prop.dm
+++ b/code/game/objects/structures/prop.dm
@@ -137,7 +137,7 @@
 	bound_width = 64
 	bound_height = 32
 	resistance_flags = UNACIDABLE
-	throwpass = FALSE
+	flags_pass = null
 	var/list/fallen_list
 
 /obj/structure/prop/mainship/ship_memorial/attackby(obj/item/I, mob/user)

--- a/code/game/objects/structures/prop.dm
+++ b/code/game/objects/structures/prop.dm
@@ -137,7 +137,7 @@
 	bound_width = 64
 	bound_height = 32
 	resistance_flags = UNACIDABLE
-	flags_pass = null
+	flags_pass = NONE
 	var/list/fallen_list
 
 /obj/structure/prop/mainship/ship_memorial/attackby(obj/item/I, mob/user)

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -7,7 +7,6 @@
 	density = TRUE
 	anchored = TRUE
 	layer = ABOVE_OBJ_LAYER
-	throwpass = TRUE	//You can throw objects over this
 	coverage = 5
 	climbable = TRUE
 	resistance_flags = XENO_DAMAGEABLE

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -14,7 +14,7 @@
 	icon = 'icons/obj/objects.dmi'
 	buckle_flags = CAN_BUCKLE|BUCKLE_PREVENTS_PULL
 	buckle_lying = 90
-	throwpass = TRUE
+	flags_pass = PASSABLE
 	resistance_flags = XENO_DAMAGEABLE
 	max_integrity = 40
 	resistance_flags = XENO_DAMAGEABLE

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -9,7 +9,6 @@
 	density = TRUE
 	anchored = TRUE
 	layer = TABLE_LAYER
-	throwpass = TRUE	//You can throw objects over this, despite it's density.")
 	climbable = TRUE
 	resistance_flags = XENO_DAMAGEABLE
 	hit_sound = 'sound/effects/metalhit.ogg'
@@ -610,7 +609,6 @@
 	density = TRUE
 	layer = TABLE_LAYER
 	anchored = TRUE
-	throwpass = TRUE	//You can shoot past it
 	coverage = 20
 	climbable = TRUE
 	var/dropmetal = TRUE   //if true drop metal when destroyed; mostly used when we need large amounts of racks without marines hoarding the metal

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -21,7 +21,7 @@
 	var/junction = 0 //Because everything is terrible, I'm making this a window-level var
 	var/damageable = TRUE
 	var/deconstructable = TRUE
-	throwpass = FALSE
+	flags_pass = PASSLASER
 
 //I hate this as much as you do
 /obj/structure/window/full

--- a/code/game/objects/structures/window_frame.dm
+++ b/code/game/objects/structures/window_frame.dm
@@ -148,6 +148,6 @@
 
 /obj/structure/window_frame/prison/hull
 	climbable = FALSE
-	flags_pass = null
+	flags_pass = NONE
 	reinforced = TRUE
 	resistance_flags = INDESTRUCTIBLE|UNACIDABLE

--- a/code/game/objects/structures/window_frame.dm
+++ b/code/game/objects/structures/window_frame.dm
@@ -6,7 +6,6 @@
 	interaction_flags = INTERACT_CHECK_INCAPACITATED
 	layer = WINDOW_FRAME_LAYER
 	density = TRUE
-	throwpass = TRUE
 	resistance_flags = DROPSHIP_IMMUNE | XENO_DAMAGEABLE
 	max_integrity = 150
 	climbable = 1 //Small enough to vault over, but you do need to vault over it
@@ -149,6 +148,6 @@
 
 /obj/structure/window_frame/prison/hull
 	climbable = FALSE
-	throwpass = FALSE
+	flags_pass = null
 	reinforced = TRUE
 	resistance_flags = INDESTRUCTIBLE|UNACIDABLE

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
@@ -10,9 +10,8 @@
 	icon = 'icons/Xeno/48x48_Xenos.dmi'
 	status_flags = GODMODE | INCORPOREAL
 	resistance_flags = RESIST_ALL|BANISH_IMMUNE
-	flags_pass = PASSFIRE //to prevent hivemind eye to catch fire when crossing lava
+	flags_pass = PASSABLE|PASSFIRE //to prevent hivemind eye to catch fire when crossing lava
 	density = FALSE
-	throwpass = TRUE
 
 	a_intent = INTENT_HELP
 
@@ -127,9 +126,8 @@
 	if(status_flags & INCORPOREAL)
 		status_flags = NONE
 		resistance_flags = BANISH_IMMUNE
-		flags_pass = PASSTABLE | PASSMOB | PASSXENO
+		flags_pass = PASSTABLE|PASSMOB|PASSXENO
 		density = TRUE
-		throwpass = FALSE
 		hive.xenos_by_upgrade[upgrade] -= src
 		upgrade = XENO_UPGRADE_MANIFESTATION
 		set_datum(FALSE)
@@ -141,8 +139,7 @@
 	status_flags = initial(status_flags)
 	resistance_flags = initial(resistance_flags)
 	flags_pass = initial(flags_pass)
-	density = initial(flags_pass)
-	throwpass = initial(throwpass)
+	density = FALSE
 	hive.xenos_by_upgrade[upgrade] -= src
 	upgrade = XENO_UPGRADE_BASETYPE
 	set_datum(FALSE)

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -99,7 +99,7 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	var/turf/next_normal_turf = get_step(T, facing)
 	for (var/atom/movable/A AS in T)
 		A.acid_spray_act(owner)
-		if(((A.density && !A.throwpass && !(A.flags_atom & ON_BORDER)) || !A.Exit(source_spray, facing)) && !isxeno(A))
+		if(((A.density && !(A.flags_pass & PASSPROJECTILE) && !(A.flags_atom & ON_BORDER)) || !A.Exit(source_spray, facing)) && !isxeno(A))
 			is_blocked = TRUE
 	if(!is_blocked)
 		if(!skip_timer)

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
@@ -64,7 +64,7 @@
 		for(var/obj/O in T)
 			if(is_type_in_typecache(O, GLOB.acid_spray_hit) && O.acid_spray_act(owner))
 				return // returned true if normal density applies
-			if(O.density && !O.throwpass && !(O.flags_atom & ON_BORDER))
+			if(O.density && !(O.flags_pass & PASSPROJECTILE) && !(O.flags_atom & ON_BORDER))
 				blocked = TRUE
 				break
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -341,7 +341,7 @@
 		for(var/turf/turf_to_check AS in turfs_to_check)
 			if((turf_to_check in target_turfs) || (turf_to_check in turfs_to_add))
 				continue
-			if(LinkBlocked(current_turf, turf_to_check, projectile = TRUE))
+			if(LinkBlocked(current_turf, turf_to_check, air_pass = TRUE))
 				continue
 			turfs_to_add += turf_to_check
 			effect_list += new /obj/effect/xeno/crush_warning(turf_to_check)

--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
@@ -59,7 +59,7 @@
 	max_integrity = 75
 	layer = ABOVE_ALL_MOB_LAYER
 	anchored = TRUE
-	flags_pass = null
+	flags_pass = NONE
 	density = FALSE
 	obj_flags = CAN_BE_HIT | PROJ_IGNORE_DENSITY
 	/// How long the leash ball lasts untill it dies

--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
@@ -59,7 +59,7 @@
 	max_integrity = 75
 	layer = ABOVE_ALL_MOB_LAYER
 	anchored = TRUE
-	throwpass = FALSE
+	flags_pass = null
 	density = FALSE
 	obj_flags = CAN_BE_HIT | PROJ_IGNORE_DENSITY
 	/// How long the leash ball lasts untill it dies
@@ -206,7 +206,7 @@
 	X.fire_resist_modifier += BURROW_FIRE_RESIST_MODIFIER
 	X.mouse_opacity = initial(X.mouse_opacity)
 	X.density = TRUE
-	X.throwpass = FALSE
+	X.flags_pass &= ~PASSABLE
 	REMOVE_TRAIT(X, TRAIT_IMMOBILE, WIDOW_ABILITY_TRAIT)
 	REMOVE_TRAIT(X, TRAIT_BURROWED, WIDOW_ABILITY_TRAIT)
 	REMOVE_TRAIT(X, TRAIT_HANDS_BLOCKED, WIDOW_ABILITY_TRAIT)
@@ -221,7 +221,7 @@
 	// This part here actually burrows the xeno
 	owner.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	owner.density = FALSE
-	owner.throwpass = TRUE
+	owner.flags_pass |= PASSABLE
 	// Here we prevent the xeno from moving or attacking or using abilities untill they unburrow by clicking the ability
 	ADD_TRAIT(owner, TRAIT_IMMOBILE, WIDOW_ABILITY_TRAIT)
 	ADD_TRAIT(owner, TRAIT_BURROWED, WIDOW_ABILITY_TRAIT)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3272,7 +3272,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 /datum/ammo/xeno/leash_ball/on_hit_obj(obj/O, obj/projectile/proj)
 	var/turf/T = get_turf(O)
-	if(T.density || (O.density && !O.throwpass))
+	if(T.density || (O.density && !(O.flags_pass & PASSPROJECTILE)))
 		T = get_turf(proj)
 	drop_leashball(T.density ? proj.loc : T, proj.firer)
 

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1191,24 +1191,6 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	to_chat(source, span_warning("Losing support, the bipod retracts!"))
 	playsound(source, 'sound/machines/click.ogg', 15, 1, 4)
 
-
-//when user fires the gun, we check if they have something to support the gun's bipod.
-/obj/item/attachable/proc/check_bipod_support(obj/item/weapon/gun/G, mob/living/user)
-	return FALSE
-
-/obj/item/attachable/bipod/check_bipod_support(obj/item/weapon/gun/G, mob/living/user)
-	var/turf/T = get_turf(user)
-	for(var/obj/O in T)
-		if(O.throwpass && O.density && O.dir == user.dir && O.flags_atom & ON_BORDER)
-			return O
-
-	T = get_step(T, user.dir)
-	for(var/obj/O in T)
-		if((istype(O, /obj/structure/window_frame)))
-			return O
-
-	return FALSE
-
 /obj/item/attachable/lace
 	name = "pistol lace"
 	desc = "A simple lace to wrap around your wrist."

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -160,7 +160,7 @@
 		if(FLAMER_STREAM_CONE)
 			//direction in degrees
 			var/dir_to_target = Get_Angle(src, target)
-			var/list/turf/turfs_to_ignite = generate_true_cone(get_turf(src), range, 1, cone_angle, dir_to_target, projectile = TRUE, bypass_xeno = TRUE)
+			var/list/turf/turfs_to_ignite = generate_true_cone(get_turf(src), range, 1, cone_angle, dir_to_target, bypass_xeno = TRUE, air_pass = TRUE)
 			recursive_flame_cone(1, turfs_to_ignite, dir_to_target, range, current_target, get_turf(src), flame_max_wall_pen_wide)
 		if(FLAMER_STREAM_RANGED)
 			return ..()
@@ -181,7 +181,7 @@
 	var/turf/turf_to_check = get_turf(src)
 	if(iteration > 1)
 		turf_to_check = path_to_target[iteration - 1]
-	if(LinkBlocked(turf_to_check, path_to_target[iteration], projectile = TRUE, bypass_xeno = TRUE)) //checks if it's actually possible to get to the next tile in the line
+	if(LinkBlocked(turf_to_check, path_to_target[iteration], bypass_xeno = TRUE, air_pass = TRUE)) //checks if it's actually possible to get to the next tile in the line
 		return
 	if(turf_to_check.density && istype(turf_to_check, /turf/closed/wall/resin))
 		walls_penetrated -= 1

--- a/code/modules/projectiles/mounted.dm
+++ b/code/modules/projectiles/mounted.dm
@@ -8,7 +8,7 @@
 	use_power = FALSE
 	hud_possible = list(MACHINE_HEALTH_HUD, MACHINE_AMMO_HUD)
 	flags_atom = ON_BORDER
-	throwpass = TRUE
+	flags_pass = PASSABLE
 	///Store user old pixel x
 	var/user_old_x = 0
 	///Store user old pixel y

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -649,7 +649,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 		return FALSE
 	if(src == proj.original_target) //clicking on the structure itself hits the structure
 		return TRUE
-	if(!throwpass)
+	if(!(flags_pass & PASSPROJECTILE))
 		return TRUE
 	if(proj.distance_travelled <= proj.ammo.barricade_clear_distance)
 		return FALSE

--- a/code/modules/projectiles/sentries.dm
+++ b/code/modules/projectiles/sentries.dm
@@ -437,15 +437,15 @@
 		if(smoke && smoke.opacity)
 			return FALSE
 
-		if(IS_OPAQUE_TURF(T) || T.density && T.throwpass == FALSE && !(T.type in ignored_terrains))
+		if(IS_OPAQUE_TURF(T) || T.density && !(T.flags_pass & PASSPROJECTILE) && !(T.type in ignored_terrains))
 			return FALSE
 
 		for(var/obj/machinery/MA in T)
-			if(MA.density && MA.throwpass == FALSE && !(MA.type in ignored_terrains))
+			if(MA.density && !(MA.flags_pass & PASSPROJECTILE) && !(MA.type in ignored_terrains))
 				return FALSE
 
 		for(var/obj/structure/S in T)
-			if(S.density && S.throwpass == FALSE && !(S.type in ignored_terrains))
+			if(S.density && !(S.flags_pass & PASSPROJECTILE) && !(S.type in ignored_terrains))
 				return FALSE
 
 	return TRUE

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -976,7 +976,7 @@
 	resistance_flags = XENO_DAMAGEABLE | DROPSHIP_IMMUNE
 	opacity = FALSE
 	layer = BELOW_OBJ_LAYER
-	flags_pass = null
+	flags_pass = NONE
 
 /obj/structure/dropship_piece/tadpole/cockpit/left
 	icon_state = "blue_cockpit_fl"

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -976,7 +976,7 @@
 	resistance_flags = XENO_DAMAGEABLE | DROPSHIP_IMMUNE
 	opacity = FALSE
 	layer = BELOW_OBJ_LAYER
-	throwpass = FALSE
+	flags_pass = null
 
 /obj/structure/dropship_piece/tadpole/cockpit/left
 	icon_state = "blue_cockpit_fl"

--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -10,6 +10,7 @@
 	blocks_emissive = EMISSIVE_BLOCK_GENERIC
 	obj_flags = CAN_BE_HIT
 	resistance_flags = XENO_DAMAGEABLE
+	flags_pass = PASSAIR
 	COOLDOWN_DECLARE(cooldown_vehicle_move)
 	///mob = bitflags of their control level.
 	var/list/mob/occupants

--- a/code/modules/vehicles/motorbike.dm
+++ b/code/modules/vehicles/motorbike.dm
@@ -11,7 +11,7 @@
 	flags_atom = PREVENT_CONTENTS_EXPLOSION
 	key_type = null
 	integrity_failure = 0.5
-	throwpass = TRUE
+	flags_pass = PASSABLE
 	coverage = 30	//It's just a bike, not hard to shoot over
 	buckle_flags = CAN_BUCKLE|BUCKLE_PREVENTS_PULL|BUCKLE_NEEDS_HAND
 	///Internal motorbick storage object

--- a/code/modules/vehicles/multitile/cm_armored.dm
+++ b/code/modules/vehicles/multitile/cm_armored.dm
@@ -256,7 +256,7 @@ GLOBAL_LIST_INIT(armorvic_dmg_distributions, list(
 /obj/vehicle/multitile/hitbox/cm_armored
 	name = "Armored Vehicle"
 	desc = "Get inside to operate the vehicle."
-	throwpass = 1 //You can lob nades over tanks, and there's some dumb check somewhere that requires this
+	flags_pass = PASSABLE
 	var/lastsound = 0
 
 //If something want to delete this, it's probably either an admin or the shuttle

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -875,7 +875,7 @@ TUNNEL
 	density = TRUE
 	resistance_flags = UNACIDABLE | DROPSHIP_IMMUNE
 	xeno_structure_flags = IGNORE_WEED_REMOVAL|HAS_OVERLAY
-	throwpass = FALSE
+	flags_pass = PASSAIR|PASSTHROW
 	///The hive it belongs to
 	var/datum/hive_status/associated_hive
 	///What kind of spit it uses

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -1051,17 +1051,17 @@ TUNNEL
 			continue
 		var/blocked = FALSE
 		for(var/turf/T AS in path)
-			if(IS_OPAQUE_TURF(T) || T.density && T.throwpass == FALSE)
+			if(IS_OPAQUE_TURF(T) || T.density && !(T.flags_pass & PASSPROJECTILE))
 				blocked = TRUE
 				break //LoF Broken; stop checking; we can't proceed further.
 
 			for(var/obj/machinery/MA in T)
-				if(MA.opacity || MA.density && MA.throwpass == FALSE)
+				if(MA.opacity || MA.density && !(MA.flags_pass & PASSPROJECTILE))
 					blocked = TRUE
 					break //LoF Broken; stop checking; we can't proceed further.
 
 			for(var/obj/structure/S in T)
-				if(S.opacity || S.density && S.throwpass == FALSE )
+				if(S.opacity || S.density && !(S.flags_pass & PASSPROJECTILE))
 					blocked = TRUE
 					break //LoF Broken; stop checking; we can't proceed further.
 		if(!blocked)


### PR DESCRIPTION

## About The Pull Request
Removes the throwpass var because it was bad and used for several related but not quite identical situations.
Replaced with flags for specific kinds of behavior. 

There's probably a bunch of stuff that could have some of these correctly assigned to fix slightly odd current behavior, but I'll leave that to some one else.
This also makes it easier to add some more specific object/turf behaviors. For example a wall/object that can let gas through but not thrown object/projectiles, etc.

The only in game changes are that warlock crush and flamers will bypass mechs and I think acid turrets like you'd expect them to.

NOTE: throwpass doesn't actually work for throwing, in most/all cases it's actually passtable, but again that's a pr for another day.
## Why It's Good For The Game
crush mech good.
## Changelog
:cl:
fix: Warlock crush and flamers will no longer get blocked by mechs
refactor: refactored throwpass
/:cl:
