### PR TITLE
Mortar sound fix

### DIFF
--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -259,7 +259,7 @@
 	shell.generate_bullet(ammo)
 	var/shell_range = min(get_dist_euclide(src,target), ammo.max_range)
 	shell.fire_at(target, src, src, shell_range, ammo.shell_speed)
-	var/fall_time = shell_range/ammo.shell_speed - 1 SECONDS
+	var/fall_time = (shell_range/(ammo.shell_speed * 5)) - 0.5 SECONDS
 	//prevent runtime
 	if(fall_time < 0.5 SECONDS)
 		fall_time = 0.5 SECONDS


### PR DESCRIPTION

## About The Pull Request
Mortar shells once again land at subsonic speeds, with their sound effect playing before landing.

I'm not entirely sure how this broke, or if just the old speed coincidentally made it just work due to the minus 1 second, but it is now actually tied to how often the projectile SS fires.
## Why It's Good For The Game
Being able to hear a mortar coming is good.
## Changelog
:cl:
fix: Fixed mortar sounds playing after they've already landed
/:cl:
