### PR TITLE
ERT Shoulder holster empty slots.

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/uniform.dm
+++ b/code/modules/clothing/modular_armor/attachments/uniform.dm
@@ -118,14 +118,23 @@
 /obj/item/armor_module/storage/uniform/holster/freelancer/Initialize()
 	. = ..()
 	new /obj/item/weapon/gun/pistol/g22(storage)
+	new /obj/item/ammo_magazine/pistol/g22(storage)
+	new /obj/item/ammo_magazine/pistol/g22(storage)
+	new /obj/item/ammo_magazine/pistol/g22(storage)
 
 /obj/item/armor_module/storage/uniform/holster/vp/Initialize()
 	. = ..()
 	new /obj/item/weapon/gun/pistol/vp70(storage)
+	new /obj/item/ammo_magazine/pistol/vp70(storage)
+	new /obj/item/ammo_magazine/pistol/vp70(storage)
+	new /obj/item/ammo_magazine/pistol/vp70(storage)
 
 /obj/item/armor_module/storage/uniform/holster/highpower/Initialize()
 	. = ..()
 	new /obj/item/weapon/gun/pistol/highpower(storage)
+	new /obj/item/ammo_magazine/pistol/highpower(storage)
+	new /obj/item/ammo_magazine/pistol/highpower(storage)
+	new /obj/item/ammo_magazine/pistol/highpower(storage)
 
 /obj/item/storage/internal/holster
 	storage_slots = 4


### PR DESCRIPTION

## About The Pull Request
These guys probably want ammo
![image](https://user-images.githubusercontent.com/66163761/219950701-7557979f-1f9a-4a0b-9528-654b99e06487.png)
## Why It's Good For The Game
3 empty slots looks ugly when you spawn as an ERT.
## Changelog
:cl:
add: fills the slots of the recently buffed shoulder holster webbing for ERTs.
/:cl:
