### PR TITLE
 removed PCs ability to cut most terrain

### DIFF
--- a/code/game/objects/items/power_cells.dm
+++ b/code/game/objects/items/power_cells.dm
@@ -111,7 +111,7 @@
 /obj/item/cell/rtg/plasma_cutter
 	name = "plasma cutter cell"
 	desc = "You shouldn't be seeing this"
-	maxcharge = 7500
+	maxcharge = 15000
 	self_recharge = TRUE
 	charge_amount = 25
 	charge_delay = 2 SECONDS //One hit on a resin thingy every 8 seconds, or one actual wall every 80 seconds.

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -44,6 +44,7 @@
 	walltype = "lvwall"
 	smoothing_behavior = DIAGONAL_SMOOTHING
 	smoothing_groups = SMOOTH_MINERAL_STRUCTURES
+	resistance_flags = PLASMACUTTER_IMMUNE
 
 /turf/closed/mineral/smooth/outdoor
 	open_turf_type = /turf/open/floor/plating/ground/mars/random/dirt


### PR DESCRIPTION

## About The Pull Request
Removes Plasmacutter's ability to qelete terrain.

Doubles PC charge so it can focus on dealing with resin walls.
Interaction with metal and rwalls untouched.
## Why It's Good For The Game
Fixes the real issues with plasmacutters and helps them focus on dealing with Xeno structures instead of terrain in general.
## Changelog
:cl:
balance: removed PCs ability to cut most terrain
balance: doubled base PC charge
/:cl:
