### PR TITLE
Moves germs to human from atom

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -16,8 +16,6 @@
 
 	var/resistance_flags = PROJECTILE_IMMUNE
 
-	var/germ_level = GERM_LEVEL_AMBIENT // The higher the germ level, the more germ on the atom.
-
 	///If non-null, overrides a/an/some in all cases
 	var/article
 

--- a/code/game/blood.dm
+++ b/code/game/blood.dm
@@ -84,7 +84,6 @@
 
 
 /atom/proc/clean_blood()
-	germ_level = 0
 	blood_color = null
 	return 1
 
@@ -104,7 +103,6 @@
 	if(gloves)
 		if(gloves.clean_blood())
 			update_inv_gloves()
-		gloves.germ_level = 0
 	else
 		blood_color = null
 		bloody_hands = 0

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -21,9 +21,6 @@
 	if(nutrition && stat != DEAD)
 		adjust_nutrition(-HUNGER_FACTOR * 0.1 * ((m_intent == MOVE_INTENT_RUN) ? 2 : 1))
 
-	// Moving around increases germ_level faster
-	if(germ_level < GERM_LEVEL_MOVE_CAP && prob(8))
-		germ_level++
 
 /mob/living/carbon/relaymove(mob/user, direction)
 	if(user.incapacitated(TRUE))

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -98,6 +98,8 @@
 
 	var/list/limbs = list()
 	var/list/internal_organs_by_name = list() // so internal organs have less ickiness too
+	///How much dirt the mob's accumulated. Harmless by itself, but can trigger issues with open wounds or surgery.
+	var/germ_level = 0
 
 	///Auras we can create, used for the order choice UI.
 	var/static/list/command_aura_allowed = list(AURA_HUMAN_MOVE, AURA_HUMAN_HOLD, AURA_HUMAN_FOCUS)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -71,4 +71,7 @@
 
 /mob/living/carbon/human/Moved(atom/oldloc, direction)
 	Process_Cloaking_Router(src)
+	// Moving around increases germ_level faster
+	if(germ_level < GERM_LEVEL_MOVE_CAP && prob(8))
+		germ_level++
 	return ..()

--- a/code/modules/mob/living/carbon/human/life/handle_status_effects.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_status_effects.dm
@@ -7,10 +7,6 @@
 	//The analgesic effect wears off slowly
 	analgesic = max(0, analgesic - 1)
 
-	//If you're dirty, your gloves will become dirty, too.
-	if(gloves && germ_level > gloves.germ_level && prob(10))
-		gloves.germ_level++
-
 	return TRUE
 
 /mob/living/carbon/human/finish_aura_cycle()

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -617,9 +617,9 @@
 /datum/reagent/sterilizine/reaction_mob(mob/living/L, method = TOUCH, volume, show_message = TRUE, touch_protection = 0)
 	if(!(method in list(TOUCH, VAPOR, PATCH)))
 		return
-	L.germ_level -= min(volume * 20 * touch_protection, L.germ_level)
 	if(ishuman(L))
 		var/mob/living/carbon/human/disinfectee = L
+		disinfectee.germ_level -= min(volume * 20 * touch_protection, disinfectee.germ_level)
 		for(var/datum/limb/limb AS in disinfectee.limbs)
 			limb.disinfect() //Only removes germs from individual external wounds. Won't help with the limb itself having a high germ level.
 	if(prob(L.getFireLoss() + L.getBruteLoss())) // >Spraying space bleach on open wounds
@@ -632,12 +632,6 @@
 		L.emote(pick("scream","pain","moan"))
 		L.flash_pain()
 		L.reagent_shock_modifier -= PAIN_REDUCTION_MEDIUM
-
-/datum/reagent/sterilizine/reaction_obj(obj/O, volume)
-	O.germ_level -= min(volume*20, O.germ_level)
-
-/datum/reagent/sterilizine/reaction_turf(turf/T, volume)
-	T.germ_level -= min(volume*20, T.germ_level)
 
 /datum/reagent/sterilizine/on_mob_life(mob/living/L, metabolism)
 	L.adjustToxLoss(effect_str)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -74,34 +74,37 @@ GLOBAL_LIST_EMPTY(surgery_steps)
 	if(!istype(user) || !istype(E))
 		return
 
+	var/applied_germ_ratio = 0
 	//Gloves
 	if(user.gloves)
 		if(istype(user.gloves, /obj/item/clothing/gloves/latex))
-			E.germ_level += user.gloves.germ_level * 0.1
-		else if(user.gloves.germ_level && user.gloves.germ_level > 60)
-			E.germ_level += user.gloves.germ_level * 0.2
+			applied_germ_ratio += 0.1
+		else
+			applied_germ_ratio += 0.2
 	else
-		E.germ_level += user.germ_level * 0.33
+		applied_germ_ratio += 0.33
 
 	//Masks
 	if(user.wear_mask)
 		if(istype(user.wear_mask, /obj/item/clothing/mask/cigarette))
-			E.germ_level += user.germ_level * 1
+			applied_germ_ratio += 1
 		else if(istype(user.wear_mask, /obj/item/clothing/mask/surgical))
-			E.germ_level += user.wear_mask.germ_level * 0.1
+			applied_germ_ratio += 0.1
 		else
-			E.germ_level += user.wear_mask.germ_level * 0.2
+			applied_germ_ratio += 0.2
 	else
-		E.germ_level += user.germ_level * 0.33
+		applied_germ_ratio += 0.33
 
 	//Suits
 	if(user.wear_suit)
 		if(istype(user.wear_suit, /obj/item/clothing/suit/surgical))
-			E.germ_level += user.germ_level * 0.1
+			applied_germ_ratio += 0.1
 		else
-			E.germ_level += user.germ_level * 0.2
+			applied_germ_ratio += 0.2
 	else
-		E.germ_level += user.germ_level * 0.33
+		applied_germ_ratio += 0.33
+
+	E.germ_level += user.germ_level * applied_germ_ratio
 
 	if(locate(/obj/structure/bed/roller, E.owner.loc))
 		E.germ_level += 50


### PR DESCRIPTION

## About The Pull Request
Strictly the only times germ_level matters is on humans and gloves, and I've folded the glove effects into human.
Also standardizes surgery gear-based germ transfer - proper gear is 10% from surgeon, improper is 20%, none is 33%. There was a weird case where having non-specialized gloves was better sometimes, that's dead now.
Humans pop out of cryosleep clean instead of moderately dirty.
## Why It's Good For The Game
One less var on almost every single atom in the game.
## Changelog
:cl:
code: germ_level moved from atom to human, no major player-facing changes
/:cl:
