### PR TITLE
mech UI reload takes time

### DIFF
--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -255,6 +255,8 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(action == "reload")
+		if(!do_after(current_firer, rearm_time, FALSE, chassis, BUSY_ICON_GENERIC))
+			return FALSE
 		rearm()
 		return TRUE
 


### PR DESCRIPTION
## About The Pull Request

mech reload via UI now takes 2 seconds just like normal autoreload

## Why It's Good For The Game

Reloading weapons via UI is easily abusable and should take time just like normal autoreload.

## Changelog
:cl:
balance: mech UI reload now takes time
/:cl:
