### PR TITLE
Primo spitter tweaks

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -156,6 +156,7 @@
 	caste_desc = "Master of ranged combat, this xeno knows no equal."
 	upgrade = XENO_UPGRADE_FOUR
 	primordial_message = "Our suppression is unmatched! Let nothing show its head!"
+	caste_flags = CASTE_EVOLUTION_ALLOWED|CASTE_ACID_BLOOD
 
 	// *** Melee Attacks *** //
 	melee_damage = 20

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -160,19 +160,12 @@
 
 		if(!(xeno_caste.caste_flags & CASTE_ACID_BLOOD))
 			return
-		var/splash_chance = 40 //Base chance of getting splashed. Decreases with # of victims.
-		var/distance = 0 //Distance, decreases splash chance.
-		var/i = 0 //Tally up our victims.
+		var/splash_chance
 		for(var/mob/living/carbon/human/victim in range(radius,src)) //Loop through all nearby victims, including the tile.
-			distance = get_dist(src,victim)
-
-			splash_chance = 80 - (i * 5)
-			if(victim.loc == loc)
-				splash_chance += 30 //Same tile? BURN
-			splash_chance += distance * -15
-			i++
-			victim.visible_message(span_danger("\The [victim] is scalded with hissing green blood!"), \
-			span_danger("You are splattered with sizzling blood! IT BURNS!"))
-			if(victim.stat != CONSCIOUS && !(victim.species.species_flags & NO_PAIN) && prob(60))
-				victim.emote("scream") //Topkek
-			victim.take_limb_damage(0, rand(10, 25)) //Sizzledam! This automagically burns a random existing body part.
+			splash_chance = (chance * 2) - (get_dist(src,victim) * 20)
+			if(prob(splash_chance))
+				victim.visible_message(span_danger("\The [victim] is scalded with hissing green blood!"), \
+				span_danger("You are splattered with sizzling blood! IT BURNS!"))
+				if(victim.stat != CONSCIOUS && !(victim.species.species_flags & NO_PAIN) && prob(60))
+					victim.emote("scream")
+				victim.take_overall_damage(rand(15, 30), BURN, ACID, updating_health = TRUE)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2934,6 +2934,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/xeno/acid/auto
 	name = "light acid spatter"
 	damage = 10
+	damage_falloff = 0.3
 	spit_cost = 25
 	added_spit_delay = 0
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2921,6 +2921,11 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/xeno/acid/on_shield_block(mob/victim, obj/projectile/proj)
 	airburst(victim, proj)
 
+/datum/ammo/xeno/acid/drop_nade(turf/T) //Leaves behind an acid pool; defaults to 1-3 seconds.
+	if(T.density)
+		return
+	new /obj/effect/xenomorph/spray(T, puddle_duration, puddle_acid_damage)
+
 /datum/ammo/xeno/acid/medium
 	name = "acid spatter"
 	damage = 30
@@ -2929,7 +2934,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/xeno/acid/auto
 	name = "light acid spatter"
 	damage = 10
-	flags_ammo_behavior = AMMO_XENO
 	spit_cost = 25
 	added_spit_delay = 0
 
@@ -2975,13 +2979,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 /datum/ammo/xeno/acid/heavy/do_at_max_range(turf/T, obj/projectile/P)
 	drop_nade(T.density ? P.loc : T)
-
-/datum/ammo/xeno/acid/drop_nade(turf/T) //Leaves behind an acid pool; defaults to 1-3 seconds.
-	if(T.density)
-		return
-
-	new /obj/effect/xenomorph/spray(T, puddle_duration, puddle_acid_damage)
-
 
 ///For the Spitter's Scatterspit ability
 /datum/ammo/xeno/acid/heavy/scatter

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2933,6 +2933,19 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	spit_cost = 25
 	added_spit_delay = 0
 
+/datum/ammo/xeno/acid/auto/on_hit_mob(mob/M, obj/projectile/P)
+	var/turf/T = get_turf(M)
+	drop_nade(T.density ? P.loc : T)
+
+/datum/ammo/xeno/acid/auto/on_hit_obj(obj/O, obj/projectile/P)
+	drop_nade(O.density ? P.loc : get_turf(O))
+
+/datum/ammo/xeno/acid/auto/on_hit_turf(turf/T, obj/projectile/P)
+	drop_nade(T.density ? P.loc : T)
+
+/datum/ammo/xeno/acid/auto/do_at_max_range(turf/T, obj/projectile/P)
+	drop_nade(T.density ? P.loc : T)
+
 /datum/ammo/xeno/acid/passthrough
 	name = "acid spittle"
 	damage = 20
@@ -2950,15 +2963,14 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	shell_speed = 2
 	max_range = 9
 
-/datum/ammo/xeno/acid/heavy/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/xeno/acid/heavy/on_hit_mob(mob/M, obj/projectile/P)
 	var/turf/T = get_turf(M)
 	drop_nade(T.density ? P.loc : T)
 
-/datum/ammo/xeno/acid/heavy/on_hit_obj(obj/O,obj/projectile/P)
-	var/turf/T = get_turf(O)
-	drop_nade(T.density ? P.loc : T)
+/datum/ammo/xeno/acid/heavy/on_hit_obj(obj/O, obj/projectile/P)
+	drop_nade(O.density ? P.loc : get_turf(O))
 
-/datum/ammo/xeno/acid/heavy/on_hit_turf(turf/T,obj/projectile/P)
+/datum/ammo/xeno/acid/heavy/on_hit_turf(turf/T, obj/projectile/P)
 	drop_nade(T.density ? P.loc : T)
 
 /datum/ammo/xeno/acid/heavy/do_at_max_range(turf/T, obj/projectile/P)


### PR DESCRIPTION
## About The Pull Request
Minor buff to primo spitter to give it a bit more area control/flavour.

Primo spitter's autofire spit now leaves acid pools on hit (like prae already does), and primo spitter now has acid blood, which is more flavour than anything, but reinforces the 'acid guy' theme.
Autospit now has the explosive flag like most spits (i.e. lands where you click).
Reduced damage fall off from 1 to 0.3 since it has almost the worst falloff in the game considering its base damage.

Also fixed a bug where acid pools on hit will bypass obstacles like cades, or entirely solid ones like glass panes etc.

And fixed a bug and reworked acid blood. Currently there is a splatter chance that... does nothing. And the splatter itself didn't respect acid armour either.
## Why It's Good For The Game
More interesting spitter primo than "shoots fast". More useful in large fight or in tight spaces.
Generally less terrible primo as it's actually incredibly bad.
## Changelog
:cl:
add: Primo spitter now leaves acid pools on hit with autospit, and has acid blood
balance: Reduced primo spitter damage falloff so it's less garbage
fix: acid pools from projectiles will no longer bypass barricades or other solid objects
fix: acid blood ignoring acid armour and splatter chance not working

/:cl:
