### PR TITLE
Adds an admin verb to disable taking over mindless/SSD mobs

### DIFF
--- a/code/_globalvars/admin.dm
+++ b/code/_globalvars/admin.dm
@@ -4,6 +4,7 @@ GLOBAL_VAR_INIT(dsay_allowed, TRUE)
 GLOBAL_VAR_INIT(enter_allowed, TRUE)
 GLOBAL_VAR_INIT(respawn_allowed, TRUE)
 GLOBAL_VAR_INIT(valhalla_allowed, TRUE)
+GLOBAL_VAR_INIT(ssd_posses_allowed, TRUE)
 
 GLOBAL_VAR_INIT(respawntime, 30 MINUTES)
 GLOBAL_VAR_INIT(fileaccess_timer, 0)

--- a/code/datums/actions/observer_action.dm
+++ b/code/datums/actions/observer_action.dm
@@ -48,6 +48,11 @@
 
 /datum/action/observer_action/take_ssd_mob/action_activate()
 	var/mob/dead/observer/dead_owner = owner
+
+	if(!GLOB.ssd_posses_allowed)
+		to_chat(owner, span_warning("Taking over SSD mobs is currently disabled."))
+		return
+
 	if(GLOB.key_to_time_of_death[owner.key] + TIME_BEFORE_TAKING_BODY > world.time && !dead_owner.started_as_observer)
 		to_chat(owner, span_warning("You died too recently to be able to take a new mob."))
 		return

--- a/code/modules/admin/server_verbs.dm
+++ b/code/modules/admin/server_verbs.dm
@@ -591,6 +591,9 @@
 		message_admins("[key_name_admin(usr)] disabled the CDN asset transport")
 		log_admin("[key_name(usr)] disabled the CDN asset transport")
 
+/**
+ * Toggles players' ability to join valhalla
+ */
 /datum/admins/proc/toggle_valhalla()
 	set category = "Server"
 	set name = "Toggle Valhalla joining"
@@ -604,6 +607,9 @@
 	log_admin("[key_name(usr)] [GLOB.valhalla_allowed ? "enabled" : "disabled"] valhalla joining.")
 	message_admins("[ADMIN_TPMONTY(usr)] [GLOB.valhalla_allowed ? "enabled" : "disabled"] valhalla joining.")
 
+/**
+ * Toggles players' ability to take over SSD mobs
+ */
 /datum/admins/proc/toggle_sdd_possesion()
 	set category = "Server"
 	set name = "Toggle taking over SSD mobs"

--- a/code/modules/admin/server_verbs.dm
+++ b/code/modules/admin/server_verbs.dm
@@ -590,3 +590,29 @@
 		SSassets.transport.dont_mutate_filenames = TRUE
 		message_admins("[key_name_admin(usr)] disabled the CDN asset transport")
 		log_admin("[key_name(usr)] disabled the CDN asset transport")
+
+/datum/admins/proc/toggle_valhalla()
+	set category = "Server"
+	set name = "Toggle Valhalla joining"
+	set desc = "Allows players to join valhalla."
+
+	if(!check_rights(R_SERVER))
+		return
+
+	GLOB.valhalla_allowed = !GLOB.valhalla_allowed
+
+	log_admin("[key_name(usr)] [GLOB.valhalla_allowed ? "enabled" : "disabled"] valhalla joining.")
+	message_admins("[ADMIN_TPMONTY(usr)] [GLOB.valhalla_allowed ? "enabled" : "disabled"] valhalla joining.")
+
+/datum/admins/proc/toggle_sdd_possesion()
+	set category = "Server"
+	set name = "Toggle taking over SSD mobs"
+	set desc = "Allows players to take over SSD mobs."
+
+	if(!check_rights(R_SERVER))
+		return
+
+	GLOB.ssd_posses_allowed = !GLOB.ssd_posses_allowed
+
+	log_admin("[key_name(usr)] [GLOB.ssd_posses_allowed ? "enabled" : "disabled"] taking over SSD mobs.")
+	message_admins("[ADMIN_TPMONTY(usr)] [GLOB.ssd_posses_allowed ? "enabled" : "disabled"] taking over SSD mobs.")


### PR DESCRIPTION

## About The Pull Request

Also makes the valhalla disable verb actually have a toggle verb.
## Why It's Good For The Game

People ruining PVE events isn't funny.
## Changelog
:cl:
add: Admins can disable players taking over ssd mobs now
fix: Admins can now actually toggle the var to disable valhalla joining
/:cl:
