### PR TITLE
MG-60 Nerf

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -641,7 +641,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/bullet/rifle/machinegun
 	name = "machinegun bullet"
 	hud_state = "rifle_heavy"
-	damage = 21.5
+	damage = 25
 	penetration = 10
 	sundering = 0.75
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -641,7 +641,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/bullet/rifle/machinegun
 	name = "machinegun bullet"
 	hud_state = "rifle_heavy"
-	damage = 25
+	damage = 23.5
 	penetration = 10
 	sundering = 0.75
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -641,7 +641,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/bullet/rifle/machinegun
 	name = "machinegun bullet"
 	hud_state = "rifle_heavy"
-	damage = 23.5
+	damage = 21.5
 	penetration = 10
 	sundering = 0.75
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -641,7 +641,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/bullet/rifle/machinegun
 	name = "machinegun bullet"
 	hud_state = "rifle_heavy"
-	damage = 25
+	damage = 21.5
 	penetration = 10
 	sundering = 0.75
 

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -822,7 +822,7 @@
 	inhand_y_dimension = 32
 
 	caliber = CALIBER_10x26_CASELESS //codex
-	max_shells = 200 //codex
+	max_shells = 250 //codex
 	force = 35
 	aim_slowdown = 1.2
 	wield_delay = 1.5 SECONDS

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -202,7 +202,7 @@
 	caliber = CALIBER_10x26_CASELESS
 	default_ammo = /datum/ammo/bullet/rifle/machinegun
 	w_class = WEIGHT_CLASS_NORMAL
-	max_rounds = 200
+	max_rounds = 250
 	reload_delay = 3 SECONDS
 	icon_state_mini = "mag_gpmg"
 


### PR DESCRIPTION
## About The Pull Request
T-60 damage nerfed from 25 to 21.5.
Mag capacity increased from 200 to 250. 
## Why It's Good For The Game
This gun wasn't really hurting for any buffs and giving it a whole extra 5 damage while it has the rate-of-fire of a whole damn SMG is goofy.  
## Changelog
:cl:
balance: MG-60 damage decreased (25 -> 21.5)
balance: MG-60 ammo capacity increased (200 -> 250)
/:cl:
