### PR TITLE
Adds a roller bed to the Synth Essential Set.

### DIFF
--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -750,6 +750,7 @@
 		/obj/item/defibrillator,
 		/obj/item/medevac_beacon,
 		/obj/item/roller/medevac,
+		/obj/item/roller,
 		/obj/item/bodybag/cryobag,
 		/obj/item/reagent_containers/hypospray/advanced/oxycodone,
 		/obj/item/tweezers,


### PR DESCRIPTION

## About The Pull Request
Simply adds a roller bed to the vendor
## Why It's Good For The Game
As the job that is expected to perform field surgery, alongside researcher or potential deployed doctors, it's frustrating to find out that all the roller beds are gone/taken. 
## Changelog
:cl:
add: a roller bed to the synth essentials kit
/:cl:
