### PR TITLE
Remove Mosin from Icy Cave

### DIFF
--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -10134,16 +10134,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/wood/broken,
 /area/icy_caves/caves/underground_cafeteria)
-"Zw" = (
-/obj/structure/closet/crate,
-/obj/item/weapon/gun/shotgun/pump/bolt,
-/obj/item/ammo_magazine/rifle/bolt,
-/obj/item/ammo_magazine/rifle/bolt,
-/obj/item/ammo_magazine/rifle/bolt,
-/obj/item/ammo_magazine/rifle/bolt,
-/obj/item/ammo_magazine/rifle/bolt,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/security)
 "Zz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8
@@ -23654,7 +23644,7 @@ tK
 Ci
 Wt
 VM
-Zw
+Ie
 pF
 Ku
 Et


### PR DESCRIPTION
## About The Pull Request

lel

## Why It's Good For The Game

I gamer too hard with mosin in Sensor Capture and Combat Patrol.

## Changelog

:cl:
del: Remove Mosin from Icy Cave due to HvH balance
/:cl:

