### PR TITLE
King summon fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
@@ -493,6 +493,7 @@
 			sister.remove_filter("summonoutline")
 		return fail_activate()
 
+	allxenos = X.hive.get_all_xenos() //refresh the list to account for any changes during the channel
 	for(var/mob/living/carbon/xenomorph/sister AS in allxenos)
 		sister.remove_filter("summonoutline")
 		sister.forceMove(get_turf(X))


### PR DESCRIPTION

## About The Pull Request
Fixed a bug with summon where dead/qdel'd xenos could get summoned.
## Why It's Good For The Game
Bug fix good.
## Changelog
:cl:
fix: fixed a bug with King's summon
/:cl:
