### PR TITLE
Changes "Belt (2)" to be "Belt Inside"

### DIFF
--- a/code/__DEFINES/equipment.dm
+++ b/code/__DEFINES/equipment.dm
@@ -386,6 +386,7 @@ GLOBAL_LIST_INIT(slot_str_to_slot, list(
 	SLOT_IN_L_POUCH,\
 	SLOT_IN_R_POUCH,\
 	SLOT_BELT,\
+	SLOT_IN_BELT,\
 	SLOT_WEAR_SUIT,\
 	SLOT_IN_STORAGE,\
 	SLOT_L_STORE,\
@@ -443,7 +444,7 @@ GLOBAL_LIST_INIT(slot_str_to_slot, list(
 	"Left Pocket",\
 	"Right Pocket",\
 	"Webbing",\
-	"Belt",\
+	"Belt Inside",\
 	"Belt Holster",\
 	"Suit Storage Holster",\
 	"Back Holster",\
@@ -469,7 +470,7 @@ GLOBAL_LIST_INIT(slot_str_to_slot, list(
 			return SLOT_R_STORE
 		if("Webbing")
 			return SLOT_IN_ACCESSORY
-		if("Belt")
+		if("Belt Inside")
 			return SLOT_IN_BELT
 		if("Belt Holster")
 			return SLOT_IN_HOLSTER
@@ -486,6 +487,8 @@ GLOBAL_LIST_INIT(slot_str_to_slot, list(
 			return "Suit Inside"
 		if(SLOT_BELT)
 			return "Belt"
+		if(SLOT_IN_BELT)
+			return "Belt Inside"
 		if(SLOT_BACK)
 			return "Back"
 		if(SLOT_IN_BOOT)
@@ -498,8 +501,6 @@ GLOBAL_LIST_INIT(slot_str_to_slot, list(
 			return "Right Pocket"
 		if(SLOT_IN_ACCESSORY)
 			return "Webbing"
-		if(SLOT_IN_BELT)
-			return "Belt"
 		if(SLOT_IN_HOLSTER)
 			return "Belt Holster"
 		if(SLOT_IN_S_HOLSTER)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -459,6 +459,8 @@
 			return shoes
 		if(SLOT_IN_B_HOLSTER)
 			return back
+		if(SLOT_IN_BELT)
+			return belt
 		if(SLOT_IN_HOLSTER)
 			return belt
 		if(SLOT_IN_STORAGE)


### PR DESCRIPTION
I am exhausted.
## About The Pull Request
Adds SLOT_IN_BELT to the required areas so I can finally make it a quick equip that works.
There was always this option in prefs, it just DIDNT WORK. 
There was always Belt, and then Belt (2)
What the fuck is belt 2, idk, but I changed it to "Belt inside"
It's basically your health scanner if you use a lifesaver belt, or ammo inside ammo belts, etc.
Quick equip Belt, is if you have a gun directly on your belt. (Or whatever else you can wear on belt that isnt a storage)
## Why It's Good For The Game
Bugfix good? 
If this is considered a bug, probably is.
## Changelog
:cl:
fix: "Belt (2") in quick equip prefs is now "Belt Inside"
/:cl:
