### PR TITLE
Makes mechs (mostly assault and vanguard) substantially less tanky.

### DIFF
--- a/code/modules/vehicles/mecha/combat/greyscale/greyscale_limbs.dm
+++ b/code/modules/vehicles/mecha/combat/greyscale/greyscale_limbs.dm
@@ -123,17 +123,17 @@ GLOBAL_LIST_INIT(mech_bodytypes, list(MECH_RECON, MECH_ASSAULT, MECH_VANGUARD))
 	visor_config = /datum/greyscale_config/mech_recon/visor
 
 /datum/mech_limb/head/assault
-	health_mod = 270
+	health_mod = 260
 	accuracy_mod = 1.4
-	slowdown_mod = 0.25
+	slowdown_mod = 0.3
 	light_range = 6
 	greyscale_type = /datum/greyscale_config/mech_assault/head
 	visor_config = /datum/greyscale_config/mech_assault/visor
 
 /datum/mech_limb/head/vanguard
-	health_mod = 360
+	health_mod = 340
 	accuracy_mod = 1.5
-	slowdown_mod = 0.3
+	slowdown_mod = 0.4
 	light_range = 5
 	greyscale_type = /datum/greyscale_config/mech_vanguard/head
 	visor_config = /datum/greyscale_config/mech_vanguard/visor
@@ -159,14 +159,14 @@ GLOBAL_LIST_INIT(mech_bodytypes, list(MECH_RECON, MECH_ASSAULT, MECH_VANGUARD))
 	greyscale_type = /datum/greyscale_config/mech_recon/torso
 
 /datum/mech_limb/torso/assault
-	health_mod = 270
-	slowdown_mod = 0.55
+	health_mod = 260
+	slowdown_mod = 0.7
 	cell_type = /obj/item/cell/mecha/medium
 	greyscale_type = /datum/greyscale_config/mech_assault/torso
 
 /datum/mech_limb/torso/vanguard
-	health_mod = 360
-	slowdown_mod = 0.7
+	health_mod = 340
+	slowdown_mod = 1.0
 	cell_type = /obj/item/cell/mecha/large
 	greyscale_type = /datum/greyscale_config/mech_vanguard/torso
 
@@ -199,15 +199,15 @@ GLOBAL_LIST_INIT(mech_bodytypes, list(MECH_RECON, MECH_ASSAULT, MECH_VANGUARD))
 	greyscale_type = /datum/greyscale_config/mech_recon/arms
 
 /datum/mech_limb/arm/assault
-	health_mod = 270
+	health_mod = 260
 	scatter_mod = -17
-	slowdown_mod = 0.25
+	slowdown_mod = 0.3
 	greyscale_type = /datum/greyscale_config/mech_assault/arms
 
 /datum/mech_limb/arm/vanguard
-	health_mod = 360
+	health_mod = 340
 	scatter_mod = -25
-	slowdown_mod = 0.3
+	slowdown_mod = 0.4
 	greyscale_type = /datum/greyscale_config/mech_vanguard/arms
 
 
@@ -221,11 +221,11 @@ GLOBAL_LIST_INIT(mech_bodytypes, list(MECH_RECON, MECH_ASSAULT, MECH_VANGUARD))
 	greyscale_type = /datum/greyscale_config/mech_recon/legs
 
 /datum/mech_limb/legs/assault
-	health_mod = 270
-	slowdown_mod = -0.4
+	health_mod = 310
+	slowdown_mod = -0.3
 	greyscale_type = /datum/greyscale_config/mech_assault/legs
 
 /datum/mech_limb/legs/vanguard
-	health_mod = 360
-	slowdown_mod = -0.1
+	health_mod = 440
+	slowdown_mod = 0.1
 	greyscale_type = /datum/greyscale_config/mech_vanguard/legs

--- a/code/modules/vehicles/mecha/combat/greyscale/greyscale_limbs.dm
+++ b/code/modules/vehicles/mecha/combat/greyscale/greyscale_limbs.dm
@@ -115,7 +115,7 @@ GLOBAL_LIST_INIT(mech_bodytypes, list(MECH_RECON, MECH_ASSAULT, MECH_VANGUARD))
 	return list(icon2appearance(overlay_icon), icon2appearance(visor_icon), emissive_appearance(visor_icon))
 
 /datum/mech_limb/head/recon
-	health_mod = 200
+	health_mod = 180
 	accuracy_mod = 1.3
 	slowdown_mod = 0.2
 	light_range = 7
@@ -123,17 +123,17 @@ GLOBAL_LIST_INIT(mech_bodytypes, list(MECH_RECON, MECH_ASSAULT, MECH_VANGUARD))
 	visor_config = /datum/greyscale_config/mech_recon/visor
 
 /datum/mech_limb/head/assault
-	health_mod = 350
+	health_mod = 270
 	accuracy_mod = 1.4
-	slowdown_mod = 0.3
+	slowdown_mod = 0.25
 	light_range = 6
 	greyscale_type = /datum/greyscale_config/mech_assault/head
 	visor_config = /datum/greyscale_config/mech_assault/visor
 
 /datum/mech_limb/head/vanguard
-	health_mod = 550
+	health_mod = 360
 	accuracy_mod = 1.5
-	slowdown_mod = 0.4
+	slowdown_mod = 0.3
 	light_range = 5
 	greyscale_type = /datum/greyscale_config/mech_vanguard/head
 	visor_config = /datum/greyscale_config/mech_vanguard/visor
@@ -153,20 +153,20 @@ GLOBAL_LIST_INIT(mech_bodytypes, list(MECH_RECON, MECH_ASSAULT, MECH_VANGUARD))
 	detached.add_cell() //replaces with a standard high cap that does not have built in recharge
 
 /datum/mech_limb/torso/recon
-	health_mod = 200
+	health_mod = 180
 	slowdown_mod = 0.4
 	cell_type = /obj/item/cell/mecha
 	greyscale_type = /datum/greyscale_config/mech_recon/torso
 
 /datum/mech_limb/torso/assault
-	health_mod = 350
-	slowdown_mod = 0.7
+	health_mod = 270
+	slowdown_mod = 0.55
 	cell_type = /obj/item/cell/mecha/medium
 	greyscale_type = /datum/greyscale_config/mech_assault/torso
 
 /datum/mech_limb/torso/vanguard
-	health_mod = 550
-	slowdown_mod = 1.0
+	health_mod = 360
+	slowdown_mod = 0.7
 	cell_type = /obj/item/cell/mecha/large
 	greyscale_type = /datum/greyscale_config/mech_vanguard/torso
 
@@ -193,21 +193,21 @@ GLOBAL_LIST_INIT(mech_bodytypes, list(MECH_RECON, MECH_ASSAULT, MECH_VANGUARD))
 	return image(overlay_icon, icon_state = "left")
 
 /datum/mech_limb/arm/recon
-	health_mod = 200
+	health_mod = 180
 	scatter_mod = -10
 	slowdown_mod = 0.2
 	greyscale_type = /datum/greyscale_config/mech_recon/arms
 
 /datum/mech_limb/arm/assault
-	health_mod = 350
+	health_mod = 270
 	scatter_mod = -17
-	slowdown_mod = 0.3
+	slowdown_mod = 0.25
 	greyscale_type = /datum/greyscale_config/mech_assault/arms
 
 /datum/mech_limb/arm/vanguard
-	health_mod = 550
+	health_mod = 360
 	scatter_mod = -25
-	slowdown_mod = 0.4
+	slowdown_mod = 0.3
 	greyscale_type = /datum/greyscale_config/mech_vanguard/arms
 
 
@@ -216,16 +216,16 @@ GLOBAL_LIST_INIT(mech_bodytypes, list(MECH_RECON, MECH_ASSAULT, MECH_VANGUARD))
 	health_mod = 300
 
 /datum/mech_limb/legs/recon
-	health_mod = 200
+	health_mod = 180
 	slowdown_mod = -0.7
 	greyscale_type = /datum/greyscale_config/mech_recon/legs
 
 /datum/mech_limb/legs/assault
-	health_mod = 500
-	slowdown_mod = -0.3
+	health_mod = 270
+	slowdown_mod = -0.4
 	greyscale_type = /datum/greyscale_config/mech_assault/legs
 
 /datum/mech_limb/legs/vanguard
-	health_mod = 700
-	slowdown_mod = 0.1
+	health_mod = 360
+	slowdown_mod = -0.1
 	greyscale_type = /datum/greyscale_config/mech_vanguard/legs


### PR DESCRIPTION
## About The Pull Request

Slightly decreases recon mech part health by 100 total, greatly decreases assault and vanguard mech part health by 550 total and 1100 total respectively. 

## Why It's Good For The Game

Using the ancient ravager and praetorian index (each does 30 damage a hit), a full recon mech needs 34 hits, the assault mech needs 64 hits, and the vanguard needs 97. This does not include the resistance modules. Mechs are simply too tanky right now, capable of absorbing so much damage that even a full swarm struggles to take one down unless the MP is very far out of position and away from support. 

Needless to say mechs aren't particularly fun to fight, and they have king syndrome of surviving situations they really shouldn't be surviving. This makes it so on that same index, full recon needs 30 hits, assault 45, and vanguard 60. Minmaxxing parts isn't going to help your hp/speed as much as it used to. 

## Changelog

:cl: Tupina
balance: Reduces mech assault leg health from 500 hp -> 310 hp
balance: Reduces mech vanguard leg health from 700 hp -> 440 hp
balance: Reduces mech recon part health from 200 hp -> 180 hp (900 total including legs)
balance: Reduces mech assault part health from 350 hp -> 260 hp (1350 total including legs)
balance: Reduces mech vanguard part health from 550 hp -> 340 hp (1800 total including legs)
/:cl:

