### PR TITLE
Hive threat reward alt fix

### DIFF
--- a/code/modules/events/hive_threat.dm
+++ b/code/modules/events/hive_threat.dm
@@ -51,7 +51,7 @@
 		receiving_xeno.salve_healing()
 		if(receiving_xeno == drainer)
 			receiving_xeno.evolution_stored = receiving_xeno.xeno_caste.evolution_threshold
-			if(receiving_xeno.tier == XENO_UPGRADE_FOUR || receiving_xeno.tier == XENO_UPGRADE_THREE)
+			if(receiving_xeno.upgrade == XENO_UPGRADE_FOUR || receiving_xeno.upgrade == XENO_UPGRADE_THREE)
 				continue
 			var/datum/xeno_caste/tier_two = GLOB.xeno_caste_datums[receiving_xeno.caste_base_type][XENO_UPGRADE_TWO]
 			if(!tier_two)


### PR DESCRIPTION

## About The Pull Request
Alternative to #12540 
Turns out that comparing upgrade defines against xeno tier isn't actually what you want to do
## Why It's Good For The Game
T3/4 xenos actually get the bump to ancient if they're low maturity, as they should
## Changelog
:cl:
fix: Hive threat event rewards instant ancient to any kind of xeno instead of sometimes de-aging a primordial t2
/:cl:
