### PR TITLE
Grenade launcher tweak

### DIFF
--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -93,6 +93,9 @@
 	walk(src, null, null)
 	return
 
+///Returns an adjusted det time, used for grenade launchers
+/obj/item/explosive/grenade/proc/launched_det_time()
+	return min(10, det_time)
 
 ////RAD GRENADE - TOTALLY RAD MAN
 

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -93,9 +93,9 @@
 	walk(src, null, null)
 	return
 
-///Returns an adjusted det time, used for grenade launchers
+///Adjusts det time, used for grenade launchers
 /obj/item/explosive/grenade/proc/launched_det_time()
-	return min(10, det_time)
+	det_time = min(10, det_time)
 
 ////RAD GRENADE - TOTALLY RAD MAN
 

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -104,7 +104,7 @@
 	return ..()
 
 /obj/item/explosive/grenade/sticky/launched_det_time()
-	return min(40, det_time)
+	det_time -= 1 SECONDS
 
 ///Cleans references to prevent hard deletes.
 /obj/item/explosive/grenade/sticky/proc/clean_refs()

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -103,6 +103,9 @@
 		clean_refs()
 	return ..()
 
+/obj/item/explosive/grenade/sticky/launched_det_time()
+	return min(40, det_time)
+
 ///Cleans references to prevent hard deletes.
 /obj/item/explosive/grenade/sticky/proc/clean_refs()
 	SIGNAL_HANDLER

--- a/code/modules/projectiles/guns/grenade_launchers.dm
+++ b/code/modules/projectiles/guns/grenade_launchers.dm
@@ -76,7 +76,7 @@ The Grenade Launchers
 	log_explosion("[key_name(gun_user)] fired a grenade ([grenade_to_launch]) from [src] at [AREACOORD(user_turf)].")
 	log_combat(gun_user, src, "fired a grenade ([grenade_to_launch]) from [src]")
 	play_fire_sound(loc)
-	grenade_to_launch.det_time = grenade_to_launch.launched_det_time()
+	grenade_to_launch.launched_det_time()
 	grenade_to_launch.launched = TRUE
 	grenade_to_launch.activate(gun_user)
 	grenade_to_launch.throwforce += grenade_to_launch.launchforce

--- a/code/modules/projectiles/guns/grenade_launchers.dm
+++ b/code/modules/projectiles/guns/grenade_launchers.dm
@@ -76,7 +76,7 @@ The Grenade Launchers
 	log_explosion("[key_name(gun_user)] fired a grenade ([grenade_to_launch]) from [src] at [AREACOORD(user_turf)].")
 	log_combat(gun_user, src, "fired a grenade ([grenade_to_launch]) from [src]")
 	play_fire_sound(loc)
-	grenade_to_launch.det_time = min(10, grenade_to_launch.det_time)
+	grenade_to_launch.det_time = grenade_to_launch.launched_det_time()
 	grenade_to_launch.launched = TRUE
 	grenade_to_launch.activate(gun_user)
 	grenade_to_launch.throwforce += grenade_to_launch.launchforce


### PR DESCRIPTION

## About The Pull Request
Adjusted sticky nade det time when fired from a GL from 1 second to 3-5 seconds.

Currently, all nades fired from a GL have their det time hard set to 1 second, giving a (very) small window to try avoid the blast.
Stickies are a bit difficult because they, well, stick, making them a guaranteed wombo combo tool.

This makes more of a trade off between normal grenades with a larger radius and shorter det time for that immediate staggerslow, and stickies with their guaranteed hit (if you hit initially) but longer det time.

This can also be used to individually tweak det times for specific grenades, if required.
## Why It's Good For The Game
Make stickies a bit less unpleasant to deal with.
## Changelog
:cl:
balance: Sticky grenades detonate after four seconds instead of one second, when fired from a grenade launcher
/:cl:
