### PR TITLE
More Xeno abilities have stagger immunity. More can be used while resting.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -6,7 +6,7 @@
 	name = "Rest"
 	action_icon_state = "resting"
 	desc = "Rest on weeds to regenerate health and plasma."
-	use_state_flags = XACT_USE_LYING|XACT_USE_CRESTED|XACT_USE_AGILITY|XACT_USE_CLOSEDTURF
+	use_state_flags = XACT_USE_LYING|XACT_USE_CRESTED|XACT_USE_AGILITY|XACT_USE_CLOSEDTURF|XACT_USE_STAGGERED //Can use this while staggered
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_REST,
 	)
@@ -30,7 +30,7 @@
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_DROP_WEEDS,
 		KEYBINDING_ALTERNATE = COMSIG_XENOABILITY_CHOOSE_WEEDS,
 	)
-	use_state_flags = XACT_USE_LYING
+	use_state_flags = XACT_USE_LYING| XACT_USE_STAGGERED //Can use this while staggered
 	///the maximum range of the ability
 	var/max_range = 0
 	///The seleted type of weeds
@@ -811,7 +811,7 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_XENO_SPIT,
 	)
-	use_state_flags = XACT_USE_LYING|XACT_USE_BUCKLED|XACT_DO_AFTER_ATTACK
+	use_state_flags = XACT_USE_LYING|XACT_USE_BUCKLED|XACT_DO_AFTER_ATTACK|XACT_USE_STAGGERED //Can use this while staggered
 	target_flags = XABB_MOB_TARGET
 	///Current target that the xeno is targeting. This is for aiming.
 	var/current_target

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -30,7 +30,7 @@
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_DROP_WEEDS,
 		KEYBINDING_ALTERNATE = COMSIG_XENOABILITY_CHOOSE_WEEDS,
 	)
-	use_state_flags = XACT_USE_LYING| XACT_USE_STAGGERED //Can use this while staggered
+	use_state_flags = XACT_USE_LYING|XACT_USE_STAGGERED
 	///the maximum range of the ability
 	var/max_range = 0
 	///The seleted type of weeds
@@ -811,7 +811,7 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_XENO_SPIT,
 	)
-	use_state_flags = XACT_USE_LYING|XACT_USE_BUCKLED|XACT_DO_AFTER_ATTACK|XACT_USE_STAGGERED //Can use this while staggered
+	use_state_flags = XACT_USE_LYING|XACT_USE_BUCKLED|XACT_DO_AFTER_ATTACK|XACT_USE_STAGGERED
 	target_flags = XABB_MOB_TARGET
 	///Current target that the xeno is targeting. This is for aiming.
 	var/current_target

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -811,7 +811,7 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_XENO_SPIT,
 	)
-	use_state_flags = XACT_USE_LYING|XACT_USE_BUCKLED|XACT_DO_AFTER_ATTACK|XACT_USE_STAGGERED
+	use_state_flags = XACT_USE_LYING|XACT_USE_BUCKLED|XACT_DO_AFTER_ATTACK
 	target_flags = XABB_MOB_TARGET
 	///Current target that the xeno is targeting. This is for aiming.
 	var/current_target

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -116,6 +116,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_PLACE_TRAP,
 	)
+	use_state_flags = XACT_USE_LYING //Can use this while resting
 
 /datum/action/xeno_action/place_trap/can_use_action(silent = FALSE, override_flags)
 	. = ..()
@@ -157,7 +158,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_SPAWN_HUGGER,
 	)
-	use_state_flags = XACT_USE_LYING
+	use_state_flags = XACT_USE_LYING|XACT_USE_STAGGERED
 
 /datum/action/xeno_action/spawn_hugger/on_cooldown_finish()
 	to_chat(owner, span_xenodanger("We can now spawn another young one."))
@@ -195,7 +196,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_DROP_ALL_HUGGER,
 	)
-	use_state_flags = XACT_USE_LYING
+	use_state_flags = XACT_USE_LYING|XACT_USE_STAGGERED //Can use this while staggered
 
 /datum/action/xeno_action/carrier_panic/give_action(mob/living/L)
 	. = ..()
@@ -251,7 +252,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_CHOOSE_HUGGER,
 		KEYBINDING_ALTERNATE = COMSIG_XENOABILITY_SWITCH_HUGGER,
 	)
-	use_state_flags = XACT_USE_LYING
+	use_state_flags = XACT_USE_LYING|XACT_USE_STAGGERED //Can use this while staggered
 
 /datum/action/xeno_action/choose_hugger_type/give_action(mob/living/L)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
@@ -23,6 +23,7 @@
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_ESSENCE_LINK,
 		KEYBINDING_ALTERNATE = COMSIG_XENOABILITY_ESSENCE_LINK_REMOVE,
 	)
+	use_state_flags = XACT_USE_LYING
 	/// Used to determine whether there is an existing Essence Link or not. Also allows access to its vars.
 	var/datum/status_effect/stacking/essence_link/existing_link
 	/// The target of an existing link, if applicable.

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -231,6 +231,7 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_CREATE_JELLY,
 	)
+	use_state_flags = XACT_USE_LYING
 
 /datum/action/xeno_action/create_jelly/can_use_action(silent = FALSE, override_flags)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
@@ -135,6 +135,7 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_CREATE_SPIDERLING,
 	)
+	use_state_flags = XACT_USE_LYING|XACT_USE_STAGGERED //Can use this while staggered
 	/// List of all our spiderlings
 	var/list/mob/living/carbon/xenomorph/spiderling/spiderlings = list()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
@@ -135,7 +135,7 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_CREATE_SPIDERLING,
 	)
-	use_state_flags = XACT_USE_LYING|XACT_USE_STAGGERED //Can use this while staggered
+	use_state_flags = XACT_USE_LYING
 	/// List of all our spiderlings
 	var/list/mob/living/carbon/xenomorph/spiderling/spiderlings = list()
 


### PR DESCRIPTION
## About The Pull Request
Resting, planting weeds and mainly Xeno spits have the stagger immune trait.
Abilities like spawning huggers, making resin traps, jelly and creating spiderlings can be used while resting.
## Why It's Good For The Game
Some nice QOLs for Xenos to make stuff while resting.

Stagger should stop Xenos from using more useful and higher impact abilities rather than basic ones. I'd lop spits in with resting and weed planting with this. This should also make stagger feel less oppressive and slightly easier to balance in the forseeable future as the biggest issue with stagger spam is also the ability to make Xenos unable to unrest and permacuck ranged castes out of spits.

Panic hugger should be stagger immune for a 'panic' ability.
## Changelog
:cl:
qol: Drone and Hivelord can create jelly while resting.
qol: Drone can essence link while resting.
qol: Carrier can place traps while resting.
qol: Widow can create spiderling while resting.
balance: Xenos can unrest/rest and plant weeds while staggered.
balance: Xenos can spit while staggered.
balance: Carrier can choose hugger types and can spawn huggers (not throw) while staggered.
balance: Carrier can panic hugger while staggered.
/:cl:
