### PR TITLE
Acid now melts everything in the container that has gotten melted minus mobs

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -188,20 +188,24 @@
 			WF.deconstruct(FALSE)
 
 		else
-			if(acid_t.contents.len) //Hopefully won't auto-delete things inside melted stuff..
-				for(var/atom/movable/M in acid_t.contents)
-					if(acid_t.loc) M.forceMove(acid_t.loc)
-			qdel(acid_t)
-			acid_t = null
+			if(length(acid_t.contents)) //Hopefully won't auto-delete mobs inside melted stuff..
+				for(var/mob/M in acid_t.contents)
+					if(acid_t.loc)
+						M.forceMove(get_turf(acid_t))
+			QDEL_NULL(acid_t)
 
 		qdel(src)
 		return
 
 	switch(strength_t - ticks)
-		if(6) visible_message(span_xenowarning("\The [acid_t] is barely holding up against the acid!"))
-		if(4) visible_message(span_xenowarning("\The [acid_t]\s structure is being melted by the acid!"))
-		if(2) visible_message(span_xenowarning("\The [acid_t] is struggling to withstand the acid!"))
-		if(0 to 1) visible_message(span_xenowarning("\The [acid_t] begins to crumble under the acid!"))
+		if(0 to 1)
+			visible_message(span_xenowarning("\The [acid_t] begins to crumble under the acid!"))
+		if(2)
+			visible_message(span_xenowarning("\The [acid_t] is struggling to withstand the acid!"))
+		if(4)
+			visible_message(span_xenowarning("\The [acid_t]\s structure is being melted by the acid!"))
+		if(6)
+			visible_message(span_xenowarning("\The [acid_t] is barely holding up against the acid!"))
 
 /obj/effect/xenomorph/warp_shadow
 	name = "warp shadow"


### PR DESCRIPTION

## About The Pull Request

- Makes it so that if you melt a container the things inside the container melt too, with the exception of mobs
- So, if you melt a medibelt you don't have to melt all the pill bottles inside then all the pills inside said bottles (guh)

(this is tehnically a partial revert of #11334)
## Why It's Good For The Game

Xenos having to babysit containers til they're full melted then babysit the contents to melt them as well (while having to spend absurd amounts of plasma to melt all the items inside as well, which makes it take even longer) is not fun!
## Changelog
:cl:
balance: If you melt a container the things inside the container melt too, with the exception of mobs
/:cl:
