### PR TITLE
Reduces bonus time for capturing a sensor tower

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -166,5 +166,5 @@
 
 #define MAX_UNBALANCED_RATIO_TWO_HUMAN_FACTIONS 1.1
 
-#define SENSOR_CAP_ADDITION_TIME_BONUS 5 MINUTES //additional time granted by capturing a sensor tower
+#define SENSOR_CAP_ADDITION_TIME_BONUS 3 MINUTES //additional time granted by capturing a sensor tower
 #define SENSOR_CAP_TIMER_PAUSED "paused"


### PR DESCRIPTION

## About The Pull Request
Reduced the extra time put on the clock for capturing a tower to 3 minutes instead of 5.

The time is a little too generous now that the clock pauses during activation.
## Why It's Good For The Game
Bit less tilted towards marines.
## Changelog
:cl:
balance: HvH: Capturing a sensor tower now adds 3 minutes to the clock instead of 5
/:cl:
