### PR TITLE
Removes Lemoline from some recipes. Doubles Lemoline bottle content.

### DIFF
--- a/code/game/objects/items/reagent_containers/glass/bottle.dm
+++ b/code/game/objects/items/reagent_containers/glass/bottle.dm
@@ -225,7 +225,7 @@
 	list_reagents = list(/datum/reagent/medicine/lemoline = 10)
 
 /obj/item/reagent_containers/glass/bottle/lemoline/doctor
-	desc = "A small bottle. Contains 30 units of lemoline, a reagent used in the creation of advanced medicine."
+	desc = "A small bottle. Contains 60 units of lemoline, a reagent used in the creation of advanced medicine."
 	list_reagents = list(/datum/reagent/medicine/lemoline = 60)
 
 /obj/item/reagent_containers/glass/bottle/doctor_delight

--- a/code/game/objects/items/reagent_containers/glass/bottle.dm
+++ b/code/game/objects/items/reagent_containers/glass/bottle.dm
@@ -226,7 +226,7 @@
 
 /obj/item/reagent_containers/glass/bottle/lemoline/doctor
 	desc = "A small bottle. Contains 30 units of lemoline, a reagent used in the creation of advanced medicine."
-	list_reagents = list(/datum/reagent/medicine/lemoline = 30)
+	list_reagents = list(/datum/reagent/medicine/lemoline = 60)
 
 /obj/item/reagent_containers/glass/bottle/doctor_delight
 	name = "\improper Doctor's Delight bottle"

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -38,7 +38,7 @@
 /datum/chemical_reaction/ryetalyn
 	name = "Ryetalyn"
 	results = list(/datum/reagent/medicine/ryetalyn = 2)
-	required_reagents = list(/datum/reagent/medicine/arithrazine = 1, /datum/reagent/carbon = 1, /datum/reagent/medicine/lemoline = 1)
+	required_reagents = list(/datum/reagent/medicine/arithrazine = 1, /datum/reagent/carbon = 1)
 
 /datum/chemical_reaction/cryoxadone
 	name = "Cryoxadone"
@@ -116,7 +116,7 @@
 /datum/chemical_reaction/synaptizine
 	name = "Synaptizine"
 	results = list(/datum/reagent/medicine/synaptizine = 3)
-	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/lithium = 1, /datum/reagent/water = 1, /datum/reagent/medicine/lemoline = 1)
+	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/lithium = 1, /datum/reagent/water = 1)
 
 /datum/chemical_reaction/leporazine
 	name = "Leporazine"
@@ -127,7 +127,7 @@
 /datum/chemical_reaction/hyronalin
 	name = "Hyronalin"
 	results = list(/datum/reagent/medicine/hyronalin = 2)
-	required_reagents = list(/datum/reagent/radium = 1, /datum/reagent/medicine/dylovene = 1, /datum/reagent/medicine/lemoline = 1)
+	required_reagents = list(/datum/reagent/radium = 1, /datum/reagent/medicine/dylovene = 1)
 
 /datum/chemical_reaction/arithrazine
 	name = "Arithrazine"

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -116,7 +116,7 @@
 /datum/chemical_reaction/synaptizine
 	name = "Synaptizine"
 	results = list(/datum/reagent/medicine/synaptizine = 3)
-	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/lithium = 1, /datum/reagent/water = 1)
+	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/lithium = 1, /datum/reagent/water = 1, /datum/reagent/lemoline = 1)
 
 /datum/chemical_reaction/leporazine
 	name = "Leporazine"
@@ -163,7 +163,7 @@
 /datum/chemical_reaction/neuraline
 	name = "Neuraline"
 	results = list(/datum/reagent/medicine/neuraline = 4, /datum/reagent/toxin/huskpowder = 1)
-	required_reagents = list(/datum/reagent/medicine/synaptizine = 1, /datum/reagent/medicine/arithrazine = 1, /datum/reagent/medicine/tricordrazine = 2, /datum/reagent/consumable/larvajellyprepared = 1)
+	required_reagents = list(/datum/reagent/medicine/arithrazine = 1, /datum/reagent/medicine/tricordrazine = 2, /datum/reagent/consumable/larvajellyprepared = 1)
 
 /datum/chemical_reaction/lemoline
 	name = "Lemoline catalysis"
@@ -220,4 +220,4 @@
 /datum/chemical_reaction/stimulum
 	name = "Stimulum"
 	results = list(/datum/reagent/medicine/research/stimulon = 1)
-	required_reagents = list(/datum/reagent/medicine/synaptizine = 10, /datum/reagent/medicine/arithrazine = 20, /datum/reagent/consumable/nutriment = 20, /datum/reagent/medicine/lemoline = 20)
+	required_reagents = list(/datum/reagent/medicine/arithrazine = 20, /datum/reagent/consumable/nutriment = 20, /datum/reagent/medicine/lemoline = 20)

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -116,7 +116,7 @@
 /datum/chemical_reaction/synaptizine
 	name = "Synaptizine"
 	results = list(/datum/reagent/medicine/synaptizine = 3)
-	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/lithium = 1, /datum/reagent/water = 1, /datum/reagent/lemoline = 1)
+	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/lithium = 1, /datum/reagent/water = 1, /datum/reagent/medicine/lemoline = 1)
 
 /datum/chemical_reaction/leporazine
 	name = "Leporazine"

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -163,6 +163,7 @@
 /datum/chemical_reaction/neuraline
 	name = "Neuraline"
 	results = list(/datum/reagent/medicine/neuraline = 4, /datum/reagent/toxin/huskpowder = 1)
+	required_catalysts = list(/datum/reagent/medicine/lemoline = 5)
 	required_reagents = list(/datum/reagent/medicine/arithrazine = 1, /datum/reagent/medicine/tricordrazine = 2, /datum/reagent/consumable/larvajellyprepared = 1)
 
 /datum/chemical_reaction/lemoline

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -164,7 +164,6 @@
 	name = "Neuraline"
 	results = list(/datum/reagent/medicine/neuraline = 4, /datum/reagent/toxin/huskpowder = 1)
 	required_reagents = list(/datum/reagent/medicine/synaptizine = 1, /datum/reagent/medicine/arithrazine = 1, /datum/reagent/medicine/tricordrazine = 2, /datum/reagent/consumable/larvajellyprepared = 1)
-	required_catalysts = list(/datum/reagent/medicine/lemoline = 5)
 
 /datum/chemical_reaction/lemoline
 	name = "Lemoline catalysis"


### PR DESCRIPTION
## About The Pull Request
Removes lemoline from the recipes of:
Hyronolin
Ryetalyn
Neuraline (As a catalyst)

Removes Synap from all recipes requiring synap to make
## Why It's Good For The Game
Allows doctors and corpsmen to work together and make certain medication for the marine force giving marines that much needed teamwork like a well oiled machine while also letting doctor's make a few better chems and a bit more roundstart (if they even bother that is). Also neuraline requiring jelly AND lemoline is wack and lame despite the potential it has.
Recipes requiring synap and lemoline to make is also wack, so removing synap from said recipes seems fine.

Players doing things to help their team mates is good.
Sweaty powergamer making their own mixes so they can avoid having to rely on team members as much as physically possible is bad.
## Changelog
:cl:
del: Removes lemoline from Hyronolin and Ryetalyn recipes.
/:cl:
