### PR TITLE
Fixes one necrosis surgery step being impossible

### DIFF
--- a/code/modules/surgery/necrosis.dm
+++ b/code/modules/surgery/necrosis.dm
@@ -43,7 +43,6 @@
 	affected.necro_surgery_stage = 1
 	affected.createwound(CUT, 30)
 	affected.germ_level = min(affected.germ_level, 600) //Ensure that necrosis won't immediately reform
-	affected.remove_limb_flags(LIMB_NECROTIZED)
 
 /datum/surgery_step/necro/fix_dead_tissue/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message(span_warning("[user]'s hand slips, slicing an artery inside [target]'s [affected.display_name] with \the [tool]!"), \
@@ -80,6 +79,7 @@
 	affected.necro_surgery_stage = 0
 	affected.heal_limb_damage(affected.brute_dam / 2, updating_health = TRUE)
 	affected.germ_level = max(0, affected.germ_level - 100) //Right at infection level 2 if it was previously above the cap
+	affected.remove_limb_flags(LIMB_NECROTIZED)
 	affected.bandage()
 
 /datum/surgery_step/treat_necrosis/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)


### PR DESCRIPTION

## About The Pull Request
Necrosis surgery requires necrosis to be performed. I moved the necrosis removal to the first step for flavor reasons (that's the step at which you're cutting it out, with the step after being healing damage tissue). This made the second step impossible to perform, since you no longer have necrosis for it. This also made it impossible* to perform necrosis removal surgery on the same limb twice, since you couldn't perform the first step again.
This pr moves the removal back to the second step.
## Why It's Good For The Game
bugfix
Also makes it more clear to the surgeon that the procedure is actually finished.
## Changelog
:cl:
fix: Moved the actual necrosis removal of surgery back to the second step, rendering it possible to perform once again
/:cl:
