### PR TITLE
Helmet module and suit light hotkeys

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -821,6 +821,8 @@
 #define COMSIG_KB_AIMMODE "keybinding_aimmode"
 #define COMSIG_KB_FIREMODE "keybind_firemode"
 #define COMSIG_KB_GIVE "keybind_give"
+#define COMSIG_KB_HELMETMODULE "keybinding_helmetmodule"
+#define COMSIG_KB_SUITLIGHT "keybinding_suitlight"
 #define COMSIG_KB_MOVEORDER "keybind_moveorder"
 #define COMSIG_KB_HOLDORDER "keybind_holdorder"
 #define COMSIG_KB_FOCUSORDER "keybind_focusorder"

--- a/code/datums/actions/item_action.dm
+++ b/code/datums/actions/item_action.dm
@@ -55,6 +55,9 @@
 	name = "Toggle [target]"
 	button.name = name
 
+/datum/action/item_action/toggle/suit_toggle
+	keybinding_signals = list(KEYBINDING_NORMAL = COMSIG_KB_SUITLIGHT)
+
 /datum/action/item_action/toggle/suit_toggle/update_button_icon()
 	set_toggle(holder_item.light_on)
 	return ..()

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -92,6 +92,20 @@
 	description = ""
 	keybind_signal = COMSIG_KB_SUITANALYZER
 
+/datum/keybinding/human/toggle_helmet_module
+	hotkey_keys = list("h")
+	name = "toggle_helmet_module"
+	full_name = "Toggle helmet module"
+	description = "Toggles your helmet module on or off"
+	keybind_signal = COMSIG_KB_HELMETMODULE
+
+/datum/keybinding/human/toggle_suit_light
+	hotkey_keys = list("l")
+	name = "toggle_suit_light"
+	full_name = "Toggle suit light"
+	description = "Toggles your suit light on or off"
+	keybind_signal = COMSIG_KB_SUITLIGHT
+
 /datum/keybinding/human/move_order
 	name = "move_order"
 	full_name = "Issue Move Order"

--- a/code/modules/clothing/modular_armor/attachments.dm
+++ b/code/modules/clothing/modular_armor/attachments.dm
@@ -59,6 +59,9 @@
 	///Starting attachments that are spawned with this.
 	var/list/starting_attachments = list()
 
+	///The signal for this module if it can toggled
+	var/toggle_signal
+
 /obj/item/armor_module/Initialize()
 	. = ..()
 	AddElement(/datum/element/attachment, slot, attach_icon, on_attach, on_detach, null, can_attach, pixel_shift_x, pixel_shift_y, flags_attach_features, attach_delay, detach_delay, mob_overlay_icon = mob_overlay_icon, mob_pixel_shift_x = mob_pixel_shift_x, mob_pixel_shift_y = mob_pixel_shift_y, attachment_layer = attachment_layer)
@@ -109,6 +112,8 @@
 		return
 	LAZYADD(actions_types, /datum/action/item_action/toggle)
 	var/datum/action/item_action/toggle/new_action = new(src)
+	if(toggle_signal)
+		new_action.keybinding_signals = list(KEYBINDING_NORMAL = toggle_signal)
 	new_action.give_action(user)
 
 /obj/item/armor_module/ui_action_click(mob/user, datum/action/item_action/toggle/action)
@@ -129,7 +134,6 @@
 /obj/item/armor_module/proc/extra_examine(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 	examine_list += "Right click [parent] with paint to color [src]"
-
 
 /**
  *  These are the basic type for modules with set variant icons.

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -476,6 +476,7 @@
 	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION|ATTACH_APPLY_ON_MOB
 	active = FALSE
 	prefered_slot = SLOT_HEAD
+	toggle_signal = COMSIG_KB_HELMETMODULE
 	///Mod for extra eye protection when activated.
 	var/eye_protection_mod = 2
 
@@ -546,6 +547,7 @@
 	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION|ATTACH_APPLY_ON_MOB
 	slot = ATTACHMENT_SLOT_HEAD_MODULE
 	prefered_slot = SLOT_HEAD
+	toggle_signal = COMSIG_KB_HELMETMODULE
 
 /obj/item/armor_module/module/binoculars/activate(mob/living/user)
 	zoom(user)
@@ -604,6 +606,7 @@
 	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION|ATTACH_APPLY_ON_MOB
 	slot = ATTACHMENT_SLOT_HEAD_MODULE
 	prefered_slot = SLOT_HEAD
+	toggle_signal = COMSIG_KB_HELMETMODULE
 	/// Reference to the datum used by the supply drop console
 	var/datum/supply_beacon/beacon_datum
 


### PR DESCRIPTION

## About The Pull Request
Adds hotkeys for helmet modules and for suit lights (this includes the suicide vest toggle).

![image](https://user-images.githubusercontent.com/7869430/224526031-8ed96187-d16a-4551-8e4b-11f79addb9d9.png)

It should be straight forwards to add hotkeys to toggleable armour modules in the future if they get added.
## Why It's Good For The Game
Hotkeys good.
## Changelog
:cl:
qol: Added hotkeys for helmet modules and suit lights
/:cl:
