### PR TITLE
Reduces cable coil material cost

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -400,7 +400,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list(new/datum/stack_recipe("cable restrain
 	var/cable_color = "yellow"
 	var/obj/structure/cable/target_type = /obj/structure/cable
 	var/target_layer = CABLE_LAYER_2
-
+materials = list(/datum/material/metal = 5)
 /obj/item/stack/cable_coil/Initialize(mapload, new_amount = null)
 	. = ..()
 	pixel_x = rand(-2,2)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -400,7 +400,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list(new/datum/stack_recipe("cable restrain
 	var/cable_color = "yellow"
 	var/obj/structure/cable/target_type = /obj/structure/cable
 	var/target_layer = CABLE_LAYER_2
-materials = list(/datum/material/metal = 5)
+	materials = list(/datum/material/metal = 5)
 
 /obj/item/stack/cable_coil/Initialize(mapload, new_amount = null)
 	. = ..()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -401,6 +401,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list(new/datum/stack_recipe("cable restrain
 	var/obj/structure/cable/target_type = /obj/structure/cable
 	var/target_layer = CABLE_LAYER_2
 materials = list(/datum/material/metal = 5)
+
 /obj/item/stack/cable_coil/Initialize(mapload, new_amount = null)
 	. = ..()
 	pixel_x = rand(-2,2)


### PR DESCRIPTION

## About The Pull Request
Changes cable autolathe material cost from 50 to 5. 
<!-- Changes cable autolathe material cost from 50 to 5 -->

## Why It's Good For The Game
Makes it more tedious to try and abuse autolathe for materials. I would like to remove the ability to make metal from thin air from autolathe all together, but that is for later. With this material cost, it only takes two thirty stacks to make, for example, mass produced crates; so it is not totally inconvenient for the lesser items.
<!-- Makes it more tedious to try and abuse autolathe for materials. I would like to remove the ability to make metal from thin air from autolathe all together, but that is for later. With this material cost, it only takes two thirty stacks to make, for example, mass produced crates; so it is not totally inconvenient for the lesser items. -->

## Changelog
:cl:
balance: cable mat cost changed to 5
/:cl:
