### PR TITLE
Fix prison camo being too effective for Jaeger Mk.I

### DIFF
--- a/code/modules/clothing/modular_armor/attachments.dm
+++ b/code/modules/clothing/modular_armor/attachments.dm
@@ -147,11 +147,20 @@
 
 	flags_attach_features = ATTACH_REMOVABLE|ATTACH_SAME_ICON|ATTACH_APPLY_ON_MOB
 
-	flags_item_map_variant = ITEM_JUNGLE_VARIANT|ITEM_ICE_VARIANT|ITEM_PRISON_VARIANT|ITEM_DESERT_VARIANT
+	flags_item_map_variant = ITEM_JUNGLE_VARIANT|ITEM_ICE_VARIANT|ITEM_DESERT_VARIANT
 	///List of icon_state suffixes for armor varients.
-	var/list/icon_state_variants = list()
+	var/list/icon_state_variants = list(
+		"black",
+		"jungle",
+		"desert",
+		"snow",
+		"alpha",
+		"bravo",
+		"charlie",
+		"delta",
+	)
 	///Current varient selected.
-	var/current_variant
+	var/current_variant = "black"
 
 /obj/item/armor_module/armor/update_icon()
 	. = ..()

--- a/code/modules/clothing/modular_armor/attachments/arm_plates.dm
+++ b/code/modules/clothing/modular_armor/attachments/arm_plates.dm
@@ -6,17 +6,6 @@
 	icon = 'icons/mob/modular/mark_one/arm_plates.dmi'
 	icon_state = "infantry"
 	slot = ATTACHMENT_SLOT_SHOULDER
-	current_variant = "black"
-	icon_state_variants = list(
-		"black",
-		"jungle",
-		"desert",
-		"snow",
-		"alpha",
-		"bravo",
-		"charlie",
-		"delta",
-	)
 
 /obj/item/armor_module/armor/arms/marine
 	name = "\improper Jaeger Pattern Infantry arm plates"

--- a/code/modules/clothing/modular_armor/attachments/chest_plates.dm
+++ b/code/modules/clothing/modular_armor/attachments/chest_plates.dm
@@ -7,17 +7,6 @@
 	icon = 'icons/mob/modular/mark_one/chest_plates.dmi'
 	icon_state = "infantry"
 	slot = ATTACHMENT_SLOT_CHESTPLATE
-	current_variant = "black"
-	icon_state_variants = list(
-		"black",
-		"jungle",
-		"desert",
-		"snow",
-		"alpha",
-		"bravo",
-		"charlie",
-		"delta",
-	)
 
 /obj/item/armor_module/armor/chest/marine
 	name = "\improper Jaeger Pattern Medium Infantry chestplates"

--- a/code/modules/clothing/modular_armor/attachments/leg_plates.dm
+++ b/code/modules/clothing/modular_armor/attachments/leg_plates.dm
@@ -6,17 +6,6 @@
 	icon = 'icons/mob/modular/mark_one/leg_plates.dmi'
 	icon_state = "infantry"
 	slot = ATTACHMENT_SLOT_KNEE
-	current_variant = "black"
-	icon_state_variants = list(
-		"black",
-		"jungle",
-		"desert",
-		"snow",
-		"alpha",
-		"bravo",
-		"charlie",
-		"delta",
-	)
 
 /obj/item/armor_module/armor/legs/marine
 	name = "\improper Jaeger Pattern Infantry leg plates"


### PR DESCRIPTION

## About The Pull Request
Jaeger Mk.I had some extremely advanced active urban camo, rendering it entirely invisible on prison station.
Marines have lost access to this amazing camo as they blew their budget on rainbow crayons.

Also cleaned up armour plate code a bit.
## Why It's Good For The Game
Bug fix good
## Changelog
:cl:
fix: fixed Jaeger Mk.I being invisible on prison station
/:cl:
