### PR TITLE
Nerfs the AI combat droid movement speed

### DIFF
--- a/code/modules/vehicles/unmanned/unmanned_droid.dm
+++ b/code/modules/vehicles/unmanned/unmanned_droid.dm
@@ -2,7 +2,7 @@
 	name = "XN-43-H combat droid"
 	desc = "A prototype combat droid, first deployed as a prototype to fight the xeno menace in the frontier sytems."
 	icon_state = "droidcombat"
-	move_delay = 3
+	move_delay = 5
 	max_integrity = 150
 	turret_pattern = PATTERN_DROID
 	can_interact = TRUE


### PR DESCRIPTION

## About The Pull Request
The AI combat droid has been reduced a speedy move_delay of 3 down to a 5, making it much less of a headache to fight against.
## Why It's Good For The Game
Having an entire hive get deleted by a machine that can outrun and outDPS them is unfun, especially since it's immune to any form of CC the xenos have at their disposal.
## Changelog
:cl:
balance: nerfed combat droid's speed
/:cl:
