### PR TITLE
CAS visual fix

### DIFF
--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -94,8 +94,12 @@
 /obj/effect/temp_visual/heavyimpact
 	name = "heavy impact"
 	icon = 'icons/effects/heavyimpact.dmi'
-	icon_state = "heavyimpact"
+	icon_state = ""
 	duration = 13
+
+/obj/effect/temp_visual/heavyimpact/Initialize()
+	. = ..()
+	flick("heavyimpact", src)
 
 /obj/effect/temp_visual/order
 	icon = 'icons/Marine/marine-items.dmi'


### PR DESCRIPTION

## About The Pull Request
CAS GAU now uses flick for it's animation. This means that the animation will actually start when that particular tile is hit, rather than them all being confusingly in sync even though they are hit at different times.
## Why It's Good For The Game
Clearer visuals
## Changelog
:cl:
add: CAS GAU animation behaves more sensibly
/:cl:
