### PR TITLE
Drops PO slots down to 1 from 2

### DIFF
--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -275,7 +275,7 @@ You are in charge of logistics and the overwatch system. You are also in line to
 	title = PILOT_OFFICER
 	paygrade = "WO"
 	comm_title = "PO"
-	total_positions = 2
+	total_positions = 1
 	access = list(ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_PILOT)
 	minimal_access = list(ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_PILOT, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_CARGO, ACCESS_MARINE_RO, ACCESS_MARINE_MEDBAY)
 	skills_type = /datum/skills/pilot


### PR DESCRIPTION

## About The Pull Request
PO's slots are down from 2 to 1.
## Why It's Good For The Game
It doesn't make sense to have 2 PO's running around when the tad is usually ran by a different role that isn't PO, it would be better to lower the slots down to 1 considering most PO's fight over who gets to tad every round and this would dedicate it into just CAS with tad on the side.
## Changelog
:cl:
tweak: Pilot Officer slots dropped down to 1.
/:cl:
