### PR TITLE
Adds maintenance activation to robots

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -69,6 +69,8 @@
 
 #define STATUS_EFFECT_INTOXICATED /datum/status_effect/stacking/intoxicated //Damage over time
 
+#define STATUS_EFFECT_REPAIR_MODE /datum/status_effect/incapacitating/repair_mode //affected is blinded and stunned, but heals over time
+
 /////////////
 // NEUTRAL //
 /////////////

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -153,6 +153,44 @@
 		if(prob(10) && owner.health > owner.health_threshold_crit)
 			owner.emote("snore")
 
+///Basically a temporary self-inflicted shutdown for maintenance
+/datum/status_effect/incapacitating/repair_mode
+	id = "repairing"
+	tick_interval = 1 SECONDS
+	///How much brute or burn per second
+	var/healing_per_tick = 4
+	///Whether the last tick made a sound effect or not
+	var/last_sound
+
+/datum/status_effect/incapacitating/repair_mode/on_apply()
+	. = ..()
+	if(!.)
+		return
+	owner.disabilities |= BLIND
+	owner.blind_eyes(1)
+	ADD_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))
+	ADD_TRAIT(owner, TRAIT_IMMOBILE, TRAIT_STATUS_EFFECT(id))
+
+/datum/status_effect/incapacitating/repair_mode/on_remove()
+	owner.disabilities &= ~BLIND
+	REMOVE_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))
+	REMOVE_TRAIT(owner, TRAIT_IMMOBILE, TRAIT_STATUS_EFFECT(id))
+	return ..()
+
+/datum/status_effect/incapacitating/repair_mode/tick()
+	var/sound_to_play
+	if(owner.getBruteLoss())
+		owner.heal_limb_damage(healing_per_tick, 0, TRUE, TRUE)
+		sound_to_play = pick('sound/items/welder.ogg', 'sound/items/welder2.ogg')
+	else if(owner.getFireLoss())
+		owner.heal_limb_damage(0, healing_per_tick, TRUE, TRUE)
+		sound_to_play = 'sound/items/deconstruct.ogg'
+	if(!sound_to_play || last_sound)
+		last_sound = FALSE
+		return
+	last_sound = TRUE
+	playsound(owner, sound_to_play, 50)
+
 
 
 /**

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -444,11 +444,17 @@ GLOBAL_VAR_INIT(join_as_robot_allowed, TRUE)
 	. = ..()
 	H.speech_span = SPAN_ROBOT
 	H.health_threshold_crit = -100
+	var/datum/action/repair_self/repair_action = new()
+	repair_action.give_action(H)
 
 /datum/species/robot/post_species_loss(mob/living/carbon/human/H)
 	. = ..()
 	H.speech_span = initial(H.speech_span)
 	H.health_threshold_crit = -50
+	var/datum/action/repair_self/repair_action = H.actions_by_path[/datum/action/repair_self]
+	repair_action.remove_action(H)
+	qdel(repair_action)
+
 
 /mob/living/carbon/human/species/robot/handle_regular_hud_updates()
 	. = ..()
@@ -461,6 +467,25 @@ GLOBAL_VAR_INIT(join_as_robot_allowed, TRUE)
 	else
 		clear_fullscreen("robothalf")
 		clear_fullscreen("robotlow")
+
+///Lets a robot repair itself over time at the cost of being stunned and blind
+/datum/action/repair_self
+	name = "Activate autorepair"
+	action_icon_state = "suit_configure"
+
+/datum/action/repair_self/can_use_action()
+	. = ..()
+	if(!.)
+		return
+	return !owner.incapacitated()
+
+/datum/action/repair_self/action_activate()
+	. = ..()
+	if(!. || !ishuman(owner))
+		return
+	var/mob/living/carbon/human/howner = owner
+	howner.apply_status_effect(STATUS_EFFECT_REPAIR_MODE, 5 SECONDS)
+	howner.balloon_alert_to_viewers("Repairing")
 
 /datum/species/robot/alpharii
 	name = "Hammerhead Combat Robot"

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -529,7 +529,7 @@
 		eye_blind = amount
 		if(client && !old_eye_blind)
 			overlay_fullscreen("blind", /atom/movable/screen/fullscreen/blind)
-	else if(!eye_blind)
+	else if(eye_blind)
 		var/blind_minimum = 0
 		if(stat != CONSCIOUS)
 			blind_minimum = 1
@@ -540,9 +540,6 @@
 		eye_blind = blind_minimum
 		if(!eye_blind)
 			clear_fullscreen("blind")
-	else
-		eye_blind = max(eye_blind, 0)
-		clear_fullscreen("blind")
 
 /mob/living/proc/blur_eyes(amount)
 	if(amount>0)


### PR DESCRIPTION

## About The Pull Request
Robots get an action button they can press to stun and blind themselves for 5 seconds while healing up to 20 total brute and burn damage.

## Why It's Good For The Game
Essentially a very light, robotic version of surgery/sleep. Commit to disabling yourself for a period and you can heal more/for free.

## Changelog

:cl:
add: Maintenance mode for robots: disable yourself for five seconds to heal up to 20 damage.
fix: Fixed blindness not clearing properly if you tried to remove it a certain way.
/:cl:
