### PR TITLE
crusher multiplier against mech is now 375 rather than 240

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -411,7 +411,7 @@
 	return (CHARGE_SPEED(charge_datum) * 10)
 
 /obj/vehicle/sealed/mecha/pre_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
-	return (CHARGE_SPEED(charge_datum) * 240)
+	return (CHARGE_SPEED(charge_datum) * 375)
 
 /obj/structure/razorwire/pre_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
 	if(CHECK_BITFIELD(resistance_flags, INDESTRUCTIBLE) || charger.is_charging < CHARGE_ON)


### PR DESCRIPTION

## About The Pull Request
240->375 mutliplier for damage, makes mechs take much more damage from getting hit by a crusher.
## Why It's Good For The Game
The damage is piddly considering the average mech has around 1400~ hp. This makes charges at lower speeds more dangerous while making high speed charges very lethal.
## Changelog
:cl:
balance: Mechs take much more damage from crusher charges, now.
/:cl:
