### PR TITLE
Fix beacon admin log message

### DIFF
--- a/code/game/objects/machinery/squad_supply/supply_beacon.dm
+++ b/code/game/objects/machinery/squad_supply/supply_beacon.dm
@@ -47,7 +47,7 @@
 	var/obj/machinery/camera/beacon_cam/BC = new(src, "[H.get_paygrade()] [H.name] [src]")
 	H.transferItemToLoc(src, H.loc)
 	beacon_cam = BC
-	message_admins("[ADMIN_TPMONTY(usr)] set up an orbital strike beacon.")
+	message_admins("[ADMIN_TPMONTY(usr)] set up a supply beacon.")
 	name = "transmitting orbital beacon - [get_area(src)] - [H]"
 	activated = TRUE
 	anchored = TRUE


### PR DESCRIPTION

## About The Pull Request
Says Orbital Strike beacon instead of supply.
## Why It's Good For The Game
Don't know why its still a thing but might as well make it accurate.
## Changelog
:cl:
spellcheck: updated beacon admin log to say 'supply' instead of 'orbital strike'
/:cl:
