### PR TITLE
Fix AGLS req oversight

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -224,7 +224,7 @@ WEAPONS
 	contains = list(/obj/item/ammo_magazine/standard_agls/fragmentation)
 	cost = 40
 
-/datum/supply_packs/weapons/ags_frag
+/datum/supply_packs/weapons/ags_incend
 	name = "AGLS-37 AGL White Phosphorous Grenades"
 	contains = list(/obj/item/ammo_magazine/standard_agls/incendiary)
 	cost = 40

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -224,7 +224,7 @@ WEAPONS
 	contains = list(/obj/item/ammo_magazine/standard_agls/fragmentation)
 	cost = 40
 
-/datum/supply_packs/weapons/ags_incend
+/datum/supply_packs/weapons/ags_incendiary
 	name = "AGLS-37 AGL White Phosphorous Grenades"
 	contains = list(/obj/item/ammo_magazine/standard_agls/incendiary)
 	cost = 40


### PR DESCRIPTION

## About The Pull Request
Somehow forgot to change the name of the AGLS WP ammo order in req, which made the normal frag ammo not able to be bought
## Why It's Good For The Game
fix
## Changelog
:cl:
fix: fixed AGLS WP magazine in req console
/:cl:
