### PR TITLE
Kills pocket var for good + loadout fix

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -183,6 +183,8 @@
 
 #define isgreyscaleattachment(A) (istype(A, /obj/item/armor_module/greyscale))
 
+#define ishat(A) (istype(A, /obj/item/clothing/head))
+
 #define ismodularhelmet(A) (istype(A, /obj/item/clothing/head/modular))
 
 #define isattachmentflashlight(A) (istype(A, /obj/item/attachable/flashlight))

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -718,6 +718,6 @@ GLOBAL_LIST_INIT(bypass_storage_content_save, typecacheof(list(
 #define MAXIMUM_LOADOUT 50
 
 /// The current loadout version
-#define CURRENT_LOADOUT_VERSION 10
+#define CURRENT_LOADOUT_VERSION 11
 
 GLOBAL_LIST_INIT(accepted_loadout_versions, list(5, 6, 7, 8, 9, 10))

--- a/code/datums/loadout/item_representation/_item_representation.dm
+++ b/code/datums/loadout/item_representation/_item_representation.dm
@@ -157,30 +157,35 @@
 	return id
 
 /datum/item_representation/boot
-	/// The item stored in the boot
-	var/datum/item_representation/boot_content
+	///List of attachments on the boot.
+	var/list/datum/item_representation/armor_module/attachments = list()
 
 /datum/item_representation/boot/New(obj/item/item_to_copy)
 	if(!item_to_copy)
 		return
-	if(!istype(item_to_copy, /obj/item/clothing/shoes/marine))
-		CRASH("/datum/item_representation/boot created from an item that is not a marine boot")
+	if(!istype(item_to_copy, /obj/item/clothing/shoes))
+		CRASH("/datum/item_representation/boot created from an item that is not a shoe")
 	..()
-	var/obj/item/clothing/shoes/marine/marine_shoes = item_to_copy
-	for(var/atom/item_in_pocket AS in marine_shoes.pockets.contents)
-		var/item_representation_type = item2representation_type(item_in_pocket.type)
-		boot_content = new item_representation_type(item_in_pocket)
+	var/obj/item/clothing/shoes/footwear = item_to_copy
 
-/datum/item_representation/boot/instantiate_object(datum/loadout_seller/seller, master, mob/living/user)
+	for(var/key in footwear.attachments_by_slot)
+		if(!isitem(footwear.attachments_by_slot[key]))
+			continue
+		if(istype(footwear.attachments_by_slot[key], /obj/item/armor_module/greyscale))
+			attachments += new /datum/item_representation/armor_module/colored(footwear.attachments_by_slot[key])
+			continue
+		if(istype(footwear.attachments_by_slot[key], /obj/item/armor_module/armor))
+			attachments += new /datum/item_representation/armor_module/armor(footwear.attachments_by_slot[key])
+			continue
+		if(istype(footwear.attachments_by_slot[key], /obj/item/armor_module/storage))
+			attachments += new /datum/item_representation/armor_module/storage(footwear.attachments_by_slot[key])
+			continue
+		attachments += new /datum/item_representation/armor_module(footwear.attachments_by_slot[key])
+
+/datum/item_representation/boot/instantiate_object(datum/loadout_seller/seller, master = null, mob/living/user)
 	. = ..()
 	if(!.)
 		return
-	var/obj/item/clothing/shoes/marine/marine_shoes = .
-	marine_shoes.pockets.delete_contents()
-	if(!boot_content)
-		return
-	var/obj/item/item_in_pocket = boot_content.instantiate_object(seller, master, user)
-	if(marine_shoes.pockets.can_be_inserted(item_in_pocket))
-		marine_shoes.pockets.handle_item_insertion(item_in_pocket)
-	else
-		qdel(item_in_pocket)
+	var/obj/item/clothing/shoes/footwear = .
+	for(var/datum/item_representation/armor_module/armor_attachement AS in attachments)
+		armor_attachement.install_on_armor(seller, footwear, user)

--- a/code/datums/loadout/item_representation/helmet_representation.dm
+++ b/code/datums/loadout/item_representation/helmet_representation.dm
@@ -1,23 +1,18 @@
 /**
- * Allow to representate a modular helmet, and to color it
- * This is only able to representate items of type /obj/item/clothing/head/modular
+ * Allow to representate a hat
+ * This is only able to representate items of type /obj/item/clothing/head
  */
-/datum/item_representation/modular_helmet
-	///The color of the helmet
-	var/greyscale_colors
+/datum/item_representation/hat
 	///The attachments installed.
 	var/list/datum/item_representation/armor_module/attachments = list()
-	///Icon_state suffix for the saved icon_state varient.
-	var/current_variant
 
-/datum/item_representation/modular_helmet/New(obj/item/item_to_copy)
+/datum/item_representation/hat/New(obj/item/item_to_copy)
 	if(!item_to_copy)
 		return
-	if(!ismodularhelmet(item_to_copy))
-		CRASH("/datum/item_representation/modular_helmet created from an item that is not an modular helmet")
+	if(!ishat(item_to_copy))
+		CRASH("/datum/item_representation/hat created from an item that is not an hat")
 	..()
-	var/obj/item/clothing/head/modular/helmet_to_copy = item_to_copy
-	current_variant = helmet_to_copy.current_variant
+	var/obj/item/clothing/head/helmet_to_copy = item_to_copy
 	for(var/key in helmet_to_copy.attachments_by_slot)
 		if(!isitem(helmet_to_copy.attachments_by_slot[key]))
 			continue
@@ -28,21 +23,92 @@
 			attachments += new /datum/item_representation/armor_module/storage(helmet_to_copy.attachments_by_slot[key])
 			continue
 		attachments += new /datum/item_representation/armor_module(helmet_to_copy.attachments_by_slot[key])
+
+/datum/item_representation/hat/instantiate_object(datum/loadout_seller/seller, master = null, mob/living/user)
+	. = ..()
+	if(!.)
+		return
+	var/obj/item/clothing/head/new_hat = .
+	for(var/datum/item_representation/armor_module/armor_attachement AS in attachments)
+		armor_attachement.install_on_armor(seller, new_hat, user)
+	new_hat.update_icon()
+
+/datum/item_representation/hat/get_tgui_data()
+	var/list/tgui_data = list()
+	tgui_data["name"] = initial(item_type.name)
+	tgui_data["icons"] = list()
+	var/icon/icon_to_convert
+	icon_to_convert = icon(initial(item_type.icon), initial(item_type.icon_state), SOUTH)
+	tgui_data["icons"] += list(list(
+				"icon" = icon2base64(icon_to_convert),
+				"translateX" = NO_OFFSET,
+				"translateY" = "40%",
+				"scale" = 1.4,
+				))
+	for(var/datum/item_representation/armor_module/module AS in attachments)
+		if(istype(module, /datum/item_representation/armor_module/colored))
+			var/datum/item_representation/armor_module/colored/colored_module = module
+			icon_to_convert = icon(SSgreyscale.GetColoredIconByType(initial(colored_module.item_type.greyscale_config), colored_module.greyscale_colors), dir = SOUTH)
+			tgui_data["icons"] += list(list(
+					"icon" = icon2base64(icon_to_convert),
+					"translateX" = NO_OFFSET,
+					"translateY" = "40%",
+					"scale" = 1.4,
+					))
+			continue
+		if(ispath(module.item_type, /obj/item/armor_module/module))
+			icon_to_convert = icon(initial(module.item_type.icon), initial(module.item_type.icon_state), SOUTH)
+			tgui_data["icons"] += list(list(
+					"icon" = icon2base64(icon_to_convert),
+					"translateX" = "40%",
+					"translateY" = "35%",
+					"scale" = 0.5,
+					))
+			continue
+		icon_to_convert = icon(initial(module.item_type.icon), initial(module.item_type.icon_state), SOUTH)
+		tgui_data["icons"] += list(list(
+					"icon" = icon2base64(icon_to_convert),
+					"translateX" = NO_OFFSET,
+					"translateY" = "40%",
+					"scale" = 1.4,
+					))
+	return tgui_data
+
+
+
+/////////////////////////////////////
+
+/**
+ * Allow to representate a modular helmet, and to color it
+ * This is only able to representate items of type /obj/item/clothing/head/modular
+ */
+/datum/item_representation/hat/modular_helmet
+	///The color of the helmet
+	var/greyscale_colors
+	///Icon_state suffix for the saved icon_state varient.
+	var/current_variant
+
+/datum/item_representation/hat/modular_helmet/New(obj/item/item_to_copy)
+	if(!item_to_copy)
+		return
+	if(!ismodularhelmet(item_to_copy))
+		CRASH("/datum/item_representation/hat/modular_helmet created from an item that is not an modular helmet")
+	..()
+	var/obj/item/clothing/head/modular/helmet_to_copy = item_to_copy
+	current_variant = helmet_to_copy.current_variant
 	greyscale_colors = helmet_to_copy.greyscale_colors
 
-/datum/item_representation/modular_helmet/instantiate_object(datum/loadout_seller/seller, master = null, mob/living/user)
+/datum/item_representation/hat/modular_helmet/instantiate_object(datum/loadout_seller/seller, master = null, mob/living/user)
 	. = ..()
 	if(!.)
 		return
 	var/obj/item/clothing/head/modular/modular_helmet = .
 	modular_helmet.current_variant = (current_variant in modular_helmet.icon_state_variants) ? current_variant : initial(modular_helmet.current_variant)
-	for(var/datum/item_representation/armor_module/armor_attachement AS in attachments)
-		armor_attachement.install_on_armor(seller, modular_helmet, user)
 	if(greyscale_colors)
 		modular_helmet.set_greyscale_colors(greyscale_colors)
 	modular_helmet.update_icon()
 
-/datum/item_representation/modular_helmet/get_tgui_data()
+/datum/item_representation/hat/modular_helmet/get_tgui_data()
 	var/list/tgui_data = list()
 	tgui_data["name"] = initial(item_type.name)
 	tgui_data["icons"] = list()

--- a/code/datums/loadout/loadout_helper.dm
+++ b/code/datums/loadout/loadout_helper.dm
@@ -97,7 +97,9 @@
 	if(ispath(item_type, /obj/item/clothing/suit))
 		return /datum/item_representation/armor_suit
 	if(ispath(item_type, /obj/item/clothing/head/modular))
-		return /datum/item_representation/modular_helmet
+		return /datum/item_representation/hat/modular_helmet
+	if(ispath(item_type, /obj/item/clothing/head))
+		return /datum/item_representation/hat
 	if(ispath(item_type, /obj/item/clothing/under))
 		return /datum/item_representation/uniform_representation
 	if(ispath(item_type, /obj/item/ammo_magazine/handful))

--- a/code/datums/loadout/loadout_manager.dm
+++ b/code/datums/loadout/loadout_manager.dm
@@ -99,7 +99,7 @@
 				to_chat(ui.user, span_warning("The loadouts was found but is from a past version, and cannot be imported."))
 				return
 			if(loadout.version != CURRENT_LOADOUT_VERSION)
-				var/datum/item_representation/modular_helmet/helmet = loadout.item_list[slot_head_str]
+				var/datum/item_representation/hat/modular_helmet/helmet = loadout.item_list[slot_head_str]
 				if(istype(helmet, /datum/item_representation/modular_helmet))
 					if(loadout.version < 7)
 						loadout.empty_slot(slot_head_str)
@@ -112,8 +112,17 @@
 							if(!istype(module, /datum/item_representation/armor_module/colored))
 								continue
 							module.greyscale_colors = initial(module.item_type.greyscale_colors)
+					if(loadout.version < 11)
+						var/datum/item_representation/modular_helmet/old_helmet = loadout.item_list[slot_head_str]
+						var/datum/item_representation/hat/modular_helmet/new_helmet = new
+						new_helmet.item_type = old_helmet.item_type
+						new_helmet.bypass_vendor_check = old_helmet.bypass_vendor_check
+						new_helmet.greyscale_colors = old_helmet.greyscale_colors
+						new_helmet.current_variant = old_helmet.current_variant
+						new_helmet.attachments = old_helmet.attachments
+						loadout.item_list[slot_head_str] = new_helmet
 				var/datum/item_representation/armor_suit/modular_armor/armor = loadout.item_list[slot_wear_suit_str]
-				if(istype(armor, /datum/item_representation/armor_suit/modular_armor))
+				if(istype(armor, /datum/item_representation/modular_armor))
 					if(loadout.version < 7)
 						loadout.empty_slot(slot_wear_suit_str)
 					if(loadout.version < 8)
@@ -124,11 +133,23 @@
 							if(!istype(module, /datum/item_representation/armor_module/colored))
 								continue
 							module.greyscale_colors = initial(module.item_type.greyscale_colors)
+					if(loadout.version < 11)
+						var/datum/item_representation/modular_armor/old_armor = loadout.item_list[slot_wear_suit_str]
+						var/datum/item_representation/armor_suit/modular_armor/new_armor = new
+						new_armor.item_type = old_armor.item_type
+						new_armor.bypass_vendor_check = old_armor.bypass_vendor_check
+						new_armor.current_variant = old_armor.current_variant
+						new_armor.attachments = old_armor.attachments
+						loadout.item_list[slot_wear_suit_str] = new_armor
 				var/datum/item_representation/uniform_representation/uniform = loadout.item_list[slot_w_uniform_str]
 				if(istype(uniform, /datum/item_representation/uniform_representation))
 					if(loadout.version < 9)
 						uniform.current_variant = null
 						uniform.attachments = list()
+				var/datum/item_representation/boot/footwear = loadout.item_list[slot_shoes_str]
+				if(loadout.version < 11)
+					if("[footwear.item_type]" == "/obj/item/clothing/shoes/marine/full")
+						loadout.empty_slot(slot_shoes_str)
 				var/message_to_send = "Please note: The loadout code has been updated and due to that:"
 				if(loadout.version < 7)
 					message_to_send += "<br>any modular helmet/suit has been removed from it due to the transitioning of loadout version 6 to 7."
@@ -138,6 +159,8 @@
 					message_to_send += "<br>any uniforms have had their webbings/accessory removed due to the transitioning of loadout version 8 to 9."
 				if(loadout.version < 10)
 					message_to_send += "<br>any modular armor pieces and jaeger helmets have had their colors reset due to the new color/greyscale system. (version 9 to 10)"
+				if(loadout.version < 11)
+					message_to_send += "<br>Some boots, helmets and armour have had their internal storage refactored and some items may be removed from your loadout. (version 10 to 11)"
 				loadout.version = CURRENT_LOADOUT_VERSION
 				message_to_send += "<br>This loadout is now on version [loadout.version]"
 				to_chat(ui.user, span_warning(message_to_send))
@@ -162,7 +185,7 @@
 				delete_loadout(ui.user, name, job)
 				CRASH("Fail to load loadouts")
 			if(loadout.version != CURRENT_LOADOUT_VERSION)
-				var/datum/item_representation/modular_helmet/helmet = loadout.item_list[slot_head_str]
+				var/datum/item_representation/hat/modular_helmet/helmet = loadout.item_list[slot_head_str]
 				if(istype(helmet, /datum/item_representation/modular_helmet))
 					if(loadout.version < 7)
 						loadout.empty_slot(slot_head_str)
@@ -175,8 +198,17 @@
 							if(!istype(module, /datum/item_representation/armor_module/colored))
 								continue
 							module.greyscale_colors = initial(module.item_type.greyscale_colors)
+					if(loadout.version < 11)
+						var/datum/item_representation/modular_helmet/old_helmet = loadout.item_list[slot_head_str]
+						var/datum/item_representation/hat/modular_helmet/new_helmet = new
+						new_helmet.item_type = old_helmet.item_type
+						new_helmet.bypass_vendor_check = old_helmet.bypass_vendor_check
+						new_helmet.greyscale_colors = old_helmet.greyscale_colors
+						new_helmet.current_variant = old_helmet.current_variant
+						new_helmet.attachments = old_helmet.attachments
+						loadout.item_list[slot_head_str] = new_helmet
 				var/datum/item_representation/armor_suit/modular_armor/armor = loadout.item_list[slot_wear_suit_str]
-				if(istype(armor, /datum/item_representation/armor_suit/modular_armor))
+				if(istype(armor, /datum/item_representation/modular_armor))
 					if(loadout.version < 7)
 						loadout.empty_slot(slot_wear_suit_str)
 					if(loadout.version < 8)
@@ -187,7 +219,6 @@
 							if(!istype(module, /datum/item_representation/armor_module/colored))
 								continue
 							module.greyscale_colors = initial(module.item_type.greyscale_colors)
-				else if(istype(armor, /datum/item_representation/modular_armor)) //please forgive this guh
 					if(loadout.version < 11)
 						var/datum/item_representation/modular_armor/old_armor = loadout.item_list[slot_wear_suit_str]
 						var/datum/item_representation/armor_suit/modular_armor/new_armor = new

--- a/code/datums/loadout/loadout_manager.dm
+++ b/code/datums/loadout/loadout_manager.dm
@@ -187,6 +187,14 @@
 							if(!istype(module, /datum/item_representation/armor_module/colored))
 								continue
 							module.greyscale_colors = initial(module.item_type.greyscale_colors)
+				else if(istype(armor, /datum/item_representation/modular_armor))
+					var/datum/item_representation/modular_armor/old_armor = loadout.item_list[slot_wear_suit_str]
+					var/datum/item_representation/armor_suit/modular_armor/new_armor = new
+					new_armor.item_type = old_armor.item_type
+					new_armor.bypass_vendor_check = old_armor.bypass_vendor_check
+					new_armor.current_variant = old_armor.current_variant
+					new_armor.attachments = old_armor.attachments
+					loadout.item_list[slot_wear_suit_str] = new_armor
 				var/datum/item_representation/uniform_representation/uniform = loadout.item_list[slot_w_uniform_str]
 				if(istype(uniform, /datum/item_representation/uniform_representation))
 					if(loadout.version < 9)

--- a/code/datums/loadout/loadout_manager.dm
+++ b/code/datums/loadout/loadout_manager.dm
@@ -236,8 +236,7 @@
 				if(loadout.version < 11)
 					if("[footwear.item_type]" == "/obj/item/clothing/shoes/marine/full")
 						var/obj/item/clothing/shoes/marine/full/new_boots = new (loadout_vendor)
-						footwear = new(new_boots)
-						loadout.item_list[slot_shoes_str] = footwear
+						loadout.item_list[slot_shoes_str] = new /datum/item_representation/boot(new_boots)
 				var/message_to_send = "Please note: The loadout code has been updated and due to that:"
 				if(loadout.version < 7)
 					message_to_send += "<br>any modular helmet/suit has been removed from it due to the transitioning of loadout version 6 to 7."

--- a/code/datums/loadout/loadout_manager.dm
+++ b/code/datums/loadout/loadout_manager.dm
@@ -210,6 +210,18 @@
 						new_helmet.current_variant = old_helmet.current_variant
 						new_helmet.attachments = old_helmet.attachments
 						loadout.item_list[slot_head_str] = new_helmet
+				else if(loadout.version < 11)
+					var/datum/item_representation/old_hat = loadout.item_list[slot_head_str]
+					var/datum/item_representation/hat/modular_helmet/new_hat = new
+					if("[old_hat.item_type]" == "/obj/item/clothing/head/helmet/marine/robot")
+						new_hat.item_type = /obj/item/clothing/head/modular/robot
+					if("[old_hat.item_type]" == "/obj/item/clothing/head/helmet/marine/robot/light")
+						new_hat.item_type = /obj/item/clothing/head/modular/robot/light
+					if("[old_hat.item_type]" == "/obj/item/clothing/head/helmet/marine/robot/heavy")
+						new_hat.item_type = /obj/item/clothing/head/modular/robot/heavy
+					new_hat.bypass_vendor_check = old_hat.bypass_vendor_check
+					new_hat.current_variant = "black"
+					loadout.item_list[slot_head_str] = new_hat
 				var/datum/item_representation/armor_suit/modular_armor/armor = loadout.item_list[slot_wear_suit_str]
 				if(istype(armor, /datum/item_representation/modular_armor))
 					if(loadout.version < 7)
@@ -229,6 +241,19 @@
 						new_armor.bypass_vendor_check = old_armor.bypass_vendor_check
 						new_armor.current_variant = old_armor.current_variant
 						new_armor.attachments = old_armor.attachments
+						loadout.item_list[slot_wear_suit_str] = new_armor
+				else if(istype(armor, /datum/item_representation/suit_with_storage))
+					if(loadout.version < 11)
+						var/datum/item_representation/suit_with_storage/old_armor = loadout.item_list[slot_wear_suit_str]
+						var/datum/item_representation/armor_suit/modular_armor/new_armor = new
+						if("[old_armor.item_type]" == "/obj/item/clothing/suit/storage/marine/robot")
+							new_armor.item_type = /obj/item/clothing/suit/modular/robot
+						if("[old_armor.item_type]" == "/obj/item/clothing/suit/storage/marine/robot/light")
+							new_armor.item_type = /obj/item/clothing/suit/modular/robot/light
+						if("[old_armor.item_type]" == "/obj/item/clothing/suit/storage/marine/robot/heavy")
+							new_armor.item_type = /obj/item/clothing/suit/modular/robot/heavy
+						new_armor.bypass_vendor_check = old_armor.bypass_vendor_check
+						new_armor.current_variant = "black"
 						loadout.item_list[slot_wear_suit_str] = new_armor
 				var/datum/item_representation/uniform_representation/uniform = loadout.item_list[slot_w_uniform_str]
 				if(istype(uniform, /datum/item_representation/uniform_representation))

--- a/code/datums/loadout/loadout_manager.dm
+++ b/code/datums/loadout/loadout_manager.dm
@@ -149,7 +149,9 @@
 				var/datum/item_representation/boot/footwear = loadout.item_list[slot_shoes_str]
 				if(loadout.version < 11)
 					if("[footwear.item_type]" == "/obj/item/clothing/shoes/marine/full")
-						loadout.empty_slot(slot_shoes_str)
+						var/obj/item/clothing/shoes/marine/full/new_boots = new (loadout_vendor)
+						loadout.item_list[slot_shoes_str] = new /datum/item_representation/boot(new_boots)
+						qdel(new_boots)
 				var/message_to_send = "Please note: The loadout code has been updated and due to that:"
 				if(loadout.version < 7)
 					message_to_send += "<br>any modular helmet/suit has been removed from it due to the transitioning of loadout version 6 to 7."
@@ -237,6 +239,7 @@
 					if("[footwear.item_type]" == "/obj/item/clothing/shoes/marine/full")
 						var/obj/item/clothing/shoes/marine/full/new_boots = new (loadout_vendor)
 						loadout.item_list[slot_shoes_str] = new /datum/item_representation/boot(new_boots)
+						qdel(new_boots)
 				var/message_to_send = "Please note: The loadout code has been updated and due to that:"
 				if(loadout.version < 7)
 					message_to_send += "<br>any modular helmet/suit has been removed from it due to the transitioning of loadout version 6 to 7."

--- a/code/datums/loadout/loadout_manager.dm
+++ b/code/datums/loadout/loadout_manager.dm
@@ -147,11 +147,12 @@
 						uniform.current_variant = null
 						uniform.attachments = list()
 				var/datum/item_representation/boot/footwear = loadout.item_list[slot_shoes_str]
-				if(loadout.version < 11)
-					if("[footwear.item_type]" == "/obj/item/clothing/shoes/marine/full")
-						var/obj/item/clothing/shoes/marine/full/new_boots = new (loadout_vendor)
-						loadout.item_list[slot_shoes_str] = new /datum/item_representation/boot(new_boots)
-						qdel(new_boots)
+				if(footwear)
+					if(loadout.version < 11)
+						if("[footwear.item_type]" == "/obj/item/clothing/shoes/marine/full")
+							var/obj/item/clothing/shoes/marine/full/new_boots = new (loadout_vendor)
+							loadout.item_list[slot_shoes_str] = new /datum/item_representation/boot(new_boots)
+							qdel(new_boots)
 				var/message_to_send = "Please note: The loadout code has been updated and due to that:"
 				if(loadout.version < 7)
 					message_to_send += "<br>any modular helmet/suit has been removed from it due to the transitioning of loadout version 6 to 7."
@@ -235,11 +236,12 @@
 						uniform.current_variant = null
 						uniform.attachments = list()
 				var/datum/item_representation/boot/footwear = loadout.item_list[slot_shoes_str]
-				if(loadout.version < 11)
-					if("[footwear.item_type]" == "/obj/item/clothing/shoes/marine/full")
-						var/obj/item/clothing/shoes/marine/full/new_boots = new (loadout_vendor)
-						loadout.item_list[slot_shoes_str] = new /datum/item_representation/boot(new_boots)
-						qdel(new_boots)
+				if(footwear)
+					if(loadout.version < 11)
+						if("[footwear.item_type]" == "/obj/item/clothing/shoes/marine/full")
+							var/obj/item/clothing/shoes/marine/full/new_boots = new (loadout_vendor)
+							loadout.item_list[slot_shoes_str] = new /datum/item_representation/boot(new_boots)
+							qdel(new_boots)
 				var/message_to_send = "Please note: The loadout code has been updated and due to that:"
 				if(loadout.version < 7)
 					message_to_send += "<br>any modular helmet/suit has been removed from it due to the transitioning of loadout version 6 to 7."

--- a/code/datums/loadout/loadout_manager.dm
+++ b/code/datums/loadout/loadout_manager.dm
@@ -201,6 +201,10 @@
 					if(loadout.version < 9)
 						uniform.current_variant = null
 						uniform.attachments = list()
+				var/datum/item_representation/boot/footwear = loadout.item_list[slot_shoes_str]
+				if(loadout.version < 11)
+					if("[footwear.item_type]" == "/obj/item/clothing/shoes/marine/full")
+						loadout.empty_slot(slot_shoes_str)
 				var/message_to_send = "Please note: The loadout code has been updated and due to that:"
 				if(loadout.version < 7)
 					message_to_send += "<br>any modular helmet/suit has been removed from it due to the transitioning of loadout version 6 to 7."
@@ -209,7 +213,9 @@
 				if(loadout.version < 9)
 					message_to_send += "<br>any uniforms have had their webbings/accessory removed due to the transitioning of loadout version 8 to 9."
 				if(loadout.version < 10)
-					message_to_send += "<br>any modular armor pieces and jaeger helmets have had their colors reset due to the new color/greyscale system. (version 9 to 10)"
+					message_to_send += "<br>any modular armor pieces and jaeger helmets have had their colors reset due to the new color/greyscale system. (version 19 to 10)"
+				if(loadout.version < 11)
+					message_to_send += "<br>Some boots, helmets and armour have had their internal storage refactored and some items may be removed from your loadout. (version 10 to 11)"
 				loadout.version = CURRENT_LOADOUT_VERSION
 				message_to_send += "<br>This loadout is now on version [loadout.version]"
 				to_chat(ui.user, span_warning(message_to_send))

--- a/code/datums/loadout/loadout_manager.dm
+++ b/code/datums/loadout/loadout_manager.dm
@@ -121,6 +121,19 @@
 						new_helmet.current_variant = old_helmet.current_variant
 						new_helmet.attachments = old_helmet.attachments
 						loadout.item_list[slot_head_str] = new_helmet
+				else if(loadout.version < 11)
+					var/datum/item_representation/old_hat = loadout.item_list[slot_head_str]
+					var/datum/item_representation/hat/modular_helmet/new_hat = new
+					if("[old_hat.item_type]" == "/obj/item/clothing/head/helmet/marine/robot")
+						new_hat.item_type = /obj/item/clothing/head/modular/robot
+					if("[old_hat.item_type]" == "/obj/item/clothing/head/helmet/marine/robot/light")
+						new_hat.item_type = /obj/item/clothing/head/modular/robot/light
+					if("[old_hat.item_type]" == "/obj/item/clothing/head/helmet/marine/robot/heavy")
+						new_hat.item_type = /obj/item/clothing/head/modular/robot/heavy
+					new_hat.bypass_vendor_check = old_hat.bypass_vendor_check
+					new_hat.current_variant = "black"
+					loadout.item_list[slot_head_str] = new_hat
+
 				var/datum/item_representation/armor_suit/modular_armor/armor = loadout.item_list[slot_wear_suit_str]
 				if(istype(armor, /datum/item_representation/modular_armor))
 					if(loadout.version < 7)
@@ -141,11 +154,26 @@
 						new_armor.current_variant = old_armor.current_variant
 						new_armor.attachments = old_armor.attachments
 						loadout.item_list[slot_wear_suit_str] = new_armor
+				else if(istype(armor, /datum/item_representation/suit_with_storage))
+					if(loadout.version < 11)
+						var/datum/item_representation/suit_with_storage/old_armor = loadout.item_list[slot_wear_suit_str]
+						var/datum/item_representation/armor_suit/modular_armor/new_armor = new
+						if("[old_armor.item_type]" == "/obj/item/clothing/suit/storage/marine/robot")
+							new_armor.item_type = /obj/item/clothing/suit/modular/robot
+						if("[old_armor.item_type]" == "/obj/item/clothing/suit/storage/marine/robot/light")
+							new_armor.item_type = /obj/item/clothing/suit/modular/robot/light
+						if("[old_armor.item_type]" == "/obj/item/clothing/suit/storage/marine/robot/heavy")
+							new_armor.item_type = /obj/item/clothing/suit/modular/robot/heavy
+						new_armor.bypass_vendor_check = old_armor.bypass_vendor_check
+						new_armor.current_variant = "black"
+						loadout.item_list[slot_wear_suit_str] = new_armor
+
 				var/datum/item_representation/uniform_representation/uniform = loadout.item_list[slot_w_uniform_str]
 				if(istype(uniform, /datum/item_representation/uniform_representation))
 					if(loadout.version < 9)
 						uniform.current_variant = null
 						uniform.attachments = list()
+
 				var/datum/item_representation/boot/footwear = loadout.item_list[slot_shoes_str]
 				if(footwear)
 					if(loadout.version < 11)
@@ -153,6 +181,7 @@
 							var/obj/item/clothing/shoes/marine/full/new_boots = new (loadout_vendor)
 							loadout.item_list[slot_shoes_str] = new /datum/item_representation/boot(new_boots)
 							qdel(new_boots)
+
 				var/message_to_send = "Please note: The loadout code has been updated and due to that:"
 				if(loadout.version < 7)
 					message_to_send += "<br>any modular helmet/suit has been removed from it due to the transitioning of loadout version 6 to 7."
@@ -164,6 +193,7 @@
 					message_to_send += "<br>any modular armor pieces and jaeger helmets have had their colors reset due to the new color/greyscale system. (version 9 to 10)"
 				if(loadout.version < 11)
 					message_to_send += "<br>Some boots, helmets and armour have had their internal storage refactored and some items may be removed from your loadout. (version 10 to 11)"
+
 				loadout.version = CURRENT_LOADOUT_VERSION
 				message_to_send += "<br>This loadout is now on version [loadout.version]"
 				to_chat(ui.user, span_warning(message_to_send))
@@ -172,11 +202,13 @@
 				delete_loadout(ui.user, name, job)
 				ui.user.client.prefs.save_loadout(loadout)
 				add_loadout(loadout)
+
 			ui.user.client.prefs.save_loadout(loadout)
 			add_loadout(loadout)
 			update_static_data(ui.user, ui)
 			loadout.loadout_vendor = loadout_vendor
 			loadout.ui_interact(ui.user)
+
 		if("selectLoadout")
 			var/job = params["loadout_job"]
 			var/name = params["loadout_name"]
@@ -222,6 +254,7 @@
 					new_hat.bypass_vendor_check = old_hat.bypass_vendor_check
 					new_hat.current_variant = "black"
 					loadout.item_list[slot_head_str] = new_hat
+
 				var/datum/item_representation/armor_suit/modular_armor/armor = loadout.item_list[slot_wear_suit_str]
 				if(istype(armor, /datum/item_representation/modular_armor))
 					if(loadout.version < 7)
@@ -255,11 +288,13 @@
 						new_armor.bypass_vendor_check = old_armor.bypass_vendor_check
 						new_armor.current_variant = "black"
 						loadout.item_list[slot_wear_suit_str] = new_armor
+
 				var/datum/item_representation/uniform_representation/uniform = loadout.item_list[slot_w_uniform_str]
 				if(istype(uniform, /datum/item_representation/uniform_representation))
 					if(loadout.version < 9)
 						uniform.current_variant = null
 						uniform.attachments = list()
+
 				var/datum/item_representation/boot/footwear = loadout.item_list[slot_shoes_str]
 				if(footwear)
 					if(loadout.version < 11)
@@ -267,6 +302,7 @@
 							var/obj/item/clothing/shoes/marine/full/new_boots = new (loadout_vendor)
 							loadout.item_list[slot_shoes_str] = new /datum/item_representation/boot(new_boots)
 							qdel(new_boots)
+
 				var/message_to_send = "Please note: The loadout code has been updated and due to that:"
 				if(loadout.version < 7)
 					message_to_send += "<br>any modular helmet/suit has been removed from it due to the transitioning of loadout version 6 to 7."
@@ -278,6 +314,7 @@
 					message_to_send += "<br>any modular armor pieces and jaeger helmets have had their colors reset due to the new color/greyscale system. (version 19 to 10)"
 				if(loadout.version < 11)
 					message_to_send += "<br>Some boots, helmets and armour have had their internal storage refactored and some items may be removed from your loadout. (version 10 to 11)"
+
 				loadout.version = CURRENT_LOADOUT_VERSION
 				message_to_send += "<br>This loadout is now on version [loadout.version]"
 				to_chat(ui.user, span_warning(message_to_send))
@@ -285,6 +322,7 @@
 				ui.user.client.prefs.save_loadout(loadout)
 				add_loadout(loadout)
 				to_chat(ui.user, span_warning("Please note: The loadout code has been updated and as such any modular helmet/suit has been removed from it due to the transitioning of loadout versions. Any future modular helmet/suit saves should have no problem being saved."))
+
 			update_static_data(ui.user, ui)
 			loadout.loadout_vendor = loadout_vendor
 			loadout.ui_interact(ui.user)

--- a/code/datums/loadout/loadout_manager.dm
+++ b/code/datums/loadout/loadout_manager.dm
@@ -99,109 +99,7 @@
 				to_chat(ui.user, span_warning("The loadouts was found but is from a past version, and cannot be imported."))
 				return
 			if(loadout.version != CURRENT_LOADOUT_VERSION)
-				var/datum/item_representation/hat/modular_helmet/helmet = loadout.item_list[slot_head_str]
-				if(istype(helmet, /datum/item_representation/modular_helmet))
-					if(loadout.version < 7)
-						loadout.empty_slot(slot_head_str)
-					if(loadout.version < 8)
-						if("[helmet.item_type]" == "/obj/item/clothing/head/modular/m10x/tech" || "[helmet.item_type]" == "/obj/item/clothing/head/modular/m10x/corpsman" ||  "[helmet.item_type]" == "/obj/item/clothing/head/modular/m10x/standard")
-							helmet.item_type = /obj/item/clothing/head/modular/m10x
-					if(loadout.version < 10)
-						helmet.greyscale_colors = initial(helmet.item_type.greyscale_colors)
-						for(var/datum/item_representation/armor_module/colored/module AS in helmet.attachments)
-							if(!istype(module, /datum/item_representation/armor_module/colored))
-								continue
-							module.greyscale_colors = initial(module.item_type.greyscale_colors)
-					if(loadout.version < 11)
-						var/datum/item_representation/modular_helmet/old_helmet = loadout.item_list[slot_head_str]
-						var/datum/item_representation/hat/modular_helmet/new_helmet = new
-						new_helmet.item_type = old_helmet.item_type
-						new_helmet.bypass_vendor_check = old_helmet.bypass_vendor_check
-						new_helmet.greyscale_colors = old_helmet.greyscale_colors
-						new_helmet.current_variant = old_helmet.current_variant
-						new_helmet.attachments = old_helmet.attachments
-						loadout.item_list[slot_head_str] = new_helmet
-				else if(loadout.version < 11)
-					var/datum/item_representation/old_hat = loadout.item_list[slot_head_str]
-					var/datum/item_representation/hat/modular_helmet/new_hat = new
-					if("[old_hat.item_type]" == "/obj/item/clothing/head/helmet/marine/robot")
-						new_hat.item_type = /obj/item/clothing/head/modular/robot
-					if("[old_hat.item_type]" == "/obj/item/clothing/head/helmet/marine/robot/light")
-						new_hat.item_type = /obj/item/clothing/head/modular/robot/light
-					if("[old_hat.item_type]" == "/obj/item/clothing/head/helmet/marine/robot/heavy")
-						new_hat.item_type = /obj/item/clothing/head/modular/robot/heavy
-					new_hat.bypass_vendor_check = old_hat.bypass_vendor_check
-					new_hat.current_variant = "black"
-					loadout.item_list[slot_head_str] = new_hat
-
-				var/datum/item_representation/armor_suit/modular_armor/armor = loadout.item_list[slot_wear_suit_str]
-				if(istype(armor, /datum/item_representation/modular_armor))
-					if(loadout.version < 7)
-						loadout.empty_slot(slot_wear_suit_str)
-					if(loadout.version < 8)
-						if("[armor.item_type]" == "/obj/item/clothing/suit/modular/pas11x")
-							armor.item_type = /obj/item/clothing/suit/modular/xenonauten
-					if(loadout.version < 10)
-						for(var/datum/item_representation/armor_module/colored/module AS in armor.attachments)
-							if(!istype(module, /datum/item_representation/armor_module/colored))
-								continue
-							module.greyscale_colors = initial(module.item_type.greyscale_colors)
-					if(loadout.version < 11)
-						var/datum/item_representation/modular_armor/old_armor = loadout.item_list[slot_wear_suit_str]
-						var/datum/item_representation/armor_suit/modular_armor/new_armor = new
-						new_armor.item_type = old_armor.item_type
-						new_armor.bypass_vendor_check = old_armor.bypass_vendor_check
-						new_armor.current_variant = old_armor.current_variant
-						new_armor.attachments = old_armor.attachments
-						loadout.item_list[slot_wear_suit_str] = new_armor
-				else if(istype(armor, /datum/item_representation/suit_with_storage))
-					if(loadout.version < 11)
-						var/datum/item_representation/suit_with_storage/old_armor = loadout.item_list[slot_wear_suit_str]
-						var/datum/item_representation/armor_suit/modular_armor/new_armor = new
-						if("[old_armor.item_type]" == "/obj/item/clothing/suit/storage/marine/robot")
-							new_armor.item_type = /obj/item/clothing/suit/modular/robot
-						if("[old_armor.item_type]" == "/obj/item/clothing/suit/storage/marine/robot/light")
-							new_armor.item_type = /obj/item/clothing/suit/modular/robot/light
-						if("[old_armor.item_type]" == "/obj/item/clothing/suit/storage/marine/robot/heavy")
-							new_armor.item_type = /obj/item/clothing/suit/modular/robot/heavy
-						new_armor.bypass_vendor_check = old_armor.bypass_vendor_check
-						new_armor.current_variant = "black"
-						loadout.item_list[slot_wear_suit_str] = new_armor
-
-				var/datum/item_representation/uniform_representation/uniform = loadout.item_list[slot_w_uniform_str]
-				if(istype(uniform, /datum/item_representation/uniform_representation))
-					if(loadout.version < 9)
-						uniform.current_variant = null
-						uniform.attachments = list()
-
-				var/datum/item_representation/boot/footwear = loadout.item_list[slot_shoes_str]
-				if(footwear)
-					if(loadout.version < 11)
-						if("[footwear.item_type]" == "/obj/item/clothing/shoes/marine/full")
-							var/obj/item/clothing/shoes/marine/full/new_boots = new (loadout_vendor)
-							loadout.item_list[slot_shoes_str] = new /datum/item_representation/boot(new_boots)
-							qdel(new_boots)
-
-				var/message_to_send = "Please note: The loadout code has been updated and due to that:"
-				if(loadout.version < 7)
-					message_to_send += "<br>any modular helmet/suit has been removed from it due to the transitioning of loadout version 6 to 7."
-				if(loadout.version < 8)
-					message_to_send += "<br>any PAS11 armor/M10x helmet has been removed from it due to the transitioning of loadout version 7 to 8(Xenonauten Addition)."
-				if(loadout.version < 9)
-					message_to_send += "<br>any uniforms have had their webbings/accessory removed due to the transitioning of loadout version 8 to 9."
-				if(loadout.version < 10)
-					message_to_send += "<br>any modular armor pieces and jaeger helmets have had their colors reset due to the new color/greyscale system. (version 9 to 10)"
-				if(loadout.version < 11)
-					message_to_send += "<br>Some boots, helmets and armour have had their internal storage refactored and some items may be removed from your loadout. (version 10 to 11)"
-
-				loadout.version = CURRENT_LOADOUT_VERSION
-				message_to_send += "<br>This loadout is now on version [loadout.version]"
-				to_chat(ui.user, span_warning(message_to_send))
-				var/job = params["loadout_job"]
-				var/name = params["loadout_name"]
-				delete_loadout(ui.user, name, job)
-				ui.user.client.prefs.save_loadout(loadout)
-				add_loadout(loadout)
+				legacy_version_fix(loadout, params["loadout_name"], params["loadout_job"], ui)
 
 			ui.user.client.prefs.save_loadout(loadout)
 			add_loadout(loadout)
@@ -220,108 +118,7 @@
 				delete_loadout(ui.user, name, job)
 				CRASH("Fail to load loadouts")
 			if(loadout.version != CURRENT_LOADOUT_VERSION)
-				var/datum/item_representation/hat/modular_helmet/helmet = loadout.item_list[slot_head_str]
-				if(istype(helmet, /datum/item_representation/modular_helmet))
-					if(loadout.version < 7)
-						loadout.empty_slot(slot_head_str)
-					if(loadout.version < 8)
-						if("[helmet.item_type]" == "/obj/item/clothing/head/modular/m10x/tech" || "[helmet.item_type]" == "/obj/item/clothing/head/modular/m10x/corpsman" || "[helmet.item_type]" == "/obj/item/clothing/head/modular/m10x/standard")
-							helmet.item_type = /obj/item/clothing/head/modular/m10x
-					if(loadout.version < 10)
-						helmet.greyscale_colors = initial(helmet.item_type.greyscale_colors)
-						for(var/datum/item_representation/armor_module/colored/module AS in helmet.attachments)
-							if(!istype(module, /datum/item_representation/armor_module/colored))
-								continue
-							module.greyscale_colors = initial(module.item_type.greyscale_colors)
-					if(loadout.version < 11)
-						var/datum/item_representation/modular_helmet/old_helmet = loadout.item_list[slot_head_str]
-						var/datum/item_representation/hat/modular_helmet/new_helmet = new
-						new_helmet.item_type = old_helmet.item_type
-						new_helmet.bypass_vendor_check = old_helmet.bypass_vendor_check
-						new_helmet.greyscale_colors = old_helmet.greyscale_colors
-						new_helmet.current_variant = old_helmet.current_variant
-						new_helmet.attachments = old_helmet.attachments
-						loadout.item_list[slot_head_str] = new_helmet
-				else if(loadout.version < 11)
-					var/datum/item_representation/old_hat = loadout.item_list[slot_head_str]
-					var/datum/item_representation/hat/modular_helmet/new_hat = new
-					if("[old_hat.item_type]" == "/obj/item/clothing/head/helmet/marine/robot")
-						new_hat.item_type = /obj/item/clothing/head/modular/robot
-					if("[old_hat.item_type]" == "/obj/item/clothing/head/helmet/marine/robot/light")
-						new_hat.item_type = /obj/item/clothing/head/modular/robot/light
-					if("[old_hat.item_type]" == "/obj/item/clothing/head/helmet/marine/robot/heavy")
-						new_hat.item_type = /obj/item/clothing/head/modular/robot/heavy
-					new_hat.bypass_vendor_check = old_hat.bypass_vendor_check
-					new_hat.current_variant = "black"
-					loadout.item_list[slot_head_str] = new_hat
-
-				var/datum/item_representation/armor_suit/modular_armor/armor = loadout.item_list[slot_wear_suit_str]
-				if(istype(armor, /datum/item_representation/modular_armor))
-					if(loadout.version < 7)
-						loadout.empty_slot(slot_wear_suit_str)
-					if(loadout.version < 8)
-						if("[armor.item_type]" == "/obj/item/clothing/suit/modular/pas11x")
-							armor.item_type = /obj/item/clothing/suit/modular/xenonauten
-					if(loadout.version < 10)
-						for(var/datum/item_representation/armor_module/colored/module AS in armor.attachments)
-							if(!istype(module, /datum/item_representation/armor_module/colored))
-								continue
-							module.greyscale_colors = initial(module.item_type.greyscale_colors)
-					if(loadout.version < 11)
-						var/datum/item_representation/modular_armor/old_armor = loadout.item_list[slot_wear_suit_str]
-						var/datum/item_representation/armor_suit/modular_armor/new_armor = new
-						new_armor.item_type = old_armor.item_type
-						new_armor.bypass_vendor_check = old_armor.bypass_vendor_check
-						new_armor.current_variant = old_armor.current_variant
-						new_armor.attachments = old_armor.attachments
-						loadout.item_list[slot_wear_suit_str] = new_armor
-				else if(istype(armor, /datum/item_representation/suit_with_storage))
-					if(loadout.version < 11)
-						var/datum/item_representation/suit_with_storage/old_armor = loadout.item_list[slot_wear_suit_str]
-						var/datum/item_representation/armor_suit/modular_armor/new_armor = new
-						if("[old_armor.item_type]" == "/obj/item/clothing/suit/storage/marine/robot")
-							new_armor.item_type = /obj/item/clothing/suit/modular/robot
-						if("[old_armor.item_type]" == "/obj/item/clothing/suit/storage/marine/robot/light")
-							new_armor.item_type = /obj/item/clothing/suit/modular/robot/light
-						if("[old_armor.item_type]" == "/obj/item/clothing/suit/storage/marine/robot/heavy")
-							new_armor.item_type = /obj/item/clothing/suit/modular/robot/heavy
-						new_armor.bypass_vendor_check = old_armor.bypass_vendor_check
-						new_armor.current_variant = "black"
-						loadout.item_list[slot_wear_suit_str] = new_armor
-
-				var/datum/item_representation/uniform_representation/uniform = loadout.item_list[slot_w_uniform_str]
-				if(istype(uniform, /datum/item_representation/uniform_representation))
-					if(loadout.version < 9)
-						uniform.current_variant = null
-						uniform.attachments = list()
-
-				var/datum/item_representation/boot/footwear = loadout.item_list[slot_shoes_str]
-				if(footwear)
-					if(loadout.version < 11)
-						if("[footwear.item_type]" == "/obj/item/clothing/shoes/marine/full")
-							var/obj/item/clothing/shoes/marine/full/new_boots = new (loadout_vendor)
-							loadout.item_list[slot_shoes_str] = new /datum/item_representation/boot(new_boots)
-							qdel(new_boots)
-
-				var/message_to_send = "Please note: The loadout code has been updated and due to that:"
-				if(loadout.version < 7)
-					message_to_send += "<br>any modular helmet/suit has been removed from it due to the transitioning of loadout version 6 to 7."
-				if(loadout.version < 8)
-					message_to_send += "<br>any PAS11 armor/M10x helmet has been removed from it due to the transitioning of loadout version 7 to 8(Xenonauten Addition)."
-				if(loadout.version < 9)
-					message_to_send += "<br>any uniforms have had their webbings/accessory removed due to the transitioning of loadout version 8 to 9."
-				if(loadout.version < 10)
-					message_to_send += "<br>any modular armor pieces and jaeger helmets have had their colors reset due to the new color/greyscale system. (version 19 to 10)"
-				if(loadout.version < 11)
-					message_to_send += "<br>Some boots, helmets and armour have had their internal storage refactored and some items may be removed from your loadout. (version 10 to 11)"
-
-				loadout.version = CURRENT_LOADOUT_VERSION
-				message_to_send += "<br>This loadout is now on version [loadout.version]"
-				to_chat(ui.user, span_warning(message_to_send))
-				delete_loadout(ui.user, name, job)
-				ui.user.client.prefs.save_loadout(loadout)
-				add_loadout(loadout)
-				to_chat(ui.user, span_warning("Please note: The loadout code has been updated and as such any modular helmet/suit has been removed from it due to the transitioning of loadout versions. Any future modular helmet/suit saves should have no problem being saved."))
+				legacy_version_fix(loadout, name, job, ui)
 
 			update_static_data(ui.user, ui)
 			loadout.loadout_vendor = loadout_vendor
@@ -331,3 +128,109 @@
 /datum/loadout_manager/ui_close(mob/user)
 	. = ..()
 	user.client?.prefs.save_loadout_list(loadouts_data, CURRENT_LOADOUT_VERSION)
+
+///Modifies a legacy loadout to make it valid for the current loadout version
+/datum/loadout_manager/proc/legacy_version_fix(datum/loadout/loadout, loadout_name, loadout_job, datum/tgui/ui)
+	var/datum/item_representation/hat/modular_helmet/helmet = loadout.item_list[slot_head_str]
+	if(istype(helmet, /datum/item_representation/modular_helmet))
+		if(loadout.version < 7)
+			loadout.empty_slot(slot_head_str)
+		if(loadout.version < 8)
+			if("[helmet.item_type]" == "/obj/item/clothing/head/modular/m10x/tech" || "[helmet.item_type]" == "/obj/item/clothing/head/modular/m10x/corpsman" || "[helmet.item_type]" == "/obj/item/clothing/head/modular/m10x/standard")
+				helmet.item_type = /obj/item/clothing/head/modular/m10x
+		if(loadout.version < 10)
+			helmet.greyscale_colors = initial(helmet.item_type.greyscale_colors)
+			for(var/datum/item_representation/armor_module/colored/module AS in helmet.attachments)
+				if(!istype(module, /datum/item_representation/armor_module/colored))
+					continue
+				module.greyscale_colors = initial(module.item_type.greyscale_colors)
+		if(loadout.version < 11)
+			var/datum/item_representation/modular_helmet/old_helmet = loadout.item_list[slot_head_str]
+			var/datum/item_representation/hat/modular_helmet/new_helmet = new
+			new_helmet.item_type = old_helmet.item_type
+			new_helmet.bypass_vendor_check = old_helmet.bypass_vendor_check
+			new_helmet.greyscale_colors = old_helmet.greyscale_colors
+			new_helmet.current_variant = old_helmet.current_variant
+			new_helmet.attachments = old_helmet.attachments
+			loadout.item_list[slot_head_str] = new_helmet
+	if(helmet) //there used to be no specific representation for generic hats
+		if(loadout.version < 11)
+			var/datum/item_representation/old_hat = loadout.item_list[slot_head_str]
+			var/datum/item_representation/hat/modular_helmet/new_hat = new
+			if("[old_hat.item_type]" == "/obj/item/clothing/head/helmet/marine/robot")
+				new_hat.item_type = /obj/item/clothing/head/modular/robot
+			if("[old_hat.item_type]" == "/obj/item/clothing/head/helmet/marine/robot/light")
+				new_hat.item_type = /obj/item/clothing/head/modular/robot/light
+			if("[old_hat.item_type]" == "/obj/item/clothing/head/helmet/marine/robot/heavy")
+				new_hat.item_type = /obj/item/clothing/head/modular/robot/heavy
+			new_hat.bypass_vendor_check = old_hat.bypass_vendor_check
+			new_hat.current_variant = "black"
+			loadout.item_list[slot_head_str] = new_hat
+
+	var/datum/item_representation/armor_suit/modular_armor/armor = loadout.item_list[slot_wear_suit_str]
+	if(istype(armor, /datum/item_representation/modular_armor))
+		if(loadout.version < 7)
+			loadout.empty_slot(slot_wear_suit_str)
+		if(loadout.version < 8)
+			if("[armor.item_type]" == "/obj/item/clothing/suit/modular/pas11x")
+				armor.item_type = /obj/item/clothing/suit/modular/xenonauten
+		if(loadout.version < 10)
+			for(var/datum/item_representation/armor_module/colored/module AS in armor.attachments)
+				if(!istype(module, /datum/item_representation/armor_module/colored))
+					continue
+				module.greyscale_colors = initial(module.item_type.greyscale_colors)
+		if(loadout.version < 11)
+			var/datum/item_representation/modular_armor/old_armor = loadout.item_list[slot_wear_suit_str]
+			var/datum/item_representation/armor_suit/modular_armor/new_armor = new
+			new_armor.item_type = old_armor.item_type
+			new_armor.bypass_vendor_check = old_armor.bypass_vendor_check
+			new_armor.current_variant = old_armor.current_variant
+			new_armor.attachments = old_armor.attachments
+			loadout.item_list[slot_wear_suit_str] = new_armor
+	else if(istype(armor, /datum/item_representation/suit_with_storage))
+		if(loadout.version < 11)
+			var/datum/item_representation/suit_with_storage/old_armor = loadout.item_list[slot_wear_suit_str]
+			var/datum/item_representation/armor_suit/modular_armor/new_armor = new
+			if("[old_armor.item_type]" == "/obj/item/clothing/suit/storage/marine/robot")
+				new_armor.item_type = /obj/item/clothing/suit/modular/robot
+			if("[old_armor.item_type]" == "/obj/item/clothing/suit/storage/marine/robot/light")
+				new_armor.item_type = /obj/item/clothing/suit/modular/robot/light
+			if("[old_armor.item_type]" == "/obj/item/clothing/suit/storage/marine/robot/heavy")
+				new_armor.item_type = /obj/item/clothing/suit/modular/robot/heavy
+			new_armor.bypass_vendor_check = old_armor.bypass_vendor_check
+			new_armor.current_variant = "black"
+			loadout.item_list[slot_wear_suit_str] = new_armor
+
+	var/datum/item_representation/uniform_representation/uniform = loadout.item_list[slot_w_uniform_str]
+	if(istype(uniform, /datum/item_representation/uniform_representation))
+		if(loadout.version < 9)
+			uniform.current_variant = null
+			uniform.attachments = list()
+
+	var/datum/item_representation/boot/footwear = loadout.item_list[slot_shoes_str]
+	if(footwear)
+		if(loadout.version < 11)
+			if("[footwear.item_type]" == "/obj/item/clothing/shoes/marine/full")
+				var/obj/item/clothing/shoes/marine/full/new_boots = new (loadout_vendor)
+				loadout.item_list[slot_shoes_str] = new /datum/item_representation/boot(new_boots)
+				qdel(new_boots)
+
+	var/message_to_send = "Please note: The loadout code has been updated and due to that:"
+	if(loadout.version < 7)
+		message_to_send += "<br>any modular helmet/suit has been removed from it due to the transitioning of loadout version 6 to 7."
+	if(loadout.version < 8)
+		message_to_send += "<br>any PAS11 armor/M10x helmet has been removed from it due to the transitioning of loadout version 7 to 8(Xenonauten Addition)."
+	if(loadout.version < 9)
+		message_to_send += "<br>any uniforms have had their webbings/accessory removed due to the transitioning of loadout version 8 to 9."
+	if(loadout.version < 10)
+		message_to_send += "<br>any modular armor pieces and jaeger helmets have had their colors reset due to the new color/greyscale system. (version 19 to 10)"
+	if(loadout.version < 11)
+		message_to_send += "<br>Some boots, helmets and armour have had their internal storage refactored and some items may be removed from your loadout. (version 10 to 11)"
+
+	loadout.version = CURRENT_LOADOUT_VERSION
+	message_to_send += "<br>This loadout is now on version [loadout.version]"
+	to_chat(ui.user, span_warning(message_to_send))
+
+	delete_loadout(ui.user, loadout_name, loadout_job)
+	ui.user.client.prefs.save_loadout(loadout)
+	add_loadout(loadout)

--- a/code/datums/loadout/loadout_manager.dm
+++ b/code/datums/loadout/loadout_manager.dm
@@ -187,14 +187,15 @@
 							if(!istype(module, /datum/item_representation/armor_module/colored))
 								continue
 							module.greyscale_colors = initial(module.item_type.greyscale_colors)
-				else if(istype(armor, /datum/item_representation/modular_armor))
-					var/datum/item_representation/modular_armor/old_armor = loadout.item_list[slot_wear_suit_str]
-					var/datum/item_representation/armor_suit/modular_armor/new_armor = new
-					new_armor.item_type = old_armor.item_type
-					new_armor.bypass_vendor_check = old_armor.bypass_vendor_check
-					new_armor.current_variant = old_armor.current_variant
-					new_armor.attachments = old_armor.attachments
-					loadout.item_list[slot_wear_suit_str] = new_armor
+				else if(istype(armor, /datum/item_representation/modular_armor)) //please forgive this guh
+					if(loadout.version < 11)
+						var/datum/item_representation/modular_armor/old_armor = loadout.item_list[slot_wear_suit_str]
+						var/datum/item_representation/armor_suit/modular_armor/new_armor = new
+						new_armor.item_type = old_armor.item_type
+						new_armor.bypass_vendor_check = old_armor.bypass_vendor_check
+						new_armor.current_variant = old_armor.current_variant
+						new_armor.attachments = old_armor.attachments
+						loadout.item_list[slot_wear_suit_str] = new_armor
 				var/datum/item_representation/uniform_representation/uniform = loadout.item_list[slot_w_uniform_str]
 				if(istype(uniform, /datum/item_representation/uniform_representation))
 					if(loadout.version < 9)

--- a/code/datums/loadout/loadout_manager.dm
+++ b/code/datums/loadout/loadout_manager.dm
@@ -235,7 +235,9 @@
 				var/datum/item_representation/boot/footwear = loadout.item_list[slot_shoes_str]
 				if(loadout.version < 11)
 					if("[footwear.item_type]" == "/obj/item/clothing/shoes/marine/full")
-						loadout.empty_slot(slot_shoes_str)
+						var/obj/item/clothing/shoes/marine/full/new_boots = new (loadout_vendor)
+						footwear = new(new_boots)
+						loadout.item_list[slot_shoes_str] = footwear
 				var/message_to_send = "Please note: The loadout code has been updated and due to that:"
 				if(loadout.version < 7)
 					message_to_send += "<br>any modular helmet/suit has been removed from it due to the transitioning of loadout version 6 to 7."

--- a/code/datums/loadout/old_typepaths.dm
+++ b/code/datums/loadout/old_typepaths.dm
@@ -9,8 +9,19 @@
 /obj/item/clothing/head/modular/marine/m10x/corpsman
 /obj/item/clothing/head/modular/marine/m10x/standard
 
+/obj/item/clothing/head/helmet/marine/robot
+/obj/item/clothing/head/helmet/marine/robot/light
+/obj/item/clothing/head/helmet/marine/robot/heavy
+
+/obj/item/clothing/suit/storage/marine/robot
+/obj/item/clothing/suit/storage/marine/robot/light
+/obj/item/clothing/suit/storage/marine/robot/heavy
 
 //Changing item_representation typepaths also breaks loadouts horribly.
+
+/datum/item_representation/suit_with_storage
+	///The storage of the suit
+	var/datum/item_representation/storage/pockets
 
 /datum/item_representation/modular_armor
 	///List of attachments on the armor.

--- a/code/datums/loadout/old_typepaths.dm
+++ b/code/datums/loadout/old_typepaths.dm
@@ -8,3 +8,12 @@
 /obj/item/clothing/head/modular/marine/m10x/tech
 /obj/item/clothing/head/modular/marine/m10x/corpsman
 /obj/item/clothing/head/modular/marine/m10x/standard
+
+
+//Changing item_representation typepaths also breaks loadouts horribly, so this proc exists to convert legacy typepaths.
+
+/datum/item_representation/modular_armor
+	///List of attachments on the armor.
+	var/list/datum/item_representation/armor_module/attachments = list()
+	///Icon_state suffix for the saved icon_state varient.
+	var/current_variant

--- a/code/datums/loadout/old_typepaths.dm
+++ b/code/datums/loadout/old_typepaths.dm
@@ -10,7 +10,7 @@
 /obj/item/clothing/head/modular/marine/m10x/standard
 
 
-//Changing item_representation typepaths also breaks loadouts horribly, so this proc exists to convert legacy typepaths.
+//Changing item_representation typepaths also breaks loadouts horribly.
 
 /datum/item_representation/modular_armor
 	///List of attachments on the armor.

--- a/code/datums/loadout/old_typepaths.dm
+++ b/code/datums/loadout/old_typepaths.dm
@@ -17,3 +17,11 @@
 	var/list/datum/item_representation/armor_module/attachments = list()
 	///Icon_state suffix for the saved icon_state varient.
 	var/current_variant
+
+/datum/item_representation/modular_helmet
+	///The attachments installed.
+	var/list/datum/item_representation/armor_module/attachments = list()
+	///The color of the helmet
+	var/greyscale_colors
+	///Icon_state suffix for the saved icon_state varient.
+	var/current_variant

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -659,27 +659,26 @@ GLOBAL_DATUM_INIT(welding_sparks_prepdoor, /mutable_appearance, mutable_appearan
 		if(SLOT_IN_HEAD)
 			if(!H.head)
 				return FALSE
-			if(istype(H.head, /obj/item/clothing/head/modular))
-				var/obj/item/clothing/head/modular/T = H.head
-				if(!T.attachments_by_slot[ATTACHMENT_SLOT_STORAGE])
-					return FALSE
-				var/obj/item/armor_module/storage/U = T.attachments_by_slot[ATTACHMENT_SLOT_STORAGE]
-				var/obj/item/storage/S = U.storage
-				if(S.can_be_inserted(src, warning))
-					return TRUE
-			if(istype(H.head, /obj/item/clothing/head/helmet/marine)) //old hats use the pocket var instead of storage attachments
-				var/obj/item/clothing/head/helmet/marine/T = H.head
-				if(!T.pockets)
-					return FALSE
-				var/obj/item/storage/internal/S = T.pockets
-				if(S.can_be_inserted(src, warning))
-					return TRUE
-		if(SLOT_IN_BOOT)
-			var/obj/item/clothing/shoes/marine/S = H.shoes
-			if(!istype(S) || !S.pockets)
+			if(!istype(H.shoes, /obj/item/clothing/head))
 				return FALSE
-			var/obj/item/storage/internal/T = S.pockets
-			if(T.can_be_inserted(src, warning))
+			var/obj/item/clothing/head/headwear = H.head
+			if(!headwear.attachments_by_slot[ATTACHMENT_SLOT_STORAGE])
+				return FALSE
+			var/obj/item/armor_module/storage/storage_module = headwear.attachments_by_slot[ATTACHMENT_SLOT_STORAGE]
+			var/obj/item/storage/storage = storage_module.storage
+			if(storage.can_be_inserted(src, warning))
+				return TRUE
+		if(SLOT_IN_BOOT)
+			if(H.shoes)
+				return FALSE
+			if(!istype(H.shoes, /obj/item/clothing/shoes))
+				return FALSE
+			var/obj/item/clothing/shoes/footwear = H.shoes
+			if(!footwear.attachments_by_slot[ATTACHMENT_SLOT_STORAGE])
+				return FALSE
+			var/obj/item/armor_module/storage/storage_module = footwear.attachments_by_slot[ATTACHMENT_SLOT_STORAGE]
+			var/obj/item/storage/storage = storage_module.storage
+			if(storage.can_be_inserted(src, warning))
 				return TRUE
 	return FALSE //Unsupported slot
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -58,6 +58,14 @@
 	..()
 	return user.equip_to_appropriate_slot(src)
 
+/obj/item/clothing/on_pocket_insertion()
+	. = ..()
+	update_icon()
+
+/obj/item/clothing/on_pocket_removal()
+	. = ..()
+	update_icon()
+
 //Updates the icons of the mob wearing the clothing item, if any.
 /obj/item/clothing/proc/update_clothing_icon()
 	return

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -251,3 +251,12 @@
 	if (ismob(src.loc))
 		var/mob/M = src.loc
 		M.update_inv_shoes()
+
+/obj/item/clothing/shoes/MouseDrop(over_object, src_location, over_location)
+	if(!attachments_by_slot[ATTACHMENT_SLOT_STORAGE])
+		return ..()
+	if(!istype(attachments_by_slot[ATTACHMENT_SLOT_STORAGE], /obj/item/armor_module/storage))
+		return ..()
+	var/obj/item/armor_module/storage/armor_storage = attachments_by_slot[ATTACHMENT_SLOT_STORAGE]
+	if(armor_storage.storage.handle_mousedrop(usr, over_object))
+		return ..()

--- a/code/modules/clothing/head/head.dm
+++ b/code/modules/clothing/head/head.dm
@@ -14,6 +14,15 @@
 		var/mob/M = loc
 		M.update_inv_head()
 
+/obj/item/clothing/head/MouseDrop(over_object, src_location, over_location)
+	if(!attachments_by_slot[ATTACHMENT_SLOT_STORAGE])
+		return ..()
+	if(!istype(attachments_by_slot[ATTACHMENT_SLOT_STORAGE], /obj/item/armor_module/storage))
+		return ..()
+	var/obj/item/armor_module/storage/armor_storage = attachments_by_slot[ATTACHMENT_SLOT_STORAGE]
+	if(armor_storage.storage.handle_mousedrop(usr, over_object))
+		return ..()
+
 /obj/item/clothing/head/beanie
 	name = "\improper TGMC beanie"
 	desc = "A standard military beanie, often worn by non-combat military personnel and support crews, though the occasional one finds its way to the front line. Popular due to being comfortable and snug."

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -161,13 +161,6 @@
 	. = ..()
 	helmet_overlays = list("damage","band","item") //To make things simple.
 
-
-//obj/item/clothing/head/helmet/marine/on_pocket_insertion()
-//	update_icon()
-
-//obj/item/clothing/head/helmet/marine/on_pocket_removal()
-//	update_icon()
-
 /obj/item/clothing/head/helmet/marine/update_icon()
 	if(!attachments_by_slot[ATTACHMENT_SLOT_STORAGE])
 		return

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -343,11 +343,6 @@
 	desc = "A helmet that goes with the sergeant armour, unlike the flak variant, this one will actually protect you."
 	icon_state = "guardhelm"
 	soft_armor = list(MELEE = 85, BULLET = 85, LASER = 85, ENERGY = 85, BOMB = 85, BIO = 50, FIRE = 80, ACID = 80)
-	//pockets = /obj/item/storage/internal/imperialhelmet
-
-//obj/item/storage/internal/imperialhelmet
-//	max_w_class = 2
-//	max_storage_space = 6
 
 /obj/item/clothing/head/helmet/marine/imperial/sergeant/veteran
 	name = "\improper Imperial Guard carapace helmet"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -122,10 +122,15 @@
 	var/list/helmet_overlays
 	flags_inventory = BLOCKSHARPOBJ
 	flags_inv_hide = HIDEEARS
+	attachments_by_slot = list(
+		ATTACHMENT_SLOT_STORAGE,
+	)
+	attachments_allowed = list(
+		/obj/item/armor_module/storage/helmet,
+	)
+	starting_attachments = list(/obj/item/armor_module/storage/helmet)
 	///marine helmet behaviour flags
 	var/flags_marine_helmet = HELMET_GARB_OVERLAY|HELMET_DAMAGE_OVERLAY|HELMET_STORE_GARB
-	///reference to helmet storage object
-	var/obj/item/storage/internal/pockets = /obj/item/storage/internal/marinehelmet
 	/// items that fit in the helmet: strict type = iconstate to show
 	var/static/list/allowed_helmet_items = list(
 		/obj/item/tool/lighter/random = "helmet_lighter_",
@@ -152,50 +157,31 @@
 		/obj/item/clothing/head/hairflower = "flower_pin",
 	)
 
-/obj/item/storage/internal/marinehelmet
-	storage_slots = 2
-	max_w_class = WEIGHT_CLASS_TINY
-	bypass_w_limit = list(
-		/obj/item/clothing/glasses,
-		/obj/item/reagent_containers/food/snacks,
-	)
-	cant_hold = list(
-		/obj/item/stack,
-	)
-	max_storage_space = 2
-
 /obj/item/clothing/head/helmet/marine/Initialize()
 	. = ..()
 	helmet_overlays = list("damage","band","item") //To make things simple.
-	pockets = new pockets(src)
 
 
-/obj/item/clothing/head/helmet/marine/attack_hand(mob/living/user)
-	if(pockets.handle_attack_hand(user))
-		return ..()
+//obj/item/clothing/head/helmet/marine/on_pocket_insertion()
+//	update_icon()
 
-/obj/item/clothing/head/helmet/marine/MouseDrop(over_object, src_location, over_location)
-	if(pockets.handle_mousedrop(usr, over_object))
-		..()
-
-/obj/item/clothing/head/helmet/marine/attackby(obj/item/I, mob/user, params)
-	. = ..()
-	return pockets.attackby(I, user, params)
-
-/obj/item/clothing/head/helmet/marine/on_pocket_insertion()
-	update_icon()
-
-/obj/item/clothing/head/helmet/marine/on_pocket_removal()
-	update_icon()
+//obj/item/clothing/head/helmet/marine/on_pocket_removal()
+//	update_icon()
 
 /obj/item/clothing/head/helmet/marine/update_icon()
-	if(pockets.contents.len && (flags_marine_helmet & HELMET_GARB_OVERLAY))
+	if(!attachments_by_slot[ATTACHMENT_SLOT_STORAGE])
+		return
+	if(!istype(attachments_by_slot[ATTACHMENT_SLOT_STORAGE], /obj/item/armor_module/storage))
+		return
+	var/obj/item/armor_module/storage/armor_storage = attachments_by_slot[ATTACHMENT_SLOT_STORAGE]
+
+	if(length(armor_storage.storage.contents) && (flags_marine_helmet & HELMET_GARB_OVERLAY))
 		if(!helmet_overlays["band"])
 			var/image/I = image('icons/obj/clothing/cm_hats.dmi', src, "helmet_band")
 			helmet_overlays["band"] = I
 
 		if(!helmet_overlays["item"])
-			var/obj/O = pockets.contents[1]
+			var/obj/O = armor_storage.storage.contents[1]
 			if(O.type in allowed_helmet_items)
 				var/image/I = image('icons/obj/clothing/cm_hats.dmi', src, "[allowed_helmet_items[O.type]][O.type == /obj/item/tool/lighter/random ? O:clr : ""]")
 				helmet_overlays["item"] = I
@@ -357,11 +343,11 @@
 	desc = "A helmet that goes with the sergeant armour, unlike the flak variant, this one will actually protect you."
 	icon_state = "guardhelm"
 	soft_armor = list(MELEE = 85, BULLET = 85, LASER = 85, ENERGY = 85, BOMB = 85, BIO = 50, FIRE = 80, ACID = 80)
-	pockets = /obj/item/storage/internal/imperialhelmet
+	//pockets = /obj/item/storage/internal/imperialhelmet
 
-/obj/item/storage/internal/imperialhelmet
-	max_w_class = 2
-	max_storage_space = 6
+//obj/item/storage/internal/imperialhelmet
+//	max_w_class = 2
+//	max_storage_space = 6
 
 /obj/item/clothing/head/helmet/marine/imperial/sergeant/veteran
 	name = "\improper Imperial Guard carapace helmet"

--- a/code/modules/clothing/modular_armor/attachments/storage.dm
+++ b/code/modules/clothing/modular_armor/attachments/storage.dm
@@ -309,17 +309,6 @@
 	storage =  /obj/item/storage/internal/shoes/boot_knife
 	flags_attach_features = ATTACH_APPLY_ON_MOB
 
-/obj/item/armor_module/storage/boot/on_attach(obj/item/attaching_to, mob/user)
-	. = ..()
-	parent.RegisterSignal(storage, COMSIG_ATOM_UPDATE_ICON, /atom/proc/update_icon)
-	parent.update_icon()
-
-/obj/item/armor_module/storage/boot/on_detach(obj/item/detaching_from, mob/user)
-	parent.UnregisterSignal(storage, COMSIG_ATOM_UPDATE_ICON)
-	var/obj/item/clothing/current_parent = parent
-	. = ..()
-	current_parent.update_icon()
-
 /obj/item/storage/internal/shoes/boot_knife
 	max_storage_space = 3
 	storage_slots = 1

--- a/code/modules/clothing/modular_armor/attachments/storage.dm
+++ b/code/modules/clothing/modular_armor/attachments/storage.dm
@@ -302,11 +302,57 @@
 		/obj/item/reagent_containers/food/drinks/cans,
 	)
 
+/obj/item/armor_module/storage/boot
+	name = "boot storage module"
+	desc = "A small set of straps to hold something in your boot."
+	icon_state = ""
+	storage =  /obj/item/storage/internal/shoes/boot_knife
+	flags_attach_features = ATTACH_APPLY_ON_MOB
+
+/obj/item/armor_module/storage/boot/on_attach(obj/item/attaching_to, mob/user)
+	. = ..()
+	parent.RegisterSignal(storage, COMSIG_ATOM_UPDATE_ICON, /atom/proc/update_icon)
+	parent.update_icon()
+
+/obj/item/armor_module/storage/boot/on_detach(obj/item/detaching_from, mob/user)
+	parent.UnregisterSignal(storage, COMSIG_ATOM_UPDATE_ICON)
+	var/current_parent = parent
+	. = ..()
+	current_parent.update_icon()
+
+/obj/item/storage/internal/shoes/boot_knife
+	max_storage_space = 3
+	storage_slots = 1
+	draw_mode = TRUE
+	can_hold = list(
+		/obj/item/weapon/combat_knife,
+		/obj/item/weapon/gun/pistol/standard_pocketpistol,
+		/obj/item/weapon/gun/shotgun/double/derringer,
+		/obj/item/attachable/bayonetknife,
+		/obj/item/stack/throwing_knife,
+		/obj/item/storage/box/MRE,
+	)
+
+/obj/item/armor_module/storage/boot/full/Initialize()
+	. = ..()
+	new /obj/item/attachable/bayonetknife(storage)
+
 /obj/item/armor_module/storage/helmet
 	name = "Jaeger Pattern helmet storage"
 	desc = "A small set of bands and straps to allow easy storage of small items."
-	icon_state = "invisible" //It is invisible
+	icon_state = ""
 	storage =  /obj/item/storage/internal/marinehelmet
-	slowdown = 0
 	show_storage = TRUE
 	flags_attach_features = NONE
+
+/obj/item/storage/internal/marinehelmet
+	max_storage_space = 2
+	storage_slots = 2
+	max_w_class = WEIGHT_CLASS_TINY
+	bypass_w_limit = list(
+		/obj/item/clothing/glasses,
+		/obj/item/reagent_containers/food/snacks,
+	)
+	cant_hold = list(
+		/obj/item/stack,
+	)

--- a/code/modules/clothing/modular_armor/attachments/storage.dm
+++ b/code/modules/clothing/modular_armor/attachments/storage.dm
@@ -316,7 +316,7 @@
 
 /obj/item/armor_module/storage/boot/on_detach(obj/item/detaching_from, mob/user)
 	parent.UnregisterSignal(storage, COMSIG_ATOM_UPDATE_ICON)
-	var/current_parent = parent
+	var/obj/item/clothing/current_parent = parent
 	. = ..()
 	current_parent.update_icon()
 

--- a/code/modules/clothing/modular_armor/modular.dm
+++ b/code/modules/clothing/modular_armor/modular.dm
@@ -375,15 +375,6 @@
 	paint.uses--
 	update_icon()
 
-/obj/item/clothing/head/modular/MouseDrop(over_object, src_location, over_location)
-	if(!attachments_by_slot[ATTACHMENT_SLOT_STORAGE])
-		return ..()
-	if(!istype(attachments_by_slot[ATTACHMENT_SLOT_STORAGE], /obj/item/armor_module/storage))
-		return ..()
-	var/obj/item/armor_module/storage/armor_storage = attachments_by_slot[ATTACHMENT_SLOT_STORAGE]
-	if(armor_storage.storage.handle_mousedrop(usr, over_object))
-		return ..()
-
 /obj/item/clothing/head/modular/apply_custom(mutable_appearance/standing)
 	. = ..()
 	if(attachments_by_slot[ATTACHMENT_SLOT_STORAGE] && istype(attachments_by_slot[ATTACHMENT_SLOT_STORAGE], /obj/item/armor_module/storage))

--- a/code/modules/clothing/modular_armor/modular.dm
+++ b/code/modules/clothing/modular_armor/modular.dm
@@ -139,14 +139,6 @@
 			if(flags_item_map_variant & ITEM_DESERT_VARIANT)
 				current_variant = "desert"
 
-/obj/item/clothing/suit/modular/on_pocket_insertion()
-	. = ..()
-	update_icon()
-
-/obj/item/clothing/suit/modular/on_pocket_removal()
-	. = ..()
-	update_icon()
-
 /obj/item/clothing/suit/modular/apply_custom(mutable_appearance/standing)
 	. = ..()
 	if(!attachments_by_slot[ATTACHMENT_SLOT_STORAGE] || !istype(attachments_by_slot[ATTACHMENT_SLOT_STORAGE], /obj/item/armor_module/storage))
@@ -341,14 +333,6 @@
 		if(MAP_ARMOR_STYLE_DESERT)
 			if(flags_item_map_variant & ITEM_DESERT_VARIANT)
 				current_variant = "desert"
-
-/obj/item/clothing/head/modular/on_pocket_insertion()
-	. = ..()
-	update_icon()
-
-/obj/item/clothing/head/modular/on_pocket_removal()
-	. = ..()
-	update_icon()
 
 /obj/item/clothing/head/modular/attackby(obj/item/I, mob/user, params)
 	. = ..()

--- a/code/modules/clothing/shoes/marine_shoes.dm
+++ b/code/modules/clothing/shoes/marine_shoes.dm
@@ -19,6 +19,10 @@
 	)
 	starting_attachments = list(/obj/item/armor_module/storage/boot)
 
+/obj/item/clothing/shoes/marine/Initialize()
+	. = ..()
+	update_icon()
+
 /obj/item/clothing/shoes/marine/update_icon_state()
 	icon_state = initial(icon_state)
 	if(!attachments_by_slot[ATTACHMENT_SLOT_STORAGE])

--- a/code/modules/clothing/shoes/marine_shoes.dm
+++ b/code/modules/clothing/shoes/marine_shoes.dm
@@ -19,16 +19,6 @@
 	)
 	starting_attachments = list(/obj/item/armor_module/storage/boot)
 
-/obj/item/clothing/shoes/marine/Initialize()
-	. = ..()
-	//if(!attachments_by_slot[ATTACHMENT_SLOT_STORAGE])
-	//	return
-	//if(!istype(attachments_by_slot[ATTACHMENT_SLOT_STORAGE], /obj/item/armor_module/storage))
-	//	return
-	//var/obj/item/armor_module/storage/armor_storage = attachments_by_slot[ATTACHMENT_SLOT_STORAGE]
-	//RegisterSignal(armor_storage.storage, COMSIG_ATOM_UPDATE_ICON, /atom/proc/update_icon)
-	//update_icon()
-
 /obj/item/clothing/shoes/marine/update_icon_state()
 	icon_state = initial(icon_state)
 	if(!attachments_by_slot[ATTACHMENT_SLOT_STORAGE])

--- a/code/modules/clothing/shoes/marine_shoes.dm
+++ b/code/modules/clothing/shoes/marine_shoes.dm
@@ -9,70 +9,39 @@
 	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
 	max_heat_protection_temperature = SHOE_MAX_HEAT_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.7
-	var/obj/item/storage/internal/pockets = /obj/item/storage/internal/shoes/boot_knife
 
-/obj/item/storage/internal/shoes/boot_knife
-	max_storage_space = 3
-	storage_slots = 1
-	draw_mode = TRUE
-	can_hold = list(
-		/obj/item/weapon/combat_knife,
-		/obj/item/weapon/gun/pistol/standard_pocketpistol,
-		/obj/item/weapon/gun/shotgun/double/derringer,
-		/obj/item/attachable/bayonetknife,
-		/obj/item/stack/throwing_knife,
-		/obj/item/storage/box/MRE,
+	attachments_by_slot = list(
+		ATTACHMENT_SLOT_STORAGE,
 	)
+	attachments_allowed = list(
+		/obj/item/armor_module/storage/boot,
+		/obj/item/armor_module/storage/boot/full,
+	)
+	starting_attachments = list(/obj/item/armor_module/storage/boot)
 
 /obj/item/clothing/shoes/marine/Initialize()
 	. = ..()
-	pockets = new pockets(src)
-	RegisterSignal(pockets, COMSIG_ATOM_UPDATE_ICON, /atom/proc/update_icon)
-	update_icon()
-
-/obj/item/clothing/shoes/marine/Destroy()
-	QDEL_NULL(pockets)
-	return ..()
-
-
-/obj/item/clothing/shoes/marine/attack_hand(mob/living/user)
-	if(pockets.handle_attack_hand(user))
-		return ..()
-
-
-/obj/item/clothing/shoes/marine/MouseDrop(over_object, src_location, over_location)
-	if(!pockets)
-		return ..()
-	if(pockets.handle_mousedrop(usr, over_object))
-		return ..()
-
-
-/obj/item/clothing/shoes/marine/attackby(obj/item/I, mob/user, params)
-	. = ..()
-	if(.)
-		return
-	if(!pockets)
-		return
-
-	return pockets.attackby(I, user, params)
-
-
-/obj/item/clothing/shoes/marine/emp_act(severity)
-	pockets?.emp_act(severity)
-	return ..()
+	//if(!attachments_by_slot[ATTACHMENT_SLOT_STORAGE])
+	//	return
+	//if(!istype(attachments_by_slot[ATTACHMENT_SLOT_STORAGE], /obj/item/armor_module/storage))
+	//	return
+	//var/obj/item/armor_module/storage/armor_storage = attachments_by_slot[ATTACHMENT_SLOT_STORAGE]
+	//RegisterSignal(armor_storage.storage, COMSIG_ATOM_UPDATE_ICON, /atom/proc/update_icon)
+	//update_icon()
 
 /obj/item/clothing/shoes/marine/update_icon_state()
 	icon_state = initial(icon_state)
-	for(var/atom/item_in_pocket AS in pockets.contents)
+	if(!attachments_by_slot[ATTACHMENT_SLOT_STORAGE])
+		return
+	if(!istype(attachments_by_slot[ATTACHMENT_SLOT_STORAGE], /obj/item/armor_module/storage))
+		return
+	var/obj/item/armor_module/storage/armor_storage = attachments_by_slot[ATTACHMENT_SLOT_STORAGE]
+	for(var/atom/item_in_pocket AS in armor_storage.storage.contents)
 		if(istype(item_in_pocket, /obj/item/weapon/combat_knife) || istype(item_in_pocket, /obj/item/attachable/bayonetknife) || istype(item_in_pocket, /obj/item/stack/throwing_knife))
 			icon_state += "-knife"
 
 /obj/item/clothing/shoes/marine/full
-	pockets = /obj/item/storage/internal/shoes/boot_knife/full
-
-/obj/item/storage/internal/shoes/boot_knife/full/Initialize()
-	. = ..()
-	new /obj/item/attachable/bayonetknife(src)
+	starting_attachments = list(/obj/item/armor_module/storage/boot/full)
 
 /obj/item/clothing/shoes/marine/brown
 	name = "brown marine combat boots"
@@ -80,7 +49,7 @@
 	item_state = "marine_brown"
 
 /obj/item/clothing/shoes/marine/brown/full
-	pockets = /obj/item/storage/internal/shoes/boot_knife/full
+	starting_attachments = list(/obj/item/armor_module/storage/boot/full)
 
 /obj/item/clothing/shoes/marine/pyro
 	name = "flame-resistant combat boots"
@@ -150,7 +119,7 @@
 	item_state = "som"
 
 /obj/item/clothing/shoes/marine/som/knife
-	pockets = /obj/item/storage/internal/shoes/boot_knife/full
+	starting_attachments = list(/obj/item/armor_module/storage/boot/full)
 
 /obj/item/clothing/shoes/sectoid
 	name = "psionic field"
@@ -174,7 +143,7 @@
 	item_state = "boots"
 
 /obj/item/clothing/shoes/marine/clf/full
-	pockets = /obj/item/storage/internal/shoes/boot_knife/full
+	starting_attachments = list(/obj/item/armor_module/storage/boot/full)
 
 /obj/item/clothing/shoes/marine/icc
 	name = "\improper Modelle/32 combat shoes"
@@ -182,7 +151,7 @@
 	icon_state = "icc"
 
 /obj/item/clothing/shoes/marine/icc/knife
-	pockets = /obj/item/storage/internal/shoes/boot_knife/full
+	starting_attachments = list(/obj/item/armor_module/storage/boot/full)
 
 /obj/item/clothing/shoes/marine/icc/guard
 	name = "\improper Modelle/33 tactical shoes"
@@ -190,4 +159,4 @@
 	icon_state  = "icc_guard"
 
 /obj/item/clothing/shoes/marine/icc/guard/knife
-	pockets = /obj/item/storage/internal/shoes/boot_knife/full
+	starting_attachments = list(/obj/item/armor_module/storage/boot/full)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -374,26 +374,23 @@
 			S.handle_item_insertion(W, TRUE, src)
 		if(SLOT_IN_SUIT)
 			if(istype(wear_suit, /obj/item/clothing/suit))
-				var/obj/item/clothing/suit/T = wear_suit
-				var/obj/item/armor_module/storage/U = T.attachments_by_slot[ATTACHMENT_SLOT_STORAGE]
-				var/obj/item/storage/S = U.storage
-				S.handle_item_insertion(W, FALSE, src)
-				S.close(src)
+				var/obj/item/clothing/suit/suit = wear_suit
+				if(!suit.attachments_by_slot[ATTACHMENT_SLOT_STORAGE])
+					return FALSE
+				var/obj/item/armor_module/storage/storage_module = suit.attachments_by_slot[ATTACHMENT_SLOT_STORAGE]
+				var/obj/item/storage/storage = storage_module.storage
+				storage.handle_item_insertion(W, FALSE, src)
 		if(SLOT_IN_BELT)
 			var/obj/item/storage/belt/S = belt
 			S.handle_item_insertion(W, FALSE, src)
 		if(SLOT_IN_HEAD)
-			if(istype(head, /obj/item/clothing/head/modular))
-				var/obj/item/clothing/head/modular/T = head
-				var/obj/item/armor_module/storage/U = T.attachments_by_slot[ATTACHMENT_SLOT_STORAGE]
-				var/obj/item/storage/S = U.storage
-				S.handle_item_insertion(W, FALSE, src)
-				S.close(src)
-			if(istype(head, /obj/item/clothing/head/helmet/marine)) //old hats use pocket var instead of storage attachments
-				var/obj/item/clothing/head/helmet/marine/T = head
-				var/obj/item/storage/internal/S = T.pockets
-				S.handle_item_insertion(W, FALSE, src)
-				S.close(src)
+			if(istype(head, /obj/item/clothing/head))
+				var/obj/item/clothing/head/headwear = head
+				if(!headwear.attachments_by_slot[ATTACHMENT_SLOT_STORAGE])
+					return FALSE
+				var/obj/item/armor_module/storage/storage_module = headwear.attachments_by_slot[ATTACHMENT_SLOT_STORAGE]
+				var/obj/item/storage/storage = storage_module.storage
+				storage.handle_item_insertion(W, FALSE, src)
 		if(SLOT_IN_HOLSTER)
 			var/obj/item/storage/S = belt
 			S.handle_item_insertion(W, FALSE, src)


### PR DESCRIPTION
## About The Pull Request
Kills the pocket var on boots and hats, and fixes the loadout screen BSOD from the previous change.

Pushes loadout version to 11 to cover the changes.

Contains a few related changes/
## Why It's Good For The Game
Snowflake var bad, attachment good.
Bug fix good.
## Changelog
:cl:
fix: fixed a loadout screen BSOD
code: removed the pocket var from boots and some hats, replacing them with irremovable attachments.
code: Loadout version progressed to 11.
/:cl:
