### PR TITLE
CIC-Overwatch and CAS missions get minimaps, improves AIs minimap

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -626,6 +626,7 @@
 #define COMSIG_KB_HOLD_RUN_MOVE_INTENT_UP "keybinding_hold_run_move_intent_up"
 #define COMSIG_KB_EMOTE "keybinding_emote"
 #define COMSIG_KB_TOGGLE_MINIMAP "toggle_minimap"
+#define COMSIG_KB_TOGGLE_EXTERNAL_MINIMAP "toggle_external_minimap"
 #define COMSIG_KB_SELFHARM "keybind_selfharm"
 
 // mecha keybinds

--- a/code/controllers/subsystem/minimaps.dm
+++ b/code/controllers/subsystem/minimaps.dm
@@ -373,6 +373,9 @@ SUBSYSTEM_DEF(minimaps)
 /datum/action/minimap
 	name = "Toggle Minimap"
 	action_icon_state = "minimap"
+	keybinding_signals = list(
+		KEYBINDING_NORMAL = COMSIG_KB_TOGGLE_MINIMAP,
+	)
 	///Flags to allow the owner to see others of this type
 	var/minimap_flags = MINIMAP_FLAG_ALL
 	///marker flags this will give the target, mostly used for marine minimaps
@@ -385,11 +388,8 @@ SUBSYSTEM_DEF(minimaps)
 	var/atom/movable/locator_override
 	///Minimap "You are here" indicator for when it's up
 	var/atom/movable/screen/minimap_locator/locator
-	///This is mostly for the AI & other things which do not move groundside.
+	///Sets a fixed z level to be tracked by this minimap action instead of being influenced by the owner's / locator override's z level.
 	var/default_overwatch_level = 0
-	keybinding_signals = list(
-		KEYBINDING_NORMAL = COMSIG_KB_TOGGLE_MINIMAP,
-	)
 
 /datum/action/minimap/New(Target)
 	. = ..()

--- a/code/controllers/subsystem/minimaps.dm
+++ b/code/controllers/subsystem/minimaps.dm
@@ -492,16 +492,16 @@ SUBSYSTEM_DEF(minimaps)
 		owner.client.screen -= map
 	map = null
 	if(!SSminimaps.minimaps_by_z["[newz]"] || !SSminimaps.minimaps_by_z["[newz]"].hud_image)
+		if(minimap_displayed)
+			owner.client.screen -= locator
+			locator.UnregisterSignal(tracking, COMSIG_MOVABLE_MOVED)
+			minimap_displayed = FALSE
 		return
-	if(default_overwatch_level)
+	if(default_overwatch_level) //This is mildly scuffed at the moment.
 		map = SSminimaps.fetch_minimap_object(default_overwatch_level, minimap_flags)
 		return
 	map = SSminimaps.fetch_minimap_object(newz, minimap_flags)
-	if(minimap_displayed && !map)
-		owner.client.screen -= locator
-		locator.UnregisterSignal(tracking, COMSIG_MOVABLE_MOVED)
-		minimap_displayed = FALSE
-	else if(minimap_displayed)
+	if(minimap_displayed)
 		owner.client.screen += map
 
 

--- a/code/controllers/subsystem/minimaps.dm
+++ b/code/controllers/subsystem/minimaps.dm
@@ -478,8 +478,8 @@ SUBSYSTEM_DEF(minimaps)
 /datum/action/minimap/remove_action(mob/M)
 	var/atom/movable/tracking = locator_override ? locator_override : M
 	if(minimap_displayed)
-		owner.client.screen -= map
-		owner.client.screen -= locator
+		owner.client?.screen -= map
+		owner.client?.screen -= locator
 		locator.UnregisterSignal(tracking, COMSIG_MOVABLE_MOVED)
 		minimap_displayed = FALSE
 	UnregisterSignal(tracking, COMSIG_MOVABLE_Z_CHANGED)
@@ -492,28 +492,34 @@ SUBSYSTEM_DEF(minimaps)
 	SIGNAL_HANDLER
 	var/atom/movable/tracking = locator_override ? locator_override : owner
 	if(minimap_displayed)
-		owner.client.screen -= map
+		owner.client?.screen -= map
 	map = null
 	if(default_overwatch_level)
 		if(!SSminimaps.minimaps_by_z["[default_overwatch_level]"] || !SSminimaps.minimaps_by_z["[default_overwatch_level]"].hud_image)
 			if(minimap_displayed)
-				owner.client.screen -= locator
+				owner.client?.screen -= locator
 				locator.UnregisterSignal(tracking, COMSIG_MOVABLE_MOVED)
 				minimap_displayed = FALSE
 			return
 		map = SSminimaps.fetch_minimap_object(default_overwatch_level, minimap_flags)
 		if(minimap_displayed)
-			owner.client.screen += map
+			if(owner.client)
+				owner.client.screen += map
+			else
+				minimap_displayed = FALSE
 		return
 	if(!SSminimaps.minimaps_by_z["[newz]"] || !SSminimaps.minimaps_by_z["[newz]"].hud_image)
 		if(minimap_displayed)
-			owner.client.screen -= locator
+			owner.client?.screen -= locator
 			locator.UnregisterSignal(tracking, COMSIG_MOVABLE_MOVED)
 			minimap_displayed = FALSE
 		return
 	map = SSminimaps.fetch_minimap_object(newz, minimap_flags)
 	if(minimap_displayed)
-		owner.client.screen += map
+		if(owner.client)
+			owner.client.screen += map
+		else
+			minimap_displayed = FALSE
 
 
 

--- a/code/datums/components/remote_control.dm
+++ b/code/datums/components/remote_control.dm
@@ -27,15 +27,21 @@
 	RegisterSignal(controlled, COMSIG_PARENT_QDELETING, PROC_REF(on_control_terminate))
 	RegisterSignal(controlled, COMSIG_MOVABLE_HEAR, PROC_REF(on_hear))
 	RegisterSignal(parent, list(COMSIG_REMOTECONTROL_UNLINK, COMSIG_PARENT_QDELETING), PROC_REF(on_control_terminate))
+	RegisterSignal(controlled, COMSIG_PARENT_PREQDELETED, PROC_REF(disable_controls))
 
 
 /datum/component/remote_control/Destroy(force=FALSE, silent=FALSE)
-	if(is_controlling)
-		remote_control_off()
+	UnregisterSignal(controlled, COMSIG_PARENT_PREQDELETED)
 	controlled = null
 	left_click_proc = null
 	right_click_proc = null
 	return ..()
+
+///I want controls to be disabled *before* actually qdeling due to some race conditions of my own creation.
+/datum/component/remote_control/proc/disable_controls()
+	SIGNAL_HANDLER
+	if(is_controlling)
+		remote_control_off()
 
 ///Called when Controlling should not be resumed and deleted the component
 /datum/component/remote_control/proc/on_control_terminate(datum/source)

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -322,8 +322,14 @@
 /datum/keybinding/mob/toggle_minimap
 	name = "toggle_minimap"
 	full_name = "Toggle minimap"
-	description = "Toggle the minimap screen"
+	description = "Toggle your character's inherent or headset-based minimap screen"
 	keybind_signal = COMSIG_KB_TOGGLE_MINIMAP
+
+/datum/keybinding/mob/toggle_external_minimap
+	name = "toggle_external_minimap"
+	full_name = "Toggle external minimap"
+	description = "Toggle external minimap screens received from e.g. consoles or similar objects"
+	keybind_signal = COMSIG_KB_TOGGLE_EXTERNAL_MINIMAP
 
 /datum/keybinding/mob/toggle_self_harm
 	name = "toggle_self_harm"

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -47,6 +47,9 @@
 	miner_status = MINER_DESTROYED
 	icon_state = "mining_drill_error"
 
+/obj/machinery/miner/damaged/init_marker()
+	return //Marker will be set by itself once processing pauses when it detects this miner is broke.
+
 /obj/machinery/miner/damaged/platinum
 	name = "\improper Nanotrasen platinum Mining Well"
 	desc = "A Nanotrasen platinum drill with an internal export module. Produces even more valuable materials than it's phoron counterpart"
@@ -54,9 +57,12 @@
 
 /obj/machinery/miner/Initialize()
 	. = ..()
-	SSminimaps.add_marker(src, z, hud_flags = MINIMAP_FLAG_ALL, iconstate = "miner_[mineral_value >= PLATINUM_CRATE_SELL_AMOUNT ? "platinum" : "phoron"]_off")
+	init_marker()
 	start_processing()
 	RegisterSignal(SSdcs, COMSIG_GLOB_DROPSHIP_HIJACKED, PROC_REF(disable_on_hijack))
+
+/obj/machinery/miner/proc/init_marker()
+	SSminimaps.add_marker(src, z, hud_flags = MINIMAP_FLAG_ALL, iconstate = "miner_[mineral_value >= PLATINUM_CRATE_SELL_AMOUNT ? "platinum" : "phoron"]_on")
 
 /obj/machinery/miner/update_icon()
 	switch(miner_status)

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -61,6 +61,10 @@
 	start_processing()
 	RegisterSignal(SSdcs, COMSIG_GLOB_DROPSHIP_HIJACKED, PROC_REF(disable_on_hijack))
 
+/**
+ * This proc is called during Initialize() and should be used to initially setup the minimap marker of a functional miner.
+ * * For a miner starting broken, it should be overridden and immediately return instead, as broken miners will automatically set their minimap marker during their first process()
+ **/
 /obj/machinery/miner/proc/init_marker()
 	SSminimaps.add_marker(src, z, hud_flags = MINIMAP_FLAG_ALL, iconstate = "miner_[mineral_value >= PLATINUM_CRATE_SELL_AMOUNT ? "platinum" : "phoron"]_on")
 

--- a/code/game/objects/machinery/overwatch.dm
+++ b/code/game/objects/machinery/overwatch.dm
@@ -49,7 +49,7 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 	///datum used when sending a rally order
 	var/datum/action/innate/order/rally_order/send_rally_order
 	///Groundside minimap for overwatch
-	var/datum/action/minimap/cic_mini
+	var/datum/action/minimap/marine/cic_mini
 
 /obj/machinery/computer/camera_advanced/overwatch/Initialize()
 	. = ..()

--- a/code/game/objects/machinery/overwatch.dm
+++ b/code/game/objects/machinery/overwatch.dm
@@ -49,7 +49,7 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 	///datum used when sending a rally order
 	var/datum/action/innate/order/rally_order/send_rally_order
 	///Groundside minimap for overwatch
-	var/datum/action/minimap/marine/cic_mini
+	var/datum/action/minimap/marine/external/cic_mini
 
 /obj/machinery/computer/camera_advanced/overwatch/Initialize()
 	. = ..()

--- a/code/game/objects/machinery/overwatch.dm
+++ b/code/game/objects/machinery/overwatch.dm
@@ -48,6 +48,8 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 	var/datum/action/innate/order/defend_order/send_defend_order
 	///datum used when sending a rally order
 	var/datum/action/innate/order/rally_order/send_rally_order
+	///Groundside minimap for overwatch
+	var/datum/action/minimap/cic_mini
 
 /obj/machinery/computer/camera_advanced/overwatch/Initialize()
 	. = ..()
@@ -55,6 +57,18 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 	send_defend_order = new
 	send_retreat_order = new
 	send_rally_order = new
+	cic_mini = new
+
+/obj/machinery/computer/camera_advanced/overwatch/Destroy()
+	QDEL_NULL(send_attack_order)
+	QDEL_NULL(send_defend_order)
+	QDEL_NULL(send_retreat_order)
+	QDEL_NULL(send_rally_order)
+	QDEL_NULL(cic_mini)
+	current_order = null
+	selected_target = null
+	current_squad = null
+	return ..()
 
 /obj/machinery/computer/camera_advanced/overwatch/give_actions(mob/living/user)
 	. = ..()
@@ -74,6 +88,10 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 		send_rally_order.target = user
 		send_rally_order.give_action(user)
 		actions += send_rally_order
+	if(cic_mini)
+		cic_mini.target = user
+		cic_mini.give_action(user)
+		actions += cic_mini
 
 /obj/machinery/computer/camera_advanced/overwatch/main
 	icon_state = "overwatch_main"
@@ -125,6 +143,7 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 	eyeobj.visible_icon = TRUE
 	eyeobj.icon = 'icons/mob/cameramob.dmi'
 	eyeobj.icon_state = "generic_camera"
+	cic_mini.override_locator(eyeobj)
 
 /obj/machinery/computer/camera_advanced/overwatch/give_eye_control(mob/user)
 	. = ..()

--- a/code/game/objects/structures/droppod.dm
+++ b/code/game/objects/structures/droppod.dm
@@ -308,16 +308,27 @@ GLOBAL_LIST_INIT(blocked_droppod_tiles, typecacheof(list(/turf/open/space/transi
 	name = "Set drop pod target"
 	action_icon = 'icons/mecha/actions_mecha.dmi'
 	action_icon_state = "mech_zoom_on"
+	///Locks activating this action again while choosing to prevent signal shenanigan runtimes.
+	var/choosing = FALSE
 
+/datum/action/innate/set_drop_target/can_use_action()
+	if(choosing)
+		return FALSE
+	return ..()
+	
 /datum/action/innate/set_drop_target/Activate()
 	. = ..()
 	//yes this is hardcoded bite me
 	var/atom/movable/screen/minimap/map = SSminimaps.fetch_minimap_object(2, MINIMAP_FLAG_MARINE)
 	owner.client.screen += map
+	choosing = TRUE
 	var/list/polled_coords = map.get_coords_from_click(owner)
 	if(!polled_coords)
+		owner.client?.screen -= map
+		choosing = FALSE
 		return
 	owner.client?.screen -= map
+	choosing = FALSE
 	var/obj/structure/droppod/pod = target
 	pod.set_target(polled_coords[1], polled_coords[2])
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -75,6 +75,8 @@
 	laws += "Protect: Protect the personnel of your assigned vessel, and all other TerraGov personnel to the best of your abilities, with priority as according to their rank and role."
 	laws += "Preserve: Do not allow unauthorized personnel to tamper with your equipment."
 
+	mini = new
+	mini.give_action(src)
 	create_eye()
 
 	if(!job)
@@ -99,7 +101,6 @@
 	var/datum/action/innate/order/retreat_order/send_retreat_order = new
 	var/datum/action/innate/order/rally_order/send_rally_order = new
 	var/datum/action/control_vehicle/control = new
-	mini = new
 	var/datum/action/innate/squad_message/squad_message = new
 	send_attack_order.target = src
 	send_attack_order.give_action(src)
@@ -111,7 +112,6 @@
 	send_rally_order.give_action(src)
 	control.give_action(src)
 	squad_message.give_action(src)
-	mini.give_action(src)
 
 /mob/living/silicon/ai/Destroy()
 	GLOB.ai_list -= src
@@ -398,9 +398,11 @@
 
 /mob/living/silicon/ai/set_remote_control(atom/movable/controlled)
 	if(controlled)
+		mini.override_locator(controlled)
 		reset_perspective(controlled, FALSE)
 	else
-		eyeobj.forceMove(remote_control)
+		eyeobj.forceMove(get_turf(remote_control))
+		mini.override_locator(eyeobj)
 		reset_perspective()
 	remote_control = controlled
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -56,6 +56,9 @@
 	///Linked artillery for remote targeting.
 	var/obj/machinery/deployable/mortar/linked_artillery
 
+	///Referenec to the AIs minimap.
+	var/datum/action/minimap/ai/mini
+
 
 /mob/living/silicon/ai/Initialize(mapload, ...)
 	. = ..()
@@ -96,7 +99,7 @@
 	var/datum/action/innate/order/retreat_order/send_retreat_order = new
 	var/datum/action/innate/order/rally_order/send_rally_order = new
 	var/datum/action/control_vehicle/control = new
-	var/datum/action/minimap/ai/mini = new
+	mini = new
 	var/datum/action/innate/squad_message/squad_message = new
 	send_attack_order.target = src
 	send_attack_order.give_action(src)
@@ -120,6 +123,7 @@
 	UnregisterSignal(SSdcs, COMSIG_GLOB_OB_LASER_CREATED)
 	UnregisterSignal(SSdcs, COMSIG_GLOB_CAS_LASER_CREATED)
 	UnregisterSignal(SSdcs, COMSIG_GLOB_SHUTTLE_TAKEOFF)
+	QDEL_NULL(mini)
 	return ..()
 
 ///Print order visual to all marines squad hud and give them an arrow to follow the waypoint

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -83,6 +83,13 @@
 		ai.master_multicam.refresh_view()
 	update_parallax_contents()
 
+/mob/camera/aiEye/abstract_move(atom/new_loc)
+	var/turf/old_turf = get_turf(src)
+	var/turf/new_turf = get_turf(new_loc)
+	if(old_turf?.z != new_turf?.z)
+		onTransitZ(old_turf?.z, new_turf?.z)
+	return ..()
+
 
 /mob/camera/aiEye/Move()
 	return FALSE
@@ -165,6 +172,7 @@
 	eyeobj.setLoc(loc)
 	eyeobj.name = "[name] (AI Eye)"
 	eyeobj.real_name = eyeobj.name
+	mini.override_locator(eyeobj)
 	set_eyeobj_visible(TRUE)
 
 

--- a/code/modules/shuttle/cas_plane.dm
+++ b/code/modules/shuttle/cas_plane.dm
@@ -197,7 +197,7 @@
 	///Our currently selected weapon we will fire
 	var/obj/structure/dropship_equipment/weapon/active_weapon
 	///Minimap for the pilot to know where the marines have ran off to
-	var/datum/action/minimap/marine/cas_mini
+	var/datum/action/minimap/marine/external/cas_mini
 
 /obj/docking_port/mobile/marine_dropship/casplane/Initialize()
 	. = ..()

--- a/code/modules/shuttle/cas_plane.dm
+++ b/code/modules/shuttle/cas_plane.dm
@@ -197,7 +197,7 @@
 	///Our currently selected weapon we will fire
 	var/obj/structure/dropship_equipment/weapon/active_weapon
 	///Minimap for the pilot to know where the marines have ran off to
-	var/datum/action/minimap/cas_mini
+	var/datum/action/minimap/marine/cas_mini
 
 /obj/docking_port/mobile/marine_dropship/casplane/Initialize()
 	. = ..()

--- a/code/modules/shuttle/cas_plane.dm
+++ b/code/modules/shuttle/cas_plane.dm
@@ -196,15 +196,20 @@
 	var/fuel_max = 40
 	///Our currently selected weapon we will fire
 	var/obj/structure/dropship_equipment/weapon/active_weapon
+	///Minimap for the pilot to know where the marines have ran off to
+	var/datum/action/minimap/cas_mini
 
 /obj/docking_port/mobile/marine_dropship/casplane/Initialize()
 	. = ..()
 	off_action = new
+	cas_mini = new
 	RegisterSignal(src, COMSIG_SHUTTLE_SETMODE, PROC_REF(update_state))
 
 /obj/docking_port/mobile/marine_dropship/casplane/Destroy(force)
 	STOP_PROCESSING(SSslowprocess, src)
 	end_cas_mission(chair?.occupant)
+	QDEL_NULL(off_action)
+	QDEL_NULL(cas_mini)
 	return ..()
 
 /obj/docking_port/mobile/marine_dropship/casplane/process()
@@ -290,6 +295,8 @@
 	if(!eyeobj)
 		eyeobj = new()
 		eyeobj.origin = src
+		cas_mini.override_locator(eyeobj)
+
 	if(eyeobj.eye_user)
 		to_chat(user, span_warning("CAS mode is already in-use!"))
 		return
@@ -312,6 +319,8 @@
 /obj/docking_port/mobile/marine_dropship/casplane/proc/give_eye_control(mob/user)
 	off_action.target = user
 	off_action.give_action(user)
+	cas_mini.target = user
+	cas_mini.give_action(user)
 	eyeobj.eye_user = user
 	eyeobj.name = "CAS Camera Eye ([user.name])"
 	user.remote_control = eyeobj
@@ -329,6 +338,7 @@
 	UnregisterSignal(user, COMSIG_MOB_CLICKON)
 	user.client.mouse_pointer_icon = initial(user.client.mouse_pointer_icon)
 	off_action.remove_action(user)
+	cas_mini.remove_action(user)
 	for(var/V in eyeobj.visibleCameraChunks)
 		var/datum/camerachunk/C = V
 		C.remove(eyeobj)


### PR DESCRIPTION
## About The Pull Request
This PR adds a minimap to CIC's consoles while in the overwatch camera view, which updates its z to the one currently viewed (or none if the z is minimapless).
Similarly, the AI minimap is now improved to track whichever z the AI's eye is on currently.
CAS also gets a minimap while running strike missions, and this might allow it to give it laze locations on the minimap at a later time (would be out of scope for this PR and I'm already doing enough here)

The locator also tracks the eyes and not the user in CIC / wherever, for all of these added / modified minimaps.
Minimap code may contain a little bit of signal sorcery to achieve this but it should work fine. Please do testmerge this before fullmerging, as there may nonetheless be things I missed or oopsied.

Also fixes two minor minimap related things,
one is that *default_overwatch_level* for minimaps didn't work properly due to a missing return call (though *default_overwatch_level*s aren't used at the moment now that I made AIs able to view different z's maps)
second was that miners used to runtime due to doing some minimap related things twice
## Why It's Good For The Game
CIC: Overwatch is supposed to be able to coordinate marines and be their eyes, which is somewhat difficult without easy access to the minimaps every single groundside marine has. This should make keeping an eye on the force as a whole easier, while also helping navigate the map.

AI: AIs minimap at the moment is effectively useless, only ever showing the ship's map which only matters when xenos board. This should allow it to be a more useful "eye" to the marines, akin to CIC.

CAS: As CAS pilot, it can sometimes be difficult to ascertain where marines are, aswell as where major combat is happening, especially ever since lazes were made unnecessary to deploy into strike mode. This should make it easier to locate marines and engagements, while also being able to coordinate somewhat better.

Bugfixes: Fix man good.
## Changelog
:cl:
add: CIC Overwatch now has a minimap while using the camera system.
add: CAS now has a minimap while on a groundside strike mission.
balance: AI's minimap now tracks the z the AI's eye is on, instead of only shipside
fix: Miners no longer cause minimap-related runtimes every init.
fix: default_overwatch_level for minimaps should now work properly.
code: Minimaps now support tracking atoms which aren't the owner of the action.
fix: Fixes a very minor, easy to trigger, droppod runtime.
/:cl:
