### PR TITLE
Cautery no longer disinfects

### DIFF
--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -265,7 +265,6 @@
 	span_notice("You cauterize the incision on [target]'s [affected.display_name] with \the [tool]."))
 	target.balloon_alert_to_viewers("Success")
 	affected.surgery_open_stage = 0
-	affected.germ_level = 0
 	affected.remove_limb_flags(LIMB_BLEEDING)
 	DISABLE_BITFIELD(affected.limb_wound_status, LIMB_WOUND_CLAMPED) //Once the incision is closed, any clamping we did doesn't matter
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -104,7 +104,7 @@ GLOBAL_LIST_EMPTY(surgery_steps)
 		E.germ_level += user.germ_level * 0.33
 
 	if(locate(/obj/structure/bed/roller, E.owner.loc))
-		E.germ_level += 75
+		E.germ_level += 50
 	else if(locate(/obj/structure/table/, E.owner.loc))
 		E.germ_level += 100
 


### PR DESCRIPTION

## About The Pull Request
Finishing a surgery no longer automatically sets the limb to entirely germless.
Reduces the germs from using a roller bed by a third.
## Why It's Good For The Game
Automatic disinfection from any surgery means that surgery infection becomes incredibly binary: either you do enough to generate necrosis, or it's irrelevant - and shorter surgeries with proper care shouldn't causes necrosis, groundside or not.
Minor infections are mostly annoying, just messages and a bit of toxloss, and can be ignored entirely by using a chem slot on spaceacillin (one pill of which will fully clear up any existing issue), but still present a potential threat and take time to clear up.
Roller germ reduction brings down the unavoidable germs to make it less likely to cause serious infection if you wash yourself first but still stay high enough to ensure you'll at least have something lingering.
## Changelog
:cl:
balance: Cautery to finish surgery no longer clears germs
balance: Roller bed surgery germs reduced (separate from germ transfer by surgeon, you still need to keep yourself clean)
/:cl:
