### PR TITLE
Reverts #11387 . Warrior can lunge in 6 tiles again.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -77,7 +77,7 @@
 	if(!.)
 		return FALSE
 
-	if(get_dist_euclide_square(A, owner) > 20)
+	if(get_dist_euclide_square(A, owner) > 36)
 		if(!silent)
 			to_chat(owner, span_xenonotice("You are too far!"))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

This PR reverts #11387 by allowing warriors to lunge within a 6 tile range.

## Why It's Good For The Game

Lunge caught a stray nerf, to an entirely damage related issue with warriors kit. Its ability was within marine screen view range, and was countered by using flares/lights. It also allowed for warriors to engage without being forced to be within shotgun/slug wield range, due in part to how warriors lunge has a long cooldown and requires precise clicks. Now, it's been nerfed to 4 tiles which means you are at complete risk in engagements for an ability that can potentially kill you, and you will almost always be seen before being lunged IE there is no factor to pushing blindly into darkness that a warrior might teeter the edge and lunge you.  In the PR even, it states that 6 tile lunges allowed for warriors to be "too good at what they do" which was true, warriors were too good with their **flings** and their **damage dealing** abilities, and **NOT** their main ability, lunge which was only a setup for said abilities. 

Also something to consider in mind before pitch forks are raised about concerns with grapple toss, that ability has already been nerfed and requires a competent hive and warrior to setup kills as so. A 6 tile lunge did not change this, and nerfing lunge to 4 tiles was not good for the game.

## Changelog

:cl:
balance: Warrior lunge is now 6 tiles, up from 4
/:cl:
