### PR TITLE
Adds dispenser to req hell.

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -315,7 +315,6 @@ GLOBAL_LIST_INIT(engineer_clothes_listed_products, list(
 		/obj/item/storage/holster/blade/machete/full = list(CAT_BAK, "Machete scabbard", 0, "black"),
 		/obj/item/storage/backpack/marine/engineerpack = list(CAT_BAK, "Welderpack", 0, "black"),
 		/obj/item/storage/backpack/marine/radiopack = list(CAT_BAK, "Radio Pack", 0, "black"),
-		/obj/item/storage/backpack/dispenser = list(CAT_BAK, "Dispenser", 0, "black"),
 		/obj/item/armor_module/storage/uniform/brown_vest = list(CAT_WEB, "Tactical brown vest", 0, "orange"),
 		/obj/item/armor_module/storage/uniform/webbing = list(CAT_WEB, "Tactical webbing", 0, "black"),
 		/obj/item/armor_module/storage/uniform/holster = list(CAT_WEB, "Shoulder handgun holster", 0, "black"),


### PR DESCRIPTION

## About The Pull Request
Engis can no longer vend roundstart dispensers.
Closes https://github.com/tgstation/TerraGov-Marine-Corps/pull/12589
## Why It's Good For The Game
If maintainers prefer not deleting dispenser, it should remain as req only.
## Changelog
:cl:
balance: Dispenser is no longer freely available to engineers in prep, it's in req.
/:cl:
