### PR TITLE
Eviscerating charge now cost less, deals stagger but has much less stun.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -7,7 +7,7 @@
 	desc = "Charge up to 4 tiles and viciously attack your target."
 	ability_name = "charge"
 	cooldown_timer = 20 SECONDS
-	plasma_cost = 500 //Can't ignore pain/Charge and ravage in the same timeframe, but you can combo one of them.
+	plasma_cost = 300
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_RAVAGER_CHARGE,
 	)

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
@@ -29,6 +29,7 @@
 	target_turf =  get_step_rand(target_turf) //Scatter
 	H.throw_at(get_turf(target_turf), RAV_CHARGEDISTANCE, RAV_CHARGESPEED, H)
 	H.Paralyze(0.2 SECONDS)
+	H.adjust_stagger(2)
 
 /mob/living/carbon/xenomorph/ravager/fire_act()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
@@ -18,7 +18,7 @@
 // ***************************************
 // *********** Mob overrides
 // ***************************************
-/mob/living/carbon/xenomorph/ravager/Bump(atom/A)
+/mob/living/carbon/xenomorph/ravager/Bump(atom/A) // This is mostly triggered by eviscerating charge
 	if(!throwing || !usedPounce || !throw_source || !thrower) //Must currently be charging to knock aside and slice marines in it's path
 		return ..() //It's not pouncing; do regular Bump() IE body block but not throw_impact() because ravager isn't being thrown
 	if(!ishuman(A)) //Must also be a human; regular Bump() will default to throw_impact() which means ravager will plow through tables but get stopped by cades and walls
@@ -28,7 +28,7 @@
 	var/target_turf = get_step_away(src, H, rand(1, 3)) //This is where we blast our target
 	target_turf =  get_step_rand(target_turf) //Scatter
 	H.throw_at(get_turf(target_turf), RAV_CHARGEDISTANCE, RAV_CHARGESPEED, H)
-	H.Paralyze(2 SECONDS)
+	H.Paralyze(0.2 SECONDS)
 
 /mob/living/carbon/xenomorph/ravager/fire_act()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
1/10ths Eviscerating charges stun duration, it now deals 2 stagger.
Decreases cooldown from 20 to 15 seconds.
Charge plasma cost reduced by 40%.
## Why It's Good For The Game
The fire changes weren't really enough to move Ravager back down to a reasonable level of balance, so I believe these changes are fine since the caste will still be very viable, .2 stun is enough to force marines to drop their weapon and combo'ed with ravage is still a high amount of stun.

Ravager has around 3 seconds of stun in current state, this is very long for an ability that isn't very hard to land, and on the highest damage caste in the game with a large duration of EHP is quite strong, these changes should generally make Ravager easier to deal with, while keeping charge useful as an ability by letting you use it more often in an engagement and team fight.

I considered nerfing Ravage but that would be a far harsher nerf in my opinion as its generally used more often than charge, and my issue with the caste right now is the 3 seconds overall of stun the combo has.
## Changelog
:cl:
balance: Eviscerating charge stuns for .2 seconds rather than 2 seconds, charge cooldown reduced to 15 seconds from 20. Charge cost reduced by 40%.
/:cl:
