### PR TITLE
Removes No_Decap_Flag from Berets, Red headbands and commissar cap 

### DIFF
--- a/code/modules/clothing/head/head.dm
+++ b/code/modules/clothing/head/head.dm
@@ -38,7 +38,7 @@
 	icon_state = "beret"
 	soft_armor = list(MELEE = 15, BULLET = 15, LASER = 15, ENERGY = 15, BOMB = 10, BIO = 5, FIRE = 5, ACID = 5)
 	flags_item_map_variant = NONE
-	flags_armor_features = ARMOR_NO_DECAP
+
 
 /obj/item/clothing/head/tgmcberet/tan
 	name = "\improper Tan beret"
@@ -176,7 +176,7 @@
 		slot_r_hand_str = 'icons/mob/items_righthand_1.dmi',)
 	icon_state = "headband"
 	soft_armor = list(MELEE = 15, BULLET = 15, LASER = 15, ENERGY = 15, BOMB = 10, BIO = 5, FIRE = 5, ACID = 5)
-	flags_armor_features = ARMOR_NO_DECAP
+
 
 /obj/item/clothing/head/headband/red
 	name = "\improper Red headband"
@@ -373,7 +373,7 @@
 	icon = 'icons/obj/clothing/cm_hats.dmi'
 	icon_state = "commissar_cap"
 	soft_armor = list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 15, BIO = 10, FIRE = 20, ACID = 20)
-	flags_armor_features = ARMOR_NO_DECAP
+	
 
 /obj/item/clothing/head/strawhat
 	name = "\improper straw hat"

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -56,7 +56,7 @@
 	icon_state = "beret"
 	siemens_coefficient = 0.9
 	soft_armor = list(MELEE = 15, BULLET = 15, LASER = 15, ENERGY = 15, BOMB = 10, BIO = 5, FIRE = 5, ACID = 5)
-	flags_armor_features = ARMOR_NO_DECAP
+	
 
 //Security
 /obj/item/clothing/head/beret/sec


### PR DESCRIPTION


## About The Pull Request

Simply removes NO_DECAP flags from head gears that visually don't protect the Neck. Excluding standard issue helmets. 
## Why It's Good For The Game

If you want to have amour on your snowflake-wearing berets, fine Idc have it, but I am drawing the line at full-blown no decap flags that barely make any sense other than you just want to wear your drip without repercussions. 

If you decide to come down to the front wearing Less than front line worthy clothing you should be paying for it because this is not some kind of fashion show, this is war. 

The people who don't like this can go back to wearing regular headgear that stops this from happening while the full brew chads can continue as normal because they are probably robust enough to where this won't even affect them.  

## Changelog


:cl:

balance: Removes Decap Flag from Berets, Red headbands and commissar cap 

/:cl:
