### PR TITLE
white dress jacket can now carry instruments and sword/sword holsters

### DIFF
--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -170,6 +170,13 @@
 	icon_state = "white_dress_jacket" //with thanks to Baystation12
 	item_state = "white_dress_jacket" //with thanks to Baystation12
 
+	allowed = list(
+		/obj/item/instrument,
+		/obj/item/storage/holster/blade,
+		/obj/item/weapon/claymore,
+		/obj/item/weapon/twohanded,
+	)
+
 
 /obj/item/clothing/suit/straight_jacket
 	name = "straight jacket"


### PR DESCRIPTION

## About The Pull Request
![image](https://user-images.githubusercontent.com/46353991/223129809-27d17cd6-b33d-4770-9cab-e3ddada773a2.png)
## Why It's Good For The Game
Makes white dress able to carry something. It holds less than real armor, but instruments and blades are fine I would say.
## Changelog
:cl:
balance: white dress jacket can now hold instruments, swords+sword holsters.
/:cl:
