### PR TITLE
Moves green disk to engineering on LV

### DIFF
--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -7437,6 +7437,10 @@
 /obj/effect/turf_decal/warning_stripes,
 /turf/open/floor/mech_bay_recharge_floor,
 /area/shuttle/drop2/lz2)
+"hIs" = (
+/obj/machinery/computer/nuke_disk_generator/green,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "hIC" = (
 /obj/structure/table,
 /obj/item/book/manual/research_and_development,
@@ -14819,7 +14823,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/computer/nuke_disk_generator/green,
+/obj/structure/table,
+/obj/item/clothing/suit/apron,
 /turf/open/floor/tile/green/greentaupe{
 	dir = 5
 	},
@@ -44184,7 +44189,7 @@ xFy
 iVO
 agv
 jNQ
-sTw
+hIs
 tch
 aEp
 kWA


### PR DESCRIPTION

## About The Pull Request

Moves green disk across the river to engineering on LV.
## Why It's Good For The Game

I really hate how LV is being played right now. 

Every round is the exact same pointless marine push to engi followed by them just sitting there until the xenos attrition them enough. This should make that push a bit less pointless and give marines a timer to gtfo out of engi once the disk is done instead of sitting there eternally.

On the other hand this should also help with how marine sided the disks (and LV as a whole) are if the marines actually go for disks because it's harder to get compared to green being in hydro which is essentially free as it stands right now.
## Changelog
:cl:
balance: Moved green disk to engineering on LV
/:cl:
