### PR TITLE
Fixes and enhances escape objectives

### DIFF
--- a/code/datums/gamemodes/objective.dm
+++ b/code/datums/gamemodes/objective.dm
@@ -75,12 +75,28 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
  * Escaped includes minds with alive, non-exiled mobs generally.
  */
 
-/proc/considered_escaped(datum/mind/escapee)
+/proc/considered_escaped(datum/mind/escapee, admin_override = FALSE)
 	if(!considered_alive(escapee))
 		return FALSE
 	//if(SSticker.force_ending) // Just let them win.
 		//return TRUE
-	var/area/current_area = get_area(escapee)
+	var/area/current_area = get_area(escapee.current)
+	var/list/allowed_areas = list(
+		/area/shuttle/ert/pmc,
+		/area/shuttle/big_ert,
+		/area/shuttle/ert/ufo,
+		/area/shuttle/ert/upp,
+		/area/shuttle/pod_1,
+		/area/shuttle/pod_2,
+		/area/shuttle/pod_3,
+		/area/shuttle/pod_4,
+		/area/shuttle/escape_pod,
+	)
+	if(admin_override)
+		if(is_mainship_level(escapee.current.z))
+			return FALSE
+		if(current_area.type in allowed_areas) // Ship only
+			return TRUE
 	if(!current_area)
 		return FALSE
 	if(!istype(current_area, /area/shuttle/escape_pod)) //have to escape in a pod or escape shuttle, at least for the time being
@@ -213,25 +229,33 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 	name = "escape"
 	explanation_text = "Escape on a shuttle or an escape pod alive and without being in custody."
 	team_explanation_text = "Have all members of your team escape on a shuttle or pod alive, without being in custody."
+	///passed to considered_escaped, if true allows greentext by simply being on a shuttle not on ship level by round end
+	var/admin_event = FALSE
 
 /datum/objective/escape/check_completion()
-	if(!considered_escaped(owner))
+	if(!considered_escaped(owner, admin_event))
 		return FALSE
 	return TRUE
 
 /datum/objective/escape/find_target(dupe_search_range, blacklist)
 	return
 
+/datum/objective/escape/admin_edit(mob/admin)
+	if(tgui_alert(admin, "Relax escape requirements (recommended for admin events)?", "Continue?", list("Yes", "No")) != "No")
+		admin_event = TRUE
+
 /datum/objective/escape_with
 	name = "kidnap"
 	explanation_text = "Have both you and your target escape alive and unharmed on a shuttle or pod."
 	team_explanation_text = "Have both you and your target escape alive and unharmed on a shuttle or pod."
 	avoid_double_target = TRUE
+	///passed to considered_escaped, if true allows greentext by simply being on a shuttle not on ship level by round end
+	var/admin_event = FALSE
 
 /datum/objective/escape_with/check_completion()
-	if(!considered_escaped(owner))
+	if(!considered_escaped(owner, admin_event))
 		return FALSE
-	if(!considered_escaped(target))
+	if(!considered_escaped(target, admin_event))
 		return FALSE
 	for(var/mob/M in range(4)) //enough to cover the entirety of an escape shuttle
 		if(M.mind == null)
@@ -251,6 +275,8 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 
 /datum/objective/escape_with/admin_edit(mob/admin)
 	admin_simple_target_pick(admin)
+	if(tgui_alert(admin, "Relax escape requirements (recommended for admin events)?", "Continue?", list("Yes", "No")) != "No")
+		admin_event = TRUE
 
 /datum/objective/survive
 	name = "survive"


### PR DESCRIPTION

## About The Pull Request

Currently to receive greentext for an escape objective, you have to be in the shuttle during the evac process and escape. This check does not work, so I fixed it.

In the process I added an extra option for admins, it loosens the restrictions on escaping and allows for completion of the goal as long as the person is just in an escape shuttle/pod/ert ship and not on mainship level. This is probably better than forcing admins to force all the escape procedures for the sake of an event.

## Why It's Good For The Game

Bugs bad. QOL improvements so admins don't have to initiate SD and force escape pods every time they assign escape objectives good.

## Changelog
:cl:
qol: Created an option for admins to loosen the success requirements for the escape objective.
fix: Fixed the escape objective not completing successfully.
/:cl:
