### PR TITLE
Scopeless SR-127 randomly spawns in planetside due to HvH

### DIFF
--- a/code/game/objects/effects/spawners/random.dm
+++ b/code/game/objects/effects/spawners/random.dm
@@ -843,7 +843,7 @@
 		/obj/item/weapon/gun/smg/standard_machinepistol,
 		/obj/item/weapon/gun/rifle/standard_dmr,
 		/obj/item/weapon/gun/rifle/standard_br,
-		/obj/item/weapon/gun/rifle/chambered,
+		/obj/item/weapon/gun/rifle/chambered/unscoped,
 		/obj/item/weapon/gun/shotgun/pump/bolt/unscoped,
 		/obj/item/weapon/gun/shotgun/double/martini,
 		/obj/item/weapon/gun/pistol/standard_pistol,

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1289,6 +1289,8 @@
 	cock_delay = 0.7 SECONDS
 	movement_acc_penalty_mult = 6
 
+/obj/item/weapon/gun/rifle/chambered/unscoped
+	starting_attachment_types = list(/obj/item/attachable/stock/tl127stock)
 
 //-------------------------------------------------------
 //SR-81 Auto-Sniper


### PR DESCRIPTION

## About The Pull Request

All SR-127 that spawn in planetside shall be scopeless due to HvH.

## Why It's Good For The Game

Some players noticed that they could get a scope weapon in HvH, especially the SR-127. I have seen this in HvH round, and in fact I have it recorded.

No scope weapons in HvH.

## Changelog

:cl:
add: SR-127 now spawn scopeless in planetside due to HvH balance
/:cl:

