### PR TITLE
Rebalances a few guns strange sundering values

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -814,7 +814,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 50
 	damage_falloff = 0.5
 	penetration = 15
-	sundering = 7
+	sundering = 6
 
 /datum/ammo/bullet/shotgun/flechette_spread
 	name = "additional flechette"
@@ -826,7 +826,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 40
 	damage_falloff = 1
 	penetration = 25
-	sundering = 5
+	sundering = 4
 
 /datum/ammo/bullet/shotgun/buckshot
 	name = "shotgun buckshot shell"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -694,7 +694,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	max_range = 40
 	damage = 65
 	penetration = 15
-	sundering = 2
+	sundering = 3.5
 
 /datum/ammo/bullet/rifle/standard_br
 	name = "light marksman bullet"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -616,7 +616,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "revolver_heavy"
 	damage = 70
 	penetration = 20
-	sundering = 1.25
+	sundering = 5
 
 /datum/ammo/bullet/rifle/repeater/on_hit_mob(mob/M, obj/projectile/P)
 	staggerstun(M, P, max_range = 3, slowdown = 2, stagger = 1)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -355,7 +355,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 20
 	penetration = 12.5
 	shrapnel_chance = 25
-	sundering = 2
+	sundering = 1.25
 
 /datum/ammo/bullet/pistol/heavy
 	name = "heavy pistol bullet"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1062,7 +1062,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	max_range = 40
 	damage = 90
 	penetration = 50
-	sundering = 15
+	sundering = 12.5
 
 /datum/ammo/bullet/sniper/incendiary
 	name = "incendiary sniper bullet"
@@ -1094,7 +1094,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	handful_amount = 5
 	damage = 75
 	penetration = 35
-	sundering = 15
+	sundering = 12.5
 
 /datum/ammo/bullet/sniper/martini
 	name = "crude heavy sniper bullet"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -616,7 +616,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "revolver_heavy"
 	damage = 70
 	penetration = 20
-	sundering = 5
+	sundering = 3.5
 
 /datum/ammo/bullet/rifle/repeater/on_hit_mob(mob/M, obj/projectile/P)
 	staggerstun(M, P, max_range = 3, slowdown = 2, stagger = 1)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1062,7 +1062,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	max_range = 40
 	damage = 90
 	penetration = 50
-	sundering = 12.5
+	sundering = 15
 
 /datum/ammo/bullet/sniper/incendiary
 	name = "incendiary sniper bullet"
@@ -1094,7 +1094,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	handful_amount = 5
 	damage = 75
 	penetration = 35
-	sundering = 12.5
+	sundering = 15
 
 /datum/ammo/bullet/sniper/martini
 	name = "crude heavy sniper bullet"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1104,7 +1104,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	damage = 120
 	penetration = 20
-	sundering = 10
+	sundering = 15
 
 /datum/ammo/bullet/sniper/martini/on_hit_mob(mob/M, obj/projectile/P)
 	staggerstun(M, P, weaken = 1, stagger = 1, knockback = 2, slowdown = 0.5, max_range = 5)


### PR DESCRIPTION
## About The Pull Request
AS OF 2023/01/01 15:05 EST THIS PR HAS HAD ITS VALUES CHANGED, CHECK THE LIST

This PR changes the sundering values of some guns that frankly, made very little sense.

Flechette: 17 -> 14 ( 7 + 5 + 5 -> 6 + 4 + 4)
88Mod auto pistol: 2 -> 1.25 
Martini Henry: 10 -> 15
Repeater: 1.25 -> 3.5
DMR: 2 -> 3.5

## Why It's Good For The Game
Some balancing of the sunder was overall very fucky. I tried fixing up some of the stranger cases now that sunder is being examined more closely. Im a data dork and have charts if anyone wants to see comparisons, @ me on #balance

1 shot of 88mod was 4 times more sundering than a basic assault rifle
Martini Henry, a gun known for being extremely powerful/an elephant hunter is no longer worth 20 MP-19 shots
Repeater was worth the same amount as an AR-11, now it is worth 4 AR-11 shots
DMR, for being a DMR, didnt feel like only 2 sundering felt appropriate


## Changelog
:cl:
balance: flechette shells sundering changed from: 17 -> 14 ( 7+5+5 -> 6+4+4 )
balance: 88Mod auto pistol sundering changed: 2 -> 1.25 
balance: Martini Henry sundering changed: 10 -> 15
balance: Repeater sundering changed: 1.25 -> 3.5
balance: DMR sundering changed: 2 -> 3.5
/:cl:
