### PR TITLE
RPG tweaks

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1865,6 +1865,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "rpg_fire"
 	icon_state = "rpg_incendiary"
 	flags_ammo_behavior = AMMO_ROCKET
+	effect_radius = 5
 
 /datum/ammo/rocket/wp/quad/ds
 	name = "super thermobaric rocket"
@@ -2019,7 +2020,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/rocket/som/heat/on_hit_obj(obj/O, obj/projectile/P)
 	drop_nade(get_turf(O))
 	if(ismecha(O))
-		P.damage *= 2 //this is specifically designed to hurt mechs
+		P.damage *= 3 //this is specifically designed to hurt mechs
 
 /datum/ammo/rocket/som/heat/drop_nade(turf/T)
 	explosion(T, 0, 1, 0, 1)


### PR DESCRIPTION

## About The Pull Request
Incendiary RPG radius increased to 5 from 3.
HEAT RPG increased mech damage mult to 3 from 2.
## Why It's Good For The Game
Incendiary RPG's are pretty bad, as they have a tiny AOE and no explosive damage. They're still worse than RR rockets in HvH, but should now be good area denial.

Mechs have a lot of health, and especially from the front are hard to kill, so this helps for mech HvH events (or the rare SOM ert vs mech).
## Changelog
:cl:
balance: Increased Incendiary RPG radius to 5 from 3
balance: Increased HEAT RPG mech damage multiplier to 3 from 2
/:cl:
