### PR TITLE
Add keybind for activate autorepair for combat robots

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -822,7 +822,7 @@
 #define COMSIG_KB_FIREMODE "keybind_firemode"
 #define COMSIG_KB_GIVE "keybind_give"
 #define COMSIG_KB_HELMETMODULE "keybinding_helmetmodule"
-#define COMSIG_KB_AUTOREPAIR "keybinding_autorepair"
+#define COMSIG_KB_ROBOT_AUTOREPAIR "keybinding_robot_autorepair"
 #define COMSIG_KB_SUITLIGHT "keybinding_suitlight"
 #define COMSIG_KB_MOVEORDER "keybind_moveorder"
 #define COMSIG_KB_HOLDORDER "keybind_holdorder"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -822,6 +822,7 @@
 #define COMSIG_KB_FIREMODE "keybind_firemode"
 #define COMSIG_KB_GIVE "keybind_give"
 #define COMSIG_KB_HELMETMODULE "keybinding_helmetmodule"
+#define COMSIG_KB_AUTOREPAIR "keybinding_autorepair"
 #define COMSIG_KB_SUITLIGHT "keybinding_suitlight"
 #define COMSIG_KB_MOVEORDER "keybind_moveorder"
 #define COMSIG_KB_HOLDORDER "keybind_holdorder"

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -106,6 +106,13 @@
 	description = "Toggles your suit light on or off"
 	keybind_signal = COMSIG_KB_SUITLIGHT
 
+/datum/keybinding/human/activate_autorepair
+	hotkey_keys = list("g")
+	name = "autorepair"
+	full_name = "Activate autorepair"
+	description = "Activate combat robot's autorepair"
+	keybind_signal = COMSIG_KB_AUTOREPAIR
+
 /datum/keybinding/human/move_order
 	name = "move_order"
 	full_name = "Issue Move Order"

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -106,12 +106,12 @@
 	description = "Toggles your suit light on or off"
 	keybind_signal = COMSIG_KB_SUITLIGHT
 
-/datum/keybinding/human/activate_autorepair
+/datum/keybinding/human/activate_robot_autorepair
 	hotkey_keys = list("g")
 	name = "autorepair"
-	full_name = "Activate autorepair"
+	full_name = "Activate combat robot autorepair"
 	description = "Activate combat robot's autorepair"
-	keybind_signal = COMSIG_KB_AUTOREPAIR
+	keybind_signal = COMSIG_KB_ROBOT_AUTOREPAIR
 
 /datum/keybinding/human/move_order
 	name = "move_order"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -471,7 +471,7 @@
 	name = "Activate autorepair"
 	action_icon_state = "suit_configure"
 	keybinding_signals = list(
-		KEYBINDING_NORMAL = COMSIG_KB_AUTOREPAIR,
+		KEYBINDING_NORMAL = COMSIG_KB_ROBOT_AUTOREPAIR,
 	)
 
 /datum/action/repair_self/can_use_action()

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -470,6 +470,9 @@
 /datum/action/repair_self
 	name = "Activate autorepair"
 	action_icon_state = "suit_configure"
+	keybinding_signals = list(
+		KEYBINDING_NORMAL = COMSIG_KB_AUTOREPAIR,
+	)
 
 /datum/action/repair_self/can_use_action()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

title.


https://user-images.githubusercontent.com/6610922/226139268-481dfa3b-7c19-411e-b55a-798e1d7bfd0d.mp4



## Why It's Good For The Game

Having keybinds for this action is good for combat robots that don't want to click action button. QoL, essentially.

## Changelog

:cl:
add: Add keybind for activate autorepair for combat robots
/:cl:

