### PR TITLE
Add teleporter in req vendor due to mjp's nerf

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -802,6 +802,7 @@
 		"Surplus Special Equipment" = list(
 			/obj/item/pinpointer = 1,
 			/obj/item/beacon/supply_beacon = 1,
+			/obj/effect/teleporter_linker = 1,
 			/obj/item/ammo_magazine/rifle/autosniper = 3,
 			/obj/item/ammo_magazine/rifle/tx8 = 3,
 			/obj/item/ammo_magazine/rocket/sadar = 3,


### PR DESCRIPTION
## About The Pull Request

Title. Merge if #12128 gets merged.

## Why It's Good For The Game

1) Req vendor, or operational supplies vendor, is limited to shipside maps. There is no req vendor in bury / Crash, meaning that if anyone were to add a req vendor in bury / Crash, they need to be reminded that they cannot.

2) Req hell is bad. If Bravemole was here, he would not let #12128 merge without a compensation for engineers round start. This is way better than having multiple teleporters for engineers to chain link teleporters, but this also mean the engineer with the fastest hand gets the round start teleporter.

3) Xenomorphs won't have to contend to dealing with multiple teleporters but ONE teleporter, and if they want to stop marines from having more, they would have to stop miners. Then again, I don't see marines buying teleporters in this meta for now.

4) I foresee that synthetics and PO will grab the free teleporters from req vendor for the tadpole. I will let the maintainers determine if they want this or not.

## Changelog

:cl:
add: Add teleporter in req vendor
balance: only shipside maps can get this, making crash gamemode unable to get this
balance: synthetic and PO will have access to a set of teleporters if they are available in operational vendor
/:cl:

