### PR TITLE
Style hats have helmet-level armor

### DIFF
--- a/code/modules/clothing/modular_armor/style_line.dm
+++ b/code/modules/clothing/modular_armor/style_line.dm
@@ -98,7 +98,7 @@
 
 	flags_inv_hide = NONE
 
-	soft_armor = list(MELEE = 15, BULLET = 15, LASER = 15, ENERGY = 15, BOMB = 10, BIO = 5, FIRE = 5, ACID = 5)
+	soft_armor = list(MELEE = 50, BULLET = 70, LASER = 70, ENERGY = 60, BOMB = 50, BIO = 50, FIRE = 50, ACID = 60)
 	starting_attachments = list(/obj/item/armor_module/storage/helmet)
 
 /obj/item/clothing/head/modular/style/update_item_sprites()


### PR DESCRIPTION

## About The Pull Request
I was told to atomize this into parts, so style hats have helmet armor now.
## Why It's Good For The Game
Suffering for your drip is sadge, and style in general is about form and function.
## Changelog
:cl:
balance: Style hats now have helmet-level armor.
/:cl:
