### PR TITLE
mech APFDS (Heavy cannon) and sniper no longer sunder

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1100,7 +1100,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING|AMMO_SNIPER|AMMO_IFF
 	damage = 100
 	penetration = 35
-	sundering = 5
+	sundering = 0
 	damage_falloff = 0.3
 
 /*
@@ -1255,7 +1255,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	max_range = 14
 	damage = 150
 	penetration = 100
-	sundering = 20
+	sundering = 0
 	bullet_color = COLOR_PULSE_BLUE
 	on_pierce_multiplier = 0.85
 


### PR DESCRIPTION
## About The Pull Request
0 sunder, nada.
## Why It's Good For The Game
These are free, roundstart and on an incredibly tough piece to kill, they shouldn't really sunder at all considering their high damage and penetration.

## Changelog
:cl:
balance: Mech Heavy Cannon and sniper no longer have sunder.
/:cl:
