### PR TITLE
CAS can no longer be launched before shutters open, or before Tadpole launches

### DIFF
--- a/code/modules/shuttle/cas_plane.dm
+++ b/code/modules/shuttle/cas_plane.dm
@@ -50,6 +50,7 @@
 	cas_usable++
 	if(occupant)
 		to_chat(occupant, span_notice("Combat initiated, CAS now available."))
+	UnregisterSignal(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_CRASH, COMSIG_GLOB_OPEN_SHUTTERS_EARLY))
 
 ///Handles updating the cockpit overlay
 /obj/structure/caspart/caschair/proc/set_cockpit_overlay(new_state)

--- a/code/modules/shuttle/cas_plane.dm
+++ b/code/modules/shuttle/cas_plane.dm
@@ -22,13 +22,13 @@
 	///Animated cockpit /image overlay, 96x96
 	var/image/cockpit
 	/// Whether CAS is usable or not.
-	var/cas_usable = 0
+	var/cas_usable
 
 /obj/structure/caspart/caschair/Initialize()
 	. = ..()
 	set_cockpit_overlay("cockpit_closed")
 	RegisterSignal(SSdcs, COMSIG_GLOB_CAS_LASER_CREATED, .proc/receive_laser_cas)
-	RegisterSignal(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_CRASH, COMSIG_GLOB_OPEN_SHUTTERS_EARLY, COMSIG_GLOB_TADPOLE_LAUNCHED), .proc/cas_usable)
+	RegisterSignal(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_SHUTTERS_EARLY, COMSIG_GLOB_TADPOLE_LAUNCHED), .proc/cas_usable)
 
 /obj/structure/caspart/caschair/Destroy()
 	owner?.chair = null
@@ -47,10 +47,10 @@
 
 /obj/structure/caspart/caschair/proc/cas_usable(datum/source)
 	SIGNAL_HANDLER
-	cas_usable++
+	UnregisterSignal(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_SHUTTERS_EARLY, COMSIG_GLOB_TADPOLE_LAUNCHED))
+	cas_usable = TRUE
 	if(occupant)
 		to_chat(occupant, span_notice("Combat initiated, CAS now available."))
-	UnregisterSignal(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_CRASH, COMSIG_GLOB_OPEN_SHUTTERS_EARLY, COMSIG_GLOB_TADPOLE_LAUNCHED))
 
 ///Handles updating the cockpit overlay
 /obj/structure/caspart/caschair/proc/set_cockpit_overlay(new_state)

--- a/code/modules/shuttle/cas_plane.dm
+++ b/code/modules/shuttle/cas_plane.dm
@@ -21,11 +21,14 @@
 	var/mob/living/carbon/human/occupant
 	///Animated cockpit /image overlay, 96x96
 	var/image/cockpit
+	/// Whether CAS is usable or not.
+	var/cas_usable = 0
 
 /obj/structure/caspart/caschair/Initialize()
 	. = ..()
 	set_cockpit_overlay("cockpit_closed")
 	RegisterSignal(SSdcs, COMSIG_GLOB_CAS_LASER_CREATED, .proc/receive_laser_cas)
+	RegisterSignal(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_CRASH, COMSIG_GLOB_OPEN_SHUTTERS_EARLY), .proc/cas_usable)
 
 /obj/structure/caspart/caschair/Destroy()
 	owner?.chair = null
@@ -41,6 +44,12 @@
 	playsound(src, 'sound/effects/binoctarget.ogg', 15)
 	if(occupant)
 		to_chat(occupant, span_notice("CAS laser detected. Target: [AREACOORD_NO_Z(incoming_laser)]"))
+
+/obj/structure/caspart/caschair/proc/cas_usable(datum/source)
+	SIGNAL_HANDLER
+	cas_usable++
+	if(occupant)
+		to_chat(occupant, span_notice("Combat initiated, CAS now available."))
 
 ///Handles updating the cockpit overlay
 /obj/structure/caspart/caschair/proc/set_cockpit_overlay(new_state)
@@ -433,6 +442,9 @@
 
 	switch(action)
 		if("launch")
+			if(!cas_usable)
+				to_chat(usr, "<span class='warning'>Combat has not yet initiated, CAS unavailable.")
+				return
 			if(owner.state == PLANE_STATE_FLYING || owner.mode != SHUTTLE_IDLE)
 				return
 			if(owner.fuel_left <= LOW_FUEL_THRESHOLD)

--- a/code/modules/shuttle/cas_plane.dm
+++ b/code/modules/shuttle/cas_plane.dm
@@ -28,7 +28,7 @@
 	. = ..()
 	set_cockpit_overlay("cockpit_closed")
 	RegisterSignal(SSdcs, COMSIG_GLOB_CAS_LASER_CREATED, .proc/receive_laser_cas)
-	RegisterSignal(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_CRASH, COMSIG_GLOB_OPEN_SHUTTERS_EARLY), .proc/cas_usable)
+	RegisterSignal(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_CRASH, COMSIG_GLOB_OPEN_SHUTTERS_EARLY, COMSIG_GLOB_TADPOLE_LAUNCHED), .proc/cas_usable)
 
 /obj/structure/caspart/caschair/Destroy()
 	owner?.chair = null
@@ -50,7 +50,7 @@
 	cas_usable++
 	if(occupant)
 		to_chat(occupant, span_notice("Combat initiated, CAS now available."))
-	UnregisterSignal(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_CRASH, COMSIG_GLOB_OPEN_SHUTTERS_EARLY))
+	UnregisterSignal(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_CRASH, COMSIG_GLOB_OPEN_SHUTTERS_EARLY, COMSIG_GLOB_TADPOLE_LAUNCHED))
 
 ///Handles updating the cockpit overlay
 /obj/structure/caspart/caschair/proc/set_cockpit_overlay(new_state)


### PR DESCRIPTION
## About The Pull Request
Per title.

## Why It's Good For The Game
I am getting so tired of the classic PO griefing the round for whatever reason.

## Changelog
:cl: Lewdcifer
fix: CAS is no longer usable before shutters open, or before Tadpole launches.
/:cl: