### PR TITLE
Fixes a parallax runtime

### DIFF
--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -133,7 +133,7 @@
 	if (C.parallax_animate_timer)
 		deltimer(C.parallax_animate_timer)
 	var/datum/callback/CB = CALLBACK(src, .proc/update_parallax_motionblur, C, animatedir, new_parallax_movedir, newtransform)
-	if(skip_windups)
+	if(skip_windups || !shortesttimer) //shorttest timer can be null/0 if we don't have any parallax layers (ie the pref is off)
 		CB.Invoke()
 	else
 		C.parallax_animate_timer = addtimer(CB, min(shortesttimer, PARALLAX_LOOP_TIME), TIMER_CLIENT_TIME|TIMER_STOPPABLE)


### PR DESCRIPTION

## About The Pull Request

Fixes a runtime related to not having any parallax layers because the preference, thus resulting in a 0 second timer.
## Why It's Good For The Game

Runtime bad.
## Changelog
:cl:
fix: Fixes a runtime related to parallax
/:cl:
