### PR TITLE
Return of the cargo void

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -3443,6 +3443,9 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
+"jJ" = (
+/turf/open/floor/mainship/empty/cargovoid,
+/area/mainship/squads/req)
 "jK" = (
 /obj/effect/turf_decal/warning_stripes/engineer,
 /obj/effect/turf_decal/warning_stripes/box/small{
@@ -9229,7 +9232,7 @@
 /area/mainship/living/pilotbunks)
 "AU" = (
 /obj/effect/attach_point/weapon/dropship2{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
@@ -9250,7 +9253,7 @@
 /area/mainship/command/self_destruct)
 "AY" = (
 /obj/effect/attach_point/weapon/dropship2{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
@@ -12308,7 +12311,7 @@
 /area/mainship/living/bridgebunks)
 "JZ" = (
 /turf/closed/shuttle/ert/engines/right{
-	dir = 1;
+	dir = 1
 	},
 /area/space)
 "Ka" = (
@@ -12814,7 +12817,7 @@
 /area/mainship/living/numbertwobunks)
 "LB" = (
 /obj/effect/attach_point/weapon/dropship1{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
@@ -14716,7 +14719,7 @@
 /area/mainship/engineering/engineering_workshop)
 "Rb" = (
 /turf/closed/shuttle/ert/engines/left{
-	dir = 1;
+	dir = 1
 	},
 /area/space)
 "Rc" = (
@@ -14968,7 +14971,7 @@
 /area/mainship/living/tankerbunks)
 "RQ" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 4;
+	dir = 4
 	},
 /area/mainship/hallways/hangar)
 "RR" = (
@@ -14990,7 +14993,7 @@
 /area/mainship/living/grunt_rnr)
 "RU" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 8;
+	dir = 8
 	},
 /area/mainship/hallways/hangar)
 "RV" = (
@@ -26754,7 +26757,7 @@ vi
 vi
 vi
 vi
-vi
+jJ
 sV
 vg
 ob

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -15580,6 +15580,9 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"tWb" = (
+/turf/open/floor/mainship/empty/cargovoid,
+/area/mainship/squads/req)
 "tWq" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -51572,7 +51575,7 @@ gMb
 gMb
 gMb
 gMb
-gMb
+tWb
 hSb
 jWh
 iiU

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -10483,7 +10483,7 @@
 /area/sulaco/cargo/prep)
 "bwn" = (
 /obj/effect/attach_point/weapon/dropship1{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
@@ -12887,7 +12887,7 @@
 /area/sulaco/hallway/central_hall)
 "eNh" = (
 /obj/effect/attach_point/weapon/dropship2{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/sulaco/hangar/cas)
@@ -16294,7 +16294,7 @@
 /area/sulaco/maintenance/upperdeck_north_maint)
 "jBs" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 4;
+	dir = 4
 	},
 /area/sulaco/hangar)
 "jBX" = (
@@ -19431,6 +19431,9 @@
 	dir = 4
 	},
 /turf/open/floor/prison,
+/area/sulaco/cargo)
+"nUR" = (
+/turf/open/floor/mainship/empty/cargovoid,
 /area/sulaco/cargo)
 "nUZ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -23430,7 +23433,7 @@
 /area/sulaco/hangar)
 "sYa" = (
 /obj/effect/attach_point/weapon/dropship2{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/sulaco/hangar/cas)
@@ -26148,7 +26151,7 @@
 /area/sulaco/cafeteria)
 "wKu" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 8;
+	dir = 8
 	},
 /area/sulaco/hangar)
 "wKB" = (
@@ -52432,7 +52435,7 @@ uxf
 uxf
 uxf
 uxf
-uxf
+nUR
 hNu
 eOE
 txO

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -449,7 +449,7 @@
 	input_tag = "waste_lower_in";
 	name = "Lower Deck Waste Tank Control";
 	output_tag = "waste_lower_out";
-	sensors = list("waste_sensor" = "Tank")
+	sensors = list("waste_sensor"="Tank")
 	},
 /turf/open/floor/mainship/orange,
 /area/mainship/hull/starboard_hull)
@@ -719,7 +719,7 @@
 /obj/machinery/computer/general_air_control/large_tank_control{
 	name = "Lower Oxygen Supply Console";
 	output_tag = "oxygen_lower_out";
-	sensors = list("oxy_sensor" = "Tank")
+	sensors = list("oxy_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -735,7 +735,7 @@
 /obj/machinery/computer/general_air_control/large_tank_control{
 	name = "Lower Nitrogen Control Console";
 	output_tag = "nit_lower_out";
-	sensors = list("nit_sensor" = "Tank")
+	sensors = list("nit_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -758,7 +758,7 @@
 	input_tag = "mix_lower_in";
 	name = "Lower Mixed Air Control";
 	output_tag = "mix_lower_out";
-	sensors = list("mix_sensor" = "Tank")
+	sensors = list("mix_sensor"="Tank")
 	},
 /turf/open/floor/mainship/orange{
 	dir = 5
@@ -8184,7 +8184,7 @@
 /obj/machinery/door/poddoor/mainship/open{
 	dir = 2;
 	id = "CIC Lockdown";
-	name = "\improper Combat Information Center Blast Door";
+	name = "\improper Combat Information Center Blast Door"
 	},
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -8259,6 +8259,9 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
+"cPz" = (
+/turf/open/floor/mainship/empty/cargovoid,
+/area/mainship/squads/req)
 "cPD" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -11996,7 +11999,7 @@
 /area/mainship/hallways/bow_hallway)
 "jjN" = (
 /obj/effect/attach_point/weapon/dropship1{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
@@ -13188,7 +13191,7 @@
 "lto" = (
 /obj/machinery/door/poddoor/mainship/open{
 	id = "CIC Lockdown";
-	name = "\improper Combat Information Center Blast Door";
+	name = "\improper Combat Information Center Blast Door"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14167,7 +14170,7 @@
 /obj/machinery/door/poddoor/mainship/open{
 	dir = 2;
 	id = "Brig Lockdown";
-	name = "\improper Brig Lockdown Podlocks";
+	name = "\improper Brig Lockdown Podlocks"
 	},
 /turf/open/floor/plating,
 /area/mainship/living/tankerbunks)
@@ -15892,7 +15895,7 @@
 "pTq" = (
 /obj/machinery/door/poddoor/mainship/open{
 	id = "CIC Lockdown";
-	name = "\improper Combat Information Center Blast Door";
+	name = "\improper Combat Information Center Blast Door"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -17000,7 +17003,7 @@
 /obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/door/poddoor/mainship/open{
 	id = "CIC Lockdown";
-	name = "\improper Combat Information Center Blast Door";
+	name = "\improper Combat Information Center Blast Door"
 	},
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/plating,
@@ -19848,7 +19851,7 @@
 /area/space)
 "wQl" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 4;
+	dir = 4
 	},
 /area/mainship/hallways/hangar)
 "wQK" = (
@@ -19895,7 +19898,7 @@
 /area/space)
 "wVm" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 8;
+	dir = 8
 	},
 /area/mainship/hallways/hangar)
 "wVv" = (
@@ -61801,7 +61804,7 @@ xhL
 xhL
 xhL
 xhL
-xhL
+cPz
 bAK
 jER
 iYu

--- a/_maps/shuttles/supply.dmm
+++ b/_maps/shuttles/supply.dmm
@@ -3,7 +3,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/shuttle/supply)
 "b" = (
-/turf/open/floor/plating,
+/turf/open/floor/mainship/cargo,
 /area/shuttle/supply)
 "c" = (
 /obj/docking_port/mobile/supply,

--- a/code/game/turfs/floor_types.dm
+++ b/code/game/turfs/floor_types.dm
@@ -177,6 +177,9 @@
 /turf/open/floor/mainship/empty/attackby(obj/item/I, mob/user, params) //This should fix everything else. No cables, etc
 	return
 
+/turf/open/floor/mainship/empty/cargovoid
+	icon = 'icons/effects/160x160.dmi'
+	icon_state = "supply_elevator_lowered"
 
 //Others
 /turf/open/floor/mainship/terragov


### PR DESCRIPTION

## About The Pull Request

Replaces cargo black abyss tiles with some adequate cargo void. (the icon for it was always in files)
![dreamseeker_E6USJ35jmW](https://user-images.githubusercontent.com/100090741/213594661-68c78e8e-a5c4-4eb1-abd3-929a724e7659.png)

Also replaced a few generic platings on a cargo platform with some actual plating.
![dreamseeker_MIfbJwfISa](https://user-images.githubusercontent.com/100090741/213594969-efd71102-2267-4fc4-ab7b-d7591e428a0b.gif)

## Why It's Good For The Game

Good looking, fitting, no more black abyss.

## Changelog

:cl:
add: Added new cargo voids, instead of a plain darkness
/:cl:
