### PR TITLE
fixed typo in the warrior's caste_desc

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
@@ -145,7 +145,7 @@
 
 /datum/xeno_caste/warrior/primordial
 	upgrade_name = "Primordial"
-	caste_desc = "A champion of the hive, methodically shatters its opponents with punches rather slashes."
+	caste_desc = "A champion of the hive, methodically shatters its opponents with punches rather than slashes."
 	primordial_message = "Our rhythm is unmatched and our strikes lethal, no single foe can stand against us."
 	upgrade = XENO_UPGRADE_FOUR
 


### PR DESCRIPTION

## About The Pull Request
Fixed a simple typo in the primo warrior's caste_desc
## Why It's Good For The Game
_vastly_ improved immersion
## Changelog
:cl:
Fixed a typo in the primo warrior's description
/:cl:
