### PR TITLE
Fix Plasma OB detonating in OB room

### DIFF
--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -414,11 +414,11 @@
 	name = "\improper Plasma draining orbital warhead"
 	warhead_kind = "plasma"
 	icon_state = "ob_warhead_4"
-	var/datum/effect_system/smoke_spread/plasmaloss/smoke
+
 
 /obj/structure/ob_ammo/warhead/plasmaloss/warhead_impact(turf/target, inaccuracy_amt = 0)
 	. = ..()
-	smoke = new(src)
+	var/datum/effect_system/smoke_spread/plasmaloss/smoke = new
 	smoke.set_up(25, target, 3 SECONDS)//Vape nation
 	smoke.start()
 


### PR DESCRIPTION
## About The Pull Request

Fixs Plasma OB going off in the OB room

this solution works when i test it on a local server, but i have no idea why it works, if someone who know how this stuff works could check it that would be great

also can someone explain to me why this works?
## Why It's Good For The Game

being able to use the plasma OB and not having it blow up in the OB room and basically waste fuel is nice.
## Changelog
:cl:
fix: Plasma OB will now hit the lased position instead of going off in the OB room
/:cl:
