### PR TITLE
Changes dylovene to tricordrazine in combat injector

### DIFF
--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -48,7 +48,7 @@
 	list_reagents = list(
 		/datum/reagent/medicine/bicaridine = 10,
 		/datum/reagent/medicine/kelotane = 10,
-		/datum/reagent/medicine/dylovene = 5,
+		/datum/reagent/medicine/tricordrazine = 5,
 		/datum/reagent/medicine/tramadol = 5,
 	)
 	description_overlay = "Cb"


### PR DESCRIPTION

## About The Pull Request
Combat injectors now come with 5u of tricordrazine instead of 5u of dylovene.

## Why It's Good For The Game
Alternative to #11830 so as to make combat injectors not chop stamina regen by half due to the dylov in it. Would make dylovene its own toxin-dedicated med.

## Changelog

:cl:
balance: Combat injectors now have tricordrazine in replacement of dylovene.
/:cl:

