### PR TITLE
Mateba, General revolver changes and SAA buff.

### DIFF
--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -321,5 +321,6 @@
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 22,"rail_x" = 17, "rail_y" = 22, "under_x" = 22, "under_y" = 17, "stock_x" = 22, "stock_y" = 19)
 
 	fire_delay = 0.15 SECONDS
-	scatter_unwielded = 5
+	damage_mult = 1.1
+	scatter_unwielded = 0
 	scatter = 0

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -27,8 +27,8 @@
 	fire_delay = 2
 	accuracy_mult_unwielded = 0.85
 	scatter_unwielded = 25
-	recoil = 2
-	recoil_unwielded = 3
+	recoil = 0
+	recoil_unwielded = 1
 
 	placed_overlay_iconstate = "revolver"
 
@@ -189,10 +189,10 @@
 	fire_delay = 0.2 SECONDS
 	aim_fire_delay = 0.3 SECONDS
 	recoil = 0
-	accuracy_mult = 1.1
+	accuracy_mult = 1.15
 	scatter = 0
-	accuracy_mult_unwielded = 0.6
-	scatter_unwielded = 7
+	accuracy_mult_unwielded = 0.8
+	scatter_unwielded = 3
 
 /obj/item/weapon/gun/revolver/mateba/notmarine
 	name = "\improper Mateba autorevolver"
@@ -321,3 +321,5 @@
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 22,"rail_x" = 17, "rail_y" = 22, "under_x" = 22, "under_y" = 17, "stock_x" = 22, "stock_y" = 19)
 
 	fire_delay = 0.15 SECONDS
+	scatter_unwielded = 5
+	scatter = 0

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -26,7 +26,7 @@
 	movement_acc_penalty_mult = 3
 	fire_delay = 2
 	accuracy_mult_unwielded = 0.85
-	scatter_unwielded = 25
+	scatter_unwielded = 15
 	recoil = 0
 	recoil_unwielded = 1
 
@@ -85,9 +85,7 @@
 	akimbo_additional_delay = 0.6 // Ends up as 0.249, so it'll get moved up to 0.25.
 	accuracy_mult_unwielded = 0.85
 	accuracy_mult = 1
-	scatter_unwielded = 15
 	scatter = -1
-	recoil = 0
 	recoil_unwielded = 0.75
 
 /obj/item/weapon/gun/revolver/standard_revolver/Initialize(mapload, spawn_empty)
@@ -121,7 +119,7 @@
 	attachable_offset = list("muzzle_x" = 28, "muzzle_y" = 21,"rail_x" = 14, "rail_y" = 23, "under_x" = 24, "under_y" = 19, "stock_x" = 24, "stock_y" = 19)
 
 	damage_mult = 1.05
-	recoil = 0
+	scatter_unwielded = 12
 	recoil_unwielded = 0
 
 
@@ -151,8 +149,6 @@
 	)
 	attachable_offset = list("muzzle_x" = 30, "muzzle_y" = 19,"rail_x" = 12, "rail_y" = 21, "under_x" = 20, "under_y" = 15, "stock_x" = 20, "stock_y" = 15)
 
-	scatter_unwielded = 20
-	recoil = 0
 	recoil_unwielded = 0
 
 
@@ -188,11 +184,10 @@
 
 	fire_delay = 0.2 SECONDS
 	aim_fire_delay = 0.3 SECONDS
-	recoil = 0
 	accuracy_mult = 1.15
 	scatter = 0
 	accuracy_mult_unwielded = 0.8
-	scatter_unwielded = 3
+	scatter_unwielded = 7
 
 /obj/item/weapon/gun/revolver/mateba/notmarine
 	name = "\improper Mateba autorevolver"
@@ -231,9 +226,9 @@
 	attachable_offset = list("muzzle_x" = 29, "muzzle_y" = 22,"rail_x" = 11, "rail_y" = 25, "under_x" = 20, "under_y" = 18, "stock_x" = 20, "stock_y" = 18)
 
 	fire_delay = 0.15 SECONDS
+	scatter_unwielded = 12
 	burst_amount = 3
 	burst_delay = 0.1 SECONDS
-	scatter_unwielded = 20
 	damage_mult = 1.05
 
 //-------------------------------------------------------
@@ -270,7 +265,6 @@
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 22,"rail_x" = 17, "rail_y" = 22, "under_x" = 22, "under_y" = 17, "stock_x" = 22, "stock_y" = 19)
 
 	fire_delay = 0.35 SECONDS
-	recoil = 0
 	scatter = 8 // Only affects buckshot considering marksman has -15 scatter.
 	damage_falloff_mult = 1.2
 
@@ -322,5 +316,3 @@
 
 	fire_delay = 0.15 SECONDS
 	damage_mult = 1.1
-	scatter_unwielded = 0
-	scatter = 0


### PR DESCRIPTION
## About The Pull Request
SAA has a bit higher damage (10% more damage) than normal revolvers.
Mateba and revolvers in geneal have significantly less screen recoil, and recoil.
Revolver scatter in general normalized to TP-44 levels (15), revolvers with revolver/small bullets normalized to 12 (CMB and Nagant Revolver)
Mateba has better gun accuracy stats.
## Why It's Good For The Game
Mateba and SAA are pretty much worse than normal revolver due to poor handling stats, and revolvers in general no longer should have as much screenshake considering the stat has been entirely reworked compared to the last time the stat was set.
## Changelog
:cl:
balance:Revolvers in general have less screenshake, and scatter. mateba has better accuracy. SAA has a bit of extra damage compared to stock revolvers.
/:cl:
