### PR TITLE
Small chemfridge refactor

### DIFF
--- a/tgui/packages/tgui/interfaces/SmartVend.js
+++ b/tgui/packages/tgui/interfaces/SmartVend.js
@@ -33,19 +33,19 @@ export const SmartVend = (props, context) => {
               {map((value, key) => {
                 return (
                   <Table.Row key={key}>
-                    <Table.Cell>{value.name}</Table.Cell>
-                    <Table.Cell>{value.amount}</Table.Cell>
+                    <Table.Cell>{key}</Table.Cell>
+                    <Table.Cell>{value}</Table.Cell>
                     <Table.Cell>
                       <Button
-                        disabled={value.amount < 1}
+                        disabled={value < 1}
                         onClick={() =>
-                          act('Release', { name: value.name, amount: 1 })
+                          act('Release', { name: key, amount: 1 })
                         }>
                         One
                       </Button>
                       <Button
-                        disabled={value.amount <= 1}
-                        onClick={() => act('Release', { name: value.name })}>
+                        disabled={value <= 1}
+                        onClick={() => act('Release', { name: key })}>
                         Many
                       </Button>
                     </Table.Cell>


### PR DESCRIPTION

## About The Pull Request
Fridges now generate/alter their storage lists when something is added or removed instead of every time the ui updates
Fridges clean names to prevent weirdness with "\improper Thing" and "Thing" being equal some times and not other times
## Why It's Good For The Game
Minor opt, fixes #11893 
## Changelog
:cl:
fix: Vended reagent bottles can be taken back out of the chem smartfridge
/:cl:
