### PR TITLE
Marine Riot armor buff

### DIFF
--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -289,8 +289,8 @@
 	name = "\improper M5 riot control armor"
 	desc = "A heavily modified suit of M2 MP Armor used to supress riots from buckethead marines and their guns. Slows you down a lot."
 	icon_state = "marine_riot"
-	slowdown = 1.3
-	soft_armor = list(MELEE = 65, BULLET = 110, LASER = 110, ENERGY = 10, BOMB = 60, BIO = 50, FIRE = 50, ACID = 30)
+	slowdown = SLOWDOWN_ARMOR_HEAVY
+	soft_armor = list(MELEE = 75, BULLET = 110, LASER = 110, ENERGY = 10, BOMB = 60, BIO = 50, FIRE = 50, ACID = 25)
 	allowed = list(
 		/obj/item/weapon/gun,
 		/obj/item/storage/belt/sparepouch,


### PR DESCRIPTION

## About The Pull Request
65->75 melee armor.
30->25 acid armor.
1.3->1 slowdown.
## Why It's Good For The Game
Makes Marine riot armor the ultimate hyperspecialization, you have insanely high FF/Melee armor, but dogwater acid armor. The slowdown change is because 1.3 is a lot in modern TGMC.
## Changelog
:cl:
balance: Marine riot armor now has 75 melee armor, a bit less acid armor, and less slowdown overall, but still higher than most other armors in the game.
/:cl:
