### PR TITLE
Sentinel Drain sting shows up in end-round stats.

### DIFF
--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -440,6 +440,8 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.weeds_destroyed] weed tiles removed."
 	if(GLOB.round_statistics.trap_holes)
 		parts += "[GLOB.round_statistics.trap_holes] holes for acid and huggers were made."
+	if(GLOB.round_statistics.sentinel_drain_stings)
+		parts += "[GLOB.round_statistics.sentinel_drain_stings] number of times sentinel drain sting was used."
 	if(GLOB.round_statistics.sentinel_neurotoxin_stings)
 		parts += "[GLOB.round_statistics.sentinel_neurotoxin_stings] number of times neurotoxin sting was used."
 	if(GLOB.round_statistics.defiler_defiler_stings)

--- a/code/datums/round_statistics.dm
+++ b/code/datums/round_statistics.dm
@@ -63,6 +63,7 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	var/queen_screech = 0
 	var/now_pregnant = 0
 	var/sentinel_drain_stings = 0
+	var/sentinel_neurotoxin_stings = 0
 	var/ozelomelyn_stings = 0
 	var/defiler_defiler_stings = 0
 	var/defiler_neurogas_uses = 0

--- a/code/datums/round_statistics.dm
+++ b/code/datums/round_statistics.dm
@@ -62,7 +62,7 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	var/rocket_shells_fired = 0
 	var/queen_screech = 0
 	var/now_pregnant = 0
-	var/sentinel_neurotoxin_stings = 0
+	var/sentinel_drain_stings = 0
 	var/ozelomelyn_stings = 0
 	var/defiler_defiler_stings = 0
 	var/defiler_neurogas_uses = 0

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -189,6 +189,7 @@
 	debuff.stacks -= round(debuff.stacks * 0.7)
 	succeed_activate()
 	add_cooldown()
+	GLOB.round_statistics.sentinel_drain_stings++
 
 /datum/action/xeno_action/activable/drain_sting/on_cooldown_finish()
 	playsound(owner.loc, 'sound/voice/alien_drool1.ogg', 50, 1)

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -190,6 +190,7 @@
 	succeed_activate()
 	add_cooldown()
 	GLOB.round_statistics.sentinel_drain_stings++
+	SSblackbox.record_feedback("tally", "round_statistics", 1, "sentinel_drain_stings")
 
 /datum/action/xeno_action/activable/drain_sting/on_cooldown_finish()
 	playsound(owner.loc, 'sound/voice/alien_drool1.ogg', 50, 1)


### PR DESCRIPTION

## About The Pull Request
Adds Sentinel drain sting to round stats.
## Why It's Good For The Game
I like stats.
## Changelog
:cl:
add: Sentinel Drain Sting shows up in post-round stats.
/:cl:
