### PR TITLE
Fix xenonauten_light not vending properly

### DIFF
--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -832,6 +832,12 @@
 		/obj/item/clothing/suit/modular/jaeger/heavy/eod,
 	)
 
+/obj/effect/vendor_bundle/xenonauten_light
+	desc = "A set of light Xenonauten pattern armor, including an armor suit and helmet."
+	gear_to_spawn = list(
+		/obj/item/clothing/head/modular/m10x,
+		/obj/item/clothing/suit/modular/xenonauten/light,
+	)
 
 /obj/effect/vendor_bundle/xenonauten_medium
 	desc = "A set of medium Xenonauten pattern armor, including an armor suit and helmet."


### PR DESCRIPTION
## About The Pull Request
Bugfix.
![image](https://user-images.githubusercontent.com/66163761/226257664-5e71abc8-bd21-4885-a5e5-b0b7f320f396.png)
## Why It's Good For The Game
Bugfix
Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/12453
## Changelog
:cl:
fix: Fixes xenonauten light armor not vending in GHMME.
/:cl:
