### PR TITLE
MP cant enter the mech with jetpack of his back

### DIFF
--- a/code/modules/vehicles/mecha/mecha_mob_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_mob_interaction.dm
@@ -28,6 +28,10 @@
 		to_chat(M, span_warning("You can't enter the exosuit with other creatures attached to you!"))
 		log_message("Permission denied (Attached mobs).", LOG_MECHA)
 		return FALSE
+	var/obj/item/I = M.get_item_by_slot(SLOT_BACK)
+	if(I && istype(I, /obj/item/jetpack_marine))
+		to_chat(M, span_warning("Something on your back prevents you from entering the mech!"))
+		return FALSE
 	return ..()
 
 ///proc called when a new non-mmi/AI mob enters this mech
@@ -40,6 +44,7 @@
 	newoccupant.forceMove(src)
 	newoccupant.update_mouse_pointer()
 	add_fingerprint(newoccupant)
+	newoccupant.drop_all_held_items()
 	log_message("[newoccupant] moved in as pilot.", LOG_MECHA)
 	setDir(dir_in)
 	playsound(src, 'sound/machines/windowdoor.ogg', 50, TRUE)

--- a/code/modules/vehicles/mecha/mecha_mob_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_mob_interaction.dm
@@ -40,11 +40,11 @@
 		return FALSE
 	if(ishuman(newoccupant) && !Adjacent(newoccupant))
 		return FALSE
+	newoccupant.drop_all_held_items()
 	add_occupant(newoccupant)
 	newoccupant.forceMove(src)
 	newoccupant.update_mouse_pointer()
 	add_fingerprint(newoccupant)
-	newoccupant.drop_all_held_items()
 	log_message("[newoccupant] moved in as pilot.", LOG_MECHA)
 	setDir(dir_in)
 	playsound(src, 'sound/machines/windowdoor.ogg', 50, TRUE)


### PR DESCRIPTION

## About The Pull Request

Mech pilot now cant enter the mech while wearing jetpack. Also pilot will drop items in hands to prevent cheese.

## Why It's Good For The Game

Mech pilots can escape easily on mech destruction, which encourages reckless pushes with little to no risk of being killed. Inability to wear a jetpack makes pushes actually dangerous and punishable.

## Changelog
:cl:
balance: mech pilot cant enter the mech while wearing jetpack, and will drop items in hands on entering the mech.
/:cl:
