### PR TITLE
Announces xeno autobalance to both sides.

### DIFF
--- a/code/controllers/subsystem/monitor.dm
+++ b/code/controllers/subsystem/monitor.dm
@@ -213,6 +213,6 @@ SUBSYSTEM_DEF(monitor)
 		for(var/upgrade in GLOB.xeno_caste_datums[xeno_caste_typepath])
 			var/datum/xeno_caste/caste = GLOB.xeno_caste_datums[xeno_caste_typepath][upgrade]
 			caste.melee_damage = initial(caste.melee_damage) * GLOB.xeno_stat_multiplicator_buff
-	priority_announce("Our sensors have picked up a spike in psionic energy coming from the hive. Our experts estimate that the xenomorphs will be [GLOB.xeno_stat_multiplicator_buff*100]% stronger.", "Priority Alert")
-	xeno_message("A rabid fervor of energy sweeps across the hive; we feel [GLOB.xeno_stat_multiplicator_buff*100]% more fierce. The Queen Mother has sent us her strength!", force = TRUE)
+	priority_announce("Our sensors have picked up a spike in psionic energy coming from the hive. Resident experts estimate that the xenomorphs will be [(GLOB.xeno_stat_multiplicator_buff*100)-100]% stronger.", "Priority Alert") //if xeno buff is set to 150%, will announce that xenos are 50% stronger
+	xeno_message("A rabid fervor of energy sweeps across the hive; we feel [(GLOB.xeno_stat_multiplicator_buff*100)-100]% more fierce. The Queen Mother has sent us her strength!", force = TRUE) //same as above
 	SEND_SOUND(GLOB.alive_xeno_list, sound(get_sfx("queen"), channel = CHANNEL_ANNOUNCEMENTS, volume = 50))

--- a/code/controllers/subsystem/monitor.dm
+++ b/code/controllers/subsystem/monitor.dm
@@ -213,3 +213,6 @@ SUBSYSTEM_DEF(monitor)
 		for(var/upgrade in GLOB.xeno_caste_datums[xeno_caste_typepath])
 			var/datum/xeno_caste/caste = GLOB.xeno_caste_datums[xeno_caste_typepath][upgrade]
 			caste.melee_damage = initial(caste.melee_damage) * GLOB.xeno_stat_multiplicator_buff
+	priority_announce("Our sensors have picked up a spike in psionic energy coming from the hive. Our experts estimate that the xenomorphs will be [GLOB.xeno_stat_multiplicator_buff*100]% stronger.", "Priority Alert")
+	xeno_message("A rabid fervor of energy sweeps across the hive; we feel [GLOB.xeno_stat_multiplicator_buff*100]% more fierce. The Queen Mother has sent us her strength!", force = TRUE)
+	SEND_SOUND(GLOB.alive_xeno_list, sound(get_sfx("queen"), channel = CHANNEL_ANNOUNCEMENTS, volume = 50))


### PR DESCRIPTION
## About The Pull Request
Per title. Will send a flavored announcement unique to each side when xeno autobalance is implemented. As an example, a 150% buff will multiply stats by 1.5. In this instance, it will be announced that xenos are 50% stronger.
## Why It's Good For The Game
Recently there was a round where many players on both sides did not know autobalance was on. This resulted in a lot of anger. Although some of it was misguided, I do think that transparency is important in a mechanic that affects gameplay so greatly. This is not a one-off occurrence, and occurs in crash rounds and lowpop frequently. It is never known to the player when this is implemented, and causes confusion to both marines and xenos as to why it feels gameplay has shifted so suddenly. 
## Changelog
:cl:
qol: Announces xeno autobalance to both sides when activated.
/:cl:
