### PR TITLE
HvH E-shields

### DIFF
--- a/code/datums/quick_load_outfits.dm
+++ b/code/datums/quick_load_outfits.dm
@@ -103,7 +103,7 @@
 	ears = /obj/item/radio/headset/mainship/marine
 	w_uniform = /obj/item/clothing/under/marine/black_vest
 	shoes = /obj/item/clothing/shoes/marine/full
-	wear_suit = /obj/item/clothing/suit/modular/xenonauten/heavy
+	wear_suit = /obj/item/clothing/suit/modular/xenonauten/heavy/shield
 	gloves = /obj/item/clothing/gloves/marine
 	mask = /obj/item/clothing/mask/gas
 	head = /obj/item/clothing/head/modular/marine/m10x
@@ -287,7 +287,7 @@
 	desc = "For when you need the biggest gun you can carry. Equipped with an MG-27 machinegun and miniscope and a MR-25 SMG as a side arm, as well as medium armor and a small amount of construction supplies. Allows for devestating, albeit static firepower."
 
 	belt = /obj/item/storage/holster/m25
-	wear_suit = /obj/item/clothing/suit/modular/xenonauten
+	wear_suit = /obj/item/clothing/suit/modular/xenonauten/shield
 	suit_store = /obj/item/weapon/gun/standard_mmg/machinegunner
 	l_store = /obj/item/storage/pouch/construction
 
@@ -1034,7 +1034,7 @@
 	ears = /obj/item/radio/headset/mainship/som
 	w_uniform = /obj/item/clothing/under/som/webbing
 	shoes = /obj/item/clothing/shoes/marine/som/knife
-	wear_suit = /obj/item/clothing/suit/modular/som
+	wear_suit = /obj/item/clothing/suit/modular/som/shield
 	gloves = /obj/item/clothing/gloves/marine/som
 	mask = /obj/item/clothing/mask/gas
 	head = /obj/item/clothing/head/modular/som
@@ -1173,7 +1173,7 @@
 	desc = "Heavy armored breaching configuration. Equipped with a V-21 submachine gun with variable firerate allowing for extreme rates of fire when properly wielded, heavy armor, a boarding shield and a good selection of grenades. Offers outstanding protection although damage may be lacking, particular at longer range."
 
 	glasses = /obj/item/clothing/glasses/welding
-	wear_suit = /obj/item/clothing/suit/modular/som/heavy
+	wear_suit = /obj/item/clothing/suit/modular/som/heavy/shield
 	suit_store = /obj/item/weapon/gun/smg/som/one_handed
 	belt = /obj/item/storage/belt/marine/som/som_smg
 	r_hand = /obj/item/weapon/shield/riot/marine/som
@@ -1549,7 +1549,7 @@
 	ears = /obj/item/radio/headset/mainship/som
 	w_uniform = /obj/item/clothing/under/som/veteran/webbing
 	shoes = /obj/item/clothing/shoes/marine/som/knife
-	wear_suit = /obj/item/clothing/suit/modular/som/heavy
+	wear_suit = /obj/item/clothing/suit/modular/som/heavy/shield
 	gloves = /obj/item/clothing/gloves/marine/som/veteran
 	mask = /obj/item/clothing/mask/gas
 	head = /obj/item/clothing/head/modular/som/veteran

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -283,7 +283,7 @@
 	icon_state = "mod_eshield"
 	item_state = "mod_eshield_a"
 	slot = ATTACHMENT_SLOT_MODULE
-	soft_armor = list(MELEE = -10, BULLET = -5, LASER = 0, ENERGY = 0, BOMB = 0, BIO = -5, FIRE = 0, ACID = -5)
+	soft_armor = list(MELEE = -10, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = -5, FIRE = 0, ACID = -5)
 	variants_by_parent_type = list(/obj/item/clothing/suit/modular/xenonauten = "mod_eshield_xn", /obj/item/clothing/suit/modular/xenonauten/light = "mod_eshield_xn", /obj/item/clothing/suit/modular/xenonauten/heavy = "mod_eshield_xn")
 
 	///Current shield Health

--- a/code/modules/clothing/modular_armor/modular.dm
+++ b/code/modules/clothing/modular_armor/modular.dm
@@ -271,6 +271,9 @@
 /obj/item/clothing/suit/modular/xenonauten/mimir
 	starting_attachments = list(/obj/item/armor_module/module/mimir_environment_protection/mark1)
 
+/obj/item/clothing/suit/modular/xenonauten/shield
+	starting_attachments = list(/obj/item/armor_module/module/eshield)
+
 /obj/item/clothing/suit/modular/xenonauten/rownin
 	name = "\improper Rownin Skeleton"
 	desc = "A light armor, if you can even called it that, for dedicated marines that want to travel light and have agility in exchange of protection. Alt-Click to remove attached items. Use it to toggle the built-in flashlight."
@@ -343,6 +346,9 @@
 
 /obj/item/clothing/suit/modular/xenonauten/heavy/surt
 	starting_attachments = list(/obj/item/armor_module/module/fire_proof, /obj/item/armor_module/storage/general)
+
+/obj/item/clothing/suit/modular/xenonauten/heavy/shield
+	starting_attachments = list(/obj/item/armor_module/module/eshield)
 
 /** Core helmet module */
 /obj/item/clothing/head/modular
@@ -830,6 +836,9 @@
 /obj/item/clothing/suit/modular/som/engineer
 	starting_attachments = list(/obj/item/armor_module/storage/engineering)
 
+/obj/item/clothing/suit/modular/som/shield
+	starting_attachments = list(/obj/item/armor_module/module/eshield/som)
+
 /obj/item/clothing/suit/modular/som/light
 	name = "\improper SOM scout armor"
 	desc = "The M-11 scout armor is a lightweight suit that that allows for minimal encumberance while still providing reasonable protection. Often seen on scouts or other specialist units that aren't normally getting shot at. Alt-Click to remove attached items. Use it to toggle the built-in flashlight."
@@ -861,6 +870,9 @@
 
 /obj/item/clothing/suit/modular/som/heavy/mithridatius
 	starting_attachments = list(/obj/item/armor_module/module/mimir_environment_protection/som)
+
+/obj/item/clothing/suit/modular/som/heavy/shield
+	starting_attachments = list(/obj/item/armor_module/module/eshield/som)
 
 /obj/item/clothing/suit/modular/som/heavy/leader
 	name = "\improper SOM Gorgon pattern assault armor"


### PR DESCRIPTION

## About The Pull Request
Bit of an experiment to see how it changes the game.

Adds eshields to all default loadouts (i.e. loadouts that don't already have another module), excluding engies and medics.

This should add a level of survivability, and especially help against plinking hits/surprise attacks.

Also removes the weird -5 bullet armour. There was no negative for any other human specific armour types so it never really worked, and 'you get FF'd worse' is a pretty meme idea anyway.
## Why It's Good For The Game
More survivability in HvH
## Changelog
:cl:
balance: eshields no longer have -5 bullet armour
balance: HvH: eshields added as default modules for roles other than engie and medic, where another module is not present

/:cl:
