### PR TITLE
Fixes xenos being unable to evolve to t4 from t1 due to missing t2 slots

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -188,10 +188,10 @@
 
 
 	if(!regression)
-		if(tier == XENO_TIER_ONE && no_room_tier_two)
+		if(new_caste_type.tier == XENO_TIER_TWO && no_room_tier_two)
 			to_chat(src, span_warning("The hive cannot support another Tier 2, wait for either more aliens to be born or someone to die."))
 			return
-		if(tier == XENO_TIER_TWO && no_room_tier_three)
+		if(new_caste_type.tier == XENO_TIER_THREE && no_room_tier_three)
 			to_chat(src, span_warning("The hive cannot support another Tier 3, wait for either more aliens to be born or someone to die."))
 			return
 		var/potential_queens = length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/larva]) + length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/drone])
@@ -219,10 +219,10 @@
 		return
 
 	else if(!regression) // these shouldnt be checked if trying to become a queen.
-		if(tier == XENO_TIER_ONE && no_room_tier_two)
+		if(new_caste_type.tier == XENO_TIER_TWO && no_room_tier_two)
 			to_chat(src, span_warning("Another sister evolved meanwhile. The hive cannot support another Tier 2."))
 			return
-		else if(tier == XENO_TIER_TWO && no_room_tier_three)
+		else if(new_caste_type.tier == XENO_TIER_THREE && no_room_tier_three)
 			to_chat(src, span_warning("Another sister evolved meanwhile. The hive cannot support another Tier 3."))
 			return
 


### PR DESCRIPTION
## About The Pull Request
Makes evolution consider the caste tier of what they're trying to evolve to, instead of checking their own caste when considering blocking evolution due to lack of tiered slots.
## Why It's Good For The Game
It fixes drones being unable to evolve into T4 caste (shrikes, queen, king) if they lack t2 slots, as the slot checking used to be completely bypassed for shrike before my previous PR, the issue was neither noticed during the testmerges.
## Changelog
:cl:
fix: Evolution doesn't check the evolving xeno's tier when checking if there are enough tier slots, instead it checks the tier of the  caste the xeno is evolving to.
/:cl:
