### PR TITLE
Makes Saline restore nutrition.

### DIFF
--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -279,6 +279,7 @@
 	name = "Saline-Glucose"
 	description = "Saline-Glucose can be used to restore blood in a pinch."
 	color = "#d4f1f9"
+	var/nutriment_factor = 1.5
 	custom_metabolism = REAGENTS_METABOLISM * 2
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
@@ -286,8 +287,10 @@
 	scannable = TRUE
 
 /datum/reagent/medicine/saline_glucose/on_mob_life(mob/living/L, metabolism)
-	if(L.blood_volume < BLOOD_VOLUME_NORMAL)
-		L.blood_volume += 1.2
+	var/mob/living/carbon/human = L
+	if(human.blood_volume < BLOOD_VOLUME_NORMAL)
+		human.blood_volume += 1.2
+	human.adjust_nutrition(nutriment_factor)
 	return ..()
 
 /datum/reagent/medicine/saline_glucose/overdose_process(mob/living/L, metabolism)


### PR DESCRIPTION

## About The Pull Request
Creates var/nutriment_factor on saline glucose.
Makes saline restore nutrition.
## Why It's Good For The Game
I've received several complaints that removing nutriment from isotonics was a bad change, so I'm adding some kind of nutrition restoration to it.
A protein bar (8 nutriment) restores ~150 nutrition.
1 Isotonic pill at var/nutriment_factor 1.5 will restore ~50 nutrition.
This is balanced by the fact that saline-glucose now occupies a chem slot, whereas nutriment and iron do not/did not.
## Changelog
:cl:
balance: Isotonics restore minor nutrition again.
/:cl:
