### PR TITLE
Fixes storage getting stuck in mobs

### DIFF
--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -76,10 +76,12 @@
 		switch(over_object.name)
 			if("r_hand")
 				usr.temporarilyRemoveItemFromInventory(src)
-				usr.put_in_r_hand(src)
+				if(!usr.put_in_r_hand(src))
+					usr.dropItemToGround(src)
 			if("l_hand")
 				usr.temporarilyRemoveItemFromInventory(src)
-				usr.put_in_l_hand(src)
+				if(!usr.put_in_l_hand(src))
+					usr.dropItemToGround(src)
 
 /obj/item/storage/proc/return_inv()
 


### PR DESCRIPTION

## About The Pull Request
Unequipping storage into a full hand would remove it from any of your inventory slots but keep it inside the mob, where it was more or less stuck.
## Why It's Good For The Game
Fixes #11839 

## Changelog
:cl:
fix: Dragging equipped storage into an occupied hand won't leave the storage stuck unavailable
/:cl:
