### PR TITLE
Prevents starting vali boosting while not awake

### DIFF
--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -243,6 +243,9 @@
 		if(resource_storage_current < resource_drain_amount)
 			wearer.balloon_alert(wearer, "Insufficient green blood to begin operation")
 			return
+		if(wearer.stat)
+			wearer.balloon_alert(wearer, "Not conscious")
+			return
 	boost_on = !boost_on
 	SEND_SIGNAL(src, COMSIG_CHEMSYSTEM_TOGGLED, boost_on)
 	if(!boost_on)


### PR DESCRIPTION

## About The Pull Request
As title. You can still disable it whenever, because automatic full necrosis if you get knocked out with it active would be too much
Wasn't sure between this option and checking incapacitated, but I thought starting it while stunned was probably alright.
## Why It's Good For The Game
Mostly because being able to self-apply crit heal chems is excessive, but in general being in crit should by and large disable you.
## Changelog
:cl:
balance: Vali boosting can't be toggled on while you're in crit
/:cl:
