### PR TITLE
Xeno Ex_act fix

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -472,6 +472,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define KING_DEATH_TIMER 7 MINUTES
 #define XENO_DEADHUMAN_DRAG_SLOWDOWN 2
 #define XENO_EXPLOSION_RESIST_3_MODIFIER 0.25 //multiplies top level explosive damage by this amount.
+#define XENO_EXPLOSION_GIB_THRESHOLD 5 //under this level of bomb armour, devestating explosion will gib xenos
 
 #define KING_SUMMON_TIMER_DURATION 5 MINUTES
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -85,7 +85,7 @@
 	upgrade_threshold = TIER_THREE_MATURE_THRESHOLD
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 75, BULLET = 65, LASER = 65, ENERGY = 65, BOMB = 100, BIO = 90, FIRE = 30, ACID = 90)
+	soft_armor = list(MELEE = 75, BULLET = 65, LASER = 65, ENERGY = 65, BOMB = 110, BIO = 90, FIRE = 30, ACID = 90)
 
 	// *** Abilities *** //
 	stomp_damage = 50
@@ -114,7 +114,7 @@
 	upgrade_threshold = TIER_THREE_ELDER_THRESHOLD
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 80, BULLET = 70, LASER = 70, ENERGY = 70, BOMB = 100, BIO = 95, FIRE = 35, ACID = 95)
+	soft_armor = list(MELEE = 80, BULLET = 70, LASER = 70, ENERGY = 70, BOMB = 120, BIO = 95, FIRE = 35, ACID = 95)
 
 	// *** Abilities *** //
 	stomp_damage = 55
@@ -143,7 +143,7 @@
 	upgrade_threshold = TIER_THREE_ANCIENT_THRESHOLD
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 90, BULLET = 75, LASER = 75, ENERGY = 75, BOMB = 100, BIO = 100, FIRE = 40, ACID = 100)
+	soft_armor = list(MELEE = 90, BULLET = 75, LASER = 75, ENERGY = 75, BOMB = 130, BIO = 100, FIRE = 40, ACID = 100)
 	// *** Abilities *** //
 	stomp_damage = 60
 	crest_toss_distance = 6
@@ -169,7 +169,7 @@
 	max_health = 400
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 90, BULLET = 75, LASER = 75, ENERGY = 75, BOMB = 100, BIO = 100, FIRE = 40, ACID = 100)
+	soft_armor = list(MELEE = 90, BULLET = 75, LASER = 75, ENERGY = 75, BOMB = 130, BIO = 100, FIRE = 40, ACID = 100)
 	// *** Abilities *** //
 	stomp_damage = 60
 	crest_toss_distance = 6

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -282,7 +282,7 @@
 	if(X.fortify)
 		var/fortifyAB = X.xeno_caste.fortify_armor
 		X.soft_armor = X.soft_armor.modifyAllRatings(fortifyAB)
-		X.soft_armor = X.soft_armor.setRating(bomb = 100)
+		X.soft_armor = X.soft_armor.setRating(bomb = 130)
 		last_fortify_bonus = fortifyAB
 
 /datum/action/xeno_action/fortify/on_cooldown_finish()

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -13,19 +13,16 @@
 	if(status_flags & (INCORPOREAL|GODMODE))
 		return
 
-	var/bomb_armor = soft_armor.getRating("bomb")
-	if(bomb_armor >= 100)
-		return //immune
-
-	var/bomb_effective_armor = (bomb_armor/100)*get_sunder()
+	var/bomb_effective_armor = (soft_armor.getRating("bomb")/100)*get_sunder()
 	var/bomb_slow_multiplier = max(0, 1 - 3.5*bomb_effective_armor)
 	var/bomb_sunder_multiplier = max(0, 1 - bomb_effective_armor)
 
-	//lowered to account for new armor values but keep old gibs
-	//probs needs to be a define somewhere
-	var/gib_min_armor = 10
-	if(severity == EXPLODE_DEVASTATE && bomb_armor < gib_min_armor)
-		return gib()    //Gibs unprotected benos
+	if(bomb_effective_armor >= 100)
+		return //immune
+
+
+	if(severity == EXPLODE_DEVASTATE && bomb_effective_armor <= XENO_EXPLOSION_GIB_THRESHOLD)
+		return gib() //Gibs unprotected benos
 
 	//Slowdown and stagger
 	var/ex_slowdown = (2 + (4 - severity)) * bomb_slow_multiplier


### PR DESCRIPTION

## About The Pull Request
Having a base bomb armour of 100 or more no longer makes a xeno entirely immune to explosions.
Xeno gib threshold now takes sunder into account and changed to 5 (this still only applies to devastate level explosions).
Crusher and defender's fortify bomb armour slightly increased.

Currently, if something like a crusher is sundered by 50% (i.e. it only has 50 bomb armour currently) it is still entirely immune to explosions due to the check occuring prior to sunder being taken into account. Now, it will check armour after sunder and pheromones are taken into account.

This isn't as dramatic as it might seem at first glance. Explosion damage, slowdown and stagger are all modified by bomb armour anyway, so unless you're severely sundered, mr crusher is still not really going to care much.
## Why It's Good For The Game
Sunder actually working is good.
## Changelog
:cl:
balance: Sunder is now taken into account when calculating xeno bomb immunity and devastating explosion gib thresholds
balance: Crusher and defender fortify bomb armour increased slightly

/:cl:
