### PR TITLE
Bicaridine, Kelotane, and Tramadol reagent bottles are infinite in medical vendors

### DIFF
--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -173,9 +173,9 @@
 			/obj/item/reagent_containers/hypospray/advanced/dylovene = 5,
 		),
 		"Reagent Bottle" = list(
-			/obj/item/reagent_containers/glass/bottle/bicaridine = 6,
-			/obj/item/reagent_containers/glass/bottle/kelotane = 6,
-			/obj/item/reagent_containers/glass/bottle/tramadol = 6,
+			/obj/item/reagent_containers/glass/bottle/bicaridine = -1,
+			/obj/item/reagent_containers/glass/bottle/kelotane = -1,
+			/obj/item/reagent_containers/glass/bottle/tramadol = -1,
 			/obj/item/reagent_containers/glass/bottle/dylovene = 6,
 			/obj/item/reagent_containers/glass/bottle/inaprovaline = 6,
 			/obj/item/reagent_containers/glass/bottle/dexalin = 6,


### PR DESCRIPTION
## About The Pull Request
Per title.

## Why It's Good For The Game
I have no idea what kind of silly war is being waged against chemicals, power gaming, and whatever other reason is being thrown around -- Vali and its players have been getting the short end of the stick, and recent changes have essentially disabled any other role besides Corpsman from being able to use it properly.

You probably shouldn't be disabling an entire playstyle regardless of excuses.

## Changelog
:cl: Lewdcifer
balance: Bicaridine, Kelotane, and Tramadol bottles are infinite in medical vendors.
/:cl: