### PR TITLE
Hyposprays can draw reagent with right click.

### DIFF
--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -70,7 +70,7 @@
 
 	//For drawing reagents, will check if it's possible to draw, then draws.
 	if(can_draw_reagent(A, user, FALSE))
-		return TRUE
+		return
 
 	if(!reagents.total_volume)
 		to_chat(user, span_warning("[src] is empty."))

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -101,20 +101,20 @@
 
 			reagents.handle_reactions()
 			user.visible_message("<span clas='warning'>[user] takes a blood sample from [A].</span>",
-									span_notice("You take a blood sample from [A]."), null, 4)
+								span_notice("You take a blood sample from [A]."), null, 4)
 
-		else if(istype(A, /obj)) //if not mob
-			if(!A.reagents.total_volume)
-				to_chat(user, "<span class='warning'>[A] is empty.")
-				return
+	else if(istype(A, /obj)) //if not mob
+		if(!A.reagents.total_volume)
+			to_chat(user, "<span class='warning'>[A] is empty.")
+			return
 
-			if(!A.is_drawable())
-				to_chat(user, span_warning("You cannot directly remove reagents from this object."))
-				return
+		if(!A.is_drawable())
+			to_chat(user, span_warning("You cannot directly remove reagents from this object."))
+			return
 
-			draw_reagent(A, user)
-			on_reagent_change()
-			return TRUE
+		draw_reagent(A, user)
+	on_reagent_change()
+	return TRUE
 
 
 	if(!reagents.total_volume)

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -121,16 +121,14 @@
 
 	return TRUE
 
-///Always draws reagents on right click
 /obj/item/reagent_containers/hypospray/afterattack_alternate(atom/A, mob/living/user)
 	if(!istype(user))
 		return FALSE
 	if(!in_range(A, user) || !user.Adjacent(A)) //So we arent drawing reagent from a container behind a window
 		return FALSE
-	can_draw_reagent(A, user, TRUE)
+	can_draw_reagent(A, user, TRUE) //Always draws reagents on right click
 
 ///If it's possible to draw from something. Will draw_blood() when targetting a carbon, or draw_reagent() when targetting a non-carbon
-///Returns TRUE if we successfully draw from something
 /obj/item/reagent_containers/hypospray/proc/can_draw_reagent(atom/A, mob/living/user)
 	if(!A.reagents)
 		return FALSE

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -73,48 +73,7 @@
 	if(!in_range(A, user) || !user.Adjacent(A))
 		return
 	if(inject_mode == HYPOSPRAY_INJECT_MODE_DRAW) //if we're draining
-		if(reagents.holder_full())
-			to_chat(user, span_warning("[src] is full."))
-			inject_mode = HYPOSPRAY_INJECT_MODE_INJECT
-			update_icon() //So we now display as Inject
-			return
-
-		if(iscarbon(A))
-			var/amount = min(reagents.maximum_volume - reagents.total_volume, amount_per_transfer_from_this)
-			var/mob/living/carbon/C = A
-			if(C.get_blood_id() && reagents.has_reagent(C.get_blood_id()))
-				to_chat(user, span_warning("There is already a blood sample in [src]."))
-				return
-			if(!C.blood_type)
-				to_chat(user, span_warning("You are unable to locate any blood."))
-				return
-
-			if(ishuman(C))
-				var/mob/living/carbon/human/H = C
-				if(H.species.species_flags & NO_BLOOD)
-					to_chat(user, span_warning("You are unable to locate any blood."))
-					return
-				else
-					C.take_blood(src,amount)
-			else
-				C.take_blood(src,amount)
-
-			reagents.handle_reactions()
-			user.visible_message("<span clas='warning'>[user] takes a blood sample from [A].</span>",
-								span_notice("You take a blood sample from [A]."), null, 4)
-
-		else if(istype(A, /obj)) //if not mob
-			if(!A.reagents.total_volume)
-				to_chat(user, "<span class='warning'>[A] is empty.")
-				return
-
-			if(!A.is_drawable())
-				to_chat(user, span_warning("You cannot directly remove reagents from this object."))
-				return
-
-			var/trans = A.reagents.trans_to(src, amount_per_transfer_from_this)
-
-			to_chat(user, span_notice("You fill [src] with [trans] units of the solution."))
+		draw_reagent(A, user)
 
 		on_reagent_change()
 		return TRUE
@@ -167,6 +126,10 @@
 	return TRUE
 
 /obj/item/reagent_containers/hypospray/afterattack_alternate(atom/A, mob/living/user)
+	draw_reagent(A, user)
+
+///Draws reagent from container A.
+/obj/item/reagent_containers/hypospray/proc/draw_reagent(atom/A, mob/living/user)
 	if(reagents.holder_full())
 		to_chat(user, span_warning("[src] is full."))
 		inject_mode = HYPOSPRAY_INJECT_MODE_INJECT

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -46,6 +46,11 @@
 	label = str
 
 /obj/item/reagent_containers/hypospray/afterattack(atom/A, mob/living/user)
+	if(!istype(user))
+		return FALSE
+	if(!in_range(A, user) || !user.Adjacent(A))
+		return FALSE
+
 	if(istype(A, /obj/item/storage/pill_bottle) && is_open_container()) //this should only run if its a pillbottle
 		if(reagents.total_volume >= volume)
 			to_chat(user, span_warning("[src] is full."))
@@ -64,11 +69,6 @@
 		A.contents -= pill
 		qdel(pill)
 		return
-
-	if(!istype(user))
-		return FALSE
-	if(!in_range(A, user) || !user.Adjacent(A))
-		return FALSE
 
 	//For drawing reagents, will check if it's possible to draw, then draws.
 	if(inject_mode == HYPOSPRAY_INJECT_MODE_DRAW)

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -72,8 +72,8 @@
 
 	//For drawing reagents, will check if it's possible to draw, then draws.
 	if(inject_mode == HYPOSPRAY_INJECT_MODE_DRAW)
-		if(can_draw_reagent(A, user, FALSE))
-			return
+		can_draw_reagent(A, user, FALSE)
+		return
 
 	if(!reagents.total_volume)
 		to_chat(user, span_warning("[src] is empty."))

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -103,18 +103,19 @@
 			user.visible_message("<span clas='warning'>[user] takes a blood sample from [A].</span>",
 								span_notice("You take a blood sample from [A]."), null, 4)
 
-	else if(istype(A, /obj)) //if not mob
-		if(!A.reagents.total_volume)
-			to_chat(user, "<span class='warning'>[A] is empty.")
-			return
+		else if(istype(A, /obj)) //if not mob
+			if(!A.reagents.total_volume)
+				to_chat(user, "<span class='warning'>[A] is empty.")
+				return
 
-		if(!A.is_drawable())
-			to_chat(user, span_warning("You cannot directly remove reagents from this object."))
-			return
+			if(!A.is_drawable())
+				to_chat(user, span_warning("You cannot directly remove reagents from this object."))
+				return
 
-		draw_reagent(A, user)
-	on_reagent_change()
-	return TRUE
+			draw_reagent(A, user)
+
+		on_reagent_change()
+		return TRUE
 
 
 	if(!reagents.total_volume)
@@ -164,47 +165,19 @@
 	return TRUE
 
 /obj/item/reagent_containers/hypospray/afterattack_alternate(atom/A, mob/living/user)
-	draw_reagent(A, user)
-	on_reagent_change()
-
-///Draws reagent from container A.
-/obj/item/reagent_containers/hypospray/proc/draw_reagent(atom/A, mob/living/user)
-	var/trans = A.reagents.trans_to(src, amount_per_transfer_from_this)
-	to_chat(user, span_notice("You fill [src] with [trans] units of the solution."))
-
-
-/*
+	if(!A.reagents)
+		return
+	if(!istype(user))
+		return
+	if(!in_range(A, user) || !user.Adjacent(A))
+		return
 	if(reagents.holder_full())
 		to_chat(user, span_warning("[src] is full."))
 		inject_mode = HYPOSPRAY_INJECT_MODE_INJECT
 		update_icon() //So we now display as Inject
 		return
 
-	if(iscarbon(A))
-		var/amount = min(reagents.maximum_volume - reagents.total_volume, amount_per_transfer_from_this)
-		var/mob/living/carbon/C = A
-		if(C.get_blood_id() && reagents.has_reagent(C.get_blood_id()))
-			to_chat(user, span_warning("There is already a blood sample in [src]."))
-			return
-		if(!C.blood_type)
-			to_chat(user, span_warning("You are unable to locate any blood."))
-			return
-
-		if(ishuman(C))
-			var/mob/living/carbon/human/H = C
-			if(H.species.species_flags & NO_BLOOD)
-				to_chat(user, span_warning("You are unable to locate any blood."))
-				return
-			else
-				C.take_blood(src,amount)
-		else
-			C.take_blood(src,amount)
-
-		reagents.handle_reactions()
-		user.visible_message("<span clas='warning'>[user] takes a blood sample from [A].</span>",
-							span_notice("You take a blood sample from [A]."), null, 4)
-
-	else if(istype(A, /obj)) //if not mob
+	if(istype(A, /obj)) //if not mob
 		if(!A.reagents.total_volume)
 			to_chat(user, "<span class='warning'>[A] is empty.")
 			return
@@ -213,9 +186,13 @@
 			to_chat(user, span_warning("You cannot directly remove reagents from this object."))
 			return
 
-		var/trans = A.reagents.trans_to(src, amount_per_transfer_from_this)
+		draw_reagent(A, user)
+		on_reagent_change()
 
-		to_chat(user, span_notice("You fill [src] with [trans] units of the solution."))*/
+///Draws reagent from container A.
+/obj/item/reagent_containers/hypospray/proc/draw_reagent(atom/A, mob/living/user)
+	var/trans = A.reagents.trans_to(src, amount_per_transfer_from_this)
+	to_chat(user, span_notice("You fill [src] with [trans] units of the solution."))
 
 /obj/item/reagent_containers/hypospray/on_reagent_change()
 	if(reagents.holder_full())

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -125,6 +125,7 @@
 	can_draw_reagent(A, user, TRUE)
 
 ///If it's possible to draw from something. Will draw_blood() when targetting a carbon, or draw_reagent() when targetting a non-carbon
+///Returns TRUE if we successfully draw from something
 /obj/item/reagent_containers/hypospray/proc/can_draw_reagent(atom/A, mob/living/user, alternate_draw_mode)
 	if(!A.reagents)
 		return FALSE
@@ -139,10 +140,12 @@
 		return FALSE
 
 	if(iscarbon(A))
-		return draw_blood(A, user)
+		draw_blood(A, user)
+		return TRUE
 
 	if(isobj(A)) //if not mob
-		return draw_reagent(A, user)
+		draw_reagent(A, user)
+		return TRUE
 
 ///Checks if the carbon has blood, then tries to draw blood from it
 /obj/item/reagent_containers/hypospray/proc/draw_blood(atom/A, mob/living/user)
@@ -153,6 +156,9 @@
 		return
 	if(!C.blood_type)
 		to_chat(user, span_warning("You are unable to locate any blood."))
+		return
+	if(C.blood_volume <= BLOOD_VOLUME_SURVIVE)
+		to_chat(user, span_warning("This body doesn't have enough blood to draw from."))
 		return
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -166,6 +166,50 @@
 
 	return TRUE
 
+/obj/item/reagent_containers/hypospray/afterattack_alternate(atom/A, mob/living/user)
+	if(reagents.holder_full())
+		to_chat(user, span_warning("[src] is full."))
+		inject_mode = HYPOSPRAY_INJECT_MODE_INJECT
+		update_icon() //So we now display as Inject
+		return
+
+	if(iscarbon(A))
+		var/amount = min(reagents.maximum_volume - reagents.total_volume, amount_per_transfer_from_this)
+		var/mob/living/carbon/C = A
+		if(C.get_blood_id() && reagents.has_reagent(C.get_blood_id()))
+			to_chat(user, span_warning("There is already a blood sample in [src]."))
+			return
+		if(!C.blood_type)
+			to_chat(user, span_warning("You are unable to locate any blood."))
+			return
+
+		if(ishuman(C))
+			var/mob/living/carbon/human/H = C
+			if(H.species.species_flags & NO_BLOOD)
+				to_chat(user, span_warning("You are unable to locate any blood."))
+				return
+			else
+				C.take_blood(src,amount)
+		else
+			C.take_blood(src,amount)
+
+		reagents.handle_reactions()
+		user.visible_message("<span clas='warning'>[user] takes a blood sample from [A].</span>",
+							span_notice("You take a blood sample from [A]."), null, 4)
+
+	else if(istype(A, /obj)) //if not mob
+		if(!A.reagents.total_volume)
+			to_chat(user, "<span class='warning'>[A] is empty.")
+			return
+
+		if(!A.is_drawable())
+			to_chat(user, span_warning("You cannot directly remove reagents from this object."))
+			return
+
+		var/trans = A.reagents.trans_to(src, amount_per_transfer_from_this)
+
+		to_chat(user, span_notice("You fill [src] with [trans] units of the solution."))
+
 /obj/item/reagent_containers/hypospray/on_reagent_change()
 	if(reagents.holder_full())
 		inject_mode = HYPOSPRAY_INJECT_MODE_INJECT

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -72,9 +72,8 @@
 		return
 	if(!in_range(A, user) || !user.Adjacent(A))
 		return
-	if(inject_mode == HYPOSPRAY_INJECT_MODE_DRAW) //if we're draining
+	if(inject_mode == HYPOSPRAY_INJECT_MODE_DRAW) //if we're drawing
 		draw_reagent(A, user)
-
 		on_reagent_change()
 		return TRUE
 
@@ -127,6 +126,7 @@
 
 /obj/item/reagent_containers/hypospray/afterattack_alternate(atom/A, mob/living/user)
 	draw_reagent(A, user)
+	on_reagent_change()
 
 ///Draws reagent from container A.
 /obj/item/reagent_containers/hypospray/proc/draw_reagent(atom/A, mob/living/user)


### PR DESCRIPTION
## About The Pull Request
Makes new proc draw_reagent(). Afterattack_alternate just calls this proc after some checks.
## Why It's Good For The Game
The UI is clunky and slow, this goes around the problem in a TG-esque way. Being able to draw reagents with right click instead of having to open the UI, set it to draw mode and then left click your container.
I HAVE NOT TOUCHED THE UI OR DRAW MODE, just added draw mode innately to right click.
## Changelog
:cl:
add: Hyposprays can now draw reagent with right click (Autoinjectors are also hyposprays fyi).
/:cl:
