### PR TITLE
Disables resin wall weeds

### DIFF
--- a/code/controllers/subsystem/weeds.dm
+++ b/code/controllers/subsystem/weeds.dm
@@ -78,6 +78,8 @@ SUBSYSTEM_DEF(weeds)
 		return
 	var/obj/alien/weeds/weed_to_spawn = node.weed_type
 	var/swapped = FALSE
+	if(iswallturf(T))
+		weed_to_spawn = /obj/alien/weeds/weedwall
 	for (var/obj/O in T)
 		if(istype(O, /obj/structure/window/framed))
 			weed_to_spawn = /obj/alien/weeds/weedwall/window

--- a/code/controllers/subsystem/weeds.dm
+++ b/code/controllers/subsystem/weeds.dm
@@ -78,8 +78,6 @@ SUBSYSTEM_DEF(weeds)
 		return
 	var/obj/alien/weeds/weed_to_spawn = node.weed_type
 	var/swapped = FALSE
-	if(iswallturf(T))
-		weed_to_spawn = /obj/alien/weeds/weedwall
 	for (var/obj/O in T)
 		if(istype(O, /obj/structure/window/framed))
 			weed_to_spawn = /obj/alien/weeds/weedwall/window

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -216,6 +216,23 @@
 		return ..()
 	return WF.MouseDrop_T(dropping, user)
 
+/obj/alien/weeds/weedwall/frame/specialclick(mob/living/carbon/user)
+	var/obj/structure/window_frame/WF = locate() in loc
+	if(!WF)
+		return ..()
+	return WF.specialclick(user)
+
+/obj/alien/weeds/weedwall/frame/attackby(obj/item/I, mob/user, params) //yes, this blocks attacking the weed itself, but if you destroy the frame you destroy the weed!
+	var/obj/structure/window_frame/WF = locate() in loc
+	if(!WF)
+		return ..()
+	return WF.attackby(I, user, params)
+
+/obj/alien/weeds/weedwall/frame/attack_alien(mob/living/carbon/xenomorph/X, damage_amount, damage_type, damage_flag, effects, armor_penetration, isrightclick)
+	var/obj/structure/window_frame/WF = locate() in loc
+	if(!WF)
+		return ..()
+	return WF.attack_alien(X, damage_amount, damage_type, damage_flag, effects, armor_penetration, isrightclick)
 
 // =================
 // weed node - grows other weeds

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -529,6 +529,12 @@
 /turf/proc/is_weedable()
 	return !density
 
+/turf/closed/wall/is_weedable()
+	return TRUE
+
+/turf/closed/wall/resin/is_weedable()
+	return FALSE
+
 /turf/open/space/is_weedable()
 	return FALSE
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -529,9 +529,6 @@
 /turf/proc/is_weedable()
 	return !density
 
-/turf/closed/wall/is_weedable()
-	return TRUE
-
 /turf/open/space/is_weedable()
 	return FALSE
 


### PR DESCRIPTION
## About The Pull Request

Disables weeds crawling up resin walls after being planted.

Also makes your clicks with weapons, ctrl clicks and xeno attacks on the weed transfer directly to the window frame it's on so you don't have to pixel hunt.

## Why It's Good For The Game

The weeds cause issues with visibility.

Also pixel hunting is not fun.

![image](https://user-images.githubusercontent.com/22431091/224192299-b30106a2-aa88-440e-89ef-5760d2d1ea81.png)
![image](https://user-images.githubusercontent.com/22431091/224192481-c0fbe43e-6ae6-49df-a79e-923efbb49280.png)
## Changelog
:cl:
del: Disabled wall weeds
/:cl:
