### PR TITLE
Nerfs the dispenser storage, can no longer hold bulky items.

### DIFF
--- a/code/game/objects/items/storage/dispenser.dm
+++ b/code/game/objects/items/storage/dispenser.dm
@@ -113,8 +113,8 @@
 	icon = 'icons/obj/items/storage/storage_48.dmi'
 	icon_state = "dispenser"
 	flags_equip_slot = ITEM_SLOT_BACK
-	max_w_class = 6
-	max_storage_space = 48
+	max_w_class = WEIGHT_CLASS_NORMAL
+	max_storage_space = 36
 	max_integrity = 250
 
 /obj/item/storage/backpack/dispenser/Initialize(mapload, ...)

--- a/code/game/objects/items/storage/dispenser.dm
+++ b/code/game/objects/items/storage/dispenser.dm
@@ -114,7 +114,7 @@
 	icon_state = "dispenser"
 	flags_equip_slot = ITEM_SLOT_BACK
 	max_w_class = WEIGHT_CLASS_NORMAL
-	max_storage_space = 36
+	max_storage_space = 48
 	max_integrity = 250
 
 /obj/item/storage/backpack/dispenser/Initialize(mapload, ...)

--- a/code/game/objects/items/storage/dispenser.dm
+++ b/code/game/objects/items/storage/dispenser.dm
@@ -113,7 +113,6 @@
 	icon = 'icons/obj/items/storage/storage_48.dmi'
 	icon_state = "dispenser"
 	flags_equip_slot = ITEM_SLOT_BACK
-	max_w_class = WEIGHT_CLASS_NORMAL
 	max_storage_space = 48
 	max_integrity = 250
 


### PR DESCRIPTION
## About The Pull Request
Dispenser can only hold items of w_class 3, no more bulky items fitting in the dispenser.
Dispenser reduced to 36 storage capacity, 1.5x the size of a backpack.
## Why It's Good For The Game
Carrying bulky items allows degenerate strategies and bypasses how items are balanced:
- Multiple plasma cutters in a dispenser means you will  never run out of charge (Intended downtime that xenos can play around)
- Multiple sentries means that any xeno that even thinks of approaching will just get gunned down by auto-targetting turrets.
- Allowing things like infinite welding kits to enable permanent flamethrowing is unreasonable (no downtime for xenos to exploit when you have infinite fuel without reliance on fob/req)

Carrying a huge amount of items, is not as bad as carrying bulky items, but it is still problematic:
The game is balanced around marines running out of steam: As in, run out of meds, run out of ammo, run out of health, etc.
Dispenser just bypasses that problem by allowing you to just carry a FUCK LOAD of extra ammo, meds, and gear.
## Changelog
:cl:
balance: Dispenser can no longer carry bulky items.
/:cl:
