### PR TITLE
Minor smoothing and map fixes

### DIFF
--- a/_maps/map_files/Twin_Pillars/Twin_Pillars.dmm
+++ b/_maps/map_files/Twin_Pillars/Twin_Pillars.dmm
@@ -1799,11 +1799,11 @@
 /area/mainship/hull/lower_hull)
 "bOh" = (
 /obj/structure/rack,
-/obj/item/tool/pickaxe/plasmacutter,
+/obj/item/tool/pickaxe,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/tool/pickaxe/plasmacutter,
+/obj/item/tool/pickaxe,
 /obj/item/storage/belt/utility/full,
 /obj/item/storage/belt/utility/full,
 /obj/item/tool/weldpack,
@@ -4038,11 +4038,11 @@
 /area/mainship/command/self_destruct/rebel)
 "dNQ" = (
 /obj/structure/rack,
-/obj/item/tool/pickaxe/plasmacutter,
+/obj/item/tool/pickaxe,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/tool/pickaxe/plasmacutter,
+/obj/item/tool/pickaxe,
 /obj/item/storage/belt/utility/full,
 /obj/item/storage/belt/utility/full,
 /obj/item/tool/weldpack,

--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -8543,10 +8543,10 @@
 /area/gelida/indoors/a_block/executive)
 "fxp" = (
 /obj/structure/rack/nometal,
-/obj/item/tool/pickaxe/plasmacutter,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
+/obj/item/tool/pickaxe,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_east_street)
 "fxu" = (

--- a/_maps/map_files/oscar_outpost/oscar_outpost.dmm
+++ b/_maps/map_files/oscar_outpost/oscar_outpost.dmm
@@ -1815,9 +1815,7 @@
 "np" = (
 /obj/machinery/power/apc/hyper,
 /obj/structure/cable,
-/obj/effect/spawner/random/structure/powergenerator/superweighted{
-	power_gen = 25000
-	},
+/obj/effect/spawner/random/structure/powergenerator/superweighted,
 /turf/open/floor/tile/dark,
 /area/oscar_outpost)
 "nt" = (

--- a/_maps/modularmaps/big_red/bigredsecornervar6.dmm
+++ b/_maps/modularmaps/big_red/bigredsecornervar6.dmm
@@ -227,10 +227,6 @@
 /obj/machinery/door/airlock/mainship/generic,
 /turf/open/floor/plating/plating_catwalk,
 /area/bigredv2/caves/secomplex)
-"nb" = (
-/obj/item/tool/pickaxe/plasmacutter,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/southeast)
 "nc" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
@@ -370,11 +366,6 @@
 /area/bigredv2/caves/secomplex)
 "vs" = (
 /turf/open/floor/tile/blue,
-/area/bigredv2/caves/secomplex)
-"vH" = (
-/obj/structure/rack,
-/obj/item/tool/pickaxe/plasmacutter,
-/turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "vT" = (
 /obj/effect/turf_decal/sandedge{
@@ -767,7 +758,7 @@
 /turf/open/floor/mainship/mono,
 /area/bigredv2/caves/secomplex)
 "SZ" = (
-/obj/effect/landmarkweed_node,
+/obj/effect/landmark/weed_node,
 /obj/effect/landmark/patrol_point{
 	id = "TGMC_11";
 	name = "TGMC exit point 11"
@@ -1545,7 +1536,7 @@ Dx
 Dx
 Dx
 Dx
-nb
+Ro
 Ro
 Ir
 qY
@@ -3946,7 +3937,7 @@ Ir
 Ro
 Ro
 Ro
-nb
+Ro
 Ro
 Ir
 Ro
@@ -4332,7 +4323,7 @@ My
 Ir
 Ro
 le
-vH
+Iv
 tu
 Iv
 nY

--- a/_maps/modularmaps/oscaroutpost/oscarsouthvar1.dmm
+++ b/_maps/modularmaps/oscaroutpost/oscarsouthvar1.dmm
@@ -1093,7 +1093,7 @@
 	name = "Req Line Shutters";
 	pixel_x = 7;
 	pixel_y = 1;
-	
+
 	},
 /turf/open/floor/grayscale/black,
 /area/oscar_outpost/village/abandonedbase)
@@ -1934,14 +1934,14 @@
 	name = "Req Line Shutters";
 	pixel_x = 7;
 	pixel_y = -2;
-	
+
 	},
 /obj/structure/table/mainship,
 /obj/machinery/line_nexter_control{
 	id = "UPPreqturn";
 	pixel_x = -6;
 	pixel_y = -2;
-	
+
 	},
 /turf/open/floor/grayscale/black,
 /area/oscar_outpost/village/abandonedbase)
@@ -2279,9 +2279,7 @@
 /turf/open/floor/grayscale/black,
 /area/oscar_outpost/village/abandonedbase)
 "BN" = (
-/obj/effect/spawner/random/structure/powergenerator/superweighted{
-	power_gen = 25000
-	},
+/obj/effect/spawner/random/structure/powergenerator/superweighted,
 /turf/open/floor/tile/dark,
 /area/oscar_outpost/village/abandonedbase)
 "Ce" = (

--- a/_maps/modularmaps/oscaroutpost/oscarsouthvar2.dmm
+++ b/_maps/modularmaps/oscaroutpost/oscarsouthvar2.dmm
@@ -1044,7 +1044,7 @@
 	name = "Req Line Shutters";
 	pixel_x = 7;
 	pixel_y = 1;
-	
+
 	},
 /turf/open/floor/grayscale/black,
 /area/oscar_outpost/village/abandonedbase)
@@ -1809,14 +1809,14 @@
 	name = "Req Line Shutters";
 	pixel_x = 7;
 	pixel_y = -2;
-	
+
 	},
 /obj/structure/table/mainship,
 /obj/machinery/line_nexter_control{
 	id = "UPPreqturn";
 	pixel_x = -6;
 	pixel_y = -2;
-	
+
 	},
 /turf/open/floor/grayscale/black,
 /area/oscar_outpost/village/abandonedbase)
@@ -2122,9 +2122,7 @@
 /turf/open/floor/grayscale/black,
 /area/oscar_outpost/village/abandonedbase)
 "BN" = (
-/obj/effect/spawner/random/structure/powergenerator/superweighted{
-	power_gen = 25000
-	},
+/obj/effect/spawner/random/structure/powergenerator/superweighted,
 /turf/open/floor/tile/dark,
 /area/oscar_outpost/village/abandonedbase)
 "Ce" = (

--- a/_maps/modularmaps/oscaroutpost/oscarsouthvar3.dmm
+++ b/_maps/modularmaps/oscaroutpost/oscarsouthvar3.dmm
@@ -1080,7 +1080,7 @@
 	name = "Req Line Shutters";
 	pixel_x = 7;
 	pixel_y = 1;
-	
+
 	},
 /turf/open/floor/grayscale/black,
 /area/oscar_outpost/village/abandonedbase)
@@ -1914,7 +1914,7 @@
 	name = "Req Line Shutters";
 	pixel_x = 7;
 	pixel_y = -2;
-	
+
 	},
 /obj/structure/table/mainship,
 /obj/machinery/door_control/old{
@@ -1922,7 +1922,7 @@
 	name = "Req Line Shutters";
 	pixel_x = -7;
 	pixel_y = -2;
-	
+
 	},
 /turf/open/floor/grayscale/black,
 /area/oscar_outpost/village/abandonedbase)
@@ -2251,9 +2251,7 @@
 /turf/closed/wall/mainship/outer,
 /area/oscar_outpost/outside/rock)
 "BN" = (
-/obj/effect/spawner/random/structure/powergenerator/superweighted{
-	power_gen = 25000
-	},
+/obj/effect/spawner/random/structure/powergenerator/superweighted,
 /turf/open/floor/tile/dark,
 /area/oscar_outpost/village/abandonedbase)
 "Ce" = (

--- a/_maps/modularmaps/oscaroutpost/oscarsouthvar5.dmm
+++ b/_maps/modularmaps/oscaroutpost/oscarsouthvar5.dmm
@@ -1042,7 +1042,7 @@
 	name = "Req Line Shutters";
 	pixel_x = 7;
 	pixel_y = 1;
-	
+
 	},
 /turf/open/floor/grayscale/black,
 /area/oscar_outpost/village/abandonedbase)
@@ -1815,14 +1815,14 @@
 	name = "Req Line Shutters";
 	pixel_x = 7;
 	pixel_y = -2;
-	
+
 	},
 /obj/structure/table/mainship,
 /obj/machinery/line_nexter_control{
 	id = "UPPreqturn";
 	pixel_x = -6;
 	pixel_y = -2;
-	
+
 	},
 /turf/open/floor/grayscale/black,
 /area/oscar_outpost/village/abandonedbase)
@@ -2128,9 +2128,7 @@
 /turf/open/floor/grayscale/black,
 /area/oscar_outpost/village/abandonedbase)
 "BN" = (
-/obj/effect/spawner/random/structure/powergenerator/superweighted{
-	power_gen = 25000
-	},
+/obj/effect/spawner/random/structure/powergenerator/superweighted,
 /turf/open/floor/tile/dark,
 /area/oscar_outpost/village/abandonedbase)
 "Ce" = (

--- a/_maps/shuttles/minidropship.dmm
+++ b/_maps/shuttles/minidropship.dmm
@@ -70,7 +70,7 @@
 /obj/machinery/door/poddoor/mainship/open{
 	id = "minidropship_podlock"
 	},
-/obj/machinery/door/poddoor/shutters/transit,
+/obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "q" = (
@@ -91,14 +91,14 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/shuttle/minidropship)
 "v" = (
-/obj/machinery/door/poddoor/shutters/transit{
-	dir = 2
-	},
 /obj/machinery/door/poddoor/mainship/open{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
 /obj/structure/barricade/plasteel,
+/obj/machinery/door/poddoor/shutters/transit/nonsmoothing{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "y" = (
@@ -108,7 +108,7 @@
 /obj/machinery/door/poddoor/mainship/open{
 	id = "minidropship_podlock"
 	},
-/obj/machinery/door/poddoor/shutters/transit,
+/obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "A" = (
@@ -127,10 +127,10 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/obj/machinery/door/poddoor/shutters/transit,
 /obj/machinery/door/poddoor/mainship/open{
 	id = "minidropship_podlock"
 	},
+/obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "C" = (
@@ -143,10 +143,10 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/obj/machinery/door/poddoor/shutters/transit,
 /obj/machinery/door/poddoor/mainship/open{
 	id = "minidropship_podlock"
 	},
+/obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "E" = (
@@ -178,21 +178,21 @@
 /obj/machinery/door/poddoor/mainship/open{
 	id = "minidropship_podlock"
 	},
-/obj/machinery/door/poddoor/shutters/transit,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "Q" = (
-/obj/machinery/door/poddoor/shutters/transit{
-	dir = 2
-	},
 /obj/machinery/door/poddoor/mainship/open{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
 /obj/structure/barricade/plasteel,
+/obj/machinery/door/poddoor/shutters/transit/nonsmoothing{
+	dir = 1
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/shuttle/minidropship)
 "S" = (
@@ -212,10 +212,10 @@
 /obj/machinery/door/poddoor/mainship/open{
 	id = "minidropship_podlock"
 	},
-/obj/machinery/door/poddoor/shutters/transit,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "U" = (

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -471,7 +471,14 @@
 
 /obj/structure/window/framed/mainship/hull/canterbury //So we can wallsmooth properly.
 	smoothing_groups = list(SMOOTH_GROUP_CANTERBURY)
-	canSmoothWith = list(SMOOTH_GROUP_CANTERBURY)
+	canSmoothWith = list(
+		SMOOTH_GROUP_AIRLOCK,
+		SMOOTH_GROUP_WINDOW_FRAME,
+		SMOOTH_GROUP_WINDOW_FULLTILE,
+		SMOOTH_GROUP_SHUTTERS,
+		SMOOTH_GROUP_CANTERBURY,
+	)
+
 
 /obj/structure/window/framed/mainship/requisitions
 	name = "kevlar-weave infused bulletproof window"
@@ -500,6 +507,7 @@
 	base_icon_state = "ship_gray_window"
 	window_frame = /obj/structure/window_frame/mainship/gray
 	reinf = FALSE
+	smoothing_groups = list(SMOOTH_GROUP_WINDOW_FULLTILE)
 	canSmoothWith = list(
 		SMOOTH_GROUP_WINDOW_FULLTILE,
 		SMOOTH_GROUP_AIRLOCK,

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -74,6 +74,7 @@
 	icon_state = "darkfrostwall-0"
 	walltype = "darkfrostwall"
 	base_icon_state = "darkfrostwall"
+	resistance_flags = PLASMACUTTER_IMMUNE
 
 /turf/closed/mineral/smooth/darkfrostwall/indestructible
 	resistance_flags = RESIST_ALL

--- a/code/game/turfs/floor_ground.dm
+++ b/code/game/turfs/floor_ground.dm
@@ -177,7 +177,7 @@
 /turf/open/floor/plating/ground/mars/random/dirt
 	name = "dirt"
 	icon_state = "mars_dirt"
-	smoothing_groups = list(SMOOTH_GROUP_RED_DIRT)
+	smoothing_groups = list(SMOOTH_GROUP_RED_DIRT, SMOOTH_GROUP_OPEN_FLOOR)
 
 /turf/open/floor/plating/ground/mars/random/sand
 	name = "sand"

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -27,7 +27,13 @@
 
 /turf/closed/wall/mainship/outer/canterbury
 	smoothing_groups = list(SMOOTH_GROUP_CANTERBURY)
-	canSmoothWith = list(SMOOTH_GROUP_CANTERBURY)
+	canSmoothWith = list(
+		SMOOTH_GROUP_AIRLOCK,
+		SMOOTH_GROUP_WINDOW_FRAME,
+		SMOOTH_GROUP_WINDOW_FULLTILE,
+		SMOOTH_GROUP_SHUTTERS,
+		SMOOTH_GROUP_CANTERBURY,
+	)
 
 /turf/closed/wall/mainship/white
 	icon = 'icons/turf/walls/wwall.dmi'
@@ -47,6 +53,16 @@
 	resistance_flags = RESIST_ALL
 
 /turf/closed/wall/mainship/white/canterbury //For ship smoothing.
+	smoothing_groups = list(SMOOTH_GROUP_CANTERBURY)
+	canSmoothWith = list(
+		SMOOTH_GROUP_AIRLOCK,
+		SMOOTH_GROUP_WINDOW_FRAME,
+		SMOOTH_GROUP_WINDOW_FULLTILE,
+		SMOOTH_GROUP_SHUTTERS,
+		SMOOTH_GROUP_CANTERBURY,
+	)
+
+
 
 /turf/closed/wall/mainship/white/outer
 	name = "outer hull"

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -766,6 +766,9 @@
 /turf/open/shuttle/dropship/floor
 	icon_state = "rasputin15"
 
+/obj/machinery/door/poddoor/shutters/transit/nonsmoothing
+	smoothing_groups = NONE
+
 /turf/open/shuttle/dropship/floor/alt
 	icon_state = "rasputin14"
 
@@ -979,6 +982,7 @@
 	icon_state = "shuttle_glass1"
 	resistance_flags = NONE
 	opacity = FALSE
+	flags_pass = PASSLASER
 
 /obj/structure/dropship_piece/glasstwo
 	icon = 'icons/turf/dropship2.dmi'
@@ -989,6 +993,7 @@
 	icon_state = "shuttle_glass2"
 	resistance_flags = NONE
 	opacity = FALSE
+	flags_pass = PASSLASER
 
 /obj/structure/dropship_piece/singlewindow/tadpole
 	icon = 'icons/turf/dropship2.dmi'


### PR DESCRIPTION

## About The Pull Request

Just a small PR that fixes some minor smoothing and map issues, formerly part of the round end PR before it was atomized.
Check the changelog for details.

## Why It's Good For The Game

Fixes good, bugs bad.

## Changelog
:cl:
balance: Removed some plasma cutters from Gelida and one modular of Big Red.
fix: Fixed Oscar Outpost runtiming on load due to bad vars.
fix: Fixed lava basalt incorrectly smoothing with regular floors.
fix: Fixed Tadpole shutters smoothing with walls.
fix: Fixed Canterbury smoothing issues with walls and windows.
fix: Fixed Tadpole windows allowing bullets through them.
/:cl:
