### PR TITLE
no silenced GPMG

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -843,7 +843,6 @@
 		/obj/item/attachable/foldable/bipod,
 		/obj/item/attachable/extended_barrel,
 		/obj/item/attachable/heavy_barrel,
-		/obj/item/attachable/suppressor,
 		/obj/item/attachable/bayonet,
 		/obj/item/attachable/bayonetknife,
 		/obj/item/attachable/scope,


### PR DESCRIPTION

## About The Pull Request
Removes the suppressor from the MG60.
## Why It's Good For The Game
It's kinda weird that it has it to start with, and all it serves to do is make BAS turrets difficult to be aware of/tell that its the highest dps gun in the game on it.
## Changelog
:cl:
balance: MG-60 can no longer take a suppressor
/:cl:
