### PR TITLE
Fix hive threat reward

### DIFF
--- a/code/modules/events/hive_threat.dm
+++ b/code/modules/events/hive_threat.dm
@@ -51,12 +51,7 @@
 		receiving_xeno.salve_healing()
 		if(receiving_xeno == drainer)
 			receiving_xeno.evolution_stored = receiving_xeno.xeno_caste.evolution_threshold
-			if(receiving_xeno.tier == XENO_UPGRADE_FOUR || receiving_xeno.tier == XENO_UPGRADE_THREE)
-				continue
-			var/datum/xeno_caste/tier_two = GLOB.xeno_caste_datums[receiving_xeno.caste_base_type][XENO_UPGRADE_TWO]
-			if(!tier_two)
-				continue
-			receiving_xeno.upgrade_stored = tier_two.upgrade_threshold
+			receiving_xeno.upgrade_stored += 1000
 	SEND_SOUND(GLOB.alive_xeno_list_hive[XENO_HIVE_NORMAL], sound(get_sfx("queen"), channel = CHANNEL_ANNOUNCEMENTS, volume = 50))
 	addtimer(CALLBACK(src, PROC_REF(remove_blessing)), 2 MINUTES)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The changes to how maturity work/are stored messed with the rewards for draining a target.

Made it now just give a flat 1000 maturity points.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Properly working rewards are good.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Draining a hive threat now gives a flat 1000 maturity points
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
