### PR TITLE
RL72 no longer vends empty in valhalla.

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1493,7 +1493,6 @@
 			/obj/item/weapon/gun/minigun/smart_minigun = -1,
 			/obj/item/ammo_magazine/minigun_powerpack/smartgun = -1,
 			/obj/item/weapon/gun/launcher/rocket/oneuse = -1,
-			/obj/item/ammo_magazine/rocket/oneuse = -1,
 			/obj/item/storage/belt/gun/mateba/full = -1,
 			/obj/item/ammo_magazine/revolver/mateba = -1,
 			/obj/item/ammo_magazine/packet/mateba = -1,

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -608,9 +608,7 @@
 		playsound(src, vending_sound, 25, 0)
 	else
 		playsound(src, "vending", 25, 0)
-	if(ispath(R.product_path,/obj/item/weapon/gun/launcher/rocket/oneuse))
-		return new R.product_path(get_turf(src))
-	else if(ispath(R.product_path,/obj/item/weapon/gun))
+	if(ispath(R.product_path,/obj/item/weapon/gun))
 		return new R.product_path(get_turf(src), 1)
 	else
 		return new R.product_path(get_turf(src))

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -608,10 +608,7 @@
 		playsound(src, vending_sound, 25, 0)
 	else
 		playsound(src, "vending", 25, 0)
-	if(ispath(R.product_path,/obj/item/weapon/gun))
-		return new R.product_path(get_turf(src), 1)
-	else
-		return new R.product_path(get_turf(src))
+	return new R.product_path(get_turf(src))
 
 
 /obj/machinery/vending/MouseDrop_T(atom/movable/A, mob/user)

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -608,7 +608,12 @@
 		playsound(src, vending_sound, 25, 0)
 	else
 		playsound(src, "vending", 25, 0)
-	return new R.product_path(get_turf(src))
+	if(ispath(R.product_path,/obj/item/weapon/gun/launcher/rocket/oneuse))
+		return new R.product_path(get_turf(src))
+	else if(ispath(R.product_path,/obj/item/weapon/gun))
+		return new R.product_path(get_turf(src), 1)
+	else
+		return new R.product_path(get_turf(src))
 
 
 /obj/machinery/vending/MouseDrop_T(atom/movable/A, mob/user)

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -765,6 +765,9 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	recoil = 3
 	scatter = -100
 
+/obj/item/weapon/gun/launcher/rocket/oneuse/Initialize(mapload, spawn_empty)
+	. = ..(mapload, FALSE)
+
 // Do a short windup, swap the extension status of the rocket if successful, then swap the flags.
 /obj/item/weapon/gun/launcher/rocket/oneuse/unique_action(mob/living/user)
 	playsound(user, 'sound/weapons/guns/misc/oneuse_deploy.ogg', 25, 1)


### PR DESCRIPTION
## About The Pull Request
RL72 no longer vends empty from the vendor.
RL72 ammo removed (You can't reload this thing)
## Why It's Good For The Game
Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/12019
## Changelog
:cl:
fix: RL72 is no longer broken in valhalla
/:cl:
