### PR TITLE
Battle against req hell: import edition

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1374,7 +1374,7 @@ Imports
 	contains = list(
 		/obj/item/ammo_magazine/smg/mp7,
 		/obj/item/ammo_magazine/smg/mp7,
-		/obj/item/ammo_magazine/smg/mp7
+		/obj/item/ammo_magazine/smg/mp7,
 	)
 	cost = 10
 

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1314,8 +1314,12 @@ Imports
 	cost = 50
 
 /datum/supply_packs/imports/m41a/ammo
-	name = "PR-11 Pulse Rifle Ammo"
-	contains = list(/obj/item/ammo_magazine/rifle/m41a)
+	name = "PR-11 Pulse Rifle Ammo (x3)"
+	contains = list(
+		/obj/item/ammo_magazine/rifle/m41a,
+		/obj/item/ammo_magazine/rifle/m41a,
+		/obj/item/ammo_magazine/rifle/m41a,
+	)
 	cost = 10
 
 /datum/supply_packs/imports/m412
@@ -1324,8 +1328,12 @@ Imports
 	cost = 50
 
 /datum/supply_packs/imports/m41a2/ammo
-	name = "PR-412 Pulse Rifle Ammo"
-	contains = list(/obj/item/ammo_magazine/rifle)
+	name = "PR-412 Pulse Rifle Ammo (x3)"
+	contains = list(
+		/obj/item/ammo_magazine/rifle,
+		/obj/item/ammo_magazine/rifle,
+		/obj/item/ammo_magazine/rifle,
+	)
 	cost = 10
 
 /datum/supply_packs/imports/m412l1
@@ -1334,8 +1342,12 @@ Imports
 	cost = 150
 
 /datum/supply_packs/imports/m412l1/ammo
-	name = "PR-412L1 Heavy Pulse Rifle Ammo"
-	contains = list(/obj/item/ammo_magazine/m412l1_hpr)
+	name = "PR-412L1 Heavy Pulse Rifle Ammo (x3)"
+	contains = list(
+		/obj/item/ammo_magazine/m412l1_hpr,
+		/obj/item/ammo_magazine/m412l1_hpr,
+		/obj/item/ammo_magazine/m412l1_hpr,
+	)
 	cost = 50
 
 /datum/supply_packs/imports/type71	//Moff gun
@@ -1344,8 +1356,12 @@ Imports
 	cost = 50
 
 /datum/supply_packs/imports/type71/ammo
-	name = "Type 71 Pulse Rifle Ammo"
-	contains = list(/obj/item/ammo_magazine/rifle/type71)
+	name = "Type 71 Pulse Rifle Ammo (x3)"
+	contains = list(
+		/obj/item/ammo_magazine/rifle/type71,
+		/obj/item/ammo_magazine/rifle/type71,
+		/obj/item/ammo_magazine/rifle/type71,
+	)
 	cost = 10
 
 /datum/supply_packs/imports/mp7
@@ -1354,8 +1370,12 @@ Imports
 	cost = 50
 
 /datum/supply_packs/imports/mp7/ammo
-	name = "SMG-27 SMG Ammo"
-	contains = list(/obj/item/ammo_magazine/smg/mp7)
+	name = "SMG-27 SMG Ammo (x3)"
+	contains = list(
+		/obj/item/ammo_magazine/smg/mp7,
+		/obj/item/ammo_magazine/smg/mp7,
+		/obj/item/ammo_magazine/smg/mp7
+	)
 	cost = 10
 
 /datum/supply_packs/imports/m25
@@ -1364,19 +1384,27 @@ Imports
 	cost = 50
 
 /datum/supply_packs/imports/m25/ammo
-	name = "SMG-25 SMG Ammo"
-	contains = list(/obj/item/ammo_magazine/smg/m25)
+	name = "SMG-25 SMG Ammo (x3)"
+	contains = list(
+		/obj/item/ammo_magazine/smg/m25,
+		/obj/item/ammo_magazine/smg/m25,
+		/obj/item/ammo_magazine/smg/m25,
+	)
 	cost = 10
 
 /datum/supply_packs/imports/skorpion
 	name = "CZ-81 Skorpion SMG"
 	contains = list(/obj/item/weapon/gun/smg/skorpion)
-	cost = 150
+	cost = 50
 
 /datum/supply_packs/imports/skorpion/ammo
 	name = "CZ-81 Skorpion SMG Ammo"
-	contains = list(/obj/item/ammo_magazine/smg/skorpion)
-	cost = 50
+	contains = list(
+		/obj/item/ammo_magazine/smg/skorpion,
+		/obj/item/ammo_magazine/smg/skorpion,
+		/obj/item/ammo_magazine/smg/skorpion,
+	)
+	cost = 10
 
 /datum/supply_packs/imports/uzi
 	name = "SMG-2 Uzi SMG"
@@ -1384,8 +1412,12 @@ Imports
 	cost = 50
 
 /datum/supply_packs/imports/uzi/ammo
-	name = "SMG-2 Uzi SMG Ammo"
-	contains = list(/obj/item/ammo_magazine/smg/uzi)
+	name = "SMG-2 Uzi SMG Ammo (x3)"
+	contains = list(
+		/obj/item/ammo_magazine/smg/uzi,
+		/obj/item/ammo_magazine/smg/uzi,
+		/obj/item/ammo_magazine/smg/uzi,
+	)
 	cost = 10
 
 /datum/supply_packs/imports/ppsh
@@ -1394,53 +1426,40 @@ Imports
 	cost = 50
 
 /datum/supply_packs/imports/ppsh/ammo
-	name = "PPSh-17b SMG Ammo Drum"
-	contains = list(/obj/item/ammo_magazine/smg/ppsh/extended)
+	name = "PPSh-17b SMG Ammo Drum (x3)"
+	contains = list(
+		/obj/item/ammo_magazine/smg/ppsh/extended,
+		/obj/item/ammo_magazine/smg/ppsh/extended,
+		/obj/item/ammo_magazine/smg/ppsh/extended,
+	)
 	cost = 10
 
 /datum/supply_packs/imports/sawnoff
 	name = "Sawn Off Shotgun"
 	contains = list(/obj/item/weapon/gun/shotgun/double/sawn)
-	cost = 150
+	cost = 100
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/imports/leveraction
 	name = "Lever Action Rifle"
 	contains = list(/obj/item/weapon/gun/shotgun/pump/lever)
-	cost = 150
-	available_against_xeno_only = TRUE
-
-/datum/supply_packs/imports/leveraction/ammo
-	name = "Lever Action Rifle Ammo"
-	contains = list(/obj/item/ammo_magazine/packet/magnum)
 	cost = 50
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/imports/mbx900
 	name = "MBX 900"
 	contains = list(/obj/item/weapon/gun/shotgun/pump/lever/mbx900)
-	cost = 150
+	cost = 50
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/imports/mbx900/buckshot
-	name = "MBX-900 Buckshot Shells"
-	contains = list(/obj/item/ammo_magazine/shotgun/mbx900/buckshot)
-	cost = 50
-	available_against_xeno_only = TRUE
-
-/datum/supply_packs/imports/mosin
-	name = "Mosin Nagant Sniper"
-	contains = list(/obj/item/weapon/gun/shotgun/pump/bolt)
-	cost = 150
-	available_against_xeno_only = TRUE
-
-/datum/supply_packs/imports/mosin/ammo
-	name = "Mosin Nagant Sniper Ammo (x2)"
+	name = "MBX-900 Buckshot Shells (x3)"
 	contains = list(
-		/obj/item/ammo_magazine/rifle/bolt,
-		/obj/item/ammo_magazine/rifle/bolt,
+		/obj/item/ammo_magazine/shotgun/mbx900/buckshot,
+		/obj/item/ammo_magazine/shotgun/mbx900/buckshot,
+		/obj/item/ammo_magazine/shotgun/mbx900/buckshot,
 	)
-	cost = 50
+	cost = 10
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/imports/dragunov
@@ -1450,8 +1469,12 @@ Imports
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/imports/dragunov/ammo
-	name = "SVD Dragunov Sniper Ammo"
-	contains = list(/obj/item/ammo_magazine/sniper/svd)
+	name = "SVD Dragunov Sniper Ammo (x3)"
+	contains = list(
+		/obj/item/ammo_magazine/sniper/svd,
+		/obj/item/ammo_magazine/sniper/svd,
+		/obj/item/ammo_magazine/sniper/svd,
+	)
 	cost = 50
 	available_against_xeno_only = TRUE
 
@@ -1461,8 +1484,12 @@ Imports
 	cost = 50
 
 /datum/supply_packs/imports/mpi_km/ammo
-	name = "MPi-KM Assault Rifle Ammo"
-	contains = list(/obj/item/ammo_magazine/rifle/mpi_km/plum)
+	name = "MPi-KM Assault Rifle Ammo (x3)"
+	contains = list(
+		/obj/item/ammo_magazine/rifle/mpi_km/plum,
+		/obj/item/ammo_magazine/rifle/mpi_km/plum,
+		/obj/item/ammo_magazine/rifle/mpi_km/plum,
+	)
 	cost = 10
 
 /datum/supply_packs/imports/mpi_km/ammo_packet
@@ -1476,8 +1503,12 @@ Imports
 	cost = 50
 
 /datum/supply_packs/imports/mkh/ammo
-	name = "MKH-98 Assault Rifle Ammo"
-	contains = list(/obj/item/ammo_magazine/rifle/mkh)
+	name = "MKH-98 Assault Rifle Ammo (x3)"
+	contains = list(
+		/obj/item/ammo_magazine/rifle/mkh,
+		/obj/item/ammo_magazine/rifle/mkh,
+		/obj/item/ammo_magazine/rifle/mkh,
+	)
 	cost = 10
 
 /datum/supply_packs/imports/garand
@@ -1486,8 +1517,12 @@ Imports
 	cost = 50
 
 /datum/supply_packs/imports/garand/ammo
-	name = "CAU C1 Ammo"
-	contains = list(/obj/item/ammo_magazine/rifle/garand)
+	name = "CAU C1 Ammo (x3)"
+	contains = list(
+		/obj/item/ammo_magazine/rifle/garand,
+		/obj/item/ammo_magazine/rifle/garand,
+		/obj/item/ammo_magazine/rifle/garand,
+	)
 	cost = 10
 
 /datum/supply_packs/imports/judge
@@ -1496,13 +1531,25 @@ Imports
 	cost = 50
 
 /datum/supply_packs/imports/judge/ammo
-	name = "Judge Ammo"
-	contains = list(/obj/item/ammo_magazine/revolver/judge)
+	name = "Judge Ammo (x5)"
+	contains = list(
+		/obj/item/ammo_magazine/revolver/judge,
+		/obj/item/ammo_magazine/revolver/judge,
+		/obj/item/ammo_magazine/revolver/judge,
+		/obj/item/ammo_magazine/revolver/judge,
+		/obj/item/ammo_magazine/revolver/judge,
+	)
 	cost = 10
 
 /datum/supply_packs/imports/judge/buck_ammo
-	name = "Judge Buckshot Ammo"
-	contains = list(/obj/item/ammo_magazine/revolver/judge/buckshot)
+	name = "Judge Buckshot Ammo (x5)"
+	contains = list(
+		/obj/item/ammo_magazine/revolver/judge/buckshot,
+		/obj/item/ammo_magazine/revolver/judge/buckshot,
+		/obj/item/ammo_magazine/revolver/judge/buckshot,
+		/obj/item/ammo_magazine/revolver/judge/buckshot,
+		/obj/item/ammo_magazine/revolver/judge/buckshot,
+	)
 	cost = 10
 
 /datum/supply_packs/imports/m16	//Vietnam time
@@ -1511,8 +1558,12 @@ Imports
 	cost = 50
 
 /datum/supply_packs/imports/m16/ammo
-	name = "FN M16 Assault Rifle Ammo"
-	contains = list(/obj/item/ammo_magazine/rifle/m16)
+	name = "FN M16 Assault Rifle Ammo (x3)"
+	contains = list(
+		/obj/item/ammo_magazine/rifle/m16,
+		/obj/item/ammo_magazine/rifle/m16,
+		/obj/item/ammo_magazine/rifle/m16,
+	)
 	cost = 10
 
 /datum/supply_packs/imports/m16/ammo_packet
@@ -1526,9 +1577,13 @@ Imports
 	cost = 150
 
 /datum/supply_packs/imports/famas/ammo
-	name = "FAMAS Assault Rifle Ammo"
-	contains = list(/obj/item/ammo_magazine/rifle/famas)
-	cost = 50
+	name = "FAMAS Assault Rifle Ammo (x3)"
+	contains = list(
+		/obj/item/ammo_magazine/rifle/famas,
+		/obj/item/ammo_magazine/rifle/famas,
+		/obj/item/ammo_magazine/rifle/famas,
+	)
+	cost = 10
 
 /datum/supply_packs/imports/rev357
 	name = "'Rebota' Revolver"
@@ -1536,8 +1591,14 @@ Imports
 	cost = 50
 
 /datum/supply_packs/imports/rev357/ammo
-	name = "Rebota' 357 Revolver Ammo"
-	contains = list(/obj/item/ammo_magazine/revolver/small)
+	name = "Rebota' 357 Revolver Ammo (x5)"
+	contains = list(
+		/obj/item/ammo_magazine/revolver/small,
+		/obj/item/ammo_magazine/revolver/small,
+		/obj/item/ammo_magazine/revolver/small,
+		/obj/item/ammo_magazine/revolver/small,
+		/obj/item/ammo_magazine/revolver/small,
+	)
 	cost = 10
 
 /datum/supply_packs/imports/rev44
@@ -1546,9 +1607,15 @@ Imports
 	cost = 50
 
 /datum/supply_packs/imports/rev357/ammo
-	name = "R-44 SAA Revolver Ammo"
-	contains = list(/obj/item/ammo_magazine/revolver)
-	cost = 50
+	name = "R-44 SAA Revolver Ammo (x5)"
+	contains = list(
+		/obj/item/ammo_magazine/revolver,
+		/obj/item/ammo_magazine/revolver,
+		/obj/item/ammo_magazine/revolver,
+		/obj/item/ammo_magazine/revolver,
+		/obj/item/ammo_magazine/revolver,
+	)
+	cost = 10
 
 /datum/supply_packs/imports/g22
 	name = "P-22 Handgun"
@@ -1556,8 +1623,14 @@ Imports
 	cost = 50
 
 /datum/supply_packs/imports/beretta92fs/ammo
-	name = "P-22 Handgun Ammo"
-	contains = list(/obj/item/ammo_magazine/pistol/g22)
+	name = "P-22 Handgun Ammo (x5)"
+	contains = list(
+		/obj/item/ammo_magazine/pistol/g22,
+		/obj/item/ammo_magazine/pistol/g22,
+		/obj/item/ammo_magazine/pistol/g22,
+		/obj/item/ammo_magazine/pistol/g22,
+		/obj/item/ammo_magazine/pistol/g22,
+	)
 	cost = 10
 
 /datum/supply_packs/imports/deagle
@@ -1566,8 +1639,14 @@ Imports
 	cost = 50
 
 /datum/supply_packs/imports/deagle/ammo
-	name = "Desert Eagle Handgun Ammo"
-	contains = list(/obj/item/ammo_magazine/pistol/heavy)
+	name = "Desert Eagle Handgun Ammo (x5)"
+	contains = list(
+		/obj/item/ammo_magazine/pistol/heavy,
+		/obj/item/ammo_magazine/pistol/heavy,
+		/obj/item/ammo_magazine/pistol/heavy,
+		/obj/item/ammo_magazine/pistol/heavy,
+		/obj/item/ammo_magazine/pistol/heavy,
+	)
 	cost = 10
 
 /datum/supply_packs/imports/vp78
@@ -1576,8 +1655,14 @@ Imports
 	cost = 50
 
 /datum/supply_packs/imports/vp78/ammo
-	name = "VP78 Handgun Ammo"
-	contains = list(/obj/item/ammo_magazine/pistol/vp78)
+	name = "VP78 Handgun Ammo (x5)"
+	contains = list(
+		/obj/item/ammo_magazine/pistol/vp78,
+		/obj/item/ammo_magazine/pistol/vp78,
+		/obj/item/ammo_magazine/pistol/vp78,
+		/obj/item/ammo_magazine/pistol/vp78,
+		/obj/item/ammo_magazine/pistol/vp78,
+	)
 	cost = 10
 
 /datum/supply_packs/imports/highpower
@@ -1586,8 +1671,14 @@ Imports
 	cost = 50
 
 /datum/supply_packs/imports/highpower/ammo
-	name = "Highpower Automag Ammo"
-	contains = list(/obj/item/ammo_magazine/pistol/highpower)
+	name = "Highpower Automag Ammo (x5)"
+	contains = list(
+		/obj/item/ammo_magazine/pistol/highpower,
+		/obj/item/ammo_magazine/pistol/highpower,
+		/obj/item/ammo_magazine/pistol/highpower,
+		/obj/item/ammo_magazine/pistol/highpower,
+		/obj/item/ammo_magazine/pistol/highpower,
+	)
 	cost = 10
 
 /datum/supply_packs/imports/m1911
@@ -1596,8 +1687,14 @@ Imports
 	cost = 50
 
 /datum/supply_packs/imports/m1911/ammo
-	name = "P-1911 service pistol ammo"
-	contains = list(/obj/item/ammo_magazine/pistol/m1911)
+	name = "P-1911 service pistol ammo (x5)"
+	contains = list(
+		/obj/item/ammo_magazine/pistol/m1911,
+		/obj/item/ammo_magazine/pistol/m1911,
+		/obj/item/ammo_magazine/pistol/m1911,
+		/obj/item/ammo_magazine/pistol/m1911,
+		/obj/item/ammo_magazine/pistol/m1911,
+	)
 	cost = 10
 
 /datum/supply_packs/imports/strawhat


### PR DESCRIPTION

## About The Pull Request
Makes ammo for import guns both less costly and also more user friendly. Long guns get 3 magazines per order and pistols 5 per order. Instead of lowering the individual cost, I thought it was better if you bought multiple mags to save on clicking, especially considering how ammo intensive small arms are.

Included are a couple price changes:
- scorpion 150 -> 50 (lol, it was 150 points), ammo 50 -> 10
- sawn off 150 --> 100 (50 is too cheap and spammable but 150 too expensive for what it is)
- FAMAS ammo 50 -> 10 (gun stays expensive, but the mags are very small and shouldn't cost as must as HPR ones)
- MBX 150 -> 50 and ammo 50 -> 10 (it's really not that good, it's like a worse repeater)
- lever action 150 -> 50, and removed ammo because .44 packets are free (it's legit a worse repeater)
- moist nugget removed. Funny oversight that's been there for years
## Why It's Good For The Game
No more req hell due to exorbitant ammo price for guns that are in seasonals anyway or not even good (lever action, MBX) or have infinite ammo anyway due to sharing calibers with marine guns (almost every single import gun)
## Changelog
:cl:
balance: rebalanced prices of scorpion, sawn off, mbx and repeater (both guns and ammo)
balance: rebalanced famas ammo cost
balance: all import gun magazines come in 3x (long arms) or 5x (handguns)
fix: fixed the mosin still being in imports
/:cl:
