### PR TITLE
PoS Medbay Fixes

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -819,12 +819,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/medical/upper_medical)
 "bcv" = (
-/obj/effect/decal/cleanable/blood/writing{
-	desc = "It looks like a writing in blood. It says, 'If you see this, you will join the dead.'";
+/obj/machinery/camera/autoname/mainship,
+/obj/structure/bed/chair/wood/wings{
 	dir = 4
 	},
-/turf/open/floor/plating/mainship,
-/area/mainship/hallways/starboard_hallway)
+/turf/open/floor/wood,
+/area/mainship/medical/upper_medical)
 "bcF" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/cic)
@@ -4209,12 +4209,9 @@
 	},
 /area/mainship/living/chapel)
 "ftY" = (
-/obj/effect/decal/cleanable/blood/writing{
-	desc = "It looks like a writing in blood. It says, 'We are the monsters all along.'";
-	dir = 4
-	},
-/turf/open/floor/mainship/floor,
-/area/crew_quarters/toilet)
+/obj/structure/table/woodentable,
+/turf/open/floor/wood,
+/area/mainship/medical/upper_medical)
 "fuf" = (
 /obj/machinery/telecomms/server/presets/requisitions,
 /turf/open/floor/mainship/tcomms,
@@ -5339,9 +5336,14 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "gZf" = (
-/obj/structure/sign/safety/cryogenic,
-/turf/closed/wall/mainship/white,
-/area/mainship/medical/lower_medical)
+/obj/structure/bed/chair/wood/wings{
+	dir = 8
+	},
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/mainship/medical/upper_medical)
 "gZv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -9169,7 +9171,6 @@
 	},
 /area/mainship/command/airoom)
 "lVR" = (
-/obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/mainship/sterile/side{
 	dir = 5
 	},
@@ -12358,6 +12359,20 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "qfF" = (
+/obj/structure/table/mainship/nometal,
+/obj/item/storage/box/syringes{
+	pixel_x = -7
+	},
+/obj/item/storage/box/pillbottles{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/mass_spectrometer,
+/obj/item/mass_spectrometer,
 /turf/open/floor/mainship/sterile/purple/side,
 /area/mainship/medical/chemistry)
 "qfG" = (
@@ -14556,23 +14571,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/mainship/sterile/plain,
 /area/mainship/living/pilotbunks)
-"tbW" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/storage/box/syringes{
-	pixel_x = -7
-	},
-/obj/item/storage/box/pillbottles{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/mass_spectrometer,
-/obj/item/tool/hand_labeler,
-/obj/item/storage/box/beakers{
-	pixel_x = -7;
-	pixel_y = 7
-	},
-/turf/open/floor/mainship/sterile/purple/side,
-/area/mainship/medical/chemistry)
 "tdm" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship/sterile/dark,
@@ -14706,10 +14704,6 @@
 	dir = 1
 	},
 /obj/machinery/light/mainship/small,
-/obj/effect/decal/cleanable/blood/writing{
-	desc = "It looks like a writing in blood. It says, 'I want to go home.'";
-	dir = 4
-	},
 /obj/effect/landmark/corpsespawner/marine/regular,
 /obj/item/weapon/gun/pistol/standard_heavypistol/suppressed,
 /turf/open/floor/mainship/floor,
@@ -14726,20 +14720,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "tkS" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/storage/box/autoinjectors{
-	pixel_x = 7
-	},
-/obj/item/storage/box/pillbottles{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/mass_spectrometer,
-/obj/item/tool/hand_labeler,
-/obj/item/storage/box/beakers{
-	pixel_x = -7;
-	pixel_y = 7
-	},
 /turf/open/floor/mainship/sterile/purple/side,
 /area/mainship/medical/chemistry)
 "tkW" = (
@@ -16189,6 +16169,7 @@
 /obj/item/stack/sheet/mineral/phoron,
 /obj/item/reagent_containers/dropper,
 /obj/structure/table/mainship/nometal,
+/obj/item/tool/hand_labeler,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "uWP" = (
@@ -16566,7 +16547,6 @@
 /area/mainship/hallways/starboard_hallway)
 "vwL" = (
 /obj/machinery/smartfridge/chemistry,
-/obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/plating/platebotc,
 /area/mainship/medical/chemistry)
 "vxx" = (
@@ -43061,9 +43041,9 @@ mvs
 qje
 mvs
 mvs
+bcv
 xzF
-xzF
-xzF
+bxv
 bmo
 tMy
 wnJ
@@ -43318,9 +43298,9 @@ eSw
 lMn
 lsc
 mvs
+ftY
 xzF
-xzF
-xzF
+bxv
 bmo
 mzF
 vTy
@@ -43575,9 +43555,9 @@ bUC
 lAT
 wFY
 mvs
-xzF
+gZf
 mmC
-xzF
+bxv
 giW
 tMy
 vFi
@@ -43834,7 +43814,7 @@ fvg
 mvs
 lCL
 xzF
-xzF
+bxv
 bmo
 vrx
 npN
@@ -44091,7 +44071,7 @@ evD
 mvs
 lQb
 xzF
-xzF
+bxv
 bmo
 rEY
 uFV
@@ -44348,7 +44328,7 @@ mvs
 ntb
 sJE
 xzF
-xzF
+bxv
 olX
 wcT
 wcT
@@ -44602,7 +44582,7 @@ qqU
 cYE
 qqU
 xXW
-gZf
+mvs
 mvs
 eUN
 eeY
@@ -48207,7 +48187,7 @@ dLo
 fZP
 uVk
 xXt
-tbW
+tkS
 xyS
 hUf
 nTx
@@ -51053,7 +51033,7 @@ hZr
 aNM
 aNM
 aNM
-bcv
+aNM
 aNM
 aNM
 aNM
@@ -54613,7 +54593,7 @@ hEa
 uzm
 fAJ
 rip
-ftY
+kCk
 kCk
 uIy
 fAJ

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -2494,7 +2494,7 @@
 	},
 /area/space)
 "dgm" = (
-/obj/machinery/computer/med_data,
+/obj/machinery/computer/crew,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "dgy" = (


### PR DESCRIPTION
## About The Pull Request

Add more soul to medbay break room.

Allow chemists to reach to fridge.

Remove funny dropship landing on medbay that allow xenomorphs to fling marines to space.

Add back the crew monitoring computer back.

## Why It's Good For The Game

Sometimes, mappers didn't see mistakes, and players give feedback to improve map.

## Changelog

:cl:
add: more soul to POS medbay break room.
fix: Allow POS chemists to reach to fridge.
del: Remove funny dropship landing on POS medbay that allow xenomorphs to fling marines to space.
fix: Add back the crew monitoring computer back in PoS
/:cl:

