### PR TITLE
damage_mult applies to sunder and penetration

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1591,6 +1591,8 @@
 /obj/item/weapon/gun/proc/apply_gun_modifiers(obj/projectile/projectile_to_fire, atom/target, firer)
 	projectile_to_fire.shot_from = src
 	projectile_to_fire.damage *= damage_mult
+	projectile_to_fire.penetration *= damage_mult
+	projectile_to_fire.sundering *= damage_mult
 	projectile_to_fire.damage_falloff *= damage_falloff_mult
 	projectile_to_fire.projectile_speed = projectile_to_fire.ammo.shell_speed
 	projectile_to_fire.projectile_speed += shell_speed_mod

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -255,6 +255,8 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(action == "reload")
+		if(!do_after(current_firer, rearm_time, FALSE, chassis, BUSY_ICON_GENERIC))
+			return FALSE
 		rearm()
 		return TRUE
 

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -255,8 +255,6 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(action == "reload")
-		if(!do_after(current_firer, rearm_time, FALSE, chassis, BUSY_ICON_GENERIC))
-			return FALSE
 		rearm()
 		return TRUE
 


### PR DESCRIPTION

## About The Pull Request

title

## Why It's Good For The Game

both values are quite important, this is mainly to fix quick-fire shotguns applying sunder too fast.

## Changelog
:cl:
fix: damage_mult applies to sunder and penetration
/:cl:
