### PR TITLE
Nerfs the bible

### DIFF
--- a/code/game/objects/items/storage/bible.dm
+++ b/code/game/objects/items/storage/bible.dm
@@ -4,6 +4,7 @@
 	icon_state ="bible"
 	throw_speed = 1
 	throw_range = 5
+	storage_slots = 1
 	w_class = WEIGHT_CLASS_NORMAL
 	var/mob/affecting = null
 	var/deity_name = "Christ"
@@ -17,6 +18,11 @@
 	name = "bible"
 	desc = "To be applied to the head repeatedly."
 	icon_state ="bible"
+	storage_slots = 7
+	can_hold = list(
+		/obj/item/reagent_containers/food/drinks/cans,
+		/obj/item/spacecash,
+	)
 
 /obj/item/storage/bible/booze/Initialize(mapload, ...)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Bible can only hold 1 thing inside it, down from 7
Booze bible can still hold 7 but only cans and cash.
## Why It's Good For The Game
Book having as much storage as a pouch while fitting inside plenty of other containers is bad.
## Changelog
:cl:
balance: The bible is no longer in and of itself a miracle
/:cl:
