### PR TITLE
Slows down cryo fracture healing

### DIFF
--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1166,6 +1166,8 @@
 	if(host.bodytemperature < 170)
 		for(var/datum/limb/limb_to_fix AS in host.limbs)
 			if(limb_to_fix.limb_status & (LIMB_BROKEN | LIMB_SPLINTED | LIMB_STABILIZED))
+				if(!(prob(10) || limb_to_fix.brute_dam > limb_to_fix.min_broken_damage))
+					continue //Once every 20s on average, but guaranteed if the limb'll just break again so we get maximum crunchtube.
 				limb_to_fix.remove_limb_flags(LIMB_BROKEN | LIMB_SPLINTED | LIMB_STABILIZED)
 				limb_to_fix.add_limb_flags(LIMB_REPAIRED)
 				break

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1166,8 +1166,8 @@
 	if(host.bodytemperature < 170)
 		for(var/datum/limb/limb_to_fix AS in host.limbs)
 			if(limb_to_fix.limb_status & (LIMB_BROKEN | LIMB_SPLINTED | LIMB_STABILIZED))
-				if(!(prob(10) || limb_to_fix.brute_dam > limb_to_fix.min_broken_damage))
-					continue //Once every 20s on average, but guaranteed if the limb'll just break again so we get maximum crunchtube.
+				if(!(prob(20) || limb_to_fix.brute_dam > limb_to_fix.min_broken_damage))
+					continue //Once every 10s average while active, but guaranteed if the limb'll just break again so we get maximum crunchtube.
 				limb_to_fix.remove_limb_flags(LIMB_BROKEN | LIMB_SPLINTED | LIMB_STABILIZED)
 				limb_to_fix.add_limb_flags(LIMB_REPAIRED)
 				break


### PR DESCRIPTION

## About The Pull Request
Reduces cryo fracture healing from one bone every 2 seconds to one every 10 on average. 'On average' because it runs on a prob(20). The fix is guaranteed if the limb has enough brute damage to just break again, because crunchtube is important.
>Why not just count ticks and fix it after a specific amount?

The way cryo injects reagents over time means that bhj isn't guaranteed to be in the body every tick. It'll run out after a bit and you'll get another dose a little later, so if healing duration was tracked on the chem it'd frequently reset without doing anything.
>What about tracking it on the limb then?

That builds complications into the question of 'is a limb broken', which is honestly annoying enough to answer as is, and sticks a system on them which is used entirely for one chem.
## Why It's Good For The Game
Not only is cryo better for fractures than any other treatment methods (surgery/autodoc), it's better by an order of magnitude. This brings it more in line to make the others more viable options when their requirements (available surgeon, a powered empty bed) are met. Autodoc's still a bunch worse, but surgery by someone competent should be a bit faster.
## Changelog
:cl:
balance: Cryo bone juice takes about ten seconds to heal a fracture, up from two
/:cl:
