### PR TITLE
Fixes prae primo giving the person it was used on the PASSMOB flag

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -174,13 +174,14 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 
 	//Swapping part
 	var/mob/living/carbon/human/target = M
+	var/owner_passmob = (owner.flags_pass & PASSMOB)
+	var/target_passmob = (target.flags_pass & PASSMOB)
 	owner.flags_pass |= PASSMOB
 	target.flags_pass |= PASSMOB
-	INVOKE_ASYNC(src, /atom/movable/proc/forceMove, get_turf(target))
-	INVOKE_ASYNC(target, /atom/movable/proc/forceMove, last_turf)
-	if(!(owner.flags_pass & PASSMOB))
+	target.forceMove(last_turf)
+	if(!owner_passmob)
 		owner.flags_pass &= ~PASSMOB
-	if(!(target.flags_pass))
+	if(!target_passmob)
 		target.flags_pass &= ~PASSMOB
 
 	target.ParalyzeNoChain(0.5 SECONDS) //Extremely brief, we don't want them to take 289732 ticks of acid


### PR DESCRIPTION

## About The Pull Request

- Fixes prae primo giving the person it was used on the PASSMOB flag because of a runtime
- Which in human terms means anyone who the prae used the ability on could walk through any mob in the game
## Why It's Good For The Game

Bug bad.
## Changelog
:cl:
fix: Fixes prae primo giving the person it was used on the PASSMOB flag
/:cl:
