### PR TITLE
Mech pilot skill and larva strength changes

### DIFF
--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -375,7 +375,7 @@ Though you are a warrant officer, your authority is limited to the dropship and 
 	job_points_needed = 40
 	job_points = 15
 	jobworth = list(
-		/datum/job/xenomorph = LARVA_POINTS_SHIPSIDE,
+		/datum/job/xenomorph = LARVA_POINTS_REGULAR,
 		/datum/job/terragov/squad/smartgunner = SMARTIE_POINTS_REGULAR,
 	)
 	html_description = {"

--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -391,7 +391,8 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 
 /datum/skills/mech_pilot
 	name = MECH_PILOT
-	engineer = SKILL_ENGINEER_ENGI
+	engineer = SKILL_ENGINEER_METAL
+	construction = SKILL_CONSTRUCTION_METAL
 	powerloader = SKILL_POWERLOADER_PRO
 	large_vehicle = SKILL_LARGE_VEHICLE_TRAINED
 
@@ -626,7 +627,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	surgery = SKILL_SURGERY_PROFESSIONAL
 
 /datum/skills/imperial/astartes
-	name = "Space Marine" 
+	name = "Space Marine"
 	cqc = SKILL_CQC_MASTER
 	melee_weapons = SKILL_MELEE_SUPER
 


### PR DESCRIPTION

## About The Pull Request
Drops MP engi skill to 1 from 3, gives them construction 1, making them fumble and take longer to repair their ride.
Larva strength upped from shipside strength to regular strength.
## Why It's Good For The Game
Mech pilots are far too self sufficent, and should look for engineers to repair them in the frontlines rather than doing it themselves, the construction part is because it'd be weird for them to know how to repair cades but not make them as well as encouraging more emergent use of your skillset outside the mech.

Larva strength is just an oversight fix..
## Changelog
:cl:
balance; Mech pilots are equal larva strength to a Squad Marine, previously they were worth the same as a Shipside role, so less.
balance; Mech pilot engineering skill nerfed to 1 from 3, added 1 construction skill.
/:cl:
