### PR TITLE
Fixes vatborn having way too much slowdown

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -349,7 +349,7 @@
 	icobase = 'icons/mob/human_races/r_vatgrown.dmi'
 	brute_mod = 1.05
 	burn_mod = 1.05
-	slowdown = 1.05
+	slowdown = 0.05
 	joinable_roundstart = FALSE
 
 /datum/species/human/vatgrown/random_name(gender)
@@ -368,7 +368,7 @@
 	name_plural = "Early Vat-Grown Humans"
 	brute_mod = 1.3
 	burn_mod = 1.3
-	slowdown = 1.3
+	slowdown = 0.3
 
 	var/timerid
 


### PR DESCRIPTION

## About The Pull Request
Aged vatborn have 1.05 species slowdown. This would be pretty minor, were it not for the default species slowdown being 0 and not 1. Oops.
## Why It's Good For The Game
I went slow once.
It was honestly alright but this is excessive.
## Changelog
:cl:
fix: Vatborn have been given permission to take off their training weights.
/:cl:
