### PR TITLE
Hyro rework- Lemoline Cost moved to Arithazine, healing reduced.

### DIFF
--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -127,12 +127,12 @@
 /datum/chemical_reaction/hyronalin
 	name = "Hyronalin"
 	results = list(/datum/reagent/medicine/hyronalin = 2)
-	required_reagents = list(/datum/reagent/radium = 1, /datum/reagent/medicine/dylovene = 1, /datum/reagent/medicine/lemoline = 1)
+	required_reagents = list(/datum/reagent/radium = 1, /datum/reagent/medicine/dylovene = 1)
 
 /datum/chemical_reaction/arithrazine
 	name = "Arithrazine"
 	results = list(/datum/reagent/medicine/arithrazine = 2)
-	required_reagents = list(/datum/reagent/medicine/hyronalin = 1, /datum/reagent/hydrogen = 1)
+	required_reagents = list(/datum/reagent/medicine/hyronalin = 1, /datum/reagent/hydrogen = 1, /datum/reagent/medicine/lemoline = 1)
 
 /datum/chemical_reaction/kelotane
 	name = "Kelotane"

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -346,7 +346,7 @@
 	description = "Dylovene is a broad-spectrum antitoxin."
 	color = "#669900"
 	scannable = TRUE
-	purge_list = list(/datum/reagent/toxin, /datum/reagent/medicine/research/stimulon, /datum/reagent/consumable/drink/atomiccoffee, /datum/reagent/medicine/paracetamol, /datum/reagent/medicine/larvaway)
+	purge_list = list(/datum/reagent/toxin, /datum/reagent/medicine/hyronalin, /datum/reagent/medicine/research/stimulon, /datum/reagent/consumable/drink/atomiccoffee, /datum/reagent/medicine/paracetamol, /datum/reagent/medicine/larvaway)
 	purge_rate = 1
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
@@ -514,9 +514,11 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	scannable = TRUE
+	purge_list = list(/datum/reagent/medicine/dylovene)
+	purge_rate = 2
 
 /datum/reagent/medicine/hyronalin/on_mob_life(mob/living/L)
-	L.adjustToxLoss(-effect_str)
+	L.adjustToxLoss(-0.25*effect_str)
 	return ..()
 
 /datum/reagent/medicine/hyronalin/overdose_process(mob/living/L, metabolism)


### PR DESCRIPTION
## About The Pull Request
Hyro now no longer requires lemoline, it now purges dylo (and dylo purges it)
Hyro now only heals .25 per tick.
## Why It's Good For The Game
Makes Hyro a slow alternative to dylovene, but keeps it from stacking at all. If you have it in your system you're giving up a chem slot for it.
## Changelog
:cl:
balance: Hyronalin now no longer requires lemoline, it now purges dylo (and dylo purges it) however Hyronalin now only heals .25 per tick.
/:cl:
