### PR TITLE
All shoes now have the same armor unless specified otherwise

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -237,7 +237,7 @@
 	permeability_coefficient = 0.50
 	slowdown = SHOES_SLOWDOWN
 	blood_sprite_state = "shoeblood"
-
+	soft_armor = list(MELEE = 25, BULLET = 15, LASER = 5, ENERGY = 5, BOMB = 5, BIO = 5, FIRE = 5, ACID = 20)
 
 /obj/item/clothing/shoes/update_clothing_icon()
 	if (ismob(src.loc))

--- a/code/modules/clothing/shoes/marine_shoes.dm
+++ b/code/modules/clothing/shoes/marine_shoes.dm
@@ -1,12 +1,9 @@
-
-
 /obj/item/clothing/shoes/marine
 	name = "marine combat boots"
 	desc = "Standard issue combat boots for combat scenarios or combat situations. All combat, all the time."
 	icon_state = "marine"
 	item_state = "marine"
 	flags_armor_protection = FEET
-	soft_armor = list(MELEE = 25, BULLET = 15, LASER = 5, ENERGY = 5, BOMB = 5, BIO = 5, FIRE = 5, ACID = 20)
 	flags_cold_protection = FEET
 	flags_heat_protection = FEET
 	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
@@ -82,7 +79,6 @@
 	desc = "Protects you from fire and even contains a pouch for your knife!"
 	icon_state = "marine_armored"
 	hard_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 100, ACID = 0)
-
 
 /obj/item/clothing/shoes/marinechief
 	name = "chief officer shoes"


### PR DESCRIPTION
## About The Pull Request
Per title. Looking at you, western boots.

## Why It's Good For The Game
- There's many off cases where shoes have no armor values despite being supposed to.
- Just because your shoes weren't in the standard clothing vendor doesn't mean you should have 0 armor. #Justice4ERTs.
- Hardly part of my actual argument, but... c'mon. Even in real life the most poor of materials in a shoe can at least provide _some_ form of protection.

## Changelog
:cl: Lewdcifer
balance: All shoes now have the same armor unless specified otherwise.
/:cl: