### PR TITLE
Prevents rollerbeds and cocoons from being dragged by xenos

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -134,6 +134,7 @@
 #define CANUNCONSCIOUS (1<<9)
 #define CANCONFUSE (1<<10)
 #define INCORPOREAL (1<<11) // Whether not this unit should be detectable by automated means (like turrets). Used by hivemind
+#define NONDRAGGABLE (1<<12) // Whether this unit is draggable or not. Used by xenomorphs to control what should and shouldn't be dragged.
 
 // =============================
 // hive types

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -134,7 +134,7 @@
 #define CANUNCONSCIOUS (1<<9)
 #define CANCONFUSE (1<<10)
 #define INCORPOREAL (1<<11) // Whether not this unit should be detectable by automated means (like turrets). Used by hivemind
-#define NONDRAGGABLE (1<<12) // Whether this unit is draggable or not. Used by xenomorphs to control what should and shouldn't be dragged.
+#define CANNOTDRAG (1<<12) // Whether this unit is draggable or not. Used by xenomorphs to control what should and shouldn't be dragged.
 
 // =============================
 // hive types

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -134,7 +134,7 @@
 #define CANUNCONSCIOUS (1<<9)
 #define CANCONFUSE (1<<10)
 #define INCORPOREAL (1<<11) // Whether not this unit should be detectable by automated means (like turrets). Used by hivemind
-#define CANNOTDRAG (1<<12) // Whether this unit is draggable or not. Used by xenomorphs to control what should and shouldn't be dragged.
+#define CANNOTDRAG (1<<12) // Whether this unit can be dragged or not by xenos.
 
 // =============================
 // hive types

--- a/code/game/objects/items/cocoon.dm
+++ b/code/game/objects/items/cocoon.dm
@@ -9,6 +9,7 @@
 	max_integrity = 400
 	anchored = TRUE
 	obj_flags = CAN_BE_HIT
+	status_flags = CANNOTDRAG
 	///Which hive it belongs too
 	var/hivenumber
 	///What is inside the cocoon

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -216,6 +216,7 @@
 	icon_state = "roller_down"
 	anchored = FALSE
 	buckle_flags = CAN_BUCKLE
+	status_flags = NONDRAGGABLE
 	drag_delay = 0 //Pulling something on wheels is easy
 	buckling_y = 6
 	foldabletype = /obj/item/roller

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -216,7 +216,7 @@
 	icon_state = "roller_down"
 	anchored = FALSE
 	buckle_flags = CAN_BUCKLE
-	status_flags = NONDRAGGABLE
+	status_flags = CANNOTDRAG
 	drag_delay = 0 //Pulling something on wheels is easy
 	buckling_y = 6
 	foldabletype = /obj/item/roller

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -265,18 +265,18 @@
 
 /mob/living/carbon/xenomorph/start_pulling(atom/movable/AM, force = move_force, suppress_message = TRUE, bypass_crit_delay = FALSE)
 	if(do_actions)
-		return FALSE //We are already occupied with something.
+		return FALSE // We are already occupied with something.
 	if(!Adjacent(AM))
-		return FALSE //The target we're trying to pull must be adjacent and anchored.
+		return FALSE // The target we're trying to pull must be adjacent and anchored.
+	if(AM.status_flags & NONDRAGGABLE)
+		return FALSE // Objects that cannot be dragged shouldn't be dragged, y'know.
 	if(status_flags & INCORPOREAL || AM.status_flags & INCORPOREAL)
-		return FALSE //Incorporeal things can't grab or be grabbed.
-	if(AM.anchored)
-		return FALSE //We cannot grab anchored items.
+		return FALSE // Incorporeal things can't grab or be grabbed.
+	if(AM.anchored || AM.buckled)
+		return FALSE // We cannot grab anchored or buckled items.
 	if(!isliving(AM) && AM.drag_windup && !do_after(src, AM.drag_windup, TRUE, AM, BUSY_ICON_HOSTILE, BUSY_ICON_HOSTILE, extra_checks = CALLBACK(src, /mob.proc/break_do_after_checks, list("health" = src.health))))
-		return //If the target is not a living mob and has a drag_windup defined, calls a do_after. If all conditions are met, it returns. If the user takes damage during the windup, it breaks the channel.
+		return // If the target is not a living mob and has a drag_windup defined, calls a do_after. If all conditions are met, it returns. If the user takes damage during the windup, it breaks the channel.
 	var/mob/living/L = AM
-	if(L.buckled)
-		return FALSE //to stop xeno from pulling marines on roller beds.
 	if(ishuman(L))
 		if(L.stat == DEAD) //Can't drag dead human bodies.
 			to_chat(usr,span_xenowarning("This looks gross, better not touch it."))

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -268,7 +268,7 @@
 		return FALSE // We are already occupied with something.
 	if(!Adjacent(AM))
 		return FALSE // The target we're trying to pull must be adjacent and anchored.
-	if(AM.status_flags & NONDRAGGABLE)
+	if(AM.status_flags & CANNOTDRAG)
 		return FALSE // Objects that cannot be dragged shouldn't be dragged, y'know.
 	if(status_flags & INCORPOREAL || AM.status_flags & INCORPOREAL)
 		return FALSE // Incorporeal things can't grab or be grabbed.


### PR DESCRIPTION
## About The Pull Request
Per title.
The way I approached this code-wise was make a new status flag, `CANNOTDRAG`, then applied it to rollerbeds and cocoons. It is now as simple as adding this status flags to any other atoms that shouldn't be dragged.

## Why It's Good For The Game
Though I definitely disagree with the existence of a blacklist/whitelist for what can and cannot be dragged, I don't think rollerbeds and cocoons should remain something xenos can drag. You already cannot drag people that're dead, so why should we let xenos drag people that are dead but stuck in a cocoon, or on a rollerbed? It's an unnecessary form of punishment for unsuspecting marines trying to help someone else out.

## Changelog
:cl: Lewdcifer
balance: Rollerbeds and cocoons can no longer be dragged by xenos.
code: Added a new status flag, CANNOTDRAG. This can be applied to any atom that shouldn't be dragged by xenos.
/:cl: