### PR TITLE
New chem, saline-glucose. Adjusts isotonic mix.

### DIFF
--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -276,14 +276,13 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/isotonic
 	name = "isotonic solution autoinjector"
-	desc = "An auto-injector loaded with a single dose of isotonic solution, formulated to quickly recover fluid volume after blood loss or trauma."
+	desc = "An auto-injector loaded with 2 doses of isotonic solution, formulated to quickly recover fluid volume after blood loss or trauma."
 	icon_state = "autoinjector-8"
-	amount_per_transfer_from_this = 25
-	volume = 25
+	amount_per_transfer_from_this = 15
+	volume = 30
 	list_reagents = list(
-		/datum/reagent/iron = 10,
-		/datum/reagent/consumable/nutriment = 10,
-		/datum/reagent/consumable/sugar = 5,
+		/datum/reagent/iron = 15,
+		/datum/reagent/medicine/saline_glucose = 15,
 	)
 
 /obj/item/reagent_containers/hypospray/autoinjector/roulettium

--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -281,8 +281,7 @@
 	amount_per_transfer_from_this = 15
 	volume = 30
 	list_reagents = list(
-		/datum/reagent/iron = 15,
-		/datum/reagent/medicine/saline_glucose = 15,
+		/datum/reagent/medicine/saline_glucose = 30,
 	)
 
 /obj/item/reagent_containers/hypospray/autoinjector/roulettium

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -215,7 +215,7 @@
 
 
 /obj/item/reagent_containers/glass/beaker/cryomix
-	list_reagents = list(/datum/reagent/medicine/cryoxadone = 10, /datum/reagent/medicine/clonexadone = 10, /datum/reagent/iron = 5, /datum/reagent/medicine/saline_glucose = 5, /datum/reagent/medicine/tricordrazine = 10, /datum/reagent/medicine/quickclot = 5, /datum/reagent/medicine/dexalinplus = 5, /datum/reagent/medicine/spaceacillin = 5, /datum/reagent/medicine/bihexajuline = 5)
+	list_reagents = list(/datum/reagent/medicine/cryoxadone = 10, /datum/reagent/medicine/clonexadone = 10, /datum/reagent/medicine/saline_glucose = 5, /datum/reagent/medicine/tricordrazine = 10, /datum/reagent/medicine/quickclot = 5, /datum/reagent/medicine/dexalinplus = 5, /datum/reagent/medicine/spaceacillin = 5, /datum/reagent/medicine/bihexajuline = 5)
 
 
 /obj/item/reagent_containers/glass/beaker/cryomix/Initialize()

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -215,7 +215,7 @@
 
 
 /obj/item/reagent_containers/glass/beaker/cryomix
-	list_reagents = list(/datum/reagent/medicine/cryoxadone = 10, /datum/reagent/medicine/clonexadone = 10, /datum/reagent/iron = 5, /datum/reagent/medicine/tricordrazine = 10, /datum/reagent/medicine/quickclot = 5, /datum/reagent/medicine/dexalinplus = 5, /datum/reagent/medicine/spaceacillin = 5, /datum/reagent/medicine/bihexajuline = 5)
+	list_reagents = list(/datum/reagent/medicine/cryoxadone = 10, /datum/reagent/medicine/clonexadone = 10, /datum/reagent/iron = 5, /datum/reagent/medicine/saline_glucose = 5, /datum/reagent/medicine/tricordrazine = 10, /datum/reagent/medicine/quickclot = 5, /datum/reagent/medicine/dexalinplus = 5, /datum/reagent/medicine/spaceacillin = 5, /datum/reagent/medicine/bihexajuline = 5)
 
 
 /obj/item/reagent_containers/glass/beaker/cryomix/Initialize()

--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -160,7 +160,7 @@
 
 /obj/item/reagent_containers/pill/isotonic
 	pill_desc = "A pill with an isotonic solution inside. Used to stimulate blood regeneration."
-	list_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/iron = 6, /datum/reagent/consumable/sugar = 3)
+	list_reagents = list(/datum/reagent/iron = 7.5, /datum/reagent/medicine/saline_glucose = 7.5)
 	pill_id = 4
 
 /obj/item/reagent_containers/pill/inaprovaline

--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -160,7 +160,7 @@
 
 /obj/item/reagent_containers/pill/isotonic
 	pill_desc = "A pill with an isotonic solution inside. Used to stimulate blood regeneration."
-	list_reagents = list(/datum/reagent/iron = 7.5, /datum/reagent/medicine/saline_glucose = 7.5)
+	list_reagents = list(/datum/reagent/medicine/saline_glucose = 15)
 	pill_id = 4
 
 /obj/item/reagent_containers/pill/inaprovaline

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -1,3 +1,9 @@
+/datum/chemical_reaction/saline_glucose
+	name = "Saline-Glucose" //Chem to restore blood.
+	results = list(/datum/reagent/medicine/saline_glucose = 3)
+	required_reagents = list(/datum/reagent/consumable/sodiumchloride = 1, /datum/reagent/consumable/water = 1, /datum/reagent/consumable/sugar = 1)
+	mob_react = FALSE
+
 /datum/chemical_reaction/tricordrazine
 	name = "Tricordrazine"
 	results = list(/datum/reagent/medicine/tricordrazine = 2)

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -1,7 +1,7 @@
 /datum/chemical_reaction/saline_glucose
 	name = "Saline-Glucose" //Chem to restore blood.
 	results = list(/datum/reagent/medicine/saline_glucose = 3)
-	required_reagents = list(/datum/reagent/consumable/sodiumchloride = 1, /datum/reagent/consumable/water = 1, /datum/reagent/consumable/sugar = 1)
+	required_reagents = list(/datum/reagent/consumable/sodiumchloride = 1, /datum/reagent/water = 1, /datum/reagent/consumable/sugar = 1)
 	mob_react = FALSE
 
 /datum/chemical_reaction/tricordrazine

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -2,7 +2,6 @@
 	name = "Saline-Glucose" //Chem to restore blood.
 	results = list(/datum/reagent/medicine/saline_glucose = 3)
 	required_reagents = list(/datum/reagent/consumable/sodiumchloride = 1, /datum/reagent/water = 1, /datum/reagent/consumable/sugar = 1)
-	mob_react = FALSE
 
 /datum/chemical_reaction/tricordrazine
 	name = "Tricordrazine"

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -279,6 +279,7 @@
 	name = "Saline-Glucose"
 	description = "Saline-Glucose can be used to restore blood in a pinch."
 	color = "#d4f1f9"
+	custom_metabolism = REAGENTS_METABOLISM * 2
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "salty water"

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -282,8 +282,9 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "salty water"
+	scannable = TRUE
 
-//Same effects as /datum/reagent/iron 
+//Same effects as /datum/reagent/iron
 /datum/reagent/medicine/saline_glucose/on_mob_life(mob/living/L, metabolism)
 	if(L.blood_volume < BLOOD_VOLUME_NORMAL)
 		L.blood_volume += 0.8

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -286,7 +286,7 @@
 
 /datum/reagent/medicine/saline_glucose/on_mob_life(mob/living/L, metabolism)
 	if(L.blood_volume < BLOOD_VOLUME_NORMAL)
-		L.blood_volume += 0.8
+		L.blood_volume += 1.2
 	return ..()
 
 /datum/reagent/medicine/saline_glucose/overdose_process(mob/living/L, metabolism)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -275,6 +275,26 @@
 /datum/reagent/medicine/dermaline/overdose_crit_process(mob/living/L, metabolism)
 	L.apply_damages(3*effect_str, 0, 3*effect_str)
 
+/datum/reagent/medicine/saline_glucose
+	name = "Saline-Glucose"
+	description = "Saline-Glucose can be used to restore blood in a pinch."
+	color = "#d4f1f9"
+	overdose_threshold = REAGENTS_OVERDOSE
+	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
+	taste_description = "salty water"
+
+//Same effects as /datum/reagent/iron 
+/datum/reagent/medicine/saline_glucose/on_mob_life(mob/living/L, metabolism)
+	if(L.blood_volume < BLOOD_VOLUME_NORMAL)
+		L.blood_volume += 0.8
+	return ..()
+
+/datum/reagent/medicine/saline_glucose/overdose_process(mob/living/L, metabolism)
+	L.apply_damages(1, 0, 1)
+
+/datum/reagent/medicine/saline_glucose/overdose_crit_process(mob/living/L, metabolism)
+	L.apply_damages(1, 0, 1)
+
 /datum/reagent/medicine/dexalin
 	name = "Dexalin"
 	description = "Dexalin is used in the treatment of oxygen deprivation."

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -284,7 +284,6 @@
 	taste_description = "salty water"
 	scannable = TRUE
 
-//Same effects as /datum/reagent/iron
 /datum/reagent/medicine/saline_glucose/on_mob_life(mob/living/L, metabolism)
 	if(L.blood_volume < BLOOD_VOLUME_NORMAL)
 		L.blood_volume += 0.8

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -354,11 +354,6 @@
 	taste_description = "iron"
 	scannable = TRUE
 
-/datum/reagent/iron/on_mob_life(mob/living/L, metabolism)
-	if(L.blood_volume < BLOOD_VOLUME_NORMAL)
-		L.blood_volume += 0.8
-	return ..()
-
 /datum/reagent/iron/overdose_process(mob/living/L, metabolism)
 	L.apply_damages(1, 0, 1)
 

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -352,6 +352,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "iron"
+	scannable = TRUE
 
 /datum/reagent/iron/on_mob_life(mob/living/L, metabolism)
 	if(L.blood_volume < BLOOD_VOLUME_NORMAL)


### PR DESCRIPTION
## About The Pull Request
![image](https://user-images.githubusercontent.com/66163761/224888151-d789c203-301e-4913-a269-756fe8cafda9.png)
Changes isotonic from restoring nutrition, to purely restoring blood volume. Don't forget your MRE!
Removes iron regenerating blood.
Adds new chem saline glucose, restores 1.2 units of blood.
![image](https://user-images.githubusercontent.com/66163761/225319053-bc59d980-c38d-4d32-811f-72a4b3d826bd.png)
Recipe is salt, water and sugar.
![image](https://user-images.githubusercontent.com/66163761/225319159-ec5c812a-6419-42c0-9a01-5b657fbd08ff.png)

## Why It's Good For The Game
Blood restore pills restore blood, not food.
This makes it so isotonics no longer invalidate MRE in every way.
## Changelog
:cl:
add: New chem, saline glucose, restores blood at a rate of 1.2 units (QC is 0.2, Nano is 2.4)
del: Iron no longer regens blood.
add: Saline-Glucose has replaced iron in the cryomix.
refactor: Isotonics are now just 15u of saline-glucose. Pills hold 1 dose, injectors hold 2 doses.
/:cl:
