### PR TITLE
Mech repair speed reduction

### DIFF
--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -246,7 +246,7 @@
 		to_chat(user, span_notice("You close the hatch to the power unit."))
 
 /obj/vehicle/sealed/mecha/welder_act(mob/living/user, obj/item/I)
-	return welder_repair_act(user, I, 100, 2 SECONDS, 0, SKILL_ENGINEER_ENGI, 2, 3 SECONDS)
+	return welder_repair_act(user, I, 100, 4 SECONDS, 0, SKILL_ENGINEER_ENGI, 2, 4 SECONDS)
 
 /obj/vehicle/sealed/mecha/proc/full_repair(charge_cell)
 	obj_integrity = max_integrity


### PR DESCRIPTION

## About The Pull Request
Changes mech repair speed to 4 seconds instead of 2 seconds. Fumble time is also 4 seconds.

This is still fairly low all things considered however.

Currently you can repair mechs giga fast, which tends to make xenos cope as the time to repair a mech vs the time to cause that damage is pretty wack.
## Why It's Good For The Game
Makes severely damaging mechs (slightly) more rewarding for xenos.
## Changelog
:cl:
balance: Increased mech repair and fumble time to 4 seconds
/:cl:
