### PR TITLE
Smartpistol restatting

### DIFF
--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -728,12 +728,12 @@ It is a modified Beretta 93R, and can fire three round burst or single fire. Whe
 // Smart pistol, based on Calico M-950
 /obj/item/weapon/gun/pistol/smart_pistol
 	name = "\improper SP-13 smart pistol"
-	desc = "The SP-13 is a latest solution for personal officer defence produced by Terran Armories. A cutting-edge miniaturization technology allows mounting of smartgun IFF system on the pistol, albeit at high manufactoring cost. Unique design feature high-capacity mag on top of the barrel, with integrated sight. As with all smartgun systems, requires special training."
+	desc = "The SP-13 is a IFF-capable sidearm used by the TerraGov Marine Corps. A cutting-edge miniaturization technology allows mounting of a KTLD IFF system on the pistol, albeit at high manufactoring cost and the usual specialized training required to use such a pistol. Unique design feature high-capacity mag on top of the barrel, with integrated sight."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "sp13"
 	item_state = "sp13"
 	caliber = CALIBER_9X19 //codex
-	max_shells = 25 //codex
+	max_shells = 30 //codex
 	fire_sound = 'sound/weapons/guns/fire/tp14.ogg' //same bullets, same sound
 	reload_sound = 'sound/weapons/guns/interact/tp14_reload.ogg'
 	default_ammo_type = /obj/item/ammo_magazine/pistol/standard_pistol/smart_pistol
@@ -751,6 +751,8 @@ It is a modified Beretta 93R, and can fire three round burst or single fire. Whe
 
 	flags_gun_features = GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY|GUN_IFF
 	gun_skill_category = SKILL_SMARTGUN
+	actions_types = list() // Inherits aimmode, but has IFF so..
+	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC, GUN_FIREMODE_SEMIAUTO)
 
 	attachable_offset = list("muzzle_x" = 29, "muzzle_y" = 20,"rail_x" = 13, "rail_y" = 23, "under_x" = 19, "under_y" = 13, "stock_x" = 21, "stock_y" = 17)
 

--- a/code/modules/projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/magazines/pistols.dm
@@ -242,10 +242,9 @@
 
 //SP-13 (Calico)
 /obj/item/ammo_magazine/pistol/standard_pistol/smart_pistol
-	name = "\improper SP-13 magazine (9mm)"
-	desc = "A SP-13 magazine."
+	name = "\improper SP-13 magazine (9mm AP)"
 	caliber = CALIBER_9X19
 	icon_state = "tx13"
-	max_rounds = 25
+	max_rounds = 30
 	w_class = WEIGHT_CLASS_SMALL
-	default_ammo = /datum/ammo/bullet/pistol
+	default_ammo = /datum/ammo/bullet/pistol/ap


### PR DESCRIPTION
## About The Pull Request
Does a pass over smartpistol.

tl;dr makes it go from normal pistol ammo to AP, adds full auto. Makes it more light SMG-esque than full pistol.
Detailed changes below
<details>
Left(old)|Right(New)

Damage:20|20
AP:5|12.5
Sunder:1|2 [Swapped over from /pistol to /pistol/ap. in order to make it simmilar to other SGs with their higher penetration, I don't think a damage malus is necessary considering it fires at rifle fire rate.]

Mag Capacity: 25|30 [Heightens ammo count a tiny bit to make it more viable on its own.
Added Full auto [Makes sense considering this is dollar store fire support pistol, and 88mod has it which is its closest comparison statwise.]

Gun handling is unchanged, I do not believe this thing needs any nerfs in that regard, considering you need to buy it or have a Captain spawn in and hand it to you.

Gun description got a change as well.
</details>
## Why It's Good For The Game
Gun kind of poopy right now, needs some changes to make it worth picking up over a 88mod or TP-14, hopefully this is enough.

## Changelog
:cl:
balance: Smartpistol now uses pistol AP bullets rather than normal pistol bullets, and has full auto and a bit more magazine size (25->30).
/:cl:
