### PR TITLE
Stop the shuttle shadow from blocking clicks

### DIFF
--- a/code/modules/shuttle/ripple.dm
+++ b/code/modules/shuttle/ripple.dm
@@ -8,7 +8,7 @@
 	anchored = TRUE
 	density = FALSE
 	layer = RIPPLE_LAYER
-	mouse_opacity = MOUSE_OPACITY_ICON
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	alpha = 0
 
 /obj/effect/abstract/ripple/Initialize(mapload, time_left)


### PR DESCRIPTION

## About The Pull Request

Yeah. Funny.
## Why It's Good For The Game

Currently you can't interact with anything under the shadow minus using alt click to get to it. This causes funnies with drains or generally trying to save something from under tad.
## Changelog
:cl:
fix: Shuttle landing shadow doesn't block clicks anymore
/:cl:
