### PR TITLE
Turret fixes

### DIFF
--- a/code/modules/projectiles/mounted.dm
+++ b/code/modules/projectiles/mounted.dm
@@ -295,7 +295,7 @@
 	update_pixels(user, FALSE)
 	user_old_x = 0
 	user_old_y = 0
-	density = TRUE
+	density = initial(density)
 	user.move_resist = user_old_move_resist
 
 ///makes sure you can see and or use the gun

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -695,13 +695,16 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	return TRUE
 
 /obj/machinery/deployable/mounted/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
-	. = ..()
 	if(operator?.wear_id.iff_signal & proj.iff_signal)
 		return FALSE
+	if(src == proj.original_target)
+		return TRUE
+	if(density)
+		return ..()
+
 	var/hit_chance = coverage
 	hit_chance = min(hit_chance , hit_chance + 100 - proj.accuracy)
-	if(!density)
-		return prob(hit_chance)
+	return prob(hit_chance)
 
 /obj/machinery/door/poddoor/railing/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
 	return src == proj.original_target


### PR DESCRIPTION

## About The Pull Request
Fixes a couple of issues caused by the turret rework a couple of months ago.

COPE's were going dense after using manual override, and they were hilariously hard to actually shoot.

Generally made sure if you specifically click a turret (whether its being manned or not) you actually hit it.

Also cleaned up the turret hit code so its a little neater and not doing stuff needlessly.
## Why It's Good For The Game
Fixes good.
## Changelog
:cl:
fix: Fixed an issue with targeting mounted guns when manned
fix: Fixed a couple of minor  COPE sentry issues
/:cl:
