### PR TITLE
Removes the snow slowdown var and puts the water slowdown var where it's supposed to be

### DIFF
--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -103,7 +103,7 @@
 
 	if(isxeno(C))
 		var/mob/living/carbon/xenomorph/xeno = C
-		xeno.next_move_slowdown += xeno.xeno_caste.snow_slowdown
+		xeno.next_move_slowdown += xeno.xeno_caste.water_slowdown
 	else
 		C.next_move_slowdown += 1.75
 

--- a/code/game/turfs/open_ground.dm
+++ b/code/game/turfs/open_ground.dm
@@ -64,7 +64,7 @@
 
 	if(isxeno(C))
 		var/mob/living/carbon/xenomorph/xeno = C
-		xeno.next_move_slowdown += xeno.xeno_caste.snow_slowdown
+		xeno.next_move_slowdown += xeno.xeno_caste.water_slowdown
 	else
 		C.next_move_slowdown += 1.75
 

--- a/code/game/turfs/snow.dm
+++ b/code/game/turfs/snow.dm
@@ -77,7 +77,6 @@
 /turf/open/floor/plating/ground/snow/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	if(slayer > 0 && isxeno(arrived))
 		var/mob/living/carbon/xenomorph/xeno = arrived
-		xeno.next_move_slowdown += xeno.xeno_caste.snow_slowdown * slayer
 		if(xeno.is_charging >= CHARGE_ON) // chargers = snow plows
 			slayer = 0
 			update_icon(TRUE, FALSE)

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/castedatum_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/castedatum_warlock.dm
@@ -33,7 +33,6 @@
 	)
 
 	water_slowdown = 0
-	snow_slowdown = 0
 
 /datum/xeno_caste/warlock/young
 	upgrade_name = "Young"

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -235,8 +235,6 @@
 	var/silent_vent_crawl = FALSE
 	///how much water slows down this caste
 	var/water_slowdown = 1.3
-	///how much snow slows down this caste
-	var/snow_slowdown = 0.25
 	// The amount of xenos that must be alive in the hive for this caste to be able to evolve
 	var/evolve_min_xenos = 0
 	// How many of this caste may be alive at once


### PR DESCRIPTION

## About The Pull Request

I forgot to remove the slowdown on snow for xenos and lumi forgot to make water have water slowdown instead of snow slowdown. Fighting in river is once again a very very bad idea.
## Why It's Good For The Game

Unintended changes aren't.
## Changelog
:cl:
balance: River slows the amount its supposed to again
fix: Snow actually doesn't slow xenos down
/:cl:
