### PR TITLE
King HP nerf and scaling change

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -19,7 +19,7 @@
 	plasma_gain = 40
 
 	// *** Health *** //
-	max_health = 525
+	max_health = 575
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_YOUNG_THRESHOLD
@@ -77,7 +77,7 @@
 	plasma_gain = 50
 
 	// *** Health *** //
-	max_health = 550
+	max_health = 600
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_MATURE_THRESHOLD
@@ -102,7 +102,7 @@
 	plasma_gain = 60
 
 	// *** Health *** //
-	max_health = 575
+	max_health = 625
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_ELDER_THRESHOLD
@@ -129,7 +129,7 @@
 	plasma_gain = 70
 
 	// *** Health *** //
-	max_health = 600
+	max_health = 650
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_ANCIENT_THRESHOLD
@@ -156,7 +156,7 @@
 	plasma_gain = 70
 
 	// *** Health *** //
-	max_health = 600
+	max_health = 650
 
 	// *** Defense *** //
 	soft_armor = list(MELEE = 65, BULLET = 65, LASER = 65, ENERGY = 65, BOMB = 100, BIO = 60, FIRE = 100, ACID = 60)

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -19,7 +19,7 @@
 	plasma_gain = 40
 
 	// *** Health *** //
-	max_health = 450
+	max_health = 525
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_YOUNG_THRESHOLD
@@ -77,7 +77,7 @@
 	plasma_gain = 50
 
 	// *** Health *** //
-	max_health = 500
+	max_health = 550
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_MATURE_THRESHOLD
@@ -102,7 +102,7 @@
 	plasma_gain = 60
 
 	// *** Health *** //
-	max_health = 600
+	max_health = 575
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_ELDER_THRESHOLD
@@ -129,7 +129,7 @@
 	plasma_gain = 70
 
 	// *** Health *** //
-	max_health = 700
+	max_health = 600
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_ANCIENT_THRESHOLD
@@ -156,7 +156,7 @@
 	plasma_gain = 70
 
 	// *** Health *** //
-	max_health = 700
+	max_health = 600
 
 	// *** Defense *** //
 	soft_armor = list(MELEE = 65, BULLET = 65, LASER = 65, ENERGY = 65, BOMB = 100, BIO = 60, FIRE = 100, ACID = 60)

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -125,7 +125,7 @@
 	plasma_gain = 60
 
 	// *** Health *** //
-	max_health = 475
+	max_health = 500
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_ELDER_THRESHOLD
@@ -158,7 +158,7 @@
 	plasma_gain = 70
 
 	// *** Health *** //
-	max_health = 500
+	max_health = 550
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_ANCIENT_THRESHOLD

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -125,7 +125,7 @@
 	plasma_gain = 60
 
 	// *** Health *** //
-	max_health = 500
+	max_health = 475
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_ELDER_THRESHOLD
@@ -158,7 +158,7 @@
 	plasma_gain = 70
 
 	// *** Health *** //
-	max_health = 550
+	max_health = 500
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_ANCIENT_THRESHOLD


### PR DESCRIPTION
## About The Pull Request
OLD HP Scaling
450->500->600->700
New
575->600->625->650
## Why It's Good For The Game
King HP scaling right now is absurd, the difference is insane between levels, the EHP is insane at 700HP, this should help alleviate that atleast a bit, while making younger levels of kings more consistent between themselves.
## Changelog
:cl:
balance: King HP scaling changed from 450->500->600->700 to 575->600->625->650.
/:cl:
