### PR TITLE
Tad landing camview also gets a minimap

### DIFF
--- a/code/modules/shuttle/mini_dropship.dm
+++ b/code/modules/shuttle/mini_dropship.dm
@@ -46,13 +46,25 @@
 	var/damaged = FALSE
 	/// How long before you can launch tadpole after a landing
 	var/launching_delay = 10 SECONDS
+	///Minimap for use while in landing cam mode
+	var/datum/action/minimap/marine/external/tadmap
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/Initialize(mapload)
 	..()
 	start_processing()
 	set_light(3,3)
 	land_action = new
+	tadmap = new
 	return INITIALIZE_HINT_LATELOAD
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/Destroy()
+	QDEL_NULL(land_action)
+	QDEL_NULL(tadmap)
+	return ..()
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/CreateEye()
+	. = ..()
+	tadmap.override_locator(eyeobj)
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/LateInitialize()
 	shuttle_port = SSshuttle.getShuttle(shuttleId)
@@ -71,6 +83,11 @@
 		off_action.target = user
 		off_action.give_action(user)
 		actions += off_action
+	
+	if(tadmap)
+		tadmap.target = user
+		tadmap.give_action(user)
+		actions += tadmap
 
 	if(fly_state != SHUTTLE_IN_ATMOSPHERE)
 		return


### PR DESCRIPTION

## About The Pull Request
Title.
This was requested on my previous minimap-adding PR and I don't feel like it's too much of a big change.
Nonetheless labeled "balance" as the Tad being somewhat blind to the events on the ground while in flight could be considered a feature.
## Why It's Good For The Game
Should make tracking the groundside happenings and potential landing opportunies easier while in camview, however this could also be used as a negative. I'm pretty impartial to this and am mainly doing this at request.
## Changelog
:cl:
balance: Tad's landing cam view has minimap access.
/:cl:
