### PR TITLE
Slight Xeno crash buffs (fix)

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -178,7 +178,9 @@
 		if(XENO_TIER_ONE)
 			new_xeno.upgrade_xeno(XENO_UPGRADE_TWO)
 		if(XENO_TIER_TWO)
-			new_xeno.upgrade_xeno(XENO_UPGRADE_ONE)
+			new_xeno.upgrade_xeno(XENO_UPGRADE_TWO)
+		if(XENO_TIER_THREE)
+			new_xeno.upgrade_xeno(XENO_UPGRADE_TWO)
 
 /datum/game_mode/infestation/crash/can_summon_dropship(mob/user)
 	to_chat(src, span_warning("This power doesn't work in this gamemode."))

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -176,7 +176,7 @@
 	SIGNAL_HANDLER
 	switch(new_xeno.tier)
 		if(XENO_TIER_ONE)
-			new_xeno.upgrade_stored = TIER_ONE_MATURE_THRESHOLD
+			new_xeno.upgrade_stored = max(new_xeno.upgrade_stored, TIER_ONE_MATURE_THRESHOLD)
 
 /datum/game_mode/infestation/crash/can_summon_dropship(mob/user)
 	to_chat(src, span_warning("This power doesn't work in this gamemode."))

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -181,6 +181,8 @@
 			new_xeno.upgrade_xeno(XENO_UPGRADE_TWO)
 		if(XENO_TIER_THREE)
 			new_xeno.upgrade_xeno(XENO_UPGRADE_TWO)
+		if(XENO_TIER_FOUR)
+			new_xeno.upgrade_xeno(XENO_UPGRADE_TWO)
 
 /datum/game_mode/infestation/crash/can_summon_dropship(mob/user)
 	to_chat(src, span_warning("This power doesn't work in this gamemode."))

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -176,13 +176,7 @@
 	SIGNAL_HANDLER
 	switch(new_xeno.tier)
 		if(XENO_TIER_ONE)
-			new_xeno.upgrade_xeno(XENO_UPGRADE_TWO)
-		if(XENO_TIER_TWO)
-			new_xeno.upgrade_xeno(XENO_UPGRADE_TWO)
-		if(XENO_TIER_THREE)
-			new_xeno.upgrade_xeno(XENO_UPGRADE_TWO)
-		if(XENO_TIER_FOUR)
-			new_xeno.upgrade_xeno(XENO_UPGRADE_TWO)
+			new_xeno.upgrade_stored = TIER_ONE_MATURE_THRESHOLD
 
 /datum/game_mode/infestation/crash/can_summon_dropship(mob/user)
 	to_chat(src, span_warning("This power doesn't work in this gamemode."))


### PR DESCRIPTION
## About The Pull Request
T1 Xenos get the maturity points for evolving in crash.
## Why It's Good For The Game
Since maturity points carry on when evolving, crash has the issue of giving T1s Elder but starting off with 0 maturity points and makes T2s mature by default, also not giving them the points, but T3s take a massive amount of time to reach ancient since maturity changes.

This should rectify that issue and give the missing points when the first evolve is done.

This should help reintroduce the previous interaction without making Xenos too powerful whilst also being a bit of a slight buff when Xenos evolve instantly.
## Changelog
:cl:
balance: T1 Xenos get the maturity points for evolving.
/:cl:
