### PR TITLE
Warlock shield control change

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -58,7 +58,6 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_PSYCHIC_SHIELD,
 	)
-	keybind_flags = XACT_KEYBIND_USE_ABILITY
 	use_state_flags = XACT_USE_BUSY
 	///The actual shield object created by this ability
 	var/obj/effect/xeno/shield/active_shield


### PR DESCRIPTION
## About The Pull Request
Warlock shield hotkey now selects the shield ability instead of instant casts it.

This should A: help with people accidentally using it while moving and instantly cancelling it
and B: make it far easier to directionally cast.

This does mean both casting it initially and detonating the shield now require middle click (or whatever you have it bound to) but this should be a significant QOL boost.
## Why It's Good For The Game
Easier to control warlock shield
## Changelog
:cl:
qol: Warlock shield hotkey not selects the ability instead of casting it
/:cl:
