### PR TITLE
Deletes balloon alert from taking out a pill

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -304,7 +304,6 @@
 /obj/item/storage/pill_bottle/remove_from_storage(obj/item/item, atom/new_location, mob/user)
 	. = ..()
 	if(. && user)
-		balloon_alert(user, "You take out a pill")
 		playsound(user, 'sound/items/pills.ogg', 15, 1)
 
 /obj/item/storage/pill_bottle/update_overlays()


### PR DESCRIPTION

## About The Pull Request
Deletes:
		balloon_alert(user, "You take out a pill")
## Why It's Good For The Game
You take out a pill
You take out a pill
You take out a pill
You take out a pill
You take out a pill
You take out a pill

After a while this gets annoying.
## Changelog
:cl:
del: No longer spammed with balloon alerts from taking out a pill
/:cl:
