### PR TITLE
Revert an unintended sound change

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -189,7 +189,7 @@
 		last_sound = FALSE
 		return
 	last_sound = TRUE
-	playsound(owner, sound_to_play, 50, sound_range = 12)
+	playsound(owner, sound_to_play, 50)
 
 
 


### PR DESCRIPTION

## About The Pull Request
The default range of 25 for the robo repair was intended, so my bad for overriding it.
## Why It's Good For The Game
Unintended change bad.
## Changelog
:cl:
fix: Combat robot maintenance mode is audible from the correct range again.
/:cl:
