### PR TITLE
Removes wide flamer nozzle from marine vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -169,7 +169,6 @@
 			/obj/item/weapon/gun/rifle/pepperball/pepperball_mini = -1,
 			/obj/item/ammo_magazine/rifle/pepperball/pepperball_mini = -1,
 			/obj/item/attachable/flamer_nozzle = -1,
-			/obj/item/attachable/flamer_nozzle/wide = -1,
 			/obj/item/attachable/flamer_nozzle/long = -1,
 		),
 		"Boxes" = list(


### PR DESCRIPTION
## About The Pull Request

Only removes the wide nozzle attachment from the marine vendor. 

This does not remove it from the game or anywhere else.

## Why It's Good For The Game

With SURT and wide nozzle, you can functionally stand in the middle of your flame while slowly walking forward and flaming with infinite ammo, while an ungaball walks behind you ready to fire on an open and bright field from flames. 

Wide absolutely destroys mazes, the downside to wide is that it goes through ammo fast, but flamer fuel is infinite so it has 0 tangible downsides to ever using it, and not using it right now means you are going at a severe disadvantage.

Its clear that:
1) the flamer rework is never going to get done (#11625)
2) flamer fuel is going to remain infinite
3) buffing jelly by an extreme amount just to counter 1 attachment means that the attachment is the issue

Flamers suck in so many ways right now and are clearly not going to get better so this is what it has come to. You get to choose between being absolutely useless (extended) or being an absolutely monster that if you have atleast 3 braincells and some cooperative marines, you can burn down a whole map's worth of maze.

Before you whine and sob, you can PR a fix yourself if you don't like this one.

![image](https://user-images.githubusercontent.com/120620754/217099775-9e9176a8-8775-4c53-8602-902ab54139c8.png)
![image](https://user-images.githubusercontent.com/120620754/217099793-bbba2701-776b-4fc8-b3b8-3f52ab34aae8.png)
![image](https://user-images.githubusercontent.com/120620754/217100098-46ace29b-08ca-4f5b-953a-995bc0ff6930.png)

## Changelog

:cl:
del: Removed wide flamer nozzle from marine vendor
/:cl:

