### PR TITLE
Skill locks chemistry

### DIFF
--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -134,6 +134,10 @@
 		dispensable_reagents -= emagged_reagents
 
 /obj/machinery/chem_dispenser/ui_interact(mob/user, datum/tgui/ui)
+	if(needs_medical_training && ishuman(usr) && user.skills.getRating("medical") < SKILL_MEDICAL_PRACTICED)
+		balloon_alert(user, "skill issue")
+		return
+
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "ChemDispenser", name)
@@ -181,15 +185,6 @@
 	. = ..()
 	if(.)
 		return
-
-	if(needs_medical_training && ishuman(usr))
-		var/mob/living/carbon/human/user = usr
-		if(user.skills.getRating("medical") < SKILL_MEDICAL_NOVICE)
-			if(user.do_actions)
-				return
-			to_chat(user, span_notice("You start fiddling with \the [src]..."))
-			if(!do_after(user, SKILL_TASK_EASY, TRUE, src, BUSY_ICON_UNSKILLED))
-				return
 
 	switch(action)
 		if("amount")

--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -121,11 +121,6 @@
 
 	var/mob/living/user = usr
 
-	if(user.skills.getRating("medical") < SKILL_MEDICAL_NOVICE)
-		to_chat(user, span_notice("You start fiddling with \the [src]..."))
-		if(!do_after(user, SKILL_TASK_EASY, TRUE, src, BUSY_ICON_UNSKILLED))
-			return
-
 	if (href_list["ejectp"])
 		if(loaded_pill_bottle)
 			loaded_pill_bottle.loc = loc
@@ -347,6 +342,10 @@
 	. = ..()
 	if(.)
 		return
+	if(user.skills.getRating("medical") < SKILL_MEDICAL_PRACTICED)
+		balloon_alert(user, "skill issue")
+		return
+
 	if(!(user.client in has_sprites))
 		spawn()
 			has_sprites += user.client


### PR DESCRIPTION

## About The Pull Request
Ungas lack the double digits neurons to use chemistry machines. Fixed this bizarre unimmersive oversight.
![image](https://user-images.githubusercontent.com/7869430/218589763-de453ec8-85e6-49d1-af38-bb9f8dce9ea6.png)

Also powergaming chem is bad, and just punishes people for not choosing to power game every round.
## Why It's Good For The Game
Powergaming chem is lame.
## Changelog
:cl:
balance: Chemistry machines now require skill to operate
/:cl:
