### PR TITLE
HvH spawn protection

### DIFF
--- a/code/game/objects/structures/patrol_points.dm
+++ b/code/game/objects/structures/patrol_points.dm
@@ -48,6 +48,7 @@
 	user.visible_message(span_notice("[user] goes through the [src]."),
 	span_notice("You walk through the [src]."))
 	user.trainteleport(linked_point.loc)
+	add_spawn_protection(user)
 	new /atom/movable/effect/rappel_rope(linked_point.loc)
 	user.playsound_local(user, "sound/effects/CIC_order.ogg", 10, 1)
 	var/message
@@ -73,6 +74,15 @@
 		return
 
 	user.forceMove(get_turf(linked_point))
+
+///Temporarily applies godmode to prevent spawn camping
+/obj/structure/patrol_point/proc/add_spawn_protection(mob/user)
+	user.status_flags |= GODMODE
+	addtimer(CALLBACK(src, .proc/remove_spawn_protection, user), 10 SECONDS)
+
+///Removes spawn protection godmode
+/obj/structure/patrol_point/proc/remove_spawn_protection(mob/user)
+	user.status_flags &= ~GODMODE
 
 /atom/movable/effect/rappel_rope
 	name = "rope"


### PR DESCRIPTION

## About The Pull Request
Adds spawn protection when you deploy to the ground in Combat Patrol and Sensor Capture. For 10 seconds you have godmode. This may need to be tweaked if you can sprint to anything important in that time.

I got tired of watching ungas mindlessly deploying 1 by 1 into a Denholm spawn camp they know about, rather than using their brain (and map table) and just deploying to the 2nd spawn point.

As I can't cure ungabrain, I'll have to settle with this.
## Why It's Good For The Game
Removes some salt from people being dumb.
Also spawn camping is cringe.
## Changelog
:cl:
balance: HvH: You have 10 seconds of spawn protection when deploying groundside
/:cl:
