### PR TITLE
Coastfront research rework part 1A: Detaching from RNG

### DIFF
--- a/code/game/objects/effects/landmarks/excavation_site_spawner.dm
+++ b/code/game/objects/effects/landmarks/excavation_site_spawner.dm
@@ -4,7 +4,7 @@
 	///List of possible reward buckets
 	var/list/rewards_datums = list(
 		/datum/excavation_rewards,
-		/datum/excavation_rewards/xeno,
+		/datum/excavation_rewards/xeno1,
 	)
 	///Excavation rewards datum that is used when excavation is performed
 	var/datum/excavation_rewards/rewards_typepath
@@ -46,10 +46,10 @@
 		var/typepath = pick(rewards)
 		new typepath(excav_site.loc)
 
-/datum/excavation_rewards/xeno
+/datum/excavation_rewards/xeno1
 	rewards_min = 2
 	rewards_max = 4
 	map_icon = "excav_xeno"
 	rewards = list(
-		/obj/item/research_resource/xeno/tier_one,
+		/obj/item/research_resource/xeno1,
 	)

--- a/code/game/objects/items/tools/research_tools.dm
+++ b/code/game/objects/items/tools/research_tools.dm
@@ -15,10 +15,10 @@
 	///List of rewards for each xeno tier
 	var/static/list/xeno_tier_rewards = list(
 		XENO_TIER_ZERO = list(
-			/obj/item/research_resource/xeno/tier_one,
+			/obj/item/research_resource/xeno1,
 		),
 		XENO_TIER_ONE = list(
-			/obj/item/research_resource/xeno/tier_one,
+			/obj/item/research_resource/xeno1,
 		),
 		XENO_TIER_TWO = list(
 			/obj/item/research_resource/xeno/tier_two,

--- a/code/game/objects/items/tools/research_tools.dm
+++ b/code/game/objects/items/tools/research_tools.dm
@@ -21,13 +21,13 @@
 			/obj/item/research_resource/xeno1,
 		),
 		XENO_TIER_TWO = list(
-			/obj/item/research_resource/xeno/tier_two,
+			/obj/item/research_resource/xeno2
 		),
 		XENO_TIER_THREE = list(
-			/obj/item/research_resource/xeno/tier_three,
+			/obj/item/research_resource/xeno3
 		),
 		XENO_TIER_FOUR = list(
-			/obj/item/research_resource/xeno/tier_four,
+			/obj/item/research_resource/xeno4
 		),
 	)
 

--- a/code/game/objects/machinery/research.dm
+++ b/code/game/objects/machinery/research.dm
@@ -12,9 +12,8 @@
 
 //Reward tiers
 #define RES_TIER_POINTS "points"
-#define RES_TIER_ITEM "item"
-#define RES_TIER_ADVITEM "Advanced item"
-#define RES_TIER_RARE "rare"
+#define RES_TIER_ITEMS "item"
+#define RES_TIER_ADVITEMS "Advanced item"
 
 /obj/machinery/researchcomp
 	name = "research console"
@@ -41,6 +40,13 @@
 			RES_TIER_POINTS = list(
 				/obj/item/research_product/money/uncommon
 			),
+			RES_TIER_ITEMS = list(
+				/obj/item/implanter/blade,
+				/obj/item/implanter/chem/blood,
+			),
+			RES_TIER_ADVITEMS = list(
+				/obj/item/attachable/shoulder_mount
+			)
 		),
 		RES_XENO = list(
 			RES_TIER_POINTS = list(
@@ -48,26 +54,51 @@
 			),
 		),
 		RES_XENO1 = list(
-			RES_TIER_ITEM = list(
-            /obj/item/attachable/shoulder_mount
-			),
 			RES_TIER_POINTS = list(
-				/obj/item/research_product/money/basic
+				/obj/item/research_product/money/basic,
+			),
+			RES_TIER_ITEMS = list(
+				/obj/item/implanter/chem/blood,
+				/obj/item/implanter/cloak,
+			),
+			RES_TIER_ADVITEMS = list(
+				/obj/item/attachable/shoulder_mount,
 			),
 		),
 		RES_XENO2 = list(
 			RES_TIER_POINTS = list(
 				/obj/item/research_product/money/common
 			),
+			REST_TIER_ITEMS = list(
+				/obj/item/implanter/chem/blood,
+				/obj/item/implanter/cloak,
+			),
+			RES_TIER_ADVITEMS = list(
+				/obj/item/attachable/shoulder_mount,
+			),
 		),
 		RES_XENO3 = list(
 			RES_TIER_POINTS = list(
 				/obj/item/research_product/money/uncommon
 			),
+			RES_TIER_ITEMS = list(
+				/obj/item/implanter/chem/blood,
+				/obj/item/implanter/cloak,
+			),
+			RES_TIER_ADVITEMS = list(
+				/obj/item/attachable/shoulder_mount,
+			),
 		),
 		RES_XENO4 = list(
 			RES_TIER_POINTS = list(
 				/obj/item/research_product/money/rare
+			),
+			RES_TIER_ITEMS = list(
+				/obj/item/implanter/chem/blood,
+				/obj/item/implanter/cloak,
+			),
+			RES_TIER_ADVITEMS = list(
+				/obj/item/attachable/shoulder_mount,
 			),
 		),
 	)
@@ -239,10 +270,9 @@
 	desc = "Unidentified substance. The random data it provides could probably secure some funding."
 	research_type = RES_MONEY
 	reward_probs = list(
-		RES_TIER_BASIC = 100,
-		RES_TIER_COMMON = 30,
-		RES_TIER_UNCOMMON = 20,
-		RES_TIER_RARE = 5,
+		RES_TIER_POINTS = 100,
+		RES_TIER_ITEMS = 40,
+		RES_TIER_ADVITEMS = 35,
 	)
 
 /obj/item/research_resource/xeno
@@ -262,42 +292,60 @@
 	icon_state = "sample_0"
 	reward_probs = list(
 		RES_TIER_POINTS = 100,
-		RES_TIER_ITEM = 20,
+		RES_TIER_ITEMS = 20,
 	)
 
 /obj/item/research_resource/xeno1/Initialize()
 	. = ..()
 	icon_state = "sample_[rand(0, 11)]"
 
-/obj/item/research_resource/xeno/tier_two
+/obj/item/research_resource/xeno2
+	research_type = RES_XENO2
 	name = "Xenomorph research material - tier 2"
+	icon = 'icons/obj/alien_autopsy.dmi'
+	icon_state = "sample_0"
 	color = "#d6e641"
 	reward_probs = list(
-		RES_TIER_BASIC = 100,
-		RES_TIER_COMMON = 40,
-		RES_TIER_UNCOMMON = 20,
-		RES_TIER_RARE = 6,
+		RES_TIER_POINTS = 100,
+		RES_TIER_ITEMS = 25,
+		RES_TIER_ADVITEMS = 20,
 	)
 
-/obj/item/research_resource/xeno/tier_three
+/obj/item/research_resource/xeno2/Initialize()
+	. = ..()
+	icon_state = "sample_[rand(0, 11)]"
+
+/obj/item/research_resource/xeno3
+	research_type = RES_XENO3
 	name = "Xenomorph research material - tier 3"
+	icon = 'icons/obj/alien_autopsy.dmi'
+	icon_state = "sample_0"
 	color = "#e43939"
 	reward_probs = list(
-		RES_TIER_BASIC = 100,
-		RES_TIER_COMMON = 50,
-		RES_TIER_UNCOMMON = 40,
-		RES_TIER_RARE = 10,
+		RES_TIER_POINTS = 100,
+		RES_TIER_ITEMS = 40,
+		RES_TIER_ADVITEMS = 35,
 	)
 
-/obj/item/research_resource/xeno/tier_four
+/obj/item/research_resource/xeno2/Initialize()
+	. = ..()
+	icon_state = "sample_[rand(0, 11)]"
+
+/obj/item/research_resource/xeno4
+	research_type = RES_XENO4
 	name = "Xenomorph research material - tier 4"
+	icon = 'icons/obj/alien_autopsy.dmi'
+	icon_state = "sample_0"
 	color = "#a800ad"
 	reward_probs = list(
-		RES_TIER_BASIC = 100,
-		RES_TIER_COMMON = 50,
-		RES_TIER_UNCOMMON = 40,
-		RES_TIER_RARE = 50,
+		RES_TIER_POINTS = 100,
+		RES_TIER_ITEMS = 60,
+		RES_TIER_ADVITEMS = 50,
 	)
+
+/obj/item/research_resource/xeno2/Initialize()
+	. = ..()
+	icon_state = "sample_[rand(0, 11)]"
 
 ///
 ///Items designed to be products of research
@@ -332,5 +380,5 @@
 	export_points = 250
 
 /obj/item/research_product/money/rare
-	name = "credits - 800"
-	export_points = 800
+	name = "credits - 600"
+	export_points = 600

--- a/code/game/objects/machinery/research.dm
+++ b/code/game/objects/machinery/research.dm
@@ -5,11 +5,15 @@
 //Bucket names
 #define RES_MONEY "money"
 #define RES_XENO "xeno"
+#define RES_XENO1 "xeno1"
+#define RES_XENO2 "xeno2"
+#define RES_XENO3 "xeno3"
+#define RES_XENO4 "xeno4"
 
 //Reward tiers
-#define RES_TIER_BASIC "basic"
-#define RES_TIER_COMMON "common"
-#define RES_TIER_UNCOMMON "uncommon"
+#define RES_TIER_POINTS "points"
+#define RES_TIER_ITEM "item"
+#define RES_TIER_ADVITEM "Advanced item"
 #define RES_TIER_RARE "rare"
 
 /obj/machinery/researchcomp
@@ -28,48 +32,42 @@
 
 	///Research reward tiers
 	var/list/reward_tiers = list(
-		RES_TIER_BASIC,
-		RES_TIER_COMMON,
-		RES_TIER_UNCOMMON,
-		RES_TIER_RARE
+		RES_TIER_POINTS,
 		)
 
 	///List of rewards for each category
 	var/static/list/rewards_lists = list(
 		RES_MONEY = list(
-			RES_TIER_BASIC = list(
-				/obj/item/research_product/money/basic,
-				/obj/item/research_product/money/common,
-			),
-			RES_TIER_COMMON = list(
-				/obj/item/research_product/money/common,
-				/obj/item/research_product/money/uncommon,
-			),
-			RES_TIER_UNCOMMON = list(
-				/obj/item/research_product/money/uncommon,
-				/obj/item/implanter/blade,
-				/obj/item/attachable/shoulder_mount,
-			),
-			RES_TIER_RARE = list(
-				/obj/item/research_product/money/rare,
+			RES_TIER_POINTS = list(
+				/obj/item/research_product/money/uncommon
 			),
 		),
 		RES_XENO = list(
-			RES_TIER_BASIC = list(
+			RES_TIER_POINTS = list(
 				/obj/item/research_product/money/basic,
-				/obj/item/research_product/money/common,
 			),
-			RES_TIER_COMMON = list(
-				/obj/item/research_product/money/uncommon,
+		),
+		RES_XENO1 = list(
+			RES_TIER_ITEM = list(
+            /obj/item/attachable/shoulder_mount
 			),
-			RES_TIER_UNCOMMON = list(
-				/obj/item/research_product/money/uncommon,
-				/obj/item/implanter/chem/blood,
-				/obj/item/attachable/shoulder_mount,
+			RES_TIER_POINTS = list(
+				/obj/item/research_product/money/basic
 			),
-			RES_TIER_RARE = list(
-				/obj/item/research_product/money/rare,
-				/obj/item/implanter/cloak,
+		),
+		RES_XENO2 = list(
+			RES_TIER_POINTS = list(
+				/obj/item/research_product/money/common
+			),
+		),
+		RES_XENO3 = list(
+			RES_TIER_POINTS = list(
+				/obj/item/research_product/money/uncommon
+			),
+		),
+		RES_XENO4 = list(
+			RES_TIER_POINTS = list(
+				/obj/item/research_product/money/rare
 			),
 		),
 	)
@@ -256,15 +254,20 @@
 	. = ..()
 	icon_state = "sample_[rand(0, 11)]"
 
-/obj/item/research_resource/xeno/tier_one
+/obj/item/research_resource/xeno1
 	name = "Xenomorph research material - tier 1"
+	research_type = RES_XENO1
+	icon = 'icons/obj/alien_autopsy.dmi'
 	color = "#f0bee3"
+	icon_state = "sample_0"
 	reward_probs = list(
-		RES_TIER_BASIC = 100,
-		RES_TIER_COMMON = 15,
-		RES_TIER_UNCOMMON = 7,
-		RES_TIER_RARE = 1,
+		RES_TIER_POINTS = 100,
+		RES_TIER_ITEM = 20,
 	)
+
+/obj/item/research_resource/xeno1/Initialize()
+	. = ..()
+	icon_state = "sample_[rand(0, 11)]"
 
 /obj/item/research_resource/xeno/tier_two
 	name = "Xenomorph research material - tier 2"
@@ -317,8 +320,8 @@
 	. += span_notice("Rewards export points, as the name suggests.")
 
 /obj/item/research_product/money/basic
-	name = "credits - 50"
-	export_points = 50
+	name = "credits - 100"
+	export_points = 100
 
 /obj/item/research_product/money/common
 	name = "credits - 150"


### PR DESCRIPTION
## About The Pull Request

Hello, I've pitched my idea to a maintainer, and their response gave me the confidence to start this. This is part 1A of a 3 part (around 2 pr's per part) rework im planning. Each pull request is an incremental move towards it.
The end goal of these PR's is to move research from the rng hellscape it is, and to ultimately make it more skill based, and add in a tech tree for it.

Part 1A-1B aims to largely decouple research from random chance, part A addresses research sample rewards. This Pull request puts down the random chance in credit rewards. Each xeno sample tier rewards a fixxed amount of credits, 100% of the time.
The only randomized aspect of this pr, is research item acquisition, I was originally going to temporarily remove the items until I fully implement the tech tree, but that felt shitty without any immediate replacement.
The reward tiers have been changed to points, items, and advanced item. Point rewards are guaranteed, Item reward chances have been increased to become more consistent (NOTE: THEY WILL EVENTUALLY BE FULLY DETACHED FROM SAMPLES, AND MOVED TO A TECH TREE.)
The items are structured in this way: The cloak implant & blood recovery implant are normal items for xenomorph samples, cloak is replaced by blade injector for currency from yellow digsites, and the shoulder attachment is the advanced item reward.
The rates are (and awarded credits) are:
Xenomorph tier 1 samples: 100 credits, 20% chance for normal items
Xenomorph tier 2 samples: 150 credits, 25% chance for normal items, 20% chance for advanced
Xenomorph tier 3 samples: 250 credits, 40% chance for normal items, 35% chance for advanced
Xenomorph tier 4 samples: 600 credits, 60% chance for normal items, 50% chance for advanced
Currency from digsites (yellow): 250 credits, 40% chance for normal items,  35% chance for advanced.



## Why It's Good For The Game

Firstly, researcher can at times feel, very unrewarding. Regardless of how good you do, the total amount of points you can generate is ultimately limited to how much rng hates you, and does not respect time. Walking 3 tiles from the fob and doing a digsite for 1.6k, is horseshit, when you then walk 6 minutes to the other side of the map, do a digsite and get 100 bucks.
This pr alone would (partially) remedy these odds, by ultimately making the amount of money digsites yield VASTLY more consistent.
The PR that will ultimately follow after this one gets merged, will address the RNG of excavation sites, though this PR is functional on its own, as will all of my rework pr's be, with the  exception of  the last 2.
Researchers will now, at a guarantee, gain 400 from green digsites and 1,000 from yellow max, and at minimum, 500 from yellow and 200 from green. 
I do not believe making the items more common is going to completely break the game balance, as the cloak implanter is an even shittier version of the scout cloak, the blood pump is only useful for nanites, mantis is just a semi better machete, the only genuinely "good" reward is the shoulder mount, which is rarely used in favor of other armor modules, by anyone.

While I am relatively set on the item drop values, as they are ultimately a temporary measure I am willing to compromise, and the current point values can be adjusted as needed, though in the future will be changed accoording to my design plans.

The link provided is a document with my overall plans for research & researchers rework, detailing each step of implementation.

## Changelog

Sample reward pools & chances changed as follows:
Xenomorph tier 1 samples: 100 credits, 20% chance for normal items
Xenomorph tier 2 samples: 150 credits, 25% chance for normal items, 20% chance for advanced
Xenomorph tier 3 samples: 250 credits, 40% chance for normal items, 35% chance for advanced
Xenomorph tier 4 samples: 600 credits, 60% chance for normal items, 50% chance for advanced
Currency from digsites (yellow): 250 credits, 40% chance for normal items,  35% chance for advanced.
50 point coin replaced by 100 point coin
800 points changed to 600 points
:cl:
balance: all requisition point research rewards are no longer random, and are given at fixxed values per tier
balance: 50 point research grant buffed to 100
balance: 800 point research grant nerfed to 600
balance: increased chances for cloak implanter, blood implanter, mantis blade implanter, and shoulder mount
code: changed reward tiers and tier names
/:cl: