### PR TITLE
Hugger overlay fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -24,6 +24,7 @@
 	flags_atom = CRITICAL_ATOM
 	flags_item = NOBLUDGEON
 	throw_range = 1
+	worn_layer = FACEHUGGER_LAYER
 	layer = FACEHUGGER_LAYER
 
 	///Whether the hugger is dead, active or inactive


### PR DESCRIPTION

## About The Pull Request

Fixes facehugger layer being under helmet, which makes them impossible to spot.

## Why It's Good For The Game

Fix good, less confusing situations.

Before :
![dreamseeker_cr4Wy1m9hm](https://user-images.githubusercontent.com/100090741/223032415-806ca955-49b2-4025-92b8-58ac00d9450a.png)

After : 
![dreamseeker_51JNv0xBPq](https://user-images.githubusercontent.com/100090741/223032455-b8580070-7df6-41e5-b8a6-678652259511.png)

## Changelog

:cl:
add: facehugger above helmet layer rendering
/:cl:
