### PR TITLE
Heads can always reattach

### DIFF
--- a/code/modules/mob/living/brain/brain.dm
+++ b/code/modules/mob/living/brain/brain.dm
@@ -19,3 +19,14 @@
 			death()
 		ghostize()
 	return ..()
+
+/mob/living/brain/ghost()
+	if(stat == DEAD)
+		ghostize(TRUE)
+		return
+
+	if(tgui_alert(src, "Are you sure you want to ghost?\n(You are alive, as much as a head can be. If you ghost, you won't be able to chat when you return unless someone revives you.)", "Ghost", list("Yes", "No")) != "Yes")
+		return
+
+	death()
+	ghostize(TRUE)

--- a/code/modules/organs/limb_objects.dm
+++ b/code/modules/organs/limb_objects.dm
@@ -70,7 +70,6 @@
 	resistance_flags = UNACIDABLE
 	var/mob/living/brain/brainmob
 	var/brain_item_type = /obj/item/organ/brain
-	var/braindeath_on_decap = 1 //whether the brainmob dies when head is decapitated (used by synthetics)
 
 /obj/item/limb/head/Initialize(mapload, mob/living/carbon/human/H)
 	. = ..()
@@ -104,7 +103,7 @@
 
 	H.regenerate_icons()
 
-	if(braindeath_on_decap)
+	if(!H.species.species_flags & DETACHABLE_HEAD)
 		brainmob.death()
 
 	GLOB.head_list += src
@@ -124,8 +123,6 @@
 //synthetic head, allowing brain mob inside to talk
 /obj/item/limb/head/synth
 	brain_item_type = null
-	braindeath_on_decap = 0
 
 /obj/item/limb/head/robotic
 	brain_item_type = null
-	braindeath_on_decap = 0

--- a/code/modules/organs/limb_objects.dm
+++ b/code/modules/organs/limb_objects.dm
@@ -103,7 +103,7 @@
 
 	H.regenerate_icons()
 
-	if(!H.species.species_flags & DETACHABLE_HEAD)
+	if(~H.species.species_flags & DETACHABLE_HEAD)
 		brainmob.death()
 
 	GLOB.head_list += src

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -1152,10 +1152,3 @@ Note that amputating the affected organ does in fact remove the infection from t
 	..()
 	face_surgery_stage = 0
 
-
-/datum/limb/head/droplimb(amputation, delete_limb = FALSE)
-	. = ..()
-	if(!.)
-		return
-	if(!(owner.species.species_flags & DETACHABLE_HEAD) && vital)
-		owner.set_undefibbable()

--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -69,7 +69,7 @@
 
 /datum/surgery_step/head/shape/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_notice("[user] has finished repositioning flesh and tissue to something anatomically recognizable where [target]'s head used to be with \the [tool]."),	\
-	span_notice("You have finished repositioning flesh and tissue to something anatomically recognizable where [target]'s head used to be with \the [tool]."))
+	span_notice("You have finished repositioning flesh and tissue to something anatomically recognizable with \the [tool]."))
 	target.balloon_alert_to_viewers("Success")
 	affected.limb_replacement_stage = 2
 
@@ -173,8 +173,8 @@
 	..()
 
 /datum/surgery_step/head/attach/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
-	user.visible_message(span_notice("[user] has attached [target]'s head to the body."),	\
-	span_notice("You have attached [target]'s head to the body."))
+	user.visible_message(span_notice("[user] has attached [tool] to the body."),	\
+	span_notice("You have attached [tool] to the body."))
 	target.balloon_alert_to_viewers("Success")
 
 	//Update our dear victim to have a head again
@@ -188,7 +188,7 @@
 	target.update_hair()
 
 	//Prepare mind datum
-	if(B.brainmob?.mind)
+	if(B?.brainmob?.mind)
 		B.brainmob.mind.transfer_to(target)
 
 	//Deal with the head item properly

--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -158,7 +158,7 @@
 
 /datum/surgery_step/head/attach/can_use(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected, checks_only)
 	var/obj/item/limb/head/head_to_attach = tool
-	if(head_to_attach.real_name != head?.brain_mob.real_name)
+	if(target.real_name != head_to_attach?.brainmob.real_name)
 		to_chat(user, span_warning("That's not the right head for that body, or the right body for that head!"))
 		return SURGERY_INVALID
 	if(..())

--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -187,6 +187,10 @@
 	target.UpdateDamageIcon()
 	target.update_hair()
 
+	var/mob/dead/observer/ghost = B?.brainmob.get_ghost() //If they can't reenter, this'll fail
+	if(ghost)
+		to_chat(ghost, "Someone's stuck your head back to the rest of you, dragging your soul with it.")
+		ghost.reenter_corpse() //But if they can, we need them back so the ghost weakrefs to the right mob later
 	//Prepare mind datum
 	if(B?.brainmob?.mind)
 		B.brainmob.mind.transfer_to(target)

--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -3,7 +3,6 @@
 /datum/surgery_step/head
 	priority = 1
 	can_infect = 0
-	allowed_species = list("Synthetic", "Early Synthetic", "Combat Robot")
 	var/reattach_step
 
 /datum/surgery_step/head/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected, checks_only)
@@ -151,13 +150,17 @@
 
 
 /datum/surgery_step/head/attach
-	allowed_tools = list(/obj/item/limb/head/synth = 100, /obj/item/limb/head/robotic = 100)
+	allowed_tools = list(/obj/item/limb/head = 100)
 	can_infect = 0
 	min_duration = 60
 	max_duration = 80
 	reattach_step = 0
 
 /datum/surgery_step/head/attach/can_use(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected, checks_only)
+	var/obj/item/limb/head/head_to_attach = tool
+	if(head_to_attach.real_name != head?.brain_mob.real_name)
+		to_chat(user, span_warning("That's not the right head for that body, or the right body for that head!"))
+		return SURGERY_INVALID
 	if(..())
 		if(affected.limb_status & LIMB_AMPUTATED)
 			return SURGERY_CAN_USE
@@ -178,7 +181,7 @@
 
 	var/obj/item/limb/head/B = tool
 
-	affected.robotize()
+	affected.remove_limb_flags(LIMB_DESTROYED|LIMB_AMPUTATED)
 	target.updatehealth()
 	target.update_body()
 	target.UpdateDamageIcon()


### PR DESCRIPTION

## About The Pull Request
Removes the restrictions from non-robots. Everything just got decap immunity slapped on anyway, so whatever.
You can only reattach a head to the body it came from, so no bypassing going cold with this.
Synths and robots will stay 'alive' in the head after it gets removed, able to talk and not do much else. They can ghost out and return later, but it'll kill them (preventing non-dead chat) so you can't be a spooky scouting skull.
## Why It's Good For The Game
Fixes #11732 
## Changelog
:cl:
balance: Humans can have their heads stuck back on and revived, long as you have the right body
fix: Synths are no longer stuck in a living purgatory when they lose their head, unable to truly die
/:cl:
