### PR TITLE
Survivors are back.

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -83,7 +83,10 @@
 				list(/obj/item/weapon/gun/smg/m25, /obj/item/ammo_magazine/smg/m25),\
 				list(/obj/item/weapon/gun/rifle/m16, /obj/item/ammo_magazine/rifle/m16),\
 				list(/obj/item/weapon/gun/shotgun/pump/bolt, /obj/item/ammo_magazine/rifle/bolt),\
-				list(/obj/item/weapon/gun/shotgun/pump/lever, /obj/item/ammo_magazine/packet/magnum))
+				list(/obj/item/weapon/gun/shotgun/pump/lever, /obj/item/ammo_magazine/packet/magnum),\
+				list(/obj/item/weapon/gun/shotgun/pump/lever/repeater, /obj/item/ammo_magazine/packet/p4570),\
+				list(/obj/item/weapon/gun/rifle/garand, /obj/item/ammo_magazine/rifle/garand),\
+				list(/obj/item/ammo_magazine/smg/ppsh, /obj/item/ammo_magazine/smg/ppsh/extended))
 
 
 #define LATEJOIN_LARVA_DISABLED 0

--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -23,6 +23,7 @@
 		/datum/job/terragov/squad/smartgunner = 1,
 		/datum/job/terragov/squad/leader = 1,
 		/datum/job/terragov/squad/standard = -1,
+		/datum/job/survivor/rambo = 1,
 		/datum/job/xenomorph = FREE_XENO_AT_START,
 		/datum/job/xenomorph/queen = 1
 	)

--- a/code/datums/jobs/job/survivor.dm
+++ b/code/datums/jobs/job/survivor.dm
@@ -47,6 +47,8 @@
 			to_chat(M, span_notice("You are a survivor of the attack on the outpost. But you question yourself: are you truely safe now?"))
 		if(MAP_MAGMOOR_DIGSITE)
 			to_chat(M, span_notice("You are a survivor of the attack on the Magmoor Digsite IV. You worked or lived on the digsite, and managed to avoid the alien attacks... until now."))
+		if(MAP_GELIDA_IV)
+			to_chat(M, span_notice("You are a survivor of the attack on the Gelida IV. You've worked or lived on this outpost and have managed to avoid the alien attacks... until now."))
 		else
 			to_chat(M, span_notice("Through a miracle you managed to survive the attack. But are you truly safe now?"))
 

--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -227,12 +227,15 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 /datum/skills/civilian/survivor/master
 	name = "Survivor"
 	firearms = SKILL_FIREARMS_DEFAULT
-	medical = SKILL_MEDICAL_EXPERT
-	surgery = SKILL_SURGERY_EXPERT
-	construction = SKILL_CONSTRUCTION_MASTER
-	engineer = SKILL_ENGINEER_MASTER
+	medical = SKILL_MEDICAL_COMPETENT
+	surgery = SKILL_SURGERY_TRAINED
+	construction = SKILL_CONSTRUCTION_ADVANCED
+	engineer = SKILL_ENGINEER_ENGI
 	powerloader = SKILL_POWERLOADER_MASTER
 	police = SKILL_POLICE_FLASH
+	cqc = SKILL_CQC_MP
+	melee_weapons = SKILL_MELEE_TRAINED
+
 
 /datum/skills/civilian/survivor/doctor
 	name = "Survivor Doctor"
@@ -626,7 +629,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	surgery = SKILL_SURGERY_PROFESSIONAL
 
 /datum/skills/imperial/astartes
-	name = "Space Marine" 
+	name = "Space Marine"
 	cqc = SKILL_CQC_MASTER
 	melee_weapons = SKILL_MELEE_SUPER
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -188,7 +188,7 @@
 	var/obj/item/weapon/gun/holstered = null
 	flags_armor_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	flags_item = SYNTH_RESTRICTED
-	slowdown = 0
+	slowdown = 0.5
 	soft_armor = list(MELEE = 50, BULLET = 40, LASER = 40, ENERGY = 40, BOMB = 50, BIO = 40, FIRE = 50, ACID = 50)
 	siemens_coefficient = 0.7
 


### PR DESCRIPTION

## About The Pull Request
Title.

Survs no longer have the best of all skills and most have been toned down to marine specialisation equivalent.
Survs have slightly better CQC and Melee skills.

Following aims have been addressed:
Prevent rush ✔
Xenos now have RTS instant build. (If you get rushed with this, I simply have no words).

No gamer gear ✔
Slowdown added to armour. Some new weapons are also added for flavour, but apart from repeater, they're not exactly gamer gear.

No noob traps ✔
Most map reworks have removed noob traps.
Magmoor no longer has lava land but rather a lake or something but its somewhat harder to cheese and can be addressed if needed.

A non-killing Xeno objective ✔
Survivors can have a jump start on disks now that nukewar is the sole gamemode. Further objectives can be added later.
## Why It's Good For The Game
Survs were fun and now are more challenging than ever.
Xenos have RTS build, the ability to build structures like acid turrets, mat towers and silos will refund the points survivors add passively unlike its hunt counterpart. On top of that survs give larva points for joining AND getting drained/cocooned if they fail to kill any Xenos, which will be most likely.

If anything, survs might need further buffs/qols or objectives to focus on but this feels like a good starting point.
## Changelog
:cl:
add: Survivor is now pickable again
add: Adds repeater, garand and Ppsh to survivor rng starting guns.
balance: Adds slowdown to survivor armor
balance: Lowers survivor medic and engi skills to match squad corpsmen and engineers.
balance: Gives survivors slightly better CQC and Melee skills.
/:cl:
