### PR TITLE
You now spin while stop drop rolling.

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -201,7 +201,7 @@
 	SIGNAL_HANDLER
 	fire_stacks = max(fire_stacks - rand(3, 6), 0)
 	Paralyze(30)
-
+	spin(30, 1.5)
 	var/turf/T = get_turf(src)
 	if(istype(T, /turf/open/floor/plating/ground/snow))
 		visible_message(span_danger("[src] rolls in the snow, putting themselves out!"), \


### PR DESCRIPTION

## About The Pull Request

You now spin while stop drop rolling. 3 seconds of duration, same as paralyze, 1.5 abstract time value for time between direction spins.

## Why It's Good For The Game

Presumably this should pop an error out considering it's a signal handler and there's sleeps in spin(), but there weren't any so who knows. I'll invoke_async if told to.

## Changelog

:cl:
add: You now spin while stop drop rolling.
/:cl:

