### PR TITLE
remove old cm actions for guns

### DIFF
--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -197,21 +197,6 @@
 	SL_locator = new /atom/movable/screen/SL_locator
 	infodisplay += SL_locator
 
-	use_attachment = new /atom/movable/screen/firearms/attachment()
-	static_inventory += use_attachment
-
-	toggle_raillight = new /atom/movable/screen/firearms/flashlight()
-	static_inventory += toggle_raillight
-
-	eject_mag = new /atom/movable/screen/firearms/magazine()
-	static_inventory += eject_mag
-
-	toggle_firemode = new /atom/movable/screen/firearms/firemode()
-	static_inventory += toggle_firemode
-
-	unique_action = new /atom/movable/screen/firearms/unique()
-	static_inventory += unique_action
-
 	zone_sel = new /atom/movable/screen/zone_sel()
 	zone_sel.icon = ui_style
 	zone_sel.color = ui_color

--- a/code/_onclick/hud/screen_objects/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/screen_objects.dm
@@ -568,65 +568,6 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	screen_loc = ui_sl_dir
 
-/atom/movable/screen/firearms
-
-/atom/movable/screen/firearms/Click()
-	return get_active_firearm(usr)
-
-/atom/movable/screen/firearms/attachment
-	name = "Activate weapon attachment"
-	icon_state = "gun_attach"
-	screen_loc = ui_gun_attachment
-
-/atom/movable/screen/firearms/attachment/Click()
-	. = ..()
-	var/obj/item/weapon/gun/G = .
-	G?.activate_attachment_verb()
-
-/atom/movable/screen/firearms/flashlight
-	name = "Toggle Rail Flashlight"
-	icon_state = "gun_raillight"
-	screen_loc = ui_gun_railtoggle
-
-/atom/movable/screen/firearms/flashlight/Click()
-	. = ..()
-	var/obj/item/weapon/gun/G = .
-	if(!G)
-		return
-	var/obj/item/attachable/flashlight/F = LAZYACCESS(G.attachments_by_slot, ATTACHMENT_SLOT_RAIL)
-	if(F?.activate(usr))
-		playsound(usr, F.activation_sound, 15, 1)
-
-/atom/movable/screen/firearms/magazine
-	name = "Eject magazine"
-	icon_state = "gun_loaded"
-	screen_loc = ui_gun_eject
-
-/atom/movable/screen/firearms/magazine/Click()
-	. = ..()
-	var/obj/item/weapon/gun/G = .
-	G?.empty_mag()
-
-/atom/movable/screen/firearms/firemode
-	name = "Toggle fire mode"
-	icon_state = "gun_burst"
-	screen_loc = ui_gun_burst
-
-/atom/movable/screen/firearms/firemode/Click()
-	. = ..()
-	var/obj/item/weapon/gun/G = .
-	G?.toggle_firemode()
-
-/atom/movable/screen/firearms/unique
-	name = "Use unique action"
-	icon_state = "gun_unique"
-	screen_loc = ui_gun_unique
-
-/atom/movable/screen/firearms/unique/Click()
-	. = ..()
-	var/obj/item/weapon/gun/G = .
-	G?.use_unique_action()
-
 /atom/movable/screen/drop
 	name = "drop"
 	icon = 'icons/mob/screen/midnight.dmi'


### PR DESCRIPTION

## About The Pull Request
removes these things
![image](https://user-images.githubusercontent.com/98577688/213229042-c733fc7e-b5a0-4c37-aee7-ab8f5e0ec779.png)
## Why It's Good For The Game
noob bait to use, all of these things are keybindable and can be used by actions on the top left
## Changelog
:cl:
del: Removed old cm gun actions
/:cl:
