### PR TITLE
The mc now keeps track of how many times a subsystem has slept in fire()

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -109,6 +109,8 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	reverseRange(subsystems)
 	for(var/datum/controller/subsystem/ss in subsystems)
 		log_world("Shutting down [ss.name] subsystem...")
+		if (ss.slept_count > 0)
+			log_world("Warning: Subsystem `[ss.name]` slept [ss.slept_count] times.")
 		ss.Shutdown()
 	log_world("Shutdown complete")
 

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -15,20 +15,36 @@
 	var/can_fire = TRUE
 
 	// Bookkeeping variables; probably shouldn't mess with these.
-	var/last_fire = 0		//last world.time we called fire()
-	var/next_fire = 0		//scheduled world.time for next fire()
-	var/cost = 0			//average time to execute
-	var/tick_usage = 0		//average tick usage
-	var/tick_overrun = 0	//average tick overrun
-	var/state = SS_IDLE		//tracks the current state of the ss, running, paused, etc.
-	var/paused_ticks = 0	//ticks this ss is taking to run right now.
-	var/paused_tick_usage	//total tick_usage of all of our runs while pausing this run
-	var/ticks = 1			//how many ticks does this ss take to run on avg.
-	var/times_fired = 0		//number of times we have called fire()
-	var/queued_time = 0		//time we entered the queue, (for timing and priority reasons)
-	var/queued_priority 	//we keep a running total to make the math easier, if priority changes mid-fire that would break our running total, so we store it here
-	//linked list stuff for the queue
+
+	///last world.time we called fire()
+	var/last_fire = 0
+	///scheduled world.time for next fire()
+	var/next_fire = 0
+	///average time to execute
+	var/cost = 0
+	///average time to execute
+	var/tick_usage = 0
+	///average tick usage
+	var/tick_overrun = 0
+	///tracks the current state of the ss, running, paused, etc.
+	var/state = SS_IDLE
+	/// Tracks how many times a subsystem has ever slept in fire().
+	var/slept_count = 0
+	///ticks this ss is taking to run right now.
+	var/paused_ticks = 0
+	///total tick_usage of all of our runs while pausing this run
+	var/paused_tick_usage
+	///how many ticks does this ss take to run on avg.
+	var/ticks = 1
+	///number of times we have called fire()
+	var/times_fired = 0
+	///time we entered the queue, (for timing and priority reasons)
+	var/queued_time = 0
+	///we keep a running total to make the math easier, if priority changes mid-fire that would break our running total, so we store it here
+	var/queued_priority
+	/// Next subsystem in the queue of subsystems to run this tick
 	var/datum/controller/subsystem/queue_next
+	/// Previous subsystem in the queue of subsystems to run this tick
 	var/datum/controller/subsystem/queue_prev
 
 	var/runlevels = RUNLEVELS_DEFAULT	//points of the game at which the SS can fire
@@ -51,8 +67,10 @@
 	fire(resumed)
 	. = state
 	if (state == SS_SLEEPING)
+		slept_count++
 		state = SS_IDLE
 	if (state == SS_PAUSING)
+		slept_count++
 		var/QT = queued_time
 		enqueue()
 		state = SS_PAUSED


### PR DESCRIPTION

## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/72324

When I found the issue with the silo SS going to sleep I wondered "is this logged?" The answer was no, but turns out TG did.

Also some autodoc because funny comments
## Why It's Good For The Game
Logging MC issues good.
## Changelog
:cl:
code: The mc now keeps track of how many times a subsystem has slept in fire()
/:cl:
