### PR TITLE
Fixes backtanks staying attached when they shouldn't

### DIFF
--- a/code/datums/elements/deployable_item.dm
+++ b/code/datums/elements/deployable_item.dm
@@ -104,7 +104,7 @@
 
 	deployed_machine.update_icon_state()
 
-	item_to_deploy.forceMove(deployed_machine) //Moves the Item into the machine or structure
+	user.transferItemToLoc(item_to_deploy, deployed_machine, TRUE)
 	if(user)
 		item_to_deploy.balloon_alert(user, "Deployed!")
 

--- a/code/datums/elements/deployable_item.dm
+++ b/code/datums/elements/deployable_item.dm
@@ -104,9 +104,11 @@
 
 	deployed_machine.update_icon_state()
 
-	user.transferItemToLoc(item_to_deploy, deployed_machine, TRUE)
 	if(user)
 		item_to_deploy.balloon_alert(user, "Deployed!")
+		user.transferItemToLoc(item_to_deploy, deployed_machine, TRUE)
+	else
+		item_to_deploy.forceMove(deployed_machine)
 
 	ENABLE_BITFIELD(item_to_deploy.flags_item, IS_DEPLOYED)
 

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1151,7 +1151,8 @@
 			to_chat(user, span_notice("[new_mag] is empty!"))
 			return FALSE
 		var/flags_magazine_features = get_flags_magazine_features(new_mag)
-		if(flags_magazine_features && CHECK_BITFIELD(flags_magazine_features, MAGAZINE_WORN) && user && user.get_active_held_item() == new_mag)
+		if(flags_magazine_features && CHECK_BITFIELD(flags_magazine_features, MAGAZINE_WORN) && ((loc != user) || (new_mag.loc != user)))
+			to_chat(user, span_warning("You need to be carrying both [src] and [new_mag] to connect them!"))
 			return FALSE
 		if(get_magazine_reload_delay(new_mag) > 0 && user && !force)
 			to_chat(user, span_notice("You begin reloading [src] with [new_mag]."))


### PR DESCRIPTION
## About The Pull Request
Specifically, prevents loading a gun with a worn magazine (back tanks, minigun power packs) while you aren't carrying both the gun and the mag.
Causes flamethrowers to disconnect from a backtank when deployed as a sentry, they weren't leaving mob inventory correctly.
## Why It's Good For The Game
Fixes #12294 
Fixes #12097 
## Changelog
:cl:
fix: You can only attach a back-worn mag to a gun while you're carrying both
fix: Flamers will disconnect from a backtank when deployed as a sentry
/:cl:
