### PR TITLE
RR shells fit into EXP pouch

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -324,6 +324,8 @@
 	icon_state = "large_explosive"
 	storage_slots = 4
 	max_w_class = 3
+	max_storage_space = 16
+	bypass_w_limit = list(/obj/item/ammo_magazine/rocket/recoilless)
 	can_hold = list(
 		/obj/item/explosive/plastique,
 		/obj/item/explosive/mine,


### PR DESCRIPTION

## About The Pull Request

Makes a change to the Explosive pouch, allowing them to hold 4 RR shells. To make sure the RR shells stay out of normal bags, we've also allowed the EXP pouch to hold up to 16 weight, in terms of practicality, it only allows it to hold 4 RR shells.

## Why It's Good For The Game

It's always felt weird that it could hold SADAR shells, but not the smaller 67MMs, gameplay wise, this could allow for the poor sod carrying the RR to hold more than 5/6 shells at once.

Balance wise, I don't think this will be too-too groundshaking, besides maybe making an antenna module less necessary for an RR based playstyle.

## Changelog
:cl: Skye
balance: Allows the explosive pouch to hold Recoiless Rifle shells.
/:cl:
