### PR TITLE
Berets no longer have NO_DECAP

### DIFF
--- a/code/modules/clothing/head/head.dm
+++ b/code/modules/clothing/head/head.dm
@@ -38,7 +38,6 @@
 	icon_state = "beret"
 	soft_armor = list(MELEE = 15, BULLET = 15, LASER = 15, ENERGY = 15, BOMB = 10, BIO = 5, FIRE = 5, ACID = 5)
 	flags_item_map_variant = NONE
-	flags_armor_features = ARMOR_NO_DECAP
 
 /obj/item/clothing/head/tgmcberet/tan
 	name = "\improper Tan beret"


### PR DESCRIPTION

## About The Pull Request
Berets no longer have decap protection.
## Why It's Good For The Game
Berets have decap protection despite most other headwear not having it, I personally believe that only helmets should have anti-decap, as if you're wearing this thing you're doing a fashion statement and have no helmet=you're easier to have your head cut off.
## Changelog
:cl:
balance: Berets no longer have decap protection.
/:cl:
