### PR TITLE
Synths no longer enter crit

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -52,6 +52,7 @@
 //Human sub-species
 #define isrobot(H) (is_species(H, /datum/species/robot))
 #define issynth(H) (is_species(H, /datum/species/synthetic) || is_species(H, /datum/species/early_synthetic))
+#define isartificial(H) (is_species(H, /datum/species/synthetic) || is_species(H, /datum/species/early_synthetic) || is_species(H, /datum/species/robot))
 #define isspeciessynthetic(H) (H.species.species_flags & IS_SYNTHETIC)
 #define ismoth(H) (is_species(H, /datum/species/moth))
 #define issectoid(H) (is_species(H, /datum/species/sectoid))

--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -185,7 +185,7 @@
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Vital signs detected. Aborting."))
 		return
 
-	if((HAS_TRAIT(H, TRAIT_UNDEFIBBABLE ) && !issynth(H)) || H.suiciding) //synthetic species have no expiration date
+	if((HAS_TRAIT(H, TRAIT_UNDEFIBBABLE )) || H.suiciding) //synthetic species will expire
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient is braindead. No remedy possible."))
 		return
 

--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -185,11 +185,11 @@
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Vital signs detected. Aborting."))
 		return
 
-	if((HAS_TRAIT(H, TRAIT_UNDEFIBBABLE )) && !isartificial || H.suiciding) // Combat Robots will have a special message, so we want to exclude them. Synthetics also won't go perma.
+	if((HAS_TRAIT(H, TRAIT_UNDEFIBBABLE )) && !isartificial(H) || H.suiciding) // Combat Robots will have a special message, so we want to exclude them. Synthetics also won't go perma.
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient has permanently expired. No remedy possible."))
 		return
 
-	if((HAS_TRAIT(H, TRAIT_UNDEFIBBABLE) && !isrobot)) || H.suiciding)
+	if((HAS_TRAIT(H, TRAIT_UNDEFIBBABLE) && !isrobot(H)) || H.suiciding) // Robot special message
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient's neural systems have degenerated past reboot threshold. Reboot impossible."))
 		return
 

--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -185,7 +185,7 @@
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Vital signs detected. Aborting."))
 		return
 
-	if((HAS_TRAIT(H, TRAIT_UNDEFIBBABLE )) || H.suiciding)
+	if((HAS_TRAIT(H, TRAIT_UNDEFIBBABLE )) && !isartificial || H.suiciding) // Combat Robots and Synthetics will have a special message
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient has permanently expired. No remedy possible."))
 		return
 

--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -185,11 +185,11 @@
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Vital signs detected. Aborting."))
 		return
 
-	if((HAS_TRAIT(H, TRAIT_UNDEFIBBABLE )) && !isartificial || H.suiciding) // Combat Robots and Synthetics will have a special message
+	if((HAS_TRAIT(H, TRAIT_UNDEFIBBABLE )) && !isartificial || H.suiciding) // Combat Robots will have a special message, so we want to exclude them. Synthetics also won't go perma.
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient has permanently expired. No remedy possible."))
 		return
 
-	if((HAS_TRAIT(H, TRAIT_UNDEFIBBABLE) && HAS_TRAIT(H, DETACHABLE_HEAD)) || H.suiciding)
+	if((HAS_TRAIT(H, TRAIT_UNDEFIBBABLE) && !isrobot)) || H.suiciding)
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient's neural systems have degenerated past reboot threshold. Reboot impossible."))
 		return
 

--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -189,8 +189,8 @@
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient has permanently expired. No remedy possible."))
 		return
 
-	if((HAS_TRAIT(H, TRAIT_UNDEFIBBABLE, DETACHABLE_HEAD)) || H.suiciding)
-		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient's central power system is drained. Reboot impossible."))
+	if((HAS_TRAIT(H, TRAIT_UNDEFIBBABLE) && HAS_TRAIT(H, DETACHABLE_HEAD)) || H.suiciding)
+		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient's neural systems have degenerated past reboot threshold. Reboot impossible."))
 		return
 
 	if(!H.has_working_organs() && !(H.species.species_flags & ROBOTIC_LIMBS))

--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -185,8 +185,12 @@
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Vital signs detected. Aborting."))
 		return
 
-	if((HAS_TRAIT(H, TRAIT_UNDEFIBBABLE )) || H.suiciding) //synthetic species will expire
-		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient is braindead. No remedy possible."))
+	if((HAS_TRAIT(H, TRAIT_UNDEFIBBABLE )) || H.suiciding)
+		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient has permanently expired. No remedy possible."))
+		return
+
+	if((HAS_TRAIT(H, TRAIT_UNDEFIBBABLE, DETACHABLE_HEAD)) || H.suiciding)
+		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient's central power system is drained. Reboot impossible."))
 		return
 
 	if(!H.has_working_organs() && !(H.species.species_flags & ROBOTIC_LIMBS))
@@ -194,7 +198,7 @@
 		return
 
 	if((H.wear_suit && H.wear_suit.flags_atom & CONDUCT))
-		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Paddles registering >100,000 ohms, Possible cause: Suit or Armor interferring."))
+		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Paddles registering >100,000 ohms, Possible cause: Suit or Armor interfering."))
 		return
 
 	var/mob/dead/observer/G = H.get_ghost()
@@ -232,7 +236,7 @@
 	if(!issynth(H) && !isrobot(H) && heart && prob(25))
 		heart.take_damage(5) //Allow the defibrillator to possibly worsen heart damage. Still rare enough to just be the "clone damage" of the defib
 
-	if((HAS_TRAIT(H, TRAIT_UNDEFIBBABLE ) && !issynth(H)) || H.suiciding) //synthetic species have no expiration date
+	if((HAS_TRAIT(H, TRAIT_UNDEFIBBABLE )) || H.suiciding)
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient's brain has decayed too much. No remedy possible."))
 		return
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -506,12 +506,14 @@ GLOBAL_VAR_INIT(join_as_robot_allowed, TRUE)
 	. = ..()
 	var/datum/atom_hud/AH = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED_SYNTH]
 	AH.add_hud_to(H)
+	H.health_threshold_crit = -100
 
 
 /datum/species/synthetic/post_species_loss(mob/living/carbon/human/H)
 	. = ..()
 	var/datum/atom_hud/AH = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED_SYNTH]
 	AH.remove_hud_from(H)
+	H.health_threshold_crit = -50
 
 /mob/living/carbon/human/species/synthetic/binarycheck(mob/H)
 	return TRUE
@@ -558,12 +560,14 @@ GLOBAL_VAR_INIT(join_as_robot_allowed, TRUE)
 	. = ..()
 	var/datum/atom_hud/AH = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED_SYNTH]
 	AH.add_hud_to(H)
+	H.health_threshold_crit = -100
 
 
 /datum/species/early_synthetic/post_species_loss(mob/living/carbon/human/H)
 	. = ..()
 	var/datum/atom_hud/AH = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED_SYNTH]
 	AH.remove_hud_from(H)
+	H.health_threshold_crit = -50
 
 /mob/living/carbon/human/species/early_synthetic/binarycheck(mob/H)
 	return TRUE

--- a/strings/tips/marine.txt
+++ b/strings/tips/marine.txt
@@ -46,7 +46,7 @@ To throw a grenade, Activate (Default: Z) the grenade while in the active hand. 
 Quickly store items to the container (bags, satchels, belts, pouches) by pressing the Quick Equip (Default: E) key while holding an item and you are looking at a container.
 Press Quick Equip (Default: E) while you are not holding an item to the active hand to draw the weapon from whatever preferred slot (Default: Suit Storage, can be customized at the Preferences tab) you selected, otherwise you will pull out any item from a container.
 Stasis bags do not pause xenomorph infection entirely, they only slow progress by a lot.
-Stasis bags prevents the DNR (do not revive) timer to tick, meaning that if corpsmen have a lot of patients, they can prevent brain death via stasis bags.
+Stasis bags prevents the DNR (do not revive) timer from ticking. This means if a corpsman has a lot of patients, they can put them in a stasis bag to delay their expiration.
 In the Crash gamemode, cooperate as a marine! Work as a squad to capture the disks and to detonate the nuclear bomb.
 In the Crash gamemode, remember that your objective is to secure all three disks, put the disk into the nuclear device and head home while the bomb is active. Xenos will keep on respawning until all of the marines are dead.
 While securing a FOB or securing the disk site, do not wander around outside! You will risk death by xenos who are comfy in sieging down the place.


### PR DESCRIPTION
## About The Pull Request
This makes synths never enter crit and continue to exist until -125 health.
## Why It's Good For The Game
Synthetic critdragging being able to go on forever, or just being in crit permanently until you ghost, disconnect or rarely a marine realizes you're not dead and takes you away are the most annoying things ever. This annihilates both of those problems.

*Drafted probably until early 2/02 (tomorrow) for me to fix some stuff and be solid sure about the fixes*
## Changelog
:cl:
balance: Synthetics no longer have a critical state and will continue with a massive slowdown until -125 health.
/:cl:
