### PR TITLE
Buff Sentinel Intoxicated Base 1 -> 2

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -691,7 +691,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define SENTINEL_DRAIN_STING_CRIT_REQUIREMENT 20 //Amount of stacks needed to activate Drain Sting's critical effect.
 #define SENTINEL_DRAIN_MULTIPLIER 6 //Amount to multiply Drain Sting's restoration by
 #define SENTINEL_DRAIN_SURGE_ARMOR_MOD 20 //Amount to modify the Sentinel's armor by when under the effects of Drain Surge.
-#define SENTINEL_INTOXICATED_BASE_DAMAGE 1 //Amount of damage per tick dealt by the Intoxicated debuff
+#define SENTINEL_INTOXICATED_BASE_DAMAGE 2 //Amount of damage per tick dealt by the Intoxicated debuff
 #define SENTINEL_INTOXICATED_RESIST_REDUCTION 3 //Amount of stacks removed every time the Intoxicated debuff is Resisted against.
 #define SENTINEL_INTOXICATED_SANGUINAL_INCREASE 3 //Amount of debuff stacks applied for every tick of Sanguinal.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Every tick, or ~2 seconds, a marine gets 1+ [(NUMBER OF STACK) / 10] burn.

The minimum damage that a marine can get from Intoxication is 1 burn per 2 seconds, and the max is 4 burn per 2 seconds because the limit of stack is 30. 30 stacks last for 60 seconds, but since the stacks decay, the total damage of 30 stacks will be less than 240 burn damage over 60 seconds.

Argument for the premedder:

You can counter a 10 stack Intoxication with having kelo>20u and tricord (don't get me started on derm). Kelo heals 1 burn per tick, and heals an additional 0.5 burn if kelo is greater than 20u. Tricord heals 0.8 burn per tick. 

With kelo<20u & tricord, a marine can heal 1.8 burn.

With kelo>20u & tricord, a marine can heal 2.3 burn.

When this buff gets TMed or merged, a premedder can get overwhelmed from one toxic spit or toxic slash even accounting for maturity.

**With buff, the max damage for intoxication is 5 per 2 seconds, and the min damage is 2 per 2 seconds**

Argument for the non-premedder:

It is easy to counter the intoxication by resisting out of sent's sight. You won't reach 30 stacks that easily if you continue to engage the sent, though it is other xenomorphs you should be concern about.

Sent's projectile is also slow, so it is easy to dodge it. What gets marines is that they walk into sent's projectile because sent permits marines' agency to give what sent wants.

No doubt that 3 for base damage is out of the question since that would wreck any non-premed players, and we balance for the 90% of players that don't play TGMC like insane people (unfortunately, I'm those insane people).

I've seen players' resolve melt in the face of less than 10 stacks of intoxication, but players with greater resolve continue to engage sent and after 15 seconds, they just pop a kelo, tricord, and tram to heal themselves.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Buff Sentinel Intoxicated Base 1 -> 2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
