### PR TITLE
Fix bottle stuns

### DIFF
--- a/code/game/objects/items/reagent_containers/food/drinks/bottle.dm
+++ b/code/game/objects/items/reagent_containers/food/drinks/bottle.dm
@@ -44,7 +44,7 @@
 	var/datum/limb/affecting = user.zone_selected //Find what the player is aiming at
 
 	//apply damage
-	var/weaken_duration =  target.apply_damage(force, BRUTE, affecting, updating_health = TRUE)
+	var/weaken_duration =  target.apply_damage(force, BRUTE, affecting, MELEE, updating_health = TRUE)
 
 	if(affecting == "head" && istype(target, /mob/living/carbon/) && !isxeno(target))
 
@@ -53,7 +53,7 @@
 		else
 			user.visible_message(span_danger("[user] has hit [user.p_them()]self with the bottle of [name] on the head!"))
 		if(weaken_duration >= force) //if they have armor, no stun
-			target.apply_effect(10, WEAKEN)
+			target.apply_effect(2, WEAKEN)
 
 	else
 		if(target != user)


### PR DESCRIPTION
## About The Pull Request
Bottle stuns were missing an armour check, so always stunned when it should only stun against unarmoured heads.

Also reduced the stun duration from a mighty 20 seconds to 4.
## Why It's Good For The Game
Bug fix good.
20 sec stun bad
## Changelog
:cl:
fix: Fixed bottles stunning armoured heads
balance: bottle stuns last 4 seconds instead of 20
/:cl:
