### PR TITLE
Spiderlings no longer control widow movement

### DIFF
--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -304,6 +304,7 @@
 /datum/component/riding/creature/widow/vehicle_mob_unbuckle(datum/source, mob/living/former_rider, force = FALSE)
 	unequip_buckle_inhands(parent)
 	former_rider.density = initial(former_rider.density)
+	REMOVE_TRAIT(former_rider, TRAIT_IMMOBILE, WIDOW_ABILITY_TRAIT)
 	return ..()
 
 /// If the widow gets knocked over, force the riding rounys off and see if someone got hurt

--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
@@ -275,6 +275,7 @@
 			continue
 		remaining_list -= remaining_spiderling
 		owner.buckle_mob(remaining_spiderling, TRUE, TRUE, 90, 1,0)
+		ADD_TRAIT(remaining_spiderling, TRAIT_IMMOBILE, WIDOW_ABILITY_TRAIT)
 	addtimer(CALLBACK(src, .proc/grab_spiderlings, remaining_list, number_of_attempts_left - 1), 1)
 
 // ***************************************


### PR DESCRIPTION

## About The Pull Request

At last, we have done it. A 2 line fix to 6+ month old issue
## Why It's Good For The Game

Bugfix good
## Changelog
:cl:
fix: fixed spiderlings controlling widow movement
/:cl:
