### PR TITLE
Adds large 10x26mm caseless box

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -904,6 +904,7 @@
 		"Ammo Boxes" = list(
 			/obj/item/big_ammo_box = -1,
 			/obj/item/big_ammo_box/smg = -1,
+			/obj/item/big_ammo_box/mg = -1,
 			/obj/item/shotgunbox = -1,
 			/obj/item/shotgunbox/buckshot = -1,
 			/obj/item/shotgunbox/flechette = -1,

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -556,4 +556,4 @@ Turn() or Shift() as there is virtually no overhead. ~N
 /obj/item/big_ammo_box/mg
 	name = "big ammo box (10x26mm)"
 	default_ammo = /datum/ammo/bullet/rifle/machinegun
-	caliber = CALIBER_10X26_CASELESS
+	caliber = CALIBER_10x26_CASELESS

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -552,3 +552,9 @@ Turn() or Shift() as there is virtually no overhead. ~N
 	name = "Flechette Ammo Box"
 	icon_state = "ammoboxflechette"
 	ammo_type = /datum/ammo/bullet/shotgun/flechette
+	
+/obj/item/big_ammo_box/mg
+	name = "big ammo box (10x26mm)"
+	caliber = CALIBER_10X26
+	default_ammo = /datum/ammo/bullet/rifle/machinegun
+	caliber = CALIBER_10X26_CASELESS

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -555,6 +555,5 @@ Turn() or Shift() as there is virtually no overhead. ~N
 	
 /obj/item/big_ammo_box/mg
 	name = "big ammo box (10x26mm)"
-	caliber = CALIBER_10X26
 	default_ammo = /datum/ammo/bullet/rifle/machinegun
 	caliber = CALIBER_10X26_CASELESS


### PR DESCRIPTION

## About The Pull Request
Adds a large ammo box for loose 10x26mm caseless that holds 2400 rounds and can be infinitely vended from the req supplies vendor like all other large ammo boxes.

## Why It's Good For The Game
I thought it was kind of silly that you can sling large boxes of rifle and SMG ammo over your back, but no such thing existed for the quintessential machinegun caliber. You know, the caliber designed to be spammed in large volumes in the general direction of the enemy. The one that would be most useful in a large, bulk format such as a big box of loose rounds. it holds the same amount as the rifle ammo box because a backpack full of 10x26 packets is about 1200 rounds, half of 2400.
## Changelog
:cl:
add: Added big 10x26mm caseless ammo box to req operational vendor
/:cl:
