### PR TITLE
Medscanner skill threshold lowered to novice. Allows SL to use medscanner without fumble.

### DIFF
--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -68,9 +68,9 @@ REAGENT SCANNER
 	throw_speed = 5
 	throw_range = 10
 	///Skill required to bypass the fumble time.
-	var/skill_threshold = SKILL_MEDICAL_PRACTICED
+	var/skill_threshold = SKILL_MEDICAL_NOVICE
 	///Skill required to have the scanner auto refresh
-	var/upper_skill_threshold = SKILL_MEDICAL_PRACTICED
+	var/upper_skill_threshold = SKILL_MEDICAL_NOVICE
 	///Current mob being tracked by the scanner
 	var/mob/living/carbon/patient
 	///Current user of the scanner


### PR DESCRIPTION

## About The Pull Request
Per title, lowered from PRACTICED to NOVICE.
## Why It's Good For The Game
Primarily aimed at making SL's able to use medscanner without fumble. SL is given med skill to use defibs, but surprisingly isn't able to use scanner in lieu of this. SL is a supportive role that can dabble in the basic aspects of the other jobs in order to fill needed roles. I'd argue that being able to use medscanner is a basic skill that SL should have to assist in healing, especially given they are vended a free medhud and have medical access for meds.

As to the other jobs affected, I am pretty sure they are all not in the game so it shouldn't affect anyone except SL. However the datums are hard to read since the skill ratings are numerical, so let me know if anything else is affected.
## Changelog
:cl:
balance: SL able to use medscanner without fumbling
/:cl:
