### PR TITLE
Human heads can now be reattached.

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -320,7 +320,7 @@
 	name = "Human"
 	name_plural = "Humans"
 	unarmed_type = /datum/unarmed_attack/punch
-	species_flags = HAS_SKIN_TONE|HAS_LIPS|HAS_UNDERWEAR
+	species_flags = HAS_SKIN_TONE|HAS_LIPS|HAS_UNDERWEAR|DETACHABLE_HEAD
 	count_human = TRUE
 
 	screams = list(MALE = "male_scream", FEMALE = "female_scream")

--- a/code/modules/organs/limb_objects.dm
+++ b/code/modules/organs/limb_objects.dm
@@ -70,7 +70,7 @@
 	resistance_flags = UNACIDABLE
 	var/mob/living/brain/brainmob
 	var/brain_item_type = /obj/item/organ/brain
-	var/braindeath_on_decap = 1 //whether the brainmob dies when head is decapitated (used by synthetics)
+	var/braindeath_on_decap = 0 //whether the brainmob dies when head is decapitated (used by synthetics)
 
 /obj/item/limb/head/Initialize(mapload, mob/living/carbon/human/H)
 	. = ..()

--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -3,7 +3,6 @@
 /datum/surgery_step/head
 	priority = 1
 	can_infect = 0
-	allowed_species = list("Synthetic", "Early Synthetic", "Combat Robot")
 	var/reattach_step
 
 /datum/surgery_step/head/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected, checks_only)
@@ -151,7 +150,7 @@
 
 
 /datum/surgery_step/head/attach
-	allowed_tools = list(/obj/item/limb/head/synth = 100, /obj/item/limb/head/robotic = 100)
+	allowed_tools = list(/obj/item/limb/head/synth = 100, /obj/item/limb/head/robotic = 100, /obj/item/limb/head = 100)
 	can_infect = 0
 	min_duration = 60
 	max_duration = 80
@@ -178,7 +177,10 @@
 
 	var/obj/item/limb/head/B = tool
 
-	affected.robotize()
+	if(istype(tool, /obj/item/limb/head/synth || /obj/item/limb/head/robotic))
+		affected.robotize()
+	else
+		affected.biotize()
 	target.updatehealth()
 	target.update_body()
 	target.UpdateDamageIcon()


### PR DESCRIPTION

## About The Pull Request
Allows human heads to be reattached.
## Why It's Good For The Game
It's super shitty to go through the entire process of rescuing a decapped body, getting the head as well, bring it over to a surgeon (in time), only for them to perform the entire surgery and be unable to finally re-attach the head.
You still go cold in 5 minutes so time is ticking.

Robust RSRs should be rewarded if they can rescue a body and reattach a head in under 5 minutes, not only for combat robots and synths.
## Changelog
:cl:
balance: Human heads can now be reattached to their human bodies.
/:cl:
