### PR TITLE
Fixes carpet and catwalk breaking

### DIFF
--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -16080,10 +16080,6 @@
 	dir = 9
 	},
 /area/magmoor/engi/power)
-"lNM" = (
-/obj/machinery/roomba,
-/turf/open/floor/mainship/green,
-/area/magmoor/civilian/rnr)
 "lOl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
@@ -24354,7 +24350,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/roomba,
 /turf/open/floor/mainship/ntlogo/nt2,
 /area/magmoor/civilian/arrival)
 "rMh" = (
@@ -47301,7 +47296,7 @@ upk
 pCT
 ePb
 fBg
-lNM
+oOH
 upk
 aaE
 qnk

--- a/code/game/turfs/floor_types.dm
+++ b/code/game/turfs/floor_types.dm
@@ -823,6 +823,9 @@
 	floor_tile = new /obj/item/stack/tile/carpet
 	return INITIALIZE_HINT_LATELOAD
 
+/turf/open/floor/carpet/ex_act(severity)
+	return
+
 /turf/open/floor/carpet/edge2
 	icon_state = "carpetedge"
 

--- a/code/game/turfs/plating.dm
+++ b/code/game/turfs/plating.dm
@@ -103,6 +103,9 @@
 	mediumxenofootstep = FOOTSTEP_CATWALK
 	layer = CATWALK_LAYER
 
+/turf/open/floor/plating/catwalk/ex_act(severity)
+	return
+
 /turf/open/floor/plating/warning
 	icon_state = "warnplate"
 


### PR DESCRIPTION

## About The Pull Request

Currently explosions break both carpet and catwalk due to an oversight with how their parents handle explosions, this fixes that.

## Why It's Good For The Game

Bugs bad fixes good.

## Changelog
:cl:
fix: Fixed carpets and catwalks becoming blank voids after explosions.
/:cl:
