### PR TITLE
Increases passive regeneration on kitted limbs

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_organs.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_organs.dm
@@ -22,6 +22,8 @@
 	for(var/datum/internal_organ/I in internal_organs)
 		I.process()
 
+	var/multi_limb_regen_penalty = 1 / (max(1, length(get_damaged_limbs(TRUE, TRUE))) ** 0.5) //Per-limb regen decreases with multiple damaged limbs, but slower than linear
+
 	for(var/i in limbs)
 		var/datum/limb/E = i
 
@@ -32,7 +34,7 @@
 		if(!E.need_process())
 			continue
 
-		E.process()
+		E.process(multi_limb_regen_penalty)
 
 		if(!lying_angle && world.time - last_move_time < 15)
 			if(E.is_broken() && E.internal_organs && prob(15))


### PR DESCRIPTION

## About The Pull Request
A kitted limb will regen for 2 total damage split appropriately between burn and brute, up from 0.5 of each with a 75% chance.
This amount reduces with multiple damaged limbs, but you'll still heal faster with multiple damaged and treated limbs in total.
Specifically, per limb regen is divided by the square root of the damaged limb count. Four total will halve the per-limit amount and so on.
## Why It's Good For The Game
Makes kitting more valuable even when the limb stays treated for a shorter period.
## Changelog
:cl:
balance: Kitted limbs passively heal faster
/:cl:
