### PR TITLE
Adds craftable supply crates

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -63,6 +63,7 @@ GLOBAL_LIST_EMPTY(unmanned_vehicles)
 GLOBAL_LIST_INIT(supply_drops, typecacheof(list(
 	/obj/structure/closet/crate,
 	/obj/structure/largecrate/supply,
+	/obj/structure/largecrate/packed,
 	/obj/machinery/vending,
 	/obj/vehicle/unmanned)))
 

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -150,7 +150,8 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 
 	new/datum/stack_recipe("wooden door", /obj/structure/mineral_door/wood, 10, time = 2 SECONDS, max_per_turf = STACK_RECIPE_ONE_PER_TILE, on_floor = TRUE), \
 	new/datum/stack_recipe("coffin", /obj/structure/closet/coffin, 5, time = 1.5 SECONDS, max_per_turf = STACK_RECIPE_ONE_PER_TILE, on_floor = TRUE), \
-	new/datum/stack_recipe("baseball bat", /obj/item/weapon/baseballbat, 10, time = 2 SECONDS, on_floor = TRUE) \
+	new/datum/stack_recipe("baseball bat", /obj/item/weapon/baseballbat, 10, time = 2 SECONDS, on_floor = TRUE), \
+	new/datum/stack_recipe("wooden crate", /obj/structure/largecrate/packed, 1, time = 2 SECONDS, on_floor = TRUE) \
 	))
 
 /obj/item/stack/sheet/wood

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -151,7 +151,7 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 	new/datum/stack_recipe("wooden door", /obj/structure/mineral_door/wood, 10, time = 2 SECONDS, max_per_turf = STACK_RECIPE_ONE_PER_TILE, on_floor = TRUE), \
 	new/datum/stack_recipe("coffin", /obj/structure/closet/coffin, 5, time = 1.5 SECONDS, max_per_turf = STACK_RECIPE_ONE_PER_TILE, on_floor = TRUE), \
 	new/datum/stack_recipe("baseball bat", /obj/item/weapon/baseballbat, 10, time = 2 SECONDS, on_floor = TRUE), \
-	new/datum/stack_recipe("wooden crate", /obj/structure/largecrate/packed, 1, time = 2 SECONDS, on_floor = TRUE) \
+	new/datum/stack_recipe("wooden crate", /obj/structure/largecrate/packed, 5, time = 2 SECONDS, on_floor = TRUE) \
 	))
 
 /obj/item/stack/sheet/wood
@@ -161,6 +161,9 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 	icon_state = "sheet-wood"
 	merge_type = /obj/item/stack/sheet/wood
 	number_of_extra_variants = 3
+
+/obj/item/stack/sheet/wood/five
+	amount = 5
 
 /obj/item/stack/sheet/wood/large_stack
 	amount = 50

--- a/code/game/objects/machinery/squad_supply/supply_packer.dm
+++ b/code/game/objects/machinery/squad_supply/supply_packer.dm
@@ -1,9 +1,12 @@
 /obj/structure/largecrate/packed
 	name = "supplies crate"
 	icon_state = "secure_crate"
+	// This will contain all the item names inside the packed crate
 	var/list/manifest = list("This crate contains:")
-	var/static/list/black_list = typecacheof(list(/obj/structure))
-	var/max_items = 30 // while packing the entire FOB into a single crate would be funny propably not great idea
+	//black list for anything under /obj/item that you dont want to be packable
+	var/static/list/black_list = typecacheof(list())
+	// while packing the entire FOB into a single crate would be funny propably not great idea
+	var/max_items = 30
 
 /obj/structure/largecrate/packed/Initialize()
 	. = ..()
@@ -18,6 +21,8 @@
 	var/count = 0
 	for(var/obj/item/thing in loc)
 		if(is_type_in_typecache(thing,black_list))
+			continue
+		if(item.anchored)
 			continue
 		thing.forceMove(src)
 		manifest += thing.name

--- a/code/game/objects/machinery/squad_supply/supply_packer.dm
+++ b/code/game/objects/machinery/squad_supply/supply_packer.dm
@@ -16,11 +16,11 @@
 
 /obj/structure/largecrate/packed/proc/pack()
 	var/count = 0
-	for(var/obj/thing in loc)
+	for(var/obj/item/thing in loc)
+		count++
 		if(count >= max_items)
 			return
 		if(is_type_in_typecache(thing,black_list))
 			continue
 		thing.forceMove(src)
 		manifest += thing.name
-		count++

--- a/code/game/objects/machinery/squad_supply/supply_packer.dm
+++ b/code/game/objects/machinery/squad_supply/supply_packer.dm
@@ -22,7 +22,7 @@
 	for(var/obj/item/thing in loc)
 		if(is_type_in_typecache(thing,black_list))
 			continue
-		if(item.anchored)
+		if(thing.anchored)
 			continue
 		thing.forceMove(src)
 		manifest += thing.name

--- a/code/game/objects/machinery/squad_supply/supply_packer.dm
+++ b/code/game/objects/machinery/squad_supply/supply_packer.dm
@@ -17,10 +17,10 @@
 /obj/structure/largecrate/packed/proc/pack()
 	var/count = 0
 	for(var/obj/item/thing in loc)
-		count++
-		if(count >= max_items)
-			return
 		if(is_type_in_typecache(thing,black_list))
 			continue
 		thing.forceMove(src)
 		manifest += thing.name
+		count++
+		if(count >= max_items)
+			return

--- a/code/game/objects/machinery/squad_supply/supply_packer.dm
+++ b/code/game/objects/machinery/squad_supply/supply_packer.dm
@@ -1,0 +1,21 @@
+/obj/structure/largecrate/packed
+	name = "supplies crate"
+	icon_state = "secure_crate"
+	var/list/manifest = list("This crate contains:")
+	var/static/list/black_list = typecacheof(list(/obj/structure))
+
+/obj/structure/largecrate/packed/Initialize()
+	. = ..()
+	pack()
+
+/obj/structure/largecrate/packed/examine()
+	. = ..()
+	for(var/item in manifest)
+		. += span_notice(item)
+
+/obj/structure/largecrate/packed/proc/pack()
+	for(var/obj/thing in loc)
+		if(is_type_in_typecache(thing,black_list))
+			continue
+		thing.forceMove(src)
+		manifest += thing.name

--- a/code/game/objects/machinery/squad_supply/supply_packer.dm
+++ b/code/game/objects/machinery/squad_supply/supply_packer.dm
@@ -3,6 +3,7 @@
 	icon_state = "secure_crate"
 	var/list/manifest = list("This crate contains:")
 	var/static/list/black_list = typecacheof(list(/obj/structure))
+	var/max_items = 30 // while packing the entire FOB into a single crate would be funny propably not great idea
 
 /obj/structure/largecrate/packed/Initialize()
 	. = ..()
@@ -14,8 +15,12 @@
 		. += span_notice(item)
 
 /obj/structure/largecrate/packed/proc/pack()
+	var/count = 0
 	for(var/obj/thing in loc)
+		if(count >= max_items)
+			return
 		if(is_type_in_typecache(thing,black_list))
 			continue
 		thing.forceMove(src)
 		manifest += thing.name
+		count++

--- a/code/game/objects/machinery/squad_supply/supply_packer.dm
+++ b/code/game/objects/machinery/squad_supply/supply_packer.dm
@@ -12,7 +12,7 @@
 /obj/structure/largecrate/packed/examine()
 	. = ..()
 	for(var/item in manifest)
-		. += span_notice(item)
+		. += span_boldnotice(item)
 
 /obj/structure/largecrate/packed/proc/pack()
 	var/count = 0

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -40,7 +40,7 @@
 	user.visible_message(span_notice("[user] pries \the [src] open."),
 		span_notice("You pry open \the [src]."),
 		span_notice("You hear splitting wood."))
-	new /obj/item/stack/sheet/wood(loc)
+	new /obj/item/stack/sheet/wood/five(loc)
 	deconstruct(TRUE)
 	return TRUE
 

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -889,6 +889,7 @@
 #include "code\game\objects\machinery\practice\medical.dm"
 #include "code\game\objects\machinery\squad_supply\supply_beacon.dm"
 #include "code\game\objects\machinery\squad_supply\supply_console.dm"
+#include "code\game\objects\machinery\squad_supply\supply_packer.dm"
 #include "code\game\objects\machinery\squad_supply\supply_pads.dm"
 #include "code\game\objects\machinery\telecomms\broadcasting.dm"
 #include "code\game\objects\machinery\telecomms\telecomunications.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

For 1 wood, you can craft a crate which will store all the stuff your currently standing on into big crate

https://user-images.githubusercontent.com/36102060/228908965-94d596ca-08dc-447a-b5f7-3b10b79a9d84.mp4



## Why It's Good For The Game

RO's can send supplys to muhreens without using crates, these look color imo

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: You can now craft supply crates with wood
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
