### PR TITLE
Engineers can no longer buy teleporters

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -73,7 +73,6 @@ GLOBAL_LIST_INIT(engineer_gear_listed_products, list(
 		/obj/item/cell/high = list(CAT_ENGSUP, "High capacity powercell", 1, "black"),
 		/obj/item/cell/rtg/small = list(CAT_ENGSUP, "Recharger powercell", 5, "black"),
 		/obj/item/cell/rtg/large = list(CAT_ENGSUP, "Large recharger powercell", 15, "black"),
-		/obj/effect/teleporter_linker = list(CAT_ENGSUP, "Teleporters", 25, "black"),
 		/obj/item/storage/box/explosive_mines = list(CAT_ENGSUP, "M20 mine box", 18, "black"),
 		/obj/item/storage/box/explosive_mines/large = list(CAT_ENGSUP, "Large M20 mine box", 35, "black"),
 		/obj/item/minelayer = list(CAT_ENGSUP, "M21 APRDS \"Minelayer\"", 5, "black"),


### PR DESCRIPTION
## About The Pull Request
Title.
## Why It's Good For The Game
Teleporters are insanely strong for what are basically free move across the map tools for little cost, if I made them take up all your engi points they would *still* be insanely overpowered. Them costing some points (500/50) is fine in my book because that costs your team cost opportunity cost.
## Changelog
:cl:
balance: Engineers can no longer buy teleporters
/:cl:
