### PR TITLE
Repair refactor/QOL

### DIFF
--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -249,3 +249,6 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list( //Those networks can only be 
 #define MOTION_DETECTOR_HOSTILE "hostile"
 #define MOTION_DETECTOR_FRIENDLY "friendly"
 #define MOTION_DETECTOR_DEAD "dead"
+
+//Repair define
+#define BELOW_INTEGRITY_THRESHOLD "below integrity threshold"

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -160,11 +160,11 @@
 // If welding tool ran out of fuel during a construction task, construction fails.
 /obj/item/tool/weldingtool/tool_use_check(mob/living/user, amount)
 	if(!isOn() || !check_fuel())
-		to_chat(user, span_warning("[src] has to be on to complete this task!"))
+		balloon_alert(user, "[src] not on")
 		return FALSE
 
 	if(get_fuel() < amount)
-		to_chat(user, span_warning("You need more welding fuel to complete this task!"))
+		balloon_alert(user, "low fuel")
 		return FALSE
 
 	return TRUE

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -55,7 +55,7 @@
 
 	if(istype(I, /obj/item/stack/sheet/metal))
 		var/obj/item/stack/sheet/metal/metal_sheets = I
-		if(obj_integrity > (max_integrity - integrity_failure) * 0.2)
+		if(obj_integrity > integrity_failure)
 			return
 
 		if(metal_sheets.get_amount() < 1)
@@ -75,53 +75,10 @@
 
 
 /obj/item/weapon/shield/riot/welder_act(mob/living/user, obj/item/I)
-	if(user.do_actions)
-		return FALSE
-
-	var/obj/item/tool/weldingtool/WT = I
-
-	if(!WT.isOn())
-		return FALSE
-
-	if(current_acid)
-		balloon_alert(user, "It's melting")
-		return TRUE
-
-	if(obj_integrity <= (max_integrity - integrity_failure) * 0.2)
+	. = welder_repair_act(user, I, max_integrity * 0.15, 4 SECONDS, integrity_failure)
+	if(. == BELOW_INTEGRITY_THRESHOLD)
 		balloon_alert(user, "Too damaged. Use metal sheets.")
-		return TRUE
 
-	if(obj_integrity == max_integrity)
-		balloon_alert(user, "already repaired")
-		return TRUE
-
-	balloon_alert_to_viewers("starting repair...")
-
-	if(user.skills.getRating("engineer") < SKILL_ENGINEER_METAL)
-		user.visible_message(span_notice("[user] fumbles around figuring out how to repair [src]."),
-		span_notice("You fumble around figuring out how to repair [src]."))
-		var/fumbling_time = 4 SECONDS * ( SKILL_ENGINEER_METAL - user.skills.getRating("engineer") )
-		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_BUILD))
-			return TRUE
-
-	while(obj_integrity < max_integrity)
-		playsound(loc, 'sound/items/welder2.ogg', 25, TRUE)
-		if(!do_after(user, 4 SECONDS, TRUE, src, BUSY_ICON_FRIENDLY))
-			return TRUE
-
-		if(obj_integrity <= (max_integrity - integrity_failure) * 0.2 || obj_integrity == max_integrity)
-			return TRUE
-
-		if(!WT.remove_fuel(2, user))
-			balloon_alert(user, "not enough fuel")
-			return TRUE
-
-		repair_damage((max_integrity-integrity_failure) * 0.2)
-		update_icon()
-		playsound(loc, 'sound/items/welder2.ogg', 25, TRUE)
-
-	balloon_alert_to_viewers("repaired")
-	return TRUE
 
 /obj/item/weapon/shield/riot/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/weapon) && world.time >= cooldown)

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -75,7 +75,7 @@
 
 
 /obj/item/weapon/shield/riot/welder_act(mob/living/user, obj/item/I)
-	. = welder_repair_act(user, I, max_integrity * 0.15, 4 SECONDS, integrity_failure / max_integrity)
+	. = welder_repair_act(user, I, max_integrity * 0.15, 4 SECONDS, integrity_failure / max_integrity, SKILL_ENGINEER_METAL)
 	if(. == BELOW_INTEGRITY_THRESHOLD)
 		balloon_alert(user, "Too damaged. Use metal sheets.")
 

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -75,7 +75,7 @@
 
 
 /obj/item/weapon/shield/riot/welder_act(mob/living/user, obj/item/I)
-	. = welder_repair_act(user, I, max_integrity * 0.15, 4 SECONDS, integrity_failure)
+	. = welder_repair_act(user, I, max_integrity * 0.15, 4 SECONDS, integrity_failure / max_integrity)
 	if(. == BELOW_INTEGRITY_THRESHOLD)
 		balloon_alert(user, "Too damaged. Use metal sheets.")
 

--- a/code/game/objects/machinery/deployable.dm
+++ b/code/game/objects/machinery/deployable.dm
@@ -45,55 +45,7 @@
 
 ///Repairs machine
 /obj/machinery/deployable/welder_act(mob/living/user, obj/item/I)
-	if(user.do_actions)
-		return FALSE
-
-	var/obj/item/tool/weldingtool/WT = I
-
-	if(!WT.isOn())
-		return FALSE
-
-	for(var/obj/effect/xenomorph/acid/A in loc)
-		if(A.acid_t == src)
-			to_chat(user, "You can't get near that, it's melting!")
-			return TRUE
-
-	if(obj_integrity == max_integrity)
-		to_chat(user, span_warning("[src] doesn't need repairs."))
-		return TRUE
-
-	if(!WT.remove_fuel(2, user))
-		to_chat(user, span_warning("Not enough fuel to finish the task."))
-		return TRUE
-
-	var/weld_time = 5 SECONDS
-
-	if(user.skills.getRating("engineer") < SKILL_ENGINEER_METAL)
-		user.visible_message(span_notice("[user] fumbles around figuring out how to repair [src]."),
-		span_notice("You fumble around figuring out how to repair [src]."))
-		weld_time  *= ( SKILL_ENGINEER_METAL - user.skills.getRating("engineer") )
-
-	user.visible_message(span_notice("[user] begins repairing damage to [src]."),
-	span_notice("You begin repairing the damage to [src]."))
-	add_overlay(GLOB.welding_sparks)
-	playsound(loc, 'sound/items/welder2.ogg', 25, TRUE)
-
-	if(!do_after(user, weld_time, TRUE, src, BUSY_ICON_FRIENDLY))
-		cut_overlay(GLOB.welding_sparks)
-		return TRUE
-
-	if(!WT.remove_fuel(2, user))
-		to_chat(user, span_warning("Not enough fuel to finish the task."))
-		cut_overlay(GLOB.welding_sparks)
-		return TRUE
-
-	user.visible_message(span_notice("[user] repairs some damage on [src]."),
-	span_notice("You repair [src]."))
-	cut_overlay(GLOB.welding_sparks)
-	playsound(loc, 'sound/items/welder2.ogg', 25, TRUE)
-	repair_damage(120)
-	update_icon()
-	return TRUE
+	return welder_repair_act(user, I, 120, 5 SECONDS)
 
 ///Dissassembles the device
 /obj/machinery/deployable/proc/disassemble(mob/user)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -188,8 +188,12 @@
 	return
 
 ///Handles welder based repair of objects, normally called by welder_act
-/obj/proc/welder_repair_act(mob/living/user, obj/item/I, repair_amount = 150, repair_time = 5 SECONDS, repair_threshold = 0.3, skill_required = SKILL_ENGINEER_METAL, fuel_req = 2, fumble_time)
-	if(LAZYACCESS(user.do_actions, src))
+/obj/proc/welder_repair_act(mob/living/user, obj/item/I, repair_amount = 150, repair_time = 5 SECONDS, repair_threshold = 0, skill_required = SKILL_ENGINEER_METAL, fuel_req = 2, fumble_time)
+	if(user.do_actions)
+		balloon_alert(user, "busy")
+		return FALSE
+
+	if(user.a_intent == INTENT_HARM)
 		return FALSE
 
 	var/obj/item/tool/weldingtool/welder = I
@@ -223,6 +227,7 @@
 		welder.eyecheck(user)
 		if(!do_after(user, repair_time, TRUE, src, BUSY_ICON_FRIENDLY))
 			cut_overlay(GLOB.welding_sparks)
+			balloon_alert(user, "interrupted!")
 			return TRUE
 
 		if(obj_integrity <= max_integrity * repair_threshold || obj_integrity >= max_integrity)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -188,7 +188,7 @@
 	return
 
 ///Handles welder based repair of objects, normally called by welder_act
-/obj/proc/welder_repair_act(mob/living/user, obj/item/I, repair_amount = 150, repair_time = 5 SECONDS, repair_threshold = 0, skill_required = SKILL_ENGINEER_METAL, fuel_req = 2, fumble_time)
+/obj/proc/welder_repair_act(mob/living/user, obj/item/I, repair_amount = 150, repair_time = 5 SECONDS, repair_threshold = 0, skill_required = SKILL_ENGINEER_DEFAULT, fuel_req = 2, fumble_time)
 	if(user.do_actions)
 		balloon_alert(user, "busy")
 		return FALSE

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -209,14 +209,13 @@
 		balloon_alert(user, "already repaired")
 		return TRUE
 
-	balloon_alert_to_viewers("starting repair...")
-
 	if(user.skills.getRating("engineer") < skill_required)
 		user.visible_message(span_notice("[user] fumbles around figuring out how to repair [src]."),
 		span_notice("You fumble around figuring out how to repair [src]."))
 		if(!do_after(user, repair_time * (skill_required - user.skills.getRating("engineer")), TRUE, src, BUSY_ICON_BUILD))
 			return TRUE
 
+	balloon_alert_to_viewers("starting repair...")
 	add_overlay(GLOB.welding_sparks)
 	while(obj_integrity < max_integrity)
 		playsound(loc, 'sound/items/welder2.ogg', 25, TRUE)
@@ -237,5 +236,6 @@
 		update_icon()
 
 	balloon_alert_to_viewers("repaired")
+	playsound(loc, 'sound/items/welder2.ogg', 25, TRUE)
 	cut_overlay(GLOB.welding_sparks)
 	return TRUE

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -551,7 +551,7 @@
 	. += span_info("It is [barricade_upgrade_type ? "upgraded with [barricade_upgrade_type]" : "not upgraded"].")
 
 /obj/structure/barricade/metal/welder_act(mob/living/user, obj/item/I)
-	. = welder_repair_act(user, I)
+	. = welder_repair_act(user, I, repair_threshold = 0.3)
 	if(. == BELOW_INTEGRITY_THRESHOLD)
 		balloon_alert(user, "Too damaged. Use metal sheets.")
 
@@ -773,7 +773,7 @@
 			. += span_info("The protection panel has been removed and the anchor bolts loosened. It's ready to be taken apart.")
 
 /obj/structure/barricade/plasteel/welder_act(mob/living/user, obj/item/I)
-	. = welder_repair_act(user, I, skill_required = SKILL_ENGINEER_PLASTEEL)
+	. = welder_repair_act(user, I, repair_threshold = 0.3, skill_required = SKILL_ENGINEER_PLASTEEL)
 	if(. == BELOW_INTEGRITY_THRESHOLD)
 		balloon_alert(user, "Too damaged. Use plasteel sheets.")
 

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -573,32 +573,34 @@
 		return TRUE
 
 	balloon_alert_to_viewers("starting repair...")
+
 	if(user.skills.getRating("engineer") < SKILL_ENGINEER_METAL)
-		var/fumbling_time = 5 SECONDS * ( SKILL_ENGINEER_METAL - user.skills.getRating("engineer") )
-		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_BUILD))
+		user.visible_message(span_notice("[user] fumbles around figuring out how to repair [src]."),
+		span_notice("You fumble around figuring out how to repair [src]."))
+		if(!do_after(user, 5 SECONDS * (SKILL_ENGINEER_METAL - user.skills.getRating("engineer")), TRUE, src, BUSY_ICON_BUILD))
 			return TRUE
 
 	add_overlay(GLOB.welding_sparks)
-	playsound(loc, 'sound/items/welder2.ogg', 25, TRUE)
+	while(obj_integrity < max_integrity)
+		playsound(loc, 'sound/items/welder2.ogg', 25, TRUE)
+		if(!do_after(user, 5 SECONDS, TRUE, src, BUSY_ICON_FRIENDLY))
+			cut_overlay(GLOB.welding_sparks)
+			return TRUE
 
-	if(!do_after(user, 5 SECONDS, TRUE, src, BUSY_ICON_FRIENDLY))
-		cut_overlay(GLOB.welding_sparks)
-		return TRUE
+		if(obj_integrity <= max_integrity * 0.3 || obj_integrity == max_integrity)
+			cut_overlay(GLOB.welding_sparks)
+			return TRUE
 
-	if(obj_integrity <= max_integrity * 0.3 || obj_integrity == max_integrity)
-		cut_overlay(GLOB.welding_sparks)
-		return TRUE
+		if(!WT.remove_fuel(2, user))
+			balloon_alert(user, "not enough fuel")
+			cut_overlay(GLOB.welding_sparks)
+			return TRUE
 
-	if(!WT.remove_fuel(2, user))
-		balloon_alert(user, "not enough fuel")
-		cut_overlay(GLOB.welding_sparks)
-		return TRUE
+		repair_damage(150)
+		update_icon()
 
 	balloon_alert_to_viewers("repaired")
 	cut_overlay(GLOB.welding_sparks)
-	repair_damage(150)
-	update_icon()
-	playsound(loc, 'sound/items/welder2.ogg', 25, TRUE)
 	return TRUE
 
 

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -551,57 +551,9 @@
 	. += span_info("It is [barricade_upgrade_type ? "upgraded with [barricade_upgrade_type]" : "not upgraded"].")
 
 /obj/structure/barricade/metal/welder_act(mob/living/user, obj/item/I)
-	if(LAZYACCESS(user.do_actions, src))
-		return FALSE
-
-	var/obj/item/tool/weldingtool/WT = I
-
-	if(!WT.isOn())
-		return FALSE
-
-	for(var/obj/effect/xenomorph/acid/A in loc)
-		if(A.acid_t == src)
-			balloon_alert(user, "It's melting")
-			return TRUE
-
-	if(obj_integrity <= max_integrity * 0.3)
+	. = welder_repair_act(user, I)
+	if(. == BELOW_INTEGRITY_THRESHOLD)
 		balloon_alert(user, "Too damaged. Use metal sheets.")
-		return TRUE
-
-	if(obj_integrity == max_integrity)
-		balloon_alert(user, "already repaired")
-		return TRUE
-
-	balloon_alert_to_viewers("starting repair...")
-
-	if(user.skills.getRating("engineer") < SKILL_ENGINEER_METAL)
-		user.visible_message(span_notice("[user] fumbles around figuring out how to repair [src]."),
-		span_notice("You fumble around figuring out how to repair [src]."))
-		if(!do_after(user, 5 SECONDS * (SKILL_ENGINEER_METAL - user.skills.getRating("engineer")), TRUE, src, BUSY_ICON_BUILD))
-			return TRUE
-
-	add_overlay(GLOB.welding_sparks)
-	while(obj_integrity < max_integrity)
-		playsound(loc, 'sound/items/welder2.ogg', 25, TRUE)
-		if(!do_after(user, 5 SECONDS, TRUE, src, BUSY_ICON_FRIENDLY))
-			cut_overlay(GLOB.welding_sparks)
-			return TRUE
-
-		if(obj_integrity <= max_integrity * 0.3 || obj_integrity == max_integrity)
-			cut_overlay(GLOB.welding_sparks)
-			return TRUE
-
-		if(!WT.remove_fuel(2, user))
-			balloon_alert(user, "not enough fuel")
-			cut_overlay(GLOB.welding_sparks)
-			return TRUE
-
-		repair_damage(150)
-		update_icon()
-
-	balloon_alert_to_viewers("repaired")
-	cut_overlay(GLOB.welding_sparks)
-	return TRUE
 
 
 /obj/structure/barricade/metal/screwdriver_act(mob/living/user, obj/item/I)
@@ -820,7 +772,141 @@
 		if(BARRICADE_PLASTEEL_LOOSE)
 			. += span_info("The protection panel has been removed and the anchor bolts loosened. It's ready to be taken apart.")
 
-/// todo use welder_act and friends instead
+/obj/structure/barricade/plasteel/welder_act(mob/living/user, obj/item/I)
+	. = welder_repair_act(user, I, skill_required = SKILL_ENGINEER_PLASTEEL)
+	if(. == BELOW_INTEGRITY_THRESHOLD)
+		balloon_alert(user, "Too damaged. Use plasteel sheets.")
+
+/obj/structure/barricade/plasteel/screwdriver_act(mob/living/user, obj/item/I)
+	if(!isscrewdriver(I))
+		return
+
+	if(busy || !COOLDOWN_CHECK(src, tool_cooldown))
+		return
+
+	if(LAZYACCESS(user.do_actions, src))
+		return
+
+	COOLDOWN_START(src, tool_cooldown, 1 SECONDS)
+
+	switch(build_state)
+		if(BARRICADE_PLASTEEL_FIRM) //Fully constructed step. Use screwdriver to remove the protection panels to reveal the bolts
+			if(user.skills.getRating("engineer") < SKILL_ENGINEER_PLASTEEL)
+				var/fumbling_time = 1 SECONDS * ( SKILL_ENGINEER_PLASTEEL - user.skills.getRating("engineer") )
+				if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
+					return
+
+			for(var/obj/structure/barricade/B in loc)
+				if(B != src && B.dir == dir)
+					balloon_alert(user, "already a barricade here")
+					return
+
+			if(!do_after(user, 1, TRUE, src, BUSY_ICON_BUILD))
+				return
+
+			balloon_alert_to_viewers("bolt protection panel removed")
+			playsound(loc, 'sound/items/screwdriver.ogg', 25, 1)
+			build_state = BARRICADE_PLASTEEL_ANCHORED
+		if(BARRICADE_PLASTEEL_ANCHORED) //Protection panel removed step. Screwdriver to put the panel back, wrench to unsecure the anchor bolts
+			if(user.skills.getRating("engineer") < SKILL_ENGINEER_PLASTEEL)
+				var/fumbling_time = 1 SECONDS * ( SKILL_ENGINEER_PLASTEEL - user.skills.getRating("engineer") )
+				if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
+					return
+			balloon_alert_to_viewers("bolt protection panel replaced")
+			playsound(loc, 'sound/items/screwdriver.ogg', 25, 1)
+			build_state = BARRICADE_PLASTEEL_FIRM
+
+/obj/structure/barricade/plasteel/crowbar_act(mob/living/user, obj/item/I)
+	if(!iscrowbar(I))
+		return
+
+	if(busy || !COOLDOWN_CHECK(src, tool_cooldown))
+		return
+
+	if(LAZYACCESS(user.do_actions, src))
+		return
+
+	COOLDOWN_START(src, tool_cooldown, 1 SECONDS)
+
+	switch(build_state)
+		if(BARRICADE_PLASTEEL_FIRM)
+			balloon_alert_to_viewers("[linked ? "un" : "" ]linked")
+			linked = !linked
+			for(var/direction in GLOB.cardinals)
+				for(var/obj/structure/barricade/plasteel/cade in get_step(src, direction))
+					cade.update_icon()
+			update_icon()
+		if(BARRICADE_PLASTEEL_LOOSE) //Anchor bolts loosened step. Apply crowbar to unseat the panel and take apart the whole thing.
+			if(user.skills.getRating("engineer") < SKILL_ENGINEER_PLASTEEL)
+				var/fumbling_time = 5 SECONDS * ( SKILL_ENGINEER_PLASTEEL - user.skills.getRating("engineer") )
+				if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
+					return
+			balloon_alert_to_viewers("disassembling")
+			playsound(loc, 'sound/items/crowbar.ogg', 25, 1)
+			busy = TRUE
+
+			if(!do_after(user, 50, TRUE, src, BUSY_ICON_BUILD))
+				busy = FALSE
+				return
+
+			busy = FALSE
+			user.visible_message(span_notice("[user] takes [src]'s panels apart."),
+			span_notice("You take [src]'s panels apart."))
+			playsound(loc, 'sound/items/deconstruct.ogg', 25, 1)
+			var/deconstructed = TRUE
+			for(var/obj/effect/xenomorph/acid/A in loc)
+				if(A.acid_t != src)
+					continue
+				deconstructed = FALSE
+				break
+			deconstruct(deconstructed)
+
+/obj/structure/barricade/plasteel/wrench_act(mob/living/user, obj/item/I)
+	if(!iswrench(I))
+		return
+
+	if(busy || !COOLDOWN_CHECK(src, tool_cooldown))
+		return
+
+	if(LAZYACCESS(user.do_actions, src))
+		return
+
+	COOLDOWN_START(src, tool_cooldown, 1 SECONDS)
+
+	switch(build_state)
+		if(BARRICADE_PLASTEEL_ANCHORED) //Protection panel removed step. Screwdriver to put the panel back, wrench to unsecure the anchor bolts
+			if(user.skills.getRating("engineer") < SKILL_ENGINEER_PLASTEEL)
+				var/fumbling_time = 1 SECONDS * ( SKILL_ENGINEER_PLASTEEL - user.skills.getRating("engineer") )
+				if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
+					return
+			balloon_alert_to_viewers("anchor bolts loosened")
+			playsound(loc, 'sound/items/ratchet.ogg', 25, 1)
+			anchored = FALSE
+			modify_max_integrity(initial(max_integrity) * 0.5)
+			build_state = BARRICADE_PLASTEEL_LOOSE
+			update_icon() //unanchored changes layer
+		if(BARRICADE_PLASTEEL_LOOSE) //Anchor bolts loosened step. Apply crowbar to unseat the panel and take apart the whole thing. Apply wrench to rescure anchor bolts
+			var/turf/mystery_turf = get_turf(src)
+			if(!isopenturf(mystery_turf))
+				balloon_alert(user, "can't anchor here")
+				return
+
+			var/turf/open/T = mystery_turf
+			if(!T.allow_construction) //We shouldn't be able to anchor in areas we're not supposed to build; loophole closed.
+				balloon_alert(user, "can't anchor here")
+				return
+
+			if(user.skills.getRating("engineer") < SKILL_ENGINEER_PLASTEEL)
+				var/fumbling_time = 1 SECONDS * ( SKILL_ENGINEER_PLASTEEL - user.skills.getRating("engineer") )
+				if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
+					return
+			balloon_alert_to_viewers("secured bolts")
+			playsound(loc, 'sound/items/ratchet.ogg', 25, 1)
+			anchored = TRUE
+			modify_max_integrity(initial(max_integrity))
+			build_state = BARRICADE_PLASTEEL_ANCHORED
+			update_icon() //unanchored changes layer
+
 /obj/structure/barricade/plasteel/attackby(obj/item/I, mob/user, params)
 	. = ..()
 
@@ -843,150 +929,6 @@
 
 		repair_damage(max_integrity * 0.3)
 		balloon_alert_to_viewers("base repaired")
-		return
-
-	if(busy || !COOLDOWN_CHECK(src, tool_cooldown))
-		return
-
-	COOLDOWN_START(src, tool_cooldown, 1 SECONDS)
-
-	if(iswelder(I))
-		var/obj/item/tool/weldingtool/WT = I
-
-		if(user.skills.getRating("engineer") < SKILL_ENGINEER_PLASTEEL)
-			var/fumbling_time = 5 SECONDS * ( SKILL_ENGINEER_PLASTEEL - user.skills.getRating("engineer") )
-			if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED, extra_checks = CALLBACK(WT, /obj/item/tool/weldingtool/proc/isOn)))
-				return
-
-		if(obj_integrity <= max_integrity * 0.3)
-			balloon_alert(user, "Too damaged. Use plasteel sheets.")
-			return
-
-		if(obj_integrity == max_integrity)
-			balloon_alert(user, "already repaired")
-			return
-
-		balloon_alert_to_viewers("starting repair...")
-		add_overlay(GLOB.welding_sparks)
-		playsound(loc, 'sound/items/welder2.ogg', 25, 1)
-		busy = TRUE
-
-		if(!do_after(user, 5 SECONDS, TRUE, src, BUSY_ICON_FRIENDLY))
-			cut_overlay(GLOB.welding_sparks)
-			busy = FALSE
-			return
-		busy = FALSE
-
-		if(!WT.remove_fuel(2, user))
-			balloon_alert(user, "not enough fuel")
-			cut_overlay(GLOB.welding_sparks)
-			return TRUE
-
-		balloon_alert_to_viewers("repaired")
-		cut_overlay(GLOB.welding_sparks)
-		repair_damage(150)
-		update_icon()
-		playsound(loc, 'sound/items/welder2.ogg', 25, 1)
-
-	if(user.do_actions) // you can only build one cade at once but repair multiple at once
-		return
-
-	switch(build_state)
-		if(BARRICADE_PLASTEEL_FIRM) //Fully constructed step. Use screwdriver to remove the protection panels to reveal the bolts
-			if(isscrewdriver(I))
-				if(user.skills.getRating("engineer") < SKILL_ENGINEER_PLASTEEL)
-					var/fumbling_time = 1 SECONDS * ( SKILL_ENGINEER_PLASTEEL - user.skills.getRating("engineer") )
-					if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
-						return
-
-				for(var/obj/structure/barricade/B in loc)
-					if(B != src && B.dir == dir)
-						balloon_alert(user, "already a barricade here")
-						return
-
-				if(!do_after(user, 1, TRUE, src, BUSY_ICON_BUILD))
-					return
-
-				balloon_alert_to_viewers("bolt protection panel removed")
-				playsound(loc, 'sound/items/screwdriver.ogg', 25, 1)
-				build_state = BARRICADE_PLASTEEL_ANCHORED
-			else if(iscrowbar(I))
-				balloon_alert_to_viewers("[linked ? "un" : "" ]linked")
-				linked = !linked
-				for(var/direction in GLOB.cardinals)
-					for(var/obj/structure/barricade/plasteel/cade in get_step(src, direction))
-						cade.update_icon()
-				update_icon()
-		if(BARRICADE_PLASTEEL_ANCHORED) //Protection panel removed step. Screwdriver to put the panel back, wrench to unsecure the anchor bolts
-			if(isscrewdriver(I))
-				if(user.skills.getRating("engineer") < SKILL_ENGINEER_PLASTEEL)
-					var/fumbling_time = 1 SECONDS * ( SKILL_ENGINEER_PLASTEEL - user.skills.getRating("engineer") )
-					if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
-						return
-				balloon_alert_to_viewers("bolt protection panel replaced")
-				playsound(loc, 'sound/items/screwdriver.ogg', 25, 1)
-				build_state = BARRICADE_PLASTEEL_FIRM
-
-			else if(iswrench(I))
-				if(user.skills.getRating("engineer") < SKILL_ENGINEER_PLASTEEL)
-					var/fumbling_time = 1 SECONDS * ( SKILL_ENGINEER_PLASTEEL - user.skills.getRating("engineer") )
-					if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
-						return
-				balloon_alert_to_viewers("anchor bolts loosened")
-				playsound(loc, 'sound/items/ratchet.ogg', 25, 1)
-				anchored = FALSE
-				modify_max_integrity(initial(max_integrity) * 0.5)
-				build_state = BARRICADE_PLASTEEL_LOOSE
-				update_icon() //unanchored changes layer
-		if(BARRICADE_PLASTEEL_LOOSE) //Anchor bolts loosened step. Apply crowbar to unseat the panel and take apart the whole thing. Apply wrench to rescure anchor bolts
-			if(iswrench(I))
-
-				var/turf/mystery_turf = get_turf(src)
-				if(!isopenturf(mystery_turf))
-					balloon_alert(user, "can't anchor here")
-					return
-
-				var/turf/open/T = mystery_turf
-				if(!T.allow_construction) //We shouldn't be able to anchor in areas we're not supposed to build; loophole closed.
-					balloon_alert(user, "can't anchor here")
-					return
-
-				if(user.skills.getRating("engineer") < SKILL_ENGINEER_PLASTEEL)
-					var/fumbling_time = 1 SECONDS * ( SKILL_ENGINEER_PLASTEEL - user.skills.getRating("engineer") )
-					if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
-						return
-				balloon_alert_to_viewers("secured bolts")
-				playsound(loc, 'sound/items/ratchet.ogg', 25, 1)
-				anchored = TRUE
-				modify_max_integrity(initial(max_integrity))
-				build_state = BARRICADE_PLASTEEL_ANCHORED
-				update_icon() //unanchored changes layer
-
-			else if(iscrowbar(I))
-				if(user.skills.getRating("engineer") < SKILL_ENGINEER_PLASTEEL)
-					var/fumbling_time = 5 SECONDS * ( SKILL_ENGINEER_PLASTEEL - user.skills.getRating("engineer") )
-					if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
-						return
-				balloon_alert_to_viewers("disassembling")
-				playsound(loc, 'sound/items/crowbar.ogg', 25, 1)
-				busy = TRUE
-
-				if(!do_after(user, 50, TRUE, src, BUSY_ICON_BUILD))
-					busy = FALSE
-					return
-
-				busy = FALSE
-				user.visible_message(span_notice("[user] takes [src]'s panels apart."),
-				span_notice("You take [src]'s panels apart."))
-				playsound(loc, 'sound/items/deconstruct.ogg', 25, 1)
-				var/deconstructed = TRUE
-				for(var/obj/effect/xenomorph/acid/A in loc)
-					if(A.acid_t != src)
-						continue
-					deconstructed = FALSE
-					break
-				deconstruct(deconstructed)
-
 
 /obj/structure/barricade/plasteel/attack_hand(mob/living/user)
 	. = ..()

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -551,7 +551,7 @@
 	. += span_info("It is [barricade_upgrade_type ? "upgraded with [barricade_upgrade_type]" : "not upgraded"].")
 
 /obj/structure/barricade/metal/welder_act(mob/living/user, obj/item/I)
-	. = welder_repair_act(user, I, repair_threshold = 0.3)
+	. = welder_repair_act(user, I, repair_threshold = 0.3, skill_required = SKILL_ENGINEER_METAL)
 	if(. == BELOW_INTEGRITY_THRESHOLD)
 		balloon_alert(user, "Too damaged. Use metal sheets.")
 

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -24,7 +24,7 @@
 		cut_overlay(atvcover)
 	return ..()
 
-/obj/vehicle/ridden/atv/welder_act(mob/living/user, obj/item/W)
+/obj/vehicle/ridden/atv/welder_act(mob/living/user, obj/item/I)
 	return welder_repair_act(user, I, 10, 2 SECONDS, fuel_req = 1)
 
 /obj/vehicle/ridden/atv/obj_break()

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -25,31 +25,7 @@
 	return ..()
 
 /obj/vehicle/ridden/atv/welder_act(mob/living/user, obj/item/W)
-	if(user.a_intent == INTENT_HARM)
-		return
-	. = TRUE
-	if(LAZYFIND(user.do_actions, src))
-		balloon_alert(user, "you're already repairing it!")
-		return
-	if(obj_integrity >= max_integrity)
-		balloon_alert(user, "it's not damaged!")
-		return
-	if(!W.tool_start_check(user, amount=1))
-		return
-	user.balloon_alert_to_viewers("started welding [src]", "started repairing [src]")
-	audible_message(span_hear("You hear welding."))
-	var/did_the_thing
-	while(obj_integrity < max_integrity)
-		if(W.use_tool(src, user, 2.5 SECONDS, volume=50, amount=1))
-			did_the_thing = TRUE
-			obj_integrity += min(10, (max_integrity - obj_integrity))
-			audible_message(span_hear("You hear welding."))
-		else
-			break
-	if(did_the_thing)
-		user.balloon_alert_to_viewers("[(obj_integrity >= max_integrity) ? "fully" : "partially"] repaired [src]")
-	else
-		user.balloon_alert_to_viewers("stopped welding [src]", "interrupted the repair!")
+	return welder_repair_act(user, I, 10, 2 SECONDS, fuel_req = 1)
 
 /obj/vehicle/ridden/atv/obj_break()
 	START_PROCESSING(SSobj, src)

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -245,40 +245,7 @@
 		to_chat(user, span_notice("You close the hatch to the power unit."))
 
 /obj/vehicle/sealed/mecha/welder_act(mob/living/user, obj/item/W)
-	. = ..()
-	if(user.a_intent == INTENT_HARM)
-		return
-	. = TRUE
-	if(LAZYFIND(user.do_actions, src))
-		balloon_alert(user, "you're already repairing this!")
-		return
-	if(obj_integrity >= max_integrity)
-		balloon_alert(user, "it's not damaged!")
-		return
-	if(!W.tool_start_check(user, amount=1))
-		return
-	var/did_the_thing
-	var/started = FALSE
-	var/skill = user.skills.getRating("engineer")
-	while(obj_integrity < max_integrity)
-		if(skill < SKILL_ENGINEER_ENGI)
-			user.balloon_alert_to_viewers("fumbles around trying to repair")
-			if(!do_after(user, 30 * (SKILL_ENGINEER_ENGI - skill), TRUE, src, BUSY_ICON_UNSKILLED))
-				return
-		if(!started)
-			user.balloon_alert_to_viewers("started welding", "started repairing")
-			audible_message(span_hear("You hear welding."))
-			started = TRUE
-		if(W.use_tool(src, user, 2.5 SECONDS, volume=50, amount=1))
-			did_the_thing = TRUE
-			obj_integrity += min(100, (max_integrity - obj_integrity))
-			audible_message(span_hear("You hear welding."))
-		else
-			break
-	if(did_the_thing)
-		user.balloon_alert_to_viewers("[(obj_integrity >= max_integrity) ? "fully" : "partially"] repaired [src]")
-	else
-		user.balloon_alert_to_viewers("stopped welding [src]", "interrupted the repair!")
+	return welder_repair_act(user, I, 100, 2 SECONDS, 0, SKILL_ENGINEER_ENGI, 2, 3 SECONDS)
 
 /obj/vehicle/sealed/mecha/proc/full_repair(charge_cell)
 	obj_integrity = max_integrity

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -244,7 +244,7 @@
 		construction_state = MECHA_LOOSE_BOLTS
 		to_chat(user, span_notice("You close the hatch to the power unit."))
 
-/obj/vehicle/sealed/mecha/welder_act(mob/living/user, obj/item/W)
+/obj/vehicle/sealed/mecha/welder_act(mob/living/user, obj/item/I)
 	return welder_repair_act(user, I, 100, 2 SECONDS, 0, SKILL_ENGINEER_ENGI, 2, 3 SECONDS)
 
 /obj/vehicle/sealed/mecha/proc/full_repair(charge_cell)

--- a/code/modules/vehicles/motorbike.dm
+++ b/code/modules/vehicles/motorbike.dm
@@ -50,25 +50,7 @@
 	return ..()
 
 /obj/vehicle/ridden/motorbike/welder_act(mob/living/user, obj/item/I)
-	if(user.do_actions)
-		balloon_alert(user, "Already busy!")
-		return FALSE
-	if(obj_integrity >= max_integrity)
-		return TRUE
-	balloon_alert_to_viewers("[user] starts repairs", ignored_mobs = user)
-	balloon_alert(user, "You start repair")
-	if(!do_after(user, 2 SECONDS))
-		balloon_alert_to_viewers("Stops repair")
-		return
-	if(!I.use_tool(src, user, 0, volume=50, amount=1))
-		return TRUE
-	obj_integrity += min(10, max_integrity-obj_integrity)
-	if(obj_integrity == max_integrity)
-		balloon_alert_to_viewers("Fully repaired!")
-	else
-		balloon_alert_to_viewers("[user] repairs", ignored_mobs = user)
-		balloon_alert(user, "You repair damage")
-	return TRUE
+	return welder_repair_act(user, I, 10, 2 SECONDS, fuel_req = 1)
 
 /obj/vehicle/ridden/motorbike/relaymove(mob/living/user, direction)
 	if(fuel_count <= 0)

--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -288,32 +288,7 @@
 	take_damage(20, BURN, "fire")
 
 /obj/vehicle/unmanned/welder_act(mob/living/user, obj/item/I)
-	if(user.do_actions)
-		balloon_alert(user, "You're already busy!")
-		return FALSE
-	if(obj_integrity >= max_integrity)
-		balloon_alert(user, "This doesn't need repairing")
-		return TRUE
-	if(user.skills.getRating("engineer") < SKILL_ENGINEER_ENGI)
-		balloon_alert_to_viewers("[user] tries to repair the [name]" , ignored_mobs = user)
-		balloon_alert(user, "You try to repair the [name]")
-		var/fumbling_time = 10 SECONDS - 2 SECONDS * user.skills.getRating("engineer")
-		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED, extra_checks = CALLBACK(I, /obj/item/tool/weldingtool.proc/isOn)))
-			return FALSE
-	balloon_alert_to_viewers("[user] begins repairing the vehicle", ignored_mobs = user)
-	balloon_alert(user, "You begin repairing the [name]")
-	if(!do_after(user, 2 SECONDS, extra_checks = CALLBACK(I, /obj/item/tool/weldingtool.proc/isOn)))
-		balloon_alert_to_viewers("[user] stops repairing the [name]")
-		return
-	if(!I.use_tool(src, user, 0, volume=50, amount=1))
-		return TRUE
-	repair_damage(35)
-	if(obj_integrity == max_integrity)
-		balloon_alert_to_viewers("Fully repaired!")
-	else
-		balloon_alert_to_viewers("[user] repairs the [name]", ignored_mobs = user)
-		balloon_alert(user, "You finish repairing the [name]")
-	return TRUE
+	return welder_repair_act(user, I, 35, 2 SECONDS, 0, SKILL_ENGINEER_ENGI, 1, 4)
 
 /obj/vehicle/unmanned/medium
 	name = "UV-M Gecko"

--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -288,7 +288,7 @@
 	take_damage(20, BURN, "fire")
 
 /obj/vehicle/unmanned/welder_act(mob/living/user, obj/item/I)
-	return welder_repair_act(user, I, 35, 2 SECONDS, 0, SKILL_ENGINEER_ENGI, 1, 4)
+	return welder_repair_act(user, I, 35, 2 SECONDS, 0, SKILL_ENGINEER_ENGI, 1, 4 SECONDS)
 
 /obj/vehicle/unmanned/medium
 	name = "UV-M Gecko"


### PR DESCRIPTION
## About The Pull Request
Probs TM first.

Repairing anything object with a welding tool will now chain repair until you run out of fuel or it is fully repaired.

Refactored object repair to use a single proc, instead of the same thing being done is 10 slightly different, inconsistant ways.

Fixes some repairs not actually causing eye damage, and a few other minor bugs.

There may be a couple of minor fumble time changes as part of making everything consistent.

Also fixed plasteel cade code to use tool act procs instead of attack by.
## Why It's Good For The Game
Less duplicate code, code actually checking everything it should.
## Changelog
:cl:
balance: Repairs with a welder will now chain repair, fumble is only done once per chain
refactor: refactored welding repair code
refactor: refactored plasteel tool interactions
/:cl:
