### PR TITLE
Buffs M40 FLDP grenades and their related storage options

### DIFF
--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -294,7 +294,7 @@
 	det_time = 0
 	throwforce = 1
 	dangerous = FALSE
-	w_class = WEIGHT_CLASS_SMALL
+	w_class = WEIGHT_CLASS_TINY
 	hud_state = "grenade_frag"
 	light_system = MOVABLE_LIGHT
 	light_range = 6

--- a/code/game/objects/items/flashlight.dm
+++ b/code/game/objects/items/flashlight.dm
@@ -185,7 +185,7 @@
 /obj/item/flashlight/flare
 	name = "flare"
 	desc = "A NT standard emergency flare. There are instructions on the side, it reads 'pull cord, make light'."
-	w_class = WEIGHT_CLASS_SMALL
+	w_class = WEIGHT_CLASS_TINY
 	light_power = 6 //As bright as a flashlight, but more disposable. Doesn't burn forever though
 	icon_state = "flare"
 	item_state = "flare"

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -369,10 +369,10 @@
 	name = "\improper M40 FLDP flare pack"
 	desc = "A packet of seven M40 FLDP Flares. Carried by TGMC soldiers to light dark areas that cannot be reached with the usual TNR Shoulder Lamp. Can be launched from an underslung grenade launcher."
 	icon_state = "m40"
-	w_class = WEIGHT_CLASS_NORMAL
-	max_storage_space = 14
+	w_class = WEIGHT_CLASS_SMALL
+	max_storage_space = 28
 	spawn_type = /obj/item/explosive/grenade/flare
-	spawn_number = 7
+	spawn_number = 28
 
 /obj/item/storage/box/m94/update_icon()
 	icon_state = initial(icon_state)

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -370,9 +370,9 @@
 	desc = "A packet of seven M40 FLDP Flares. Carried by TGMC soldiers to light dark areas that cannot be reached with the usual TNR Shoulder Lamp. Can be launched from an underslung grenade launcher."
 	icon_state = "m40"
 	w_class = WEIGHT_CLASS_SMALL
-	max_storage_space = 28
+	max_storage_space = 14
 	spawn_type = /obj/item/explosive/grenade/flare
-	spawn_number = 28
+	spawn_number = 14
 
 /obj/item/storage/box/m94/update_icon()
 	icon_state = initial(icon_state)

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -557,12 +557,18 @@
 	max_storage_space = 28
 	icon_state = "flare"
 	storage_type_limits = list(/obj/item/weapon/gun/grenade_launcher/single_shot/flare = 1)
-
+	bypass_w_limit = list(/obj/item/weapon/gun/grenade_launcher/single_shot/flare)
+	fill_type = /obj/item/explosive/grenade/flare
 	can_hold = list(
 		/obj/item/flashlight/flare,
 		/obj/item/weapon/gun/grenade_launcher/single_shot/flare,
 		/obj/item/explosive/grenade/flare,
 	)
+
+/obj/item/storage/pouch/flare/full/Initialize()
+	var/obj/item/flare_gun = new /obj/item/weapon/gun/grenade_launcher/single_shot/flare/marine(src)
+	fill_number = max_storage_space - flare_gun.w_class
+	return ..()
 
 /obj/item/storage/pouch/flare/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/storage/box/m94))
@@ -600,13 +606,6 @@
 		flare_gun.reload(flare, user)
 		orient2hud()
 		return
-
-/obj/item/storage/pouch/flare/full/Initialize()
-	. = ..()
-	if(max_storage_space)
-		for(var/i in 1 to (max_storage_space - 1))
-			new /obj/item/explosive/grenade/flare(src)
-	new /obj/item/weapon/gun/grenade_launcher/single_shot/flare/marine(src)
 
 /obj/item/storage/pouch/radio
 	name = "radio pouch"

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -597,12 +597,7 @@
 		return ..()
 	var/obj/item/weapon/gun/grenade_launcher/single_shot/flare/flare_gun = I
 	for(var/obj/item/flare in contents)
-		if(!(flare.type in can_hold))
-			continue
-		if(user.l_hand && user.r_hand || length(flare_gun.chamber_items))
-			flare_gun.tactical_reload(flare, user)
-		else
-			flare_gun.reload(flare, user)
+		flare_gun.reload(flare, user)
 		orient2hud()
 		return
 

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -552,9 +552,9 @@
 /obj/item/storage/pouch/flare
 	name = "flare pouch"
 	desc = "A pouch designed to hold flares and a single flaregun. Refillable with a M94 flare pack."
-	max_w_class = 2
-	storage_slots = 7
-	draw_mode = 1
+	max_w_class = 1
+	storage_slots = 28
+	max_storage_space = 28
 	icon_state = "flare"
 	storage_type_limits = list(/obj/item/weapon/gun/grenade_launcher/single_shot/flare = 1)
 
@@ -563,7 +563,6 @@
 		/obj/item/weapon/gun/grenade_launcher/single_shot/flare,
 		/obj/item/explosive/grenade/flare,
 	)
-
 
 /obj/item/storage/pouch/flare/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/storage/box/m94))
@@ -593,9 +592,26 @@
 	else
 		return ..()
 
-/obj/item/storage/pouch/flare/full
-	fill_type = /obj/item/explosive/grenade/flare
-	fill_number = 7
+/obj/item/storage/pouch/flare/attackby_alternate(obj/item/I, mob/user, params)
+	if(!istype(I, /obj/item/weapon/gun/grenade_launcher/single_shot/flare))
+		return ..()
+	var/obj/item/weapon/gun/grenade_launcher/single_shot/flare/flare_gun = I
+	for(var/obj/item/flare in contents)
+		if(!(flare.type in can_hold))
+			continue
+		if(user.l_hand && user.r_hand || length(flare_gun.chamber_items))
+			flare_gun.tactical_reload(flare, user)
+		else
+			flare_gun.reload(flare, user)
+		orient2hud()
+		return
+
+/obj/item/storage/pouch/flare/full/Initialize()
+	. = ..()
+	if(max_storage_space)
+		for(var/i in 1 to (max_storage_space - 1))
+			new /obj/item/explosive/grenade/flare(src)
+	new /obj/item/weapon/gun/grenade_launcher/single_shot/flare/marine(src)
 
 /obj/item/storage/pouch/radio
 	name = "radio pouch"

--- a/code/modules/projectiles/guns/grenade_launchers.dm
+++ b/code/modules/projectiles/guns/grenade_launchers.dm
@@ -209,7 +209,7 @@ The Grenade Launchers
 	item_state = "gun"
 	fire_sound = 'sound/weapons/guns/fire/flare.ogg'
 	fire_sound = 'sound/weapons/guns/fire/flare.ogg'
-	w_class = WEIGHT_CLASS_TINY
+	w_class = WEIGHT_CLASS_SMALL
 	flags_gun_features = NONE
 	gun_skill_category = GUN_SKILL_PISTOLS
 	fire_delay = 0.5 SECONDS


### PR DESCRIPTION
## About The Pull Request
Sponsored by the cabal.
Have you ever wanted to obliterate xenos?
Have you ever wanted to farm salt off of xenos?
Seek no further. The cabal provides.

The following changes have been made:
- Flare packs (including CAS flares) have had their inventory size reduced.
- Flare packs can now hold a maximum of 14 flares.
- All flares have had their inventory size reduced.
- Flare pouches can now hold a maximum of 28 items.
- Flare guns can now be tactically reloaded with a flare pouch by right clicking it.
- Flare guns have had their inventory size increased, but it still fits in flare pouches.

## Why It's Good For The Game
Flares have sucked for the longest time, and this feels like a neat way to enhance marine visibility.
As discussed with @TiviPlus in the Discord, flares should be very spammable but easily dealt with.

## Changelog
:cl: Lewdcifer
add: Flare guns can now be tactically reloaded with a flare pouch by right clicking it.
balance: Flare packs have had their inventory size reduced.
balance: Flares have had their inventory size reduced.
balance: Flare packs can now hold a maximum of 28 items.
balance: Flare pouches can now hold a maximum of 28 items.
/:cl: