### PR TITLE
Specifies that time shift doesnt save you from death or from crit

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -637,7 +637,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	name = "Time Shift"
 	ability_name = "Time Shift"
 	action_icon_state = "rewind"
-	desc = "Save the location and status of the target. When the time is up, the target location and status are restored"
+	desc = "Save the location and status of the target. When the time is up, the target location and status are restored. Will not save it from death."
 	plasma_cost = 100
 	cooldown_timer = 30 SECONDS
 	keybinding_signals = list(

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -637,7 +637,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	name = "Time Shift"
 	ability_name = "Time Shift"
 	action_icon_state = "rewind"
-	desc = "Save the location and status of the target. When the time is up, the target location and status are restored. Will not save it from death."
+	desc = "Save the location and status of the target. When the time is up, the target location and status are restored, unless the target is dead or unconscious."
 	plasma_cost = 100
 	cooldown_timer = 30 SECONDS
 	keybinding_signals = list(


### PR DESCRIPTION
## About The Pull Request

Time Shift description now says that it will not save you from being dead or in crit when it's effect ends.

## Why It's Good For The Game

Prevents stupid deaths of new wraith players

## Changelog

:cl:
qol: Time Shift description now says that it wouldn't save the target from death or from being in crit
/:cl:
