### PR TITLE
Spaceacillin doesn't protect against necrosis

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -491,7 +491,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 				if (parent.germ_level < INFECTION_LEVEL_ONE*2 || prob(30))
 					parent.germ_level++
 //LEVEL III
-	if(germ_level >= INFECTION_LEVEL_THREE && spaceacillin < 25 && polyhexanide <2)	//overdosing is necessary to stop severe infections, or a doc-only chem
+	if(germ_level >= INFECTION_LEVEL_THREE && !polyhexanide)	//Need a chem with real drawbacks to stay safe at this point
 		if (!(limb_status & LIMB_NECROTIZED))
 			add_limb_flags(LIMB_NECROTIZED)
 			to_chat(owner, span_notice("You can't feel your [display_name] anymore..."))


### PR DESCRIPTION

## About The Pull Request
As title, only polyhex works once you're in the right germ threshold. Spaceacillin still helps avoid getting there, of course.
## Why It's Good For The Game
Necrosis is a major kind of long term damage which either arises from long term negligence or a major misplay. Spaceacillin is a basic chem with high availability and no real drawbacks for ODing. The later granting immunity to the former isn't great. Alternatives and why I don't like them:
Make spaceacillin less available - basic chems should be available, and making chems unavailable never actually lasts anyway.
Make ODing on spacea less absolutely nothing - it's a basic chem, akin to bica/kelo, and misusing it shouldn't be any more than a gentle reminder not to do that.
## Changelog
:cl:
balance: Spaceacillin OD doesn't prevent necrosis from forming
/:cl:
