### PR TITLE
Fix vent crawl 

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -164,6 +164,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/AltClick(mob/user)
 	if(!isliving(user))
 		return
+	if(isxeno(user))
+		var/mob/living/carbon/xenomorph/xeno_user = user
+		xeno_user.handle_ventcrawl(src, xeno_user.xeno_caste.vent_enter_speed, xeno_user.xeno_caste.silent_vent_crawl)
+		return
 	var/mob/living/living_user = user
 	living_user.handle_ventcrawl(src)
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -115,7 +115,7 @@
 				cut_overlay(GLOB.welding_sparks)
 				return TRUE
 			else
-				cut_overlay(GLOB.welding_sparks)	
+				cut_overlay(GLOB.welding_sparks)
 		else
 			to_chat(user, span_warning("[WT] needs to be on to start this task."))
 			cut_overlay(GLOB.welding_sparks)
@@ -150,6 +150,10 @@
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/AltClick(mob/user)
 	if(!isliving(user))
+		return
+	if(isxeno(user))
+		var/mob/living/carbon/xenomorph/xeno_user = user
+		xeno_user.handle_ventcrawl(src, xeno_user.xeno_caste.vent_enter_speed, xeno_user.xeno_caste.silent_vent_crawl)
 		return
 	var/mob/living/living_user = user
 	living_user.handle_ventcrawl(src)


### PR DESCRIPTION


## About The Pull Request

A year and a half ago, the mechanics of climbing into the ventilation were reworked. Larvae and hunters had to get into the ventilation quickly and silently. And it is. BUT ONLY IF YOU USE THE ALIEN TAB.
If you use alt-click speedup doesn't work. This pr fixes this bug.

## Why It's Good For The Game

Fix bugs good. Larva buff double good

## Changelog
:cl:
fix: Larva and hunter now crawl into the ventilation faster (as it should have been for like a year and a half)
/:cl:
