### PR TITLE
Repairing a combat robot works like kits

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -458,9 +458,10 @@ Contains most of the procs that are called when a mob is attacked by something
 
 	user.visible_message(span_notice("[user] starts to fix some of the dents on [src]'s [affecting.display_name]."),\
 		span_notice("You start fixing some of the dents on [src == user ? "your" : "[src]'s"] [affecting.display_name]."))
+	I.use_tool(volume = 50, amount = 2)
 
 	add_overlay(GLOB.welding_sparks)
-	while(do_after(user, repair_time, TRUE, src, BUSY_ICON_BUILD) && I.use_tool(volume = 50, amount = 2))
+	while(do_after(user, repair_time, TRUE, src, BUSY_ICON_BUILD))
 		if(!do_after(user, repair_time, TRUE, src, BUSY_ICON_BUILD))
 			user.cut_overlay(GLOB.welding_sparks)
 		user.visible_message(span_warning("\The [user] patches some dents on [src]'s [affecting.display_name]."), \

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -508,8 +508,9 @@ GLOBAL_LIST(cable_radial_layer_list)
 
 	user.visible_message(span_notice("[user] starts to fix some of the wires in [H]'s [affecting.display_name]."),\
 		span_notice("You start fixing some of the wires in [H == user ? "your" : "[H]'s"] [affecting.display_name]."))
+	use(2)
 
-	while(do_after(user, repair_time, TRUE, H, BUSY_ICON_BUILD) && use(1))
+	while(do_after(user, repair_time, TRUE, H, BUSY_ICON_BUILD))
 		user.visible_message(span_warning("\The [user] fixes some wires in \the [H]'s [affecting.display_name] with [src]."), \
 			span_warning("You patch some wires in \the [H]'s [affecting.display_name]."))
 		if(affecting.heal_limb_damage(0, 15, robo_repair = TRUE, updating_health = TRUE))


### PR DESCRIPTION
## About The Pull Request
Specifically, you only consume 2 units of fuel (if it's a blowtorch) or 2 cables (if it's a cable coil) to repair a combat robot entire's body. Provided you don't move or get shoved out of repairing yourself like with kits. 

I increased the stack consumed from cable coil to repair from 1 to 2 for balance purposes. Also, indirect medic buff.

## Why It's Good For The Game
Makes combat robots less ass or painful to play. You have to bring an entire YouTool just to be able to "viably" play a combat robot or even yoink an Engineer's soldering tool.

## Changelog
:cl:
balance: combat robot repairing works like kits
balance: cable consumed when repairing a robot increased from 1 to 2
/:cl:
