### PR TITLE
sunsets mp lobby mexican standoffs

### DIFF
--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -363,7 +363,7 @@ Though you are a warrant officer, your authority is limited to the dropship and 
 	req_admin_notify = TRUE
 	paygrade = "E3"
 	comm_title = "MCH"
-	total_positions = 0
+	total_positions = 1
 	skills_type = /datum/skills/mech_pilot
 	access = list(ACCESS_MARINE_WO, ACCESS_MARINE_PREP, ACCESS_MARINE_MECH, ACCESS_CIVILIAN_PUBLIC)
 	minimal_access = list(ACCESS_MARINE_WO, ACCESS_MARINE_PREP, ACCESS_MARINE_MECH, ACCESS_CIVILIAN_PUBLIC, ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_CARGO)
@@ -372,8 +372,7 @@ Though you are a warrant officer, your authority is limited to the dropship and 
 	exp_requirements = XP_REQ_EXPERT
 	exp_type = EXP_TYPE_REGULAR_ALL
 	job_flags = JOB_FLAG_LATEJOINABLE|JOB_FLAG_ROUNDSTARTJOINABLE|JOB_FLAG_ALLOWS_PREFS_GEAR|JOB_FLAG_PROVIDES_BANK_ACCOUNT|JOB_FLAG_ADDTOMANIFEST|JOB_FLAG_PROVIDES_SQUAD_HUD|JOB_FLAG_CAN_SEE_ORDERS|JOB_FLAG_ALWAYS_VISIBLE_ON_MINIMAP
-	job_points_needed = 40
-	job_points = 15
+	job_points_needed = 65
 	jobworth = list(
 		/datum/job/xenomorph = LARVA_POINTS_SHIPSIDE,
 		/datum/job/terragov/squad/smartgunner = SMARTIE_POINTS_REGULAR,


### PR DESCRIPTION

## About The Pull Request
Makes mech accesible roundstart
## Why It's Good For The Game
mech was locked behind 25 pop because balance was out of wack and people really did not want to face it at low pop
mech has recieved significant balance changes since then and currently a number of players are essentially spawncamping the slot leading to them spamming join to grab the slot .Which is both not fun and discourages others from trying it out in the first place.This aims to make mech available roundstart and changes new slots to be available every 65 players

if this gets denied my only hope is that someone adresses it better than me 
## Changelog
:cl:
balance: changed mp slots to be available roundstart ,second at 65, from 25/65 to 0/65
/:cl:
