### PR TITLE
Resolves overwatch consoles bricking in some scenarios

### DIFF
--- a/code/game/objects/machinery/computer/camera_advanced.dm
+++ b/code/game/objects/machinery/computer/camera_advanced.dm
@@ -33,12 +33,16 @@
 		if(lock_override & CAMERA_LOCK_CENTCOM)
 			z_lock |= SSmapping.levels_by_trait(ZTRAIT_CENTCOM)
 
-
+///Creates this computer's eye object and sets up its references.
 /obj/machinery/computer/camera_advanced/proc/CreateEye()
 	eyeobj = new()
 	eyeobj.origin = src
 	RegisterSignal(eyeobj, COMSIG_PARENT_QDELETING, PROC_REF(clear_eye_ref))
 
+/**
+ * This proc is used to make sure no references or other leftovers are left behind if the computer's eye is deleted.
+ * To achieve this, it reacts to the PARENT_QDELETING signal of the computer's eye object and triggers if it is sent.
+**/
 /obj/machinery/computer/camera_advanced/proc/clear_eye_ref()
 	SIGNAL_HANDLER
 	UnregisterSignal(eyeobj, COMSIG_PARENT_QDELETING)

--- a/code/game/objects/machinery/computer/camera_advanced.dm
+++ b/code/game/objects/machinery/computer/camera_advanced.dm
@@ -37,6 +37,14 @@
 /obj/machinery/computer/camera_advanced/proc/CreateEye()
 	eyeobj = new()
 	eyeobj.origin = src
+	RegisterSignal(eyeobj, COMSIG_PARENT_QDELETING, PROC_REF(clear_eye_ref))
+
+/obj/machinery/computer/camera_advanced/proc/clear_eye_ref()
+	SIGNAL_HANDLER
+	UnregisterSignal(eyeobj, COMSIG_PARENT_QDELETING)
+	if(current_user)
+		remove_eye_control(current_user)
+	eyeobj = null
 
 
 /obj/machinery/computer/camera_advanced/proc/give_actions(mob/living/user)

--- a/code/game/objects/machinery/computer/camera_advanced.dm
+++ b/code/game/objects/machinery/computer/camera_advanced.dm
@@ -195,6 +195,8 @@
 /obj/machinery/computer/camera_advanced/process()
 	if(QDELETED(tracking_target))
 		return PROCESS_KILL
+	if(QDELETED(eyeobj))
+		return PROCESS_KILL
 
 	if(!tracking_target.can_track(current_user))
 		if(!cameraticks)


### PR DESCRIPTION

## About The Pull Request
Overwatch consoles can get a little uppity if their camera eye gets deleted, especially when tracking.
This adds an additional layer of safety that should ensure the overwatch console always has its eye reference and user removed.
Fixes #11977 
## Why It's Good For The Game
Fix man good.
## Changelog
:cl:
fix: Overwatch consoles should no longer brick under certain eye-deletion related conditions.
/:cl:
