### PR TITLE
add 4 floodlights to all shipside maps

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -5234,6 +5234,12 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/port_hallway)
+"ph" = (
+/obj/machinery/floodlight/combat,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "pi" = (
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/red{
@@ -9229,7 +9235,7 @@
 /area/mainship/living/pilotbunks)
 "AU" = (
 /obj/effect/attach_point/weapon/dropship2{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
@@ -9250,7 +9256,7 @@
 /area/mainship/command/self_destruct)
 "AY" = (
 /obj/effect/attach_point/weapon/dropship2{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
@@ -12257,6 +12263,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/grunt_rnr)
 "JT" = (
+/obj/machinery/floodlight/combat,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "JU" = (
@@ -12308,7 +12315,7 @@
 /area/mainship/living/bridgebunks)
 "JZ" = (
 /turf/closed/shuttle/ert/engines/right{
-	dir = 1;
+	dir = 1
 	},
 /area/space)
 "Ka" = (
@@ -12814,7 +12821,7 @@
 /area/mainship/living/numbertwobunks)
 "LB" = (
 /obj/effect/attach_point/weapon/dropship1{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
@@ -14716,7 +14723,7 @@
 /area/mainship/engineering/engineering_workshop)
 "Rb" = (
 /turf/closed/shuttle/ert/engines/left{
-	dir = 1;
+	dir = 1
 	},
 /area/space)
 "Rc" = (
@@ -14968,7 +14975,7 @@
 /area/mainship/living/tankerbunks)
 "RQ" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 4;
+	dir = 4
 	},
 /area/mainship/hallways/hangar)
 "RR" = (
@@ -14990,7 +14997,7 @@
 /area/mainship/living/grunt_rnr)
 "RU" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 8;
+	dir = 8
 	},
 /area/mainship/hallways/hangar)
 "RV" = (
@@ -24730,7 +24737,7 @@ Ac
 VC
 Gz
 JT
-eC
+ph
 yN
 Yr
 Wb

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -27,10 +27,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "acq" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/table/mainship/nometal,
+/obj/machinery/computer/shuttle/shuttle_control/dropship,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "acR" = (
@@ -892,6 +890,12 @@
 "bdF" = (
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
+"bdS" = (
+/obj/vehicle/ridden/motorbike,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/hallways/hangar)
 "bdT" = (
 /obj/structure/prop/mainship/sensor_computer2/sd,
 /turf/open/floor/mainship/tcomms,
@@ -2645,8 +2649,8 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "dkX" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/computer/shuttle/shuttle_control/dropship,
+/obj/structure/rack,
+/obj/item/toy/deck/kotahi,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "dla" = (
@@ -3008,8 +3012,7 @@
 	},
 /area/mainship/squads/general)
 "dKF" = (
-/obj/structure/rack,
-/obj/item/toy/deck/kotahi,
+/obj/machinery/computer/camera_advanced/remote_fob,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "dLg" = (
@@ -4085,7 +4088,8 @@
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
 "feK" = (
-/obj/machinery/computer/camera_advanced/remote_fob,
+/obj/structure/rack,
+/obj/item/frame/table/gambling,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "feP" = (
@@ -4129,7 +4133,7 @@
 	},
 /area/mainship/hallways/hangar/droppod)
 "fgU" = (
-/obj/structure/largecrate/supply/supplies/water,
+/obj/machinery/floodlight/combat,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
@@ -5562,10 +5566,8 @@
 	},
 /area/mainship/command/cic)
 "hiK" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
+/obj/structure/largecrate/guns/russian,
+/turf/open/floor/mainship/office,
 /area/mainship/hallways/hangar)
 "hiO" = (
 /obj/structure/ship_ammo/minirocket,
@@ -5822,6 +5824,9 @@
 	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -6491,6 +6496,9 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "iBa" = (
@@ -6874,6 +6882,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/holopad,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "iXQ" = (
@@ -7957,6 +7968,10 @@
 "kBk" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
+"kBO" = (
+/obj/structure/largecrate/supply/ammo/standard_ammo,
+/turf/open/floor/mainship/office,
+/area/mainship/hallways/hangar)
 "kCk" = (
 /turf/open/floor/mainship/floor,
 /area/crew_quarters/toilet)
@@ -7989,7 +8004,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/warning_stripes/thin{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -8107,12 +8122,10 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
 "kLu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 10
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "kLK" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -10519,10 +10532,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"nBM" = (
-/obj/structure/largecrate/guns,
-/turf/open/floor/mainship/office,
-/area/mainship/hallways/hangar)
 "nCV" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -11949,7 +11958,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "pwa" = (
-/obj/structure/largecrate/guns/merc,
+/obj/machinery/vending/lasgun,
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
@@ -12036,7 +12045,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "pBR" = (
-/obj/structure/largecrate/guns/russian,
+/obj/structure/largecrate/guns,
 /turf/open/floor/mainship/office,
 /area/mainship/hallways/hangar)
 "pCd" = (
@@ -12051,6 +12060,12 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
+"pDT" = (
+/obj/structure/largecrate/supply/supplies/flares,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/hallways/hangar)
 "pEF" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/clothing/suit/storage/hazardvest,
@@ -12557,7 +12572,7 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "qhv" = (
-/obj/vehicle/ridden/motorbike,
+/obj/structure/largecrate/supply/supplies/water,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
@@ -15026,7 +15041,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "ttb" = (
-/obj/structure/largecrate/supply/supplies/mre,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
@@ -15598,7 +15613,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "tWV" = (
-/obj/structure/largecrate/supply/ammo/standard_ammo,
+/obj/machinery/floodlight/combat,
 /turf/open/floor/mainship/office,
 /area/mainship/hallways/hangar)
 "tXl" = (
@@ -15657,7 +15672,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "ubh" = (
-/obj/structure/largecrate/supply/supplies/flares,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
@@ -17218,6 +17233,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"vZK" = (
+/obj/structure/largecrate/supply/supplies/mre,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/hallways/hangar)
 "wag" = (
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
@@ -17994,9 +18015,10 @@
 /turf/open/floor/grass,
 /area/mainship/living/starboard_garden)
 "wXN" = (
-/obj/structure/rack,
-/obj/item/frame/table/gambling,
-/turf/open/floor/mainship/mono,
+/obj/structure/largecrate/guns/merc,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
 /area/mainship/hallways/hangar)
 "wYb" = (
 /obj/structure/table/mainship/nometal,
@@ -18888,7 +18910,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "yaL" = (
-/obj/machinery/vending/lasgun,
+/obj/machinery/floodlight/combat,
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
@@ -49498,12 +49520,12 @@ lQe
 kOe
 dpY
 dpY
+dkX
 dpY
-dpY
-dpY
-dKF
 dpY
 uKp
+wXN
+vZK
 pwa
 ttb
 yaL
@@ -49754,16 +49776,16 @@ fwq
 fwq
 dpY
 dpY
+acq
+dKF
+kLu
 dpY
-dpY
-dpY
-dkX
-feK
-hiK
 uKp
+hiK
+kBO
 pBR
 tWV
-nBM
+tWV
 tzk
 aWk
 dpY
@@ -50009,15 +50031,15 @@ mJL
 osb
 osb
 xtm
-acq
+tzk
 dpY
 dpY
+feK
 dpY
-dpY
-dpY
-wXN
 dpY
 uKp
+bdS
+pDT
 qhv
 ubh
 fgU
@@ -50273,8 +50295,8 @@ uCO
 kNb
 uCO
 iXB
-uCO
-kLu
+qMR
+qMR
 qMR
 qMR
 qMR

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -7085,6 +7085,11 @@
 /obj/structure/cable,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
+"aIN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/floodlight/combat,
+/turf/open/floor/prison,
+/area/sulaco/hallway/dropshipprep)
 "aIP" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 2
@@ -10483,7 +10488,7 @@
 /area/sulaco/cargo/prep)
 "bwn" = (
 /obj/effect/attach_point/weapon/dropship1{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
@@ -12887,7 +12892,7 @@
 /area/sulaco/hallway/central_hall)
 "eNh" = (
 /obj/effect/attach_point/weapon/dropship2{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/sulaco/hangar/cas)
@@ -13964,6 +13969,7 @@
 "gtb" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/machinery/floodlight/combat,
 /turf/open/floor/prison,
 /area/sulaco/hallway/dropshipprep)
 "gtk" = (
@@ -15521,6 +15527,7 @@
 "iyo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/floodlight/combat,
 /turf/open/floor/prison,
 /area/sulaco/hallway/dropshipprep)
 "iyJ" = (
@@ -16294,7 +16301,7 @@
 /area/sulaco/maintenance/upperdeck_north_maint)
 "jBs" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 4;
+	dir = 4
 	},
 /area/sulaco/hangar)
 "jBX" = (
@@ -23430,7 +23437,7 @@
 /area/sulaco/hangar)
 "sYa" = (
 /obj/effect/attach_point/weapon/dropship2{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/sulaco/hangar/cas)
@@ -26148,7 +26155,7 @@
 /area/sulaco/cafeteria)
 "wKu" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 8;
+	dir = 8
 	},
 /area/sulaco/hangar)
 "wKB" = (
@@ -59390,7 +59397,7 @@ aVY
 kYl
 hID
 gtb
-cIs
+aIN
 aWg
 aQw
 wLH

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -8184,7 +8184,7 @@
 /obj/machinery/door/poddoor/mainship/open{
 	dir = 2;
 	id = "CIC Lockdown";
-	name = "\improper Combat Information Center Blast Door";
+	name = "\improper Combat Information Center Blast Door"
 	},
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -11996,7 +11996,7 @@
 /area/mainship/hallways/bow_hallway)
 "jjN" = (
 /obj/effect/attach_point/weapon/dropship1{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
@@ -13188,7 +13188,7 @@
 "lto" = (
 /obj/machinery/door/poddoor/mainship/open{
 	id = "CIC Lockdown";
-	name = "\improper Combat Information Center Blast Door";
+	name = "\improper Combat Information Center Blast Door"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14167,7 +14167,7 @@
 /obj/machinery/door/poddoor/mainship/open{
 	dir = 2;
 	id = "Brig Lockdown";
-	name = "\improper Brig Lockdown Podlocks";
+	name = "\improper Brig Lockdown Podlocks"
 	},
 /turf/open/floor/plating,
 /area/mainship/living/tankerbunks)
@@ -15892,7 +15892,7 @@
 "pTq" = (
 /obj/machinery/door/poddoor/mainship/open{
 	id = "CIC Lockdown";
-	name = "\improper Combat Information Center Blast Door";
+	name = "\improper Combat Information Center Blast Door"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -17000,7 +17000,7 @@
 /obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/door/poddoor/mainship/open{
 	id = "CIC Lockdown";
-	name = "\improper Combat Information Center Blast Door";
+	name = "\improper Combat Information Center Blast Door"
 	},
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/plating,
@@ -19664,6 +19664,10 @@
 /obj/structure/window/framed/mainship/white,
 /turf/open/floor/plating,
 /area/mainship/medical/lower_medical)
+"wzV" = (
+/obj/machinery/floodlight/combat,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/repair_bay)
 "wAa" = (
 /obj/machinery/computer/camera_advanced/remote_fob,
 /turf/open/floor/mainship/mono,
@@ -19848,7 +19852,7 @@
 /area/space)
 "wQl" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 4;
+	dir = 4
 	},
 /area/mainship/hallways/hangar)
 "wQK" = (
@@ -19895,7 +19899,7 @@
 /area/space)
 "wVm" = (
 /turf/open/floor/plating/icefloor/warnplate/corner{
-	dir = 8;
+	dir = 8
 	},
 /area/mainship/hallways/hangar)
 "wVv" = (
@@ -47426,7 +47430,7 @@ kjI
 gtv
 nbP
 xmg
-nbP
+wzV
 vYD
 aVs
 fZA
@@ -47682,8 +47686,8 @@ bSf
 cbO
 bTU
 nbP
-nbP
-nbP
+wzV
+wzV
 blq
 aVs
 wem
@@ -47940,7 +47944,7 @@ nNL
 bVx
 nbP
 fLi
-nbP
+wzV
 bXq
 aVs
 qae


### PR DESCRIPTION

## About The Pull Request

title

## Why It's Good For The Game

Part of Lewd's light REBALANCE after he removed imager. He noted that combat floodlights are not used as much, so he made them cheaper to buy from req. Since the buff was not enough, he wanted to allow engineers to have a taste of what floodlights can do by making them free.

## Changelog

:cl:
add: 4 floodlights to all shipside maps
balance: xenomorphs will have a harder time engaging marine fixed positions due to more lights
/:cl:

