### PR TITLE
Mateba akimbo nerf (Additional delay)

### DIFF
--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -187,7 +187,7 @@
 	accuracy_mult = 1.15
 	scatter = 0
 	accuracy_mult_unwielded = 0.8
-	akimbo_additional_delay = 1 // Akimbo only gives more shots.
+	akimbo_additional_delay = 0.9 // Akimbo only gives more shots.
 	scatter_unwielded = 7
 
 /obj/item/weapon/gun/revolver/mateba/notmarine

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -187,6 +187,7 @@
 	accuracy_mult = 1.15
 	scatter = 0
 	accuracy_mult_unwielded = 0.8
+	akimbo_additional_delay = 1 // Akimbo only gives more shots.
 	scatter_unwielded = 7
 
 /obj/item/weapon/gun/revolver/mateba/notmarine


### PR DESCRIPTION

## About The Pull Request
Mateba now has 1 additional delay rather than .5, making akimbo basically just give you extra capacity.
## Why It's Good For The Game
Mateba getting any DPS increase from akimbo is insane, mostly because it stuns, staggers and does high enough damage that is mostly balanced by the format it comes out of which is well.. A six round revolver. Akimbo solves the capacity issue with a hefty DPS increase, so remove the DPS increase and it should be fine.
## Changelog
:cl:
balance: Mateba has much more fire delay in akimbo.
/:cl:
