### PR TITLE
Adds phermone towers to the resin silo's for crash

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -80,6 +80,7 @@
 	. = ..()
 	for(var/i in GLOB.xeno_resin_silo_turfs)
 		new /obj/structure/xeno/silo(i)
+		new /obj/structure/xeno/pherotower(i)
 
 	for(var/obj/effect/landmark/corpsespawner/corpse AS in GLOB.corpse_landmarks_list)
 		corpse.create_mob()


### PR DESCRIPTION
## About The Pull Request

This is 1 of 3 ways to add pheromones to the xeno spawns for things like reasonble healing speeds in xeno spawn

option 2 is to add the aura comp to the silo during crash(or always maby). this can then have a lesser range incase you only want it to effect roughly INSIDE the spawn and not the 32 tiles it is for the tower

option 3 is making new landmark for phero towers and adding them near the silos during crash(right now it spawns them ontop eachother
![afbeelding](https://user-images.githubusercontent.com/36102060/227936235-4abf14ad-c39f-405e-90d6-ee44d49eb1e9.png)

## Why It's Good For The Game

All xeno mains know the pain of healing without recov. this will let xenos heal reasonbly quick in exchange for having to go back to base. Also this could help when xenos get camped by switching pheros to push out more

## Changelog
:cl:
add: Phermone towers now spawn alongside the silo's during crash
/:cl:
