### PR TITLE
Fixes loadout imports

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -721,4 +721,4 @@ GLOBAL_LIST_INIT(bypass_storage_content_save, typecacheof(list(
 /// The current loadout version
 #define CURRENT_LOADOUT_VERSION 11
 
-GLOBAL_LIST_INIT(accepted_loadout_versions, list(5, 6, 7, 8, 9, 10))
+GLOBAL_LIST_INIT(accepted_loadout_versions, list(5, 6, 7, 8, 9, 10, 11))


### PR DESCRIPTION

## About The Pull Request
You can import loadouts from the current version again.
Forgot to update a list.
## Why It's Good For The Game
Feature working is good.
## Changelog
:cl:
fix: Importing loadouts works again with the current version
/:cl:
