### PR TITLE
Powerfist is easier to unload. No longer sends the user flying.

### DIFF
--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -36,7 +36,7 @@
 
 /obj/item/weapon/powerfist
 	name = "powerfist"
-	desc = "A metal gauntlet with a energy-powered fist to throw back enemies. Altclick to clamp it around your hand, use it to change power settings and screwdriver to pop out the cell."
+	desc = "A metal gauntlet with a energy-powered fist to throw back enemies. Altclick to clamp it around your hand, use it to change power settings and click with an empty off-hand or right click to pop out the cell."
 	icon_state = "powerfist"
 	item_state = "powerfist"
 	flags_equip_slot = ITEM_SLOT_BELT
@@ -101,16 +101,26 @@
 		return
 
 	var/powerused = setting * 20
-	if(powerused >= cell.charge)
+	if(powerused > cell.charge)
 		to_chat(user, span_warning("\The [src]'s cell doesn't have enough power!"))
 		M.apply_damage((force * 0.2), BRUTE, user.zone_selected, MELEE, penetration = src.penetration)
 		playsound(loc, 'sound/weapons/punch1.ogg', 50, TRUE)
-		M.visible_message(span_danger("[user]'s powerfist lets out a dull thunk as they punch [M.name]!"), \
-			span_userdanger("[user] punches you!"))
+		if(M == user)
+			user.visible_message(span_userdanger("You punch yourself!"))
+		else
+			M.visible_message(span_danger("[user]'s powerfist lets out a dull thunk as they punch [M.name]!"), \
+				span_userdanger("[user] punches you!"))
+		return ..()
+	if(M == user)
+		user.apply_damage(force * setting, BRUTE, user.zone_selected, MELEE, penetration = src.penetration)
+		user.visible_message(span_userdanger("You punch yourself!"))
+		playsound(loc, 'sound/weapons/energy_blast.ogg', 50, TRUE)
+		playsound(loc, 'sound/weapons/genhit2.ogg', 50, TRUE)
+		cell.charge -= powerused
 		return ..()
 	M.apply_damage(force * setting, BRUTE, user.zone_selected, MELEE, penetration = src.penetration)
 	M.visible_message(span_danger("[user]'s powerfist shudders as they punch [M.name], flinging them away!"), \
-		span_userdanger("You [user]'s punch flings you backwards!"))
+		span_userdanger("[user]'s punch flings you backwards!"))
 	playsound(loc, 'sound/weapons/energy_blast.ogg', 50, TRUE)
 	playsound(loc, 'sound/weapons/genhit2.ogg', 50, TRUE)
 	var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
@@ -130,21 +140,30 @@
 	user.transferItemToLoc(I,src)
 	cell = I
 	update_icon()
-	to_chat(user, span_notice("You insert the [I] into the [src]."))
+	user.balloon_alert(user, "Cell inserted")
 
-/obj/item/weapon/powerfist/screwdriver_act(mob/living/user, obj/item/I)
-	if(..())
-		return TRUE
+/obj/item/weapon/powerfist/attack_hand(mob/living/user)
+	if(!user.get_inactive_held_item(src))
+		return ..()
 	if(!cell)
-		to_chat(user, span_notice("There is no cell installed!"))
-		return TRUE
+		user.balloon_alert(user, "No cell")
+		return
 	unload(user)
-	to_chat(user, span_notice("You pop open the cover and remove the cell."))
-	return TRUE
+	user.balloon_alert(user, "Cell removed")
+	return
+
+/obj/item/weapon/powerfist/attack_hand_alternate(mob/living/user)
+	if(!cell)
+		user.balloon_alert(user, "No cell")
+		return
+	unload(user)
+	user.balloon_alert(user, "Cell removed")
+	return
 
 /// Remove the cell from the powerfist
 /obj/item/weapon/powerfist/proc/unload(mob/user)
-	user.dropItemToGround(cell)
+	if(!user.put_in_active_hand(cell))
+		user.dropItemToGround(cell)
 	cell = null
 	update_icon()
 	playsound(user, 'sound/weapons/guns/interact/rifle_reload.ogg', 25, TRUE)

--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -45,7 +45,6 @@
 	var/obj/item/cell/cell
 	///the higher the power level the harder it hits
 	var/setting = 1
-	var/powerused
 
 /obj/item/weapon/powerfist/Initialize()
 	. = ..()
@@ -62,7 +61,7 @@
 
 /obj/item/weapon/powerfist/examine(user)
 	. = ..()
-	powerused = setting * 20
+	var/powerused = setting * 20
 	. += "It's power setting is set to [setting]."
 	if(cell)
 		. += "It has [round(cell.charge/powerused, 1)] level [setting] punches remaining."
@@ -100,10 +99,10 @@
 	if(M.status_flags & INCORPOREAL || user.status_flags & INCORPOREAL) //Incorporeal beings cannot attack or be attacked
 		return
 
-	powerused = setting * 20
+	var/powerused = setting * 20
 	if(powerused > cell.charge)
 		to_chat(user, span_warning("\The [src]'s cell doesn't have enough power!"))
-		M.apply_damage((force * 0.2), BRUTE, user.zone_selected, MELEE, penetration = src.penetration)
+		M.apply_damage((force * 0.2), BRUTE, user.zone_selected, MELEE)
 		playsound(loc, 'sound/weapons/punch1.ogg', 50, TRUE)
 		if(M == user)
 			to_chat(user, span_userdanger("You punch yourself!"))
@@ -112,13 +111,13 @@
 				span_userdanger("[user] punches you!"))
 		return ..()
 	if(M == user)
-		user.apply_damage(force * setting, BRUTE, user.zone_selected, MELEE, penetration = src.penetration)
+		user.apply_damage(force * setting, BRUTE, user.zone_selected, MELEE)
 		to_chat(user, span_userdanger("You punch yourself!"))
 		playsound(loc, 'sound/weapons/energy_blast.ogg', 50, TRUE)
 		playsound(loc, 'sound/weapons/genhit2.ogg', 50, TRUE)
 		cell.charge -= powerused
 		return ..()
-	M.apply_damage(force * setting, BRUTE, user.zone_selected, MELEE, penetration = src.penetration)
+	M.apply_damage(force * setting, BRUTE, user.zone_selected, MELEE)
 	M.visible_message(span_danger("[user]'s powerfist shudders as they punch [M.name], flinging them away!"), \
 		span_userdanger("[user]'s punch flings you backwards!"))
 	playsound(loc, 'sound/weapons/energy_blast.ogg', 50, TRUE)

--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -45,6 +45,7 @@
 	var/obj/item/cell/cell
 	///the higher the power level the harder it hits
 	var/setting = 1
+	var/powerused
 
 /obj/item/weapon/powerfist/Initialize()
 	. = ..()
@@ -61,9 +62,10 @@
 
 /obj/item/weapon/powerfist/examine(user)
 	. = ..()
+	powerused = setting * 20
 	. += "It's power setting is set to [setting]."
 	if(cell)
-		. += "It has [cell.charge] power remaining."
+		. += "It has [round(cell.charge/powerused, 1)] level [setting] punches remaining."
 	else
 		. += "There is no cell installed!"
 
@@ -90,8 +92,6 @@
 		to_chat(user, span_notice("You feel the [src] loosen around your hand!"))
 		playsound(user, 'sound/weapons/fistunclamp.ogg', 25, 1, 7)
 
-
-
 /obj/item/weapon/powerfist/attack(mob/living/carbon/M, mob/living/carbon/user)
 	if(!cell)
 		to_chat(user, span_warning("\The [src] can't operate without a source of power!"))
@@ -100,20 +100,20 @@
 	if(M.status_flags & INCORPOREAL || user.status_flags & INCORPOREAL) //Incorporeal beings cannot attack or be attacked
 		return
 
-	var/powerused = setting * 20
+	powerused = setting * 20
 	if(powerused > cell.charge)
 		to_chat(user, span_warning("\The [src]'s cell doesn't have enough power!"))
 		M.apply_damage((force * 0.2), BRUTE, user.zone_selected, MELEE, penetration = src.penetration)
 		playsound(loc, 'sound/weapons/punch1.ogg', 50, TRUE)
 		if(M == user)
-			user.visible_message(span_userdanger("You punch yourself!"))
+			to_chat(user, span_userdanger("You punch yourself!"))
 		else
 			M.visible_message(span_danger("[user]'s powerfist lets out a dull thunk as they punch [M.name]!"), \
 				span_userdanger("[user] punches you!"))
 		return ..()
 	if(M == user)
 		user.apply_damage(force * setting, BRUTE, user.zone_selected, MELEE, penetration = src.penetration)
-		user.visible_message(span_userdanger("You punch yourself!"))
+		to_chat(user, span_userdanger("You punch yourself!"))
 		playsound(loc, 'sound/weapons/energy_blast.ogg', 50, TRUE)
 		playsound(loc, 'sound/weapons/genhit2.ogg', 50, TRUE)
 		cell.charge -= powerused


### PR DESCRIPTION
## About The Pull Request
You no longer need a screwdriver to unload the powerfist. Click it with off-hand while holding it or right click it.
Powerfist no longer sends you flying if you accidentally (or intentionally) punch yourself.
Powerfist can now use up the entire cell worth of charge (So you can punch 10x on level 3 instead of 9 times which was a bug)
Powerfist description is better:
![image](https://user-images.githubusercontent.com/66163761/222996360-fb78bd15-4839-4cf0-bf54-89c5c9aeb6a8.png)
![image](https://user-images.githubusercontent.com/66163761/222996365-e7ff91cf-cf33-4be6-9db2-42a8a23647f7.png)

## Why It's Good For The Game
Makes powerfist less janky to unload (why screwdriver???).
![image](https://user-images.githubusercontent.com/66163761/222993453-1da4f7f8-4fbe-462d-a07f-6636a7ecc651.png)
## Changelog
:cl:
add: Powerfist cell is easier to remove.
add: Powerfist description is better.
del: You can no send yourself flying with your own powerfist.
fix: powerfist cell can properly reach 0 charge.
/:cl:
