### PR TITLE
Underbarrel attachments no longer fire on middle click.

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -678,9 +678,8 @@
 	if(modifiers["shift"])
 		return
 
-	if(modifiers["right"] || modifiers["middle"])
+	if(modifiers["right"])
 		modifiers -= "right"
-		modifiers -= "middle"
 		params = list2params(modifiers)
 		active_attachable?.start_fire(source, object, location, control, params, bypass_checks)
 		return


### PR DESCRIPTION
## About The Pull Request
This makes it so that the underbarrel attachment no longer fires when you middle click.
## Why It's Good For The Game
Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/8182

https://user-images.githubusercontent.com/66163761/221994838-c41cd79e-af35-4ec4-9e7a-8b4fffc3f83c.mp4

This ^^ was stupid.
## Changelog
:cl:
del: You can no longer fire underbarrel attachments with middle click.
/:cl:
