### PR TITLE
PPSH can't attach bipod.

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -354,7 +354,6 @@
 		/obj/item/attachable/angledgrip,
 		/obj/item/attachable/gyro,
 		/obj/item/attachable/lasersight,
-		/obj/item/attachable/foldable/bipod,
 	)
 
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
It's a SMG and meant to be a mobile gun.
Makes no sense.
Less exploitable till fix comes out.
## Changelog
:cl:
balance: PPSH can't attach bipod.
/:cl:
