### PR TITLE
Sensor cap timer change

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -166,3 +166,4 @@
 #define MAX_UNBALANCED_RATIO_TWO_HUMAN_FACTIONS 1.1
 
 #define SENSOR_CAP_ADDITION_TIME_BONUS 5 MINUTES //additional time granted by capturing a sensor tower
+#define SENSOR_CAP_TIMER_PAUSED "paused"

--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -164,3 +164,5 @@
 #define FREE_XENO_AT_START 2
 
 #define MAX_UNBALANCED_RATIO_TWO_HUMAN_FACTIONS 1.1
+
+#define SENSOR_CAP_ADDITION_TIME_BONUS 3 MINUTES //additional time granted by capturing a sensor tower

--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -165,4 +165,4 @@
 
 #define MAX_UNBALANCED_RATIO_TWO_HUMAN_FACTIONS 1.1
 
-#define SENSOR_CAP_ADDITION_TIME_BONUS 3 MINUTES //additional time granted by capturing a sensor tower
+#define SENSOR_CAP_ADDITION_TIME_BONUS 5 MINUTES //additional time granted by capturing a sensor tower

--- a/code/datums/gamemodes/sensor_capture.dm
+++ b/code/datums/gamemodes/sensor_capture.dm
@@ -21,6 +21,11 @@
 	. = ..()
 	addtimer(CALLBACK(src, /datum/game_mode/combat_patrol.proc/set_game_timer), SSticker.round_start_time + shutters_drop_time) //game end timer will start ticking down on shutter drop
 
+/datum/game_mode/combat_patrol/sensor_capture/game_end_countdown()
+	if(game_timer == "paused")
+		return "Timer paused, tower activation in progress"
+	return ..()
+
 /datum/game_mode/combat_patrol/sensor_capture/set_game_end()
 	if(timeleft(game_timer) > 0)
 		return

--- a/code/datums/gamemodes/sensor_capture.dm
+++ b/code/datums/gamemodes/sensor_capture.dm
@@ -22,7 +22,7 @@
 	addtimer(CALLBACK(src, /datum/game_mode/combat_patrol.proc/set_game_timer), SSticker.round_start_time + shutters_drop_time) //game end timer will start ticking down on shutter drop
 
 /datum/game_mode/combat_patrol/sensor_capture/game_end_countdown()
-	if(game_timer == "paused")
+	if(game_timer == SENSOR_CAP_TIMER_PAUSED)
 		return "Timer paused, tower activation in progress"
 	return ..()
 

--- a/code/game/objects/structures/sensor_tower.dm
+++ b/code/game/objects/structures/sensor_tower.dm
@@ -86,6 +86,8 @@
 	var/activated = FALSE
 	///Prevents there being more than one sensor tower being activated
 	var/static/already_activated = FALSE
+	///How long is left in the game end timer. Recorded as a var to pause the timer while tower is activating
+	var/remaining_game_time
 
 /obj/structure/sensor_tower_patrol/Initialize()
 	. = ..()
@@ -137,6 +139,11 @@
 
 ///Starts timer and sends an alert
 /obj/structure/sensor_tower_patrol/proc/begin_activation()
+	current_timer = addtimer(CALLBACK(src, .proc/finish_activation), generate_time, TIMER_STOPPABLE)
+	already_activated = TRUE
+	toggle_game_timer()
+	update_icon()
+
 	for(var/mob/living/carbon/human/human AS in GLOB.alive_human_list)
 		human.playsound_local(human, "sound/effects/CIC_order.ogg", 10, 1)
 		if(human.faction == FACTION_TERRAGOV)
@@ -144,37 +151,39 @@
 		else
 			human.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:left valign='top'><u>OVERWATCH</u></span><br>" + "[src] is being activated, deactivate it!", /atom/movable/screen/text/screen_text/picture/potrait/som_over)
 
-	current_timer = addtimer(CALLBACK(src, .proc/finish_activation), generate_time, TIMER_STOPPABLE)
-	already_activated = TRUE
-	update_icon()
-
 ///When timer ends add a point to the point pool in sensor capture, increase game timer, and send an alert
 /obj/structure/sensor_tower_patrol/proc/finish_activation()
 	if(!current_timer)
 		return
 	if(activated)
 		return
-	playsound(src, 'sound/machines/ping.ogg', 25, 1)
+
 	current_timer = null
+	activated = TRUE
+	already_activated = FALSE
+	toggle_game_timer(SENSOR_CAP_ADDITION_TIME_BONUS)
+	update_icon()
+
+	var/datum/game_mode/combat_patrol/sensor_capture/mode = SSticker.mode
+	mode.sensors_activated += 1
+
+	playsound(src, 'sound/machines/ping.ogg', 25, 1)
 	balloon_alert_to_viewers("[src] has finished activation!")
+
 	for(var/mob/living/carbon/human/human AS in GLOB.alive_human_list)
 		human.playsound_local(human, "sound/effects/CIC_order.ogg", 10, 1)
 		if(human.faction == FACTION_TERRAGOV)
-			human.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:left valign='top'><u>OVERWATCH</u></span><br>" + "[src] is fully activated, timer increased by 7 minutes.", /atom/movable/screen/text/screen_text/picture/potrait)
+			human.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:left valign='top'><u>OVERWATCH</u></span><br>" + "[src] is fully activated, timer increased by [SENSOR_CAP_ADDITION_TIME_BONUS / 600] minutes.", /atom/movable/screen/text/screen_text/picture/potrait)
 		else
 			human.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:left valign='top'><u>OVERWATCH</u></span><br>" + "[src] is fully activated, stop further towers from being activated!", /atom/movable/screen/text/screen_text/picture/potrait/som_over)
-	var/datum/game_mode/combat_patrol/sensor_capture/mode = SSticker.mode
-	mode.sensors_activated += 1
-	var/current_time = timeleft(mode.game_timer)
-	mode.game_timer = addtimer(CALLBACK(mode, /datum/game_mode/combat_patrol.proc/set_game_end), current_time + 7 MINUTES, TIMER_STOPPABLE)
-	activated = TRUE
-	already_activated = FALSE
-	update_icon()
 
 ///Stops timer if activating and sends an alert
 /obj/structure/sensor_tower_patrol/proc/deactivate()
 	current_timer = null
 	already_activated = FALSE
+	toggle_game_timer()
+	update_icon()
+
 	for(var/mob/living/carbon/human/human AS in GLOB.alive_human_list)
 		if(human.faction == FACTION_TERRAGOV)
 			human.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:left valign='top'><u>OVERWATCH</u></span><br>" + "[src] activation process has been stopped<br>" + ",rally up and get it together team!", /atom/movable/screen/text/screen_text/picture/potrait)
@@ -182,7 +191,19 @@
 			human.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:left valign='top'><u>OVERWATCH</u></span><br>" + "[src] activation process has been stopped, glory to Mars!", /atom/movable/screen/text/screen_text/picture/potrait/som_over)
 
 		human.playsound_local(human, "sound/effects/CIC_order.ogg", 10, 1)
-	update_icon()
+
+///Pauses or restarts the gamemode timer
+/obj/structure/sensor_tower_patrol/proc/toggle_game_timer(addition_time)
+	var/datum/game_mode/combat_patrol/sensor_capture/mode = SSticker.mode
+
+	if(mode.game_timer)
+		remaining_game_time = timeleft(mode.game_timer)
+		deltimer(mode.game_timer) //game timer is paused while tower is running
+		mode.game_timer = "paused"
+		return
+
+	mode.game_timer = addtimer(CALLBACK(mode, /datum/game_mode/combat_patrol.proc/set_game_end), remaining_game_time + addition_time, TIMER_STOPPABLE)
+
 
 /obj/structure/sensor_tower_patrol/update_icon()
 	. = ..()

--- a/code/game/objects/structures/sensor_tower.dm
+++ b/code/game/objects/structures/sensor_tower.dm
@@ -196,14 +196,13 @@
 /obj/structure/sensor_tower_patrol/proc/toggle_game_timer(addition_time)
 	var/datum/game_mode/combat_patrol/sensor_capture/mode = SSticker.mode
 
-	if(mode.game_timer)
-		remaining_game_time = timeleft(mode.game_timer)
-		deltimer(mode.game_timer) //game timer is paused while tower is running
-		mode.game_timer = "paused"
+	if(mode.game_timer == SENSOR_CAP_TIMER_PAUSED)
+		mode.game_timer = addtimer(CALLBACK(mode, /datum/game_mode/combat_patrol.proc/set_game_end), remaining_game_time + addition_time, TIMER_STOPPABLE)
 		return
 
-	mode.game_timer = addtimer(CALLBACK(mode, /datum/game_mode/combat_patrol.proc/set_game_end), remaining_game_time + addition_time, TIMER_STOPPABLE)
-
+	remaining_game_time = timeleft(mode.game_timer)
+	deltimer(mode.game_timer) //game timer is paused while tower is running
+	mode.game_timer = SENSOR_CAP_TIMER_PAUSED
 
 /obj/structure/sensor_tower_patrol/update_icon()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
The Game timer is now paused when a tower is activating, and restarts when the tower fully activates or is disabled.

This makes it much easier for marines to actually try and win, without getting fucked on by the timer.

The additional time granted by capping a tower has been reduced to 5 minutes. I'll like tweak this timer and/or the capture times themselves in the future however.
## Why It's Good For The Game
Less frustrating losses when winning the game, more enjoyable rounds for both teams.
## Changelog
:cl:
balance: Sensor Capture: the game timer pauses while towers are being activated
Balance: Sensor Capture: reduced the additional game time for activating a timer to 3 minutes
/:cl:
