### PR TITLE
The flamer hydrocannon extinguishes the user.

### DIFF
--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -595,6 +595,7 @@ GLOBAL_LIST_EMPTY(flamer_particles)
 	for(var/mob/living/mob_caught in turf_to_ignite)
 		mob_caught.ExtinguishMob()
 	new /obj/effect/temp_visual/dir_setting/water_splash(turf_to_ignite, direction)
+	user.ExtinguishMob()
 
 /obj/item/weapon/gun/flamer/hydro_cannon/light_pilot(light)
 	return


### PR DESCRIPTION

## About The Pull Request
Makes the hydrocannon extinguish the user.
## Why It's Good For The Game
Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/11928
## Changelog
:cl:
fix: flamer hydrocannon extinguishes the user.
/:cl:
