### PR TITLE
Vali withers limbs directly instead of adding germs

### DIFF
--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -254,12 +254,11 @@
 		vali_necro_timer = world.time - processing_start
 		var/necrotized_counter = FLOOR(min(vali_necro_timer, 20 SECONDS)/200 + (vali_necro_timer-20 SECONDS)/100, 1)
 		if(necrotized_counter >= 1)
-			for(var/X in shuffle(wearer.limbs))
-				var/datum/limb/L = X
-				if(L.germ_level > 700)
+			for(var/datum/limb/limb_to_ruin AS in shuffle(wearer.limbs))
+				if(limb_to_ruin.limb_status & LIMB_NECROTIZED)
 					continue
-				L.germ_level += max(INFECTION_LEVEL_THREE + 50 - L.germ_level, 200)
-				necrotized_counter -= 1
+				limb_to_ruin.add_limb_flags(LIMB_NECROTIZED)
+				necrotized_counter--
 				if(necrotized_counter < 1)
 					break
 		UnregisterSignal(wearer, COMSIG_MOB_DEATH, .proc/on_off)


### PR DESCRIPTION

## About The Pull Request
Right now vali just sets the limb germs to above the threshold to cause necrosis. This changes it to setting the limb flag directly and not touching germs.
## Why It's Good For The Game
I'm of two minds about this. The core reason for opening it is actually lore (yeah, I know). It's conceptually weird that vali would add germs to the limb, given that the idea is you've burning out your body via boosting too long.

In terms of balance, there's benefits both directions. If it is germs, you can use polyhex to become immune to the kickback, but that's not a super strong option these days since a: availability and b: poly downsides means you really don't want to use that in combat. If there isn't, it's easier to clear up (if my other prs get merged, since otherwise it's the same surgery either way and nothing else), and you don't suffer the other downsides of high germs on top of the necrosis (toxin damage over time, pain).

Opinions welcomed.
## Changelog
:cl:
qol: Vali causes necrosis directly if you keep it active for too long instead of filling your limbs with germs
/:cl:
