### PR TITLE
Adds descriptions to xeno ability tooltips

### DIFF
--- a/code/datums/actions/xeno_action.dm
+++ b/code/datums/actions/xeno_action.dm
@@ -1,6 +1,6 @@
 
 /datum/action/xeno_action
-	desc = "This ability not found in codex." // If you are going to add an explanation for an ability. don't use stats, give a very brief explanation of how to use it.
+	desc = "This ability can not be found in codex." // If you are going to add an explanation for an ability. don't use stats, give a very brief explanation of how to use it.
 	var/plasma_cost = 0
 	var/use_state_flags = NONE // bypass use limitations checked by can_use_action()
 	var/last_use

--- a/code/datums/actions/xeno_action.dm
+++ b/code/datums/actions/xeno_action.dm
@@ -1,7 +1,7 @@
 
 /datum/action/xeno_action
+	desc = "This ability not found in codex." // If you are going to add an explanation for an ability. don't use stats, give a very brief explanation of how to use it.
 	var/plasma_cost = 0
-	var/mechanics_text = "This ability not found in codex." //codex. If you are going to add an explanation for an ability. don't use stats, give a very brief explanation of how to use it.
 	var/use_state_flags = NONE // bypass use limitations checked by can_use_action()
 	var/last_use
 	var/cooldown_timer

--- a/code/modules/codex/entries/mobs_codex.dm
+++ b/code/modules/codex/entries/mobs_codex.dm
@@ -46,7 +46,7 @@
 	if(length(actions))
 		xeno_strings += "<br><U>This has the following abilities</U>:"
 		for(var/datum/action/xeno_action/A in actions)
-			xeno_strings += "<U>[A.name]</U>: [A.mechanics_text]<br>"
+			xeno_strings += "<U>[A.name]</U>: [A.desc]<br>"
 
 	. += jointext(xeno_strings, "<br>")
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -5,7 +5,7 @@
 /datum/action/xeno_action/xeno_resting
 	name = "Rest"
 	action_icon_state = "resting"
-	mechanics_text = "Rest on weeds to regenerate health and plasma."
+	desc = "Rest on weeds to regenerate health and plasma."
 	use_state_flags = XACT_USE_LYING|XACT_USE_CRESTED|XACT_USE_AGILITY|XACT_USE_CLOSEDTURF
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_REST,
@@ -25,7 +25,7 @@
 	name = "Plant Weeds"
 	action_icon_state = "plant_weeds"
 	plasma_cost = 75
-	mechanics_text = "Plant a weed node on your tile."
+	desc = "Plant a weed node on your tile."
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_DROP_WEEDS,
 		KEYBINDING_ALTERNATE = COMSIG_XENOABILITY_CHOOSE_WEEDS,
@@ -173,7 +173,7 @@
 /datum/action/xeno_action/activable/secrete_resin
 	name = "Secrete Resin"
 	action_icon_state = RESIN_WALL
-	mechanics_text = "Builds whatever resin you selected"
+	desc = "Builds whatever resin you selected"
 	ability_name = "secrete resin"
 	plasma_cost = 75
 	keybinding_signals = list(
@@ -347,7 +347,7 @@
 	name = "Emit Pheromones"
 	action_icon_state = "emit_pheromones"
 	plasma_cost = 30
-	mechanics_text = "Opens your pheromone options."
+	desc = "Opens your pheromone options."
 	use_state_flags = XACT_USE_STAGGERED|XACT_USE_NOTTURF|XACT_USE_BUSY|XACT_USE_LYING
 
 /datum/action/xeno_action/pheromones/proc/apply_pheros(phero_choice)
@@ -378,7 +378,7 @@
 
 /datum/action/xeno_action/pheromones/emit_recovery
 	name = "Toggle Recovery Pheromones"
-	mechanics_text = "Increases healing for yourself and nearby teammates."
+	desc = "Increases healing for yourself and nearby teammates."
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_EMIT_RECOVERY,
 	)
@@ -391,7 +391,7 @@
 
 /datum/action/xeno_action/pheromones/emit_warding
 	name = "Toggle Warding Pheromones"
-	mechanics_text = "Increases armor for yourself and nearby teammates."
+	desc = "Increases armor for yourself and nearby teammates."
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_EMIT_WARDING,
 	)
@@ -404,7 +404,7 @@
 
 /datum/action/xeno_action/pheromones/emit_frenzy
 	name = "Toggle Frenzy Pheromones"
-	mechanics_text = "Increases damage for yourself and nearby teammates."
+	desc = "Increases damage for yourself and nearby teammates."
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_EMIT_FRENZY,
 	)
@@ -419,7 +419,7 @@
 /datum/action/xeno_action/activable/transfer_plasma
 	name = "Transfer Plasma"
 	action_icon_state = "transfer_plasma"
-	mechanics_text = "Give some of your plasma to a teammate."
+	desc = "Give some of your plasma to a teammate."
 	ability_name = "transfer plasma"
 	var/plasma_transfer_amount = PLASMA_TRANSFER_AMOUNT
 	var/transfer_delay = 2 SECONDS
@@ -495,7 +495,7 @@
 /datum/action/xeno_action/activable/corrosive_acid
 	name = "Corrosive Acid"
 	action_icon_state = "corrosive_acid"
-	mechanics_text = "Cover an object with acid to slowly melt it. Takes a few seconds."
+	desc = "Cover an object with acid to slowly melt it. Takes a few seconds."
 	ability_name = "corrosive acid"
 	plasma_cost = 100
 	var/acid_type = /obj/effect/xenomorph/acid
@@ -717,7 +717,7 @@
 /datum/action/xeno_action/activable/xeno_spit
 	name = "Xeno Spit"
 	action_icon_state = "shift_spit_neurotoxin"
-	mechanics_text = "Spit neurotoxin or acid at your target up to 7 tiles away."
+	desc = "Spit neurotoxin or acid at your target up to 7 tiles away."
 	ability_name = "xeno spit"
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_XENO_SPIT,
@@ -880,7 +880,7 @@
 /datum/action/xeno_action/xenohide
 	name = "Hide"
 	action_icon_state = "xenohide"
-	mechanics_text = "Causes your sprite to hide behind certain objects and under tables. Not the same as stealth. Does not use plasma."
+	desc = "Causes your sprite to hide behind certain objects and under tables. Not the same as stealth. Does not use plasma."
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_HIDE,
 	)
@@ -899,7 +899,7 @@
 /datum/action/xeno_action/activable/neurotox_sting
 	name = "Neurotoxin Sting"
 	action_icon_state = "neuro_sting"
-	mechanics_text = "A channeled melee attack that injects the target with neurotoxin over a few seconds, temporarily stunning them."
+	desc = "A channeled melee attack that injects the target with neurotoxin over a few seconds, temporarily stunning them."
 	ability_name = "neurotoxin sting"
 	cooldown_timer = 12 SECONDS
 	plasma_cost = 150
@@ -953,7 +953,7 @@
 /datum/action/xeno_action/activable/neurotox_sting/ozelomelyn
 	name = "Ozelomelyn Sting"
 	action_icon_state = "drone_sting"
-	mechanics_text = "A channeled melee attack that injects the target with Ozelomelyn over a few seconds, purging chemicals and dealing minor toxin damage to a moderate cap while inside them."
+	desc = "A channeled melee attack that injects the target with Ozelomelyn over a few seconds, purging chemicals and dealing minor toxin damage to a moderate cap while inside them."
 	ability_name = "ozelomelyn sting"
 	cooldown_timer = 25 SECONDS
 	keybinding_signals = list(
@@ -1050,7 +1050,7 @@
 /datum/action/xeno_action/rally_hive
 	name = "Rally Hive"
 	action_icon_state = "rally_hive"
-	mechanics_text = "Rallies the hive to a congregate at a target location, along with an arrow pointer. Gives the Hive your current health status. 60 second cooldown."
+	desc = "Rallies the hive to a congregate at a target location, along with an arrow pointer. Gives the Hive your current health status. 60 second cooldown."
 	ability_name = "rally hive"
 	plasma_cost = 0
 	keybinding_signals = list(
@@ -1075,7 +1075,7 @@
 /datum/action/xeno_action/rally_minion
 	name = "Rally Minions"
 	action_icon_state = "rally_minions"
-	mechanics_text = "Rallies the minions around you, asking them to follow you if they don't have a leader already. 60 second cooldown."
+	desc = "Rallies the minions around you, asking them to follow you if they don't have a leader already. 60 second cooldown."
 	ability_name = "rally minions"
 	plasma_cost = 0
 	keybinding_signals = list(
@@ -1098,7 +1098,7 @@
 /datum/action/xeno_action/set_agressivity
 	name = "Set minions behavior"
 	action_icon_state = "minion_agressive"
-	mechanics_text = "Order the minions escorting you to be either agressive or passive."
+	desc = "Order the minions escorting you to be either agressive or passive."
 	ability_name = "set_agressivity"
 	plasma_cost = 0
 	keybinding_signals = list(
@@ -1140,7 +1140,7 @@
 /datum/action/xeno_action/activable/psydrain
 	name = "Psy drain"
 	action_icon_state = "headbite"
-	mechanics_text = "Drain the victim of its life force to gain larva and psych points"
+	desc = "Drain the victim of its life force to gain larva and psych points"
 	use_state_flags = XACT_USE_STAGGERED|XACT_USE_FORTIFIED|XACT_USE_CRESTED //can't use while staggered, defender fortified or crest down
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_HEADBITE,
@@ -1234,7 +1234,7 @@
 /datum/action/xeno_action/activable/cocoon
 	name = "Cocoon"
 	action_icon_state = "regurgitate"
-	mechanics_text = "Devour your victim to cocoon it in your belly. This cocoon will automatically be ejected later, and while the marine inside it still has life force it will give psychic points."
+	desc = "Devour your victim to cocoon it in your belly. This cocoon will automatically be ejected later, and while the marine inside it still has life force it will give psychic points."
 	use_state_flags = XACT_USE_STAGGERED|XACT_USE_FORTIFIED|XACT_USE_CRESTED //can't use while staggered, defender fortified or crest down
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_REGURGITATE,
@@ -1324,7 +1324,7 @@
 /datum/action/xeno_action/blessing_menu
 	name = "Mothers Blessings"
 	action_icon_state = "hivestore"
-	mechanics_text = "Ask the Queen Mother for blessings for your hive in exchange for psychic energy."
+	desc = "Ask the Queen Mother for blessings for your hive in exchange for psychic energy."
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_BLESSINGSMENU,
 	)

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -28,7 +28,7 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 /datum/action/xeno_action/toggle_long_range
 	name = "Toggle Long Range Sight"
 	action_icon_state = "toggle_long_range"
-	mechanics_text = "Activates your weapon sight in the direction you are facing. Must remain stationary to use."
+	desc = "Activates your weapon sight in the direction you are facing. Must remain stationary to use."
 	plasma_cost = 20
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_LONG_RANGE_SIGHT,
@@ -55,7 +55,7 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 /datum/action/xeno_action/toggle_bomb
 	name = "Toggle Bombard Type"
 	action_icon_state = "toggle_bomb0"
-	mechanics_text = "Switches Boiler Bombard type between available glob types."
+	desc = "Switches Boiler Bombard type between available glob types."
 	use_state_flags = XACT_USE_BUSY|XACT_USE_LYING
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_TOGGLE_BOMB,
@@ -132,7 +132,7 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	name = "Create bomb"
 	action_icon_state = "toggle_bomb0" //to be changed
 	action_icon = 'icons/xeno/actions_boiler_glob.dmi'
-	mechanics_text = "Creates a Boiler Bombard of the type currently selected."
+	desc = "Creates a Boiler Bombard of the type currently selected."
 	plasma_cost = 200
 	use_state_flags = XACT_USE_BUSY|XACT_USE_LYING
 	keybinding_signals = list(
@@ -172,7 +172,7 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 /datum/action/xeno_action/activable/bombard
 	name = "Bombard"
 	action_icon_state = "bombard"
-	mechanics_text = "Launch a glob of neurotoxin or acid. Must remain stationary for a few seconds to use."
+	desc = "Launch a glob of neurotoxin or acid. Must remain stationary for a few seconds to use."
 	ability_name = "bombard"
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_BOMBARD,

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/abilities_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/abilities_bull.dm
@@ -5,7 +5,7 @@
 /datum/action/xeno_action/activable/bull_charge
 	name = "Plow Charge"
 	action_icon_state = "bull_charge"
-	mechanics_text = "The plow charge is similar to the crusher charge, as it deals damage and throws anyone hit out of your way. Hitting a host does not stop or slow you down."
+	desc = "The plow charge is similar to the crusher charge, as it deals damage and throws anyone hit out of your way. Hitting a host does not stop or slow you down."
 	ability_name = "plow charge"
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_BULLCHARGE,
@@ -20,7 +20,7 @@
 /datum/action/xeno_action/activable/bull_charge/headbutt
 	name = "Headbutt Charge"
 	action_icon_state = "bull_headbutt"
-	mechanics_text = "The headbutt charge, when it hits a host, stops your charge while knocking them down stunned for some time."
+	desc = "The headbutt charge, when it hits a host, stops your charge while knocking them down stunned for some time."
 	ability_name = "headbutt charge"
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_BULLHEADBUTT,
@@ -30,7 +30,7 @@
 /datum/action/xeno_action/activable/bull_charge/gore
 	name = "Gore Charge"
 	action_icon_state = "bull_gore"
-	mechanics_text = "The gore charge, when it hits a host, stops your charge while dealing a large amount of damage where you are targeting dependant on your charge speed."
+	desc = "The gore charge, when it hits a host, stops your charge while dealing a large amount of damage where you are targeting dependant on your charge speed."
 	ability_name = "gore charge"
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_BULLGORE,

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -36,7 +36,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 /datum/action/xeno_action/activable/throw_hugger
 	name = "Use/Throw Facehugger"
 	action_icon_state = "throw_hugger"
-	mechanics_text = "Click on a non tile and non mob to bring a facehugger into your hand. Click at a target or tile to throw a facehugger."
+	desc = "Click on a non tile and non mob to bring a facehugger into your hand. Click at a target or tile to throw a facehugger."
 	ability_name = "throw facehugger"
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_THROW_HUGGER,
@@ -111,7 +111,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 /datum/action/xeno_action/place_trap
 	name = "Place trap"
 	action_icon_state = "place_trap"
-	mechanics_text = "Place a hole on weeds that can be filled with a hugger or acid. Activates when a marine steps on it."
+	desc = "Place a hole on weeds that can be filled with a hugger or acid. Activates when a marine steps on it."
 	plasma_cost = 400
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_PLACE_TRAP,
@@ -151,7 +151,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 /datum/action/xeno_action/spawn_hugger
 	name = "Spawn Facehugger"
 	action_icon_state = "spawn_hugger"
-	mechanics_text = "Spawn a facehugger that is stored on your body."
+	desc = "Spawn a facehugger that is stored on your body."
 	plasma_cost = 200
 	cooldown_timer = 10 SECONDS
 	keybinding_signals = list(
@@ -189,7 +189,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 /datum/action/xeno_action/carrier_panic
 	name = "Drop All Facehuggers"
 	action_icon_state = "carrier_panic"
-	mechanics_text = "Drop all stored huggers in a fit of panic. Uses all remaining plasma!"
+	desc = "Drop all stored huggers in a fit of panic. Uses all remaining plasma!"
 	plasma_cost = 10
 	cooldown_timer = 50 SECONDS
 	keybinding_signals = list(
@@ -246,7 +246,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 /datum/action/xeno_action/choose_hugger_type
 	name = "Choose Hugger Type"
 	action_icon_state = "facehugger"
-	mechanics_text = "Selects which hugger type you will build with the Spawn Hugger ability."
+	desc = "Selects which hugger type you will build with the Spawn Hugger ability."
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_CHOOSE_HUGGER,
 		KEYBINDING_ALTERNATE = COMSIG_XENOABILITY_SWITCH_HUGGER,
@@ -295,7 +295,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 /datum/action/xeno_action/build_hugger_turret
 	name = "build hugger turret"
 	action_icon_state = "hugger_turret"
-	mechanics_text = "Build a hugger turret"
+	desc = "Build a hugger turret"
 	plasma_cost = 800
 	cooldown_timer = 5 MINUTES
 
@@ -346,7 +346,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 /datum/action/xeno_action/activable/call_younger
 	name = "Call of Younger"
 	action_icon_state = "call_younger"
-	mechanics_text = "Appeals to the larva inside the Marine. The Marine loses his balance, and larva's progress accelerates."
+	desc = "Appeals to the larva inside the Marine. The Marine loses his balance, and larva's progress accelerates."
 	ability_name = "call younger"
 	plasma_cost = 150
 	cooldown_timer = 20 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -4,7 +4,7 @@
 /datum/action/xeno_action/activable/stomp
 	name = "Stomp"
 	action_icon_state = "stomp"
-	mechanics_text = "Knocks all adjacent targets away and down."
+	desc = "Knocks all adjacent targets away and down."
 	ability_name = "stomp"
 	plasma_cost = 100
 	cooldown_timer = 20 SECONDS
@@ -65,7 +65,7 @@
 /datum/action/xeno_action/activable/cresttoss
 	name = "Crest Toss"
 	action_icon_state = "cresttoss"
-	mechanics_text = "Fling an adjacent target over and behind you. Also works over barricades."
+	desc = "Fling an adjacent target over and behind you. Also works over barricades."
 	ability_name = "crest toss"
 	plasma_cost = 75
 	cooldown_timer = 12 SECONDS
@@ -176,7 +176,7 @@
 /datum/action/xeno_action/activable/advance
 	name = "Rapid Advance"
 	action_icon_state = "crest_defense"
-	mechanics_text = "Charges up the crushers charge in place, then unleashes the full bulk of the crusher at the target location. Does not crush in diagonal directions."
+	desc = "Charges up the crushers charge in place, then unleashes the full bulk of the crusher at the target location. Does not crush in diagonal directions."
 	ability_name = "rapid advance"
 	plasma_cost = 175
 	cooldown_timer = 30 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -4,7 +4,7 @@
 /datum/action/xeno_action/tail_sweep
 	name = "Tail Sweep"
 	action_icon_state = "tail_sweep"
-	mechanics_text = "Hit all adjacent units around you, knocking them away and down."
+	desc = "Hit all adjacent units around you, knocking them away and down."
 	ability_name = "tail sweep"
 	plasma_cost = 35
 	use_state_flags = XACT_USE_CRESTED
@@ -88,7 +88,7 @@
 /datum/action/xeno_action/activable/forward_charge
 	name = "Forward Charge"
 	action_icon_state = "charge"
-	mechanics_text = "Charge up to 4 tiles and knockdown any targets in our way."
+	desc = "Charge up to 4 tiles and knockdown any targets in our way."
 	ability_name = "charge"
 	cooldown_timer = 10 SECONDS
 	plasma_cost = 80
@@ -191,7 +191,7 @@
 /datum/action/xeno_action/toggle_crest_defense
 	name = "Toggle Crest Defense"
 	action_icon_state = "crest_defense"
-	mechanics_text = "Increase your resistance to projectiles at the cost of move speed. Can use abilities while in Crest Defense."
+	desc = "Increase your resistance to projectiles at the cost of move speed. Can use abilities while in Crest Defense."
 	ability_name = "toggle crest defense"
 	use_state_flags = XACT_USE_FORTIFIED|XACT_USE_CRESTED // duh
 	cooldown_timer = 1 SECONDS
@@ -268,7 +268,7 @@
 /datum/action/xeno_action/fortify
 	name = "Fortify"
 	action_icon_state = "fortify"	// TODO
-	mechanics_text = "Plant yourself for a large defensive boost."
+	desc = "Plant yourself for a large defensive boost."
 	ability_name = "fortify"
 	use_state_flags = XACT_USE_FORTIFIED|XACT_USE_CRESTED // duh
 	cooldown_timer = 1 SECONDS
@@ -342,7 +342,7 @@
 /datum/action/xeno_action/regenerate_skin
 	name = "Regenerate Skin"
 	action_icon_state = "regenerate_skin"
-	mechanics_text = "Regenerate your hard exoskeleton skin, restoring some health and removing all sunder."
+	desc = "Regenerate your hard exoskeleton skin, restoring some health and removing all sunder."
 	ability_name = "regenerate skin"
 	use_state_flags = XACT_USE_FORTIFIED|XACT_USE_CRESTED|XACT_TARGET_SELF|XACT_IGNORE_SELECTED_ABILITY|XACT_KEYBIND_USE_ABILITY
 	plasma_cost = 160
@@ -384,7 +384,7 @@
 /datum/action/xeno_action/centrifugal_force
 	name = "Centrifugal force"
 	action_icon_state = "centrifugal_force"
-	mechanics_text = "Rapidly spin and hit all adjacent humans around you, knocking them away and down. Uses double plasma when crest is active."
+	desc = "Rapidly spin and hit all adjacent humans around you, knocking them away and down. Uses double plasma when crest is active."
 	ability_name = "centrifugal force"
 	plasma_cost = 15
 	use_state_flags = XACT_USE_CRESTED

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -64,7 +64,7 @@
 /datum/action/xeno_action/activable/defile
 	name = "Defile"
 	action_icon_state = "defiler_sting"
-	mechanics_text = "Channel to inject an adjacent target with an accelerant that violently reacts with xeno toxins, releasing gas and dealing heavy tox damage in proportion to the amount in their system."
+	desc = "Channel to inject an adjacent target with an accelerant that violently reacts with xeno toxins, releasing gas and dealing heavy tox damage in proportion to the amount in their system."
 	ability_name = "defiler sting"
 	plasma_cost = 100
 	cooldown_timer = 20 SECONDS
@@ -163,7 +163,7 @@
 /datum/action/xeno_action/emit_neurogas
 	name = "Emit Noxious Gas"
 	action_icon_state = "emit_neurogas"
-	mechanics_text = "Channel for 3 seconds to emit a cloud of noxious smoke, based on selected reagent, that follows the Defiler. You must remain stationary while channeling; moving will cancel the ability but will still cost plasma."
+	desc = "Channel for 3 seconds to emit a cloud of noxious smoke, based on selected reagent, that follows the Defiler. You must remain stationary while channeling; moving will cancel the ability but will still cost plasma."
 	ability_name = "emit neurogas"
 	plasma_cost = 200
 	cooldown_timer = 40 SECONDS
@@ -283,7 +283,7 @@
 /datum/action/xeno_action/activable/inject_egg_neurogas
 	name = "Inject Gas"
 	action_icon_state = "inject_egg"
-	mechanics_text = "Inject an egg with toxins, killing the larva, but filling it full with gas ready to explode."
+	desc = "Inject an egg with toxins, killing the larva, but filling it full with gas ready to explode."
 	ability_name = "inject neurogas"
 	plasma_cost = 100
 	cooldown_timer = 5 SECONDS
@@ -345,7 +345,7 @@
 /datum/action/xeno_action/select_reagent
 	name = "Select Reagent"
 	action_icon_state = "select_reagent0"
-	mechanics_text = "Selects which reagent to use for reagent slash and noxious gas. Hemodile slows by 25%, increased to 50% with neurotoxin present, and deals 20% of damage received as stamina damage. Transvitox converts brute/burn damage to toxin based on 40% of damage received up to 45 toxin on target, upon reaching which causes a stun. Neurotoxin deals increasing stamina damage the longer it remains in the victim's system and prevents stamina regeneration."
+	desc = "Selects which reagent to use for reagent slash and noxious gas. Hemodile slows by 25%, increased to 50% with neurotoxin present, and deals 20% of damage received as stamina damage. Transvitox converts brute/burn damage to toxin based on 40% of damage received up to 45 toxin on target, upon reaching which causes a stun. Neurotoxin deals increasing stamina damage the longer it remains in the victim's system and prevents stamina regeneration."
 	use_state_flags = XACT_USE_BUSY|XACT_USE_LYING
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_SELECT_REAGENT,
@@ -408,7 +408,7 @@
 /datum/action/xeno_action/reagent_slash
 	name = "Reagent Slash"
 	action_icon_state = "reagent_slash"
-	mechanics_text = "For a short duration the next 3 slashes made will inject a small amount of selected toxin."
+	desc = "For a short duration the next 3 slashes made will inject a small amount of selected toxin."
 	ability_name = "reagent slash"
 	cooldown_timer = 6 SECONDS
 	plasma_cost = 100
@@ -510,7 +510,7 @@
 /datum/action/xeno_action/activable/tentacle
 	name = "Tentacle"
 	action_icon_state = "tail_attack"
-	mechanics_text = "Throw one of your tentacles forward to grab a tallhost or item."
+	desc = "Throw one of your tentacles forward to grab a tallhost or item."
 	ability_name = "Tentacle"
 	cooldown_timer = 20 SECONDS
 	plasma_cost = 200

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
@@ -15,7 +15,7 @@
 /datum/action/xeno_action/activable/essence_link
 	name = "Essence Link"
 	action_icon_state = "healing_infusion"
-	mechanics_text = "Link to a xenomorph. This changes some of your abilities, and grants them and you both various bonuses."
+	desc = "Link to a xenomorph. This changes some of your abilities, and grants them and you both various bonuses."
 	cooldown_timer = 5 SECONDS
 	plasma_cost = 0
 	target_flags = XABB_MOB_TARGET
@@ -89,7 +89,7 @@
 /datum/action/xeno_action/activable/psychic_cure/acidic_salve
 	name = "Acidic Salve"
 	action_icon_state = "heal_xeno"
-	mechanics_text = "Apply a minor heal to the target. If applied to a linked sister, it will also apply a regenerative buff. Additionally, if that linked sister is near death, the heal's potency is increased"
+	desc = "Apply a minor heal to the target. If applied to a linked sister, it will also apply a regenerative buff. Additionally, if that linked sister is near death, the heal's potency is increased"
 	cooldown_timer = 5 SECONDS
 	plasma_cost = 150
 	keybinding_signals = list(
@@ -136,7 +136,7 @@
 /datum/action/xeno_action/enhancement
 	name = "Enhancement"
 	action_icon_state = "enhancement"
-	mechanics_text = "Apply an enhancement to the linked xeno, increasing their capabilities beyond their limits."
+	desc = "Apply an enhancement to the linked xeno, increasing their capabilities beyond their limits."
 	cooldown_timer = 120 SECONDS
 	plasma_cost = 0
 	keybinding_signals = list(

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -7,7 +7,7 @@
 /datum/action/xeno_action/activable/devour
 	name = "Devour"
 	action_icon_state = "regurgitate"
-	mechanics_text = "Devour your victim to be able to carry it faster."
+	desc = "Devour your victim to be able to carry it faster."
 	use_state_flags = XACT_USE_STAGGERED|XACT_USE_FORTIFIED|XACT_USE_CRESTED //can't use while staggered, defender fortified or crest down
 	plasma_cost = 0
 	target_flags = XABB_MOB_TARGET
@@ -89,7 +89,7 @@
 /datum/action/xeno_action/activable/drain
 	name = "Drain"
 	action_icon_state = "drain"
-	mechanics_text = "Hold a marine for some time and drain their blood, while healing. You can't attack during this time and can be shot by the marine. When used on a dead human, you heal, or gain overheal, gradually and don't gain blood."
+	desc = "Hold a marine for some time and drain their blood, while healing. You can't attack during this time and can be shot by the marine. When used on a dead human, you heal, or gain overheal, gradually and don't gain blood."
 	use_state_flags = XACT_KEYBIND_USE_ABILITY
 	cooldown_timer = 15 SECONDS
 	plasma_cost = 0
@@ -171,7 +171,7 @@
 /datum/action/xeno_action/activable/transfusion
 	name = "Transfusion"
 	action_icon_state = "transfusion"
-	mechanics_text = "Restores some of the health of another xenomorph, or overheals, at the cost of blood."
+	desc = "Restores some of the health of another xenomorph, or overheals, at the cost of blood."
 	//When used on self, drains blood continuosly, slows you down and reduces damage taken, while restoring health over time.
 	cooldown_timer = 2 SECONDS
 	plasma_cost = 20
@@ -236,7 +236,7 @@
 /datum/action/xeno_action/activable/rejuvenate
 	name = "Rejuvenate"
 	action_icon_state = "rejuvenation"
-	mechanics_text = "Drains blood continuosly, slows you down and reduces damage taken, while restoring some health over time. Cancel by activating again."
+	desc = "Drains blood continuosly, slows you down and reduces damage taken, while restoring some health over time. Cancel by activating again."
 	cooldown_timer = 4 SECONDS
 	plasma_cost = GORGER_REJUVENATE_COST
 	target_flags = XABB_MOB_TARGET
@@ -276,7 +276,7 @@
 /datum/action/xeno_action/activable/psychic_link
 	name = "Psychic Link"
 	action_icon_state = "psychic_link"
-	mechanics_text = "Link to a xenomorph and take some damage in their place. Unrest to cancel."
+	desc = "Link to a xenomorph and take some damage in their place. Unrest to cancel."
 	cooldown_timer = 50 SECONDS
 	plasma_cost = 0
 	target_flags = XABB_MOB_TARGET
@@ -372,7 +372,7 @@
 /datum/action/xeno_action/activable/carnage
 	name = "Carnage"
 	action_icon_state = "carnage"
-	mechanics_text = "Enter a state of thirst, gaining movement and healing on your next attack, scaling with missing blood. If your blood is below a certain %, you also knockdown your victim and drain some blood, during which you can't move."
+	desc = "Enter a state of thirst, gaining movement and healing on your next attack, scaling with missing blood. If your blood is below a certain %, you also knockdown your victim and drain some blood, during which you can't move."
 	cooldown_timer = 15 SECONDS
 	plasma_cost = 0
 	keybinding_signals = list(
@@ -404,7 +404,7 @@
 /datum/action/xeno_action/activable/feast
 	name = "Feast"
 	action_icon_state = "feast"
-	mechanics_text = "Enter a state of rejuvenation. During this time you use a small amount of blood and heal. You can cancel this early."
+	desc = "Enter a state of rejuvenation. During this time you use a small amount of blood and heal. You can cancel this early."
 	cooldown_timer = 180 SECONDS
 	plasma_cost = 0
 	keybinding_signals = list(

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -28,7 +28,7 @@
 /datum/action/xeno_action/toggle_speed
 	name = "Resin Walker"
 	action_icon_state = "toggle_speed"
-	mechanics_text = "Move faster on resin."
+	desc = "Move faster on resin."
 	plasma_cost = 50
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_RESIN_WALKER,
@@ -104,7 +104,7 @@
 /datum/action/xeno_action/build_tunnel
 	name = "Dig Tunnel"
 	action_icon_state = "build_tunnel"
-	mechanics_text = "Create a tunnel entrance. Use again to create the tunnel exit."
+	desc = "Create a tunnel entrance. Use again to create the tunnel exit."
 	plasma_cost = 200
 	cooldown_timer = 120 SECONDS
 	keybinding_signals = list(
@@ -193,7 +193,7 @@
 /datum/action/xeno_action/place_jelly_pod
 	name = "Place Resin Jelly pod"
 	action_icon_state = "resin_jelly_pod"
-	mechanics_text = "Place down a dispenser that allows xenos to retrieve fireproof jelly."
+	desc = "Place down a dispenser that allows xenos to retrieve fireproof jelly."
 	plasma_cost = 500
 	cooldown_timer = 1 MINUTES
 	keybinding_signals = list(
@@ -233,7 +233,7 @@
 /datum/action/xeno_action/create_jelly
 	name = "Create Resin Jelly"
 	action_icon_state = "resin_jelly"
-	mechanics_text = "Create a fireproof jelly."
+	desc = "Create a fireproof jelly."
 	plasma_cost = 100
 	cooldown_timer = 20 SECONDS
 	keybinding_signals = list(
@@ -262,7 +262,7 @@
 /datum/action/xeno_action/activable/healing_infusion
 	name = "Healing Infusion"
 	action_icon_state = "healing_infusion"
-	mechanics_text = "Psychically infuses a friendly xeno with regenerative energies, greatly improving its natural healing. Doesn't work if the target can't naturally heal."
+	desc = "Psychically infuses a friendly xeno with regenerative energies, greatly improving its natural healing. Doesn't work if the target can't naturally heal."
 	cooldown_timer = 12.5 SECONDS
 	plasma_cost = 200
 	keybinding_signals = list(
@@ -343,7 +343,7 @@
 /datum/action/xeno_action/sow
 	name = "Sow"
 	action_icon_state = "place_trap"
-	mechanics_text = "Sow the seeds of an alien plant."
+	desc = "Sow the seeds of an alien plant."
 	plasma_cost = 200
 	cooldown_timer = 45 SECONDS
 	use_state_flags = XACT_USE_LYING

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
@@ -1,7 +1,7 @@
 /datum/action/xeno_action/return_to_core
 	name = "Return to Core"
 	action_icon_state = "lay_hivemind"
-	mechanics_text = "Teleport back to your core."
+	desc = "Teleport back to your core."
 	use_state_flags = XACT_USE_CLOSEDTURF
 
 /datum/action/xeno_action/return_to_core/action_activate()
@@ -19,7 +19,7 @@
 /datum/action/xeno_action/change_form
 	name = "Change form"
 	action_icon_state = "manifest"
-	mechanics_text = "Change from your incorporal form to your physical on and vice-versa."
+	desc = "Change from your incorporal form to your physical on and vice-versa."
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOMORPH_HIVEMIND_CHANGE_FORM,
 	)
@@ -32,7 +32,7 @@
 /datum/action/xeno_action/activable/command_minions
 	name = "Command minions"
 	action_icon_state = "rally_minions"
-	mechanics_text = "Command all minions, ordering them to converge on this location."
+	desc = "Command all minions, ordering them to converge on this location."
 	ability_name = "command minions"
 	plasma_cost = 100
 	keybinding_signals = list(

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -4,7 +4,7 @@
 /datum/action/xeno_action/stealth
 	name = "Toggle Stealth"
 	action_icon_state = "stealth_on"
-	mechanics_text = "Become harder to see, almost invisible if you stand still, and ready a sneak attack. Uses plasma to move."
+	desc = "Become harder to see, almost invisible if you stand still, and ready a sneak attack. Uses plasma to move."
 	ability_name = "stealth"
 	plasma_cost = 10
 	keybinding_signals = list(
@@ -200,7 +200,7 @@
 
 /datum/action/xeno_action/stealth/disguise
 	name = "Disguise"
-	mechanics_text = "Disguise yourself as the enemy. Uses plasma to move. Select your disguise with Hunter's Mark."
+	desc = "Disguise yourself as the enemy. Uses plasma to move. Select your disguise with Hunter's Mark."
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_TOGGLE_DISGUISE,
 	)
@@ -262,7 +262,7 @@
 /datum/action/xeno_action/activable/hunter_mark
 	name = "Hunter's Mark"
 	action_icon_state = "hunter_mark"
-	mechanics_text = "Psychically mark a creature you have line of sight to, allowing you to sense its direction, distance and location with Psychic Trace."
+	desc = "Psychically mark a creature you have line of sight to, allowing you to sense its direction, distance and location with Psychic Trace."
 	plasma_cost = 25
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_HUNTER_MARK,
@@ -345,7 +345,7 @@
 /datum/action/xeno_action/psychic_trace
 	name = "Psychic Trace"
 	action_icon_state = "toggle_queen_zoom"
-	mechanics_text = "Psychically ping the creature you marked, letting you know its direction, distance and location, and general condition."
+	desc = "Psychically ping the creature you marked, letting you know its direction, distance and location, and general condition."
 	plasma_cost = 1 //Token amount
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_PSYCHIC_TRACE,
@@ -414,7 +414,7 @@
 /datum/action/xeno_action/mirage
 	name = "Mirage"
 	action_icon_state = "mirror_image"
-	mechanics_text = "Create mirror images of ourselves. Reactivate to swap with an illusion."
+	desc = "Create mirror images of ourselves. Reactivate to swap with an illusion."
 	ability_name = "mirage"
 	plasma_cost = 50
 	keybinding_signals = list(

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
@@ -6,7 +6,7 @@
 	name = "Nightfall"
 	action_icon_state = "nightfall"
 	ability_name = "Nightfall"
-	mechanics_text = "Shut down all electrical lights nearby for 10 seconds."
+	desc = "Shut down all electrical lights nearby for 10 seconds."
 	cooldown_timer = 45 SECONDS
 	plasma_cost = 100
 	keybinding_signals = list(
@@ -39,7 +39,7 @@
 /datum/action/xeno_action/activable/gravity_crush
 	name = "Gravity Crush"
 	action_icon_state = "fortify"
-	mechanics_text = "Increases the localized gravity in an area and crushes everything in it."
+	desc = "Increases the localized gravity in an area and crushes everything in it."
 	ability_name = "Gravity crush"
 	plasma_cost = 200
 	cooldown_timer = 30 SECONDS
@@ -133,7 +133,7 @@
 /datum/action/xeno_action/psychic_summon
 	name = "Psychic Summon"
 	action_icon_state = "stomp"
-	mechanics_text = "Summons all xenos in a hive to the caller's location, uses all plasma to activate."
+	desc = "Summons all xenos in a hive to the caller's location, uses all plasma to activate."
 	ability_name = "Psychic summon"
 	plasma_cost = 900 //uses all an young kings plasma
 	cooldown_timer = 10 MINUTES

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -4,7 +4,7 @@
 /datum/action/xeno_action/activable/spray_acid/cone
 	name = "Spray Acid Cone"
 	action_icon_state = "spray_acid"
-	mechanics_text = "Spray a cone of dangerous acid at your target."
+	desc = "Spray a cone of dangerous acid at your target."
 	ability_name = "spray acid"
 	plasma_cost = 300
 	cooldown_timer = 40 SECONDS
@@ -130,7 +130,7 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 /datum/action/xeno_action/activable/acid_dash
 	name = "Acid Dash"
 	action_icon_state = "charge"
-	mechanics_text = "Instantly dash, tackling the first marine in your path. If you manage to tackle someone, gain another weaker cast of the ability."
+	desc = "Instantly dash, tackling the first marine in your path. If you manage to tackle someone, gain another weaker cast of the ability."
 	ability_name = "acid dash"
 	plasma_cost = 250
 	cooldown_timer = 30 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -4,7 +4,7 @@
 /datum/action/xeno_action/hive_message
 	name = "Hive Message" // Also known as Word of Queen.
 	action_icon_state = "queen_order"
-	mechanics_text = "Announces a message to the hive."
+	desc = "Announces a message to the hive."
 	plasma_cost = 50
 	cooldown_timer = 10 SECONDS
 	keybinding_signals = list(
@@ -64,7 +64,7 @@
 /datum/action/xeno_action/activable/screech
 	name = "Screech"
 	action_icon_state = "screech"
-	mechanics_text = "A large area knockdown that causes pain and screen-shake."
+	desc = "A large area knockdown that causes pain and screen-shake."
 	ability_name = "screech"
 	plasma_cost = 250
 	cooldown_timer = 100 SECONDS
@@ -131,7 +131,7 @@
 /datum/action/xeno_action/watch_xeno
 	name = "Watch Xenomorph"
 	action_icon_state = "watch_xeno"
-	mechanics_text = "See from the target Xenomorphs vision. Click again the ability to stop observing"
+	desc = "See from the target Xenomorphs vision. Click again the ability to stop observing"
 	plasma_cost = 0
 	use_state_flags = XACT_USE_LYING
 	var/overwatch_active = FALSE
@@ -221,7 +221,7 @@
 /datum/action/xeno_action/toggle_queen_zoom
 	name = "Toggle Queen Zoom"
 	action_icon_state = "toggle_queen_zoom"
-	mechanics_text = "Zoom out for a larger view around wherever you are looking."
+	desc = "Zoom out for a larger view around wherever you are looking."
 	plasma_cost = 0
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_TOGGLE_QUEEN_ZOOM,
@@ -268,7 +268,7 @@
 /datum/action/xeno_action/set_xeno_lead
 	name = "Choose/Follow Xenomorph Leaders"
 	action_icon_state = "xeno_lead"
-	mechanics_text = "Make a target Xenomorph a leader."
+	desc = "Make a target Xenomorph a leader."
 	plasma_cost = 200
 	use_state_flags = XACT_USE_LYING
 
@@ -338,7 +338,7 @@
 /datum/action/xeno_action/activable/psychic_cure/queen_give_heal
 	name = "Heal"
 	action_icon_state = "heal_xeno"
-	mechanics_text = "Apply a minor heal to the target."
+	desc = "Apply a minor heal to the target."
 	cooldown_timer = 5 SECONDS
 	plasma_cost = 150
 	keybinding_signals = list(
@@ -377,7 +377,7 @@
 /datum/action/xeno_action/activable/queen_give_plasma
 	name = "Give Plasma"
 	action_icon_state = "queen_give_plasma"
-	mechanics_text = "Give plasma to a target Xenomorph (you must be overwatching them.)"
+	desc = "Give plasma to a target Xenomorph (you must be overwatching them.)"
 	plasma_cost = 150
 	cooldown_timer = 8 SECONDS
 	keybinding_signals = list(
@@ -443,7 +443,7 @@
 /datum/action/xeno_action/deevolve
 	name = "De-Evolve a Xenomorph"
 	action_icon_state = "xeno_deevolve"
-	mechanics_text = "De-evolve a target Xenomorph of Tier 2 or higher to the next lowest tier."
+	desc = "De-evolve a target Xenomorph of Tier 2 or higher to the next lowest tier."
 	plasma_cost = 600
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_DEEVOLVE,

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -4,7 +4,7 @@
 /datum/action/xeno_action/activable/charge
 	name = "Eviscerating Charge"
 	action_icon_state = "charge"
-	mechanics_text = "Charge up to 4 tiles and viciously attack your target."
+	desc = "Charge up to 4 tiles and viciously attack your target."
 	ability_name = "charge"
 	cooldown_timer = 20 SECONDS
 	plasma_cost = 500 //Can't ignore pain/Charge and ravage in the same timeframe, but you can combo one of them.
@@ -86,7 +86,7 @@
 /datum/action/xeno_action/activable/ravage
 	name = "Ravage"
 	action_icon_state = "ravage"
-	mechanics_text = "Attacks and knockbacks enemies in the direction your facing."
+	desc = "Attacks and knockbacks enemies in the direction your facing."
 	ability_name = "ravage"
 	plasma_cost = 200
 	cooldown_timer = 6 SECONDS
@@ -154,7 +154,7 @@
 /datum/action/xeno_action/endure
 	name = "Endure"
 	action_icon_state = "ignore_pain"
-	mechanics_text = "For the next few moments you will not go into crit and become resistant to explosives and immune to stagger and slowdown, but you still die if you take damage exceeding your crit health."
+	desc = "For the next few moments you will not go into crit and become resistant to explosives and immune to stagger and slowdown, but you still die if you take damage exceeding your crit health."
 	ability_name = "Endure"
 	plasma_cost = 200
 	cooldown_timer = 60 SECONDS
@@ -261,7 +261,7 @@
 /datum/action/xeno_action/rage
 	name = "Rage"
 	action_icon_state = "rage"
-	mechanics_text = "Use while at 50% health or lower to gain extra slash damage, resistances and speed in proportion to your missing hit points. This bonus is increased and you regain plasma while your HP is negative."
+	desc = "Use while at 50% health or lower to gain extra slash damage, resistances and speed in proportion to your missing hit points. This bonus is increased and you regain plasma while your HP is negative."
 	ability_name = "Rage"
 	plasma_cost = 0 //We're limited by cooldowns, not plasma
 	cooldown_timer = 60 SECONDS
@@ -452,7 +452,7 @@
 /datum/action/xeno_action/vampirism
 	name = "Toggle vampirism"
 	action_icon_state = "rage"
-	mechanics_text = "Toggle on to enable boosting on "
+	desc = "Toggle on to enable boosting on "
 	ability_name = "Vampirism"
 	plasma_cost = 0 //We're limited by nothing, rip and tear
 	cooldown_timer = 1 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -4,7 +4,7 @@
 /datum/action/xeno_action/toggle_savage
 	name = "Toggle Savage"
 	action_icon_state = "savage_on"
-	mechanics_text = "Toggle on to add a vicious attack to your pounce."
+	desc = "Toggle on to add a vicious attack to your pounce."
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_TOGGLE_SAVAGE,
 	)
@@ -70,7 +70,7 @@
 /datum/action/xeno_action/activable/pounce
 	name = "Pounce"
 	action_icon_state = "pounce"
-	mechanics_text = "Leap at your target, tackling and disarming them."
+	desc = "Leap at your target, tackling and disarming them."
 	ability_name = "pounce"
 	plasma_cost = 10
 	keybinding_signals = list(
@@ -208,7 +208,7 @@
 /datum/action/xeno_action/evasion
 	name = "Evasion"
 	action_icon_state = "evasion"
-	mechanics_text = "Take evasive action, forcing non-friendly projectiles that would hit you to miss for a short duration so long as you keep moving."
+	desc = "Take evasive action, forcing non-friendly projectiles that would hit you to miss for a short duration so long as you keep moving."
 	plasma_cost = 75
 	cooldown_timer = 10 SECONDS
 	keybinding_signals = list(
@@ -403,7 +403,7 @@
 /datum/action/xeno_action/activable/snatch
 	name = "Snatch"
 	action_icon_state = "snatch"
-	mechanics_text = "Take an item equipped by your target in your mouth, and carry it away."
+	desc = "Take an item equipped by your target in your mouth, and carry it away."
 	plasma_cost = 75
 	cooldown_timer = 60 SECONDS
 	keybinding_signals = list(

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -3,7 +3,7 @@
 // ***************************************
 /datum/action/xeno_action/activable/xeno_spit/toxic_spit
 	name = "Toxic Spit"
-	mechanics_text = "Spit a toxin at your target up to 7 tiles away, inflicting the Intoxicated debuff and dealing damage over time."
+	desc = "Spit a toxin at your target up to 7 tiles away, inflicting the Intoxicated debuff and dealing damage over time."
 	ability_name = "toxic spit"
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_TOXIC_SPIT,
@@ -51,7 +51,7 @@
 /datum/action/xeno_action/toxic_slash
 	name = "Toxic Slash"
 	action_icon_state = "neuroclaws_off"
-	mechanics_text = "Imbue your claws with acid for a short duration, inflicting lasting effects on your victims."
+	desc = "Imbue your claws with acid for a short duration, inflicting lasting effects on your victims."
 	ability_name = "toxic slash"
 	cooldown_timer = 10 SECONDS
 	plasma_cost = 100
@@ -142,7 +142,7 @@
 /datum/action/xeno_action/activable/drain_sting
 	name = "Drain Sting"
 	action_icon_state = "neuro_sting"
-	mechanics_text = "Sting your victim, draining them and gaining benefits if they are Intoxicated."
+	desc = "Sting your victim, draining them and gaining benefits if they are Intoxicated."
 	ability_name = "drain sting"
 	cooldown_timer = 25 SECONDS
 	plasma_cost = 75
@@ -209,7 +209,7 @@
 /datum/action/xeno_action/activable/toxic_grenade
 	name = "Toxic grenade"
 	action_icon_state = "gas mine"
-	mechanics_text = "Throws a lump of compressed acidic gases, which will inflict damage over time and Intoxicate victims."
+	desc = "Throws a lump of compressed acidic gases, which will inflict damage over time and Intoxicate victims."
 	plasma_cost = 200
 	cooldown_timer = 50 SECONDS
 	keybinding_signals = list(

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -56,7 +56,7 @@
 /datum/action/xeno_action/activable/psychic_fling
 	name = "Psychic Fling"
 	action_icon_state = "fling"
-	mechanics_text = "Sends an enemy or an item flying. A close ranged ability."
+	desc = "Sends an enemy or an item flying. A close ranged ability."
 	cooldown_timer = 12 SECONDS
 	plasma_cost = 100
 	keybinding_signals = list(
@@ -139,7 +139,7 @@
 /datum/action/xeno_action/activable/unrelenting_force
 	name = "Unrelenting Force"
 	action_icon_state = "screech"
-	mechanics_text = "Unleashes our raw psychic power, pushing aside anyone who stands in our path."
+	desc = "Unleashes our raw psychic power, pushing aside anyone who stands in our path."
 	cooldown_timer = 50 SECONDS
 	plasma_cost = 300
 	keybind_flags = XACT_KEYBIND_USE_ABILITY | XACT_IGNORE_SELECTED_ABILITY
@@ -220,7 +220,7 @@
 /datum/action/xeno_action/activable/psychic_cure
 	name = "Psychic Cure"
 	action_icon_state = "heal_xeno"
-	mechanics_text = "Heal and remove debuffs from a target."
+	desc = "Heal and remove debuffs from a target."
 	cooldown_timer = 1 MINUTES
 	plasma_cost = 200
 	keybinding_signals = list(
@@ -304,7 +304,7 @@
 /datum/action/xeno_action/place_acidwell
 	name = "Place acid well"
 	action_icon_state = "place_trap"
-	mechanics_text = "Place an acid well that can put out fires."
+	desc = "Place an acid well that can put out fires."
 	plasma_cost = 400
 	cooldown_timer = 2 MINUTES
 	keybinding_signals = list(
@@ -345,7 +345,7 @@
 /datum/action/xeno_action/activable/gravity_grenade
 	name = "Throw gravity grenade"
 	action_icon_state = "gas mine"
-	mechanics_text = "Throw a gravity grenades thats sucks everyone and everything in a radius inward."
+	desc = "Throw a gravity grenades thats sucks everyone and everything in a radius inward."
 	plasma_cost = 500
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_GRAV_NADE,

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
@@ -4,7 +4,7 @@
 /datum/action/xeno_action/activable/spray_acid/line
 	name = "Spray Acid"
 	action_icon_state = "spray_acid"
-	mechanics_text = "Spray a line of dangerous acid at your target."
+	desc = "Spray a line of dangerous acid at your target."
 	ability_name = "spray acid"
 	plasma_cost = 250
 	cooldown_timer = 30 SECONDS
@@ -106,7 +106,7 @@
 /datum/action/xeno_action/activable/scatter_spit
 	name = "Scatter Spit"
 	action_icon_state = "scatter_spit"
-	mechanics_text = "Spits a spread of acid projectiles that splatter on the ground."
+	desc = "Spits a spread of acid projectiles that splatter on the ground."
 	ability_name = "scatter spit"
 	plasma_cost = 280
 	cooldown_timer = 5 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -52,7 +52,7 @@
 	name = "Psychic Shield"
 	ability_name = "psychic shield"
 	action_icon_state = "psy_shield"
-	mechanics_text = "Channel a psychic shield at your current location that can reflect most projectiles. Activate again while the shield is active to detonate the shield forcibly, producing knockback. Must remain static to use."
+	desc = "Channel a psychic shield at your current location that can reflect most projectiles. Activate again while the shield is active to detonate the shield forcibly, producing knockback. Must remain static to use."
 	cooldown_timer = 10 SECONDS
 	plasma_cost = 200
 	keybinding_signals = list(
@@ -243,7 +243,7 @@
 /datum/action/xeno_action/activable/psy_crush
 	name = "Psychic Crush"
 	action_icon_state = "psy_crush"
-	mechanics_text = "Channel an expanding AOE crush effect, activating it again pre-maturely crushes enemies over an area. The longer it is channeled, the larger area it will affect, but will consume more plasma."
+	desc = "Channel an expanding AOE crush effect, activating it again pre-maturely crushes enemies over an area. The longer it is channeled, the larger area it will affect, but will consume more plasma."
 	ability_name = "psychic crush"
 	plasma_cost = 40
 	cooldown_timer = 12 SECONDS
@@ -470,7 +470,7 @@
 /datum/action/xeno_action/activable/psy_blast
 	name = "Psychic Blast"
 	action_icon_state = "psy_blast"
-	mechanics_text = "Launch a blast of psychic energy that deals light damage and knocks back enemies in its AOE. Must remain stationary for a few seconds to use."
+	desc = "Launch a blast of psychic energy that deals light damage and knocks back enemies in its AOE. Must remain stationary for a few seconds to use."
 	ability_name = "psychic blast"
 	cooldown_timer = 6 SECONDS
 	plasma_cost = 230

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -4,7 +4,7 @@
 /datum/action/xeno_action/toggle_agility
 	name = "Toggle Agility"
 	action_icon_state = "agility_on"
-	mechanics_text = "Move an all fours for greater speed. Cannot use abilities while in this mode."
+	desc = "Move an all fours for greater speed. Cannot use abilities while in this mode."
 	ability_name = "toggle agility"
 	cooldown_timer = 0.5 SECONDS
 	use_state_flags = XACT_USE_AGILITY
@@ -56,7 +56,7 @@
 /datum/action/xeno_action/activable/lunge
 	name = "Lunge"
 	action_icon_state = "lunge"
-	mechanics_text = "Pounce up to 5 tiles and grab a target, knocking them down and putting them in your grasp."
+	desc = "Pounce up to 5 tiles and grab a target, knocking them down and putting them in your grasp."
 	ability_name = "lunge"
 	plasma_cost = 25
 	cooldown_timer = 20 SECONDS
@@ -169,7 +169,7 @@
 /datum/action/xeno_action/activable/fling
 	name = "Fling"
 	action_icon_state = "fling"
-	mechanics_text = "Knock a target flying up to 5 tiles away."
+	desc = "Knock a target flying up to 5 tiles away."
 	ability_name = "fling"
 	plasma_cost = 18
 	cooldown_timer = 20 SECONDS //Shared cooldown with Grapple Toss
@@ -270,7 +270,7 @@
 /datum/action/xeno_action/activable/toss
 	name = "Grapple Toss"
 	action_icon_state = "grapple_toss"
-	mechanics_text = "Throw a creature you're grappling up to 3 tiles away."
+	desc = "Throw a creature you're grappling up to 3 tiles away."
 	ability_name = "grapple toss"
 	plasma_cost = 18
 	cooldown_timer = 20 SECONDS //Shared cooldown with Fling
@@ -348,7 +348,7 @@
 /datum/action/xeno_action/activable/punch
 	name = "Punch"
 	action_icon_state = "punch"
-	mechanics_text = "Strike a target, inflicting stamina damage, stagger and slowdown. Deals double damage, stagger and slowdown to grappled targets. Deals quadruple damage to structures and machinery."
+	desc = "Strike a target, inflicting stamina damage, stagger and slowdown. Deals double damage, stagger and slowdown to grappled targets. Deals quadruple damage to structures and machinery."
 	ability_name = "punch"
 	plasma_cost = 12
 	cooldown_timer = 10 SECONDS
@@ -562,7 +562,7 @@
 /datum/action/xeno_action/activable/punch/jab
 	name = "Jab"
 	action_icon_state = "jab"
-	mechanics_text = "Precisely strike your target from further away, heavily slowing them."
+	desc = "Precisely strike your target from further away, heavily slowing them."
 	plasma_cost = 10
 	range = 2
 	keybinding_signals = list(

--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
@@ -1,7 +1,7 @@
 /datum/action/xeno_action/activable/web_spit
 	name = "Web Spit"
 	ability_name = "Web Spit"
-	mechanics_text = "Spit a web to your target, this causes different effects depending on where you hit. Spitting the head causes the target to be temporarily blind, body and arms will cause the target to be weakened, and legs will snare the target for a brief while."
+	desc = "Spit a web to your target, this causes different effects depending on where you hit. Spitting the head causes the target to be temporarily blind, body and arms will cause the target to be weakened, and legs will snare the target for a brief while."
 	action_icon_state = "web_spit"
 	plasma_cost = 125
 	cooldown_timer = 10 SECONDS
@@ -28,7 +28,7 @@
 /datum/action/xeno_action/activable/leash_ball
 	name = "Leash Ball"
 	ability_name = "Leash Ball"
-	mechanics_text = "Spit a huge web ball that snares groups of targets for a brief while."
+	desc = "Spit a huge web ball that snares groups of targets for a brief while."
 	action_icon_state = "leash_ball"
 	plasma_cost = 250
 	cooldown_timer = 20 SECONDS
@@ -128,7 +128,7 @@
 /datum/action/xeno_action/create_spiderling
 	name = "Birth Spiderling"
 	ability_name = "birth_spiderling"
-	mechanics_text = "Give birth to a spiderling after a short charge-up. The spiderlings will follow you until death. You can only deploy 5 spiderlings at one time."
+	desc = "Give birth to a spiderling after a short charge-up. The spiderlings will follow you until death. You can only deploy 5 spiderlings at one time."
 	action_icon_state = "spawn_spiderling"
 	plasma_cost = 100
 	cooldown_timer = 15 SECONDS
@@ -173,7 +173,7 @@
 /datum/action/xeno_action/burrow
 	name = "Burrow"
 	ability_name = "Burrow"
-	mechanics_text = "Burrow into the ground, allowing you and your active spiderlings to hide in plain sight. You cannot use abilities, attack nor move while burrowed. Use the ability again to unburrow if you're already burrowed."
+	desc = "Burrow into the ground, allowing you and your active spiderlings to hide in plain sight. You cannot use abilities, attack nor move while burrowed. Use the ability again to unburrow if you're already burrowed."
 	action_icon_state = "burrow"
 	plasma_cost = 0
 	cooldown_timer = 20 SECONDS
@@ -239,7 +239,7 @@
 /datum/action/xeno_action/attach_spiderlings
 	name = "Attach Spiderlings"
 	ability_name = "Attach Spiderlings"
-	mechanics_text = "Attach your current spiderlings to you "
+	desc = "Attach your current spiderlings to you "
 	action_icon_state = "attach_spiderling"
 	plasma_cost = 0
 	cooldown_timer = 0 SECONDS
@@ -283,7 +283,7 @@
 /datum/action/xeno_action/activable/web_hook
 	name = "Web Hook"
 	ability_name = "Web Hook"
-	mechanics_text = "Shoot out a web and pull it to traverse forward"
+	desc = "Shoot out a web and pull it to traverse forward"
 	action_icon_state = "web_hook"
 	plasma_cost = 200
 	cooldown_timer = 10 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -10,7 +10,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	name = "Blink"
 	action_icon_state = "blink"
 	ability_name = "Blink"
-	mechanics_text = "We teleport ourselves a short distance to a location within line of sight."
+	desc = "We teleport ourselves a short distance to a location within line of sight."
 	use_state_flags = XABB_TURF_TARGET
 	plasma_cost = 30
 	cooldown_timer = 0.5 SECONDS
@@ -150,7 +150,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	name = "Banish"
 	action_icon_state = "Banish"
 	ability_name = "Banish"
-	mechanics_text = "We banish a target object or creature within line of sight to nullspace for a short duration. Can target onself and allies. Non-friendlies are banished for half as long."
+	desc = "We banish a target object or creature within line of sight to nullspace for a short duration. Can target onself and allies. Non-friendlies are banished for half as long."
 	use_state_flags = XACT_TARGET_SELF
 	plasma_cost = 50
 	cooldown_timer = 20 SECONDS
@@ -342,7 +342,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	name = "Recall"
 	ability_name = "Recall"
 	action_icon_state = "Recall"
-	mechanics_text = "We recall a target we've banished back from the depths of nullspace."
+	desc = "We recall a target we've banished back from the depths of nullspace."
 	use_state_flags = XACT_USE_NOTTURF|XACT_USE_CLOSEDTURF|XACT_USE_STAGGERED|XACT_USE_INCAP|XACT_USE_LYING //So we can recall ourselves from nether Brazil
 	cooldown_timer = 1 SECONDS //Token for anti-spam
 	keybinding_signals = list(
@@ -403,7 +403,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	name = "Time stop"
 	ability_name = "Time stop"
 	action_icon_state = "time_stop"
-	mechanics_text = "Freezes bullets in their course, and they will start to move again only after a certain time"
+	desc = "Freezes bullets in their course, and they will start to move again only after a certain time"
 	plasma_cost = 100
 	cooldown_timer = 1 MINUTES
 	keybinding_signals = list(
@@ -446,7 +446,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	name = "Portal"
 	ability_name = "Portal"
 	action_icon_state = "portal"
-	mechanics_text = "Place a portal on your location. You can travel from portal to portal. Left click to create portal one, right click to create portal two"
+	desc = "Place a portal on your location. You can travel from portal to portal. Left click to create portal one, right click to create portal two"
 	plasma_cost = 50
 	cooldown_timer = 5 SECONDS
 	keybinding_signals = list(
@@ -630,7 +630,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	name = "Time Shift"
 	ability_name = "Time Shift"
 	action_icon_state = "rewind"
-	mechanics_text = "Save the location and status of the target. When the time is up, the target location and status are restored"
+	desc = "Save the location and status of the target. When the time is up, the target location and status are restored"
 	plasma_cost = 100
 	cooldown_timer = 30 SECONDS
 	keybinding_signals = list(

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -15,7 +15,7 @@
 /datum/action/xeno_action/ready_charge
 	name = "Toggle Charging"
 	action_icon_state = "ready_charge"
-	mechanics_text = "Toggles the movement-based charge on and off."
+	desc = "Toggles the movement-based charge on and off."
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_TOGGLE_CHARGE,
 	)

--- a/code/modules/mob/living/carbon/xenomorph/evo_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evo_datum.dm
@@ -28,7 +28,7 @@
 			continue
 		.["abilities"]["[ability]"] = list(
 			"name" = initial(xeno_ability.name),
-			"desc" = initial(xeno_ability.mechanics_text),
+			"desc" = initial(xeno_ability.desc),
 			"cost" = initial(xeno_ability.plasma_cost),
 			"cooldown" = (initial(xeno_ability.cooldown_timer) / 10)
 		)
@@ -42,7 +42,7 @@
 				continue
 			caste_data["abilities"]["[ability]"] = list(
 				"name" = initial(xeno_ability.name),
-				"desc" = initial(xeno_ability.mechanics_text),
+				"desc" = initial(xeno_ability.desc),
 				"cost" = initial(xeno_ability.plasma_cost),
 				"cooldown" = (initial(xeno_ability.cooldown_timer) / 10)
 			)


### PR DESCRIPTION
## About The Pull Request

Adds descriptions to buttons of xeno abilities, makes codex use _desc_ variable rather then _mechanics_text_, and removes _mechanics_text_ variable.

## Why It's Good For The Game

Makes more easy for new players to understand what abilities do

## Changelog

:cl:
qol: Adds descriptions for buttons used by xeno abilities
/:cl: