### PR TITLE
Adds cryo to small Cant, adds cryo beakers to both variants

### DIFF
--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -161,6 +161,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/item/reagent_containers/glass/beaker/cryomix,
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "aO" = (

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -381,10 +381,15 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "bt" = (
-/obj/machinery/door/airlock/mainship/marine/canterbury{
-	dir = 8
-	},
-/turf/open/floor/mainship/red/full,
+/obj/item/lightreplacer,
+/obj/item/clothing/glasses/welding,
+/obj/item/cell/high,
+/obj/machinery/cell_charger,
+/obj/item/radio,
+/obj/item/tool/crowbar,
+/obj/item/pinpointer,
+/obj/structure/table/reinforced,
+/turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "bu" = (
 /obj/machinery/marine_selector/gear/engi,
@@ -422,18 +427,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/glass/beaker/cryomix,
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "bA" = (
-/obj/item/lightreplacer,
-/obj/item/clothing/glasses/welding,
-/obj/item/cell/high,
-/obj/machinery/cell_charger,
-/obj/item/radio,
-/obj/item/tool/crowbar,
-/obj/item/pinpointer,
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/mainship/sterile,
 /area/shuttle/canterbury/medical)
 "bB" = (
@@ -812,6 +811,12 @@
 	},
 /turf/open/floor/mainship/red,
 /area/shuttle/canterbury)
+"pY" = (
+/obj/machinery/door/airlock/mainship/marine/canterbury{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/shuttle/canterbury)
 "vY" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/mainship/orange/full,
@@ -1100,7 +1105,7 @@ an
 aV
 aD
 aD
-aD
+bt
 br
 br
 aJ
@@ -1122,8 +1127,8 @@ cU
 an
 aW
 bk
-an
-bt
+pY
+aR
 an
 cK
 aJ


### PR DESCRIPTION

## About The Pull Request

It does exactly as it says on the tin. To be more specific, these changes have been made, indicated by sharpie.

![Canterbury1](https://user-images.githubusercontent.com/38842059/229000945-f7177976-91d3-48f8-b467-9817781d9f82.png)

![Canterbury2](https://user-images.githubusercontent.com/38842059/229000967-78b99a0a-96bb-4d53-b932-8fd162c61ac5.png)


## Why It's Good For The Game

Well...It kinda sucks that one version of the Cant has cryo while the other doesn't, especially with certain clone loss causing meds. 

In an ideal world, I'd like both versions to have chemistry too, but uh...I can't be bothered to figure out how to fit chem into SmallBury

## Changelog
:cl: Skye
qol: Adds cryogenics to the TGS Smallbury, used in the Crash game mode. (Also moves a table.)
balance: Adds a cryomix beaker to both Canterbury variants.
/:cl:
