### PR TITLE
Fixes not being able to put a bootknife back into the boot.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -669,7 +669,7 @@ GLOBAL_DATUM_INIT(welding_sparks_prepdoor, /mutable_appearance, mutable_appearan
 			if(storage.can_be_inserted(src, warning))
 				return TRUE
 		if(SLOT_IN_BOOT)
-			if(H.shoes)
+			if(!H.shoes)
 				return FALSE
 			if(!istype(H.shoes, /obj/item/clothing/shoes))
 				return FALSE

--- a/code/modules/clothing/modular_armor/attachments/storage.dm
+++ b/code/modules/clothing/modular_armor/attachments/storage.dm
@@ -312,7 +312,6 @@
 /obj/item/storage/internal/shoes/boot_knife
 	max_storage_space = 3
 	storage_slots = 1
-	draw_mode = TRUE
 	can_hold = list(
 		/obj/item/weapon/combat_knife,
 		/obj/item/weapon/gun/pistol/standard_pocketpistol,


### PR DESCRIPTION

## About The Pull Request
Fixes broken check. Removes draw_mode (which doesnt work on internal storages)
## Why It's Good For The Game
Bugfix.
## Changelog
:cl:
fix: Fixes not being able to put your boot back with quick equip.
/:cl:
