### PR TITLE
Laser Pistol no longer has wielded slowdown

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -500,6 +500,7 @@
 	accuracy_mult = 1
 	accuracy_mult_unwielded = 0.9
 	damage_falloff_mult = 0.2
+	aim_slowdown = 0
 	mode_list = list(
 		"Standard" = /datum/lasrifle/base/energy_pistol_mode/standard,
 		"Heat" = /datum/lasrifle/base/energy_pistol_mode/heat,


### PR DESCRIPTION
## About The Pull Request
Per title. Laser Pistol's wielded slowdown has been reduced from 0.75 to 0.
Someone probably overlooked the parent's slowdown when doing this.

## Why It's Good For The Game
Why in tarnation does a sidearm have the equivalent wielded slowdown of a laser rifle? In fact, why does a sidearm even have slowdown in the first place?

## Changelog
:cl: Lewdcifer
balance: Laser Pistol wielded slowdown reduced from 0.75 to 0.
/:cl: