### PR TITLE
Adds toys and plushies to requisitions.

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1294,6 +1294,60 @@ SUPPLIES
 	)
 	cost = 50
 
+/datum/supply_packs/supplies/carpplush
+	name = "Carp Plushie"
+	contains = list(/obj/item/toy/plush/carp)
+	cost = 20
+
+/datum/supply_packs/supplies/lizplush
+	name = "Lizard Plushie"
+	contains = list(/obj/item/toy/plush/lizard)
+	cost = 20
+
+/datum/supply_packs/supplies/slimeplush
+	name = "Slime Plushie"
+	contains = list(/obj/item/toy/plush/slime)
+	cost = 20
+
+/datum/supply_packs/supplies/mothplush
+	name = "Moth Plushie"
+	contains = list(/obj/item/toy/plush/moth)
+	cost = 20
+
+/datum/supply_packs/supplies/rounyplush
+	name = "Rouny Plushie"
+	contains = list(/obj/item/toy/plush/rouny)
+	cost = 20
+
+/datum/supply_packs/supplies/games
+	name = "Games crate"
+	contains = list(
+		/obj/item/toy/beach_ball/basketball,
+		/obj/item/toy/bikehorn,
+		/obj/item/toy/spinningtoy,
+		/obj/item/toy/dice/d20,
+		/obj/item/toy/dice,
+		/obj/item/toy/dice,
+		/obj/item/toy/sword,
+		/obj/item/toy/sword,
+		/obj/item/toy/crossbow,
+		/obj/item/toy/crossbow,
+		/obj/item/toy/deck,
+		/obj/item/toy/deck/kotahi,
+	)
+	cost = 100
+
+/datum/supply_packs/supplies/games
+	name = "Therapy doll crate"
+	contains = list(
+		/obj/item/toy/plush/therapy_red,
+		/obj/item/toy/plush/therapy_orange,
+		/obj/item/toy/plush/therapy_yellow,
+		/obj/item/toy/plush/therapy_green,
+		/obj/item/toy/plush/therapy_blue,
+		/obj/item/toy/plush/therapy_purple,
+	)
+	cost = 50
 /*******************************************************************************
 Imports
 *******************************************************************************/

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1297,27 +1297,27 @@ SUPPLIES
 /datum/supply_packs/supplies/carpplush
 	name = "Carp Plushie"
 	contains = list(/obj/item/toy/plush/carp)
-	cost = 20
+	cost = 10
 
 /datum/supply_packs/supplies/lizplush
 	name = "Lizard Plushie"
 	contains = list(/obj/item/toy/plush/lizard)
-	cost = 20
+	cost = 10
 
 /datum/supply_packs/supplies/slimeplush
 	name = "Slime Plushie"
 	contains = list(/obj/item/toy/plush/slime)
-	cost = 20
+	cost = 10
 
 /datum/supply_packs/supplies/mothplush
 	name = "Moth Plushie"
 	contains = list(/obj/item/toy/plush/moth)
-	cost = 20
+	cost = 10
 
 /datum/supply_packs/supplies/rounyplush
 	name = "Rouny Plushie"
 	contains = list(/obj/item/toy/plush/rouny)
-	cost = 20
+	cost = 10
 
 /datum/supply_packs/supplies/games
 	name = "Games crate"
@@ -1335,7 +1335,7 @@ SUPPLIES
 		/obj/item/toy/deck,
 		/obj/item/toy/deck/kotahi,
 	)
-	cost = 100
+	cost = 80
 
 /datum/supply_packs/supplies/games
 	name = "Therapy doll crate"
@@ -1347,7 +1347,7 @@ SUPPLIES
 		/obj/item/toy/plush/therapy_blue,
 		/obj/item/toy/plush/therapy_purple,
 	)
-	cost = 50
+	cost = 40
 /*******************************************************************************
 Imports
 *******************************************************************************/


### PR DESCRIPTION

## About The Pull Request

Because everyone needs a friend.
Adds each plushie to requisitions, a games crate, and a box with each color of therapy doll.

## Why It's Good For The Game

Plushies are neat and so are games. Frankly, if requisition wants to spend their points on 50 rouny plushies, I don't see why they shouldn't be able to. Marine morale will be boosted tenfold by giving each unga a battle buddy.

## Changelog
:cl: dopamiin
add: The TGMC has approved several morale-boosting supply options to be added to requisitions. 
/:cl:
