### PR TITLE
Fixes a dispenser bug

### DIFF
--- a/code/datums/elements/deployable_item.dm
+++ b/code/datums/elements/deployable_item.dm
@@ -137,7 +137,11 @@
 	attached_item.toggle_deployment_flag()
 
 	user.unset_interaction()
-	user.put_in_hands(attached_item)
+
+	if((get_dist(deployed_machine, user) > 1) || deployed_machine.z != user.z)
+		attached_item.forceMove(get_turf(deployed_machine))
+	else
+		user.put_in_hands(attached_item)
 
 	attached_item.max_integrity = deployed_machine.max_integrity
 	attached_item.obj_integrity = deployed_machine.obj_integrity


### PR DESCRIPTION

## About The Pull Request
Dispensers will no longer teleport across time and space into your hand when they finish undeploying.

This applies to all deployables, in case you somehow get similar situations in the future.
## Why It's Good For The Game
Teleporting bag of holding bad.
## Changelog
:cl:
fix: fixed dispensers teleporting into your hand when undeploying regardless of distance
/:cl:
