### PR TITLE
You can show patients their health scan with RMB.

### DIFF
--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -80,21 +80,35 @@ REAGENT SCANNER
 
 /obj/item/healthanalyzer/attack(mob/living/carbon/M, mob/living/user)
 	. = ..()
+	analyze_vitals(M, user)
+
+/obj/item/healthanalyzer/attack_alternate(mob/living/carbon/M, mob/living/user)
+	. = ..()
+	analyze_vitals(M, user, TRUE)
+
+///Health scans a target. M is the thing being scanned, user is the person doing the scanning, show_patient will show the UI to the scanee when TRUE.
+/obj/item/healthanalyzer/proc/analyze_vitals(mob/living/carbon/M, mob/living/user, show_patient)
 	if(user.skills.getRating(SKILL_MEDICAL) < skill_threshold)
 		to_chat(user, span_warning("You start fumbling around with [src]..."))
 		if(!do_mob(user, M, max(SKILL_TASK_AVERAGE - (1 SECONDS * user.skills.getRating(SKILL_MEDICAL)), 0), BUSY_ICON_UNSKILLED))
 			return
 	playsound(src.loc, 'sound/items/healthanalyzer.ogg', 50)
-	if(CHECK_BITFIELD(M.species.species_flags, NO_SCAN))
-		to_chat(user, span_warning("Error: Cannot read vitals!"))
+	if(!iscarbon(M))
+		to_chat(user, span_warning("Error: Unable to scan"))
 		return
 	if(isxeno(M))
 		to_chat(user, span_warning("[src] can't make sense of this creature!"))
 		return
+	if(CHECK_BITFIELD(M.species.species_flags, NO_SCAN))
+		to_chat(user, span_warning("Error: Cannot read vitals!"))
+		return
 	to_chat(user, span_notice("[user] has analyzed [M]'s vitals."))
 	patient = M
 	current_user = user
-	ui_interact(user)
+	if(show_patient == TRUE)
+		ui_interact(M)
+	else
+		ui_interact(user)
 	update_static_data(user)
 	if(user.skills.getRating(SKILL_MEDICAL) < upper_skill_threshold)
 		return

--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -94,15 +94,15 @@ REAGENT SCANNER
 			return
 	playsound(src.loc, 'sound/items/healthanalyzer.ogg', 50)
 	if(!iscarbon(M))
-		to_chat(user, span_warning("Error: Unable to scan"))
+		balloon_alert(user, "Cannot scan")
 		return
 	if(isxeno(M))
-		to_chat(user, span_warning("[src] can't make sense of this creature!"))
+		balloon_alert(user, "Unknown entity")
 		return
 	if(CHECK_BITFIELD(M.species.species_flags, NO_SCAN))
-		to_chat(user, span_warning("Error: Cannot read vitals!"))
+		balloon_alert(user, "Not Organic")
 		return
-	to_chat(user, span_notice("[user] has analyzed [M]'s vitals."))
+	balloon_alert_to_viewers("Analyzed Vitals")
 	patient = M
 	current_user = user
 	if(show_patient == TRUE)

--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -99,13 +99,13 @@ REAGENT SCANNER
 	if(isxeno(M))
 		balloon_alert(user, "Unknown entity")
 		return
-	if(CHECK_BITFIELD(M.species.species_flags, NO_SCAN))
+	if(M.species.species_flags & NO_SCAN)
 		balloon_alert(user, "Not Organic")
 		return
 	balloon_alert_to_viewers("Analyzed Vitals")
 	patient = M
 	current_user = user
-	if(show_patient == TRUE)
+	if(show_patient)
 		ui_interact(M)
 	else
 		ui_interact(user)

--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -102,7 +102,7 @@ REAGENT SCANNER
 	if(M.species.species_flags & NO_SCAN)
 		balloon_alert(user, "Not Organic")
 		return
-	balloon_alert_to_viewers("Analyzed Vitals")
+	balloon_alert(user, "Analyzed Vitals")
 	patient = M
 	current_user = user
 	if(show_patient)

--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -102,7 +102,6 @@ REAGENT SCANNER
 	if(M.species.species_flags & NO_SCAN)
 		balloon_alert(user, "Not Organic")
 		return
-	balloon_alert(user, "Analyzed Vitals")
 	patient = M
 	current_user = user
 	if(show_patient)


### PR DESCRIPTION
## About The Pull Request
Moves the health scan function of the health analyzer over to a new proc analyze_vitals().
Fixes runtime error on health scan.
New functionality, RMB can be used to show the patient you are scanning their health scan.
## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/66163761/226162686-106d4346-2b0e-4b32-9dd0-3a44451df507.png)
I agree, thanks for the idea @Losenis 
## Changelog
:cl:
add: RMB with health analyzer will show the patient their health.
add: Health scanner balloon alerts.
fix: Runtime involved when health scanning non-carbons.
/:cl:
