### PR TITLE
Loadout fixes

### DIFF
--- a/code/datums/loadout/item_representation/_item_representation.dm
+++ b/code/datums/loadout/item_representation/_item_representation.dm
@@ -177,8 +177,10 @@
 		return
 	var/obj/item/clothing/shoes/marine/marine_shoes = .
 	marine_shoes.pockets.delete_contents()
-	var/obj/item/item_in_pocket = boot_content.instantiate_object(seller, master, user)
-	if(!item_in_pocket)
+	if(!boot_content)
 		return
+	var/obj/item/item_in_pocket = boot_content.instantiate_object(seller, master, user)
 	if(marine_shoes.pockets.can_be_inserted(item_in_pocket))
 		marine_shoes.pockets.handle_item_insertion(item_in_pocket)
+	else
+		qdel(item_in_pocket)

--- a/code/datums/loadout/item_representation/armor_representation.dm
+++ b/code/datums/loadout/item_representation/armor_representation.dm
@@ -236,4 +236,5 @@
 	var/obj/item/armor_module/storage/storage_module = .
 	if(!storage)
 		return
+	qdel(storage_module.storage) //an empty storage item is generated when the module is initialised
 	storage_module.storage = storage.instantiate_object(seller, storage_module, user)


### PR DESCRIPTION

## About The Pull Request
Fixes quick equip not working is some cases for items obtained from a loadout vendor.

This is a bug that has always existed in loadout code as far as I am aware. Thanks to Xander for bringing it up.

Currently loadouts create the internal storage item for storage armour modules and fills them with whatever is saved in the loadout. However the armour modules already create this storage item when initialised. This means there is a second, hidden storage item in loadout vended items.

This only really causes a problem from the quick equip hotkey, which checks the first (empty) storage item, and so assumes its empty and fails.

This includes all storage attachments (i.e. helmet storage, armour modules etc).

Also fixed a loadout vendor runtime with boot storage that I noticed.
## Why It's Good For The Game
Bug fix good.
## Changelog
:cl:
fix: fixed quick equip not working for some items obtained from loadout vendors
/:cl:
