### PR TITLE
Warlock observe hud fix

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -130,6 +130,7 @@ GLOBAL_LIST_INIT(playable_icons, list(
 	"staffofficer",
 	"synth",
 	"warrior",
+	"warlock",
 	"whiskey_engi",
 	"whiskey_leader",
 	"whiskey_medic",


### PR DESCRIPTION
## About The Pull Request

Fixed warlock having no icons in some places, like lower hive status panel or observe panel.

Before: 
![ZponUGl57l](https://user-images.githubusercontent.com/100090741/211815568-5d28cec7-b75b-4ec8-9e44-b7fc99abf72d.png)

After:
![mMTpdEMFHc](https://user-images.githubusercontent.com/100090741/211815599-0ea00b1e-7a45-4bc6-bb45-ef0f06fd1d53.png)


## Why It's Good For The Game

Fix good.

## Changelog

:cl:
fix: fixed warlock having no icon in some interfaces
/:cl:
