### PR TITLE
Ravager Rage screenshake effect will no longer affect its user

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -365,7 +365,7 @@
 		affected_tiles.Shake(4, 4, 1 SECONDS) //SFX
 
 	for(var/mob/living/L AS in GLOB.mob_living_list) //Roar that applies cool SFX
-		if(L.stat == DEAD || !L.hud_used || (get_dist(L, X) > rage_power_radius)) //We don't care about the dead
+		if(L == X || L.stat == DEAD || !L.hud_used || (get_dist(L, X) > rage_power_radius)) //We don't care about the dead
 			continue
 
 		shake_camera(L, 1 SECONDS, 1)


### PR DESCRIPTION
## About The Pull Request
Per title.

## Why It's Good For The Game
Ravager's Rage's screen shake effect is unironically pretty disrupting. It's a good thing, sure, but probably not when it affects its owner.

## Changelog
:cl: Lewdcifer
qol: Ravager's Rage's screenshake effect will no longer affect its user.
/:cl: