### PR TITLE
Sentinel nade tweak

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -231,7 +231,7 @@
 	greyscale_colors = "#42A500"
 	greyscale_config = /datum/greyscale_config/xenogrenade
 	det_time = 15
-	smoke_duration = 3
+	smoke_duration = 4
 	dangerous = TRUE
 	smoketype = /datum/effect_system/smoke_spread/xeno/toxic
 	arm_sound = 'sound/voice/alien_yell_alt.ogg'

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -231,11 +231,11 @@
 	greyscale_colors = "#42A500"
 	greyscale_config = /datum/greyscale_config/xenogrenade
 	det_time = 15
-	smoke_duration = 5
+	smoke_duration = 3
 	dangerous = TRUE
 	smoketype = /datum/effect_system/smoke_spread/xeno/toxic
 	arm_sound = 'sound/voice/alien_yell_alt.ogg'
-	smokeradius = 4
+	smokeradius = 3
 
 /obj/item/explosive/grenade/smokebomb/xeno/update_overlays()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Reduces radius from 4 to 3, and duration from 5 to 4.

Currently the radius is the same as an ancient boiler, but bypasses barricades because it's thrown.
This makes it rather good at providing a smokescreen for xenos that apply guaranteed staggerslow to anyone that goes into it, while it's very safe to use due to it's radius and instant cast.
## Why It's Good For The Game
Slightly less oppressive stagger smoke.
## Changelog
:cl:
balance: Reduced sentinel grenade radius and duration by 1 tile and 1 second respectively
/:cl:
