### PR TITLE
Gasmasks now reduce stamina regen by 50%

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -19,6 +19,8 @@
 	var/breathy = TRUE
 	///This covers most of the screen
 	var/hearing_range = 5
+	///Multiplier to stamina regen
+	var/stamina_regen_mult = -0.5
 
 /obj/item/clothing/mask/gas/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
@@ -35,6 +37,11 @@
 				continue
 			HM.playsound_local(user, "gasbreath", 20, 1)
 			TIMER_COOLDOWN_START(src, COOLDOWN_GAS_BREATH, 10 SECONDS)
+	user.add_stamina_regen_modifier(name, stamina_regen_mult)
+
+/obj/item/clothing/mask/gas/unequipped(mob/living/carbon/human/unequipper, slot)
+	unequipper.remove_stamina_regen_modifier(name)
+	return ..()
 
 /obj/item/clothing/mask/gas/tactical
 	name = "Tactical gas mask"


### PR DESCRIPTION
## About The Pull Request
title

## Why It's Good For The Game

There are currently no downsides to wearing a gasmask, thus everyone uses them at all times, making majority of xeno gas clouds useless.
Reducing stamina regen should make wearing a gasmask a more meaningful choice.

## Changelog
:cl:
balance: gasmasks now reduce stamina regen by 50%
/:cl:
