### PR TITLE
TL buff

### DIFF
--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -253,7 +253,7 @@
 	caliber = CALIBER_86X70
 	icon_state = "tl127"
 	default_ammo = /datum/ammo/bullet/sniper/pfc
-	max_rounds = 7
+	max_rounds = 11
 	icon_state_mini = "mag_sniper"
 	bonus_overlay = "tl127_mag"
 

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -253,7 +253,7 @@
 	caliber = CALIBER_86X70
 	icon_state = "tl127"
 	default_ammo = /datum/ammo/bullet/sniper/pfc
-	max_rounds = 11
+	max_rounds = 10
 	icon_state_mini = "mag_sniper"
 	bonus_overlay = "tl127_mag"
 


### PR DESCRIPTION
## About The Pull Request
Buffs the TL mag sizes to 10 rounds instead of 7. (TL Flak mags inherit this.)
## Why It's Good For The Game
TL is quite underwhelming especially compared to the DMR or even a GPMG with rail scope.
This should make it slightly better to use, without needing an ammo box constantly and without
buffing it's actual damage in combat.
## Changelog
:cl:
balance: Increases TL mag size from 7-10
/:cl:
