### PR TITLE
MG-60 reduction

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -633,7 +633,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/bullet/rifle/machinegun
 	name = "machinegun bullet"
 	hud_state = "rifle_heavy"
-	damage = 27.5
+	damage = 25
 	penetration = 10
 	sundering = 0.75
 

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -775,7 +775,7 @@
 	inhand_y_dimension = 32
 
 	caliber = CALIBER_10x26_CASELESS //codex
-	max_shells = 250 //codex
+	max_shells = 150 //codex
 	force = 35
 	aim_slowdown = 1.2
 	wield_delay = 1.5 SECONDS

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -775,7 +775,7 @@
 	inhand_y_dimension = 32
 
 	caliber = CALIBER_10x26_CASELESS //codex
-	max_shells = 150 //codex
+	max_shells = 200 //codex
 	force = 35
 	aim_slowdown = 1.2
 	wield_delay = 1.5 SECONDS

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -168,7 +168,7 @@
 	caliber = CALIBER_10x26_CASELESS
 	default_ammo = /datum/ammo/bullet/rifle/machinegun
 	w_class = WEIGHT_CLASS_NORMAL
-	max_rounds = 150
+	max_rounds = 200
 	reload_delay = 3 SECONDS
 	icon_state_mini = "mag_gpmg"
 

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -168,7 +168,7 @@
 	caliber = CALIBER_10x26_CASELESS
 	default_ammo = /datum/ammo/bullet/rifle/machinegun
 	w_class = WEIGHT_CLASS_NORMAL
-	max_rounds = 250
+	max_rounds = 150
 	reload_delay = 3 SECONDS
 	icon_state_mini = "mag_gpmg"
 


### PR DESCRIPTION

## About The Pull Request
Reduced MG-60 bullet damage to 25 from 27.5. AP and sunder unchanged.

Also reduced capacity to 200 because the damage per mag is still hugely better than what it was previously.

The MG-60 buff pushed the gun to a level of DPS exceeding anything else in the game (except the two bigger MG's) which is not particularly ideal considering it is usable in hand, and viable on the move.

It will still be better DPS that any other portable gun by a fair margin, but slightly less guh to fight.
## Why It's Good For The Game
Giga MG-60 bad.
## Changelog
:cl:
balance: Reduced MG-60 damage to 25 from 27.5, and reduced magazine capacity to 200 from 250
/:cl:
