### PR TITLE
Vendor QOL #2

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1368,7 +1368,6 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	//Otherwise fall back to putting item in player's hand
 	if(user.put_in_any_hand_if_possible(src, warning = FALSE))
 		pickup(user)
-		return
 
 ///Controls how vendors will try to equip this item. Returns whether item was sucessfully equipped
 /obj/item/proc/vendor_equip(mob/user)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1356,7 +1356,21 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	user.update_inv_l_hand(0)
 	user.update_inv_r_hand()
 
-///Used by vendors to attempt to automatically equip a vended item. Attempts to put the item in the user's hand.
-/obj/item/proc/on_vend(mob/user, faction)
+///Called by vendors when vending an item. Allows the item to specify what happens when it is given to the player.
+/obj/item/proc/on_vend(mob/user, faction, fill_container = FALSE, auto_equip = FALSE)
+	//Put item into player's currently open storage
+	if (fill_container && user.s_active && user.s_active.can_be_inserted(src, FALSE))
+		user.s_active.handle_item_insertion(src, FALSE, user)
+		return
+	//Equip item onto player
+	if (auto_equip && vendor_equip(user))
+		return
+	//Otherwise fall back to putting item in player's hand
 	if(user.put_in_any_hand_if_possible(src, warning = FALSE))
 		pickup(user)
+		return
+
+///Controls how vendors will try to equip this item. Returns whether item was sucessfully equipped
+/obj/item/proc/vendor_equip(mob/user)
+	return FALSE
+

--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -298,10 +298,9 @@
 		qdel(reequip_component)
 	reequip_component = null
 
-///When vended, tries to equip itself. Else, fallback to parent behavior.
-/obj/item/belt_harness/on_vend(mob/user, faction)
-	if (!user.equip_to_appropriate_slot(src))
-		return ..()
+/obj/item/belt_harness/vendor_equip(mob/user)
+	..()
+	return user.equip_to_appropriate_slot(src)
 
 /obj/item/belt_harness/marine
 	name = "\improper M45 pattern belt harness"

--- a/code/game/objects/items/radio/headset.dm
+++ b/code/game/objects/items/radio/headset.dm
@@ -149,10 +149,9 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	channels[RADIO_CHANNEL_REQUISITIONS] = !channels[RADIO_CHANNEL_REQUISITIONS]
 	to_chat(user, span_notice("You toggle supply comms [channels[RADIO_CHANNEL_REQUISITIONS] ? "on" : "off"]."))
 
-///When vended, tries to equip itself. Else, fallback to parent behavior.
-/obj/item/radio/headset/on_vend(mob/user, faction)
-	if (!user.equip_to_appropriate_slot(src))
-		return ..()
+/obj/item/radio/headset/vendor_equip(mob/user)
+	..()
+	return user.equip_to_appropriate_slot(src)
 
 /obj/item/radio/headset/survivor
 	freqlock = TRUE

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -41,10 +41,9 @@
 	mouse_opacity = initial(mouse_opacity)
 	..()
 
-///When vended, tries to equip itself. Else, fallback to parent behavior.
-/obj/item/storage/backpack/on_vend(mob/user, faction)
-	if (!user.equip_to_appropriate_slot(src))
-		return ..()
+/obj/item/storage/backpack/vendor_equip(mob/user)
+	..()
+	return user.equip_to_appropriate_slot(src)
 
 /*
 * Backpack Types

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -23,10 +23,9 @@
 	mouse_opacity = initial(mouse_opacity)
 	..()
 
-///When vended, tries to equip itself. Else, fallback to parent behavior.
-/obj/item/storage/belt/on_vend(mob/user, faction)
-	if (!user.equip_to_appropriate_slot(src))
-		return ..()
+/obj/item/storage/belt/vendor_equip(mob/user)
+	..()
+	return user.equip_to_appropriate_slot(src)
 
 /obj/item/storage/belt/champion
 	name = "championship belt"

--- a/code/game/objects/items/storage/holsters.dm
+++ b/code/game/objects/items/storage/holsters.dm
@@ -82,10 +82,9 @@
 	remove_from_storage(W, null, user)
 	return W
 
-///When vended, tries to equip itself. Else, fallback to parent behavior.
-/obj/item/storage/holster/on_vend(mob/user, faction)
-	if (!user.equip_to_appropriate_slot(src))
-		return ..()
+/obj/item/storage/holster/vendor_equip(mob/user)
+	..()
+	return user.equip_to_appropriate_slot(src)
 
 //backpack type holster items
 /obj/item/storage/holster/backholster

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -31,10 +31,9 @@
 	mouse_opacity = initial(mouse_opacity)
 	..()
 
-///When vended, tries to equip itself. Else, fallback to parent behavior.
-/obj/item/storage/pouch/on_vend(mob/user, faction)
-	if (!user.equip_to_appropriate_slot(src))
-		return ..()
+/obj/item/storage/pouch/vendor_equip(mob/user)
+	..()
+	return user.equip_to_appropriate_slot(src)
 
 
 

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -184,7 +184,7 @@
 						vended_items += new /obj/item/hud_tablet(loc, vendor_role, H.assigned_squad)
 
 			for (var/obj/item/vended_item in vended_items)
-				vended_item.on_vend(usr, faction)
+				vended_item.on_vend(usr, faction, auto_equip = TRUE)
 
 			if(use_points && (item_category in I.marine_points))
 				I.marine_points[item_category] -= cost

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -581,15 +581,9 @@
 			src.last_reply = world.time
 
 	var/obj/item/new_item = release_item(R, vend_delay)
-	if(faction)
-		if(ismodulararmorarmorpiece(new_item))
-			var/obj/item/armor_module/armor/armorpiece = new_item
-			armorpiece.limit_colorable_colors(faction)
-		if(ismodularhelmet(new_item))
-			var/obj/item/clothing/head/modular/helmet = new_item
-			helmet.limit_colorable_colors(faction)
-	if(istype(new_item) && user.put_in_any_hand_if_possible(new_item, warning = FALSE))
-		new_item.pickup(user)
+
+	if(istype(new_item))
+		new_item.on_vend(user, faction, fill_container = TRUE)
 	vend_ready = 1
 	updateUsrDialog()
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -54,10 +54,9 @@
 		human_unequipper.adjust_mob_accuracy(-accuracy_mod)
 	return ..()
 
-///When vended, tries to equip itself. Else, fallback to parent behavior.
-/obj/item/clothing/on_vend(mob/user, faction)
-	if (!user.equip_to_appropriate_slot(src))
-		return ..()
+/obj/item/clothing/vendor_equip(mob/user)
+	..()
+	return user.equip_to_appropriate_slot(src)
 
 //Updates the icons of the mob wearing the clothing item, if any.
 /obj/item/clothing/proc/update_clothing_icon()

--- a/code/modules/clothing/modular_armor/attachments.dm
+++ b/code/modules/clothing/modular_armor/attachments.dm
@@ -255,7 +255,7 @@
 	examine_list += "Right click the [parent] with paint to color the [src]"
 
 ///When vended, limits the paintable colors based on the vending machine's faction
-/obj/item/armor_module/armor/on_vend(mob/user, faction, fill_container = FALSE, auto_equip = FALSE, put_hand = FALSE)
+/obj/item/armor_module/armor/on_vend(mob/user, faction, fill_container = FALSE, auto_equip = FALSE)
 	. = ..()
 	if(faction)
 		limit_colorable_colors(faction)

--- a/code/modules/clothing/modular_armor/attachments.dm
+++ b/code/modules/clothing/modular_armor/attachments.dm
@@ -255,7 +255,7 @@
 	examine_list += "Right click the [parent] with paint to color the [src]"
 
 ///When vended, limits the paintable colors based on the vending machine's faction
-/obj/item/armor_module/armor/on_vend(mob/user, faction)
+/obj/item/armor_module/armor/on_vend(mob/user, faction, fill_container = FALSE, auto_equip = FALSE, put_hand = FALSE)
 	. = ..()
 	if(faction)
 		limit_colorable_colors(faction)

--- a/code/modules/clothing/modular_armor/modular.dm
+++ b/code/modules/clothing/modular_armor/modular.dm
@@ -538,7 +538,7 @@
 	. += "<br>It currently has [attachments_by_slot[ATTACHMENT_SLOT_HEAD_MODULE] ? attachments_by_slot[ATTACHMENT_SLOT_HEAD_MODULE] : "nothing"] installed."
 
 ///When vended, limits the paintable colors based on the vending machine's faction
-/obj/item/clothing/head/modular/on_vend(mob/user, faction)
+/obj/item/clothing/head/modular/on_vend(mob/user, faction, fill_container = FALSE, auto_equip = FALSE, put_hand = FALSE)
 	. = ..()
 	if(faction)
 		limit_colorable_colors(faction)

--- a/code/modules/clothing/modular_armor/modular.dm
+++ b/code/modules/clothing/modular_armor/modular.dm
@@ -538,7 +538,7 @@
 	. += "<br>It currently has [attachments_by_slot[ATTACHMENT_SLOT_HEAD_MODULE] ? attachments_by_slot[ATTACHMENT_SLOT_HEAD_MODULE] : "nothing"] installed."
 
 ///When vended, limits the paintable colors based on the vending machine's faction
-/obj/item/clothing/head/modular/on_vend(mob/user, faction, fill_container = FALSE, auto_equip = FALSE, put_hand = FALSE)
+/obj/item/clothing/head/modular/on_vend(mob/user, faction, fill_container = FALSE, auto_equip = FALSE)
 	. = ..()
 	if(faction)
 		limit_colorable_colors(faction)


### PR DESCRIPTION
## About The Pull Request
Vendors will now try to insert spawned items into the player's currently opened container, before trying to put them into their hand.
For instance, you can open your ammo belt, vend 6 mags, and they will be auto-inserted into the belt, without you having to manually click them each in.

Does not affect the auto-closet, which still attempts to auto-equip relevant items.

## Why It's Good For The Game
Reduces repetitive clicking to fill storages during prep.

## Changelog
:cl:
qol: Vendors will try to insert vended items into the player's currently opened storage. Does not affect Automated Closet.
/:cl: