### PR TITLE
Increased the chance for robotic arms to drop stuff if their arm is malfunctioning

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -928,7 +928,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			owner.emote("me", 1, "[(owner.species && owner.species.species_flags & NO_PAIN) ? "" : emote_scream ] drops what [owner.p_they()] [owner.p_were()] holding in their [hand_name]!")
 			return
 	if(is_malfunctioning())
-		if(prob(5))
+		if(prob(20))
 			owner.dropItemToGround(c_hand)
 			owner.emote("me", 1, "drops what they were holding, [owner.p_their()] [hand_name] malfunctioning!")
 			new /datum/effect_system/spark_spread(owner, owner, 5, 0, TRUE, 1 SECONDS)


### PR DESCRIPTION

## About The Pull Request

Increases the chance per tick to drop the thing youre holding from 5% to 20% if you have a robotic limb.

(For reference the chance for a normal arm to drop is 15%)
## Why It's Good For The Game

Robot arms cannot fracture, which is a big upside, so they shouldn't get less impact from their arm being hurt on top of that. This also makes robotic limbs have some sort of tradeoff for their unbreakability.
## Changelog
:cl:
balance: Increased the chance for robotic arms to drop stuff if their arm is malfunctioning
/:cl:
