### PR TITLE
Partially revert #11887 - 58fc27e25cf5fdb66ecc8808ddb8fea512f5c17b

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -83,6 +83,12 @@
 		qdel(I)
 		qdel(src)
 		user.put_in_hands(P)
+	else if(istype(I, /obj/item/clothing/glasses/night/imager_goggles))
+		var/obj/item/clothing/glasses/night/imager_goggles/eyepatch/P = new
+		to_chat(user, span_notice("You fasten the optical scanner to the inside of the eyepatch."))
+		qdel(I)
+		qdel(src)
+		user.put_in_hands(P)
 
 		update_icon(user)
 
@@ -171,6 +177,19 @@
 		else
 			var/obj/item/clothing/glasses/hud/medgoggles/S = new
 			to_chat(user, span_notice("You fasten the medical hud projector to the inside of the goggles."))
+			qdel(I)
+			qdel(src)
+			user.put_in_hands(S)
+	else if(istype(I, /obj/item/clothing/glasses/night/imager_goggles))
+		if(prescription)
+			var/obj/item/clothing/glasses/night/optgoggles/prescription/P = new
+			to_chat(user, span_notice("You fasten the optical imaging scanner to the inside of the goggles."))
+			qdel(I)
+			qdel(src)
+			user.put_in_hands(P)
+		else
+			var/obj/item/clothing/glasses/night/optgoggles/S = new
+			to_chat(user, span_notice("You fasten the optical imaging scanner to the inside of the goggles."))
 			qdel(I)
 			qdel(src)
 			user.put_in_hands(S)
@@ -324,6 +343,12 @@
 	if(istype(I, /obj/item/clothing/glasses/hud/health))
 		var/obj/item/clothing/glasses/hud/medsunglasses/P = new
 		to_chat(user, span_notice("You fasten the medical hud projector to the inside of the glasses."))
+		qdel(I)
+		qdel(src)
+		user.put_in_hands(P)
+	else if(istype(I, /obj/item/clothing/glasses/night/imager_goggles))
+		var/obj/item/clothing/glasses/night/imager_goggles/sunglasses/P = new
+		to_chat(user, span_notice("You fasten the optical imager scaner to the inside of the glasses."))
 		qdel(I)
 		qdel(src)
 		user.put_in_hands(P)

--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -62,6 +62,15 @@
 	actions_types = list(/datum/action/item_action/toggle)
 	vision_flags = SEE_TURFS
 
+/obj/item/clothing/glasses/night/imager_goggles
+	name = "optical imager goggles"
+	desc = "Uses image scanning to increase visibility of even the most dimly lit surroundings except total darkness"
+	icon_state = "securityhud"
+	deactive_state = "degoggles_sec"
+	darkness_view = 2
+	toggleable = TRUE
+	actions_types = list(/datum/action/item_action/toggle)
+
 /obj/item/clothing/glasses/night/optgoggles
 	name = "\improper Optical imager ballistic goggles"
 	desc = "Standard issue TGMC goggles. This pair has been fitted with an internal optical imaging scanner."
@@ -76,7 +85,24 @@
 	flags_equip_slot = ITEM_SLOT_EYES
 	goggles = TRUE
 
+/obj/item/clothing/glasses/night/imager_goggles/sunglasses
+	name = "\improper Optical imager sunglasses"
+	desc = "A pair of designer sunglasses. This pair has been fitted with an internal optical imager scanner."
+	icon_state = "optsunglasses"
+	item_state = "optsunglasses"
+	deactive_state = "degoggles_optsunglasses"
+	species_exception = list(/datum/species/robot)
+	sprite_sheets = list("Combat Robot" = 'icons/mob/species/robot/glasses.dmi')
+	prescription = TRUE
+
 /obj/item/clothing/glasses/night/optgoggles/prescription
 	name = "\improper Optical imager prescription ballistic goggles"
 	desc = "Standard issue TGMC prescription goggles. This pair has been fitted with an internal optical imaging scanner."
 	prescription = TRUE
+
+/obj/item/clothing/glasses/night/imager_goggles/eyepatch
+	name = "\improper Meson eyepatch"
+	desc = "An eyepatch fitted with the optical imager interface. For the disabled and/or edgy Marine."
+	icon_state = "optpatch"
+	deactive_state = "degoggles_medpatch"
+	toggleable = TRUE


### PR DESCRIPTION
## About The Pull Request
This PR partially reverts #11887.
It returns the code for the imager googles, but it does not add them back in for marines to use.

## Why It's Good For The Game
I think the googles are an interesting middle ground between mesons and full night vision, and there's a real chance that they could be used in the future. Keeping the code doesn't cost us anything, and still keeps the previous PR goals fulfilled. I could see myself giving them to an ERT, or as rare loot in future map making endeavors. 

Actually, it does cost us something. 2,2 KB of data. I think we can handle that much in our codebase. 

## Changelog
:cl:
code: Bring back imagers in the code, but not in the vendors or supply. 
/:cl:

