### PR TITLE
Can't shoot main gun with MMB.

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -678,6 +678,8 @@
 	if(modifiers["shift"])
 		return
 
+	if(modifiers["middle"])
+		return
 	if(modifiers["right"])
 		modifiers -= "right"
 		params = list2params(modifiers)


### PR DESCRIPTION

## About The Pull Request
You can no longer shoot gun with MMB
## Why It's Good For The Game
Left click to shoot gun, right click to shoot attachment. Middle click should not be doing either of these things.
## Changelog
:cl:
del: Middle click no longer shoots gun.
/:cl:
