### PR TITLE
Nerfs the R-44 revolver

### DIFF
--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -81,14 +81,14 @@
 		/obj/item/attachable/shoulder_mount,
 	)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 13, "rail_y" = 23, "under_x" = 22, "under_y" = 14, "stock_x" = 22, "stock_y" = 19)
-	fire_delay = 0.15 SECONDS
-	akimbo_additional_delay = 0.6 // Ends up as 0.249, so it'll get moved up to 0.25.
-	accuracy_mult_unwielded = 0.85
+	fire_delay = 0.3 SECONDS
+	akimbo_additional_delay = 0.8 // Ends up as 0.249, so it'll get moved up to 0.25.
+	accuracy_mult_unwielded = 0.55
 	accuracy_mult = 1
-	scatter_unwielded = 15
+	scatter_unwielded = 25
 	scatter = -1
 	recoil = 0
-	recoil_unwielded = 0.75
+	recoil_unwielded = 0.95
 
 /obj/item/weapon/gun/revolver/standard_revolver/Initialize(mapload, spawn_empty)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The current revolver meta is a very strong loadout where you use 20 or so revolvers all equipped with recoil compensators, red-dot sights and gyroscopic stabilizers which allows you to solo entire hives. I want to nerf the strength of the revolver so it stops a single marine from overpowering 4+ xenomorph players at once.

## Why It's Good For The Game

"IDED/SALT PR" Jokes aside, the current state of the game is heavily in favor of the revolver. You've seen it yourself, and squashing the meta will be healthy for the game, in my honest opinion.  By nerfing it's fire rate, the total DPS is decreased and the amount of knockback per second is also decreased. The recoil and scatter should make it much harder to hit your shots which will make it much harder for a marine to easily spam away in the general direction of his enemies. The gun is still viable, it's just not trivial anymore to steamroll an entire hive with these. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Nerfed the accuracy, fire rate, recoil and scatter of the R-44 revolver. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
