### PR TITLE
Brings the CSE's leadership down to a more reasonable level

### DIFF
--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -398,7 +398,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	name = CHIEF_SHIP_ENGINEER
 	engineer = SKILL_ENGINEER_MASTER
 	construction = SKILL_CONSTRUCTION_MASTER
-	leadership = SKILL_LEAD_MASTER
+	leadership = SKILL_LEAD_TRAINED
 	police = SKILL_POLICE_MP
 	powerloader = SKILL_POWERLOADER_MASTER
 

--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -398,7 +398,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	name = CHIEF_SHIP_ENGINEER
 	engineer = SKILL_ENGINEER_MASTER
 	construction = SKILL_CONSTRUCTION_MASTER
-	leadership = SKILL_LEAD_TRAINED
+	leadership = SKILL_LEAD_EXPERT
 	police = SKILL_POLICE_MP
 	powerloader = SKILL_POWERLOADER_MASTER
 


### PR DESCRIPTION
## About The Pull Request
The CSE had the same leadership level as the Captain/FC.
I've changed his leadership to reflect his rank shipside, earning him the same leadership level as a Squad Leader/Staff Officer
## Why It's Good For The Game
The CSE no longer has a higher leadership than squad leaders and staff officers.
## Changelog
GrayRachnid
:cl:
balance: The CSE should not be having Captain/FC level leadership
/:cl:
