### PR TITLE
Tricord/Dylo pill packet capacity 6 -> 8

### DIFF
--- a/code/game/objects/items/storage/pill_packets.dm
+++ b/code/game/objects/items/storage/pill_packets.dm
@@ -38,16 +38,16 @@
 	name = "Tricordazine pill packet"
 	desc = "This packet contains tricordazine pills. Heals all types of damage slightly. Once you take them out they don't go back in. No more than 2 pills at once."
 	pill_type_to_fill = /obj/item/reagent_containers/pill/tricordrazine
-	storage_slots = 6
-	max_storage_space = 6
+	storage_slots = 8
+	max_storage_space = 8
 
 /obj/item/storage/pill_bottle/packet/dylovene
 	name = "Dylovene pill packet"
 	icon_state = "tric_packet"
 	desc = "This packet contains dylovene pills. Used to purge toxins and heal toxic damage. Once you take them out they don't go back in. No more than 2 pills at once."
 	pill_type_to_fill = /obj/item/reagent_containers/pill/dylovene
-	storage_slots = 6
-	max_storage_space = 6
+	storage_slots = 8
+	max_storage_space = 8
 
 /obj/item/storage/pill_bottle/packet/paracetamol
 	name = "Paracematol pill packet"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the capacity of the tricordazine and dylovene pill packets from 6 to 8.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Standardizes these two meds to the 8 capacity all of the other pill packets have. Tricord and Dylo are not game-breaking chems and shouldn't have reason to have less capacity then the other meds.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Tricordazine and Dylovene pill packet capacity changed from 6->8
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
