### PR TITLE
Tweaks the Garand's reciever to eject clips after the final shot is fired.

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1757,7 +1757,7 @@
 	)
 
 	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER
-	reciever_flags = AMMO_RECIEVER_MAGAZINES|AMMO_RECIEVER_UNIQUE_ACTION_LOCKS|AMMO_RECIEVER_AUTO_EJECT
+	reciever_flags = AMMO_RECIEVER_MAGAZINES|AMMO_RECIEVER_AUTO_EJECT|AMMO_RECIEVER_CYCLE_ONLY_BEFORE_FIRE
 
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO)
 	attachable_offset = list("muzzle_x" = 40, "muzzle_y" = 19,"rail_x" = 9, "rail_y" = 22, "under_x" = 33, "under_y" = 16, "stock_x" = 0, "stock_y" = 11)


### PR DESCRIPTION

## About The Pull Request

Slightly tweaks the Garand's reciever code, removing a flag that didn't do anything, as it's intertwined with another define that the Garand lacks and replacing it with a flag that makes it's clip eject after the final round is fired.

This does, however mean you can't +1 the rifle.

## Why It's Good For The Game

I mean, it is a tad bit awkward to get the Garand Ping before it's actually empty. Though the PR isn't perfect, as you can't +1 it any more. But hey, if it doesn't get merged, at the very least attention will be brought to it!

## Changelog
:cl: Skye
fix: Removed a flag that doesn't do anything from the C1 Garand
fix: The Garand's clip now pings out after it's empty!
balance: ...And by extension the Garand cannot be +1ed. Sorry!
/:cl:
