### PR TITLE
Removes Optical Imager Goggles from the game

### DIFF
--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -4112,7 +4112,6 @@
 /area/centcom/valhalla/secondary/entry)
 "frZ" = (
 /obj/structure/rack,
-/obj/item/clothing/glasses/night/imager_goggles,
 /obj/item/clothing/glasses/night/m56_goggles,
 /obj/item/clothing/mask/gas/swat,
 /obj/item/weapon/gun/pistol/auto9,

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1453,7 +1453,6 @@
 		),
 		"Equipment" = list(
 			/obj/item/clothing/mask/gas/swat = -1,
-			/obj/item/clothing/glasses/night/imager_goggles = -1,
 			/obj/item/clothing/head/helmet/riot = -1,
 			/obj/item/clothing/suit/storage/marine/specialist = -1,
 			/obj/item/clothing/head/helmet/marine/specialist = -1,

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -83,12 +83,6 @@
 		qdel(I)
 		qdel(src)
 		user.put_in_hands(P)
-	else if(istype(I, /obj/item/clothing/glasses/night/imager_goggles))
-		var/obj/item/clothing/glasses/night/imager_goggles/eyepatch/P = new
-		to_chat(user, span_notice("You fasten the optical scanner to the inside of the eyepatch."))
-		qdel(I)
-		qdel(src)
-		user.put_in_hands(P)
 
 		update_icon(user)
 
@@ -177,19 +171,6 @@
 		else
 			var/obj/item/clothing/glasses/hud/medgoggles/S = new
 			to_chat(user, span_notice("You fasten the medical hud projector to the inside of the goggles."))
-			qdel(I)
-			qdel(src)
-			user.put_in_hands(S)
-	else if(istype(I, /obj/item/clothing/glasses/night/imager_goggles))
-		if(prescription)
-			var/obj/item/clothing/glasses/night/optgoggles/prescription/P = new
-			to_chat(user, span_notice("You fasten the optical imaging scanner to the inside of the goggles."))
-			qdel(I)
-			qdel(src)
-			user.put_in_hands(P)
-		else
-			var/obj/item/clothing/glasses/night/optgoggles/S = new
-			to_chat(user, span_notice("You fasten the optical imaging scanner to the inside of the goggles."))
 			qdel(I)
 			qdel(src)
 			user.put_in_hands(S)
@@ -343,12 +324,6 @@
 	if(istype(I, /obj/item/clothing/glasses/hud/health))
 		var/obj/item/clothing/glasses/hud/medsunglasses/P = new
 		to_chat(user, span_notice("You fasten the medical hud projector to the inside of the glasses."))
-		qdel(I)
-		qdel(src)
-		user.put_in_hands(P)
-	else if(istype(I, /obj/item/clothing/glasses/night/imager_goggles))
-		var/obj/item/clothing/glasses/night/imager_goggles/sunglasses/P = new
-		to_chat(user, span_notice("You fasten the optical imager scaner to the inside of the glasses."))
 		qdel(I)
 		qdel(src)
 		user.put_in_hands(P)

--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -62,15 +62,6 @@
 	actions_types = list(/datum/action/item_action/toggle)
 	vision_flags = SEE_TURFS
 
-/obj/item/clothing/glasses/night/imager_goggles
-	name = "optical imager goggles"
-	desc = "Uses image scanning to increase visibility of even the most dimly lit surroundings except total darkness"
-	icon_state = "securityhud"
-	deactive_state = "degoggles_sec"
-	darkness_view = 2
-	toggleable = TRUE
-	actions_types = list(/datum/action/item_action/toggle)
-
 /obj/item/clothing/glasses/night/optgoggles
 	name = "\improper Optical imager ballistic goggles"
 	desc = "Standard issue TGMC goggles. This pair has been fitted with an internal optical imaging scanner."
@@ -85,24 +76,7 @@
 	flags_equip_slot = ITEM_SLOT_EYES
 	goggles = TRUE
 
-/obj/item/clothing/glasses/night/imager_goggles/sunglasses
-	name = "\improper Optical imager sunglasses"
-	desc = "A pair of designer sunglasses. This pair has been fitted with an internal optical imager scanner."
-	icon_state = "optsunglasses"
-	item_state = "optsunglasses"
-	deactive_state = "degoggles_optsunglasses"
-	species_exception = list(/datum/species/robot)
-	sprite_sheets = list("Combat Robot" = 'icons/mob/species/robot/glasses.dmi')
-	prescription = TRUE
-
 /obj/item/clothing/glasses/night/optgoggles/prescription
 	name = "\improper Optical imager prescription ballistic goggles"
 	desc = "Standard issue TGMC prescription goggles. This pair has been fitted with an internal optical imaging scanner."
 	prescription = TRUE
-
-/obj/item/clothing/glasses/night/imager_goggles/eyepatch
-	name = "\improper Meson eyepatch"
-	desc = "An eyepatch fitted with the optical imager interface. For the disabled and/or edgy Marine."
-	icon_state = "optpatch"
-	deactive_state = "degoggles_medpatch"
-	toggleable = TRUE

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -738,11 +738,6 @@ ARMOR
 	contains = list(/obj/item/clothing/mask/gas/swat)
 	cost = 50
 
-/datum/supply_packs/armor/imager_goggle
-	name = "Optical Imager Goggles"
-	contains = list(/obj/item/clothing/glasses/night/imager_goggles)
-	cost = 50
-
 /datum/supply_packs/armor/riot
 	name = "Heavy Riot Armor Set"
 	contains = list(


### PR DESCRIPTION
## About The Pull Request
Per title. Removes Optical Imager Goggles entirely from the code, removing them from the game by extension.

## Why It's Good For The Game
My argument for this one will be a little weak since it is maintainers that have come to dislike imagers, but I will go ahead and say that imagers are in a difficult spot at the moment. They are incredibly sought after in requisitions, and prove to be one of the most common purchases; there's certainly an issue when any given marine refuses to deploy without their funny vision enhancer.

This PR is open at the same time that #11888 is; both were meant to be in the same PR, but I found it a more sensible choice to separate these into two PRs, so as to give maintainers options to choose from.

## Changelog
:cl: Lewdcifer
del: Removed Optical Imager Goggles from the code and the game.
/:cl: