### PR TITLE
Actual oxycodone OD

### DIFF
--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -156,9 +156,10 @@
 	return ..()
 
 /datum/reagent/medicine/oxycodone/overdose_process(mob/living/L, metabolism)
-	L.hallucination = max(L.hallucination, 3)
+	L.adjustStaminaLoss(5*effect_str)
 	L.set_drugginess(10)
 	L.jitter(3)
+	L.AdjustConfused(6)
 
 /datum/reagent/medicine/oxycodone/overdose_crit_process(mob/living/L, metabolism)
 	L.apply_damage(3*effect_str, TOX)


### PR DESCRIPTION

## About The Pull Request
I realised that oxy's OD functionally does nothing, which is extremely lame for a very strong pain killer.

Oxy OD now causes some stam loss and confusion.
## Why It's Good For The Game
No penalty for ODing on oxy is lame.
## Changelog
:cl:
balance: Oxycodone OD now causes stam loss and confusion
/:cl:
