### PR TITLE
Remove mosin from Research Outpost

### DIFF
--- a/_maps/map_files/Research_Outpost/Research_Outpost.dmm
+++ b/_maps/map_files/Research_Outpost/Research_Outpost.dmm
@@ -807,7 +807,6 @@
 "em" = (
 /obj/item/attachable/extended_barrel,
 /obj/item/attachable/gyro,
-/obj/item/attachable/scope,
 /obj/item/attachable/compensator,
 /obj/item/attachable/burstfire_assembly,
 /obj/item/attachable/lasersight,

--- a/_maps/map_files/Research_Outpost/Research_Outpost.dmm
+++ b/_maps/map_files/Research_Outpost/Research_Outpost.dmm
@@ -8883,12 +8883,6 @@
 /area/outpost/brig/wardens_office)
 "OQ" = (
 /obj/structure/closet/secure_closet/security,
-/obj/item/ammo_magazine/rifle/bolt,
-/obj/item/ammo_magazine/rifle/bolt,
-/obj/item/ammo_magazine/rifle/bolt,
-/obj/item/ammo_magazine/rifle/bolt,
-/obj/item/weapon/gun/shotgun/pump/bolt,
-/obj/item/attachable/bayonet,
 /turf/open/floor/tile/dark/red2{
 	dir = 9
 	},
@@ -9052,9 +9046,7 @@
 	dir = 8
 	},
 /obj/structure/paper_bin,
-/obj/effect/spawner/random/plushie{
-
-	},
+/obj/effect/spawner/random/plushie,
 /turf/open/floor/tile/dark/brown2{
 	dir = 8
 	},


### PR DESCRIPTION

## About The Pull Request

Title

## Why It's Good For The Game

Lumi can't find them all.

Funny enough, when sensor capture happened in Research Outpost, I searched up mosin in Visual Studio Code during lobby to find if there was one. Funny enough, there was, and I used it to my heart's content.

Time to delete.

## Changelog

:cl:
del: Remove mosin from Research Outpost
/:cl:

