### PR TITLE
Spray nozzle nerf

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1549,17 +1549,16 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	name = "spray flamer nozzle"
 	desc = "This specialized nozzle sprays the flames of an attached flamer in a much more broad way than the standard nozzle. It serves for wide area denial as opposed to offensive directional flaming."
 	icon_state = "flame_wide"
-	range_modifier = 0
 	pixel_shift_y = 17
 	stream_type = FLAMER_STREAM_CONE
-	burn_time_mod = 0.8
+	burn_time_mod = 0.3
 
 ///Funny red wide nozzle that can fill entire screens with flames. Admeme only.
 /obj/item/attachable/flamer_nozzle/wide/red
 	name = "red spray flamer nozzle"
 	desc = "It is red, therefore its obviously more effective."
 	icon_state = "flame_wide_red"
-	range_modifier = 0
+	range_modifier = 3
 
 ///Flamer ammo is a normal ammo datum, which means we can shoot it if we want
 /obj/item/attachable/flamer_nozzle/long


### PR DESCRIPTION

## About The Pull Request
Reduced the flame duration for the spray nozzle to 30%, down from 80%.

This makes the spray nozzle significantly less practical for burning down walls, and reduces its area denial ability.

Also made the funny admeme nozzle actually do something more than the normal one.
## Why It's Good For The Game
Less oppressive spray nozzle.
## Changelog
:cl:
balance: Reduces the duration of fire produced by spray nozzles to 30% of normal
/:cl:
