### PR TITLE
Lowers respawn timer: Electric Boogaloo 2, Revengeance - The Squeakquel

### DIFF
--- a/code/_globalvars/admin.dm
+++ b/code/_globalvars/admin.dm
@@ -6,7 +6,7 @@ GLOBAL_VAR_INIT(respawn_allowed, TRUE)
 GLOBAL_VAR_INIT(valhalla_allowed, TRUE)
 GLOBAL_VAR_INIT(ssd_posses_allowed, TRUE)
 
-GLOBAL_VAR_INIT(respawntime, 30 MINUTES)
+GLOBAL_VAR_INIT(respawntime, 20 MINUTES)
 GLOBAL_VAR_INIT(fileaccess_timer, 0)
 
 GLOBAL_VAR_INIT(custom_info, "")


### PR DESCRIPTION
## About The Pull Request

This PR lowers the respawn-timer of marines from 30 minutes to 20.

## Why It's Good For The Game

I've played this server for a long time, almost four years. Back when we had desert-outpost and specialists. The respawn-timer for marines has always been a significant curb when it comes to retaining server population due to the following;

* The majority of rounds do not last more 105 minutes <sub>(**More have gone into the ~200s as of recently, making this even more important!)</sub>
* After surveying in OOC and Discord, _most_ marines  **leave** the server when unrevivable. 
* This leads to a very boring and drug-on experience the moment marines experience a wipe, removing any chance of recovery
* Waiting half an hour (roughly 31.3% of the round) to play the game again is harsh and unforgiving towards new players

Lowering the timer to twenty minutes is more tolerable and will discourage people from leaving as much, while not completely fizzling out the balance of the game. 

## Synopsis

_In my humble opinion_ - this is more relevant than ever now, since the last time the respawn delay was touched was _long_ before we even had psi-points. A squad of 15 dying not only gives xenos primos or a silo - but crushes momentum. This wasn't something that was ever accounted for in the past, and I believe adjusting this to not be a guarantied round-end is better for the overall flow of the game. 

## Changelog

:cl:
balance: Respawn timer shortened by 10 minutes
admin: Respawn timer adjusted
/:cl: