### PR TITLE
Adds 3 more slots to hypospray belt.

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -306,7 +306,7 @@
 	desc = "The M276 is the standard load-bearing equipment of the TGMC. It consists of a modular belt with various clips. This version is a less common configuration, designed to transport hyposprays and reagent containers."
 	icon_state = "hypospraybelt"
 	item_state = "medicbag"
-	storage_slots = 18
+	storage_slots = 21
 	max_storage_space = 42
 	max_w_class = 2
 	can_hold = list(


### PR DESCRIPTION
## About The Pull Request
Adds 3 more slots to the hypospray belt.
## Why It's Good For The Game
Hypospray belt has 42 storage, but only holds w_class 2 and 18 slots, meaning it can only reach 36 weight held. This makes it objectively the worst medical belt in the game. This rectifies that.
![image](https://user-images.githubusercontent.com/66163761/224594207-4c87de0b-bc61-434e-9120-d49686f90a45.png)
## Changelog
:cl:
balance: Hypospray belt can hold 3 more slots. 
/:cl:
