### PR TITLE
Nerfs late synth engineering skill, buffed medical skill

### DIFF
--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -317,10 +317,10 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 
 /datum/skills/synthetic
 	name = SYNTHETIC
-	engineer = SKILL_ENGINEER_MASTER
-	construction = SKILL_CONSTRUCTION_MASTER
+	engineer = SKILL_ENGINEER_ENGI
+	construction = SKILL_CONSTRUCTION_ADVANCED
 	firearms = SKILL_FIREARMS_UNTRAINED
-	medical = SKILL_MEDICAL_EXPERT
+	medical = SKILL_MEDICAL_MASTER
 	cqc = SKILL_CQC_MASTER
 	surgery = SKILL_SURGERY_EXPERT
 	pilot = SKILL_PILOT_TRAINED


### PR DESCRIPTION

## About The Pull Request
In effect a less extreme version of #12057.
Nerfs late synth from 4/4 construction and engineering to 3/3. Making them Combat Engineer level rather than ship tech level.
Buffs their medical to 5. Nobody else has this good of medical skill.
## Why It's Good For The Game
Makes it a conscious choice between picking what you want to be specialized in when picking your synth choice. Do you want to be great at medical? Or great at engineering, instead of being just straight up better at everything, you're mediocre at something and great at something else. Of course the bodies themselves come with their own ups and downs..
## Changelog
:cl:
balance: Drops Late synth to 3 construction and 3 engineering skill [As good as a squad engineer, but worse than a ship tech.], and gives them 5 Medical skill, which nobody else has. For reference Early synth is basically a swap of this, being 5 Engineering/Construction. But 3 surgery and 3 medical.
/:cl:
