### PR TITLE
Grenades no longer require throw mode to throw

### DIFF
--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -11,10 +11,13 @@
 	flags_equip_slot = ITEM_SLOT_BELT
 	hitsound = 'sound/weapons/smash.ogg'
 	icon_state_mini = "grenade_red"
-	var/launched = FALSE //if launched from a UGL/grenade launcher
-	var/launchforce = 10 //bonus impact damage if launched from a UGL/grenade launcher
+	///if launched from a UGL/grenade launcher
+	var/launched = FALSE
+	///bonus impact damage if launched from a UGL/grenade launcher
+	var/launchforce = 10
 	var/det_time =  4 SECONDS
-	var/dangerous = TRUE 	//Does it make a danger overlay for humans? Can synths use it?
+	///Does it make a danger overlay for humans? Can synths use it?
+	var/dangerous = TRUE
 	var/arm_sound = 'sound/weapons/armbomb.ogg'
 	var/hud_state = "grenade_he"
 	var/hud_state_empty = "grenade_empty"
@@ -51,10 +54,12 @@
 		var/image/grenade = image('icons/mob/talk.dmi', user, "grenade")
 		user.add_emote_overlay(grenade)
 
-	if(iscarbon(user))
-		var/mob/living/carbon/C = user
-		C.throw_mode_on()
-
+/obj/item/explosive/grenade/afterattack(atom/target, mob/user, has_proximity, click_parameters)
+	. = ..()
+	user.temporarilyRemoveItemFromInventory(src)
+	forceMove(get_turf(src))
+	src.throw_at(target, throw_range, throw_speed, user, TRUE)
+	playsound(src, 'sound/effects/throw.ogg', 30, 1)
 
 /obj/item/explosive/grenade/proc/activate(mob/user)
 	if(active)

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -56,6 +56,8 @@
 
 /obj/item/explosive/grenade/afterattack(atom/target, mob/user, has_proximity, click_parameters)
 	. = ..()
+	if(!active)
+		return
 	user.temporarilyRemoveItemFromInventory(src)
 	forceMove(get_turf(src))
 	src.throw_at(target, throw_range, throw_speed, user, TRUE)

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -58,10 +58,7 @@
 	. = ..()
 	if(!active)
 		return
-	user.temporarilyRemoveItemFromInventory(src)
-	forceMove(get_turf(src))
-	src.throw_at(target, throw_range, throw_speed, user, TRUE)
-	playsound(src, 'sound/effects/throw.ogg', 30, 1)
+	user.throw_item(target)
 
 /obj/item/explosive/grenade/proc/activate(mob/user)
 	if(active)

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -374,9 +374,6 @@
 	// All good, turn it on.
 	user.visible_message(span_notice("[user] activates the flare."), span_notice("You depress the ignition button, activating it!"))
 	turn_on(user)
-	if(iscarbon(user))
-		var/mob/living/carbon/C = usr
-		C.toggle_throw_mode()
 
 /obj/item/explosive/grenade/flare/activate(mob/user)
 	if(!active)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -152,6 +152,7 @@
 	if(hud_used && hud_used.throw_icon)
 		hud_used.throw_icon.icon_state = "act_throw_on"
 
+///Throws active held item at target in params
 /mob/proc/throw_item(atom/target)
 	SHOULD_CALL_PARENT(TRUE)
 	SEND_SIGNAL(src, COMSIG_MOB_THROW, target)

--- a/strings/tips/marine.txt
+++ b/strings/tips/marine.txt
@@ -42,7 +42,7 @@ If a M40 FLDP grenade collides to any mob when thrown, the mob will be lit in a 
 SWAT masks ordered from Requisitions can block only one larval facehugger attack. If they successfully blocked an attempted attack, replace them immediately.
 Drag crates of platinum and phoron to the Automated Storage and Retrieval System (ASRS) pad inside cargo. Once the pad lowers with the applicable crates, you will gain requisition points. This applies to dead xenomorphs as well!
 In snow maps (such as Ice Colony or Icey Caves), wear a coif or scarf! You will freeze to death if you go outside of your dropship if you are not wearing them!
-To throw a grenade, Activate (Default: Z) the grenade while in the active hand. You will then automatically enter throw mode, in which then you can simply click anywhere to throw it. Do not take too long!
+To throw a grenade, Activate (Default: Z) the grenade while in the active hand. Then simply click where you want to throw it. Do not take too long!
 Quickly store items to the container (bags, satchels, belts, pouches) by pressing the Quick Equip (Default: E) key while holding an item and you are looking at a container.
 Press Quick Equip (Default: E) while you are not holding an item to the active hand to draw the weapon from whatever preferred slot (Default: Suit Storage, can be customized at the Preferences tab) you selected, otherwise you will pull out any item from a container.
 Stasis bags do not pause xenomorph infection entirely, they only slow progress by a lot.


### PR DESCRIPTION
## About The Pull Request
WE HAVE THE TECHNOLOGY, WE CAN MAKE HIM BETTER.
This makes it so that grenades throw on /afterattack , instead of just enabling throw mode.
## Why It's Good For The Game
Throw mode is janky, being able to avoid it (while still supporting it) is a better way.
## Changelog
:cl:
add: Primed grenades throw on click regardless of intent.
/:cl:
