### PR TITLE
Nerfs throwing knives DPS

### DIFF
--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -330,7 +330,7 @@
 	max_amount = 5
 	amount = 5
 	///Delay between throwing.
-	var/throw_delay = 0.2 SECONDS
+	var/throw_delay = 0.4 SECONDS
 	COOLDOWN_DECLARE(last_thrown)
 
 /obj/item/stack/throwing_knife/Initialize(mapload, new_amount)


### PR DESCRIPTION

## About The Pull Request
Nerfs throwing knives speed.
From throw_delay 0.2s -> 0.4s
## Why It's Good For The Game
DO NOT MERGE WITH https://github.com/tgstation/TerraGov-Marine-Corps/pull/12067
This is just in my opinion a more tasteful way to decrease throwing knives DPS without actually making knives worse for people who dont carry a million knives belts.
## Changelog
:cl:
balance: throwing knives have a slower throw rate.
/:cl:
