### PR TITLE
MG-42 now has T-12 burst fire and tac sensor+BFA

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -742,7 +742,7 @@
 	)
 
 	flags_gun_features = GUN_AMMO_COUNTER
-	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC)
+	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC, GUN_FIREMODE_AUTOBURST)
 	gun_skill_category = GUN_SKILL_HEAVY_WEAPONS
 	starting_attachment_types = list(/obj/item/attachable/stock/t42stock)
 	attachable_offset = list("muzzle_x" = 30, "muzzle_y" = 17,"rail_x" = 4, "rail_y" = 20, "under_x" = 16, "under_y" = 14, "stock_x" = 0, "stock_y" = 13)
@@ -752,6 +752,10 @@
 
 	fire_delay = 0.2 SECONDS
 	burst_amount = 1
+	autoburst_delay = 0.15 SECONDS //this makes it fuller auto
+	burst_accuracy_mult = 0.55
+	burst_scatter_mult = 8
+
 	accuracy_mult = 1.1
 	accuracy_mult_unwielded = 0.5
 	scatter = 2

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -723,6 +723,7 @@
 		/obj/item/attachable/flashlight/under,
 		/obj/item/attachable/lasersight,
 		/obj/item/attachable/foldable/bipod,
+		/obj/item/attachable/burstfire_assembly,
 		/obj/item/attachable/angledgrip,
 		/obj/item/attachable/extended_barrel,
 		/obj/item/attachable/heavy_barrel,
@@ -734,6 +735,7 @@
 		/obj/item/attachable/scope/mini,
 		/obj/item/attachable/compensator,
 		/obj/item/attachable/magnetic_harness,
+		/obj/item/attachable/motiondetector,
 		/obj/item/weapon/gun/pistol/plasma_pistol,
 		/obj/item/weapon/gun/shotgun/combat/masterkey,
 		/obj/item/weapon/gun/flamer/mini_flamer,
@@ -751,11 +753,8 @@
 	aim_speed_modifier = 2
 
 	fire_delay = 0.2 SECONDS
-	burst_amount = 1
-	autoburst_delay = 0.15 SECONDS //this makes it fuller auto
-	burst_accuracy_mult = 0.55
-	burst_scatter_mult = 8
-
+	burst_delay = 0.15 SECONDS
+	extra_delay = 0.05 SECONDS
 	accuracy_mult = 1.1
 	accuracy_mult_unwielded = 0.5
 	scatter = 2


### PR DESCRIPTION
## About The Pull Request
~~T~~MG-42 now has copy pasted T-12 burst fire.
It also gained 
## Why It's Good For The Game
I can't even remember the original reason it has no burst fire, this just mades it a true T-12 sidegrade. More magazine capacity in exchange for more slowdown+wield delay, meanwhile in the MGsphere its the only burst fire MG.
## Changelog
:cl:
balance: MG-42 now has AR-12 burst fire. As in completely the same.
balance: MG-42 now has BFA and tactical sensor.
/:cl:
