### PR TITLE
Normal smoke extinguishes fire

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -209,7 +209,7 @@
 
 /obj/effect/particle_effect/smoke/bad
 	lifetime = 8
-	smoke_traits = SMOKE_NERF_BEAM|SMOKE_FOUL|SMOKE_COUGH|SMOKE_OXYLOSS
+	smoke_traits = SMOKE_NERF_BEAM|SMOKE_FOUL|SMOKE_COUGH|SMOKE_OXYLOSS|SMOKE_EXTINGUISH
 
 /////////////////////////////////////////////
 // Cloak Smoke


### PR DESCRIPTION

## About The Pull Request
Makes normal smoke nades (i.e. the one that completely blocks vision) extinguish fire.

Smoke extinguishing fire is a super niche mechanic, as it only exists with boiler neuro smoke and more recently sentinel primo nades.

This is basically only relevant for HvH, but its a handy and interesting mechanic if you remember it.
## Why It's Good For The Game
Adds more counterplay/interesting interactions for HvH
## Changelog
:cl:
balance: Standard smoke grenades now extinguish fire
/:cl:
