### PR TITLE
Makes the default starting boot knife the M5 survival knife

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/storage.dm
+++ b/code/modules/clothing/modular_armor/attachments/storage.dm
@@ -332,7 +332,7 @@
 
 /obj/item/armor_module/storage/boot/full/Initialize()
 	. = ..()
-	new /obj/item/attachable/bayonetknife(storage)
+	new /obj/item/weapon/combat_knife(storage)
 
 /obj/item/armor_module/storage/helmet
 	name = "Jaeger Pattern helmet storage"


### PR DESCRIPTION

## About The Pull Request

Makes the default starting boot knife the M5 survival knife.

The difference between the two is the M5 has higher damage, at the tradeoff of being unattachable (unless you have 5 cable coil).
## Why It's Good For The Game

Generally as far as I know most people would prefer being able to 2 shot weed sacs with their boot knife rather than have the bootknife be attachable to their gun (because you can just dispense a bayonet and attach that in prep if you want to run a bayonet)

Should help new people who don't know better just use the better knife by default.
## Changelog
:cl:
balance: Makes the default starting boot knife the M5 survival knife
/:cl:
