### PR TITLE
Decouples CAS from Orbit and effectively buffs CAS

### DIFF
--- a/code/controllers/subsystem/points.dm
+++ b/code/controllers/subsystem/points.dm
@@ -1,5 +1,5 @@
 // points per minute
-#define DROPSHIP_POINT_RATE 18 * ((GLOB.current_orbit+3)/6)
+#define DROPSHIP_POINT_RATE 24
 #define SUPPLY_POINT_RATE 20 * (GLOB.current_orbit/3)
 
 SUBSYSTEM_DEF(points)

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -205,7 +205,7 @@
 	icon_state = "30mm_crate"
 	desc = "A crate full of 30mm bullets used on the dropship heavy guns. Moving this will require some sort of lifter."
 	equipment_type = /obj/structure/dropship_equipment/weapon/heavygun
-	travelling_time =  6 SECONDS
+	travelling_time = 4 SECONDS
 	ammo_count = 200
 	max_ammo_count = 200
 	transferable_ammo = TRUE
@@ -266,7 +266,7 @@
 	name = "high-velocity 30mm ammo crate"
 	icon_state = "30mm_crate_hv"
 	desc = "A crate full of 30mm high-velocity bullets used on the dropship heavy guns. Moving this will require some sort of lifter."
-	travelling_time = 3 SECONDS
+	travelling_time = 2 SECONDS
 	point_cost = 150
 
 
@@ -314,7 +314,7 @@
 	name = "high-capacity laser battery"
 	icon_state = "laser_battery"
 	desc = "A high-capacity laser battery used to power laser beam weapons. Moving this will require some sort of lifter."
-	travelling_time = 1 SECONDS
+	travelling_time = 0.5 SECONDS
 	ammo_count = 100
 	max_ammo_count = 100
 	ammo_used_per_firing = 40
@@ -382,7 +382,7 @@
 	ammo_id = ""
 	bound_width = 64
 	bound_height = 32
-	travelling_time = 4 SECONDS
+	travelling_time = 2.5 SECONDS
 	point_cost = 0
 	ammo_type = CAS_MISSILE
 
@@ -395,7 +395,7 @@
 	name = "\improper AIM-224 'Widowmaker'"
 	desc = "The AIM-224 is the latest in air to air missile technology. Earning the nickname of 'Widowmaker' from various dropship pilots after improvements to its guidence warhead prevents it from being jammed leading to its high kill rate. Not well suited for ground bombardment, but its high velocity makes it reach its target quickly. Moving this will require some sort of lifter."
 	icon_state = "single"
-	travelling_time = 3 SECONDS //not powerful, but reaches target fast
+	travelling_time = 2 SECONDS //not powerful, but reaches target fast
 	ammo_id = ""
 	point_cost = 75
 	devastating_explosion_range = 2
@@ -510,7 +510,7 @@
 	ammo_count = 6
 	max_ammo_count = 6
 	ammo_name = "minirocket"
-	travelling_time = 4 SECONDS
+	travelling_time = 2.5 SECONDS
 	transferable_ammo = TRUE
 	point_cost = 100
 	ammo_type = CAS_MINI_ROCKET

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -314,7 +314,7 @@
 	name = "high-capacity laser battery"
 	icon_state = "laser_battery"
 	desc = "A high-capacity laser battery used to power laser beam weapons. Moving this will require some sort of lifter."
-	travelling_time = 0.5 SECONDS
+	travelling_time = 0.6 SECONDS
 	ammo_count = 100
 	max_ammo_count = 100
 	ammo_used_per_firing = 40
@@ -382,7 +382,7 @@
 	ammo_id = ""
 	bound_width = 64
 	bound_height = 32
-	travelling_time = 2.5 SECONDS
+	travelling_time = 2.6 SECONDS
 	point_cost = 0
 	ammo_type = CAS_MISSILE
 
@@ -510,7 +510,7 @@
 	ammo_count = 6
 	max_ammo_count = 6
 	ammo_name = "minirocket"
-	travelling_time = 2.5 SECONDS
+	travelling_time = 2.6 SECONDS
 	transferable_ammo = TRUE
 	point_cost = 100
 	ammo_type = CAS_MINI_ROCKET

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -865,7 +865,7 @@
 	if(firing_sound)
 		playsound(loc, firing_sound, 70, 1)
 	var/obj/structure/ship_ammo/SA = ammo_equipped //necessary because we nullify ammo_equipped when firing big rockets
-	var/ammo_travelling_time = SA.travelling_time * ((GLOB.current_orbit+3)/6) //how long the rockets/bullets take to reach the ground target.
+	var/ammo_travelling_time = SA.travelling_time //how long the rockets/bullets take to reach the ground target.
 	var/ammo_warn_sound = SA.warning_sound
 	deplete_ammo()
 	COOLDOWN_START(src, last_fired, firing_delay)


### PR DESCRIPTION
## About The Pull Request

CAS now uses (roughly) minimum orbit for delay between firing and impact. CAS points are now generated at max orbit levels.

Buffs lasers, rockets, minirockets, and the banshee because rounding and I figured it'd probably be fine, can adjust if it's not fine.

## Why It's Good For The Game

CAS is currently impotent, rarely being much use to the ground force and rarely doing even a little bit of damage to the xenos due to how much time xenos have to just walk away from the very clear warning dots. 

Part of this is the inconsistency of orbit level, something POs don't even have control over, and which there may be nobody available to or willing to change. The fact orbit level effects POs at all also doesn't really make sense when it is a jet that is entirely separate from the actual ship.

Hopefully this will make CAS more rewarding to play and more impactful on the round without being awful to deal with on the xeno side.

I'd like to see how CAS performs when it consistently has the best travel times and point generations it can have simultaneously before considering any other buffs.

## Changelog
:cl: Tupina
balance: Dropship point generation is no longer reliant on orbit level, instead generating as though it were maximum orbit.
balance: Condor/CAS projectile travel time is no longer reliant on orbit level, instead traveling as though it were minimum orbit.
/:cl:
