### PR TITLE
Chemistry Lab windows and Free Access with an addition of Theseus

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -3618,13 +3618,12 @@
 /turf/open/floor/mainship/terragov/north,
 /area/space)
 "kh" = (
-/obj/machinery/door/airlock/mainship/medical/free_access{
-	dir = 2;
-	name = "Chemistry"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
+/obj/machinery/door/airlock/mainship/medical/glass/chemistry{
+	dir = 1
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "ki" = (
@@ -7146,14 +7145,13 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "vf" = (
-/obj/machinery/door/airlock/mainship/medical/free_access{
-	dir = 2;
-	name = "Chemistry"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/door/airlock/mainship/medical/glass/chemistry{
+	dir = 1
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "vg" = (
@@ -9229,7 +9227,7 @@
 /area/mainship/living/pilotbunks)
 "AU" = (
 /obj/effect/attach_point/weapon/dropship2{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
@@ -9250,7 +9248,7 @@
 /area/mainship/command/self_destruct)
 "AY" = (
 /obj/effect/attach_point/weapon/dropship2{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
@@ -12308,7 +12306,7 @@
 /area/mainship/living/bridgebunks)
 "JZ" = (
 /turf/closed/shuttle/ert/engines/right{
-	dir = 1;
+	dir = 1
 	},
 /area/space)
 "Ka" = (
@@ -12814,7 +12812,7 @@
 /area/mainship/living/numbertwobunks)
 "LB" = (
 /obj/effect/attach_point/weapon/dropship1{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
@@ -14716,7 +14714,7 @@
 /area/mainship/engineering/engineering_workshop)
 "Rb" = (
 /turf/closed/shuttle/ert/engines/left{
-	dir = 1;
+	dir = 1
 	},
 /area/space)
 "Rc" = (
@@ -14968,7 +14966,7 @@
 /area/mainship/living/tankerbunks)
 "RQ" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 4;
+	dir = 4
 	},
 /area/mainship/hallways/hangar)
 "RR" = (
@@ -14990,7 +14988,7 @@
 /area/mainship/living/grunt_rnr)
 "RU" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 8;
+	dir = 8
 	},
 /area/mainship/hallways/hangar)
 "RV" = (

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -1,6 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aam" = (
 /obj/machinery/door/airlock/mainship/generic/bathroom,
+/obj/effect/turf_decal/tracks/wheels/bloody{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "aat" = (
@@ -4205,6 +4208,7 @@
 /area/mainship/squads/general)
 "fol" = (
 /obj/effect/ai_node,
+/obj/effect/turf_decal/tracks/wheels/bloody,
 /turf/open/floor/mainship/ntlogo/nt2,
 /area/mainship/command/corporateliaison)
 "fom" = (
@@ -5842,11 +5846,11 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "hGT" = (
-/obj/structure/window/framed/mainship/white,
 /obj/machinery/door/firedoor/mainship,
 /obj/machinery/door/poddoor/shutters/opened/medbay{
 	dir = 2
 	},
+/obj/structure/window/framed/mainship/white/chemistry,
 /turf/open/floor/plating/platebotc,
 /area/mainship/medical/chemistry)
 "hHH" = (
@@ -5886,7 +5890,6 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},
-/obj/structure/closet/bodybag,
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/lower_engineering)
 "hJa" = (
@@ -6510,6 +6513,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "iDm" = (
+/obj/effect/turf_decal/tracks/wheels/bloody,
 /turf/open/floor/mainship/floor,
 /area/mainship/command/corporateliaison)
 "iDs" = (
@@ -7876,6 +7880,9 @@
 /area/space)
 "kxN" = (
 /obj/machinery/light/mainship,
+/obj/effect/turf_decal/tracks/wheels/bloody{
+	dir = 10
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/command/corporateliaison)
 "kxP" = (
@@ -8098,6 +8105,18 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
+"kJg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tracks/wheels/bloody{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/command/corporateliaison)
 "kJX" = (
 /obj/structure/window/framed/mainship/hull,
 /turf/open/floor/mainship_hull,
@@ -9501,10 +9520,6 @@
 	dir = 4
 	},
 /obj/structure/punching_bag,
-/obj/effect/decal/cleanable/blood/writing{
-	desc = "It looks like a writing in blood. It says, 'I don't want to be a marine anymore.'";
-	dir = 4
-	},
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
 "mka" = (
@@ -13345,6 +13360,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
+/obj/effect/turf_decal/tracks/wheels/bloody{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "rdS" = (
@@ -13549,6 +13567,7 @@
 /obj/item/tool/kitchen/knife/ritual,
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/rune,
+/obj/effect/landmark/corpsespawner/marine/regular,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/corporateliaison)
 "rrZ" = (
@@ -14179,15 +14198,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "soc" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood/writing{
-	desc = "It looks like a writing in blood. It says, 'The gates of Hel are open when this armory is opened.'";
-	dir = 4
-	},
-/turf/open/floor/plating/mainship,
-/area/mainship/command/cic)
+/obj/effect/landmark/corpsespawner/syndicatecommando/regular,
+/turf/open/floor/mainship_hull,
+/area/space)
 "soK" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating/icefloor/warnplate,
@@ -15121,6 +15134,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
@@ -16102,12 +16118,25 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/command/cic)
+"uCu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/tracks/wheels/bloody{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/command/corporateliaison)
 "uCO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "uDd" = (
+/obj/effect/landmark/corpsespawner/prisoner/regular,
 /turf/open/floor/mainship/research/containment/floor1,
 /area/mainship/medical/medical_science)
 "uDj" = (
@@ -16142,7 +16171,7 @@
 /obj/machinery/door/poddoor/shutters/opened/medbay{
 	dir = 2
 	},
-/obj/structure/window/framed/mainship/white,
+/obj/structure/window/framed/mainship/white/chemistry,
 /turf/open/floor/plating/platebotc,
 /area/mainship/medical/chemistry)
 "uEU" = (
@@ -16536,10 +16565,6 @@
 /obj/machinery/light/mainship{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/blood/writing{
-	desc = "It looks like a writing in blood. It says, 'Don't trust the marines.'";
-	dir = 4
-	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/commandbunks)
 "vcN" = (
@@ -16845,6 +16870,9 @@
 	},
 /obj/structure/bed/chair/nometal{
 	dir = 8
+	},
+/obj/effect/turf_decal/tracks/wheels/bloody{
+	dir = 9
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
@@ -17475,6 +17503,9 @@
 	dir = 5
 	},
 /obj/effect/ai_node,
+/obj/effect/turf_decal/tracks/wheels/bloody{
+	dir = 4
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/command/corporateliaison)
 "wsm" = (
@@ -45439,7 +45470,7 @@ rWv
 boB
 vzF
 mNK
-glN
+uCu
 ges
 bmt
 wsb
@@ -45956,7 +45987,7 @@ leu
 sFt
 rrI
 leu
-wEo
+kJg
 tBh
 pfH
 qUT
@@ -49539,7 +49570,7 @@ pyV
 pgh
 pgh
 tBj
-xyS
+hGT
 hUf
 cNy
 hUf
@@ -50861,7 +50892,7 @@ wmH
 gsj
 yaz
 bLH
-soc
+fHu
 fHu
 jBi
 qjH
@@ -57228,7 +57259,7 @@ nWT
 nWT
 nWT
 nWT
-nWT
+soc
 nWT
 nWT
 esN

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -566,8 +566,8 @@
 /turf/closed/wall/mainship/white,
 /area/sulaco/medbay)
 "abY" = (
-/obj/machinery/door/airlock/mainship/medical/glass/chemistry,
 /obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/airlock/mainship/medical/glass/chemistry,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
 	},
@@ -10483,7 +10483,7 @@
 /area/sulaco/cargo/prep)
 "bwn" = (
 /obj/effect/attach_point/weapon/dropship1{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
@@ -12887,7 +12887,7 @@
 /area/sulaco/hallway/central_hall)
 "eNh" = (
 /obj/effect/attach_point/weapon/dropship2{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/sulaco/hangar/cas)
@@ -16294,7 +16294,7 @@
 /area/sulaco/maintenance/upperdeck_north_maint)
 "jBs" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 4;
+	dir = 4
 	},
 /area/sulaco/hangar)
 "jBX" = (
@@ -17064,7 +17064,6 @@
 /turf/open/floor/prison/plate,
 /area/shuttle/distress/arrive_2)
 "kzw" = (
-/obj/machinery/door/airlock/mainship/generic,
 /obj/machinery/door/poddoor/shutters/opened/medbay,
 /obj/machinery/door/firedoor/mainship,
 /obj/structure/cable,
@@ -17075,6 +17074,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/mainship,
+/obj/machinery/door/airlock/mainship/medical/glass/chemistry,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
@@ -23430,7 +23430,7 @@
 /area/sulaco/hangar)
 "sYa" = (
 /obj/effect/attach_point/weapon/dropship2{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/sulaco/hangar/cas)
@@ -24841,7 +24841,7 @@
 /turf/open/floor/prison/marked,
 /area/sulaco/cargo)
 "uPy" = (
-/obj/structure/window/framed/mainship/white,
+/obj/structure/window/framed/mainship/white/chemistry,
 /turf/open/floor/plating/platebotc,
 /area/sulaco/medbay/chemistry)
 "uQi" = (
@@ -26148,7 +26148,7 @@
 /area/sulaco/cafeteria)
 "wKu" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 8;
+	dir = 8
 	},
 /area/sulaco/hangar)
 "wKB" = (

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -2008,8 +2008,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "aEX" = (
-/obj/structure/window/framed/mainship/white,
 /obj/machinery/door/firedoor/mainship,
+/obj/structure/window/framed/mainship/white/chemistry,
 /turf/open/floor/plating,
 /area/mainship/medical/medical_science)
 "aFq" = (
@@ -4326,12 +4326,13 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "bqV" = (
-/obj/machinery/door/airlock/multi_tile/mainship/research{
-	dir = 2;
-	name = "Research Chemical Lab"
-	},
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 1
+	},
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
+	dir = 1;
+	name = "Chemistry";
+	req_one_access = list(2,8,40)
 	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/medical_science)
@@ -5446,6 +5447,8 @@
 "bDQ" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/stack/sheet/metal/large_stack,
+/obj/item/uav_turret/droid,
+/obj/item/uav_turret/droid,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
 "bDR" = (
@@ -8184,7 +8187,7 @@
 /obj/machinery/door/poddoor/mainship/open{
 	dir = 2;
 	id = "CIC Lockdown";
-	name = "\improper Combat Information Center Blast Door";
+	name = "\improper Combat Information Center Blast Door"
 	},
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -11996,7 +11999,7 @@
 /area/mainship/hallways/bow_hallway)
 "jjN" = (
 /obj/effect/attach_point/weapon/dropship1{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
@@ -13188,7 +13191,7 @@
 "lto" = (
 /obj/machinery/door/poddoor/mainship/open{
 	id = "CIC Lockdown";
-	name = "\improper Combat Information Center Blast Door";
+	name = "\improper Combat Information Center Blast Door"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14167,7 +14170,7 @@
 /obj/machinery/door/poddoor/mainship/open{
 	dir = 2;
 	id = "Brig Lockdown";
-	name = "\improper Brig Lockdown Podlocks";
+	name = "\improper Brig Lockdown Podlocks"
 	},
 /turf/open/floor/plating,
 /area/mainship/living/tankerbunks)
@@ -15007,6 +15010,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
+"okX" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/vehicle/unmanned/droid,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/engineering/lower_engineering)
 "olA" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -15892,7 +15904,7 @@
 "pTq" = (
 /obj/machinery/door/poddoor/mainship/open{
 	id = "CIC Lockdown";
-	name = "\improper Combat Information Center Blast Door";
+	name = "\improper Combat Information Center Blast Door"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -17000,7 +17012,7 @@
 /obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/door/poddoor/mainship/open{
 	id = "CIC Lockdown";
-	name = "\improper Combat Information Center Blast Door";
+	name = "\improper Combat Information Center Blast Door"
 	},
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/plating,
@@ -17982,6 +17994,13 @@
 /obj/machinery/computer/station_alert,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/engineering/lower_engine_monitoring)
+"tsP" = (
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/obj/structure/window/framed/mainship/white/chemistry,
+/turf/open/floor/plating,
+/area/mainship/medical/medical_science)
 "ttM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19848,7 +19867,7 @@
 /area/space)
 "wQl" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 4;
+	dir = 4
 	},
 /area/mainship/hallways/hangar)
 "wQK" = (
@@ -19895,7 +19914,7 @@
 /area/space)
 "wVm" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 8;
+	dir = 8
 	},
 /area/mainship/hallways/hangar)
 "wVv" = (
@@ -58210,7 +58229,7 @@ bpc
 bpd
 nCj
 bMw
-aEX
+tsP
 ruj
 bQv
 ruj
@@ -58467,7 +58486,7 @@ saZ
 ogn
 aDE
 bpj
-aEX
+tsP
 rbP
 rMd
 eeo
@@ -58724,7 +58743,7 @@ rvJ
 gRX
 jEn
 eRr
-aEX
+tsP
 ruj
 bQv
 ruj
@@ -71051,8 +71070,8 @@ baU
 fxK
 bzB
 bDP
-bDP
-bDP
+okX
+okX
 bEW
 bjs
 azj

--- a/code/game/objects/machinery/doors/airlock_types.dm
+++ b/code/game/objects/machinery/doors/airlock_types.dm
@@ -549,7 +549,7 @@
 
 /obj/machinery/door/airlock/mainship/medical/glass/chemistry
 	name = "\improper Chemistry Laboratory"
-	req_access = list(ACCESS_MARINE_CHEMISTRY)
+	req_access = null
 
 /obj/machinery/door/airlock/mainship/medical/rebel/glass/chemistry
 	name = "\improper Chemistry Laboratory"

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -460,6 +460,13 @@
 	basestate = "white_rwindow"
 	window_frame = /obj/structure/window_frame/mainship/white
 
+/obj/structure/window/framed/mainship/white/chemistry
+	name = "chemistry lab window"
+	desc = "Chemistry lab's own window."
+	max_integrity = 1000
+	deconstructable = FALSE
+	resistance_flags = PLASMACUTTER_IMMUNE | PROJECTILE_IMMUNE
+
 /obj/structure/window/framed/mainship/white/canterbury //So we can wallsmooth properly.
 	smoothing_groups = SMOOTH_CANTERBURY
 


### PR DESCRIPTION
## About The Pull Request

Chemistry lab windows now have 1,000 max integrity, cannot be deconstructed, cannot be plasma cut, and cannot get shot at. Due to this, chemistry lab has free access.

Also, give Theseus combat drones. Someone forgot to add these in Theseus.

## Why It's Good For The Game

Admins are tired of chem lab getting destroyed.

Players are tired of getting notes from trying to get into chem lab, and it got one player banned due to excessive notes (I also contributed to this ban as well). In fact, I have notes of breaking into chem lab.

Both Minerva and Sulaco have free access to chem lab, but not Theseus and Pillar of Spring. To incentize players to use the door, chem lab windows are stronger. This reminds me of the time when marine players would break into req despite them havnig no access to use console.

I have headmin and code maintainer given their word that this is a good idea.

## Changelog

:cl:
add: stronger chemistry lab windows and free access to chemistry lab
add: combat drones in Theseus
/:cl:

