### PR TITLE
Adds statistics to end-round for Bull

### DIFF
--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -463,6 +463,12 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.spitter_scatter_spits] number of times Spitters horked up scatter spits."
 	if(GLOB.round_statistics.ravager_endures)
 		parts += "[GLOB.round_statistics.ravager_endures] number of times Ravagers used Endure."
+	if(GLOB.round_statistics.bull_crush_hit)
+		parts += "[GLOB.round_statistics.bull_crush_hit] number of times Bulls crushed marines."
+	if(GLOB.round_statistics.bull_gore_hit)
+		parts += "[GLOB.round_statistics.bull_gore_hit] number of times Bulls gored marines."
+	if(GLOB.round_statistics.bull_headbutt_hit)
+		parts += "[GLOB.round_statistics.bull_headbutt_hit] number of times Bulls headbutted marines."
 	if(GLOB.round_statistics.hunter_marks)
 		parts += "[GLOB.round_statistics.hunter_marks] number of times Hunters marked a target for death."
 	if(GLOB.round_statistics.ravager_rages)

--- a/code/datums/round_statistics.dm
+++ b/code/datums/round_statistics.dm
@@ -78,6 +78,9 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	var/wraith_phase_shifts = 0
 	var/wraith_blinks = 0
 	var/wraith_banishes = 0
+	var/bull_crush_hit = 0
+	var/bull_gore_hit = 0
+	var/bull_headbutt_hit = 0
 	var/ravager_endures = 0
 	var/hunter_marks = 0
 	var/hunter_silence_targets = 0

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -576,6 +576,8 @@
 			charger.visible_message(span_danger("[charger] rams [src]!"),
 			span_xenodanger("We ram [src]!"))
 			charge_datum.speed_down(1) //Lose one turf worth of speed.
+			GLOB.round_statistics.bull_crush_hit++
+			SSblackbox.record_feedback("tally", "round_statistics", 1, "bull_crush_hit")
 			return PRECRUSH_PLOWED
 
 		if(CHARGE_BULL_GORE)
@@ -588,6 +590,9 @@
 					throw_at(destination, 1, 1, charger, FALSE)
 				charger.visible_message(span_danger("[charger] gores [src]!"),
 					span_xenowarning("We gore [src] and skid to a halt!"))
+				GLOB.round_statistics.bull_gore_hit++
+				SSblackbox.record_feedback("tally", "round_statistics", 1, "bull_gore_hit")
+
 
 		if(CHARGE_BULL_HEADBUTT)
 			var/fling_dir = charger.a_intent == INTENT_HARM ? charger.dir : REVERSE_DIR(charger.dir)
@@ -605,6 +610,8 @@
 
 			charger.visible_message(span_danger("[charger] rams into [src] and flings [p_them()] away!"),
 				span_xenowarning("We ram into [src] and skid to a halt!"))
+			GLOB.round_statistics.bull_headbutt_hit++
+			SSblackbox.record_feedback("tally", "round_statistics", 1, "bull_headbutt_hit")
 
 	charge_datum.do_stop_momentum(FALSE)
 	return PRECRUSH_STOPPED


### PR DESCRIPTION
## About The Pull Request
Adds bull stats: Marines Crushed, Gored and Headbutted.
![image](https://user-images.githubusercontent.com/66163761/225800435-fc159afd-d897-431b-b6fd-d3301aaedd56.png)

## Why It's Good For The Game
I like stats.
## Changelog
:cl:
add: Bull abilities have their stats in the end-round popup. Marines Crushed, gored and headbutted.
/:cl:
