### PR TITLE
Mech weapons dont detach on destruction

### DIFF
--- a/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
+++ b/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
@@ -31,12 +31,11 @@
 
 /obj/item/mecha_parts/mecha_equipment/Destroy()
 	if(chassis)
-		detach(get_turf(src))
-		log_message("[src] is destroyed.", LOG_MECHA)
 		if(LAZYLEN(chassis.occupants))
 			to_chat(chassis.occupants, "[icon2html(src, chassis.occupants)][span_danger("[src] is destroyed!")]")
 			playsound(chassis, destroy_sound, 50)
-		chassis = null
+		detach(get_turf(src))
+		log_message("[src] is destroyed.", LOG_MECHA)
 	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/try_attach_part(mob/user, obj/vehicle/sealed/mecha/M, attach_right = FALSE)

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -241,9 +241,9 @@
 		occupant.hud_used.add_ammo_hud(src, hud_icons, projectiles)
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/detach(atom/moveto)
-	. = ..()
 	for(var/mob/occupant AS in chassis.occupants)
 		occupant.hud_used.remove_ammo_hud(src)
+	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/action_checks(target)
 	if(!..())

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -25,16 +25,16 @@
 			gear = equip_by_category[MECHA_R_ARM]
 	if(!gear)
 		return
-	if(gear.obj_integrity <= 1)
-		to_chat(occupants, "[icon2html(src, occupants)][span_danger("[gear] is critically damaged!")]")
-		playsound(src, gear.destroy_sound, 50)
-		gear.detach()
 
 	// always leave at least 1 health
 	var/damage_to_deal = min(gear.obj_integrity - 1, damage)
 	if(damage_to_deal <= 0)
 		return
 	gear.take_damage(damage_to_deal)
+
+	if(gear.obj_integrity <= 1)
+		to_chat(occupants, "[icon2html(src, occupants)][span_danger("[gear] is critically damaged!")]")
+		playsound(src, gear.destroy_sound, 50)
 
 /obj/vehicle/sealed/mecha/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = TRUE, attack_dir, armour_penetration)
 	var/damage_taken = ..()

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -25,15 +25,16 @@
 			gear = equip_by_category[MECHA_R_ARM]
 	if(!gear)
 		return
-	// always leave at least 1 health
-	var/damage_to_deal = min(obj_integrity - 1, damage)
-	if(damage_to_deal <= 0)
-		return
-
-	gear.take_damage(damage_to_deal)
 	if(gear.obj_integrity <= 1)
 		to_chat(occupants, "[icon2html(src, occupants)][span_danger("[gear] is critically damaged!")]")
 		playsound(src, gear.destroy_sound, 50)
+		gear.detach()
+
+	// always leave at least 1 health
+	var/damage_to_deal = min(gear.obj_integrity - 1, damage)
+	if(damage_to_deal <= 0)
+		return
+	gear.take_damage(damage_to_deal)
 
 /obj/vehicle/sealed/mecha/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = TRUE, attack_dir, armour_penetration)
 	var/damage_taken = ..()


### PR DESCRIPTION
## About The Pull Request

Now mech weapons keep 1 integrity on destruction like they were intended to.
Mech weapons dont detach from taking damage.
Fixed few related runtime errors.

## Why It's Good For The Game

Fix good

## Changelog
:cl:
fix: mech weapons dont detach from taking damage. fixed a few related runtime errors.
/:cl:
