### PR TITLE
Fixes mobs getting stuck on eachother and other mobs when moving diagonally

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -360,7 +360,7 @@
 						to_chat(src, span_warning("[L] is restraining [P], you cannot push past."))
 					return
 
-		if(!L.buckled && !L.anchored && !moving_diagonally)
+		if(!L.buckled && !L.anchored)
 			var/mob_swap_mode = NO_SWAP
 			//the puller can always swap with its victim if on grab intent
 			if(L.pulledby == src && a_intent == INTENT_GRAB)


### PR DESCRIPTION

## About The Pull Request

Before:  (I am trying to diagonal shuffle very hard)

![dreamseeker_iylNYQxvie](https://user-images.githubusercontent.com/22431091/228351762-a6d578d6-7e89-49c2-a05f-215044fb1b8e.gif)

After: 
![dreamseeker_hSu5tCaOh1](https://user-images.githubusercontent.com/22431091/228351790-7749951b-5e0e-46f2-8622-934fdaca14a1.gif)

Closes #10916 and reverts #9534. Priorities, brave.
## Why It's Good For The Game

I've seen countless, countless xenos die to being just stuck because there was another xeno standing on the tile cardinal to them and the destination (that was diagonal of them) and they just stand there and die. The shuffle destination being slightly off is not as big of an issue as xenos getting punished for trying to use diagonal movement to get away.
## Changelog
:cl:
fix: Fixed mobs getting stuck on eachother and other mobs when moving diagonally
/:cl:
