### PR TITLE
Confirmation for return to corpse if you are in larva queue

### DIFF
--- a/code/_onclick/hud/ghost.dm
+++ b/code/_onclick/hud/ghost.dm
@@ -34,6 +34,10 @@
 
 /atom/movable/screen/ghost/reenter_corpse/Click()
 	var/mob/dead/observer/G = usr
+	if(G.larva_position)
+		var/confirm = tgui_alert(usr, "Returning to your corpse will make you leave larva queue.", "Confirm.", list("Yes", "No"))
+		if(confirm == "No")
+			return
 	G.reenter_corpse()
 
 

--- a/code/_onclick/hud/ghost.dm
+++ b/code/_onclick/hud/ghost.dm
@@ -35,7 +35,7 @@
 /atom/movable/screen/ghost/reenter_corpse/Click()
 	var/mob/dead/observer/G = usr
 	if(G.larva_position)
-		var/confirm = tgui_alert(usr, "Returning to your corpse will make you leave larva queue.", "Confirm.", list("Yes", "No"))
+		var/confirm = tgui_alert(usr, "Returning to your corpse will make you leave the larva queue.", "Confirm.", list("Yes", "No"))
 		if(confirm == "No")
 			return
 	G.reenter_corpse()


### PR DESCRIPTION
## About The Pull Request

Adds a confirmation for returning to your corpse if you are in the larva queue, so you wouldn't accidentally go out of it. It appears only if you are in the larva queue, and if you are not it works as before.

## Why It's Good For The Game

People wouldn't accidentally loose their position in the queue if they unintentionally click on the corpse returning button or due to not knowing that returning to their corpse will make them out of it.

## Changelog

:cl:
qol: Returning to your corpse while being in larva queue will require a confirmation, so you wouldn't accidentally loose your place.
/:cl:
