### PR TITLE
Fix MLRS reqtorio

### DIFF
--- a/code/modules/factory/parts.dm
+++ b/code/modules/factory/parts.dm
@@ -518,7 +518,7 @@ GLOBAL_LIST_INIT(mlrs_rocket, list(
 	desc = "An unfinished high explosive rocket"
 	result = /obj/item/storage/box/mlrs_rockets
 
-/obj/item/factory_part/mlrs_rockets/Initialize()
+/obj/item/factory_part/mlrs_rocket/Initialize()
 	. = ..()
 	recipe = GLOB.mlrs_rocket
 


### PR DESCRIPTION

## About The Pull Request

currently if you place the MLRS factory refill into an unboxer it just outputs the final product right away, turns out this is because of a small typo, this should fix it and make it have to go through all its required machines
## Why It's Good For The Game

makes it so the MLRS ammo boxs cannot be fabricated by just unboxing them
## Changelog
:cl:
fix: MLRS reqtorio refils will now work properly and not just pop out the final product from the unboxer
/:cl:
