### PR TITLE
ALF improvements

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1511,7 +1511,6 @@
 	aim_slowdown = 0.3
 	wield_delay = 0.4 SECONDS
 	damage_falloff_mult = 3
-	damage_mult = 1.05
 
 	movement_acc_penalty_mult = 4
 

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1490,7 +1490,7 @@
 	allowed_ammo_types = list(/obj/item/ammo_magazine/rifle/alf_machinecarbine)
 	attachable_allowed = list(
 		/obj/item/attachable/flashlight,
-		/obj/item/attachable/foldable/bipod,
+		/obj/item/attachable/flashlight/under,
 		/obj/item/attachable/verticalgrip,
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/heavy_barrel,
@@ -1505,14 +1505,13 @@
 
 	fire_delay = 0.2 SECONDS
 	burst_delay = 0.1 SECONDS
-	extra_delay = 0.5 SECONDS
-	///Same delay as normal burst mode
-	autoburst_delay = 0.7 SECONDS
+	extra_delay = 0.2 SECONDS
 	scatter = 4
 	burst_amount = 4
 	aim_slowdown = 0.3
 	wield_delay = 0.4 SECONDS
 	damage_falloff_mult = 3
+	damage_mult = 1.05
 
 	movement_acc_penalty_mult = 4
 

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -339,7 +339,7 @@
 	desc = "A box magazine for the ALF-51B machinecarbine."
 	icon_state = "t60"
 	caliber = CALIBER_10X25_CASELESS
-	default_ammo = /datum/ammo/bullet/rifle/heavy
+	default_ammo = /datum/ammo/bullet/rifle/som_machinegun
 	w_class = WEIGHT_CLASS_NORMAL
 	max_rounds = 80
 	reload_delay = 1 SECONDS


### PR DESCRIPTION
## About The Pull Request
Improved ALF performance, reduced extra burst delay to 0.2 from 0.5 (for reference T18 has an extra delay of 0.1)
Changed the projectile to the SOM MG bullet. This has the same damage, slightly more AP, less sunder, but does 0.5 slowdown on hit.

The ALF has a triple damage falloff multiplier, or 6 times higher than almost all rifles, which means its damage becomes utterly terrible after just a few tiles. The very long burst delay also made it somewhat punishing to use on top of having a rather low rate of fire, so both of these things combined to make the ALF an extremely terrible gun in terms of damage (some like less than half the dps of a T12 even at close range). 

This is in addition to having a 1 second reload time and no underbarrel weapon options. So it being called a CQC king is kinda funny when its just generally quite bad.

After these changes the ALF will still have lower DPS then a T18 outside of actual PB range, but will now server well at closing the distance with a bit of slowdown, to actually bring its damage to bear.

Also removed the bipod option because there is precisely zero reason you'd ever want to bipod it, and added the underbarrel flashlight because why not.
## Why It's Good For The Game
Less garbage gun good.
## Changelog
:cl:
balance: Improved ALF burst fire rate
balance: ALF now inflicts small amounts of slowdown on hit, and has slightly better AP but worse sunder
/:cl:
