### PR TITLE
Adds Jerrycan to req for 100 points.

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1627,6 +1627,11 @@ VEHICLES
 	cost = 200
 	contains = list(/obj/item/sidecar)
 
+/datum/supply_packs/vehicles/jerrycan
+	name = "Jerry Can"
+	cost = 100
+	contains = list(/obj/item/reagent_containers/jerrycan)
+
 /datum/supply_packs/vehicles/droid_combat
 	name = "Combat droid with weapon equipped"
 	contains = list(/obj/vehicle/unmanned/droid)


### PR DESCRIPTION

## About The Pull Request
Adds Jerrycan to req for 100 points.
## Why It's Good For The Game
There are no ways to obtain these outside of looting the few that spawn on ship.
This adds a reasonably priced way to get cans.
## Changelog
:cl:
add: Jerrycans are now in the vehicles category in req for 100 points.
/:cl:
