### PR TITLE
Remove the xeno tier limit on tier 2 and 3 casts

### DIFF
--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -26,8 +26,6 @@ SUBSYSTEM_DEF(silo)
 	current_larva_spawn_rate += larva_spawn_rate_temporary_buff
 	GLOB.round_statistics.larva_from_silo += current_larva_spawn_rate / xeno_job.job_points_needed
 	xeno_job.add_job_points(current_larva_spawn_rate)
-	var/datum/hive_status/normal_hive = GLOB.hive_datums[XENO_HIVE_NORMAL]
-	normal_hive.update_tier_limits()
 
 ///Activate the subsystem when shutters open and remove the free spawning when marines are joining
 /datum/controller/subsystem/silo/proc/start_spawning()

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -196,7 +196,6 @@
 	if(larva_surplus < 1)
 		return //Things are balanced, no burrowed needed
 	xeno_job.add_job_positions(1)
-	xeno_hive.update_tier_limits()
 
 /datum/game_mode/infestation/crash/get_total_joblarvaworth(list/z_levels, count_flags)
 	. = 0

--- a/code/datums/jobs/job/job.dm
+++ b/code/datums/jobs/job/job.dm
@@ -214,8 +214,6 @@ GLOBAL_PROTECT(exp_specialmap)
 				continue
 			GLOB.round_statistics.larva_from_marine_spawning += jobworth[index] / scaled_job.job_points_needed
 		scaled_job.add_job_points(jobworth[index])
-	var/datum/hive_status/normal_hive = GLOB.hive_datums[XENO_HIVE_NORMAL]
-	normal_hive.update_tier_limits()
 	return TRUE
 
 /datum/job/proc/free_job_positions(amount)

--- a/code/game/objects/items/cocoon.dm
+++ b/code/game/objects/items/cocoon.dm
@@ -64,8 +64,6 @@
 	if(must_release_victim)
 		var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
 		xeno_job.add_job_points(larva_point_reward)
-		var/datum/hive_status/hive_status = GLOB.hive_datums[hivenumber]
-		hive_status.update_tier_limits()
 		GLOB.round_statistics.larva_from_cocoon += larva_point_reward / xeno_job.job_points_needed
 		release_victim()
 	update_icon()

--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -287,6 +287,7 @@ REAGENT SCANNER
 	. = ..()
 	if(user.gloves == src)
 		RegisterSignal(user, COMSIG_HUMAN_MELEE_UNARMED_ATTACK, PROC_REF(on_unarmed_attack))
+		RegisterSignal(user,COMSIG_CLICK_RIGHT, PROC_REF(on_right_click))
 	else
 		UnregisterSignal(user, COMSIG_HUMAN_MELEE_UNARMED_ATTACK)
 
@@ -294,6 +295,9 @@ REAGENT SCANNER
 /obj/item/healthanalyzer/gloves/proc/on_unarmed_attack(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(istype(user) && istype(target))
 		attack(target,user)
+
+/obj/item/healthanalyzer/gloves/proc/on_right_click(user,target)
+	//yada yada
 
 /obj/item/analyzer
 	desc = "A hand-held environmental scanner which reports current gas levels."

--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -287,7 +287,6 @@ REAGENT SCANNER
 	. = ..()
 	if(user.gloves == src)
 		RegisterSignal(user, COMSIG_HUMAN_MELEE_UNARMED_ATTACK, PROC_REF(on_unarmed_attack))
-		RegisterSignal(user,COMSIG_CLICK_RIGHT, PROC_REF(on_right_click))
 	else
 		UnregisterSignal(user, COMSIG_HUMAN_MELEE_UNARMED_ATTACK)
 
@@ -295,9 +294,6 @@ REAGENT SCANNER
 /obj/item/healthanalyzer/gloves/proc/on_unarmed_attack(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(istype(user) && istype(target))
 		attack(target,user)
-
-/obj/item/healthanalyzer/gloves/proc/on_right_click(user,target)
-	//yada yada
 
 /obj/item/analyzer
 	desc = "A hand-held environmental scanner which reports current gas levels."

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1314,7 +1314,6 @@
 	SSpoints.add_psy_points(X.hivenumber, psy_points_reward)
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
 	xeno_job.add_job_points(larva_point_reward)
-	X.hive.update_tier_limits()
 	GLOB.round_statistics.larva_from_psydrain +=larva_point_reward / xeno_job.job_points_needed
 
 	log_combat(victim, owner, "was drained.")

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -18,7 +18,6 @@
 	QDEL_NULL(leader_current_aura)
 
 	hive?.on_xeno_death(src)
-	hive.update_tier_limits() //Update our tier limits.
 
 	if(is_zoomed)
 		zoom_out()

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -57,7 +57,7 @@
 /mob/living/carbon/xenomorph/proc/do_evolve(caste_type, forced_caste_name, regression = FALSE)
 	if(!generic_evolution_checks())
 		return
-	
+
 	if(caste_type == /mob/living/carbon/xenomorph/hivemind && tgui_alert(src, "You are about to evolve into a hivemind, which places its core on the tile you're on when evolving. This core cannot be moved and you cannot regress. Are you sure you would like to place your core here?", "Evolving to hivemind", list("Yes", "No"), FALSE) == "No")
 		return
 
@@ -245,8 +245,6 @@
 		balloon_alert(src, "We can't evolve to that caste from our current one")
 		return FALSE
 
-	var/no_room_tier_two = length(hive.xenos_by_tier[XENO_TIER_TWO]) >= hive.tier2_xeno_limit
-	var/no_room_tier_three = length(hive.xenos_by_tier[XENO_TIER_THREE]) >= hive.tier3_xeno_limit
 	var/datum/xeno_caste/new_caste_type = GLOB.xeno_caste_datums[new_mob_type][XENO_UPGRADE_BASETYPE]
 	// Initial can access uninitialized vars, which is why it's used here.
 	var/new_caste_flags = new_caste_type.caste_flags
@@ -297,12 +295,6 @@
 				new_mob_type = /mob/living/carbon/xenomorph/queen/Corrupted/fallen
 
 	if(!regression)
-		if(new_caste_type.tier == XENO_TIER_TWO && no_room_tier_two)
-			balloon_alert(src, "The hive cannot support another Tier 2, wait for either more aliens to be born or someone to die")
-			return FALSE
-		if(new_caste_type.tier == XENO_TIER_THREE && no_room_tier_three)
-			balloon_alert(src, "The hive cannot support another Tier 3, wait for either more aliens to be born or someone to die")
-			return FALSE
 		var/potential_queens = length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/larva]) + length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/drone])
 		if(SSticker.mode?.flags_round_type & MODE_XENO_RULER && !hive.living_xeno_ruler && potential_queens == 1)
 			if(isxenolarva(src) && new_mob_type != /mob/living/carbon/xenomorph/drone)

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -70,7 +70,6 @@
 	ADD_TRAIT(src, TRAIT_FLASHBANGIMMUNE, XENO_TRAIT)
 	if(xeno_caste.caste_flags & CASTE_STAGGER_RESISTANT)
 		ADD_TRAIT(src, TRAIT_STAGGER_RESISTANT, XENO_TRAIT)
-	hive.update_tier_limits()
 	if(CONFIG_GET(flag/xenos_on_strike))
 		replace_by_ai()
 	if(z) //Larva are initiated in null space
@@ -252,9 +251,7 @@
 	GLOB.xeno_mob_list -= src
 	GLOB.dead_xeno_list -= src
 
-	var/datum/hive_status/hive_placeholder = hive
 	remove_from_hive()
-	hive_placeholder.update_tier_limits() //Update our tier limits.
 
 	vis_contents -= wound_overlay
 	vis_contents -= fire_overlay

--- a/tgui/packages/tgui/interfaces/HiveStatus.tsx
+++ b/tgui/packages/tgui/interfaces/HiveStatus.tsx
@@ -6,7 +6,6 @@ import { round } from 'common/math';
 type InputPack = {
   // ------- Hive info --------
   hive_name: string;
-  hive_max_tier_two: number;
   hive_larva_current: number;
   hive_larva_threshold: number;
   hive_larva_rate: number;
@@ -507,7 +506,6 @@ const PopulationPyramid = (_props, context) => {
         direction="column-reverse"
         align={compact_display ? 'left' : 'center'}>
         {pyramid_data.map((tier_info, tier) => {
-          // Hardcoded tier check for limited slots.
           const slot_text = tier_info.total;
           // Praetorian name way too long. Clips into Rav.
           const row_width = tier === 3 ? 8 : 7;
@@ -535,10 +533,7 @@ const PopulationPyramid = (_props, context) => {
             }
             return (
               <Box key={tier}>
-                Tier {tier}:{' '}
-                {tier === 2 || tier === 3
-                  ? ` (${tier_info.total}) `
-                  : ` ${tier_info.total} `}
+                Tier {tier}: {tier_info.total}
                 Sisters {!empty_display && tier_info.total === 0 ? '' : '| '}
                 {tier_info.index
                   .map((value, idx) => {

--- a/tgui/packages/tgui/interfaces/HiveStatus.tsx
+++ b/tgui/packages/tgui/interfaces/HiveStatus.tsx
@@ -508,17 +508,7 @@ const PopulationPyramid = (_props, context) => {
         align={compact_display ? 'left' : 'center'}>
         {pyramid_data.map((tier_info, tier) => {
           // Hardcoded tier check for limited slots.
-          const TierSlots = (_props, _context) => {
-            return (
-              <Box
-                as="span"
-                textColor={'good'}>
-                ({tier_info.total})
-              </Box>
-            );
-          };
-          const slot_text =
-            tier === 2 || tier === 3 ? <TierSlots /> : tier_info.total;
+          const slot_text = tier_info.total;
           // Praetorian name way too long. Clips into Rav.
           const row_width = tier === 3 ? 8 : 7;
           const primordial = primos[tier] ? (

--- a/tgui/packages/tgui/interfaces/HiveStatus.tsx
+++ b/tgui/packages/tgui/interfaces/HiveStatus.tsx
@@ -7,7 +7,6 @@ type InputPack = {
   // ------- Hive info --------
   hive_name: string;
   hive_max_tier_two: number;
-  hive_max_tier_three: number;
   hive_larva_current: number;
   hive_larva_threshold: number;
   hive_larva_rate: number;
@@ -406,8 +405,6 @@ type PyramidCalc = {
 const PopulationPyramid = (_props, context) => {
   const { act, data } = useBackend<InputPack>(context);
   const {
-    hive_max_tier_two,
-    hive_max_tier_three,
     hive_minion_count,
     hive_primos,
     xeno_info,
@@ -511,18 +508,12 @@ const PopulationPyramid = (_props, context) => {
         align={compact_display ? 'left' : 'center'}>
         {pyramid_data.map((tier_info, tier) => {
           // Hardcoded tier check for limited slots.
-          const max_slots =
-            tier === 2
-              ? hive_max_tier_two
-              : 0 + tier === 3
-                ? hive_max_tier_three
-                : 0;
           const TierSlots = (_props, _context) => {
             return (
               <Box
                 as="span"
-                textColor={tier_info.total === max_slots ? 'bad' : 'good'}>
-                ({tier_info.total}/{max_slots})
+                textColor={'good'}>
+                ({tier_info.total})
               </Box>
             );
           };
@@ -556,7 +547,7 @@ const PopulationPyramid = (_props, context) => {
               <Box key={tier}>
                 Tier {tier}:{' '}
                 {tier === 2 || tier === 3
-                  ? ` (${tier_info.total}/${max_slots || 0}) `
+                  ? ` (${tier_info.total}) `
                   : ` ${tier_info.total} `}
                 Sisters {!empty_display && tier_info.total === 0 ? '' : '| '}
                 {tier_info.index


### PR DESCRIPTION

## About The Pull Request

Removes the limit, making PR to also debate the topic

## Why It's Good For The Game

I argue for because while the tier 3 xenos are some what better, they are not THAT much better that they warent being hard locked. this is even more true for tier 2. I'd rather see these xenos being closer together in terms of power and making it more akin to picking a loadout for marines then.  You ultimitaly still want a mix of xenos and stacking a bunch of 1 cast may work only if it catches the enemy completely off guard.

This also prevents you being locked at tier 1, which sometimes it not fun if you want to say play carrier.

Something to consider could also be only removing tier limit on tier 2, if tier 3's are really too strong. but most of the xenos are in tier 3 currently so letting players play as those would be more fun

## Changelog
:cl:
balance: There is no limit on xeno's per tier anymore
/:cl:
