### PR TITLE
Xenos no longer get interrupted on psydraining

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1162,10 +1162,6 @@
 		return FALSE
 	if(!X.Adjacent(victim)) //checks if owner next to target
 		return FALSE
-	if(X.on_fire)
-		if(!silent)
-			to_chat(X, span_warning("We're too busy being on fire to do this!"))
-		return FALSE
 	if(victim.stat != DEAD)
 		if(!silent)
 			to_chat(X, span_warning("This creature is struggling too much for us to drain its life force."))
@@ -1187,7 +1183,7 @@
 	span_danger("We slowly drain \the [victim]'s life force!"), null, 20)
 	var/channel = SSsounds.random_available_channel()
 	playsound(X, 'sound/magic/nightfall.ogg', 40, channel = channel)
-	if(!do_after(X, 5 SECONDS, FALSE, victim, BUSY_ICON_DANGER, extra_checks = CALLBACK(X, /mob.proc/break_do_after_checks, list("health" = X.health))))
+	if(!do_after(X, 5 SECONDS, FALSE, victim, BUSY_ICON_DANGER))
 		X.visible_message(span_xenowarning("\The [X] retracts its inner jaw."), \
 		span_danger("We retract our inner jaw."), null, 20)
 		X.stop_sound_channel(channel)


### PR DESCRIPTION

## About The Pull Request
Psydrain (But not cocooning) no longer are interrupted if the xeno is on fire or taking damage.

## Why It's Good For The Game
Xenos have trouble having kills be meaningful if they can't apply the cloneloss damage before the marine gets revived, and this is impossible if there's a marine on screen with half a braincell to shoot and interrupt said psydrain. This is made worse by how you can now heal cloneloss by just sleeping, so the marine doesn't even need to go shipside anymore, and gets healed even faster with a bed and blanket.

Now xenos might be able to land a few psydrains midcombat to actually make the deaths matter before marines recover their bodies. If marines can't recover them, well nothing really changes honestly.

## Changelog

:cl:
balance: Xeno psydrain will no longer be interrupted by fire or damage. Cocoon remains interruptible.
/:cl:

