### PR TITLE
(Hopefully) fixes Admin Observers not appearing on staffwho and being unable to use MSAY

### DIFF
--- a/code/modules/admin/holder.dm
+++ b/code/modules/admin/holder.dm
@@ -552,8 +552,6 @@ GLOBAL_PROTECT(admin_verbs_log)
 		return FALSE
 	if(!C?.holder?.rank?.rights)
 		return FALSE
-	if(check_other_rights(C, R_ADMINTICKET, FALSE))
-		return FALSE
 	if(!check_other_rights(C, R_MENTOR, FALSE))
 		return FALSE
 	return TRUE

--- a/code/modules/admin/holder.dm
+++ b/code/modules/admin/holder.dm
@@ -552,6 +552,8 @@ GLOBAL_PROTECT(admin_verbs_log)
 		return FALSE
 	if(!C?.holder?.rank?.rights)
 		return FALSE
+	if(check_other_rights(C, R_ADMIN, FALSE))
+		return FALSE
 	if(!check_other_rights(C, R_MENTOR, FALSE))
 		return FALSE
 	return TRUE


### PR DESCRIPTION
## About The Pull Request
Per title. Due to a recent change in admin observer perms, they no longer appear on staffwho and are unable to use MSAY. This is because they recently acquired `+ADMINTICKET`.
This PR aims to fix that. I have no way to test this on local due to a lack of config and the likes, but I'm pretty sure these two lines of code are the culprits.

Would appreciate this being (test)merged as soon as possible since it does mess with their abilities and complicates the learning process.

## Why It's Good For The Game
Fix good.

## Changelog
:cl: Lewdcifer
admin: Admin Observers should now appear on staffwho and be able to use msay now that they have +ADMINTICKET.
/:cl: