### PR TITLE
Primo rav fix and adjustment

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -511,8 +511,8 @@
 	if(timeleft(timer_ref) > 0)
 		return
 	var/mob/living/carbon/xenomorph/x = owner
-	x.adjustBruteLoss(-((x.xeno_caste.max_health - x.health) / 4))
-	x.adjustFireLoss(-((x.xeno_caste.max_health - x.health) / 4))
+	x.adjustBruteLoss(-x.bruteloss * 0.25)
+	x.adjustFireLoss(-x.fireloss * 0.25)
 	update_button_icon()
 	particle_holder = new(x, /particles/xeno_slash/vampirism)
 	particle_holder.pixel_y = 18

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -511,8 +511,8 @@
 	if(timeleft(timer_ref) > 0)
 		return
 	var/mob/living/carbon/xenomorph/x = owner
-	x.adjustBruteLoss(-x.bruteloss * 0.25)
-	x.adjustFireLoss(-x.fireloss * 0.25)
+	x.adjustBruteLoss(-x.bruteloss * 0.125)
+	x.adjustFireLoss(-x.fireloss * 0.125)
 	update_button_icon()
 	particle_holder = new(x, /particles/xeno_slash/vampirism)
 	particle_holder.pixel_y = 18


### PR DESCRIPTION

## About The Pull Request
Fixed a bug where vampirism would separetely heal both brute and burn for 25% of total health lost, effectively meaning the heal could be 200+ health.

Reduced the heal amount to 12.5% from 25%.

25% heal every 2 seconds is simply not balanced, even without the bug, especially taking into account endure and (super) rage.

I'm not entirely happy with the vampirism mechanic because it's essentially passive, but the previous one was trash.
## Why It's Good For The Game
Bug fix good.
Having a queen healing you every 2 seconds bad.
## Changelog
:cl:
balance: Reduced Ravager vampirism healing by 50%.
fix: fixed Ravager vampirism healing more than it should
/:cl:
