### PR TITLE
Reorganization of Lobby Art

### DIFF
--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -282,7 +282,7 @@
 /turf/closed/wall/indestructible/splashscreen/New()
 	..()
 	if(icon_state == "title_painting1")
-		icon_state = "title_painting[rand(0,33)]"
+		icon_state = "title_painting[rand(0,26)]"
 
 /turf/closed/wall/indestructible/other
 	icon_state = "r_wall"


### PR DESCRIPTION
## About The Pull Request

Add four new lobby art! One from Ocelot!

![image](https://user-images.githubusercontent.com/6610922/215307071-0f155004-fe46-4cb1-ac55-536c673b4ee4.png)

Two from me.

![image](https://user-images.githubusercontent.com/6610922/215307082-29e56eba-98e3-4a8f-81d4-a4b6cb9ba089.png)

![image](https://user-images.githubusercontent.com/6610922/215369646-fcd438b4-d9e5-4dbd-a3d7-d9ae9153b378.png)

Another one from Sleepy EyedRobot!

![image](https://user-images.githubusercontent.com/6610922/215386882-2e8d1865-62d7-4dd9-9f59-d1c2d5b6d057.png)

Also, have to change one of the lobby art of Sleepy EyedRobot to have no name reference to statics.

Many lobby art will share the same screen time when server loads round. These compilations share similar themes.

![image](https://user-images.githubusercontent.com/6610922/215307105-2859512c-a039-4eba-b89c-d18c8d4dcd2c.png)

![image](https://user-images.githubusercontent.com/6610922/215307110-e748168d-d9d6-4443-a796-633c2b3eacec.png)

![image](https://user-images.githubusercontent.com/6610922/215307123-6e8682ae-cb5d-4345-822a-53771016eb52.png)

![image](https://user-images.githubusercontent.com/6610922/215307134-c8bbd226-f6b8-4512-8093-f1cd35a7cb2f.png)

For my own sake and contributors, I add organizational structure in DMI.

![image](https://user-images.githubusercontent.com/6610922/215307148-fd021550-1d1d-4198-8714-01d9cc18d711.png)


## Why It's Good For The Game

I compress the lobby art from 34 to 27 since many lobby arts can share the same screen time with others, allowing for TGMC players to see them all without the RNG gods to cycle through 34.

I also organize the DMI file via theme to hopefully explain to future contributors why I organize them the way they are.

## Changelog

:cl:
add: Reorganization of Lobby Art
imageadd: 2 new lobby arts! Two from me, another from Ocelot, and another from Sleepy EyedRobot!
/:cl:

