### PR TITLE
Pilot Officer Slot Reduction: Electric Boogaloo

### DIFF
--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -275,7 +275,7 @@ You are in charge of logistics and the overwatch system. You are also in line to
 	title = PILOT_OFFICER
 	paygrade = "WO"
 	comm_title = "PO"
-	total_positions = 2
+	total_positions = 1
 	access = list(ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_PILOT)
 	minimal_access = list(ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_PILOT, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_CARGO, ACCESS_MARINE_RO, ACCESS_MARINE_MEDBAY)
 	skills_type = /datum/skills/pilot


### PR DESCRIPTION
## About The Pull Request

Reduces PO slots to one.
<sub>For preface, this is intended to be different from #11702, as Naani didn't originally advertise it in the way that I thought was best for the server. ...Only after they were given a shitload of dislikes did it look like something marginally reasonable. </sub>

## Why It's Good For The Game

PO is an ...interesting role, to say the least. I've got around ~110 hours on it, mostly flying CAS, which I think gives me some say in the way things work here. There is a lingering issue with having multiple pilots, and I'll explain that here.

1. Latejoin as PO
2. Tadpole is gone <sub>(Synth/CSE/FC/etc took it, these roles are allowed and encouraged to do this)</sub>
3. The other pilot is doing CAS
4. You are functionally useless and without a job. 

Imagine if we treated other roles the same way. Picture spawning in as a regular squad marine to see every gun and vendor empty. You'd either wait and scavenge around, or cryo.

That is exactly how the PO feels. I feel like this is a terrible oversight; one that I and many others have experienced. And I don't feel like rebranding the role to CAS is the right away to go about things, since it can be mind-numbingly boring at times.
### TL;DR

* Two POs roundstart leads to bloat since other roles want (and will) use the tadpole

## Changelog

:cl:
balance: PO has a singular slot.
/:cl: