### PR TITLE
Re-adds MMB for guns.

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -678,9 +678,8 @@
 		return
 
 	if(modifiers["right"] || modifiers["middle"])
-	modifiers -= "right"
-	modifiers -= "middle"
-	modifiers -= "right"
+		modifiers -= "right"
+		modifiers -= "middle"
 		params = list2params(modifiers)
 		active_attachable?.start_fire(source, object, location, control, params, bypass_checks)
 		return

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -677,10 +677,10 @@
 	if(modifiers["shift"])
 		return
 
-	if(modifiers["middle"])
-		return
-	if(modifiers["right"])
-		modifiers -= "right"
+	if(modifiers["right"] || modifiers["middle"])
+	modifiers -= "right"
+	modifiers -= "middle"
+	modifiers -= "right"
 		params = list2params(modifiers)
 		active_attachable?.start_fire(source, object, location, control, params, bypass_checks)
 		return


### PR DESCRIPTION
## About The Pull Request

In, #12282, MMB was changed so that it could not be used to fire selected objects, such as an underbarrel shotgun, or grenade launcher. This was done in the guise of being a "bugfix" - but as someone who uses MMB for underbarrels AND jetpacks, I feel like completely removing this was stupid and not the right way to go about things.

## Why It's Good For The Game

Allowing players to use the control scheme they've been used to for years is a good thing. Suddenly changing something a large portion of the server uses without informing the community isn't.

..And yes. I know there is the *VERY* specific scenario where a jetpack user could fly into their own flames. And that IS an issue. But removing MMB entirely isn't a fix. It's hardly even a band-aid. We wouldn't remove right-click because there was an issue caused by an oversight involved with it, now would we?


## Changelog
:cl:
add: MMB returns for usage in underbarrel attachments.
/:cl: