### PR TITLE
feat: use vis flag to determine direction

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -143,17 +143,6 @@
 /atom/movable/vis_obj/xeno_wounds
 	icon = 'icons/Xeno/wound_overlays.dmi'
 	vis_flags = VIS_INHERIT_DIR
-	var/mob/living/carbon/xenomorph/wound_owner
-
-/atom/movable/vis_obj/xeno_wounds/Initialize(mapload, mob/living/carbon/xenomorph/owner)
-	. = ..()
-	if(owner)
-		wound_owner = owner
-
-/atom/movable/vis_obj/xeno_wounds/Destroy()
-	if(wound_owner)
-		wound_owner = null
-	return ..()
 
 /atom/movable/vis_obj/xeno_wounds/fire_overlay
 	icon = 'icons/Xeno/2x2_Xenos.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -107,6 +107,7 @@
 		return
 	var/health_thresholds
 	wound_overlay.layer = layer + 0.3
+	wound_overlay.vis_flags |= VIS_HIDE
 	if(HAS_TRAIT(src, TRAIT_MOB_ICON_UPDATE_BLOCKED))
 		wound_overlay.icon_state = "none"
 		return
@@ -132,6 +133,7 @@
 		wound_overlay.icon_state = "[xeno_caste.wound_type]_wounded_[health_thresholds]"
 	else
 		wound_overlay.icon_state = handle_special_wound_states(health_thresholds)
+	wound_overlay.vis_flags &= ~VIS_HIDE // Show the overlay
 
 /mob/living/carbon/xenomorph/update_transform()
 	..()
@@ -140,23 +142,18 @@
 ///Used to display the xeno wounds without rapidly switching overlays
 /atom/movable/vis_obj/xeno_wounds
 	icon = 'icons/Xeno/wound_overlays.dmi'
+	vis_flags = VIS_INHERIT_DIR
 	var/mob/living/carbon/xenomorph/wound_owner
 
 /atom/movable/vis_obj/xeno_wounds/Initialize(mapload, mob/living/carbon/xenomorph/owner)
 	. = ..()
 	if(owner)
 		wound_owner = owner
-		RegisterSignal(owner, COMSIG_ATOM_DIR_CHANGE, .proc/on_dir_change)
 
 /atom/movable/vis_obj/xeno_wounds/Destroy()
 	if(wound_owner)
 		wound_owner = null
 	return ..()
-
-/atom/movable/vis_obj/xeno_wounds/proc/on_dir_change(mob/living/carbon/xenomorph/source, olddir, newdir)
-	SIGNAL_HANDLER
-	if(newdir != dir)
-		dir = newdir
 
 /atom/movable/vis_obj/xeno_wounds/fire_overlay
 	icon = 'icons/Xeno/2x2_Xenos.dmi'


### PR DESCRIPTION

## About The Pull Request

Instead of using a signal to set the dir of the wounds overlay, we can just use the vis_flags of inherit dir from parent.
Additionally using the vis_hide flag for wounds when they have nothing to show.

This helps remove them from the right click menu (but they will return when xenos are hurt).

## Why It's Good For The Game
Just a cleanup

## Changelog
:cl:
code: removed an extraneous signal
refactor: hide xeno wounds when they have nothing to show
/:cl:
