### PR TITLE
Misspelling fix when trying to remove cloning vat beaker

### DIFF
--- a/code/game/objects/machinery/cloning/cloning.dm
+++ b/code/game/objects/machinery/cloning/cloning.dm
@@ -151,7 +151,7 @@ These act as a respawn mechanic growning a body and offering it up to ghosts.
 		return
 
 	if(timerid || occupant) // You need to stop the process or remove the human first.
-		to_chat(user, span_notice("You can't get to the beaker while the machine growing a clone."))
+		to_chat(user, span_notice("You can't get to the beaker while the machine is growing a clone."))
 		return
 
 	beaker.forceMove(drop_location())


### PR DESCRIPTION

## About The Pull Request
From "You can't get to the beaker while the machine growing a clone"
to "You can't get to the beaker while the machine is growing a clone."
## Why It's Good For The Game
No more popped blood vessels from seeing a grammar issue in 2023.
## Changelog
:cl:
fix: added a missing "is" to clone vat's error message when removing a beaker
/:cl:
