### PR TITLE
Reduces surgery tool material costs

### DIFF
--- a/code/game/objects/items/tools/surgery_tools.dm
+++ b/code/game/objects/items/tools/surgery_tools.dm
@@ -4,7 +4,7 @@
 /obj/item/tool/surgery
 	icon = 'icons/obj/items/surgery_tools.dmi'
 	attack_speed = 11 //Used to be 4 which made them attack insanely fast.
-	materials = list(/datum/material/metal = 5000, /datum/material/glass = 2500)
+	materials = list(/datum/material/metal = 50, /datum/material/glass = 25)
 
 /*
 * Retractor


### PR DESCRIPTION

## About The Pull Request
Y'all can't behave so yet another infinite material exploit is being patched.
## Why It's Good For The Game
Fixes #12012 
## Changelog
:cl:
balance: Surgery tool cost reduced by 99% to prevent quick infinite free metal by vending pouches.
/:cl:
