### PR TITLE
Autocannon flak now does 2.5x damage to all walls.

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1294,6 +1294,11 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/bullet/auto_cannon/flak/on_hit_mob(mob/victim, obj/projectile/proj)
 	airburst(victim, proj)
 
+/datum/ammo/bullet/auto_cannon/flak/on_hit_turf(turf/T, obj/projectile/P)
+	. = ..()
+	if(iswallturf(T))
+		P.damage *= 2.5 // This will ANNHILATE walls.
+
 /datum/ammo/bullet/railgun
 	name = "armor piercing railgun slug"
 	hud_state = "railgun_ap"

--- a/code/modules/projectiles/magazines/mounted.dm
+++ b/code/modules/projectiles/magazines/mounted.dm
@@ -146,7 +146,7 @@
 
 /obj/item/ammo_magazine/auto_cannon/flak
 	name = "autocannon smart-detonating magazine(20mm)"
-	desc = "A box of 80 smart-detonating 20mm rounds for the ATR-22 mounted autocannon. Will pierce cover, but detonate on hitting a target"
+	desc = "A box of 80 smart-detonating 20mm rounds for the ATR-22 mounted autocannon. Will pierce through cover and people, and will shred walls better than most ammo."
 	icon_state = "ac_mag_flak"
 	item_state = "ac_flak"
 	default_ammo = /datum/ammo/bullet/auto_cannon/flak

--- a/code/modules/projectiles/magazines/mounted.dm
+++ b/code/modules/projectiles/magazines/mounted.dm
@@ -146,7 +146,7 @@
 
 /obj/item/ammo_magazine/auto_cannon/flak
 	name = "autocannon smart-detonating magazine(20mm)"
-	desc = "A box of 80 smart-detonating 20mm rounds for the ATR-22 mounted autocannon. Will pierce through cover and people, and will shred walls better than most ammo."
+	desc = "A box of 80 smart-detonating 20mm rounds for the ATR-22 mounted autocannon. Will pierce through cover aswell as shredding through walls better than most ammo."
 	icon_state = "ac_mag_flak"
 	item_state = "ac_flak"
 	default_ammo = /datum/ammo/bullet/auto_cannon/flak


### PR DESCRIPTION

## About The Pull Request
Autocannon flak does x2.5 damage to all walls, desc changed to reflect this.
## Why It's Good For The Game
Gives flak an actual gimmick, it annhilates walls now, not much else to add.
## Changelog
:cl:
balance: Autocannon flak ammo does x2.5 damage to walls such as resin or metal walls.
/:cl:
