### PR TITLE
Balances vial, small and large beakers.

### DIFF
--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -10,7 +10,7 @@
 	icon_state = "null"
 	item_state = "null"
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,15,20,30,45,60,120)
+	possible_transfer_amounts = list(5,10,15,20,30,40,60,120)
 	volume = 120
 	init_reagent_flags = OPENCONTAINER
 
@@ -127,7 +127,7 @@
 
 /obj/item/reagent_containers/glass/beaker
 	name = "beaker"
-	desc = "A beaker. Can hold up to 90 units."
+	desc = "A beaker. Can hold up to 120 units."
 	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "beaker"
 	item_state = "beaker"

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -10,8 +10,8 @@
 	icon_state = "null"
 	item_state = "null"
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,15,20,30,45,90)
-	volume = 90
+	possible_transfer_amounts = list(5,10,15,20,30,45,60,120)
+	volume = 120
 	init_reagent_flags = OPENCONTAINER
 
 	var/label_text = ""
@@ -175,11 +175,12 @@
 
 /obj/item/reagent_containers/glass/beaker/large
 	name = "large beaker"
-	desc = "A large beaker. Can hold up to 120 units."
+	desc = "A large beaker. Can hold up to 240 units."
 	icon_state = "beakerlarge"
-	volume = 120
+	w_class = WEIGHT_CLASS_NORMAL
+	volume = 240
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,15,20,30,40,60,120)
+	possible_transfer_amounts = list(5,10,15,20,30,40,60,120,240)
 
 /obj/item/reagent_containers/glass/beaker/noreact
 	name = "cryostasis beaker"

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -10,8 +10,8 @@
 	icon_state = "null"
 	item_state = "null"
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,15,20,30,60)
-	volume = 60
+	possible_transfer_amounts = list(5,10,15,20,30,45,90)
+	volume = 90
 	init_reagent_flags = OPENCONTAINER
 
 	var/label_text = ""
@@ -127,7 +127,7 @@
 
 /obj/item/reagent_containers/glass/beaker
 	name = "beaker"
-	desc = "A beaker. Can hold up to 60 units."
+	desc = "A beaker. Can hold up to 90 units."
 	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "beaker"
 	item_state = "beaker"
@@ -199,11 +199,12 @@
 
 /obj/item/reagent_containers/glass/beaker/vial
 	name = "vial"
-	desc = "A small glass vial. Can hold up to 30 units."
+	desc = "A tiny glass vial. Can hold up to 60 units."
 	icon_state = "vial"
-	volume = 30
+	volume = 60
+	w_class = WEIGHT_CLASS_TINY
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,15,25)
+	possible_transfer_amounts = list(5,10,15,20,30,60)
 
 /obj/item/reagent_containers/glass/beaker/cryoxadone
 	list_reagents = list(/datum/reagent/medicine/cryoxadone = 30)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Buffs beakers to hold 120 units
Buffs vials to hold 60 units
Buffs vials to be w_class tiny, they fit in helmets and hold the same amount of liquid as a combat canteen.
Makes large beakers larger, but hold more reagent.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Vials and small beakers are literally just downgrades to large beakers. This change intends on giving each one it's own purpose.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Vials are smaller, hold 60u.
balance: Small beakers hold more reagent 120u.
balance: Large beakers are bigger and hold 240u.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
