### PR TITLE
Fixes plasma OB

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -199,7 +199,7 @@
 		lifetime = smoke_time
 
 /datum/effect_system/smoke_spread/start()
-	if(!QDELETED(holder))
+	if(QDELETED(location) && !QDELETED(holder))
 		location = get_turf(holder)
 	new smoke_type(location, range, lifetime, src)
 


### PR DESCRIPTION

## About The Pull Request
Fixes plasma OB's spawning in the OB room.

There's actually more than one way to fix this, I'm not sure if this is the best way as I'm not certain why this was changed to begin with.
## Why It's Good For The Game
Plasma OB working is quite handy
## Changelog
:cl:
fix: fixed plasma OBs detonating shipside
/:cl:
