### PR TITLE
Removes TURRET_INACCURATE flag

### DIFF
--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -120,7 +120,6 @@
 #define TURRET_ALERTS (1<<4)
 #define TURRET_RADIAL (1<<5)
 #define TURRET_IMMOBILE (1<<6)
-#define TURRET_INACCURATE (1<<7)
 
 #define SQUAD_LOCK (1<<0)
 #define JOB_LOCK (1<<1)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -352,7 +352,6 @@
 	max_shots = 6 //codex stuff
 	rounds_per_shot = 100
 	fire_delay = 4 SECONDS
-	turret_flags = TURRET_INACCURATE
 	attachable_allowed = list(
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/magnetic_harness,
@@ -402,7 +401,6 @@
 	rounds_per_shot = 12
 	gun_firemode = GUN_FIREMODE_AUTOMATIC
 	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC)
-	turret_flags = TURRET_INACCURATE
 	ammo_level_icon = "te"
 	attachable_allowed = list(
 		/obj/item/attachable/bayonet,

--- a/code/modules/projectiles/sentries.dm
+++ b/code/modules/projectiles/sentries.dm
@@ -55,10 +55,6 @@
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
 
-	if(CHECK_BITFIELD(gun.turret_flags, TURRET_INACCURATE))
-		gun.accuracy_mult -= 0.15
-		gun.scatter += 10
-
 	if(CHECK_BITFIELD(gun.turret_flags, TURRET_HAS_CAMERA))
 		camera = new (src)
 		camera.network = list("military")
@@ -477,10 +473,6 @@
 		to_chat(user, span_notice("Access denied."))
 		return
 	. = ..()
-	var/obj/item/weapon/gun/gun = internal_item
-	if(CHECK_BITFIELD(gun.turret_flags, TURRET_INACCURATE))
-		gun.accuracy_mult += 0.15
-		gun.scatter -= 10
 
 ///Checks the users faction against turret IFF, used to stop hostile factions from interacting with turrets in ways they shouldn't.
 /obj/machinery/deployable/mounted/sentry/proc/match_iff(mob/user)


### PR DESCRIPTION
## About The Pull Request
This is how Laser Rifle BAS performs with the flag:
[turret inaccurate.webm](https://user-images.githubusercontent.com/94504089/211525073-a4b29998-711a-4196-8b29-8170a10168a2.webm)
Not even the baldest of the baldest PVT marine will miss that many shots on a stationary runner.

This is how the same BAS gun performs without the flag:
[no turret inaccurate.webm](https://user-images.githubusercontent.com/94504089/211525428-217da023-80b3-42f1-bc12-02824b258715.webm)
And with overcharge:
[overcharge no turret inaccurate.webm](https://user-images.githubusercontent.com/94504089/211525443-a7c8b365-3f8d-4305-bd5e-65de92868d82.webm)

This is apparently how it should look like with the turret_inaccurate flag, taken from [https://github.com/tgstation/TerraGov-Marine-Corps/pull/8655](https://github.com/tgstation/TerraGov-Marine-Corps/pull/8655) (same range by the way)
[https://gyazo.com/12cc68fb72fa926eae6e8a8914d3a291](https://gyazo.com/12cc68fb72fa926eae6e8a8914d3a291)

## Why It's Good For The Game
The accuracy of Laser Rifle BAS without the flag looks fine to me, it's even missing a couple shots. 

## Changelog
:cl:
del: turret_inaccurate flag
/:cl:
