### PR TITLE
delete var/atom/B2

### DIFF
--- a/code/modules/reqs/supply.dm
+++ b/code/modules/reqs/supply.dm
@@ -179,7 +179,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 				continue
 			if(!firstpack.containertype)
 				break
-			var/atom/B2 = new typepath(A)
+			new typepath(A)
 
 		SSpoints.shoppinglist[faction] -= "[SO.id]"
 		SSpoints.shopping_history += SO


### PR DESCRIPTION

## About The Pull Request
deletes var/atom/B2 which was causing checks to fail due to the error: 
code\modules\reqs\supply.dm:182:warning: B2: variable defined but not used
I dont know if just deleting it is the fix so I'm PRing this to see if it passes the check.
