### PR TITLE
Nerfs mech laser rifles damage/sunder

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2604,7 +2604,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 /datum/ammo/energy/lasgun/marine/mech/smg
 	name = "superheated pulsed laser bolt"
-	damage = 15
+	damage = 10
 	penetration = 10
 
 // Plasma //

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2591,15 +2591,15 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 /datum/ammo/energy/lasgun/marine/mech
 	name = "superheated laser bolt"
-	damage = 45
+	damage = 25
 	penetration = 20
-	sundering = 1
+	sundering = 0
 	damage_falloff = 0.5
 
 /datum/ammo/energy/lasgun/marine/mech/burst
-	damage = 30
+	damage = 20
 	penetration = 10
-	sundering = 0.75
+	sundering = 0
 	damage_falloff = 0.6
 
 /datum/ammo/energy/lasgun/marine/mech/smg


### PR DESCRIPTION
## About The Pull Request
Nerfs mech laser damage/sunder

Laser projector
30->20
Sunder->0
New damage profile is 20 damage, 10 pen and 0 sunder from 30 damage, 20 pen and 1 sunder.

Laser rifle
45->25
Sunder->0
New damage profile is 25 damage, 20 pen and 0 sunder from 45 damage, 20 pen and 1 sunder.
## Why It's Good For The Game
The laser weapons can be stacked together to create comical levels of damage, they have effectively infinite ammo and are hitscan. There is barely any reason to pick anything else considering it basically makes your tank controls irrelevant, does way more damage than ballistics and have infinite ammo.
## Changelog
:cl:
balance: Mech Laser rifles have had their damage reduced overall across the board.
/:cl:
