### PR TITLE
Only humans spin when stop drop and rolling

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -343,6 +343,11 @@ Contains most of the procs that are called when a mob is attacked by something
 			msg_admin_ff("[ADMIN_TPMONTY(living_thrower)] hit [ADMIN_TPMONTY(src)] with \the [thrown_item] (thrown) in [ADMIN_VERBOSEJMP(T)] [hit_report.Join(" ")].")
 
 
+/mob/living/carbon/human/resist_fire(datum/source)
+	spin(30, 1.5)
+	return ..()
+
+
 /mob/living/carbon/human/proc/bloody_hands(mob/living/source, amount = 2)
 	if (istype(gloves))
 		gloves.add_mob_blood(source)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -200,7 +200,6 @@
 	SIGNAL_HANDLER
 	fire_stacks = max(fire_stacks - rand(3, 6), 0)
 	Paralyze(30)
-	spin(30, 1.5)
 	var/turf/T = get_turf(src)
 	if(istype(T, /turf/open/floor/plating/ground/snow))
 		visible_message(span_danger("[src] rolls in the snow, putting themselves out!"), \


### PR DESCRIPTION

## About The Pull Request

Title. 

https://user-images.githubusercontent.com/22431091/217038012-1d857e05-9799-4fe5-a298-64d951b0e3be.mp4
## Why It's Good For The Game

Xenos don't roll when they resist fire (at least not visually), so there's no point. Plus they kept spinning way after they were done rolling which was annoying. 
## Changelog
:cl:
qol: Only humans spin when stop drop and rolling
/:cl:
