### PR TITLE
FC Pistol buff, removes Mateba from FC loadout

### DIFF
--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -182,7 +182,7 @@ Make the TGMC proud!"})
 	r_store = /obj/item/storage/pouch/general/large/command
 	l_store = /obj/item/hud_tablet/fieldcommand
 	back = /obj/item/storage/backpack/marine/satchel
-	suit_store = /obj/item/storage/belt/gun/mateba/officer/full
+	suit_store = /obj/item/storage/belt/gun/pistol/m4a3/fieldcommander
 
 /datum/outfit/job/command/fieldcommander/rebel
 	jobtype = /datum/job/terragov/command/fieldcommander/rebel

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -428,7 +428,6 @@
 		/obj/item/armor_module/storage/uniform/black_vest = list(CAT_WEB, "Tactical black vest", 0, "black"),
 		/obj/item/armor_module/storage/uniform/webbing = list(CAT_WEB, "Tactical webbing", 0, "black"),
 		/obj/item/armor_module/storage/uniform/holster = list(CAT_WEB, "Shoulder handgun holster", 0, "black"),
-		/obj/item/storage/belt/gun/pistol/m4a3/fieldcommander = list(CAT_BEL, "1911-custom belt", 0, "black"),
 		/obj/item/storage/belt/marine = list(CAT_BEL, "Standard ammo belt", 0, "black"),
 		/obj/item/storage/belt/shotgun = list(CAT_BEL, "Shotgun ammo belt", 0, "black"),
 		/obj/item/storage/belt/knifepouch = list(CAT_BEL, "Knives belt", 0, "black"),

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -246,7 +246,8 @@
 		/obj/item/attachable/shoulder_mount,
 	)
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
-	fire_delay = 0.15 SECONDS
+	fire_delay = 0.1 SECONDS
+	damage_mult = 1.25
 
 //-------------------------------------------------------
 //P-22. Blocc

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -246,8 +246,8 @@
 		/obj/item/attachable/shoulder_mount,
 	)
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
-	fire_delay = 0.1 SECONDS
-	damage_mult = 1.25
+	fire_delay = 0.15 SECONDS
+	damage_mult = 1.3
 
 //-------------------------------------------------------
 //P-22. Blocc


### PR DESCRIPTION
## About The Pull Request
FC pistol is now snowflake cracked rather than bad sidegrade, it does 30% more damage.
FC no longer spawns with a mateba.
## Why It's Good For The Game
I don't know whoever gave FC a mateba, but the 1911 is their snowflake sidearm, Captain is the one with the Mateba and should probably start being that way again.
I haven't seen anyone use the custom pistol in ages, this should give it the snowflake power it needs to be good considering it has no autoeject.
## Changelog
:cl:
balance: FC no longer spawns with a Mateba belt, they instead spawn with their custom 1911.
balance: 1911 custom buffed,  it now does much more damage.
/:cl:
