### PR TITLE
Fixes mecha tactical smoke

### DIFF
--- a/code/modules/vehicles/mecha/equipment/tools/greyscale_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/greyscale_tools.dm
@@ -178,4 +178,4 @@
 	icon_state = "smoke_gas"
 	mech_flags = EXOSUIT_MODULE_GREYSCALE
 	ability_to_grant = /datum/action/vehicle/sealed/mecha/mech_smoke
-	smoke_type = /obj/effect/particle_effect/smoke/tactical
+	smoke_type = /datum/effect_system/smoke_spread/tactical


### PR DESCRIPTION

## About The Pull Request
This fixes mecha smoke module having the wrong smoke path

![image](https://user-images.githubusercontent.com/6613514/212802564-daa9deba-50db-4e0b-8960-3f2a24b8bb02.png)
## Why It's Good For The Game
A fixed module is a better module
## Changelog
GrayRachnid
:cl:
fix: fixed mecha tactical smoke, now properly launches cloaking smoke.
/:cl:
