### PR TITLE
Polyhexanide bottle has 60 units

### DIFF
--- a/code/game/objects/items/reagent_containers/glass/bottle.dm
+++ b/code/game/objects/items/reagent_containers/glass/bottle.dm
@@ -216,7 +216,7 @@
 	name = "\improper Polyhexanide bottle"
 	desc = "A small bottle. Contains one and a half doses of polyhexanide, a sterilizer for internal surgical use."
 	icon_state = "bottle2"
-	list_reagents = list(/datum/reagent/medicine/polyhexanide = 30)
+	list_reagents = list(/datum/reagent/medicine/polyhexanide = 60)
 
 /obj/item/reagent_containers/glass/bottle/lemoline
 	name = "\improper Lemoline bottle"

--- a/code/game/objects/items/reagent_containers/glass/bottle.dm
+++ b/code/game/objects/items/reagent_containers/glass/bottle.dm
@@ -214,7 +214,7 @@
 
 /obj/item/reagent_containers/glass/bottle/polyhexanide
 	name = "\improper Polyhexanide bottle"
-	desc = "A small bottle. Contains one and a half doses of polyhexanide, a sterilizer for internal surgical use."
+	desc = "A small bottle. Contains polyhexanide - Used as a powerful sterilizer for internal surgical use."
 	icon_state = "bottle2"
 	list_reagents = list(/datum/reagent/medicine/polyhexanide = 60)
 


### PR DESCRIPTION

## About The Pull Request
Updates polyhexanide bottle to have 60 units of reagent.
## Why It's Good For The Game
Every other bottle in the Nanotrasen Medplus has 60 units, except polyhex. This looks like an oversight so I'm updating it to the match the other reagent bottles. This is hardly a balance change anyways since you can always just restock the bottles, this just aims at making it less tedious when transferring to pills.
## Changelog
:cl:
balance: Polyhexanide reagent bottles in the medplus contain 60 units like the other bottles in the vendor.
/:cl:
