### PR TITLE
Fixes some questionable boiler glob behavior

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3249,7 +3249,8 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 
 /datum/ammo/xeno/boiler_gas/on_hit_mob(mob/living/victim, obj/projectile/proj)
-	drop_nade(get_turf(proj), proj.firer)
+	var/turf/target_turf = get_turf(victim)
+	drop_nade(target_turf.density ? get_turf(proj) : target_turf, proj.firer)
 
 	if(!istype(victim) || victim.stat == DEAD || victim.issamexenohive(proj.firer))
 		return


### PR DESCRIPTION
## About The Pull Request
I'm sure you know this, a boiler glob splats you (or your target if you are the boiler), but the gas appears multiple tiles away from it. This is because /mob hits for boiler globs are the only type of target where it does not trigger gas on the target's turf, but on the projectile's, as opposed to turfs / objects / etc, which is sometimes unreliable, more so when TD is high.
This resolves that and should make direct hits always create the gas on the hit target's tile, especially when at high TD.
## Why It's Good For The Game
Fix man good.
## Changelog
:cl:
fix: boiler glob direct hits should more reliably deposit their gas on the target's tile
/:cl:
