### PR TITLE
Buffs Combat Floodlights

### DIFF
--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -2193,7 +2193,7 @@
 	},
 /area/sulaco/bridge)
 "akv" = (
-/obj/machinery/floodlightcombat,
+/obj/machinery/floodlight/combat,
 /turf/open/floor/prison/red{
 	dir = 5
 	},
@@ -11139,7 +11139,7 @@
 /turf/open/floor/prison,
 /area/sulaco/cargo/office)
 "cvT" = (
-/obj/machinery/floodlightcombat,
+/obj/machinery/floodlight/combat,
 /obj/machinery/door_control/unmeltable{
 	id = "sd_blastdoor";
 	name = "Self Destruct Blast Door Control";

--- a/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
+++ b/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
@@ -240,7 +240,7 @@
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
 "aW" = (
-/obj/machinery/floodlightcombat,
+/obj/machinery/floodlight/combat,
 /turf/open/floor/prison,
 /area/whiskey_outpost)
 "aY" = (
@@ -5058,7 +5058,7 @@
 /turf/open/shuttle/dropship/eight,
 /area/whiskey_outpost/outside/east)
 "zM" = (
-/obj/machinery/floodlightcombat,
+/obj/machinery/floodlight/combat,
 /turf/open/floor/plating,
 /area/whiskey_outpost/outside/north)
 "zP" = (

--- a/code/game/objects/machinery/floodlight.dm
+++ b/code/game/objects/machinery/floodlight.dm
@@ -80,41 +80,37 @@
 	. = ..()
 	set_light(brightness_on)
 
-/obj/machinery/floodlightcombat
+/obj/machinery/floodlight/combat
 	name = "armoured floodlight"
-	icon = 'icons/obj/machines/floodlight.dmi'
 	icon_state = "floodlightcombat_off"
 	anchored = FALSE
-	density = TRUE
-	light_power = SQRTWO
-	light_system = STATIC_LIGHT
+	resistance_flags = UNACIDABLE|XENO_DAMAGEABLE
 	///the cell powering this floodlight
 	var/obj/item/cell/cell
 	/// The charge consumption every 2 seconds
-	var/energy_consummed = 6
+	var/energy_consummed = 4
 	/// The lighting power of the floodlight
 	var/floodlight_light_range = 15
 
-/obj/machinery/floodlightcombat/Initialize()
+/obj/machinery/floodlight/combat/Initialize()
 	. = ..()
 	cell = new()
 	GLOB.nightfall_toggleable_lights += src
 
-/obj/machinery/floodlightcombat/Destroy()
+/obj/machinery/floodlight/combat/Destroy()
 	QDEL_NULL(cell)
 	GLOB.nightfall_toggleable_lights -= src
 	return ..()
 
-
-/obj/machinery/floodlightcombat/examine(mob/user)
+/obj/machinery/floodlight/combat/examine(mob/user)
 	. = ..()
 	if(!cell)
-		. += span_notice("It has no cell installed")
+		. += span_notice("It has no cell installed.")
 		return
-	. += span_notice("[cell] has [CEILING(cell.charge / cell.maxcharge * 100, 1)]% charge left")
+	. += span_notice("[cell] has [CEILING(cell.charge / cell.maxcharge * 100, 1)]% charge left.")
 
 /// Handles the wrench act .
-/obj/machinery/floodlightcombat/wrench_act(mob/living/user, obj/item/I)
+/obj/machinery/floodlight/combat/wrench_act(mob/living/user, obj/item/I)
 	. = ..()
 	to_chat(user , span_notice("You begin wrenching \the [src]'s bolts."))
 	playsound(loc, 'sound/items/ratchet.ogg', 60, FALSE)
@@ -129,7 +125,7 @@
 		to_chat(user , span_notice("You wrench down \the [src]'s bolts."))
 		anchored = TRUE
 
-/obj/machinery/floodlightcombat/crowbar_act(mob/living/user, obj/item/I)
+/obj/machinery/floodlight/combat/crowbar_act(mob/living/user, obj/item/I)
 	. = ..()
 	if(!user)
 		return
@@ -144,20 +140,20 @@
 	cell = null
 	turn_light(user, FALSE, forced = TRUE)
 
-/obj/machinery/floodlightcombat/process()
+/obj/machinery/floodlight/combat/process()
 	cell.charge -= energy_consummed
 	if(cell.charge > 0)
 		return
 	cell.charge = 0
 	turn_light(null, FALSE, forced = TRUE)
 
-/obj/machinery/floodlightcombat/attackby(obj/item/I, mob/user, params)
+/obj/machinery/floodlight/combat/attackby(obj/item/I, mob/user, params)
 	if(!ishuman(user))
 		return FALSE
 	if(!istype(I, /obj/item/cell))
 		return FALSE
 	if(cell)
-		to_chat(user , span_warning("There is already a cell inside, use a crowbar to remove it."))
+		to_chat(user, span_warning("There is already a cell inside, use a crowbar to remove it."))
 		return
 	if(!do_after(user, 2 SECONDS, TRUE, src))
 		return FALSE
@@ -166,7 +162,7 @@
 	cell = I
 	playsound(loc, 'sound/items/deconstruct.ogg', 25, 1)
 
-/obj/machinery/floodlightcombat/turn_light(user, toggle_on , cooldown, sparks, forced)
+/obj/machinery/floodlight/combat/turn_light(user, toggle_on , cooldown, sparks, forced)
 	. = ..()
 	if(. != CHECKS_PASSED)
 		return
@@ -179,7 +175,7 @@
 	playsound(src,'sound/machines/click.ogg', 15, 1)
 	update_icon()
 
-/obj/machinery/floodlightcombat/attack_hand(mob/living/user)
+/obj/machinery/floodlight/combat/attack_hand(mob/living/user)
 	if(!ishuman(user))
 		return FALSE
 	if(!anchored)
@@ -194,16 +190,7 @@
 	turn_light(user, !light_on)
 	return TRUE
 
-/obj/machinery/floodlightcombat/attack_alien(mob/living/carbon/xenomorph/X, damage_amount, damage_type, damage_flag, effects, armor_penetration, isrightclick)
-	if(!light_on)
-		return ..()
-	X.do_attack_animation(src, ATTACK_EFFECT_CLAW)
-	X.visible_message(span_danger("[X] slashes \the [src]!"), \
-	span_danger("We slash \the [src]!"), null, 5)
-	playsound(loc, "alien_claw_metal", 25, 1)
-	turn_light(X, FALSE, forced = TRUE)
-
-/obj/machinery/floodlightcombat/update_icon_state()
+/obj/machinery/floodlight/combat/update_icon_state()
 	icon_state = "floodlightcombat" + (light_on ? "_on" : "_off")
 
 #define FLOODLIGHT_TICK_CONSUMPTION 800

--- a/code/game/objects/machinery/floodlight.dm
+++ b/code/game/objects/machinery/floodlight.dm
@@ -88,7 +88,7 @@
 	///the cell powering this floodlight
 	var/obj/item/cell/cell
 	/// The charge consumption every 2 seconds
-	var/energy_consummed = 4
+	var/energy_consummed = 6
 	/// The lighting power of the floodlight
 	var/floodlight_light_range = 15
 	/// The amount of integrity repaired with every welder act.

--- a/code/game/objects/machinery/floodlight.dm
+++ b/code/game/objects/machinery/floodlight.dm
@@ -144,32 +144,7 @@
 	turn_light(user, FALSE, forced = TRUE)
 
 /obj/machinery/floodlight/combat/welder_act(mob/living/user, obj/item/I)
-	if(user.do_actions)
-		return FALSE
-	var/obj/item/tool/weldingtool/welder = I
-	if(obj_integrity >= max_integrity)
-		to_chat(user, span_notice("[src] doesn't need repairs."))
-		return FALSE
-	if(!welder.tool_use_check(user, 2))
-		return FALSE
-	if(user.skills.getRating("engineer") < SKILL_ENGINEER_ENGI)
-		user.visible_message(span_notice("[user] fumbles around figuring out how to repair [src]."),
-		span_notice("You fumble around figuring out how to repair [src]."))
-		var/fumbling_time = 4 SECONDS * (SKILL_ENGINEER_ENGI - user.skills.getRating("engineer"))
-		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
-			return
-	user.visible_message(span_notice("[user] begins repairing damage to [src]."),
-	span_notice("You begin repairing the damage to [src]."))
-	playsound(loc, 'sound/items/welder2.ogg', 25, 1)
-	if(!do_after(user, 4 SECONDS, TRUE, src, BUSY_ICON_BUILD))
-		return
-	if(!welder.remove_fuel(2, user))
-		to_chat(user, span_warning("Not enough fuel to finish the task."))
-		return TRUE
-	playsound(loc, 'sound/items/welder2.ogg', 25, 1)
-	user.visible_message(span_notice("[user] repairs [src]'s damage."),
-	span_notice("You repair [src]."))
-	obj_integrity += repair_amount
+	return welder_repair_act(user, I, repair_amount, 4 SECONDS)
 
 /obj/machinery/floodlight/combat/process()
 	cell.charge -= energy_consummed

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1172,7 +1172,7 @@ ENGINEERING
 /datum/supply_packs/engineering/floodlight
 	name = "Combat Grade Floodlight"
 	contains = list(/obj/machinery/floodlight/combat)
-	cost = 20
+	cost = 30
 
 /datum/supply_packs/engineering/advanced_generator
 	name = "Wireless power generator"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1171,8 +1171,8 @@ ENGINEERING
 
 /datum/supply_packs/engineering/floodlight
 	name = "Combat Grade Floodlight"
-	contains = list(/obj/machinery/floodlightcombat)
-	cost = 100
+	contains = list(/obj/machinery/floodlight/combat)
+	cost = 20
 
 /datum/supply_packs/engineering/advanced_generator
 	name = "Wireless power generator"


### PR DESCRIPTION
## About The Pull Request
The following changes have been made to Combat Floodlights:
- Fixed a typepath issue.
- No longer acidable, but can now be damaged by slashes.
  - Floodlights have a maximum integrity of 500.
  - Can now be repaired using welders. Each welder use will restore 100 integrity.
  - Remaining integrity is visible by examining the floodlight.
- Reduced their cost in requisitions from 100 to 30 points.

## Why It's Good For The Game
Further enhances marine visibility and makes Combat Floodlights worth a damn.
As discussed with @TiviPlus, floodlights should be complicated to deal with, but scarce in amount.

## Changelog
:cl: Lewdcifer
balance: Combat Floodlights are no longer acidable, but can now be damaged by slashes.
balance: Combat Floodlights can now be repaired using welders. Examine the Floodlight to see its remaining integrity.
balance: Combat Floodlights have had their cost in requisitions reduced from 100 to 30.
/:cl: