### PR TITLE
Fix sensor capture timer bug

### DIFF
--- a/code/datums/gamemodes/combat_patrol.dm
+++ b/code/datums/gamemodes/combat_patrol.dm
@@ -21,6 +21,7 @@
 	)
 	whitelist_ship_maps = list(MAP_COMBAT_PATROL_BASE)
 	blacklist_ship_maps = null
+	blacklist_ground_maps = list(MAP_WHISKEY_OUTPOST)
 	/// Timer used to calculate how long till round ends
 	var/game_timer
 	///The length of time until round ends.
@@ -33,7 +34,8 @@
 	var/max_time_reached = FALSE
 	/// Time between two bioscan
 	var/bioscan_interval = 3 MINUTES
-	blacklist_ground_maps = list(MAP_WHISKEY_OUTPOST)
+	///Delay from shutter drop until game timer starts
+	var/game_timer_delay = 5 MINUTES
 
 /datum/game_mode/combat_patrol/post_setup()
 	. = ..()
@@ -83,7 +85,7 @@
 	. = ..()
 	//Starts the round timer when the game starts proper
 	var/datum/game_mode/combat_patrol/D = SSticker.mode
-	addtimer(CALLBACK(D, /datum/game_mode/combat_patrol.proc/set_game_timer), SSticker.round_start_time + shutters_drop_time + 5 MINUTES) //game cannot end until at least 5 minutes after shutter drop
+	addtimer(CALLBACK(D, /datum/game_mode/combat_patrol.proc/set_game_timer), SSticker.round_start_time + shutters_drop_time + game_timer_delay) //game cannot end until at least 5 minutes after shutter drop
 	addtimer(CALLBACK(D, /datum/game_mode/combat_patrol.proc/respawn_wave), SSticker.round_start_time + shutters_drop_time) //starts wave respawn on shutter drop and begins timer
 	addtimer(CALLBACK(D, /datum/game_mode/combat_patrol.proc/intro_sequence), SSticker.round_start_time + shutters_drop_time - 10 SECONDS) //starts intro sequence 10 seconds before shutter drop
 	TIMER_COOLDOWN_START(src, COOLDOWN_BIOSCAN, SSticker.round_start_time + shutters_drop_time + bioscan_interval)

--- a/code/datums/gamemodes/sensor_capture.dm
+++ b/code/datums/gamemodes/sensor_capture.dm
@@ -5,10 +5,10 @@
 	config_tag = "Sensor Capture"
 	wave_timer_length = 2 MINUTES
 	max_game_time = 10 MINUTES
+	blacklist_ground_maps = list(MAP_WHISKEY_OUTPOST)
+	game_timer_delay = 0
 	///The amount of activated sensor towers in sensor capture
 	var/sensors_activated = 0
-	blacklist_ground_maps = list(MAP_WHISKEY_OUTPOST)
-
 
 /datum/game_mode/combat_patrol/sensor_capture/post_setup()
 	. = ..()
@@ -19,19 +19,10 @@
 	to_chat(world, "<b>The current game mode is - Sensor Capture!</b>")
 	to_chat(world, "<b>The SOM have launched an invasion to this sector. TerraGov and SOM forces fight over the sensor towers around the sector.</b>")
 
-/datum/game_mode/combat_patrol/sensor_capture/setup_blockers()
-	. = ..()
-	addtimer(CALLBACK(src, /datum/game_mode/combat_patrol.proc/set_game_timer), SSticker.round_start_time + shutters_drop_time) //game end timer will start ticking down on shutter drop
-
 /datum/game_mode/combat_patrol/sensor_capture/game_end_countdown()
 	if(game_timer == SENSOR_CAP_TIMER_PAUSED)
 		return "Timer paused, tower activation in progress"
 	return ..()
-
-/datum/game_mode/combat_patrol/sensor_capture/set_game_end()
-	if(timeleft(game_timer) > 0)
-		return
-	max_time_reached = TRUE
 
 //End game checks
 /datum/game_mode/combat_patrol/sensor_capture/check_finished()


### PR DESCRIPTION

## About The Pull Request
Fixed an issue where SC rounds could suddenly end while there is still time on the clock.

Cleaned up the code a little as well.

SC was setting the game timer in addition to the base code for combat patrol already doing this. Although there was a check to see if an existing timer was present, that's not the best way to do it, and after I made towers pause the timer, it meant if a tower was contested at the 5 minute mark, a phantom game timer would be set.
## Why It's Good For The Game
Gamemode working properly is good.
## Changelog
:cl:
fix: Sensor Capture: Fixed an issue where the game could end unexpectedly
/:cl:
