### PR TITLE
Warlock's Psychic Shield gets a trigger bind (again)

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -796,6 +796,7 @@
 #define COMSIG_XENOABILITY_SPIDERLING_MARK "xenoability_spiderling_mark"
 
 #define COMSIG_XENOABILITY_PSYCHIC_SHIELD "xenoability_psychic_shield"
+#define COMSIG_XENOABILITY_TRIGGER_PSYCHIC_SHIELD "xenoability_trigger_psychic_shield"
 #define COMSIG_XENOABILITY_PSYCHIC_BLAST "xenoability_psychic_blast"
 #define COMSIG_XENOABILITY_PSYCHIC_CRUSH "xenoability_psychic_crush"
 

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -881,6 +881,12 @@
 	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_SHIELD
 	hotkey_keys = list("E")
 
+/datum/keybinding/xeno/trigger_psychic_shield
+	name = "Trigger Psychic Shield"
+	full_name = "Warlock: Trigger Psychic Shield"
+	description = "Triggers the Psychic Shield ability without selecting it."
+	keybind_signal = COMSIG_XENOABILITY_TRIGGER_PSYCHIC_SHIELD
+
 /datum/keybinding/xeno/psychic_blast
 	name = "Psychic Blast"
 	full_name = "Warlock: Psychic Blast"

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -57,6 +57,7 @@
 	plasma_cost = 200
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_PSYCHIC_SHIELD,
+		KEYBINDING_ALTERNATE = COMSIG_XENOABILITY_TRIGGER_PSYCHIC_SHIELD,
 	)
 	use_state_flags = XACT_USE_BUSY
 	///The actual shield object created by this ability
@@ -71,6 +72,12 @@
 /datum/action/xeno_action/activable/psychic_shield/on_cooldown_finish()
 	owner.balloon_alert(owner, "Shield ready")
 	return ..()
+
+//Overrides parent.
+/datum/action/xeno_action/activable/psychic_shield/alternate_action_activate()
+	if(can_use_ability(null, FALSE, XACT_IGNORE_SELECTED_ABILITY))
+		INVOKE_ASYNC(src, PROC_REF(use_ability))
+	
 
 /datum/action/xeno_action/activable/psychic_shield/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/xeno_owner = owner


### PR DESCRIPTION

## About The Pull Request
Somewhat recently, Warlock's shield got changed to be a selected ability, requiring you to select it before being able to use it.
This, in some cases, is useful for targetting a specific target, but in others, can also be hindering in reactive or quick use of the ability, as not only does it require two clicks to execute, but also adds an additional click to any other action you'd maybe prefer stayed selected (e.g. your psychic shot). As this is purely a matter of preference, I have added a keybind that triggers the ability immediately without selecting it, towards your current direction, as before the initial change. It starts unbound, but is there for anyone who preferred the original behavior.
## Why It's Good For The Game
Ability use behaving like players prefer tends to be a good thing.
## Changelog
:cl:
qol: Readds the original psychic shield keybind behavior as an alternate keybind option.
/:cl:
