### PR TITLE
RR Tfoot shells to normal vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -142,6 +142,7 @@
 			/obj/item/ammo_magazine/rocket/recoilless/heat = 16,
 			/obj/item/ammo_magazine/rocket/recoilless/cloak = 16,
 			/obj/item/ammo_magazine/rocket/recoilless/smoke = 16,
+			/obj/item/ammo_magazine/rocket/recoilless/plasmaloss = 16,
 		),
 		"Attachments" = list(
 			/obj/item/attachable/bayonet = -1,

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -503,7 +503,6 @@
 			/obj/item/weapon/gun/flamer/big_flamer/marinestandard = -1,
 			/obj/item/ammo_magazine/flamer_tank/large = -1,
 			/obj/item/ammo_magazine/flamer_tank/backtank = -1,
-			/obj/item/storage/holster/backholster/rpg/full = -1,
 			/obj/item/jetpack_marine = -1,
 		),
 		"Heavy Weapons" = list(
@@ -514,6 +513,12 @@
 			/obj/item/storage/box/tl102 = -1,
 			/obj/item/weapon/gun/heavymachinegun = -1,
 			/obj/item/ammo_magazine/heavymachinegun = -1,
+			/obj/item/storage/holster/backholster/rpg/full = -1,
+			/obj/item/ammo_magazine/rocket/recoilless = -1,
+			/obj/item/ammo_magazine/rocket/recoilless/light = -1,
+			/obj/item/ammo_magazine/rocket/recoilless/heat = -1,
+			/obj/item/ammo_magazine/rocket/recoilless/cloak = -1,
+			/obj/item/ammo_magazine/rocket/recoilless/smoke = -1,
 		),
 		"Attachments" = list(
 			/obj/item/attachable/bayonet = -1,
@@ -1520,6 +1525,7 @@
 			/obj/item/armor_module/module/fire_proof = -1,
 			/obj/item/armor_module/module/tyr_extra_armor = -1,
 			/obj/item/armor_module/module/tyr_head = -1,
+			/obj/item/attachable/shoulder_mount = -1,
 			/obj/item/armor_module/module/mimir_environment_protection = -1,
 			/obj/item/armor_module/module/mimir_environment_protection/mimir_helmet = -1,
 			/obj/item/armor_module/module/better_shoulder_lamp = -1,
@@ -1529,6 +1535,8 @@
 			/obj/item/clothing/suit/storage/marine/riot = -1,
 			/obj/item/clothing/head/helmet/marine/riot = -1,
 			/obj/item/clothing/suit/storage/marine/harness/boomvest = -1,
+			/obj/item/implanter/cloak = -1,
+			/obj/item/implanter/chem/blood = -1,
 		),
 		"Reqtorio" = list(
 			/obj/item/paper/factoryhowto = -1,

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -519,6 +519,7 @@
 			/obj/item/ammo_magazine/rocket/recoilless/heat = -1,
 			/obj/item/ammo_magazine/rocket/recoilless/cloak = -1,
 			/obj/item/ammo_magazine/rocket/recoilless/smoke = -1,
+			/obj/item/ammo_magazine/rocket/recoilless/plasmaloss = -1,
 		),
 		"Attachments" = list(
 			/obj/item/attachable/bayonet = -1,


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
Every other RR shell has a free amount round start. Colour me surprised when I found out Tfoot shells (that are never bought) wasn't.

More fun for our demo boys that'll either wipe the hive or the marines.
## Changelog
:cl:
add: Adds RR Tfoot shells to normal vendor
/:cl:
