### PR TITLE
Spawners are no longer purchasable

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -223,14 +223,6 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	building_loc = 0 //This results in spawning the structure under the user.
 	building_time = 5 SECONDS
 
-/datum/hive_upgrade/building/spawner
-	name = "Spawner"
-	desc = "Constructs a spawner that generates ai xenos over time"
-	psypoint_cost = 600
-	icon = "spawner"
-	flags_upgrade = ABILITY_DISTRESS
-	building_type = /obj/structure/xeno/spawner
-
 /datum/hive_upgrade/defence
 	category = "Defences"
 
@@ -299,14 +291,6 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 
 /datum/hive_upgrade/xenos
 	category = "Xenos"
-
-/datum/hive_upgrade/xenos/smart_minions
-	name = GHOSTS_CAN_TAKE_MINIONS
-	desc = "Allow ghosts to take control of minions"
-	icon = "smartminions"
-	flags_gamemode = ABILITY_DISTRESS
-	flags_upgrade = UPGRADE_FLAG_ONETIME|UPGRADE_FLAG_MESSAGE_HIVE
-	psypoint_cost = 500
 
 /datum/hive_upgrade/primordial
 	category = "Xenos"


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
Minion spam attributes to an amount of lag and are generally unfun and don't provide any engaging combat.
AI Xenos function perfectly no matter the dilation and players suffer instead.
King works around any pathfinding issues but just summoning them.
(There's a separate server that caters to players that desire this sort of gameplay.)
## Changelog
:cl:
balance: Xenos may no longer purchase Spawners or Smart minions.
/:cl:
