### PR TITLE
Adds MBX to standard marine vendors, rebalances MBX SABOT

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -63,7 +63,6 @@
 			/obj/item/weapon/gun/shotgun/pump/lever/mbx900 = -1,
 			/obj/item/ammo_magazine/shotgun/mbx900 = -1,
 			/obj/item/ammo_magazine/shotgun/mbx900/buckshot = -1,
-
 		),
 		"Machinegun" = list(
 			/obj/item/weapon/gun/rifle/standard_lmg = -1,

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -265,6 +265,9 @@
 			/obj/item/weapon/gun/rifle/standard_autoshotgun = -1,
 			/obj/item/ammo_magazine/rifle/tx15_flechette = -1,
 			/obj/item/ammo_magazine/rifle/tx15_slug = -1,
+			/obj/item/weapon/gun/shotgun/pump/lever/mbx900 = -1,
+			/obj/item/ammo_magazine/shotgun/mbx900 = -1,
+			/obj/item/ammo_magazine/shotgun/mbx900/buckshot = -1,
 		),
 		"Machinegun" = list(
 			/obj/item/weapon/gun/rifle/standard_lmg = -1,
@@ -444,6 +447,9 @@
 			/obj/item/weapon/gun/rifle/standard_autoshotgun = -1,
 			/obj/item/ammo_magazine/rifle/tx15_flechette = -1,
 			/obj/item/ammo_magazine/rifle/tx15_slug = -1,
+			/obj/item/weapon/gun/shotgun/pump/lever/mbx900 = -1,
+			/obj/item/ammo_magazine/shotgun/mbx900 = -1,
+			/obj/item/ammo_magazine/shotgun/mbx900/buckshot = -1,
 		),
 		"Machinegun" = list(
 			/obj/item/weapon/gun/rifle/standard_lmg = -1,
@@ -630,6 +636,9 @@
 			/obj/item/weapon/gun/rifle/standard_autoshotgun = -1,
 			/obj/item/ammo_magazine/rifle/tx15_flechette = -1,
 			/obj/item/ammo_magazine/rifle/tx15_slug = -1,
+			/obj/item/weapon/gun/shotgun/pump/lever/mbx900 = -1,
+			/obj/item/ammo_magazine/shotgun/mbx900 = -1,
+			/obj/item/ammo_magazine/shotgun/mbx900/buckshot = -1,
 		),
 		"Machinegun" = list(
 			/obj/item/weapon/gun/rifle/standard_lmg = -1,
@@ -809,7 +818,6 @@
 			/obj/item/ammo_magazine/rifle/tx8 = 3,
 			/obj/item/ammo_magazine/rocket/sadar = 3,
 			/obj/item/ammo_magazine/minigun_powerpack = 2,
-			/obj/item/ammo_magazine/shotgun/mbx900 = 2,
 			/obj/item/explosive/plastique = 5,
 			/obj/item/fulton_extraction_pack = 2,
 			/obj/item/clothing/suit/storage/marine/harness/boomvest = 20,

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -60,6 +60,10 @@
 			/obj/item/weapon/gun/rifle/standard_autoshotgun = -1,
 			/obj/item/ammo_magazine/rifle/tx15_flechette = -1,
 			/obj/item/ammo_magazine/rifle/tx15_slug = -1,
+			/obj/item/weapon/gun/shotgun/pump/lever/mbx900 = -1,
+			/obj/item/ammo_magazine/shotgun/mbx900 = -1,
+			/obj/item/ammo_magazine/shotgun/mbx900/buckshot = -1,
+
 		),
 		"Machinegun" = list(
 			/obj/item/weapon/gun/rifle/standard_lmg = -1,

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -952,9 +952,9 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	shell_speed = 5
 	max_range = 30
-	damage = 60
+	damage = 50
 	penetration = 40
-	sundering = 2
+	sundering = 3
 
 /datum/ammo/bullet/shotgun/mbx900_tracker
 	name = "light shotgun tracker round"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -957,7 +957,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	sundering = 1
 
 /datum/ammo/bullet/shotgun/mbx900_sabot/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, slowdown = 0.5)
+	staggerstun(M, P, slowdown = 1)
 
 /datum/ammo/bullet/shotgun/mbx900_tracker
 	name = "light shotgun tracker round"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -952,9 +952,9 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	shell_speed = 5
 	max_range = 30
-	damage = 50
+	damage = 60
 	penetration = 40
-	sundering = 3
+	sundering = 2
 
 /datum/ammo/bullet/shotgun/mbx900_tracker
 	name = "light shotgun tracker round"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -952,9 +952,12 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	shell_speed = 5
 	max_range = 30
-	damage = 50
+	damage = 30
 	penetration = 40
-	sundering = 3
+	sundering = 1
+
+/datum/ammo/bullet/shotgun/mbx900_sabot/on_hit_mob(mob/M,obj/projectile/P)
+	staggerstun(M, P, slowdown = 0.5)
 
 /datum/ammo/bullet/shotgun/mbx900_tracker
 	name = "light shotgun tracker round"

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -605,7 +605,7 @@
 //------------------------------------------------------
 //MBX900 Lever Action Shotgun
 /obj/item/weapon/gun/shotgun/pump/lever/mbx900
-	name = "\improper MBX lever action shotgun"
+	name = "\improper MBX lever action light shotgun"
 	desc = "A .410 bore lever action shotgun that fires nearly as fast as you can operate the lever. Renowed due to its extremely reliable design while retaining a light frame. Uses .410 shells."
 	icon_state = "mbx900"
 	item_state = "mbx900"

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -606,7 +606,7 @@
 //MBX900 Lever Action Shotgun
 /obj/item/weapon/gun/shotgun/pump/lever/mbx900
 	name = "\improper MBX lever action shotgun"
-	desc = "A .410 bore lever action shotgun that fires nearly as fast as you can operate the lever. Renowed due to its devastating and extremely reliable design."
+	desc = "A .410 bore lever action shotgun that fires nearly as fast as you can operate the lever. Renowed due to its extremely reliable design while retaining a light frame. Uses .410 shells."
 	icon_state = "mbx900"
 	item_state = "mbx900"
 	fire_sound = 'sound/weapons/guns/fire/shotgun_light.ogg'//I like how this one sounds.

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1421,18 +1421,6 @@ Imports
 	cost = 50
 	available_against_xeno_only = TRUE
 
-/datum/supply_packs/imports/mbx900
-	name = "MBX 900"
-	contains = list(/obj/item/weapon/gun/shotgun/pump/lever/mbx900)
-	cost = 150
-	available_against_xeno_only = TRUE
-
-/datum/supply_packs/imports/mbx900/buckshot
-	name = "MBX-900 Buckshot Shells"
-	contains = list(/obj/item/ammo_magazine/shotgun/mbx900/buckshot)
-	cost = 50
-	available_against_xeno_only = TRUE
-
 /datum/supply_packs/imports/mosin
 	name = "Mosin Nagant Sniper"
 	contains = list(/obj/item/weapon/gun/shotgun/pump/bolt)


### PR DESCRIPTION
## About The Pull Request
1:1 adds MBX to marine vendor, buckshot and gun handling stats unchanged as I do not believe they require any changes.

SABOT has been reworked to deal slowdown on hit, it has lost damage in exchange for that, making it a unique chasing gun.
SABOT damage stats are 30/40/1 and 1 slowdown on hit. Old stats are 50/40/3 and no slowodwn.

The nomeculture change is that it is now a "Light Shotgun" rather than just shotgun to better represent its role.
## Why It's Good For The Game
The MBX fills the role and niche of a light chasing shotgun, it has good CQC statistics, low slowdown, buckshot for CQC, and SABOT for midrange combat even if it is rather poor at anything but pen, this gun is focused around a chasing and mobile playstyle compared to something like the T-35, which serves a more devastating CQC role.

Though I'd say the closest cousin would be the autoshotty which is more focused around the midrange/support shotgun style with flechette/slugs which deal solid midrange damage and support respectively.
## Changelog
:cl:
add: Added the MBX lever action to marine vendors.
balance: MBX sabot reworked, it now slows down on hit but has lost damage and sunder for that. 
/:cl:
