### PR TITLE
Minor Big red LZ2 tweak

### DIFF
--- a/_maps/modularmaps/big_red/bigredlz2var1.dmm
+++ b/_maps/modularmaps/big_red/bigredlz2var1.dmm
@@ -49,7 +49,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/marking/asteroidwarning{
-	dir = 4
+	dir = 1
 	},
 /area/shuttle/drop2/lz2)
 "db" = (
@@ -65,12 +65,6 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
-"dU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/marking/asteroidwarning{
-	dir = 6
-	},
-/area/shuttle/drop2/lz2)
 "eg" = (
 /obj/machinery/landinglight/ds2/delaythree{
 	dir = 1
@@ -319,6 +313,10 @@
 /obj/machinery/landinglight/ds2/delayone,
 /turf/open/floor/marking/asteroidwarning,
 /area/shuttle/drop2/lz2)
+"xH" = (
+/obj/structure/cable,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/shuttle/drop2/lz2)
 "yh" = (
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 9
@@ -368,7 +366,9 @@
 /area/shuttle/drop2/lz2)
 "zI" = (
 /obj/effect/ai_node,
-/turf/open/floor/asteroidfloor,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 4
+	},
 /area/shuttle/drop2/lz2)
 "Aa" = (
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
@@ -481,9 +481,7 @@
 /obj/machinery/button/door/open_only/landing_zone/lz2{
 	dir = 8
 	},
-/turf/open/floor/marking/asteroidwarning{
-	dir = 4
-	},
+/turf/open/floor/plating/ground/mars/random/dirt,
 /area/shuttle/drop2/lz2)
 "HG" = (
 /turf/open/floor/plating/icefloor/warnplate{
@@ -596,9 +594,7 @@
 "Nx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/shuttle/shuttle_control/dropship/two,
-/turf/open/floor/marking/asteroidwarning{
-	dir = 4
-	},
+/turf/open/floor/plating/ground/mars/random/dirt,
 /area/lv624/lazarus/console)
 "NM" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
@@ -753,14 +749,16 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/marking/asteroidwarning{
-	dir = 4
-	},
+/turf/open/floor/plating/ground/mars/random/dirt,
 /area/shuttle/drop2/lz2)
 "Wv" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/mineral/smooth/bigred,
 /area/bigredv2/outside/sw)
+"WW" = (
+/obj/structure/cable,
+/turf/open/floor/marking/asteroidwarning,
+/area/shuttle/drop2/lz2)
 "Xm" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -2337,7 +2335,7 @@ mU
 mU
 mU
 mU
-Nb
+qY
 sZ
 BT
 MO
@@ -2377,32 +2375,32 @@ LR
 mU
 mU
 mU
-qY
-sZ
-BT
-MO
-BT
-BT
+wE
+mo
+Eh
+yR
+Eh
+Eh
 zI
-BT
-BT
-BT
-BT
-BT
-BT
-BT
-BT
-BT
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
 zI
-BT
-BT
-BT
-BT
-BT
+Eh
+Eh
+Eh
+Eh
+Eh
 zI
-sZ
-BT
-MO
+mo
+Eh
+yR
 BT
 Zi
 Sp
@@ -2417,33 +2415,33 @@ mU
 mU
 mU
 zl
-qY
-wE
+xH
+xH
 cW
-dU
-BT
-BT
-BT
-BT
-BT
-BT
-BT
+ES
+mU
+mU
+mU
+mU
+mU
+mU
+mU
 mS
 Nx
 Wq
-wR
-wR
-wR
+xH
+qY
+WW
 Hl
-wR
-wR
-wR
-Eh
-Eh
-mo
-Eh
-yR
-Eh
+xH
+xH
+qY
+MO
+mU
+mU
+mU
+mU
+mU
 Zi
 Sp
 "}

--- a/_maps/modularmaps/big_red/bigredlz2var1.dmm
+++ b/_maps/modularmaps/big_red/bigredlz2var1.dmm
@@ -1548,7 +1548,7 @@ Ng
 Ng
 Ng
 mq
-Ng
+mq
 Ng
 Ng
 Ng
@@ -1589,21 +1589,21 @@ LT
 LT
 GB
 mq
-Ng
-Ng
-Ng
-Ng
-Ng
-Ng
-Ng
-Ng
-Ng
-Ng
-Ng
-Ng
-Ng
-Ng
-Ng
+mq
+mq
+mq
+mq
+mq
+mq
+mq
+mq
+mq
+mq
+mq
+mq
+mq
+mq
+mq
 Ng
 Ng
 "}
@@ -1617,7 +1617,7 @@ sZ
 MO
 fz
 fz
-fz
+ze
 fz
 fz
 fz
@@ -1628,23 +1628,23 @@ fz
 fz
 Zi
 GB
+Wv
+Wv
+Wv
+Wv
+Wv
+Wv
+Wv
+Wv
+Wv
+Wv
+Wv
+Wv
+Wv
+Wv
+Wv
 Ng
 mq
-mq
-mq
-mq
-mq
-mq
-mq
-mq
-mq
-mq
-mq
-mq
-mq
-mq
-mq
-Ng
 Ng
 "}
 (22,1,1) = {"
@@ -1657,53 +1657,13 @@ UT
 MO
 fz
 fz
-ze
-fz
-fz
-fz
-fz
-fz
-tY
-fz
-fz
-Zi
-GB
-Wv
-Wv
-Wv
-Wv
-Wv
-Wv
-Wv
-Wv
-Wv
-Wv
-Wv
-Wv
-Wv
-Wv
-Wv
-Ng
-mq
-Ng
-"}
-(23,1,1) = {"
-qM
-Ng
-Ng
-am
-mU
-sZ
-MO
-fz
-fz
 fz
 fz
 fz
 fz
 GZ
 aX
-fz
+tY
 fz
 fz
 Zi
@@ -1727,7 +1687,7 @@ Ng
 Ng
 mq
 "}
-(24,1,1) = {"
+(23,1,1) = {"
 qM
 Ng
 Ng
@@ -1736,7 +1696,7 @@ mU
 sZ
 MO
 fz
-GZ
+fz
 aX
 fz
 GZ
@@ -1767,9 +1727,9 @@ Wv
 Wv
 Wv
 "}
-(25,1,1) = {"
+(24,1,1) = {"
 qM
-qM
+Ng
 Ng
 am
 mU
@@ -1807,8 +1767,8 @@ Zi
 Zi
 Sp
 "}
-(26,1,1) = {"
-VI
+(25,1,1) = {"
+qM
 qM
 Ng
 am
@@ -1847,8 +1807,8 @@ BT
 Zi
 Sp
 "}
-(27,1,1) = {"
-UJ
+(26,1,1) = {"
+VI
 qM
 Ng
 am
@@ -1887,8 +1847,8 @@ BT
 Zi
 Sp
 "}
-(28,1,1) = {"
-VI
+(27,1,1) = {"
+UJ
 qM
 Ng
 am
@@ -1927,16 +1887,16 @@ BT
 Zi
 Sp
 "}
-(29,1,1) = {"
-Kk
+(28,1,1) = {"
+VI
 qM
 Ng
 am
 mU
 sZ
-BT
-kH
-RW
+MO
+fz
+GZ
 sZ
 QV
 it
@@ -1967,16 +1927,16 @@ BT
 Zi
 Sp
 "}
-(30,1,1) = {"
-Mi
+(29,1,1) = {"
+Kk
 qM
 Ng
 am
 mU
-UT
+sZ
 BT
-Eh
-yR
+kH
+RW
 sZ
 Qt
 it
@@ -2007,16 +1967,16 @@ BT
 Zi
 Sp
 "}
-(31,1,1) = {"
+(30,1,1) = {"
 Mi
 qM
 Ng
 am
 mU
-sZ
-MO
-fz
-GZ
+UT
+BT
+Eh
+yR
 sZ
 nq
 it
@@ -2047,8 +2007,8 @@ BT
 Zi
 Sp
 "}
-(32,1,1) = {"
-pu
+(31,1,1) = {"
+Mi
 qM
 Ng
 am
@@ -2056,7 +2016,7 @@ mU
 sZ
 MO
 fz
-rf
+GZ
 sZ
 kW
 it
@@ -2087,16 +2047,16 @@ BT
 Zi
 Sp
 "}
-(33,1,1) = {"
-qa
-Id
-Id
+(32,1,1) = {"
+pu
+qM
+Ng
 am
 mU
 sZ
 MO
 fz
-GZ
+rf
 sZ
 xp
 it
@@ -2127,16 +2087,16 @@ BT
 Zi
 Sp
 "}
-(34,1,1) = {"
-CN
-mU
-mU
-mU
+(33,1,1) = {"
+qa
+Id
+Id
+am
 mU
 sZ
 MO
-Aa
-mU
+fz
+GZ
 sZ
 Qt
 it
@@ -2167,16 +2127,16 @@ BT
 Zi
 Sp
 "}
-(35,1,1) = {"
+(34,1,1) = {"
 CN
-rN
-bV
-bV
-kH
-BT
-BT
-kH
-kH
+mU
+mU
+mU
+mU
+sZ
+MO
+Aa
+mU
 sZ
 EV
 it
@@ -2207,16 +2167,16 @@ BT
 Zi
 Sp
 "}
-(36,1,1) = {"
-Xm
-sZ
-zk
+(35,1,1) = {"
+CN
+rN
+bV
+bV
+kH
 BT
 BT
-zk
-zk
-BT
-BT
+kH
+kH
 sZ
 kW
 it
@@ -2247,17 +2207,17 @@ BT
 Zi
 Sp
 "}
-(37,1,1) = {"
-ZF
-qY
-Nb
-Nb
-Nb
-OQ
-wR
-wR
-wR
-qY
+(36,1,1) = {"
+Xm
+sZ
+zk
+BT
+BT
+zk
+zk
+BT
+BT
+sZ
 QV
 it
 tR
@@ -2287,16 +2247,16 @@ BT
 Zi
 Sp
 "}
-(38,1,1) = {"
-CN
-sZ
-BT
-BT
-ES
-mU
-mU
-mU
-mU
+(37,1,1) = {"
+ZF
+qY
+Nb
+Nb
+Nb
+OQ
+wR
+wR
+wR
 qY
 Qt
 Ti
@@ -2327,11 +2287,11 @@ BT
 Zi
 Sp
 "}
-(39,1,1) = {"
+(38,1,1) = {"
 CN
-vJ
+sZ
 BT
-zk
+BT
 ES
 mU
 mU
@@ -2363,6 +2323,46 @@ cI
 Lb
 kH
 ri
+BT
+Zi
+Sp
+"}
+(39,1,1) = {"
+CN
+vJ
+BT
+zk
+ES
+mU
+mU
+mU
+mU
+Nb
+sZ
+BT
+MO
+BT
+BT
+BT
+BT
+BT
+BT
+BT
+BT
+BT
+BT
+BT
+BT
+BT
+BT
+BT
+BT
+BT
+BT
+BT
+sZ
+BT
+MO
 BT
 Zi
 Sp

--- a/_maps/modularmaps/big_red/bigredlz2var2.dmm
+++ b/_maps/modularmaps/big_red/bigredlz2var2.dmm
@@ -110,9 +110,6 @@
 	},
 /turf/closed/mineral/smooth/bigred,
 /area/bigredv2/caves/rock)
-"jC" = (
-/turf/closed/mineral/smooth/bigred,
-/area/bigredv2/outside/sw)
 "jR" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall/r_wall,
@@ -495,9 +492,6 @@
 /obj/machinery/landinglight/ds2/delaythree,
 /turf/open/floor/marking/asteroidwarning,
 /area/shuttle/drop2/lz2)
-"KF" = (
-/turf/closed/mineral/smooth/bigred,
-/area/bigredv2/outside/w)
 "KG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning,
@@ -665,7 +659,7 @@
 /turf/open/floor/marking/asteroidwarning{
 	dir = 4
 	},
-/area/shuttle/drop2/lz2)
+/area/lv624/lazarus/console)
 "Uj" = (
 /turf/closed/mineral/smooth/bigred,
 /area/bigredv2/caves/rock)
@@ -1525,24 +1519,24 @@ Dq
 Dq
 Dq
 Dq
-KF
+dj
 JK
 dC
-Uj
-Uj
-Uj
-Uj
-Uj
-Uj
-Uj
-Uj
-Uj
-Uj
-Uj
-Uj
-Uj
-Uj
-Uj
+dC
+dC
+dC
+dC
+dC
+dC
+dC
+dC
+dC
+dC
+dC
+dC
+dC
+dC
+dC
 Uj
 Uj
 "}
@@ -1556,34 +1550,34 @@ Uj
 Uj
 Dq
 Dq
+SF
 Dq
 Dq
 Dq
 Dq
+SF
 Dq
 Dq
-Dq
-Dq
-Dq
-KF
+SF
+dj
 JK
+af
+af
+af
+af
+af
+af
+af
+af
+af
+af
+af
+af
+af
+af
+af
 Uj
 dC
-dC
-dC
-dC
-dC
-dC
-dC
-dC
-dC
-dC
-dC
-dC
-dC
-dC
-dC
-Uj
 Uj
 "}
 (22,1,1) = {"
@@ -1596,35 +1590,35 @@ Uj
 Dq
 Dq
 Dq
-SF
 Dq
 Dq
 Dq
 Dq
-SF
+dA
+zI
 Dq
 Dq
-SF
-KF
+Dq
+dj
+dj
+dj
+dj
+dj
+dj
+dj
+dj
+dj
+dj
+dj
+dj
+dj
+dj
+dj
+dj
 JK
-af
-af
-af
-af
-af
-af
-af
-af
-af
-af
-af
-af
-af
-af
-af
+Uj
 Uj
 dC
-Uj
 "}
 (23,1,1) = {"
 xo
@@ -1636,46 +1630,6 @@ Dq
 Dq
 Dq
 Dq
-Dq
-Dq
-Dq
-Dq
-dA
-zI
-Dq
-Dq
-Dq
-KF
-jC
-jC
-jC
-jC
-Uj
-Uj
-Uj
-Uj
-Uj
-Uj
-Uj
-Uj
-Uj
-Uj
-Uj
-JK
-Uj
-Uj
-dC
-"}
-(24,1,1) = {"
-xo
-Uj
-JK
-Uj
-Dq
-Dq
-Dq
-Dq
-dA
 zI
 Dq
 dA
@@ -1700,13 +1654,13 @@ Et
 aX
 mo
 Dq
-jC
+dj
 JK
 af
 af
 af
 "}
-(25,1,1) = {"
+(24,1,1) = {"
 xo
 Uj
 JK
@@ -1714,8 +1668,8 @@ Uj
 Dq
 Dq
 Dq
+Dq
 dA
-aX
 gi
 gi
 Ve
@@ -1740,21 +1694,21 @@ Ve
 Ve
 Ve
 Ve
-jC
-jC
-jC
-jC
+dj
+dj
+dj
+dj
 JK
 "}
-(26,1,1) = {"
-zY
+(25,1,1) = {"
+xo
 Uj
 JK
 Uj
 Dq
-SF
 Dq
-Et
+Dq
+dA
 aX
 EB
 dt
@@ -1783,16 +1737,16 @@ BV
 BV
 BV
 As
-jC
+dj
 JK
 "}
-(27,1,1) = {"
+(26,1,1) = {"
 zY
 Uj
 JK
 Uj
 Dq
-Dq
+SF
 Dq
 Et
 aX
@@ -1823,12 +1777,12 @@ ky
 BV
 BV
 BV
-jC
+dj
 JK
 "}
-(28,1,1) = {"
+(27,1,1) = {"
 zY
-xo
+Uj
 JK
 Uj
 Dq
@@ -1863,11 +1817,11 @@ ub
 BV
 BV
 BV
-jC
+dj
 JK
 "}
-(29,1,1) = {"
-mq
+(28,1,1) = {"
+zY
 xo
 JK
 Uj
@@ -1903,11 +1857,11 @@ vN
 BV
 BV
 BV
-jC
+dj
 JK
 "}
-(30,1,1) = {"
-Bg
+(29,1,1) = {"
+mq
 xo
 JK
 Uj
@@ -1946,7 +1900,7 @@ BV
 dj
 JK
 "}
-(31,1,1) = {"
+(30,1,1) = {"
 Bg
 xo
 JK
@@ -1954,7 +1908,7 @@ Uj
 Dq
 Dq
 Dq
-HM
+Et
 aX
 dt
 ZR
@@ -1986,16 +1940,16 @@ BV
 dj
 JK
 "}
-(32,1,1) = {"
-dh
+(31,1,1) = {"
+Bg
 xo
 JK
+Uj
 Dq
 Dq
 Dq
-Dq
-Dq
-Et
+HM
+aX
 dt
 tq
 ic
@@ -2026,16 +1980,16 @@ BV
 dj
 JK
 "}
-(33,1,1) = {"
-xo
+(32,1,1) = {"
+dh
 xo
 JK
-pQ
-zI
-SF
 Dq
-dA
-aX
+Dq
+Dq
+Dq
+Dq
+Et
 EB
 tZ
 ic
@@ -2063,18 +2017,18 @@ vN
 BV
 BV
 As
-Uj
+dj
 JK
 "}
-(34,1,1) = {"
-HR
-af
+(33,1,1) = {"
+xo
+xo
 JK
-aX
-aX
-pc
-pc
-aX
+pQ
+zI
+SF
+Dq
+dA
 aX
 dt
 vT
@@ -2103,19 +2057,19 @@ QQ
 BV
 BV
 BV
-Uj
+dj
 JK
 "}
-(35,1,1) = {"
+(34,1,1) = {"
 HR
-Gd
-BC
-BC
-Ve
-Ve
-Ve
-Ve
-Ve
+af
+JK
+aX
+aX
+pc
+pc
+aX
+aX
 dt
 Kj
 ic
@@ -2143,19 +2097,19 @@ yz
 BV
 BV
 BV
-Uj
+dj
 JK
 "}
-(36,1,1) = {"
-vB
-dt
-JF
-BV
-BV
-JF
-JF
-BV
-BV
+(35,1,1) = {"
+HR
+Gd
+BC
+BC
+Ve
+Ve
+Ve
+Ve
+Ve
 dt
 tq
 fC
@@ -2183,20 +2137,20 @@ ub
 BV
 BV
 BV
-Uj
+dj
 JK
 "}
-(37,1,1) = {"
-Qa
-Jz
-SC
-SC
-SC
-zX
-Nu
-Nu
-Nu
-Jz
+(36,1,1) = {"
+vB
+dt
+JF
+BV
+BV
+JF
+JF
+BV
+BV
+dt
 YQ
 ic
 ic
@@ -2223,19 +2177,19 @@ vN
 BV
 BV
 BV
-Uj
+dj
 JK
 "}
-(38,1,1) = {"
-HR
-dt
-BV
-BV
-KG
-aX
-aX
-aX
-aX
+(37,1,1) = {"
+Qa
+Jz
+SC
+SC
+SC
+zX
+Nu
+Nu
+Nu
 Jz
 vT
 ic
@@ -2263,14 +2217,14 @@ QQ
 BV
 BV
 BV
-Uj
+dj
 JK
 "}
-(39,1,1) = {"
+(38,1,1) = {"
 HR
-DP
+dt
 BV
-JF
+BV
 KG
 aX
 aX
@@ -2303,7 +2257,47 @@ JI
 Ve
 Pa
 BV
-Uj
+dj
+JK
+"}
+(39,1,1) = {"
+HR
+DP
+BV
+JF
+KG
+aX
+aX
+aX
+aX
+Jz
+dt
+BV
+os
+BV
+BV
+BV
+BV
+BV
+BV
+BV
+BV
+BV
+BV
+BV
+BV
+BV
+BV
+BV
+BV
+BV
+BV
+BV
+dt
+BV
+os
+BV
+dj
 JK
 "}
 (40,1,1) = {"
@@ -2343,7 +2337,7 @@ dt
 BV
 os
 BV
-Uj
+dj
 JK
 "}
 (41,1,1) = {"
@@ -2383,7 +2377,7 @@ AV
 UL
 YL
 er
-Uj
+dj
 JK
 "}
 (42,1,1) = {"
@@ -2423,7 +2417,7 @@ aX
 aX
 CL
 Dq
-Uj
+dj
 JK
 "}
 (43,1,1) = {"

--- a/_maps/modularmaps/big_red/bigredlz2var2.dmm
+++ b/_maps/modularmaps/big_red/bigredlz2var2.dmm
@@ -1706,7 +1706,7 @@ Uj
 JK
 Uj
 Dq
-Dq
+SF
 Dq
 dA
 aX
@@ -1746,7 +1746,7 @@ Uj
 JK
 Uj
 Dq
-SF
+Dq
 Dq
 Et
 aX
@@ -1990,7 +1990,7 @@ Dq
 Dq
 Dq
 Et
-EB
+dt
 tZ
 ic
 ic
@@ -2016,7 +2016,7 @@ ic
 vN
 BV
 BV
-As
+BV
 dj
 JK
 "}
@@ -2030,7 +2030,7 @@ SF
 Dq
 dA
 aX
-dt
+EB
 vT
 ic
 ic
@@ -2056,7 +2056,7 @@ ic
 QQ
 BV
 BV
-BV
+As
 dj
 JK
 "}

--- a/_maps/modularmaps/big_red/bigredlz2var2.dmm
+++ b/_maps/modularmaps/big_red/bigredlz2var2.dmm
@@ -110,6 +110,13 @@
 	},
 /turf/closed/mineral/smooth/bigred,
 /area/bigredv2/caves/rock)
+"jq" = (
+/obj/effect/ai_node,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 4
+	},
+/area/shuttle/drop2/lz2)
 "jR" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall/r_wall,
@@ -150,6 +157,10 @@
 "ni" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/southwest)
+"nz" = (
+/obj/structure/cable,
+/turf/open/floor/marking/asteroidwarning,
+/area/shuttle/drop2/lz2)
 "oc" = (
 /obj/machinery/landinglight/ds2/delaytwo{
 	dir = 8
@@ -210,6 +221,13 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"sz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/shuttle/drop2/lz2)
 "sF" = (
 /obj/machinery/landinglight/ds2/delaytwo{
 	dir = 4
@@ -252,9 +270,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/marking/asteroidwarning{
-	dir = 4
-	},
+/turf/open/floor/plating/ground/mars/random/dirt,
 /area/shuttle/drop2/lz2)
 "vB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -275,6 +291,10 @@
 "vT" = (
 /obj/machinery/landinglight/ds2,
 /turf/open/floor/marking/asteroidwarning,
+/area/shuttle/drop2/lz2)
+"wy" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
 /area/shuttle/drop2/lz2)
 "wG" = (
 /obj/structure/cable,
@@ -329,12 +349,6 @@
 "zI" = (
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
 	dir = 10
-	},
-/area/shuttle/drop2/lz2)
-"zS" = (
-/obj/structure/cable,
-/turf/open/floor/marking/asteroidwarning{
-	dir = 5
 	},
 /area/shuttle/drop2/lz2)
 "zX" = (
@@ -520,13 +534,6 @@
 /obj/docking_port/stationary/marine_dropship/lz2,
 /turf/open/floor/plating,
 /area/shuttle/drop2/lz2)
-"Mj" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/marking/asteroidwarning{
-	dir = 4
-	},
-/area/shuttle/drop2/lz2)
 "Mv" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
@@ -565,6 +572,10 @@
 	dir = 4
 	},
 /area/shuttle/drop2/lz2)
+"OB" = (
+/obj/structure/cable,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/shuttle/drop2/lz2)
 "Pa" = (
 /obj/structure/prop/mainship/hangar_stencil/two,
 /turf/open/floor/marking/asteroidwarning{
@@ -586,9 +597,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/floor/marking/asteroidwarning{
-	dir = 4
-	},
+/turf/open/floor/plating/ground/mars/random/dirt,
 /area/shuttle/drop2/lz2)
 "Qa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -656,9 +665,7 @@
 "Tq" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/shuttle/shuttle_control/dropship/two,
-/turf/open/floor/marking/asteroidwarning{
-	dir = 4
-	},
+/turf/open/floor/plating/ground/mars/random/dirt,
 /area/lv624/lazarus/console)
 "Uj" = (
 /turf/closed/mineral/smooth/bigred,
@@ -683,6 +690,13 @@
 "UL" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 4
+	},
+/area/shuttle/drop2/lz2)
+"UU" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 5
 	},
 /area/shuttle/drop2/lz2)
 "Ve" = (
@@ -2310,32 +2324,32 @@ aX
 aX
 aX
 aX
-yN
-dt
-As
-os
-BV
-BV
-BV
-As
-BV
-BV
-BV
-BV
-BV
-BV
-As
-BV
-As
-BV
-BV
-As
-BV
-BV
-BV
-dt
-BV
-os
+UU
+AV
+jq
+Qh
+UL
+UL
+UL
+er
+UL
+UL
+UL
+UL
+UL
+UL
+er
+UL
+er
+UL
+UL
+er
+UL
+UL
+UL
+AV
+UL
+YL
 BV
 dj
 JK
@@ -2350,33 +2364,33 @@ aX
 aX
 aX
 aX
-Jz
-zS
-zX
-Qh
-BV
-BV
-BV
-BV
-BV
-BV
-BV
+OB
+OB
+sz
+KG
+aX
+aX
+aX
+aX
+aX
+aX
+aX
 ky
 Tq
 vg
-Nu
-Nu
-Nu
+OB
+Jz
+nz
 Pq
-Nu
-Nu
-Mj
-UL
-UL
-AV
-UL
-YL
-er
+OB
+OB
+yN
+os
+aX
+aX
+aX
+aX
+wy
 dj
 JK
 "}


### PR DESCRIPTION

## About The Pull Request
shifts the landing pad in LZ2 one tile to the left. Currently the east side of the LZ is 3 tiles wide, and even has the dropship computer clogging the way reducing it down to 2 wide.

This makes the LZ pretty unpleasant to move around in, let alone defend.

![image](https://user-images.githubusercontent.com/7869430/229667898-6b893df0-aac7-4122-8652-b3e2669cb7b1.png)
## Why It's Good For The Game
Slightly less painful LZ is good.
## Changelog
:cl:
balance: Big Red LZ2 is slightly wider on the right hand side
/:cl:
