### PR TITLE
Sentinel spit now travels properly instead of stopping at the tile you aimed

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -16,8 +16,6 @@
 	damage = 12
 	spit_cost = 30
 	flags_ammo_behavior = AMMO_XENO|AMMO_SKIPS_ALIENS
-	/// The owner of this projectile.
-	var/mob/living/carbon/xenomorph/xeno_owner
 	/// The amount of stacks applied on hit.
 	var/intoxication_stacks = SENTINEL_TOXIC_SPIT_STACKS_PER
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -15,7 +15,7 @@
 	bullet_color = COLOR_PALE_GREEN_GRAY
 	damage = 12
 	spit_cost = 30
-	flags_ammo_behavior = AMMO_XENO|AMMO_EXPLOSIVE|AMMO_SKIPS_ALIENS
+	flags_ammo_behavior = AMMO_XENO|AMMO_SKIPS_ALIENS
 	/// The owner of this projectile.
 	var/mob/living/carbon/xenomorph/xeno_owner
 	/// The amount of stacks applied on hit.


### PR DESCRIPTION

## About The Pull Request

They go the normal distance like all the other spits now. Also removes an unused var.

Closes #12621
## Why It's Good For The Game

Unintended. This was kept from when it had neuro spit.
## Changelog
:cl:
fix: Sentinel spit now travels properly instead of stopping at the tile you aimed
/:cl:
