### PR TITLE
unfucks powerfist.

### DIFF
--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -142,7 +142,7 @@
 	user.balloon_alert(user, "Cell inserted")
 
 /obj/item/weapon/powerfist/attack_hand(mob/living/user)
-	if(!user.get_inactive_held_item(src))
+	if(!(user.get_inactive_held_item() == src))
 		return ..()
 	if(!cell)
 		user.balloon_alert(user, "No cell")


### PR DESCRIPTION
## About The Pull Request
I made a mistake
Powerfist can't be taken out of an inventory if you have an item in your offhand.
Changes if(!user.get_inactive_held_item(src)) to if(!(user.get_inactive_held_item() == src))
## Why It's Good For The Game
Fixes the mistake
## Changelog
:cl:
fix: You can pull out a powerfist while holding something in your off-hand (oops)
/:cl:
