### PR TITLE
Fixes valhalla buttons

### DIFF
--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -22,6 +22,13 @@
 	},
 /turf/open/floor/grass,
 /area/centcom/valhalla/hydroponics)
+"ade" = (
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/machinery/button/valhalla/marine_button{
+	link = "xenoclose2"
+	},
+/turf/open/floor/plating,
+/area/centcom/valhalla/security/brig)
 "adx" = (
 /obj/structure/table,
 /obj/item/toy/dice,
@@ -2585,6 +2592,13 @@
 	},
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla/security/brig/interiorcavern)
+"dur" = (
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/machinery/button/valhalla/marine_button{
+	link = "xenofar2"
+	},
+/turf/open/floor/plating,
+/area/centcom/valhalla/security/brig)
 "dve" = (
 /turf/closed/wall,
 /area/centcom/valhalla/starboard_hallway)
@@ -4658,9 +4672,6 @@
 /obj/structure/window/reinforced/windowstake{
 	dir = 4
 	},
-/obj/machinery/button/valhalla/marine_button{
-	link = "close2"
-	},
 /turf/open/floor/mainship/stripesquare,
 /area/centcom/valhalla/security/brig)
 "ggF" = (
@@ -4695,9 +4706,6 @@
 /obj/structure/table/mainship,
 /obj/structure/window/reinforced/windowstake{
 	dir = 4
-	},
-/obj/machinery/button/valhalla/marine_button{
-	link = "far2"
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/centcom/valhalla/security/brig)
@@ -26166,7 +26174,7 @@ aMq
 bbR
 fbp
 geA
-hdk
+ade
 hDu
 ioO
 ivu
@@ -26580,7 +26588,7 @@ dXi
 eFA
 fbp
 ghB
-hdk
+dur
 hGL
 ivs
 jdS

--- a/code/game/objects/machinery/buttons.dm
+++ b/code/game/objects/machinery/buttons.dm
@@ -268,6 +268,9 @@
 	if(!xeno_wanted)
 		return
 	QDEL_NULL(linked)
+	if(!get_turf(GLOB.valhalla_button_spawn_landmark[link]))
+		to_chat(user, span_warning("An error occured, yell at the coders."))
+		CRASH("Valhalla button linked with an improper landmark: button ID: [link].")
 	linked = new xeno_wanted(get_turf(GLOB.valhalla_button_spawn_landmark[link]))
 
 /obj/machinery/button/valhalla/xeno_button
@@ -292,6 +295,9 @@
 		return
 
 	QDEL_NULL(linked)
+	if(!get_turf(GLOB.valhalla_button_spawn_landmark[link]))
+		to_chat(X, span_warning("An error occured, yell at the coders."))
+		CRASH("Valhalla button linked with an improper landmark: button ID: [link].")
 	linked = new /mob/living/carbon/human(get_turf(GLOB.valhalla_button_spawn_landmark[link]))
 	if(selected_outfit == "Naked" || !selected_outfit)
 		return


### PR DESCRIPTION
## About The Pull Request

Fixes valhalla buttons spawning xenos in nullspace and adds a check to prevent future bugs like this.

Thank you Blundir from pointing out how to reproduce this.

## Why It's Good For The Game

Bugs not good. Xenos are spawning in nullspace and taking up slots.
## Changelog
:cl:
fix: Fixed valhalla buttons
/:cl:
