### PR TITLE
conveyor belts n switches on the op vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -821,6 +821,8 @@
 			/obj/machinery/factory/former = 1,
 			/obj/machinery/factory/reconstructor = 1,
 			/obj/machinery/unboxer = 1,
+			/obj/item/stack/conveyor/thirty = -1,
+			/obj/item/conveyor_switch_construct = -1,
 		),
 		"Grenade Boxes" = list(
 			/obj/item/storage/box/visual/grenade/frag = 2,


### PR DESCRIPTION

## About The Pull Request

Conveyor belts and switches on the vendor to smoothen out the experience of reqtorio without having to shove metal and wait for it to print in the autolahte. You can already print effectively infinite conveyors and switches in the autolathe, this PR attempts to streamline it.

## Why It's Good For The Game

smoother reqtorio experience

## Changelog
:cl:

add: conveyors and conveyor switches to op vendor

/:cl:
