### PR TITLE
Removes flamethrowers from crash vendors.

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -333,10 +333,6 @@
 		"Specialized" = list(
 			/obj/item/weapon/gun/rifle/pepperball = 4,
 			/obj/item/ammo_magazine/rifle/pepperball = 40,
-			/obj/item/weapon/gun/flamer/big_flamer/marinestandard = 4,
-			/obj/item/ammo_magazine/flamer_tank/large = 30,
-			/obj/item/ammo_magazine/flamer_tank/backtank = 4,
-			/obj/item/ammo_magazine/flamer_tank/water = -1,
 			/obj/item/jetpack_marine = 3,
 		),
 		"Attachments" = list(
@@ -361,14 +357,9 @@
 			/obj/item/attachable/burstfire_assembly = -1,
 			/obj/item/weapon/gun/shotgun/combat/masterkey = -1,
 			/obj/item/weapon/gun/grenade_launcher/underslung = -1,
-			/obj/item/weapon/gun/flamer/mini_flamer = -1,
-			/obj/item/ammo_magazine/flamer_tank/mini = -1,
 			/obj/item/weapon/gun/rifle/pepperball/pepperball_mini = -1,
 			/obj/item/ammo_magazine/rifle/pepperball/pepperball_mini = -1,
 			/obj/item/attachable/stock/t76 = -1,
-			/obj/item/attachable/flamer_nozzle = -1,
-			/obj/item/attachable/flamer_nozzle/wide = -1,
-			/obj/item/attachable/flamer_nozzle/long = -1,
 		),
 		"Boxes" = list(
 			/obj/item/ammo_magazine/packet/p9mm = -1,


### PR DESCRIPTION
## About The Pull Request
Removes flamethrowers from crash vendors.
## Why It's Good For The Game
After playing both as marine, and as Xeno. I have come to the conclusion that having flamers on lowpop is incredibly detrimental to the experience for both sides.
Flamethrowers are incredibly powerful, but they are kept in check by their fuel limits, counterplay (acid wells, hivelord, being able to re-maze) and map size. On Nuclear war, you can simply avoid the flamer and re-maze behind them, but Crash is played on smaller maps, with less xenos. Very rarely will you see a hivelord or drone putting jelly to counter flamers on crash, because they are not combat castes in a gamemode filled with constant combat.
As a marine, having fire basically turns the game into easy mode, it becomes unfun and there is 0 risk in any decision you take. Especially with the lack of psy drain, xenos have no way to punish a flamerthrower user who overextended and got punished.
## Changelog
:cl:
del: You can no longer vend flamers on crash.
/:cl:
