### PR TITLE
Makes Dylovene's stamina debuff only trigger at >5u

### DIFF
--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -352,11 +352,6 @@
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "a roll of gauze"
 
-/datum/reagent/medicine/dylovene/on_mob_add(mob/living/L, metabolism)
-	if(volume > 5)
-		L.add_stamina_regen_modifier(name, -0.5)
-	return ..()
-
 /datum/reagent/medicine/dylovene/on_mob_delete(mob/living/L, metabolism)
 	L.remove_stamina_regen_modifier(name)
 	return ..()
@@ -364,6 +359,8 @@
 /datum/reagent/medicine/dylovene/on_mob_life(mob/living/L,metabolism)
 	L.hallucination = max(0, L.hallucination -  2.5*effect_str)
 	L.adjustToxLoss(-effect_str)
+	if(volume > 5)
+		L.add_stamina_regen_modifier(name, -0.5)
 	return ..()
 
 /datum/reagent/medicine/dylovene/overdose_process(mob/living/L, metabolism)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -353,7 +353,8 @@
 	taste_description = "a roll of gauze"
 
 /datum/reagent/medicine/dylovene/on_mob_add(mob/living/L, metabolism)
-	L.add_stamina_regen_modifier(name, -0.5)
+	if(volume > 5)
+			L.add_stamina_regen_modifier(name, -0.5)
 	return ..()
 
 /datum/reagent/medicine/dylovene/on_mob_delete(mob/living/L, metabolism)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -354,7 +354,7 @@
 
 /datum/reagent/medicine/dylovene/on_mob_add(mob/living/L, metabolism)
 	if(volume > 5)
-			L.add_stamina_regen_modifier(name, -0.5)
+		L.add_stamina_regen_modifier(name, -0.5)
 	return ..()
 
 /datum/reagent/medicine/dylovene/on_mob_delete(mob/living/L, metabolism)


### PR DESCRIPTION

## About The Pull Request
Dylovene's stamina debuff now only triggers at >5u rather than at any volume of the reagent in the body.

## Why It's Good For The Game
The stamina debuff change didn't account for combat injectors having trace amounts of dylovene, so using a combat injector cucked you off your stamina despite being something to use in combat. This will make combat injectors safe to use while still making dylovene pills cause stamina debuff.

## Changelog

:cl:
balance: Dylovene's stamina debuff now only happens at >5u of reagents in the body.
/:cl:

