### PR TITLE
Burstfire aimdelay now respects burstfire shots amount

### DIFF
--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -645,12 +645,12 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 		REMOVE_TRAIT(src, TRAIT_GUN_IS_AIMING, GUN_TRAIT)
 		user.remove_movespeed_modifier(MOVESPEED_ID_AIM_MODE_SLOWDOWN)
 		modify_fire_delay(-aim_fire_delay)
-		modify_auto_burst_delay(-aim_fire_delay)
+		modify_auto_burst_delay(-aim_fire_delay * burst_amount)
 		///if your attached weapon has aim mode, stops it from aimming
 		if( (gunattachment) && (/datum/action/item_action/aim_mode in gunattachment.actions_types) )
 			REMOVE_TRAIT(gunattachment, TRAIT_GUN_IS_AIMING, GUN_TRAIT)
 			gunattachment.modify_fire_delay(-aim_fire_delay)
-			gunattachment.modify_auto_burst_delay(-aim_fire_delay)
+			gunattachment.modify_auto_burst_delay(-aim_fire_delay * burst_amount)
 		to_chat(user, span_notice("You cease aiming."))
 		return
 	if(!CHECK_BITFIELD(flags_item, WIELDED) && !CHECK_BITFIELD(flags_item, IS_DEPLOYED))
@@ -674,12 +674,12 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 	ADD_TRAIT(src, TRAIT_GUN_IS_AIMING, GUN_TRAIT)
 	user.add_movespeed_modifier(MOVESPEED_ID_AIM_MODE_SLOWDOWN, TRUE, 0, NONE, TRUE, aim_speed_modifier)
 	modify_fire_delay(aim_fire_delay)
-	modify_auto_burst_delay(aim_fire_delay)
+	modify_auto_burst_delay(aim_fire_delay * burst_amount)
 	///if your attached weapon has aim mode, makes it aim
 	if( (gunattachment) && (/datum/action/item_action/aim_mode in gunattachment.actions_types) )
 		ADD_TRAIT(gunattachment, TRAIT_GUN_IS_AIMING, GUN_TRAIT)
 		gunattachment.modify_fire_delay(aim_fire_delay)
-		gunattachment.modify_auto_burst_delay(aim_fire_delay)
+		gunattachment.modify_auto_burst_delay(aim_fire_delay * burst_amount)
 	to_chat(user, span_notice("You line up your aim, allowing you to shoot past allies.</b>"))
 
 /// Signal handler to activate the rail attachement of that gun if it's in our active hand


### PR DESCRIPTION

## About The Pull Request

Changes aim fire delay for burst fire from (aim_fire_delay) to (aim_fire_delay * burst_amount)

## Why It's Good For The Game

Currently aim fire delay applies to burstfire only once, essentially making it 1/n times as impactful. I feel this is unfair and cheesy, so now aim fire delay is applied n times (equal to amount of shots in burst) between bursts.

## Changelog
:cl:
balance: burstfire aimdelay now respects burstfire shots amount
/:cl:
