### PR TITLE
Kills chem grenade disassembly

### DIFF
--- a/code/game/objects/items/explosives/grenades/chem_grenade.dm
+++ b/code/game/objects/items/explosives/grenades/chem_grenade.dm
@@ -109,8 +109,8 @@
 			return
 
 	else if(stage == CG_READY && I.tool_behaviour == TOOL_WIRECUTTER && !active)
-		stage_change(CG_WIRED)
-		to_chat(user, span_notice("You unlock the [initial(name)] assembly."))
+		to_chat(user, span_notice("Patented marine-proof Dura-Cable prevents you from taking apart the grenade."))
+		return
 
 	else if(stage == CG_WIRED && I.tool_behaviour == TOOL_WRENCH)
 		if(length(beakers))


### PR DESCRIPTION

## About The Pull Request
Chem grenade production from scratch was disabled, but you could still take out the contents of available finished ones (engineering, janitorial) and replace it with your own mix.
## Why It's Good For The Game
Arbitrary chem grenades grotesquely OP.
## Changelog
:cl:
del: Removed repurposing existing chem grenades with a new payload.
/:cl:
