### PR TITLE
Balance Fix: Shrike req points 50->500

### DIFF
--- a/code/modules/requisitions/supply_export.dm
+++ b/code/modules/requisitions/supply_export.dm
@@ -24,7 +24,7 @@
 	return new /datum/export_report(., name, faction_selling)
 
 /mob/living/carbon/xenomorph/shrike/supply_export(faction_selling)
-	SSpoints.supply_points[faction_selling] += 50
+	SSpoints.supply_points[faction_selling] += 500
 	return new /datum/export_report(50, name, faction_selling)
 
 

--- a/code/modules/requisitions/supply_export.dm
+++ b/code/modules/requisitions/supply_export.dm
@@ -25,7 +25,7 @@
 
 /mob/living/carbon/xenomorph/shrike/supply_export(faction_selling)
 	SSpoints.supply_points[faction_selling] += 500
-	return new /datum/export_report(50, name, faction_selling)
+	return new /datum/export_report(500, name, faction_selling)
 
 
 /mob/living/carbon/human/supply_export(faction_selling)


### PR DESCRIPTION

## About The Pull Request

Inflation adjustment for selling shrike.

## Why It's Good For The Game

I observed that when I sold shrike, its price was 50 req points, meaning that the shrike cost the same as a single smartgunner T-29 drum. MJP did not know that there was a dedicated code that shrike sold separately than what is usually sold as a T4. A shrike is a T4 and yet is sold as a T3.

## Changelog

:cl:
fix: Shrike req points 50->500
balance: Shrike req points 50->500
/:cl:

