### PR TITLE
Mech weapon rebalances.

### DIFF
--- a/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
@@ -151,12 +151,12 @@
 	)
 	ammotype = /datum/ammo/bullet/shotgun/mech
 	max_integrity = 350
-	projectiles = 10
-	projectiles_cache = 120
-	projectiles_cache_max = 120
+	projectiles = 20
+	projectiles_cache = 200
+	projectiles_cache_max = 200
 	variance = 6
 	projectile_delay = 2.0 SECONDS
-	slowdown = 0.3
+	slowdown = 0.5
 	harmful = TRUE
 	ammo_type = MECHA_AMMO_SHOTGUN
 	hud_icons = list("shotgun_buckshot", "shotgun_empty")
@@ -179,8 +179,8 @@
 	projectiles_cache = 1200
 	projectiles_cache_max = 1200
 	variance = 25
-	projectile_delay = 0.15 SECONDS
-	slowdown = 0.3
+	projectile_delay = 0.2 SECONDS
+	slowdown = 0.6
 	harmful = TRUE
 	ammo_type = MECHA_AMMO_GREY_LMG
 	hud_icons = list("rifle_heavy", "rifle_empty")
@@ -199,9 +199,9 @@
 	)
 	ammotype = /datum/ammo/tx54/mech
 	max_integrity = 400
-	projectiles = 30
-	projectiles_cache = 300
-	projectiles_cache_max = 300
+	projectiles = 16
+	projectiles_cache = 64
+	projectiles_cache_max = 64
 	variance = 20
 	projectile_delay = 0.7 SECONDS
 	slowdown = 0.4
@@ -226,7 +226,7 @@
 	energy_drain = 10
 	variance = 0
 	projectile_delay = 0.4 SECONDS
-	slowdown = 0.4
+	slowdown = 0.3
 	harmful = TRUE
 	fire_mode = GUN_FIREMODE_AUTOMATIC
 
@@ -388,11 +388,12 @@
 	ammotype = /datum/ammo/flamethrower/mech_flamer
 	max_integrity = 250
 	projectiles = 20
-	projectiles_cache = 20 // low ammo counts so player cant just spam fire while rushing infinitely
-	projectiles_cache_max = 20
+	projectiles_cache = 100 // low ammo counts so player cant just spam fire while rushing infinitely
+	projectiles_cache_max = 100
 	variance = 0
 	projectile_delay = 2 SECONDS
-	slowdown = 0.4
+	// Reduces rushing significantly
+	slowdown = 0.7
 	harmful = TRUE
 	ammo_type = MECHA_AMMO_FLAMER
 	hud_icons = list("flame", "flame_empty")
@@ -412,8 +413,8 @@
 	ammotype = /datum/ammo/rocket/mech
 	max_integrity = 400
 	projectiles = 1
-	projectiles_cache = 1
-	projectiles_cache_max = 1
+	projectiles_cache = 4
+	projectiles_cache_max = 4
 	variance = 0
 	projectile_delay = 2 SECONDS
 	slowdown = 0.7
@@ -435,10 +436,11 @@
 	desc = "A specialized mech laser blade made out of compressed energy with unimaginable power. Its compact size allows fast, short-ranged attacks. When activated, overloads the leg actuators to dash forward, before cutting with a superheated plasma beam. Melee core increases area cut and distance dashed. Heavy, but it is the top-of-the-line melee weapon of TGMC's fine line of mecha close-range offensive capability."
 	icon_state = "moonlight"
 	mech_flags = EXOSUIT_MODULE_GREYSCALE
-	max_integrity = 400
+	/// high integrity , CQC.
+	max_integrity = 800
 	slowdown = 0
 	harmful = TRUE
-	equip_cooldown = 3 SECONDS
+	equip_cooldown = 2 SECONDS
 	energy_drain = 100
 	range = MECHA_MELEE|MECHA_RANGED
 	force = 150


### PR DESCRIPTION

## About The Pull Request
Rebalances mech weaponary
Missile pod now gets 5 rockets instead of just 2
Flamethrower ammo increased , slowdown increase from 0.4 to 0.7
Leto autocannon ammo per mag decreased to 16 , total extra ammo decreased to 64
Briareus LMG firerate decreased from 6.6 rounds per second to 5, and slowdown increase from 0.3 to 0.6 
Moonlight cutter integrity buffed to 800, and delay decreased to 2 seconds instead of 3
Phoebe shotgun ammo mag increased to 20 , with cache increased too.
Laser rifle slowdown reduced from 0.4 to 0.3

## Why It's Good For The Game
The missile pod has only 75 damage + no devastation , meaning its not that great and its also hard to hit since mechs can barely turn, thus not beign used at all.
The flamethrower had too little ammo to be usefull at melting , and fire is not that usefull for a mech that has to go constantly refill, slowdown was increased to justify worries about constant rushing
The letoautocannon has a huge mag capacity and as thus is seen constantly spammed to break off walls or resin structures instead of the flamethrower , along with the huge damage potential of its grenades , the reduction aims to make MP's more conservative of it.
The briarus LMG had too little slowdown for being quite almost the same as the vulcan , thus its slowdown was doubled and its fire-rate reduced , its main advantage being that its more accurate 
Moonlight cutter has rarely seen use due to the super slow slash rate , and along with the fact that xenos kept spinning around it and taking off the arms , the doubled integrity and faster hit-rate should help.
Phoebe shotgun had too little ammo for it to be used on the front constantly , along with the horrendous accuracy and spread.
Laser rifle just had too much slowdown for just being a infinite-ammo hitscan rifle.
## Changelog
:cl:
balance: Missile pod now has 5 missiles 
balance: Flamethrower ammo capacity buffed , slowdown increased from 0.4 to 0.7
balance: Leto autocannon ammo mag capacity decreased from 30 to 16, and mag cache decreased from 300 to 64
balance: Briarus LMG slowdown increased from 0.3 to 0.6 , firerate decreased from 6.6 bullets per second to 5.
balance: Moonlight cutter slash rate increased from 3.3 per second to 5 per second , integrity doubled from 400 to 800
balance: Phoebe shotgun ammo capacity increased from 10 per mag to 20 per mag , and from 120 in the cache to 200
balance: Laser rifle slowdown reduced from 0.4 to 0.3
/:cl:
