### PR TITLE
Two synth head fixes

### DIFF
--- a/code/modules/mob/living/brain/brain.dm
+++ b/code/modules/mob/living/brain/brain.dm
@@ -19,3 +19,14 @@
 			death()
 		ghostize()
 	return ..()
+
+/mob/living/brain/ghost()
+	if(stat == DEAD)
+		ghostize(TRUE)
+		return
+
+	if(tgui_alert(src, "Are you sure you want to ghost?\n(You are alive, as much as a head can be. If you ghost, you won't be able to chat when you return unless someone revives you.)", "Ghost", list("Yes", "No")) != "Yes")
+		return
+
+	death()
+	ghostize(TRUE)

--- a/code/modules/organs/limb_objects.dm
+++ b/code/modules/organs/limb_objects.dm
@@ -120,6 +120,7 @@
 	if(H.mind)
 		H.mind.transfer_to(brainmob)
 	brainmob.container = src
+	brainmob.copy_known_languages_from(H, TRUE)
 
 //synthetic head, allowing brain mob inside to talk
 /obj/item/limb/head/synth


### PR DESCRIPTION

## About The Pull Request
Lets synth heads ghost without it counting as suicide, although it'll still kill them.
Heads inherit languages from the origin mobs (applies to nonsynths too, but they don't tend to have heads that can speak)
## Why It's Good For The Game
Fixes #12230 
Fixes #11732 
Fixes #11504 
## Changelog
:cl:
fix: Beheaded synths can ghost and return to their head later
fix: Beheaded mobs keep their old known languages
/:cl:
