### PR TITLE
Fix RO revolver

### DIFF
--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -338,7 +338,7 @@
 	caliber = CALIBER_44 //codex
 	max_chamber_items = 6
 	default_ammo_type = /obj/item/ammo_magazine/revolver
-	allowed_ammo_types = list(/obj/item/ammo_magazine/revolver)
+	allowed_ammo_types = list(/obj/item/ammo_magazine/revolver, /obj/item/ammo_magazine/revolver/marksman, /obj/item/ammo_magazine/revolver/heavy)
 	force = 8
 	attachable_allowed = list(
 		/obj/item/attachable/bayonet,


### PR DESCRIPTION

## About The Pull Request
RO revolver wasn't allowed to use their speedloaders. This is a fix.
Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/12086
## Why It's Good For The Game
Bugfix good.
## Changelog
:cl:
fix: RO SAA Revolver can use the 2 special speedloaders.
/:cl:
