### PR TITLE
Cade repair improvements

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -551,7 +551,7 @@
 	. += span_info("It is [barricade_upgrade_type ? "upgraded with [barricade_upgrade_type]" : "not upgraded"].")
 
 /obj/structure/barricade/metal/welder_act(mob/living/user, obj/item/I)
-	. = welder_repair_act(user, I, repair_threshold = 0.3, skill_required = SKILL_ENGINEER_METAL)
+	. = welder_repair_act(user, I, 85, 2.5 SECONDS, 0.3, SKILL_ENGINEER_METAL, 1)
 	if(. == BELOW_INTEGRITY_THRESHOLD)
 		balloon_alert(user, "Too damaged. Use metal sheets.")
 
@@ -773,7 +773,7 @@
 			. += span_info("The protection panel has been removed and the anchor bolts loosened. It's ready to be taken apart.")
 
 /obj/structure/barricade/plasteel/welder_act(mob/living/user, obj/item/I)
-	. = welder_repair_act(user, I, repair_threshold = 0.3, skill_required = SKILL_ENGINEER_PLASTEEL)
+	. = welder_repair_act(user, I, 85, 2.5 SECONDS, 0.3, SKILL_ENGINEER_PLASTEEL, 1)
 	if(. == BELOW_INTEGRITY_THRESHOLD)
 		balloon_alert(user, "Too damaged. Use plasteel sheets.")
 


### PR DESCRIPTION
## About The Pull Request
Two changes. Cade repair time and fuel use cut in half (2.5 seconds from 5 seconds, and 1 fuel from 2).
Repair amount reduced to slightly above 50% (85hp from 150).

This should make it easier to do minor repairs, especially if it's difficult to stand there for a prolonged period of time due to boiler acid etc.

There's more ways of damaging cades, in particular damaging multiple cades for xenos, and no more multirepair, so I buffed the repair/second very slightly to make it less guh to try hold cades.
## Why It's Good For The Game
Repair QOL, make cade repairing slightly more effective against modern xeno cade murdering options.
## Changelog
:cl:
balance: Barricade repair time and fuel use cut in half. Repair amount reduced from 150 to 85
/:cl:
