### PR TITLE
Buffs and QoL improvements to large water and fuel tanks

### DIFF
--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -62,7 +62,7 @@
 	desc = "A watertank"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "watertank"
-	obj_integrity = 200
+	max_integrity = 200
 	amount_per_transfer_from_this = 500
 	possible_transfer_amounts = list(10, 25, 50, 100, 500)
 	tank_volume = 10000
@@ -74,7 +74,7 @@
 	desc = "A fueltank"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "weldtank"
-	obj_integrity = 200
+	max_integrity = 200
 	amount_per_transfer_from_this = 500
 	possible_transfer_amounts = list(10, 25, 50, 100, 500)
 	tank_volume = 10000

--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -62,17 +62,24 @@
 	desc = "A watertank"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "watertank"
-	amount_per_transfer_from_this = 10
-	list_reagents = list(/datum/reagent/water = 1000)
-
-
+	obj_integrity = 200
+	amount_per_transfer_from_this = 500
+	possible_transfer_amounts = list(10, 25, 50, 100, 500)
+	tank_volume = 10000
+	list_reagents = list(/datum/reagent/water = 10000)
+	drag_delay = 0
 
 /obj/structure/reagent_dispensers/fueltank
 	name = "fueltank"
 	desc = "A fueltank"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "weldtank"
-	list_reagents = list(/datum/reagent/fuel = 1000)
+	obj_integrity = 200
+	amount_per_transfer_from_this = 500
+	possible_transfer_amounts = list(10, 25, 50, 100, 500)
+	tank_volume = 10000
+	list_reagents = list(/datum/reagent/fuel = 10000)
+	drag_delay = 0
 	///Whether this tank is modded to drip fuel when its moved
 	var/modded = FALSE
 	///Rig we attached to this fuel tank
@@ -178,9 +185,9 @@
 	if(exploding)
 		return
 	exploding = TRUE
-	if (reagents.total_volume > 500)
+	if (reagents.total_volume > tank_volume/2)
 		explosion(loc, light_impact_range = 4, flame_range = 4, small_animation = TRUE)
-	else if (reagents.total_volume > 100)
+	else if (reagents.total_volume > tank_volume/10)
 		explosion(loc, light_impact_range = 3, flame_range = 3, small_animation = TRUE)
 	else
 		explosion(loc, light_impact_range = 2, flame_range = 2, small_animation = TRUE)


### PR DESCRIPTION

## About The Pull Request

- Double integrity so they aren't made of paper
- 10x more reagents inside each tank, that way they are actually useful to keep around
- 0 drag delay so you can move them around faster (THEY LITERALLY HAVE WHEELS)
- The default dispensing amount is 500 so you can fill most things in one click

## Why It's Good For The Game

Fuel tanks are pretty much useless because of how little fuel they have. The other issues like low durability and slowing you down when dragging just add to how awful of an item it is. Water is marginally more useful only because water is depleted slower. These changes should make bringing these tanks into play worth _something_.

## Changelog
:cl:
qol: Fuel and water tanks dispense reagents at a rate of 500 units by default.
balance: Fuel and water tanks: 100 -> 200 HP, 1K -> 10K reagent amount, 0 drag delay
/:cl:
