### PR TITLE
Mech sniper changes, slashes damage in half, adds reverse falloff, ups pen a bit.

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1114,10 +1114,10 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/bullet/sniper/mech
 	name = "light anti-tank bullet"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING|AMMO_SNIPER|AMMO_IFF
-	damage = 100
-	penetration = 35
+	damage = 50
+	penetration = 45
 	sundering = 0
-	damage_falloff = 0.3
+	damage_falloff = -2.5
 
 /*
 //================================================


### PR DESCRIPTION

## About The Pull Request
Mech sniper stats are 50/45 and with -2.5 falloff, meaning it gains damage per tile.
## Why It's Good For The Game
Mech sniper rework that ideally aims to make the gun an actual sniper rather than a IFF DMR you use in combo with other high damage weapons to just one shot people randomly, the reverse falloff isn't actually as insane as it seems as at 21 tiles you only deal like, 100 damage.
## Changelog
:cl:
balance; Mech sniper reworked, slashed base damage in half, upped penetration by a bit. It now uses reverse falloff meaning it gains damage per tile rather than lose any.
/:cl:
