### PR TITLE
Fixed king stagger interaction

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
@@ -57,11 +57,11 @@
 	REMOVE_TRAIT(owner, TRAIT_STAGGER_RESISTANT, XENO_TRAIT)
 	ADD_TRAIT(owner, TRAIT_IMMOBILE, PETRIFY_ABILITY_TRAIT)
 
-	if(!do_after(owner, PETRIFY_WINDUP_TIME, FALSE, owner, BUSY_ICON_DANGER))
+	if(!do_after(owner, PETRIFY_WINDUP_TIME, FALSE, owner, BUSY_ICON_DANGER, extra_checks = CALLBACK(src, .proc/can_use_action, FALSE, XACT_USE_BUSY)))
 		flick("eye_closing", eye)
 		addtimer(CALLBACK(src, .proc/remove_eye, eye), 7, TIMER_CLIENT_TIME)
 		finish_charging()
-		add_cooldown(5 SECONDS)
+		add_cooldown(10 SECONDS)
 		return fail_activate()
 
 	finish_charging()
@@ -211,7 +211,7 @@
 	if(!do_after(owner, SHATTERING_ROAR_CHARGE_TIME, TRUE, owner, BUSY_ICON_DANGER, extra_checks = CALLBACK(src, .proc/can_use_action, FALSE, XACT_USE_BUSY)))
 		owner.balloon_alert(owner, "interrupted!")
 		finish_charging()
-		add_cooldown(5 SECONDS)
+		add_cooldown(10 SECONDS)
 		return fail_activate()
 
 	finish_charging()
@@ -364,12 +364,12 @@
 	REMOVE_TRAIT(owner, TRAIT_STAGGER_RESISTANT, XENO_TRAIT)
 	ADD_TRAIT(owner, TRAIT_IMMOBILE, ZERO_FORM_BEAM_ABILITY_TRAIT)
 
-	if(!do_after(owner, ZEROFORM_CHARGE_TIME, FALSE, owner, BUSY_ICON_DANGER))
+	if(!do_after(owner, ZEROFORM_CHARGE_TIME, FALSE, owner, BUSY_ICON_DANGER, extra_checks = CALLBACK(src, .proc/can_use_action, FALSE, XACT_USE_BUSY)))
 		QDEL_NULL(beam)
 		QDEL_NULL(particles)
 		targets = null
 		REMOVE_TRAIT(owner, TRAIT_IMMOBILE, ZERO_FORM_BEAM_ABILITY_TRAIT)
-		add_cooldown(5 SECONDS)
+		add_cooldown(10 SECONDS)
 		return fail_activate()
 
 	REMOVE_TRAIT(owner, TRAIT_IMMOBILE, ZERO_FORM_BEAM_ABILITY_TRAIT)
@@ -488,7 +488,7 @@
 		sister.add_filter("summonoutline", 2, outline_filter(1, COLOR_VIOLET))
 
 	if(!do_after(X, 10 SECONDS, FALSE, X, BUSY_ICON_HOSTILE))
-		add_cooldown(3 SECONDS)
+		add_cooldown(5 SECONDS)
 		for(var/mob/living/carbon/xenomorph/sister AS in allxenos)
 			sister.remove_filter("summonoutline")
 		return fail_activate()


### PR DESCRIPTION

## About The Pull Request
Fixed stagger not applying against king in some instances where it should be.
King is vulnerable to projectile based stagger when channeling abilities, but the way it was actually checking for stagger was inconsistant.

Also increases the penalty cooldowns for getting interrupted, to make it a bit more beneficial outside of cancel itself.
## Why It's Good For The Game
Bug fix good.
Interrupt more rewarding
## Changelog
:cl:
fix: King is now consistantly vulnerable to stagger when channeling abilities
balance: Interrupting a king while channeling now put the ability on cooldown for 10 seconds instead of 5
/:cl:
