### PR TITLE
King slash scaling normalization and nerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -9,7 +9,7 @@
 	wound_type = "king" //used to match appropriate wound overlays
 
 	// *** Melee Attacks *** //
-	melee_damage = 20
+	melee_damage = 24
 
 	// *** Speed *** //
 	speed = 0.1
@@ -67,7 +67,6 @@
 
 	upgrade = XENO_UPGRADE_ONE
 
-	melee_damage = 23
 
 	// *** Speed *** //
 	speed = 0.1
@@ -119,7 +118,7 @@
 	upgrade = XENO_UPGRADE_THREE
 
 	// *** Melee Attacks *** //
-	melee_damage = 30
+	melee_damage = 26
 
 	// *** Speed *** //
 	speed = -0.1
@@ -146,7 +145,7 @@
 	upgrade = XENO_UPGRADE_FOUR
 
 	// *** Melee Attacks *** //
-	melee_damage = 30
+	melee_damage = 26
 
 	// *** Speed *** //
 	speed = -0.1


### PR DESCRIPTION

## About The Pull Request
King slashes are normalized to the two bracket system every other xeno uses.
King slash changed from from 20->23->26->30 to 24->26.
## Why It's Good For The Game
King slash now works like every other xenos slash damage values, you gain slash at elder.
King slash is no longer ravager levels, it is now overall above average for its weight class.
## Changelog
:cl:
balance: King now scales like every other xenos, instead of gaining damage every maturity, it now gains slash at elder, new stats are 24 for young and mature, and 26 at Elder+. Old values were 20->23->26->30, so a net nerf at ancient maturity.
/:cl:
