### PR TITLE
The Queen Rework

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -378,27 +378,6 @@ Contains most of the procs that are called when a mob is attacked by something
 		if(access_tag in C.access)
 			return TRUE
 
-/mob/living/carbon/human/screech_act(mob/living/carbon/xenomorph/queen/Q, screech_range = WORLD_VIEW, within_sight = TRUE)
-	var/dist_pct = get_dist(src, Q) / screech_range
-
-	// Intensity is reduced by a 80% if you can't see the queen. Hold orders will reduce by an extra 10% per rank.
-	var/reduce_within_sight = within_sight ? 1 : 0.2
-	var/reduce_prot_aura = protection_aura * 0.1
-
-	var/reduction = max(min(1, reduce_within_sight - reduce_prot_aura), 0.1) // Capped at 90% reduction
-	var/stun_duration = (LERP(1, 0.4, dist_pct) * reduction) * 20 //Max 1.5 beside Queen, 0.4 at the edge.
-
-	to_chat(src, span_danger("An ear-splitting guttural roar tears through your mind and makes your world convulse!"))
-	Stun(stun_duration)
-	Paralyze(stun_duration)
-	//15 Next to queen , 3 at max distance.
-	adjust_stagger(LERP(7, 3, dist_pct) * reduction)
-	//Max 140 under Queen, 130 beside Queen, 70 at the edge. Reduction of 10 per tile distance from Queen.
-	apply_damage(LERP(140, 70, dist_pct) * reduction, STAMINA, updating_health = TRUE)
-	if(!ear_deaf)
-		adjust_ear_damage(deaf = stun_duration)  //Deafens them temporarily
-	//Perception distorting effects of the psychic scream*
-
 /mob/living/carbon/human/attackby(obj/item/I, mob/living/user, params)
 	if(stat != DEAD || I.sharp < IS_SHARP_ITEM_ACCURATE || user.a_intent != INTENT_HARM)
 		return ..()

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph_defense.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph_defense.dm
@@ -2,9 +2,6 @@
 Contains most of the procs that are called when a xeno is attacked by something
 */
 
-/mob/living/carbon/xenomorph/screech_act(mob/living/carbon/xenomorph/queen/Q)
-	return
-
 /mob/living/carbon/xenomorph/has_smoke_protection()
 	return TRUE
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -216,10 +216,7 @@
 		ExtinguishMob()
 
 
-//Mobs on Fire end
-// When they are affected by a queens screech
-/mob/living/proc/screech_act(mob/living/carbon/xenomorph/queen/Q)
-	shake_camera(src, 3 SECONDS, 1)
+//Mobs on Fire
 
 /mob/living/effect_smoke(obj/effect/particle_effect/smoke/S)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Queen is kind of a crappy caste to play, optimally being played by running in with screech and then running back and spamming spit. Otherwise you might as well avoid combat altogether and just build, which is more fun and easier with the dedicated support castes.

The goal of this rework is to turn the Queen into something with an actual identity, which I am dubbing the resinweaver. This is a bit more complex than the original idea but I think it will do a lot more, essentially turning her into an aggressive defense powerhouse that makes her own frontlines wherever she goes.

- [ ] Give queen ability to make resin jelly.
- [ ] Add an AOE resin ability which changes effects based on whether walls, doors, or sticky resin is selected. After a short delay, will generally give anyone in that aoe a bad day.
- [ ] Add a ranged node spitting ability that is based on the selected weed type. Can be toggled to regular sticky resin spit.
- [ ] Add a node detonation ability that has different effects depending on node type, while destroying the node and all nearby weeds.
- [ ] Replaces queen heal with an ability that summons the weeds of a given type on a xeno to give them a buff.
- [ ] Lets primo queen charge on weeds, but not off of them. Completely smashes through resin walls without being stopped.

## Why It's Good For The Game

Queen has a very boring kit and nobody wants to play her. The hive is leaderless for extended periods of time almost every round until someone essentially sacrifices themselves to play leader.

100 Second cooldown mass screen wide stun isn't really an interesting ability, and when that's not up Queen just has spit and spitslashing as her only combat abilities. The support side of her is less interesting than dedicated support castes as well. So broadly not great.

## Changelog

:cl: Tupina
add: placeholder
/:cl:
