### PR TITLE
Crusher buffs. Takes more damage from Razor too.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -17,7 +17,7 @@
 	speed = -0.1
 
 	// *** Plasma *** //
-	plasma_max = 200
+	plasma_max = 300
 	plasma_gain = 10
 
 	// *** Health *** //
@@ -76,7 +76,7 @@
 	speed = -0.1
 
 	// *** Plasma *** //
-	plasma_max = 300
+	plasma_max = 400
 	plasma_gain = 15
 
 	// *** Health *** //
@@ -105,7 +105,7 @@
 	speed = -0.1
 
 	// *** Plasma *** //
-	plasma_max = 400
+	plasma_max = 500
 	plasma_gain = 30
 
 	// *** Health *** //
@@ -134,7 +134,7 @@
 	speed = -0.1
 
 	// *** Plasma *** //
-	plasma_max = 400
+	plasma_max = 500
 	plasma_gain = 30
 
 	// *** Health *** //
@@ -163,11 +163,11 @@
 	speed = -0.1
 
 	// *** Plasma *** //
-	plasma_max = 400
+	plasma_max = 500
 	plasma_gain = 30
 
 	// *** Health *** //
-	max_health = 400
+	max_health = 450
 
 	// *** Defense *** //
 	soft_armor = list(MELEE = 90, BULLET = 75, LASER = 75, ENERGY = 75, BOMB = 130, BIO = 100, FIRE = 40, ACID = 100)

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -21,7 +21,7 @@
 	plasma_gain = 10
 
 	// *** Health *** //
-	max_health = 325
+	max_health = 350
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_YOUNG_THRESHOLD
@@ -33,7 +33,7 @@
 	caste_traits = null
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 70, BULLET = 60, LASER = 60, ENERGY = 60, BOMB = 100, BIO = 80, FIRE = 25, ACID = 80)
+	soft_armor = list(MELEE = 70, BULLET = 65, LASER = 65, ENERGY = 65, BOMB = 100, BIO = 80, FIRE = 25, ACID = 80)
 
 	// *** Minimap Icon *** //
 	minimap_icon = "crusher"
@@ -80,13 +80,13 @@
 	plasma_gain = 15
 
 	// *** Health *** //
-	max_health = 345
+	max_health = 375
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_MATURE_THRESHOLD
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 75, BULLET = 65, LASER = 65, ENERGY = 65, BOMB = 110, BIO = 90, FIRE = 30, ACID = 90)
+	soft_armor = list(MELEE = 75, BULLET = 70, LASER = 70, ENERGY = 70, BOMB = 110, BIO = 90, FIRE = 30, ACID = 90)
 
 	// *** Abilities *** //
 	stomp_damage = 50
@@ -99,36 +99,7 @@
 	upgrade = XENO_UPGRADE_TWO
 
 	// *** Melee Attacks *** //
-	melee_damage = 24
-
-	// *** Speed *** //
-	speed = -0.1
-
-	// *** Plasma *** //
-	plasma_max = 400
-	plasma_gain = 30
-
-	// *** Health *** //
-	max_health = 370
-
-	// *** Evolution *** //
-	upgrade_threshold = TIER_THREE_ELDER_THRESHOLD
-
-	// *** Defense *** //
-	soft_armor = list(MELEE = 80, BULLET = 70, LASER = 70, ENERGY = 70, BOMB = 120, BIO = 95, FIRE = 35, ACID = 95)
-
-	// *** Abilities *** //
-	stomp_damage = 55
-	crest_toss_distance = 5
-
-/datum/xeno_caste/crusher/ancient
-	upgrade_name = "Ancient"
-	caste_desc = "It always has the right of way."
-	ancient_message = "We are the physical manifestation of a Tank. Almost nothing can harm us."
-	upgrade = XENO_UPGRADE_THREE
-
-	// *** Melee Attacks *** //
-	melee_damage = 24
+	melee_damage = 25
 
 	// *** Speed *** //
 	speed = -0.1
@@ -141,10 +112,39 @@
 	max_health = 400
 
 	// *** Evolution *** //
+	upgrade_threshold = TIER_THREE_ELDER_THRESHOLD
+
+	// *** Defense *** //
+	soft_armor = list(MELEE = 80, BULLET = 75, LASER = 75, ENERGY = 75, BOMB = 120, BIO = 95, FIRE = 35, ACID = 95)
+
+	// *** Abilities *** //
+	stomp_damage = 55
+	crest_toss_distance = 5
+
+/datum/xeno_caste/crusher/ancient
+	upgrade_name = "Ancient"
+	caste_desc = "It always has the right of way."
+	ancient_message = "We are the physical manifestation of a Tank. Almost nothing can harm us."
+	upgrade = XENO_UPGRADE_THREE
+
+	// *** Melee Attacks *** //
+	melee_damage = 25
+
+	// *** Speed *** //
+	speed = -0.1
+
+	// *** Plasma *** //
+	plasma_max = 400
+	plasma_gain = 30
+
+	// *** Health *** //
+	max_health = 450
+
+	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_ANCIENT_THRESHOLD
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 90, BULLET = 75, LASER = 75, ENERGY = 75, BOMB = 130, BIO = 100, FIRE = 40, ACID = 100)
+	soft_armor = list(MELEE = 90, BULLET = 80, LASER = 80, ENERGY = 80, BOMB = 130, BIO = 100, FIRE = 40, ACID = 100)
 	// *** Abilities *** //
 	stomp_damage = 60
 	crest_toss_distance = 6
@@ -157,7 +157,7 @@
 	upgrade = XENO_UPGRADE_FOUR
 
 	// *** Melee Attacks *** //
-	melee_damage = 24
+	melee_damage = 25
 
 	// *** Speed *** //
 	speed = -0.1

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -170,7 +170,7 @@
 	max_health = 450
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 90, BULLET = 75, LASER = 75, ENERGY = 75, BOMB = 130, BIO = 100, FIRE = 40, ACID = 100)
+	soft_armor = list(MELEE = 90, BULLET = 80, LASER = 80, ENERGY = 80, BOMB = 130, BIO = 100, FIRE = 40, ACID = 100)
 	// *** Abilities *** //
 	stomp_damage = 60
 	crest_toss_distance = 6

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -500,7 +500,7 @@
 	razorwire_tangle(charger, RAZORWIRE_ENTANGLE_DELAY * 0.10) //entangled for only 10% as long or 0.5 seconds
 	charger.visible_message(span_danger("The barbed wire slices into [charger]!"),
 	span_danger("The barbed wire slices into you!"), null, 5)
-	charger.Paralyze(0.5 SECONDS)
+	charger.Paralyze(1 SECONDS)
 	charger.apply_damage(RAZORWIRE_BASE_DAMAGE * RAZORWIRE_MIN_DAMAGE_MULT_HIGH, BRUTE, sharp = TRUE, updating_health = TRUE) //Armor is being ignored here.
 	playsound(src, 'sound/effects/barbed_wire_movement.ogg', 25, 1)
 	update_icon()

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -497,7 +497,7 @@
 /obj/structure/razorwire/post_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
 	if(!anchored)
 		return ..()
-	razorwire_tangle(charger, RAZORWIRE_ENTANGLE_DELAY * 0.10) //entangled for only 10% as long or 0.5 seconds
+	razorwire_tangle(charger, RAZORWIRE_ENTANGLE_DELAY * 0.20) //entangled for only 10% as long or 0.5 seconds
 	charger.visible_message(span_danger("The barbed wire slices into [charger]!"),
 	span_danger("The barbed wire slices into you!"), null, 5)
 	charger.Paralyze(1 SECONDS)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -497,7 +497,7 @@
 /obj/structure/razorwire/post_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
 	if(!anchored)
 		return ..()
-	razorwire_tangle(charger, RAZORWIRE_ENTANGLE_DELAY * 0.20) //entangled for only 10% as long or 0.5 seconds
+	razorwire_tangle(charger, RAZORWIRE_ENTANGLE_DELAY * 0.20) //entangled for only 20% as long or 1 second
 	charger.visible_message(span_danger("The barbed wire slices into [charger]!"),
 	span_danger("The barbed wire slices into you!"), null, 5)
 	charger.Paralyze(1 SECONDS)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -501,7 +501,7 @@
 	charger.visible_message(span_danger("The barbed wire slices into [charger]!"),
 	span_danger("The barbed wire slices into you!"), null, 5)
 	charger.Paralyze(0.5 SECONDS)
-	charger.apply_damage(RAZORWIRE_BASE_DAMAGE * RAZORWIRE_MIN_DAMAGE_MULT_MED, BRUTE, sharp = TRUE, updating_health = TRUE) //Armor is being ignored here.
+	charger.apply_damage(RAZORWIRE_BASE_DAMAGE * RAZORWIRE_MIN_DAMAGE_MULT_HIGH, BRUTE, sharp = TRUE, updating_health = TRUE) //Armor is being ignored here.
 	playsound(src, 'sound/effects/barbed_wire_movement.ogg', 25, 1)
 	update_icon()
 	return PRECRUSH_ENTANGLED //Let's return this so that the charger may enter the turf in where it's entangled, if it survived the wounds without gibbing.


### PR DESCRIPTION

## About The Pull Request
Health buffs:
From: 325-345-370-400
To: 350-375-400-450

+100 plasma for all maturities
+5 bullet, laser and energy armor across all maturities
+1 melee damage for elder+
Crusher takes more damage from razorwire
Crusher stun from razorwire doubled from 0.5 to 1 second
## Why It's Good For The Game
Most underwhelming siege caste by far.
These buffs should help it compete with other siege castes by making it beefier and even more cqc potent while allowing it to take a bit more punishment (when not sundered).
Razor wire is the best anti crusher tool and already easily countered when acid castes come into play. Making it more efficient vs crushers should keep some of these buffs in check.
## Changelog
:cl:
balance: Buffs crusher health: From: 325-345-370-400 To: 350-375-400-450
balance: Buffs crusher melee at elder and above from 24 to 25
balance: Buffs crusher plasma: From: 200-300-400 To: 300-400-500
balance: Buffs crusher Bullet, laser and energy armor: From: 60-65-70-75 To: 65-70-75-80
balance: Increase razorwire stun from 0.5 to 1 second
/:cl:
