### PR TITLE
Ozelomelyn Sting is now a tracked ability in stats.

### DIFF
--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -442,6 +442,8 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.trap_holes] holes for acid and huggers were made."
 	if(GLOB.round_statistics.sentinel_neurotoxin_stings)
 		parts += "[GLOB.round_statistics.sentinel_neurotoxin_stings] number of times neurotoxin sting was used."
+	if(GLOB.round_statistics.ozelomelyn_stings)
+		parts += "[GLOB.round_statistics.ozelomelyn_stings] number of times ozelomelyn sting was used."
 	if(GLOB.round_statistics.defiler_defiler_stings)
 		parts += "[GLOB.round_statistics.defiler_defiler_stings] number of times Defilers stung."
 	if(GLOB.round_statistics.defiler_neurogas_uses)

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1036,7 +1036,8 @@
 
 	track_stats()
 
-/datum/action/xeno_action/activable/neurotox_sting/track_stats()
+///Adds ability tally to the end-round statistics.
+/datum/action/xeno_action/activable/neurotox_sting/proc/track_stats()
 	GLOB.round_statistics.sentinel_neurotoxin_stings++
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "sentinel_neurotoxin_stings")
 
@@ -1053,6 +1054,7 @@
 	plasma_cost = 100
 	sting_chemical = /datum/reagent/toxin/xeno_ozelomelyn
 
+///Adds ability tally to the end-round statistics.
 /datum/action/xeno_action/activable/neurotox_sting/ozelomelyn/track_stats()
 	GLOB.round_statistics.ozelomelyn_stings++
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "ozelomelyn_stings")

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1034,12 +1034,11 @@
 	add_cooldown()
 	X.recurring_injection(A, sting_chemical, XENO_NEURO_CHANNEL_TIME, XENO_NEURO_AMOUNT_RECURRING)
 
-	if(type == /datum/action/xeno_action/activable/neurotox_sting)
-		GLOB.round_statistics.sentinel_neurotoxin_stings++
-		SSblackbox.record_feedback("tally", "round_statistics", 1, "sentinel_neurotoxin_stings")
-	if(type == /datum/action/xeno_action/activable/neurotox_sting/ozelomelyn)
-		GLOB.round_statistics.ozelomelyn_stings++
-		SSblackbox.record_feedback("tally", "round_statistics", 1, "ozelomelyn_stings")
+	track_stats()
+
+/datum/action/xeno_action/activable/neurotox_sting/track_stats()
+	GLOB.round_statistics.sentinel_neurotoxin_stings++
+	SSblackbox.record_feedback("tally", "round_statistics", 1, "sentinel_neurotoxin_stings")
 
 //Ozelomelyn Sting
 /datum/action/xeno_action/activable/neurotox_sting/ozelomelyn
@@ -1053,6 +1052,10 @@
 	)
 	plasma_cost = 100
 	sting_chemical = /datum/reagent/toxin/xeno_ozelomelyn
+
+/datum/action/xeno_action/activable/neurotox_sting/ozelomelyn/track_stats()
+	GLOB.round_statistics.ozelomelyn_stings++
+	SSblackbox.record_feedback("tally", "round_statistics", 1, "ozelomelyn_stings")
 
 // ***************************************
 // *********** Psychic Whisper

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1032,11 +1032,14 @@
 	succeed_activate()
 
 	add_cooldown()
-
-	GLOB.round_statistics.sentinel_neurotoxin_stings++
-	SSblackbox.record_feedback("tally", "round_statistics", 1, "sentinel_neurotoxin_stings")
-
 	X.recurring_injection(A, sting_chemical, XENO_NEURO_CHANNEL_TIME, XENO_NEURO_AMOUNT_RECURRING)
+
+	if(name == "Neurotoxin Sting")
+		GLOB.round_statistics.sentinel_neurotoxin_stings++
+		SSblackbox.record_feedback("tally", "round_statistics", 1, "sentinel_neurotoxin_stings")
+	else
+		GLOB.round_statistics.ozelomelyn_stings++
+		SSblackbox.record_feedback("tally", "round_statistics", 1, "ozelomelyn_stings")
 
 //Ozelomelyn Sting
 /datum/action/xeno_action/activable/neurotox_sting/ozelomelyn
@@ -1050,7 +1053,6 @@
 	)
 	plasma_cost = 100
 	sting_chemical = /datum/reagent/toxin/xeno_ozelomelyn
-
 
 // ***************************************
 // *********** Psychic Whisper

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1034,10 +1034,10 @@
 	add_cooldown()
 	X.recurring_injection(A, sting_chemical, XENO_NEURO_CHANNEL_TIME, XENO_NEURO_AMOUNT_RECURRING)
 
-	if(name == "Neurotoxin Sting")
+	if(type == /datum/action/xeno_action/activable/neurotox_sting)
 		GLOB.round_statistics.sentinel_neurotoxin_stings++
 		SSblackbox.record_feedback("tally", "round_statistics", 1, "sentinel_neurotoxin_stings")
-	else
+	if(type == /datum/action/xeno_action/activable/neurotox_sting/ozelomelyn)
 		GLOB.round_statistics.ozelomelyn_stings++
 		SSblackbox.record_feedback("tally", "round_statistics", 1, "ozelomelyn_stings")
 


### PR DESCRIPTION

## About The Pull Request
Makes the amount of Ozelomelyn stings be tracked in the end-round screen.
## Why It's Good For The Game
I like stats.
## Changelog
:cl:
add: Ozelomelyn Sting is now a tallied ability.
/:cl:
