### PR TITLE
Melee stun chance now factor in armour

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -200,7 +200,7 @@ Contains most of the procs that are called when a mob is attacked by something
 		switch(hit_area)
 			if("head")//Harder to score a stun but if you do it lasts a bit longer
 				if(prob(applied_damage) && stat == CONSCIOUS)
-					Paralyze(modify_by_armor(10, MELEE, def_zone = affecting))
+					Paralyze(modify_by_armor(16, MELEE, def_zone = affecting))
 					visible_message(span_danger("[src] has been knocked unconscious!"),
 									span_danger("You have been knocked unconscious!"), null, 5)
 					hit_report += "(KO)"
@@ -218,7 +218,7 @@ Contains most of the procs that are called when a mob is attacked by something
 
 			if("chest")//Easier to score a stun but lasts less time
 				if(prob((applied_damage + 5)) && !incapacitated())
-					apply_effect(modify_by_armor(3, MELEE, def_zone = def_zone), WEAKEN)
+					apply_effect(modify_by_armor(6, MELEE, def_zone = def_zone), WEAKEN)
 					visible_message(span_danger("[src] has been knocked down!"),
 									span_danger("You have been knocked down!"), null, 5)
 					hit_report += "(KO)"

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -199,8 +199,8 @@ Contains most of the procs that are called when a mob is attacked by something
 
 		switch(hit_area)
 			if("head")//Harder to score a stun but if you do it lasts a bit longer
-				if(prob(damage) && stat == CONSCIOUS)
-					Paralyze(modify_by_armor(16, MELEE, def_zone = affecting))
+				if(prob(applied_damage) && stat == CONSCIOUS)
+					Paralyze(modify_by_armor(10, MELEE, def_zone = affecting))
 					visible_message(span_danger("[src] has been knocked unconscious!"),
 									span_danger("You have been knocked unconscious!"), null, 5)
 					hit_report += "(KO)"
@@ -217,8 +217,8 @@ Contains most of the procs that are called when a mob is attacked by something
 						update_inv_glasses(0)
 
 			if("chest")//Easier to score a stun but lasts less time
-				if(prob((damage + 10)) && !incapacitated())
-					apply_effect(modify_by_armor(6, MELEE, def_zone = def_zone), WEAKEN)
+				if(prob((applied_damage + 5)) && !incapacitated())
+					apply_effect(modify_by_armor(3, MELEE, def_zone = def_zone), WEAKEN)
 					visible_message(span_danger("[src] has been knocked down!"),
 									span_danger("You have been knocked down!"), null, 5)
 					hit_report += "(KO)"


### PR DESCRIPTION
## About The Pull Request
What it says on the tin.

Currently the chance to stun a human is based off raw damage, not damage done after armour is taken into account.

Edit: PR not only effects stun chance, no change to stun durations.
## Why It's Good For The Game
stuns ignoring armour is bad.
## Changelog
:cl:
balance: Melee stuns now respect armour when calculating probability
/:cl:
