### PR TITLE
Reduces Medium and Heavy armor slowdown. 

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/chestplates.dm
+++ b/code/modules/clothing/modular_armor/attachments/chestplates.dm
@@ -13,7 +13,7 @@
 	desc = "Designed for use with the Jaeger Combat Exoskeleton. It provides moderate protection and encumbrance when attached and is fairly easy to attach and remove from armor. Click on the armor frame to attach it. This armor appears to be marked as a Infantry armor piece."
 	icon_state = "infantry_chest"
 	soft_armor = list(MELEE = 25, BULLET = 45, LASER = 45, ENERGY = 35, BOMB = 30, BIO = 30, FIRE = 30, ACID = 35)
-	slowdown = 0.3
+	slowdown = 0.2
 	greyscale_config = /datum/greyscale_config/modularchest
 
 /obj/item/armor_module/armor/chest/marine/skirmisher
@@ -35,7 +35,7 @@
 	desc = "Designed for use with the Jaeger Combat Exoskeleton. It provides high protection and encumbrance when attached and is fairly easy to attach and remove from armor. Click on the armor frame to attach it. This armor appears to be marked as a Assault armor piece."
 	icon_state = "assault_chest"
 	soft_armor = list(MELEE = 30, BULLET = 50, LASER = 50, ENERGY = 40, BOMB = 30, BIO = 30, FIRE = 30, ACID = 40)
-	slowdown = 0.5
+	slowdown = 0.3
 	greyscale_config = /datum/greyscale_config/modularchest/assault
 
 /obj/item/armor_module/armor/chest/marine/eva //Medium armor alt look

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -448,12 +448,12 @@
 /obj/item/armor_module/module/style/medium_armor
 	name = "\improper Medium Armor Equalizer"
 	soft_armor = list(MELEE = 45, BULLET = 65, LASER = 65, ENERGY = 55, BOMB = 50, BIO = 50, FIRE = 50, ACID = 55)
-	slowdown = 0.5
+	slowdown = 0.4
 
 /obj/item/armor_module/module/style/heavy_armor
 	name = "\improper Heavy Armor Equalizer"
 	soft_armor = list(MELEE = 50, BULLET = 70, LASER = 70, ENERGY = 60, BOMB = 50, BIO = 50, FIRE = 50, ACID = 60)
-	slowdown = 0.7
+	slowdown = 0.5
 
 //original Martian design, donutsteel
 /obj/item/armor_module/module/eshield/som

--- a/code/modules/clothing/modular_armor/modular.dm
+++ b/code/modules/clothing/modular_armor/modular.dm
@@ -231,7 +231,7 @@
 	soft_armor = list(MELEE = 45, BULLET = 65, LASER = 65, ENERGY = 55, BOMB = 50, BIO = 50, FIRE = 50, ACID = 55)
 	icon_state = "medium"
 	item_state = "medium"
-	slowdown = 0.5
+	slowdown = 0.4
 
 	attachments_allowed = list(
 		/obj/item/armor_module/module/better_shoulder_lamp,
@@ -336,7 +336,7 @@
 	soft_armor = list(MELEE = 50, BULLET = 70, LASER = 70, ENERGY = 60, BOMB = 50, BIO = 50, FIRE = 50, ACID = 60)
 	icon_state = "heavy"
 	item_state = "heavy"
-	slowdown = 0.7
+	slowdown = 0.5
 
 /obj/item/clothing/suit/modular/xenonauten/heavy/leader
 	starting_attachments = list(/obj/item/armor_module/module/valkyrie_autodoc, /obj/item/armor_module/storage/general)
@@ -897,7 +897,7 @@
 	soft_armor = list(MELEE = 45, BULLET = 70, LASER = 60, ENERGY = 60, BOMB = 50, BIO = 50, FIRE = 50, ACID = 50)
 	icon_state = "som_medium"
 	item_state = "som_medium"
-	slowdown = 0.5
+	slowdown = 0.4
 
 	attachments_allowed = list(
 		/obj/item/armor_module/module/better_shoulder_lamp,
@@ -949,7 +949,7 @@
 	soft_armor = list(MELEE = 50, BULLET = 75, LASER = 65, ENERGY = 65, BOMB = 50, BIO = 50, FIRE = 60, ACID = 55)
 	icon_state = "som_heavy"
 	item_state = "som_heavy"
-	slowdown = 0.7
+	slowdown = 0.5
 
 /obj/item/clothing/suit/modular/som/heavy/pyro
 	starting_attachments = list(

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -21,7 +21,7 @@
 	soft_armor = list(MELEE = 40, BULLET = 60, LASER = 60, ENERGY = 45, BOMB = 45, BIO = 45, FIRE = 45, ACID = 50)
 	siemens_coefficient = 0.7
 	permeability_coefficient = 0.8
-	slowdown = 0.5
+	slowdown = 0.4
 	allowed = list(
 		/obj/item/weapon/gun,
 		/obj/item/instrument,
@@ -202,7 +202,7 @@
 	desc = "A standard TerraGov Navy N2 Personal Armor System. Protects the chest from ballistic rounds, bladed objects and accidents. It has a small leather pouch strapped to it for limited storage."
 	icon_state = "mp"
 	soft_armor = list(MELEE = 40, BULLET = 60, LASER = 60, ENERGY = 45, BOMB = 45, BIO = 45, FIRE = 45, ACID = 50)
-	slowdown = 0.5
+	slowdown = 0.4
 	flags_item_map_variant = NONE
 	allowed = list(
 		/obj/item/weapon/gun,
@@ -282,7 +282,7 @@
 	desc = "A somewhat outdated but robust armored vest, still in use despite the rise of exoskeleton armor due to ease of use and manufacturing. Tougher than it looks. Use it to toggle the built-in flashlight."
 	icon_state = "2"
 	soft_armor = list(MELEE = 40, BULLET = 60, LASER = 60, ENERGY = 45, BOMB = 45, BIO = 45, FIRE = 45, ACID = 50)
-	slowdown = 0.5 //a bit less
+	slowdown = 0.4 //a bit less
 	light_range = 6
 
 /obj/item/clothing/suit/storage/marine/riot
@@ -893,7 +893,7 @@
 	species_exception = list(/datum/species/robot)
 	flags_item_map_variant = (ITEM_JUNGLE_VARIANT|ITEM_ICE_VARIANT|ITEM_PRISON_VARIANT)
 	soft_armor = list(MELEE = 45, BULLET = 65, LASER = 65, ENERGY = 55, BOMB = 50, BIO = 50, FIRE = 50, ACID = 55)
-	slowdown = 0.5
+	slowdown = 0.4
 
 /obj/item/clothing/suit/storage/marine/robot/mob_can_equip(mob/M, slot, warning, override_nodrop)
 	. = ..()
@@ -915,4 +915,4 @@
 	icon_state = "robot_armor_heavy"
 	item_state = "robot_armor_heavy"
 	soft_armor = list(MELEE = 50, BULLET = 70, LASER = 70, ENERGY = 55, BOMB = 50, BIO = 50, FIRE = 50, ACID = 60)
-	slowdown = 0.7
+	slowdown = 0.5


### PR DESCRIPTION
## About The Pull Request

Increases medium and heavy armor speeds from 0.5 and 0.7 to 0.4 and 0.5 respectively

## Why It's Good For The Game

Each tier of armor generally only lets you take an additional hit and sometimes not get fract when you otherwise would, which in a game where movespeed is more important than health most of the time, is kinda goofy. Light ends up being a pretty obvious choice if you are competent, unless you are using very specific loadouts that rely on modules with their own slowdown to balance things out.

This should hopefully make medium and heavy armor more appealing as choices. Small armor buffs should warrant smaller slowdown penalties. 

## Changelog

:cl: Tupina
balance: Reduces medium and heavy armor slowdown penalties.
/:cl:

