### PR TITLE
Warrior nerfs empowered punch, removes blind on jab and reduces grabbed damage mult from 1.5 to 1.25.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -490,7 +490,7 @@
 
 /mob/living/punch_act(mob/living/carbon/xenomorph/warrior/X, damage, target_zone, push = TRUE, punch_description = "powerful", stagger_stacks = 3, slowdown_stacks = 3)
 	if(pulledby == X) //If we're being grappled by the Warrior punching us, it's gonna do extra damage and debuffs; combolicious
-		damage *= 1.1
+		damage *= 1.25
 		slowdown_stacks *= 2
 		stagger_stacks *= 2
 		ParalyzeNoChain(0.5 SECONDS)

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -404,7 +404,7 @@
 	var/target_zone = check_zone(X.zone_selected)
 
 	if(X.empower())
-		damage *= 1.5
+		damage *= 1.25
 	if(!A.punch_act(X, damage, target_zone))
 		return fail_activate()
 
@@ -490,7 +490,7 @@
 
 /mob/living/punch_act(mob/living/carbon/xenomorph/warrior/X, damage, target_zone, push = TRUE, punch_description = "powerful", stagger_stacks = 3, slowdown_stacks = 3)
 	if(pulledby == X) //If we're being grappled by the Warrior punching us, it's gonna do extra damage and debuffs; combolicious
-		damage *= 1.5
+		damage *= 1.1
 		slowdown_stacks *= 2
 		stagger_stacks *= 2
 		ParalyzeNoChain(0.5 SECONDS)
@@ -578,7 +578,6 @@
 	if(!target.punch_act(X, damage, target_zone, push = FALSE, punch_description = "precise", stagger_stacks = 3, slowdown_stacks = 6))
 		return fail_activate()
 	if(X.empower())
-		target.blind_eyes(3)
 		target.blur_eyes(6)
 		to_chat(target, span_highdanger("The concussion from the [X]'s blow blinds us!"))
 		target.Confused(3 SECONDS) //Does literally nothing for now, will have to re-add confusion code.


### PR DESCRIPTION
## About The Pull Request
Removes blind on empowered jab. You still have blur.
Nerfs empowered punch to 1.25 from 1.5.
Grabbed damage mult for punch reduced from 1.5 to 1.25, you still have a stun, stagger and slowdown after pulling off a punch combo.
## Why It's Good For The Game
Warrior punch combo is incredibly effective for how much damage it deals, and how low risk it is to lunge->punch->slash up a marine and then run away due to agility form, most other combos like toss are irrelevant due to how utterly effective it is. You'll still have slowdown, stagger and your stun on a marine you grab combo but just lunge+punch is far less effective now.

Blind on jab is just obnoxious to play against, you have blur and that's enough.
## Changelog
:cl:
balance: Blind on empowered jab has been removed, empowered punch has been reduced to 1.25x damage from 1.5x. Punching a grabbed opponent as warrior reduced to 1.25x damage mult.
/:cl:
