### PR TITLE
Fix xeno bomb checks

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -17,11 +17,11 @@
 	var/bomb_slow_multiplier = max(0, 1 - 3.5*bomb_effective_armor)
 	var/bomb_sunder_multiplier = max(0, 1 - bomb_effective_armor)
 
-	if(bomb_effective_armor >= 100)
+	if(bomb_effective_armor >= 1)
 		return //immune
 
 
-	if(severity == EXPLODE_DEVASTATE && bomb_effective_armor <= XENO_EXPLOSION_GIB_THRESHOLD)
+	if((severity == EXPLODE_DEVASTATE) && ((bomb_effective_armor * 100) <= XENO_EXPLOSION_GIB_THRESHOLD))
 		return gib() //Gibs unprotected benos
 
 	//Slowdown and stagger


### PR DESCRIPTION

## About The Pull Request
Fixed xenos getting gibbed by OB's when they shouldn't.

I did a funny and forgot to update a thing.
## Why It's Good For The Game
Every xeno getting gibbed by OB is not ideal
## Changelog
:cl:
fix: fixed xenos getting gibbed by devestating explosions when they shouldn't have
/:cl:
