### PR TITLE
Brings node.bat to what TG has, to fix several jukebuild problems

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -11,8 +11,8 @@ export BYOND_MINOR=1589
 export RUST_G_VERSION=1.0.2
 
 #node version
-export NODE_VERSION=16
-export NODE_VERSION_PRECISE=16.13.1
+export NODE_VERSION=14
+export NODE_VERSION_PRECISE=14.16.1
 
 # SpacemanDMM git tag
 export SPACEMAN_DMM_VERSION=suite-1.7.2

--- a/tools/bootstrap/node.bat
+++ b/tools/bootstrap/node.bat
@@ -1,4 +1,5 @@
 @echo off
+set NODE_SKIP_PLATFORM_CHECK=1
 call powershell -NoLogo -ExecutionPolicy Bypass -File "%~dp0\node_.ps1" Download-Node
 for /f "tokens=* USEBACKQ" %%s in (`
 	call powershell -NoLogo -ExecutionPolicy Bypass -File "%~dp0\node_.ps1" Get-Path

--- a/tools/bootstrap/node.bat
+++ b/tools/bootstrap/node.bat
@@ -1,11 +1,4 @@
 @echo off
-where node.exe >nul 2>nul
-if %errorlevel% == 0 (
-	echo | set /p printed_str="Using system-wide Node "
-	call node.exe --version
-	call node.exe %*
-	goto exit_with_last_error_level
-)
 call powershell -NoLogo -ExecutionPolicy Bypass -File "%~dp0\node_.ps1" Download-Node
 for /f "tokens=* USEBACKQ" %%s in (`
 	call powershell -NoLogo -ExecutionPolicy Bypass -File "%~dp0\node_.ps1" Get-Path

--- a/tools/bootstrap/node_.ps1
+++ b/tools/bootstrap/node_.ps1
@@ -30,8 +30,8 @@ if ($Env:TG_BOOTSTRAP_CACHE) {
 	$Cache = $Env:TG_BOOTSTRAP_CACHE
 }
 $NodeVersion = Extract-Variable -Path "$BaseDir\..\..\dependencies.sh" -Key "NODE_VERSION_PRECISE"
-$NodeSource = "https://nodejs.org/download/release/v$NodeVersion/win-x86/node.exe"
-$NodeTargetDir = "$Cache\node-v$NodeVersion"
+$NodeSource = "https://nodejs.org/download/release/v$NodeVersion/win-x64/node.exe"
+$NodeTargetDir = "$Cache\node-v$NodeVersion-x64"
 $NodeTarget = "$NodeTargetDir\node.exe"
 
 ## Just print the path and exit


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This ports https://github.com/tgstation/tgstation/pull/64461
and https://github.com/tgstation/tgstation/pull/64513
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes the nodeJS Error::0308010C:digital envelope routines::unsupported, and possibly other errors as well
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Jukebuild will now only vendored nodeJS as the latest version is prone to issues.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
This does add some bloat in the form of the vendored nodeJS executable, but it's probably worthwhile to have this as the latest version of nodeJS doesn't work without a specific flag, and stylemistake clearly didn't add that on purpose. Make sure to run bin/clean.cmd after this PR is merged, as I've noticed issues cropping up without doing so, somehow.