### PR TITLE
Minisentry cost buff and Comrade sentry return

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1169,8 +1169,8 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 /datum/ammo/bullet/turret/mini
 	name = "small caliber autocannon bullet"
-	damage = 15
-	penetration = 30
+	damage = 20
+	penetration = 20
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SENTRY
 
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1169,8 +1169,8 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 /datum/ammo/bullet/turret/mini
 	name = "small caliber autocannon bullet"
-	damage = 20
-	penetration = 20
+	damage = 15
+	penetration = 30
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SENTRY
 
 

--- a/code/modules/projectiles/guns/sentries.dm
+++ b/code/modules/projectiles/guns/sentries.dm
@@ -177,8 +177,15 @@
 	flags_item = IS_DEPLOYABLE|TWOHANDED|DEPLOY_ON_INITIALIZE
 
 /obj/item/weapon/gun/sentry/big_sentry/dropship
+	default_ammo_type = /obj/item/ammo_magazine/sentry/dropship
+	allowed_ammo_types = list(/obj/item/ammo_magazine/sentry/dropship)
+	max_shells = 1000
 	ammo_datum_type = /datum/ammo/bullet/turret/gauss
 	sentry_iff_signal = TGMC_LOYALIST_IFF
+	burst_delay = 0.15 SECONDS
+	burst_amount = 10
+	extra_delay = 1 SECONDS
+	gun_firemode_list = list(GUN_FIREMODE_AUTOBURST)
 	flags_item = IS_DEPLOYABLE|TWOHANDED|DEPLOY_ON_INITIALIZE|DEPLOYED_NO_PICKUP
 	var/obj/structure/dropship_equipment/sentry_holder/deployment_system
 	turret_flags = TURRET_HAS_CAMERA|TURRET_IMMOBILE
@@ -248,7 +255,7 @@
 	desc = "A deployable, semi-automated turret with AI targeting capabilities. Armed with an armor penetrating MIC Gauss Cannon and a high-capacity drum magazine."
 	icon_state = "sentry"
 	turret_flags = TURRET_HAS_CAMERA|TURRET_ON|TURRET_IMMOBILE|TURRET_SAFETY|TURRET_RADIAL
-	max_shells = 100
+	max_shells = 1000
 
 	ammo_datum_type = /datum/ammo/bullet/turret/gauss
 	default_ammo_type = /obj/item/ammo_magazine/sentry

--- a/code/modules/projectiles/magazines/sentries.dm
+++ b/code/modules/projectiles/magazines/sentries.dm
@@ -18,7 +18,6 @@
 	max_rounds = 1000
 	default_ammo = /datum/ammo/bullet/turret/gauss
 
-
 /obj/item/ammo_magazine/minisentry
 	name = "\improper M30 box magazine (10x20mm Caseless)"
 	desc = "A box of 100 10x20mm caseless rounds for the ST-580 point defense sentry. Just feed it into the sentry gun's ammo port when its ammo is depleted."

--- a/code/modules/projectiles/magazines/sentries.dm
+++ b/code/modules/projectiles/magazines/sentries.dm
@@ -1,12 +1,23 @@
 /obj/item/ammo_magazine/sentry
 	name = "\improper M30 box magazine (10x28mm Caseless)"
-	desc = "A drum of 50 10x28mm caseless rounds for the ST-571 sentry gun. Just feed it into the sentry gun's ammo port when its ammo is depleted."
+	desc = "A drum of 500 10x28mm caseless rounds for the ST-571 sentry gun. Just feed it into the sentry gun's ammo port when its ammo is depleted."
 	w_class = WEIGHT_CLASS_BULKY
 	icon_state = "ua571c"
 	flags_magazine = NONE //can't be refilled or emptied by hand
 	caliber = CALIBER_10X28
 	max_rounds = 500
 	default_ammo = /datum/ammo/bullet/turret
+
+/obj/item/ammo_magazine/sentry/dropship
+	name = "\improper M30 box magazine (10x28mm Tungsten Caseless)"
+	desc = "A drum of 1000 10x28mm high-velocity tungsten caseless rounds for the ST-571 sentry gun only dropship variants can feed this due to the high energy required. Just feed it into the sentry gun's ammo port when its ammo is depleted."
+	w_class = WEIGHT_CLASS_BULKY
+	icon_state = "ua571c"
+	flags_magazine = NONE //can't be refilled or emptied by hand
+	caliber = CALIBER_10X28
+	max_rounds = 1000
+	default_ammo = /datum/ammo/bullet/turret/gauss
+
 
 /obj/item/ammo_magazine/minisentry
 	name = "\improper M30 box magazine (10x20mm Caseless)"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -164,12 +164,12 @@ WEAPONS
 /datum/supply_packs/weapons/minisentry
 	name = "ST-580 Portable Sentry"
 	contains = list(/obj/item/storage/box/minisentry)
-	cost = 400
+	cost = 350
 
 /datum/supply_packs/weapons/minisentry_ammo
 	name = "ST-580 point defense sentry ammo"
 	contains = list(/obj/item/ammo_magazine/minisentry)
-	cost = 100
+	cost = 25
 
 /datum/supply_packs/weapons/buildasentry
 	name = "Build-A-Sentry Attachment System"


### PR DESCRIPTION
## About The Pull Request
Comrade sentry returns. 
He now uses his proper gauss bullet. So he does 60 damage per bullet rather than a measly 25, I also reverted the stats to the stats of yore., which is .15 burst delay, 10 round bursts and 1 second inbetween bursts.

Minisentry costs 50 points less, the ammo is also much, much cheaper at 25 rather than 100 points.

## Why It's Good For The Game
Dropship turrets are fixed, if you're fighting infront of the dropship expect some pain, but otherwise just bait it.
## Changelog
:cl:
balance: Mini-Sentry now costs 50 points less, ammo costs 75 points less.
balance: DS turrets have 10 round bursts, and .15 burst delay. However there is a ten second delay between every burst.
fix: DS turrets use their proper bullet. They now use gauss bullets, rather than normal autocannon bullets.
/:cl:
