### PR TITLE
Integrates throwing knives into the autofire system.

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -752,7 +752,7 @@
 
 /obj/item/storage/belt/knifepouch
 	name="\improper M276 pattern knife rig"
-	desc="The M276 is the standard load-bearing equipment of the TGMC. It consists of a modular belt with various clips. This version is specially designed with four holsters to store throwing knives. Not commonly issued, but kept in service."
+	desc="The M276 is the standard load-bearing equipment of the TGMC. It consists of a modular belt with various clips. This version is specially designed with six holsters to store throwing knives. Not commonly issued, but kept in service."
 	icon_state="knifebelt"
 	item_state="knifebelt"
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -331,11 +331,15 @@
 	amount = 5
 	///Delay between throwing.
 	var/throw_delay = 0.2 SECONDS
-	COOLDOWN_DECLARE(last_thrown)
+	///Current Target that knives are being thrown at. This is for aiming
+	var/current_target
+	///The person throwing knives
+	var/mob/living/living_user
 
 /obj/item/stack/throwing_knife/Initialize(mapload, new_amount)
 	. = ..()
 	RegisterSignal(src, COMSIG_MOVABLE_POST_THROW, .proc/post_throw)
+	AddComponent(/datum/component/automatedfire/autofire, throw_delay, _fire_mode = GUN_FIREMODE_AUTOMATIC, _callback_reset_fire = CALLBACK(src, .proc/reset_fire), _callback_fire = CALLBACK(src, .proc/throw_knife))
 
 /obj/item/stack/throwing_knife/update_icon()
 	. = ..()
@@ -344,39 +348,67 @@
 
 /obj/item/stack/throwing_knife/equipped(mob/user, slot)
 	. = ..()
-	if(!isliving(user))
+	if(user.get_active_held_item() != src && user.get_inactive_held_item() != src)
 		return
-	var/mob/living/living_user = user
-	if(living_user.get_active_held_item() != src && living_user.get_inactive_held_item() != src)
-		return
-	RegisterSignal(user, COMSIG_MOB_ITEM_AFTERATTACK, .proc/throw_knife)
+	living_user = user
+	RegisterSignal(user, COMSIG_MOB_MOUSEDRAG, .proc/change_target)
+	RegisterSignal(user, COMSIG_MOB_MOUSEUP, .proc/stop_fire)
+	RegisterSignal(user, COMSIG_MOB_MOUSEDOWN, .proc/start_fire)
 
 /obj/item/stack/throwing_knife/unequipped(mob/unequipper, slot)
 	. = ..()
+	living_user?.client?.mouse_pointer_icon = initial(living_user.client.mouse_pointer_icon) // Force resets the mouse pointer to default so it defaults when the last knife is thrown
 	UnregisterSignal(unequipper, COMSIG_MOB_ITEM_AFTERATTACK)
+	UnregisterSignal(unequipper, list(COMSIG_MOB_MOUSEUP, COMSIG_MOB_MOUSEDRAG, COMSIG_MOB_MOUSEDOWN))
+	living_user = null
+
+/obj/item/stack/throwing_knife/proc/change_target(datum/source, atom/src_object, atom/over_object, turf/src_location, turf/over_location, src_control, over_control, params)
+	SIGNAL_HANDLER
+	set_target(get_turf_on_clickcatcher(over_object, source, params))
+	living_user.face_atom(current_target)
+
+/obj/item/stack/throwing_knife/proc/stop_fire()
+	SIGNAL_HANDLER
+	living_user?.client?.mouse_pointer_icon = initial(living_user.client.mouse_pointer_icon)
+	SEND_SIGNAL(src, COMSIG_GUN_STOP_FIRE)
+
+/obj/item/stack/throwing_knife/proc/start_fire(datum/source, atom/object, turf/location, control, params)
+	SIGNAL_HANDLER
+	if(living_user.hand && !istype(living_user.l_hand, /obj/item/stack/throwing_knife/) || !living_user.hand && !istype(living_user.r_hand, /obj/item/stack/throwing_knife/)) // If the object in our active hand is not a throwing knife, abort
+		return
+	var/list/modifiers = params2list(params)
+	if(modifiers["shift"] || modifiers["ctrl"])
+		return
+	set_target(get_turf_on_clickcatcher(object, living_user, params))
+	if(!current_target)
+		return
+	SEND_SIGNAL(src, COMSIG_GUN_FIRE)
+	living_user?.client?.mouse_pointer_icon = 'icons/effects/supplypod_target.dmi'
 
 ///Throws a knife from the stack, or, if the stack is one, throws the stack.
-/obj/item/stack/throwing_knife/proc/throw_knife(datum/source, atom/target, params)
+/obj/item/stack/throwing_knife/proc/throw_knife()
 	SIGNAL_HANDLER
-	var/mob/living/user = source
-	if(user.Adjacent(target) || user.get_active_held_item() != src || !COOLDOWN_CHECK(src, last_thrown))
+	if(living_user.get_active_held_item() != src)
 		return
+	if(living_user.Adjacent(current_target))
+		return AUTOFIRE_CONTINUE
 	var/thrown_thing = src
 	if(amount == 1)
-		user.temporarilyRemoveItemFromInventory(src)
+		living_user.temporarilyRemoveItemFromInventory(src)
 		forceMove(get_turf(src))
-		throw_at(target, throw_range, throw_speed, user, TRUE)
+		throw_at(current_target, throw_range, throw_speed, living_user, TRUE)
+		current_target = null
 	else
 		var/obj/item/stack/throwing_knife/knife_to_throw = new(get_turf(src))
 		knife_to_throw.amount = 1
 		knife_to_throw.update_icon()
-		knife_to_throw.throw_at(target, throw_range, throw_speed, user, TRUE)
+		knife_to_throw.throw_at(current_target, throw_range, throw_speed, living_user, TRUE)
 		amount--
 		thrown_thing = knife_to_throw
 	playsound(src, 'sound/effects/throw.ogg', 30, 1)
-	visible_message(span_warning("[user] expertly throws [thrown_thing]."), null, null, 5)
+	visible_message(span_warning("[living_user] expertly throws [thrown_thing]."), null, null, 5)
 	update_icon()
-	COOLDOWN_START(src, last_thrown, throw_delay)
+	return AUTOFIRE_CONTINUE
 
 ///Fills any stacks currently in the tile that this object is thrown to.
 /obj/item/stack/throwing_knife/proc/post_throw()
@@ -391,6 +423,25 @@
 			continue
 		break
 
+/*'icons/effects/supplypod_target.dmi'*/
+///Resets the autofire component.
+/obj/item/stack/throwing_knife/proc/reset_fire()
+	set_target(null)
+	living_user?.client?.mouse_pointer_icon = initial(living_user.client.mouse_pointer_icon)
+
+///Sets the current target and registers for qdel to prevent hardels
+/obj/item/stack/throwing_knife/proc/set_target(atom/object)
+	if(object == current_target || object == living_user)
+		return
+	if(current_target)
+		UnregisterSignal(current_target, COMSIG_PARENT_QDELETING)
+	current_target = object
+	if(current_target)
+		RegisterSignal(current_target, COMSIG_PARENT_QDELETING, .proc/clean_target)
+
+/obj/item/stack/throwing_knife/proc/clean_target()
+	SIGNAL_HANDLER
+	current_target = get_turf(living_user)
 
 /obj/item/weapon/chainsword
 	name = "chainsword"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->


## About The Pull Request
Adds the autofire component to throwing knives so that they are "fired" at a consistent rate instead of requiring an autoclicker to get the full benefit of them.

Also, the throwing knives pouch description wasnt updated when it was buffed from 4 slots -> 6 slots.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This makes knives much more usable, and makes it easy to balance by changing a single value (throw_delay).
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: You can hold click to throw knives at a constant rate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
