### PR TITLE
Mech Rocket nerf removes heavy explosion, +1 Light explosion

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1713,7 +1713,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	max_range = 30
 
 /datum/ammo/rocket/mech/drop_nade(turf/T)
-	explosion(T, 0, 2, 4, 5)
+	explosion(T, 0, 0, 5, 5)
 
 /datum/ammo/rocket/heavy_rr
 	name = "75mm round"


### PR DESCRIPTION

## About The Pull Request
Title.
2 heavy, 4 light to 5 light.
## Why It's Good For The Game
Free HE sadar roundstart is goofy, this should be better considering its closer to RR LE than anything else.
## Changelog
:cl:
balance: Mech Rocket launcher no longer has heavy explosion, it now has 1 more tile of light explosive range.
/:cl:
