### PR TITLE
Fix long range soldering and cabling

### DIFF
--- a/code/game/objects/items/tools/soldering_tool.dm
+++ b/code/game/objects/items/tools/soldering_tool.dm
@@ -32,7 +32,7 @@
 	user.visible_message(span_notice("[user] starts to solder the wounds on [H == user ? "[H.p_their()]" : "[H]'s"] [affecting.display_name]."),\
 		span_notice("You start soldering the wounds on [H == user ? "your" : "[H]'s"] [affecting.display_name]."))
 
-	while((affecting.burn_dam || affecting.brute_dam) && do_after(user, repair_time, TRUE, src, BUSY_ICON_BUILD))
+	while((affecting.burn_dam || affecting.brute_dam) && do_after(user, repair_time, TRUE, H, BUSY_ICON_BUILD))
 		user.visible_message(span_warning("\The [user] solders the wounds on [H == user ? "[H.p_their()]" : "[H]'s"] [affecting.display_name] with \the [src]."), \
 			span_warning("You solder the wounds on [H == user ? "your" : "[H]'s"] [affecting.display_name]."))
 		if(affecting.heal_limb_damage(10, 10, robo_repair = TRUE, updating_health = TRUE))

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -509,7 +509,7 @@ GLOBAL_LIST(cable_radial_layer_list)
 	user.visible_message(span_notice("[user] starts to fix some of the wires in [H]'s [affecting.display_name]."),\
 		span_notice("You start fixing some of the wires in [H == user ? "your" : "[H]'s"] [affecting.display_name]."))
 
-	while(do_after(user, repair_time, TRUE, src, BUSY_ICON_BUILD) && use(1))
+	while(do_after(user, repair_time, TRUE, H, BUSY_ICON_BUILD) && use(1))
 		user.visible_message(span_warning("\The [user] fixes some wires in \the [H]'s [affecting.display_name] with [src]."), \
 			span_warning("You patch some wires in \the [H]'s [affecting.display_name]."))
 		if(affecting.heal_limb_damage(0, 15, robo_repair = TRUE, updating_health = TRUE))


### PR DESCRIPTION
## About The Pull Request
1. A solder or cable coil B
2. B move away from A
3. A is still soldering/cabling
What should happen is A should stop like with Blowtorch.

Honestly, I didn't even know you can do that with cables.

## Why It's Good For The Game

## Changelog
:cl:
fix: long range solder and cable
/:cl:
