### PR TITLE
Fixes Reqtorio AMR incendiary ammo printing violins

### DIFF
--- a/code/modules/factory/parts.dm
+++ b/code/modules/factory/parts.dm
@@ -205,7 +205,7 @@ GLOBAL_LIST_INIT(IFF_ammo, list(
 	. = ..()
 	recipe = GLOB.IFF_ammo
 
-/obj/item/factory_part/AMR_magazine_incend
+/obj/item/factory_part/amr_magazine_incend
 	name = "IFF antimaterial Incendiary bullet box"
 	desc = "A box with unfinished antimaterial Incendiary rifle rounds inside"
 	result = /obj/item/ammo_magazine/sniper/incendiary


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Someone capsed out the amr which is a non-existing item.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
amr_magazine_incend is an item in the game.
AMR_magazine_incend does not exist and defaults to creating violins.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: No more violins from Reqtorio AMR incendiary rounds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
