### PR TITLE
GL 70 nerf

### DIFF
--- a/code/modules/projectiles/guns/grenade_launchers.dm
+++ b/code/modules/projectiles/guns/grenade_launchers.dm
@@ -115,7 +115,7 @@ The Grenade Launchers
 	)
 	starting_attachment_types = list(/obj/item/attachable/stock/t70stock)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 14, "rail_y" = 22, "under_x" = 19, "under_y" = 14, "stock_x" = 11, "stock_y" = 12)
-	fire_delay = 1.2 SECONDS
+	fire_delay = 2 SECONDS
 	max_chamber_items = 5
 
 


### PR DESCRIPTION

## About The Pull Request
Increases the fire delay of the GL 70 to 2
## Why It's Good For The Game
Nade spamming shouldn't be as easy as it is, this should tone it down a bit and AGLS will retain it's top spot for nade spam.
## Changelog
:cl:
balance: Increases GL 70 fire delay to 2
/:cl:
