### PR TITLE
Re-adds a plasmacutter to the synth vendor.

### DIFF
--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -760,6 +760,7 @@
 		/obj/item/reagent_containers/hypospray/advanced/oxycodone,
 		/obj/item/tweezers,
 		/obj/item/tool/surgery/solderingtool,
+		/obj/item/tool/pickaxe/plasmacutter,
 	)
 
 /obj/effect/vendor_bundle/white_dress


### PR DESCRIPTION

## About The Pull Request
Re-adds synth plasmacutter
## Why It's Good For The Game

Currently, marines have a massively better maze clearing option (widenozzle), engineers can buy plasmacutters and have a fair amount of points left over, the plasmacutter has a fairly slow recharge period, and to top it out: Synthetic isn't even absurdly well suited to using it in an extremely offensive way.
Synth is a slow, poorly armored role whose main option in combat is running away, and mainly acts as Bonus MD or Bonus Engie, this is just an option for synths beyond ye olde machete to cut down walls, and will likely have trouble being used as offensively as it once was.

And as a reminder, if we want to somehow argue that synthetic has an absurd degree of synergy with a PC beyond it giving them a bit more independance in caded making/setting up an area:
A combat robot engineer, of which there can be several, in medium armor, not only has more HP than a synth, and can take more abuse than a synth, will never drop into crit, so no crit dragging, via the magic of a dispenser, sacrifice their belt slot for a belt harness with relatively little impact to themself.

If a synthetic packs a shield, belt harness, goes full plasmacutter build, they are both less useful than a flamer ever, are a walkspeed-tier enemy for xenos without any med benefits, who can only wear light armor. Never mind losing a belt slot detrimenting their storage of the 10+ different things they need to take to maximize their roles potential.
If an engie does it, they still have an entire dispenser of space to do their job.
A synth, unless if their massively detriment themself, can really only use the plasmacutter supportively, and without a ton of frequency.
I do not believe this is going to break the game OR give marines more maze clearing than they already easily can do (Again, widenozzle flamer is just plasma cutter but better and faster, with less downtime between clears.)
This would just give synthetics another loadout option for flexibility, without having to beg engineers or spend req points. This just gives them moderately more freedom in terms of traversing walled areas (i.e "the nukedisk room has another 60 walls in it")
And on "but synthetics don't have a revive timer!" if a synthetic gets dragged off and brutally murdered, there's also generally then room to acid the PC/ now drag it away since IIRC xenos can drag items now.

## Changelog
:cl:
balance: re-added the plasmacutter to the essential synthetic kit.
/:cl:
