### PR TITLE
Modernizes deathsquad standard/gunner loadouts, adds magnetic harness to dsquad pulse rifle

### DIFF
--- a/code/datums/jobs/job/deathsquad.dm
+++ b/code/datums/jobs/job/deathsquad.dm
@@ -26,7 +26,7 @@
 	mask = /obj/item/clothing/mask/gas/pmc
 	head = /obj/item/clothing/head/helmet/marine/veteran/pmc/commando
 	glasses = /obj/item/clothing/glasses/night/tx8
-	suit_store = /obj/item/weapon/gun/rifle/m412/elite
+	suit_store = /obj/item/weapon/gun/rifle/m412/elite/deathsquad
 	r_store = /obj/item/storage/pouch/magazine/large/pmc_rifle
 	l_store = /obj/item/storage/pouch/medkit
 	back = /obj/item/storage/backpack/commando
@@ -189,7 +189,7 @@
 	mask = /obj/item/clothing/mask/gas/pmc
 	head = /obj/item/clothing/head/helmet/marine/veteran/pmc/commando
 	glasses = /obj/item/clothing/glasses/night/m56_goggles
-	suit_store = /obj/item/weapon/gun/rifle/standard_smartmachinegun
+	suit_store = /obj/item/weapon/gun/rifle/standard_smartmachinegun/pmc
 	r_store = /obj/item/storage/pouch/magazine/drum
 	l_store = /obj/item/storage/pouch/medkit
 	back = /obj/item/storage/backpack/commando

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -206,6 +206,9 @@
 	default_ammo_type = /obj/item/cell/lasgun/pulse
 	allowed_ammo_types = list(/obj/item/cell/lasgun/pulse)
 
+	attachable_allowed = list(/obj/item/attachable/magnetic_harness)
+	starting_attachment_types = list(/obj/item/attachable/magnetic_harness)
+
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_ENERGY|GUN_AMMO_COUNT_BY_SHOTS_REMAINING|GUN_NO_PITCH_SHIFT_NEAR_EMPTY
 	attachable_offset = list("muzzle_x" = 32, "muzzle_y" = 18,"rail_x" = 12, "rail_y" = 23, "under_x" = 23, "under_y" = 15, "stock_x" = 22, "stock_y" = 12)
 	ammo_level_icon = "m19c4"

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -445,6 +445,8 @@
 	scatter = -2
 	force = 20
 
+/obj/item/weapon/gun/rifle/m412/elite/deathsquad
+	starting_attachment_types = list(/obj/item/attachable/magnetic_harness, /obj/item/attachable/verticalgrip, /obj/item/attachable/bayonet)
 
 //-------------------------------------------------------
 //PR-11


### PR DESCRIPTION

## About The Pull Request
Dsquad standard loadouts modernized. Kinetic rifle has a Bayonet, VGrip and MagH. Energy has A magnetic harness.
pulse rifle now holds magh, and always spawns with one as nothing else fits on it and its an adminspawn soo...
## Why It's Good For The Game
Makes dsquad more modernized, which should be ok.
## Changelog
:cl:
balance: Modernized some Deathsquad loadouts.
/:cl:
