### PR TITLE
FIX: Big Canterbury Left Button

### DIFF
--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -279,7 +279,7 @@
 	dir = 8
 	},
 /obj/machinery/door_control{
-	id = "starboard_umbilical_outer";
+	id = "port_umbilical_outer";
 	name = "outer door-control";
 	pixel_y = 32
 	},


### PR DESCRIPTION

A simple one-line change I did by opening the .dmm in notepad, CTRL+F'ing the id and rewriting it to a proper one.
## About The Pull Request
Right now the left button controls the right shutters instead of the left ones, leaving the left side to be unable to be opened by ungas. This PR fixes that
## Why It's Good For The Game
Bug fix good, not being able to ever open left door on big canter was a meme
## Changelog
:cl:
fix: fixed big canterbury left button opening right shutters instead
/:cl:
