### PR TITLE
Deagle rework

### DIFF
--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -297,7 +297,7 @@
 
 /obj/item/weapon/gun/pistol/heavy
 	name = "\improper Desert Eagle pistol"
-	desc = "A magnum chambered in .50AE that comes with a serious kick. This one is engraved, <i>\"Peace through superior firepower\"</i>."
+	desc = "A magnum chambered in .50AE, the kick on followup shots will be hell, shoot with care to your shoulder. This one is engraved, <i>\"Peace through superior firepower\"</i>."
 	icon_state = "deagle"
 	item_state = "deagle"
 	caliber = CALIBER_50AE //codex
@@ -314,11 +314,9 @@
 	attachable_allowed = list(
 		/obj/item/attachable/reddot,
 		/obj/item/attachable/flashlight,
-		/obj/item/attachable/extended_barrel,
 		/obj/item/attachable/heavy_barrel,
 		/obj/item/attachable/quickfire,
 		/obj/item/attachable/lasersight,
-		/obj/item/attachable/compensator,
 		/obj/item/attachable/flashlight/under,
 		/obj/item/attachable/lace,
 		/obj/item/attachable/buildasentry,
@@ -328,20 +326,35 @@
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
 	attachable_offset = list("muzzle_x" = 31, "muzzle_y" = 19,"rail_x" = 9, "rail_y" = 23, "under_x" = 22, "under_y" = 14, "stock_x" = 20, "stock_y" = 17)
 
-	fire_delay = 0.7 SECONDS
+	fire_delay = 0.25 SECONDS
+	damage_mult = 2
+	recoil = 0
+	recoil_unwielded = 3
+
+	scatter = 0
+	min_scatter = 0
+	scatter_increase = 15
 	scatter_unwielded = 25
-	recoil = 1
-	recoil_unwielded = 2
-	scatter = 4
-	scatter_unwielded = 7
+	scatter_decay = 3
+	scatter_decay_unwielded = 2
+
 	accuracy_mult = 1
 	accuracy_mult_unwielded = 0.7
 
 /obj/item/weapon/gun/pistol/heavy/gold
 	name = "\improper Desert Eagle custom pistol"
-	desc = "A magnum chambered in .50AE that comes with a serious kick. This one is in a gold finish, with lots of stylistic engravings."
+	desc = "A magnum chambered in .50AE that comes with a serious kick. This one is in a gold finish, with lots of stylistic engravings and an internal barrel charger. It will kick like hell. Better hit."
 	icon_state = "g_deagle"
 	item_state = "g_deagle"
+
+	damage_mult = 4
+	recoil = 1
+	recoil_unwielded = 3
+
+	scatter_increase = 30
+	scatter_unwielded = 50
+	scatter_decay = 4
+
 //-------------------------------------------------------
 //MAUSER MERC PISTOL //Inspired by the Makarov.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Deagle damage mult goes from 1->2 (45x2=90)
Deagle fire rate goes from 0.7 to .25.
Deagle Recoil is now 0.
Loses all barrel attachies other than barrel charger due to the scatter changes in this PR.
Scatter is now 0, the minimum is 0, the max is 360.
It now has increasing scatter on shots, 15 per shot. It decays at a rate of 3 per second.

Golden Deagle is now a true admeme gun, it does x4 damage, but has insanely high scatter on shot. Better hit.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the Deagle unique via the use of scatter increasing per shots, and is a good testbed to try this out for other guns in general in my opinion.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Deagle reworked, it now has .25 fire rate, no more barrel attachments, doubled the damage to 90. It has 0 scatter and recoil. It now builds scatter per shot, at a rate of 15 scatter every time you fire. This scatter decays at a rate of 3 per second.
balance: Golden Deagle is now gamebreakingly overpowered. It has x4 damage mult, enabling it to two shots runners.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
