### PR TITLE
Reduce Stun grenade detonation time

### DIFF
--- a/code/game/objects/items/explosives/grenades/flashbang.dm
+++ b/code/game/objects/items/explosives/grenades/flashbang.dm
@@ -161,12 +161,13 @@
 
 //Slows and staggers instead of hardstunning, balanced for HvH
 /obj/item/explosive/grenade/flashbang/stun
-	name = "\improper stun grenade"
+	name = "stun grenade"
 	desc = "A grenade designed to disorientate the senses of anyone caught in the blast radius with a blinding flash of light and viciously loud noise. Repeated use can cause deafness."
 	icon_state = "flashbang2"
 	item_state = "flashbang2"
 	arm_sound = 'sound/weapons/armbombpin.ogg'
 	inner_range = 3
+	det_time = 2 SECONDS
 	mp_only = FALSE
 
 /obj/item/explosive/grenade/flashbang/stun/base_effect(turf/T , mob/living/carbon/M, ear_safety)

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -13,7 +13,7 @@
 	icon_state_mini = "grenade_red"
 	var/launched = FALSE //if launched from a UGL/grenade launcher
 	var/launchforce = 10 //bonus impact damage if launched from a UGL/grenade launcher
-	var/det_time =  40
+	var/det_time =  4 SECONDS
 	var/dangerous = TRUE 	//Does it make a danger overlay for humans? Can synths use it?
 	var/arm_sound = 'sound/weapons/armbomb.ogg'
 	var/hud_state = "grenade_he"
@@ -24,7 +24,7 @@
 
 /obj/item/explosive/grenade/Initialize()
 	. = ..()
-	det_time = rand(det_time - 10, det_time + 10)
+	det_time = rand(det_time - 1 SECONDS, det_time + 1 SECONDS)
 
 /obj/item/explosive/grenade/attack_self(mob/user)
 	if(active)

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -118,7 +118,7 @@
 	desc = "The M40 HIDP is a small, but deceptively strong incendiary grenade. It is set to detonate in 4 seconds."
 	icon_state = "grenade_fire"
 	item_state = "grenade_fire"
-	det_time = 40
+	det_time = 4 SECONDS
 	hud_state = "grenade_fire"
 	icon_state_mini = "grenade_orange"
 
@@ -143,7 +143,7 @@
 
 
 /obj/item/explosive/grenade/incendiary/molotov
-	name = "\improper improvised firebomb"
+	name = "improvised firebomb"
 	desc = "A potent, improvised firebomb, coupled with a pinch of gunpowder. Cheap, very effective, and deadly in confined spaces. Commonly found in the hands of rebels and terrorists. It can be difficult to predict how many seconds you have before it goes off, so be careful. Chances are, it might explode in your face."
 	icon_state = "molotov"
 	item_state = "molotov"
@@ -151,7 +151,7 @@
 
 /obj/item/explosive/grenade/incendiary/molotov/Initialize()
 	. = ..()
-	det_time = rand(10,40)//Adds some risk to using this thing.
+	det_time = rand(1 SECONDS, 4 SECONDS)//Adds some risk to using this thing.
 
 /obj/item/explosive/grenade/incendiary/molotov/prime()
 	playsound(loc, 'sound/effects/hit_on_shattered_glass.ogg', 35, TRUE, 4)
@@ -166,7 +166,7 @@
 	icon = 'icons/obj/items/grenade.dmi'
 	icon_state = "ags_grenade"
 	item_state = "ags_grenade"
-	det_time = 20
+	det_time = 2 SECONDS
 	light_impact_range = 3
 
 
@@ -175,7 +175,7 @@
 	desc = "The M40 HSDP is a small, but powerful smoke grenade. Based off the same platform as the M40 HEDP. It is set to detonate in 2 seconds."
 	icon_state = "grenade_smoke"
 	item_state = "grenade_smoke"
-	det_time = 20
+	det_time = 2 SECONDS
 	hud_state = "grenade_smoke"
 	dangerous = FALSE
 	icon_state_mini = "grenade_blue"
@@ -201,7 +201,7 @@
 	desc = "A smoke grenade containing a concentrated neurotoxin developed by Nanotrasen, supposedly derived from xenomorphs. Banned in some sectors as a chemical weapon, but classed as a less lethal riot control tool by the TGMC."
 	icon_state = "grenade_neuro"
 	item_state = "grenade_neuro"
-	det_time = 40
+	det_time = 4 SECONDS
 	dangerous = TRUE
 	smoketype = /datum/effect_system/smoke_spread/xeno/neuro/medium
 	smokeradius = 6
@@ -211,7 +211,7 @@
 	desc = "A grenade set to release a cloud of extremely acidic smoke developed by Nanotrasen, supposedly derived from xenomorphs. Has a shiny acid resistant shell. Its use is considered a warcrime under several treaties, none of which Terra Gov is a signatory to."
 	icon_state = "grenade_acid"
 	item_state = "grenade_acid"
-	det_time = 40
+	det_time = 4 SECONDS
 	dangerous = TRUE
 	smoketype = /datum/effect_system/smoke_spread/xeno/acid
 	smokeradius = 5
@@ -221,7 +221,7 @@
 	desc = "A smoke grenade containing a nerve agent that can debilitate victims with severe pain, while purging common painkillers."
 	icon_state = "grenade_nerve"
 	item_state = "grenade_nerve"
-	det_time = 40
+	det_time = 4 SECONDS
 	dangerous = TRUE
 	smoketype = /datum/effect_system/smoke_spread/satrapine
 	smokeradius = 6
@@ -240,7 +240,7 @@
 	desc = "The M40-T is a small, but powerful Tanglefoot grenade, designed to remove plasma with minimal side effects. Based off the same platform as the M40 HEDP. It is set to detonate in 6 seconds."
 	icon_state = "grenade_pgas"
 	item_state = "grenade_pgas"
-	det_time = 60
+	det_time = 6 SECONDS
 	icon_state_mini = "grenade_blue"
 	dangerous = TRUE
 	smoketype = /datum/effect_system/smoke_spread/plasmaloss
@@ -250,7 +250,7 @@
 	desc = "The M40 HPDP is a small, but powerful phosphorus grenade. It is set to detonate in 2 seconds."
 	icon_state = "grenade_phos"
 	item_state = "grenade_phos"
-	det_time = 20
+	det_time = 2 SECONDS
 	hud_state = "grenade_hide"
 	var/datum/effect_system/smoke_spread/phosphorus/smoke
 	icon_state_mini = "grenade_cyan"
@@ -284,7 +284,7 @@
 	icon_state = "grenade_impact"
 	item_state = "grenade_impact"
 	hud_state = "grenade_frag"
-	det_time = 40
+	det_time = 4 SECONDS
 	dangerous = TRUE
 	icon_state_mini = "grenade_blue_white"
 	light_impact_range = 3


### PR DESCRIPTION

## About The Pull Request
HvH: Reduced stun grenade det time to 2 seconds (same as smoke grenades).

Also makes det time use SECONDS consistantly, and clears out unneeded impropers.
## Why It's Good For The Game
Shorter det time makes it easier to use stun grenades more defensively.
## Changelog
:cl:
balance: HvH: Stun grenade detonation time reduced to 2 seconds from 4 seconds
/:cl:
