### PR TITLE
Radial preference fix

### DIFF
--- a/code/modules/client/preferences_ui.dm
+++ b/code/modules/client/preferences_ui.dm
@@ -116,8 +116,8 @@
 			.["show_typing"] = show_typing
 			.["tooltips"] = tooltips
 			.["widescreenpref"] = widescreenpref
-			.["radialmedicalpref"] = toggles_gameplay & RADIAL_MEDICAL
-			.["radialstackspref"] = toggles_gameplay & RADIAL_STACKS
+			.["radialmedicalpref"] = ((toggles_gameplay & RADIAL_MEDICAL) ? 1 : 0)
+			.["radialstackspref"] = ((toggles_gameplay & RADIAL_STACKS) ? 1 : 0)
 			.["scaling_method"] = scaling_method
 			.["pixel_size"] = pixel_size
 			.["parallax"] = parallax

--- a/code/modules/client/preferences_ui.dm
+++ b/code/modules/client/preferences_ui.dm
@@ -116,8 +116,8 @@
 			.["show_typing"] = show_typing
 			.["tooltips"] = tooltips
 			.["widescreenpref"] = widescreenpref
-			.["radialmedicalpref"] = ((toggles_gameplay & RADIAL_MEDICAL) ? 1 : 0)
-			.["radialstackspref"] = ((toggles_gameplay & RADIAL_STACKS) ? 1 : 0)
+			.["radialmedicalpref"] = !!(toggles_gameplay & RADIAL_MEDICAL)
+			.["radialstackspref"] = !!(toggles_gameplay & RADIAL_STACKS)
 			.["scaling_method"] = scaling_method
 			.["pixel_size"] = pixel_size
 			.["parallax"] = parallax


### PR DESCRIPTION

## About The Pull Request
Fixes the radial preferences for construction stacks and medical stuff. Medical stuff worked purely due to jank, but the construction stack visually did not show if you had it toggled on.
## Why It's Good For The Game
Bug fix good.
## Changelog
:cl:
fix: fixed the preference for radial construction not actually showing when it was enabled
/:cl:
