### PR TITLE
king death timer fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -230,7 +230,7 @@
 			return
 
 		if(hivenumber == XENO_HIVE_NORMAL && SSticker?.mode && hive.xeno_king_timer)
-			to_chat(src, "<span class='warning'>We must wait about [timeleft(hive.xeno_king_timer) * 0.1] seconds for the hive to recover from the previous Queen's death.<span>")
+			to_chat(src, "<span class='warning'>We must wait about [timeleft(hive.xeno_king_timer) * 0.1] seconds for the hive to recover from the previous King's death.<span>")
 			return
 
 		if(isxenoresearcharea(get_area(src)))

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -438,6 +438,12 @@
 		return
 	HS.update_ruler()
 
+/mob/living/carbon/xenomorph/king/add_to_hive(datum/hive_status/HS, force = FALSE)
+	. = ..()
+
+	if(HS.living_xeno_king)
+		return
+	HS.living_xeno_king = src
 
 /mob/living/carbon/xenomorph/proc/add_to_hive_by_hivenumber(hivenumber, force=FALSE) // helper function to add by given hivenumber
 	if(!GLOB.hive_datums[hivenumber])


### PR DESCRIPTION

## About The Pull Request
The king PR is turns out was merged before a final change was pushed, so the death timer wasn't working. Honk.

King death timer is 7 minutes (queen is 5 minutes for comparison).
## Why It's Good For The Game
Bug fix good
## Changelog
:cl:
fix: fixed the King death timer
/:cl:
