### PR TITLE
nerf combat droid speed

### DIFF
--- a/code/modules/vehicles/unmanned/unmanned_droid.dm
+++ b/code/modules/vehicles/unmanned/unmanned_droid.dm
@@ -2,7 +2,7 @@
 	name = "XN-43-H combat droid"
 	desc = "A prototype combat droid, first deployed as a prototype to fight the xeno menace in the frontier sytems."
 	icon_state = "droidcombat"
-	move_delay = 3
+	move_delay = 4
 	max_integrity = 150
 	turret_pattern = PATTERN_DROID
 	can_interact = TRUE


### PR DESCRIPTION

## About The Pull Request

title

## Why It's Good For The Game

mjp mood

It can run faster than a combat robot, which I find amusing. Since xenomorphs cannot stun a speedy machine like this and it is for free for AI players to use, something free like this shouldn't be a better combat robot.

## Changelog

:cl:
balance: nerf combat droid speed
/:cl:

