### PR TITLE
Rownin Skeleton gets 8 light range like other armor with 0 soft armor

### DIFF
--- a/code/modules/clothing/modular_armor/modular.dm
+++ b/code/modules/clothing/modular_armor/modular.dm
@@ -278,6 +278,7 @@
 	icon_state = "rownin_skeleton"
 	item_state = "rownin_skeleton"
 	slowdown = 0
+	light_range = 8
 
 	icon_state_variants = list()
 


### PR DESCRIPTION

## About The Pull Request

Title.

## Why It's Good For The Game

#11789.

Become the flashlight for the marines when you charge at xenomorphs with vali + Rownin Skeleton

## Changelog

:cl:
balance: Rownin Skeleton gets 8 light range like other armor with 0 soft armor
/:cl:

