### PR TITLE
Fixes robots being able to spawn in HvH

### DIFF
--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -118,7 +118,7 @@
 		hive.purchases.setup_upgrades()
 	return TRUE
 
-
+///Gamemode setup run after the game has started
 /datum/game_mode/proc/post_setup()
 	addtimer(CALLBACK(src, .proc/display_roundstart_logout_report), ROUNDSTART_LOGOUT_REPORT_TIME)
 	if(flags_round_type & MODE_SILO_RESPAWN)

--- a/code/datums/gamemodes/civil_war.dm
+++ b/code/datums/gamemodes/civil_war.dm
@@ -70,7 +70,6 @@
 		new /obj/structure/sensor_tower(T)
 	if(GLOB.zones_to_control.len)
 		points_per_zone_per_second = 1 / GLOB.zones_to_control.len
-	GLOB.join_as_robot_allowed = FALSE
 
 /datum/game_mode/civil_war/announce()
 	to_chat(world, "<b>The current game mode is - Civil War!</b>")

--- a/code/datums/gamemodes/combat_patrol.dm
+++ b/code/datums/gamemodes/combat_patrol.dm
@@ -49,7 +49,6 @@
 				area_to_lit.set_base_lighting(COLOR_WHITE, 75)
 			if(CEILING_DEEP_UNDERGROUND to CEILING_DEEP_UNDERGROUND_METAL)
 				area_to_lit.set_base_lighting(COLOR_WHITE, 50)
-	GLOB.join_as_robot_allowed = FALSE
 
 /datum/game_mode/combat_patrol/scale_roles()
 	. = ..()

--- a/code/datums/jobs/job/terragov.dm
+++ b/code/datums/jobs/job/terragov.dm
@@ -18,7 +18,7 @@
 /datum/job/terragov/return_spawn_type(datum/preferences/prefs)
 	switch(prefs?.species)
 		if("Combat Robot")
-			if(GLOB.join_as_robot_allowed)
+			if(!(SSticker.mode?.flags_round_type & MODE_HUMAN_ONLY))
 				if(prefs && prefs.robot_type == "Basic")
 					return /mob/living/carbon/human/species/robot
 				if(prefs && prefs.robot_type == "Hammerhead")

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -388,8 +388,6 @@
 	H.set_species("Vat-Grown Human")
 
 
-GLOBAL_VAR_INIT(join_as_robot_allowed, TRUE)
-
 /datum/species/robot
 	name = "Combat Robot"
 	name_plural = "Combat Robots"


### PR DESCRIPTION

## About The Pull Request
So it turns out robots spawning in HvH has been broken since robots were first added, because the proc where the restriction is added happens... after the game starts, meaning anyone readied up could spawn as a robot.

It now directly checks the gamemode flag instead of the glob var (I didn't see any reason to keep it).
## Why It's Good For The Game
Bug fix good.
## Changelog
:cl:
fix: fixed combat robots being able to spawn in HvH
/:cl:
