### PR TITLE
Loadout attachment fix

### DIFF
--- a/code/datums/loadout/item_representation/gun_representation.dm
+++ b/code/datums/loadout/item_representation/gun_representation.dm
@@ -36,7 +36,6 @@
 ///Instantiates and instals the type onto gun_to_attach
 /datum/item_representation/gun/proc/install_on_gun(seller, obj/item/weapon/gun/gun_to_attach, mob/living/user)
 	var/gun_to_vend
-	var/obj/item/weapon/gun/attachment_type = item_type
 	if(item_type in gun_to_attach.starting_attachment_types)
 		bypass_vendor_check = TRUE
 	gun_to_vend = instantiate_object(seller, null, user)
@@ -59,7 +58,6 @@
 ///Attach the instantiated attachment to the gun
 /datum/item_representation/gun_attachement/proc/install_on_gun(seller, obj/item/weapon/gun/gun_to_attach, mob/living/user)
 	var/attachment_to_vend
-	var/obj/item/attachable/attachment_type = item_type
 	if(item_type in gun_to_attach.starting_attachment_types)
 		bypass_vendor_check = TRUE
 	attachment_to_vend = instantiate_object(seller, null, user)

--- a/code/datums/loadout/item_representation/gun_representation.dm
+++ b/code/datums/loadout/item_representation/gun_representation.dm
@@ -37,7 +37,7 @@
 /datum/item_representation/gun/proc/install_on_gun(seller, obj/item/weapon/gun/gun_to_attach, mob/living/user)
 	var/gun_to_vend
 	var/obj/item/weapon/gun/attachment_type = item_type
-	if(!(initial(attachment_type.flags_attach_features) & ATTACH_REMOVABLE))
+	if(item_type in gun_to_attach.starting_attachment_types)
 		bypass_vendor_check = TRUE
 	gun_to_vend = instantiate_object(seller, null, user)
 	if(!gun_to_vend)
@@ -60,7 +60,7 @@
 /datum/item_representation/gun_attachement/proc/install_on_gun(seller, obj/item/weapon/gun/gun_to_attach, mob/living/user)
 	var/attachment_to_vend
 	var/obj/item/attachable/attachment_type = item_type
-	if(!(initial(attachment_type.flags_attach_features) & ATTACH_REMOVABLE))//Unremovable attachment are not in vendors
+	if(item_type in gun_to_attach.starting_attachment_types)
 		bypass_vendor_check = TRUE
 	attachment_to_vend = instantiate_object(seller, null, user)
 	if(!attachment_to_vend)


### PR DESCRIPTION
## About The Pull Request
Fixes loadout vendors not vending guns with starting attachments unavailable in the weapon vendor separately.
i.e. GL-54 scope, AR-11 scope etc.

Fixes #11837
Fixes #11776 
Fixes #10365
Fixes #8335

Note:
I've seen some people have an issue with stocks not spawning on their guns. I have no idea if that is related as I can't replicate it, but just noting that this isn't regarding that particular issue.
## Why It's Good For The Game
Bug fix good.
## Changelog
:cl:
fix: fixed loadout vendors not vending weapons with certain default attachments
/:cl:
