### PR TITLE
Removes Roombas from 4 Shipmaps

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -9229,7 +9229,7 @@
 /area/mainship/living/pilotbunks)
 "AU" = (
 /obj/effect/attach_point/weapon/dropship2{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
@@ -9250,7 +9250,7 @@
 /area/mainship/command/self_destruct)
 "AY" = (
 /obj/effect/attach_point/weapon/dropship2{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
@@ -11827,13 +11827,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
-"IF" = (
-/obj/machinery/roomba,
-/obj/structure/mirror{
-	dir = 4
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/general)
 "IH" = (
 /obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/mono,
@@ -12308,7 +12301,7 @@
 /area/mainship/living/bridgebunks)
 "JZ" = (
 /turf/closed/shuttle/ert/engines/right{
-	dir = 1;
+	dir = 1
 	},
 /area/space)
 "Ka" = (
@@ -12814,7 +12807,7 @@
 /area/mainship/living/numbertwobunks)
 "LB" = (
 /obj/effect/attach_point/weapon/dropship1{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
@@ -14716,7 +14709,7 @@
 /area/mainship/engineering/engineering_workshop)
 "Rb" = (
 /turf/closed/shuttle/ert/engines/left{
-	dir = 1;
+	dir = 1
 	},
 /area/space)
 "Rc" = (
@@ -14968,7 +14961,7 @@
 /area/mainship/living/tankerbunks)
 "RQ" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 4;
+	dir = 4
 	},
 /area/mainship/hallways/hangar)
 "RR" = (
@@ -14990,7 +14983,7 @@
 /area/mainship/living/grunt_rnr)
 "RU" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 8;
+	dir = 8
 	},
 /area/mainship/hallways/hangar)
 "RV" = (
@@ -28633,7 +28626,7 @@ Dp
 UW
 YG
 cg
-IF
+cg
 JK
 KP
 Lq

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -6304,10 +6304,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
-"its" = (
-/obj/machinery/roomba,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "iuw" = (
 /obj/machinery/light/mainship,
 /obj/structure/sink{
@@ -55396,7 +55392,7 @@ eYx
 cPg
 cPg
 cMq
-its
+cPg
 cPg
 sqc
 kQp

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -10483,7 +10483,7 @@
 /area/sulaco/cargo/prep)
 "bwn" = (
 /obj/effect/attach_point/weapon/dropship1{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
@@ -12887,7 +12887,7 @@
 /area/sulaco/hallway/central_hall)
 "eNh" = (
 /obj/effect/attach_point/weapon/dropship2{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/sulaco/hangar/cas)
@@ -16294,7 +16294,7 @@
 /area/sulaco/maintenance/upperdeck_north_maint)
 "jBs" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 4;
+	dir = 4
 	},
 /area/sulaco/hangar)
 "jBX" = (
@@ -20202,15 +20202,6 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/hallway/evac)
-"oPD" = (
-/obj/machinery/roomba,
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/turf/open/floor/prison/green{
-	dir = 4
-	},
-/area/sulaco/marine)
 "oQG" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -23430,7 +23421,7 @@
 /area/sulaco/hangar)
 "sYa" = (
 /obj/effect/attach_point/weapon/dropship2{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/sulaco/hangar/cas)
@@ -25817,7 +25808,6 @@
 /area/sulaco/hallway/central_hall3)
 "whS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/roomba,
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/prison/red,
 /area/sulaco/cargo/prep)
@@ -26148,7 +26138,7 @@
 /area/sulaco/cafeteria)
 "wKu" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 8;
+	dir = 8
 	},
 /area/sulaco/hangar)
 "wKB" = (
@@ -48583,7 +48573,7 @@ aMv
 iHP
 aLF
 alq
-oPD
+qaA
 azx
 xJd
 xKf

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -449,7 +449,7 @@
 	input_tag = "waste_lower_in";
 	name = "Lower Deck Waste Tank Control";
 	output_tag = "waste_lower_out";
-	sensors = list("waste_sensor" = "Tank")
+	sensors = list("waste_sensor"="Tank")
 	},
 /turf/open/floor/mainship/orange,
 /area/mainship/hull/starboard_hull)
@@ -719,7 +719,7 @@
 /obj/machinery/computer/general_air_control/large_tank_control{
 	name = "Lower Oxygen Supply Console";
 	output_tag = "oxygen_lower_out";
-	sensors = list("oxy_sensor" = "Tank")
+	sensors = list("oxy_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -735,7 +735,7 @@
 /obj/machinery/computer/general_air_control/large_tank_control{
 	name = "Lower Nitrogen Control Console";
 	output_tag = "nit_lower_out";
-	sensors = list("nit_sensor" = "Tank")
+	sensors = list("nit_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -758,7 +758,7 @@
 	input_tag = "mix_lower_in";
 	name = "Lower Mixed Air Control";
 	output_tag = "mix_lower_out";
-	sensors = list("mix_sensor" = "Tank")
+	sensors = list("mix_sensor"="Tank")
 	},
 /turf/open/floor/mainship/orange{
 	dir = 5
@@ -828,7 +828,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/roomba,
 /turf/open/floor/mainship/purple{
 	dir = 1
 	},
@@ -8184,7 +8183,7 @@
 /obj/machinery/door/poddoor/mainship/open{
 	dir = 2;
 	id = "CIC Lockdown";
-	name = "\improper Combat Information Center Blast Door";
+	name = "\improper Combat Information Center Blast Door"
 	},
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -9651,12 +9650,6 @@
 	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
-"fpW" = (
-/obj/machinery/roomba,
-/turf/open/floor/mainship/green{
-	dir = 4
-	},
-/area/mainship/squads/req)
 "fqH" = (
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/surgery_hallway)
@@ -10160,10 +10153,6 @@
 	dir = 8
 	},
 /area/mainship/engineering/ce_room)
-"gbG" = (
-/obj/machinery/roomba,
-/turf/open/floor/mainship/orange,
-/area/mainship/squads/alpha)
 "gcJ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 10
@@ -11996,7 +11985,7 @@
 /area/mainship/hallways/bow_hallway)
 "jjN" = (
 /obj/effect/attach_point/weapon/dropship1{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
@@ -13188,7 +13177,7 @@
 "lto" = (
 /obj/machinery/door/poddoor/mainship/open{
 	id = "CIC Lockdown";
-	name = "\improper Combat Information Center Blast Door";
+	name = "\improper Combat Information Center Blast Door"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14167,7 +14156,7 @@
 /obj/machinery/door/poddoor/mainship/open{
 	dir = 2;
 	id = "Brig Lockdown";
-	name = "\improper Brig Lockdown Podlocks";
+	name = "\improper Brig Lockdown Podlocks"
 	},
 /turf/open/floor/plating,
 /area/mainship/living/tankerbunks)
@@ -15892,7 +15881,7 @@
 "pTq" = (
 /obj/machinery/door/poddoor/mainship/open{
 	id = "CIC Lockdown";
-	name = "\improper Combat Information Center Blast Door";
+	name = "\improper Combat Information Center Blast Door"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -17000,7 +16989,7 @@
 /obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/door/poddoor/mainship/open{
 	id = "CIC Lockdown";
-	name = "\improper Combat Information Center Blast Door";
+	name = "\improper Combat Information Center Blast Door"
 	},
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/plating,
@@ -19848,7 +19837,7 @@
 /area/space)
 "wQl" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 4;
+	dir = 4
 	},
 /area/mainship/hallways/hangar)
 "wQK" = (
@@ -19858,12 +19847,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/command/cic)
-"wRf" = (
-/obj/machinery/roomba,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
 "wRi" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/purple/corner{
@@ -19895,7 +19878,7 @@
 /area/space)
 "wVm" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 8;
+	dir = 8
 	},
 /area/mainship/hallways/hangar)
 "wVv" = (
@@ -52033,7 +52016,7 @@ bHi
 iGu
 iGu
 bJG
-wRf
+vuV
 qvb
 dFM
 iGu
@@ -60257,7 +60240,7 @@ bAG
 bnD
 bLG
 bnD
-fpW
+bnD
 bnD
 bLG
 bnD
@@ -63066,7 +63049,7 @@ iJv
 bfJ
 fgi
 fEX
-gbG
+kMY
 brj
 oWI
 ahU


### PR DESCRIPTION

## About The Pull Request
Removes the Roomba(s) from Sulaco, Pillar of Spring, Theseus, and Minerva Shipmaps
## Why It's Good For The Game
Roombas are at best ineffective and at worst obtrusive. Having them instantly teleport any item they walk over to Cryo Storage has, on multiple occasions, been frustrating or otherwise annoying.

 Most often in prep rooms, they will suck up items that a person is trying to manage from a loadout or otherwise, making it a hassle to get your loadout set up.

 Given their near indestructible nature as well, it would seem the most effective means of removing such a menace is to remove it's entire presence in the first place.

 (I would also like to mention this is my first PR and I most likely fucked up everything somehow)
## Changelog
:cl:
del: Removed Roomba(s) from Sulaco, Theseus, Pillar of Spring, and Minerva
/:cl:
