### PR TITLE
annihilate extra tcomm in Sulaco w/ dorm changes

### DIFF
--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -2754,20 +2754,14 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/hallway/central_hall)
 "aop" = (
-/obj/structure/window/reinforced/toughened{
-	dir = 1
-	},
-/obj/structure/window/reinforced/toughened{
-	dir = 8
-	},
-/obj/machinery/telecomms/hub/preset/cicbackup,
-/turf/open/floor/mainship/tcomms,
-/area/sulaco/bridge)
-"aoq" = (
-/obj/structure/window/framed/mainship/gray/toughened/hull,
-/obj/machinery/door/poddoor/opened/bridge,
-/turf/open/floor/plating/platebotc,
-/area/sulaco/hallway/central_hall)
+/obj/structure/table/woodentable,
+/obj/item/storage/backpack/satchel/norm,
+/obj/item/storage/fancy/cigar,
+/obj/item/tool/lighter/zippo,
+/obj/machinery/power/apc/mainship,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "aor" = (
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall2)
@@ -2951,9 +2945,6 @@
 	dir = 1
 	},
 /area/sulaco/bridge)
-"aps" = (
-/turf/closed/wall/mainship/gray/outer,
-/area/sulaco/hallway/central_hall)
 "apu" = (
 /turf/open/floor/prison/red{
 	dir = 1
@@ -3247,15 +3238,13 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/engineering/engine)
 "aqT" = (
-/obj/structure/window/reinforced/toughened{
-	dir = 4
+/obj/structure/table/woodentable,
+/obj/machinery/computer/squad_changer{
+	density = 0
 	},
-/obj/structure/window/reinforced/toughened{
-	dir = 1
-	},
-/obj/machinery/telecomms/processor/preset_four/cicbackup,
-/turf/open/floor/mainship/tcomms,
-/area/sulaco/bridge)
+/obj/machinery/alarm,
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "aqU" = (
 /obj/structure/stairs/seamless{
 	dir = 4
@@ -3287,12 +3276,8 @@
 "arb" = (
 /obj/structure/cable,
 /obj/machinery/camera/autoname,
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/yellow/hidden,
 /turf/open/floor/prison/red,
 /area/sulaco/bridge)
 "arc" = (
@@ -3551,23 +3536,14 @@
 "asf" = (
 /obj/structure/sign/prop1,
 /turf/closed/wall/mainship/gray,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge/quarters)
 "asg" = (
-/obj/structure/table/woodentable,
-/obj/item/flashlight/lamp,
-/obj/structure/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/storage/box/ids,
-/obj/item/folder/blue,
-/obj/item/tool/pen,
 /obj/machinery/firealarm,
 /obj/machinery/light/mainship{
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge/quarters)
 "asi" = (
 /turf/open/floor/prison/red/corner{
 	dir = 1
@@ -3788,15 +3764,6 @@
 /obj/machinery/door/poddoor/opened/port,
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
-"atd" = (
-/obj/structure/window/reinforced/toughened{
-	dir = 1
-	},
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/tcomms,
-/area/sulaco/bridge)
 "atk" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 6
@@ -3882,20 +3849,16 @@
 	},
 /turf/open/floor/prison/red,
 /area/sulaco/bridge)
-"atz" = (
-/obj/structure/table/woodentable,
-/obj/machinery/computer/squad_changer{
-	density = 0
-	},
-/obj/machinery/alarm,
-/turf/open/floor/wood,
-/area/sulaco/bridge/office)
 "atA" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
+/obj/structure/table/woodentable,
+/obj/item/flashlight/lamp,
+/obj/structure/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
+/obj/item/tool/pen,
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge/quarters)
 "atB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
@@ -3953,20 +3916,12 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 6
 	},
+/obj/machinery/holopad,
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge/quarters)
 "atI" = (
-/obj/structure/table/woodentable,
-/obj/item/storage/backpack/satchel/norm,
-/obj/item/storage/fancy/cigar,
-/obj/item/tool/lighter/zippo,
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
-"atJ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/captain,
-/turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge/quarters)
 "atL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -4275,13 +4230,13 @@
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
-/obj/machinery/door/airlock/mainship/command/CPToffice{
-	dir = 2
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/mainship/command/CPToffice{
+	dir = 2
+	},
 /turf/open/floor/carpet,
 /area/sulaco/cap_office)
 "auQ" = (
@@ -4357,14 +4312,13 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall2)
 "avg" = (
-/obj/effect/landmark/start/job/fieldcommander,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge/quarters)
 "avh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge/quarters)
 "avk" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -4406,12 +4360,9 @@
 /turf/open/floor/prison/marked,
 /area/sulaco/hallway/central_hall)
 "avp" = (
-/obj/machinery/holopad,
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
+/obj/structure/table/woodentable,
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge/quarters)
 "avq" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
@@ -4720,10 +4671,6 @@
 	},
 /turf/open/floor/carpet,
 /area/sulaco/cap_office)
-"awv" = (
-/obj/machinery/marine_selector/clothes/commander,
-/turf/open/floor/wood,
-/area/sulaco/bridge/office)
 "awx" = (
 /obj/structure/bed/chair/nometal{
 	dir = 4
@@ -4746,9 +4693,11 @@
 	},
 /area/sulaco/bridge)
 "awC" = (
-/obj/machinery/loadout_vendor,
+/obj/structure/bed,
+/obj/item/bedsheet/captain,
+/obj/effect/landmark/start/job/staffofficer,
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge/quarters)
 "awI" = (
 /turf/open/floor/prison/red{
 	dir = 1
@@ -4786,7 +4735,7 @@
 	dir = 9
 	},
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge/quarters)
 "awT" = (
 /obj/structure/prop/mainship/sensor_computer1,
 /turf/open/floor/prison/bright_clean,
@@ -8032,9 +7981,6 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/marine)
-"aOa" = (
-/turf/open/floor/mainship/tcomms,
-/area/sulaco/bridge)
 "aOb" = (
 /obj/structure/sign/biohazard{
 	pixel_y = 30
@@ -8050,11 +7996,8 @@
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/medbay/hangar)
 "aOk" = (
-/obj/structure/window/reinforced/toughened,
-/obj/machinery/telecomms/broadcaster/preset_right/cicbackup,
-/obj/machinery/light/mainship,
-/turf/open/floor/mainship/tcomms,
-/area/sulaco/bridge)
+/turf/closed/wall/mainship/gray/outer,
+/area/sulaco/bridge/office)
 "aOl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -10100,9 +10043,6 @@
 /turf/closed/wall/mainship/gray,
 /area/sulaco/liaison/quarters)
 "bdr" = (
-/obj/machinery/door/airlock/mainship/command/cic{
-	dir = 1
-	},
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
@@ -10110,8 +10050,11 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/door/airlock/mainship/command/officer{
+	dir = 2
+	},
 /turf/open/floor/wood,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge/quarters)
 "bdv" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
 /turf/open/floor/mainship/tcomms,
@@ -10663,11 +10606,11 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall)
 "bKr" = (
-/obj/machinery/door/window/secure/bridge{
+/obj/machinery/light/mainship/small{
 	dir = 8
 	},
-/turf/open/floor/mainship/tcomms,
-/area/sulaco/bridge)
+/turf/open/floor/plating,
+/area/sulaco/maintenance/upperdeck_north_maint)
 "bKI" = (
 /obj/item/radio/intercom/general,
 /turf/open/floor/prison/red,
@@ -10854,9 +10797,22 @@
 /turf/open/floor/mainship/sterile/plain,
 /area/sulaco/mechpilotquarters)
 "bZD" = (
-/obj/structure/window/framed/mainship/gray/toughened/hull,
-/turf/open/floor/plating/platebotc,
-/area/sulaco/bridge)
+/obj/structure/table/woodentable,
+/obj/item/flashlight/lamp,
+/obj/structure/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/storage/box/ids,
+/obj/item/folder/blue,
+/obj/item/tool/pen,
+/obj/machinery/firealarm,
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "bZP" = (
 /obj/machinery/vending/weapon,
 /turf/open/floor/prison,
@@ -11053,7 +11009,7 @@
 /obj/structure/window/framed/mainship/gray/toughened,
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/plating/platebotc,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge/quarters)
 "csq" = (
 /obj/machinery/landinglight/ds2/delaythree{
 	dir = 1
@@ -12737,7 +12693,7 @@
 "eEh" = (
 /obj/effect/soundplayer,
 /turf/closed/wall/mainship/gray,
-/area/sulaco/bridge)
+/area/sulaco/bridge/office)
 "eEB" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -13239,6 +13195,11 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
+"fqm" = (
+/obj/structure/bed,
+/obj/item/bedsheet/captain,
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "fqu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -14486,7 +14447,7 @@
 "heV" = (
 /obj/effect/soundplayer,
 /turf/closed/wall/mainship/gray,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge/quarters)
 "hff" = (
 /obj/effect/decal/cleanable/cobweb{
 	dir = 1
@@ -14683,12 +14644,11 @@
 /turf/open/floor/prison,
 /area/sulaco/cargo/office)
 "hrC" = (
-/obj/structure/window/reinforced/toughened{
-	dir = 8
-	},
-/obj/machinery/telecomms/bus/preset_four/cicbackup,
-/turf/open/floor/mainship/tcomms,
-/area/sulaco/bridge)
+/obj/effect/landmark/start/job/fieldcommander,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "hrG" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
@@ -15854,12 +15814,11 @@
 	},
 /area/mainship/living/basketball)
 "iTU" = (
-/obj/structure/window/reinforced/toughened{
-	dir = 4
+/obj/structure/bed/chair/office/dark{
+	dir = 1
 	},
-/obj/machinery/telecomms/relay/preset/telecomms/cicbackup,
-/turf/open/floor/mainship/tcomms,
-/area/sulaco/bridge)
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "iUQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/structure/cable,
@@ -16912,6 +16871,18 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
+"kps" = (
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/obj/machinery/door/airlock/mainship/command/cic{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/structure/cable,
+/turf/open/floor/prison,
+/area/sulaco/bridge/office)
 "kqp" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mainship/gray,
@@ -17262,12 +17233,9 @@
 /turf/open/floor/wood,
 /area/sulaco/medbay/west)
 "kNy" = (
-/obj/structure/window/reinforced/toughened{
-	dir = 4
-	},
-/obj/machinery/telecomms/server/presets/common/cicbackup,
-/turf/open/floor/mainship/tcomms,
-/area/sulaco/bridge)
+/obj/machinery/marine_selector/clothes/commander,
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "kNF" = (
 /obj/structure/cable,
 /obj/structure/table/mainship/nometal,
@@ -17495,12 +17463,9 @@
 /turf/closed/wall/mainship/gray,
 /area/shuttle/distress/arrive_2)
 "ljR" = (
-/obj/structure/window/reinforced/toughened{
-	dir = 4
-	},
-/obj/structure/window/reinforced/toughened,
-/turf/open/floor/mainship/tcomms,
-/area/sulaco/bridge)
+/obj/machinery/loadout_vendor,
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "lkp" = (
 /turf/open/floor/prison/red,
 /area/mainship/shipboard/weapon_room)
@@ -20830,7 +20795,7 @@
 /obj/machinery/door/poddoor/opened/sb,
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/plating/platebotc,
-/area/sulaco/bridge/office)
+/area/sulaco/bridge/quarters)
 "pBI" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison,
@@ -22549,13 +22514,9 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/hallway/central_hall)
 "rXM" = (
-/obj/structure/window/reinforced/toughened,
-/obj/machinery/telecomms/receiver/preset_right/cicbackup,
-/obj/structure/window/reinforced/windowstake{
-	dir = 8
-	},
-/turf/open/floor/mainship/tcomms,
-/area/sulaco/bridge)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "rZU" = (
 /obj/machinery/computer3/server,
 /turf/open/floor/mainship/tcomms,
@@ -25157,6 +25118,14 @@
 	dir = 10
 	},
 /area/sulaco/marine)
+"vlf" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "vln" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -25682,6 +25651,9 @@
 	},
 /turf/open/floor/prison/red,
 /area/mainship/shipboard/weapon_room)
+"vYY" = (
+/turf/closed/wall/mainship/gray,
+/area/sulaco/bridge/quarters)
 "waf" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/window/framed/mainship/gray/toughened,
@@ -25939,6 +25911,12 @@
 	dir = 1
 	},
 /area/space)
+"wtu" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "wtB" = (
 /obj/machinery/door/airlock/mainship/secure/free_access{
 	name = "Self Destruct Room"
@@ -26687,6 +26665,13 @@
 	dir = 1
 	},
 /area/sulaco/hangar)
+"xxx" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 9
+	},
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/sulaco/bridge/office)
 "xxy" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
@@ -48974,10 +48959,10 @@ aEH
 aEH
 cub
 aEH
-aop
-hrC
-bKr
-rXM
+aBR
+aBR
+aBR
+aBR
 apu
 auu
 txF
@@ -49230,10 +49215,10 @@ mDu
 mDu
 mDu
 aEH
-aEH
-atd
-aOa
-aOa
+aOk
+aOk
+aOk
+aOk
 aOk
 eEh
 aqV
@@ -49487,12 +49472,12 @@ vDU
 vDU
 vDU
 mDu
-aEH
+aOk
 aqT
 iTU
 kNy
 ljR
-tbJ
+aOk
 atw
 asn
 lpA
@@ -49744,12 +49729,12 @@ aaa
 aaa
 aaa
 nzi
-aEH
+aOk
 bZD
-bZD
-bZD
-bZD
-aEH
+hrC
+vlf
+wtu
+kps
 arb
 aso
 awp
@@ -50001,12 +49986,12 @@ aaa
 aaa
 aaa
 nzi
-mDu
-mDu
-mDu
-mDu
-mDu
-aEH
+aOk
+aop
+rXM
+xxx
+fqm
+aOk
 atw
 avk
 lpA
@@ -50258,12 +50243,12 @@ aaa
 aaa
 aaa
 nzi
-mDu
-mDu
-aps
-aoq
-aoq
-aEH
+aOk
+aOk
+aOk
+aOk
+aOk
+aOk
 goL
 ivr
 aok
@@ -50515,8 +50500,8 @@ aaa
 aaa
 emV
 mDu
-mDu
-mDu
+aYZ
+bKr
 aYZ
 aoi
 aoi
@@ -50773,7 +50758,7 @@ wRO
 mDu
 mDu
 aYZ
-aYZ
+aaW
 aYZ
 aoi
 aoi
@@ -52063,10 +52048,10 @@ sTR
 aon
 arc
 asf
-avr
+vYY
 pBA
-avr
-avr
+vYY
+vYY
 awI
 rhM
 aoi
@@ -52319,11 +52304,11 @@ aRh
 aoi
 aon
 arc
-avr
-atz
+vYY
+awC
 atA
-awv
-avr
+awC
+vYY
 ymf
 bax
 aoi
@@ -52576,7 +52561,7 @@ aRh
 kLy
 jGA
 ard
-avr
+vYY
 asg
 avg
 atH
@@ -52837,7 +52822,7 @@ crv
 atI
 avh
 awR
-avr
+vYY
 azQ
 eMl
 aoi
@@ -53090,11 +53075,11 @@ aGO
 aoi
 jGA
 hhb
-avr
-atJ
+vYY
+awC
 avp
 awC
-avr
+vYY
 awI
 ozD
 aoi
@@ -53348,10 +53333,10 @@ mHi
 apF
 arc
 heV
-avr
-avr
-avr
-avr
+vYY
+vYY
+vYY
+vYY
 axX
 aBj
 stp


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/6610922/215627779-9c1dfc3c-ba87-4fcb-bf72-a9a2fae7ec89.png)


Title

## Why It's Good For The Game

Sulaco has a comm issue that can be fixed by replacing extra comm with FC dorms. From the void from FC dorm, SOs have dorms for themselves.

## Changelog

:cl:
add: new FC and SO dorms
fix: extra tcomm in Sulaco, which annihilate comm issues in Sulaco
/:cl:

