### PR TITLE
Brings back MMB for special abilities

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -676,11 +676,11 @@
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"])
 		return
-		
+
 if(modifiers["right"] || modifiers["middle"])
 		modifiers -= "right"
 		modifiers -= "middle"
-		
+
 		params = list2params(modifiers)
 		active_attachable?.start_fire(source, object, location, control, params, bypass_checks)
 		return

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -677,10 +677,9 @@
 	if(modifiers["shift"])
 		return
 
-if(modifiers["right"] || modifiers["middle"])
+	if(modifiers["right"] || modifiers["middle"])
 		modifiers -= "right"
 		modifiers -= "middle"
-
 		params = list2params(modifiers)
 		active_attachable?.start_fire(source, object, location, control, params, bypass_checks)
 		return

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -676,11 +676,11 @@
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"])
 		return
-
-	if(modifiers["middle"])
-		return
-	if(modifiers["right"])
+		
+if(modifiers["right"] || modifiers["middle"])
 		modifiers -= "right"
+		modifiers -= "middle"
+		
 		params = list2params(modifiers)
 		active_attachable?.start_fire(source, object, location, control, params, bypass_checks)
 		return


### PR DESCRIPTION
## About The Pull Request

In #12282, middle-click was removed as a means to use underbarrel weapons, or for abilities in general. This PR returns things to the way they previously were. 
<sub>(OF NOTE:) 12282 could not be reverted due to recent changes, this PR was made as a result. </sub>

## Why It's Good For The Game

Middle-mouse is used by a large chunk of the community for abilities. A function of this caliber being completely removed is disruptive and does more harm than good. For those who use right click primarily; imagine if it were removed at the drop of a hat. This is no different. 

In a **_very_** specific context, MMB would cause a player wearing a jetpack to fly into the fire produced from their underbarrel flamer. I find this to be more of a skill issue than a mechanical bug above all else. At a minimum, I don't think removing the ability to use MMB in it's _fucking entirety_ is the right way to go about things.

## Changelog

:cl:
code: MMB returns as an ability key.
/:cl: