### PR TITLE
Smoke nade duration var and sentinel primo fix

### DIFF
--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -170,11 +170,13 @@
 	var/datum/effect_system/smoke_spread/smoketype = /datum/effect_system/smoke_spread/bad
 	///radius this smoke grenade will encompass
 	var/smokeradius = 7
+	///The duration of the smoke
+	var/smoke_duration = 11
 
 /obj/item/explosive/grenade/smokebomb/prime()
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
 	playsound(loc, 'sound/effects/smoke.ogg', 25, 1, 4)
-	smoke.set_up(smokeradius, loc, 11)
+	smoke.set_up(smokeradius, loc, smoke_duration)
 	smoke.start()
 	qdel(src)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -231,7 +231,7 @@
 	greyscale_colors = "#42A500"
 	greyscale_config = /datum/greyscale_config/xenogrenade
 	det_time = 15
-	smoke_duration = 2
+	smoke_duration = 5
 	dangerous = TRUE
 	smoketype = /datum/effect_system/smoke_spread/xeno/toxic
 	arm_sound = 'sound/voice/alien_yell_alt.ogg'

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -231,6 +231,7 @@
 	greyscale_colors = "#42A500"
 	greyscale_config = /datum/greyscale_config/xenogrenade
 	det_time = 15
+	smoke_duration = 2
 	dangerous = TRUE
 	smoketype = /datum/effect_system/smoke_spread/xeno/toxic
 	arm_sound = 'sound/voice/alien_yell_alt.ogg'


### PR DESCRIPTION

## About The Pull Request
Adds duration as a var to smoke nades, instead of being hardcoded to 11 seconds.
Reduced Sentinel nade duration to 5 seconds (it was supposed to be set at 2 seconds)
## Why It's Good For The Game
Magic number bad.
Bug fix good
## Changelog
:cl:
fix: fixed sentinel gas grenades lasting longer than they should
/:cl:
