### PR TITLE
Unjanks rav fire interation

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
@@ -30,6 +30,14 @@
 	H.throw_at(get_turf(target_turf), RAV_CHARGEDISTANCE, RAV_CHARGESPEED, H)
 	H.Paralyze(2 SECONDS)
 
+/mob/living/carbon/xenomorph/ravager/fire_act()
+	. = ..()
+	if(stat)
+		return
+	plasma_stored = min(xeno_caste.plasma_max, plasma_stored + 50)
+	if(prob(15))
+		emote("roar")
+		to_chat(src, span_xenodanger("The heat of the fire roars in our veins! KILL! CHARGE! DESTROY!"))
 
 // ***************************************
 // *********** Ability related

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
@@ -34,7 +34,7 @@
 	. = ..()
 	if(stat)
 		return
-	plasma_stored = min(xeno_caste.plasma_max, plasma_stored + 50)
+	gain_plasma(50)
 	if(prob(15))
 		emote("roar")
 		to_chat(src, span_xenodanger("The heat of the fire roars in our veins! KILL! CHARGE! DESTROY!"))

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -615,17 +615,6 @@ GLOBAL_LIST_EMPTY(flamer_particles)
 /mob/living/carbon/xenomorph/queen/flamer_fire_act(burnlevel)
 	to_chat(src, span_xenowarning("Our extra-thick exoskeleton protects us from the flames."))
 
-/mob/living/carbon/xenomorph/ravager/flamer_fire_act(burnlevel)
-	if(stat)
-		return
-	plasma_stored = xeno_caste.plasma_max
-	var/datum/action/xeno_action/charge = actions_by_path[/datum/action/xeno_action/activable/charge]
-	if(charge)
-		charge.clear_cooldown() //Reset charge cooldown
-	to_chat(src, span_xenodanger("The heat of the fire roars in our veins! KILL! CHARGE! DESTROY!"))
-	if(prob(70))
-		emote("roar")
-
 /obj/item/weapon/gun/flamer/hydro_cannon
 	name = "underslung hydrocannon"
 	desc = "For the quenching of unfortunate mistakes."


### PR DESCRIPTION

## About The Pull Request
Ravagers now gain 50 rage every tick while on fire.

Currently, they completely refill their rage AND reset their charge cooldown every time a fire turf ticks while they are standing on it.
This is extremely powerful when abused, but also super unintuitive as you can move on and off fireturfs and never get the buff, or get it for touching a turf for 0.1 second.
## Why It's Good For The Game
Fire is no longer giga for rav, and provides a more modest, consistant bonus.
## Changelog
:cl:
balance: Ravagers now gain rage every tick when on fire, instead of refilling rage entirely when on a flame turf
/:cl:
