### PR TITLE
Adds a missing loadout vendor next to the clone vat on minerva

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -6661,11 +6661,10 @@
 	},
 /area/mainship/hallways/hangar)
 "tM" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/glass/beaker/biomass,
 /obj/machinery/light/mainship{
 	dir = 1
 	},
+/obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/sterile/corner{
 	dir = 1
 	},
@@ -7764,6 +7763,13 @@
 	dir = 4
 	},
 /area/mainship/squads/req)
+"wR" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/beaker/biomass,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "wT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -22741,7 +22747,7 @@ Bm
 qN
 AJ
 kq
-tN
+wR
 uX
 jc
 wz
@@ -22839,7 +22845,7 @@ GZ
 mi
 SG
 kq
-tO
+tN
 uX
 jc
 nA
@@ -22937,7 +22943,7 @@ pG
 sa
 sa
 fJ
-qM
+tO
 un
 vK
 wB


### PR DESCRIPTION

## About The Pull Request
Adds a missing loadout vendor next to the clone vat on minerva
![image](https://user-images.githubusercontent.com/66163761/221385504-20910292-657d-449f-bc52-53e628a000cf.png)
## Why It's Good For The Game
Every other map has a loadout vendor for recently awakened clones. Minerva lacks this.
## Changelog
:cl:
add: Loadout vendor in minerva medbay
/:cl:
