### PR TITLE
Adjusts some things on drain sting, fixes do_after stacking

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -698,7 +698,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define SENTINEL_DRAIN_MULTIPLIER 6 //Amount to multiply Drain Sting's restoration by
 #define SENTINEL_DRAIN_SURGE_ARMOR_MOD 20 //Amount to modify the Sentinel's armor by when under the effects of Drain Surge.
 #define SENTINEL_INTOXICATED_BASE_DAMAGE 1 //Amount of damage per tick dealt by the Intoxicated debuff
-#define SENTINEL_INTOXICATED_RESIST_REDUCTION 3 //Amount of stacks removed every time the Intoxicated debuff is Resisted against.
+#define SENTINEL_INTOXICATED_RESIST_REDUCTION 10 //Amount of stacks removed every time the Intoxicated debuff is Resisted against.
 #define SENTINEL_INTOXICATED_SANGUINAL_INCREASE 3 //Amount of debuff stacks applied for every tick of Sanguinal.
 
 //Wraith defines

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -698,7 +698,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define SENTINEL_DRAIN_MULTIPLIER 6 //Amount to multiply Drain Sting's restoration by
 #define SENTINEL_DRAIN_SURGE_ARMOR_MOD 20 //Amount to modify the Sentinel's armor by when under the effects of Drain Surge.
 #define SENTINEL_INTOXICATED_BASE_DAMAGE 1 //Amount of damage per tick dealt by the Intoxicated debuff
-#define SENTINEL_INTOXICATED_RESIST_REDUCTION 10 //Amount of stacks removed every time the Intoxicated debuff is Resisted against.
+#define SENTINEL_INTOXICATED_RESIST_REDUCTION 8 //Amount of stacks removed every time the Intoxicated debuff is Resisted against.
 #define SENTINEL_INTOXICATED_SANGUINAL_INCREASE 3 //Amount of debuff stacks applied for every tick of Sanguinal.
 
 //Wraith defines

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -698,7 +698,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define SENTINEL_DRAIN_MULTIPLIER 6 //Amount to multiply Drain Sting's restoration by
 #define SENTINEL_DRAIN_SURGE_ARMOR_MOD 20 //Amount to modify the Sentinel's armor by when under the effects of Drain Surge.
 #define SENTINEL_INTOXICATED_BASE_DAMAGE 1 //Amount of damage per tick dealt by the Intoxicated debuff
-#define SENTINEL_INTOXICATED_RESIST_REDUCTION 10 //Amount of stacks removed every time the Intoxicated debuff is Resisted against.
+#define SENTINEL_INTOXICATED_RESIST_REDUCTION 6 //Amount of stacks removed every time the Intoxicated debuff is Resisted against.
 #define SENTINEL_INTOXICATED_SANGUINAL_INCREASE 3 //Amount of debuff stacks applied for every tick of Sanguinal.
 
 //Wraith defines

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -698,7 +698,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define SENTINEL_DRAIN_MULTIPLIER 6 //Amount to multiply Drain Sting's restoration by
 #define SENTINEL_DRAIN_SURGE_ARMOR_MOD 20 //Amount to modify the Sentinel's armor by when under the effects of Drain Surge.
 #define SENTINEL_INTOXICATED_BASE_DAMAGE 1 //Amount of damage per tick dealt by the Intoxicated debuff
-#define SENTINEL_INTOXICATED_RESIST_REDUCTION 6 //Amount of stacks removed every time the Intoxicated debuff is Resisted against.
+#define SENTINEL_INTOXICATED_RESIST_REDUCTION 10 //Amount of stacks removed every time the Intoxicated debuff is Resisted against.
 #define SENTINEL_INTOXICATED_SANGUINAL_INCREASE 3 //Amount of debuff stacks applied for every tick of Sanguinal.
 
 //Wraith defines

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -506,7 +506,7 @@
 		return
 	if(HAS_TRAIT(debuff_owner, TRAIT_INTOXICATION_RESISTANT) || (debuff_owner.get_soft_armor(BIO) > 65))
 		stack_decay = 2
-	var/debuff_damage = SENTINEL_INTOXICATED_BASE_DAMAGE + round(stacks / 10) * is_resisting ? 0.7 : 1 // If they're resisting, reduce the damage taken by 30%.
+	var/debuff_damage = SENTINEL_INTOXICATED_BASE_DAMAGE + round(stacks / 10) * is_resisting ? 0.7 : 1 // If they're resisting, reduce the extra damage taken by 30%.
 	debuff_owner.adjustFireLoss(debuff_damage)
 	playsound(debuff_owner.loc, "sound/bullets/acid_impact1.ogg", 4)
 	particle_holder.particles.spawning = 1 + round(stacks / 2)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -506,7 +506,7 @@
 		return
 	if(HAS_TRAIT(debuff_owner, TRAIT_INTOXICATION_RESISTANT) || (debuff_owner.get_soft_armor(BIO) > 65))
 		stack_decay = 2
-	var/debuff_damage = SENTINEL_INTOXICATED_BASE_DAMAGE + round(stacks / 10)
+	var/debuff_damage = SENTINEL_INTOXICATED_BASE_DAMAGE + round(stacks / 10) * is_resisting ? 0.7 : 1 // If they're resisting, reduce the damage by 30%
 	debuff_owner.adjustFireLoss(debuff_damage)
 	playsound(debuff_owner.loc, "sound/bullets/acid_impact1.ogg", 4)
 	particle_holder.particles.spawning = 1 + round(stacks / 2)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -470,6 +470,8 @@
 	var/mob/living/carbon/debuff_owner
 	/// Used for particles. Holds the particles instead of the mob. See particle_holder for documentation.
 	var/obj/effect/abstract/particle_holder/particle_holder
+	/// Prevents you from stacking resists to instantly rid yourself of the debuff.
+	var/is_resisting = FALSE
 
 /datum/status_effect/stacking/intoxicated/can_gain_stacks()
 	if(owner.status_flags & GODMODE)
@@ -519,9 +521,12 @@
 
 /// Resisting the debuff will allow the debuff's owner to remove some stacks from themselves.
 /datum/status_effect/stacking/intoxicated/proc/resist_debuff()
-	if(!do_after(debuff_owner, 3 SECONDS, TRUE, debuff_owner, BUSY_ICON_GENERIC))
+	is_resisting = TRUE
+	if(!do_after(debuff_owner, 5 SECONDS, TRUE, debuff_owner, BUSY_ICON_GENERIC))
+		is_resisting = FALSE
 		debuff_owner.balloon_alert("Interrupted")
 		return
+	is_resisting = FALSE
 	playsound(debuff_owner.loc, 'sound/effects/slosh.ogg', 30)
 	debuff_owner.balloon_alert("Succeeded")
 	stacks -= SENTINEL_INTOXICATED_RESIST_REDUCTION

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -470,8 +470,6 @@
 	var/mob/living/carbon/debuff_owner
 	/// Used for particles. Holds the particles instead of the mob. See particle_holder for documentation.
 	var/obj/effect/abstract/particle_holder/particle_holder
-	/// Prevents you from stacking resists to instantly rid yourself of the debuff.
-	var/is_resisting = FALSE
 
 /datum/status_effect/stacking/intoxicated/can_gain_stacks()
 	if(owner.status_flags & GODMODE)
@@ -506,7 +504,7 @@
 		return
 	if(HAS_TRAIT(debuff_owner, TRAIT_INTOXICATION_RESISTANT) || (debuff_owner.get_soft_armor(BIO) > 65))
 		stack_decay = 2
-	var/debuff_damage = SENTINEL_INTOXICATED_BASE_DAMAGE + (round(stacks / 10) * is_resisting ? 0.5 : 1) // If they're resisting, reduce the extra damage taken by 50%.
+	var/debuff_damage = SENTINEL_INTOXICATED_BASE_DAMAGE + round(stacks / 10)
 	debuff_owner.adjustFireLoss(debuff_damage)
 	playsound(debuff_owner.loc, "sound/bullets/acid_impact1.ogg", 4)
 	particle_holder.particles.spawning = 1 + round(stacks / 2)
@@ -521,6 +519,9 @@
 
 /// Resisting the debuff will allow the debuff's owner to remove some stacks from themselves.
 /datum/status_effect/stacking/intoxicated/proc/resist_debuff()
+	if(length(debuff_owner.do_actions))
+		is_resisting = FALSE
+		return
 	is_resisting = TRUE
 	if(!do_after(debuff_owner, 5 SECONDS, TRUE, debuff_owner, BUSY_ICON_GENERIC))
 		is_resisting = FALSE

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -470,8 +470,6 @@
 	var/mob/living/carbon/debuff_owner
 	/// Used for particles. Holds the particles instead of the mob. See particle_holder for documentation.
 	var/obj/effect/abstract/particle_holder/particle_holder
-	/// Whether or not the owner of the debuff is actively resisting it. Used for keeping track of damage reduction.
-	var/is_resisting = FALSE
 
 /datum/status_effect/stacking/intoxicated/can_gain_stacks()
 	if(owner.status_flags & GODMODE)
@@ -506,7 +504,7 @@
 		return
 	if(HAS_TRAIT(debuff_owner, TRAIT_INTOXICATION_RESISTANT) || (debuff_owner.get_soft_armor(BIO) > 65))
 		stack_decay = 2
-	var/debuff_damage = SENTINEL_INTOXICATED_BASE_DAMAGE + round(stacks / 10) * (is_resisting ? 0.5 : 1) // If resisting, reduce extra damage by half.
+	var/debuff_damage = SENTINEL_INTOXICATED_BASE_DAMAGE + round(stacks / 10)
 	debuff_owner.adjustFireLoss(debuff_damage)
 	playsound(debuff_owner.loc, "sound/bullets/acid_impact1.ogg", 4)
 	particle_holder.particles.spawning = 1 + round(stacks / 2)
@@ -522,12 +520,9 @@
 /// Resisting the debuff will allow the debuff's owner to remove some stacks from themselves.
 /datum/status_effect/stacking/intoxicated/proc/resist_debuff()
 	if(length(debuff_owner.do_actions))
-		is_resisting = FALSE
 		return
-	is_resisting = TRUE
 	if(!do_after(debuff_owner, 5 SECONDS, TRUE, debuff_owner, BUSY_ICON_GENERIC))
 		debuff_owner.balloon_alert("Interrupted")
-		is_resisting = FALSE
 		return
 	playsound(debuff_owner.loc, 'sound/effects/slosh.ogg', 30)
 	debuff_owner.balloon_alert("Succeeded")
@@ -535,4 +530,3 @@
 	if(stacks > 0)
 		resist_debuff() // We repeat ourselves as long as the debuff persists.
 		return
-	is_resisting = FALSE

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -506,7 +506,7 @@
 		return
 	if(HAS_TRAIT(debuff_owner, TRAIT_INTOXICATION_RESISTANT) || (debuff_owner.get_soft_armor(BIO) > 65))
 		stack_decay = 2
-	var/debuff_damage = SENTINEL_INTOXICATED_BASE_DAMAGE + round(stacks / 10) * is_resisting ? 0.7 : 1 // If they're resisting, reduce the extra damage taken by 30%.
+	var/debuff_damage = SENTINEL_INTOXICATED_BASE_DAMAGE + (round(stacks / 10) * is_resisting ? 0.5 : 1) // If they're resisting, reduce the extra damage taken by 50%.
 	debuff_owner.adjustFireLoss(debuff_damage)
 	playsound(debuff_owner.loc, "sound/bullets/acid_impact1.ogg", 4)
 	particle_holder.particles.spawning = 1 + round(stacks / 2)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -521,7 +521,7 @@
 /datum/status_effect/stacking/intoxicated/proc/resist_debuff()
 	if(length(debuff_owner.do_actions))
 		return
-	if(!do_after(debuff_owner, 3 SECONDS, TRUE, debuff_owner, BUSY_ICON_GENERIC))
+	if(!do_after(debuff_owner, 5 SECONDS, TRUE, debuff_owner, BUSY_ICON_GENERIC))
 		debuff_owner.balloon_alert("Interrupted")
 		return
 	playsound(debuff_owner.loc, 'sound/effects/slosh.ogg', 30)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -526,7 +526,8 @@
 		is_resisting = FALSE
 		debuff_owner.balloon_alert("Interrupted")
 		return
-	is_resisting = FALSE
 	playsound(debuff_owner.loc, 'sound/effects/slosh.ogg', 30)
 	debuff_owner.balloon_alert("Succeeded")
 	stacks -= SENTINEL_INTOXICATED_RESIST_REDUCTION
+	if(stacks > 0)
+		resist_debuff() // We repeat ourselves as long as the debuff persists.

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -520,11 +520,8 @@
 /// Resisting the debuff will allow the debuff's owner to remove some stacks from themselves.
 /datum/status_effect/stacking/intoxicated/proc/resist_debuff()
 	if(length(debuff_owner.do_actions))
-		is_resisting = FALSE
 		return
-	is_resisting = TRUE
-	if(!do_after(debuff_owner, 5 SECONDS, TRUE, debuff_owner, BUSY_ICON_GENERIC))
-		is_resisting = FALSE
+	if(!do_after(debuff_owner, 3 SECONDS, TRUE, debuff_owner, BUSY_ICON_GENERIC))
 		debuff_owner.balloon_alert("Interrupted")
 		return
 	playsound(debuff_owner.loc, 'sound/effects/slosh.ogg', 30)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -521,10 +521,10 @@
 
 /// Resisting the debuff will allow the debuff's owner to remove some stacks from themselves.
 /datum/status_effect/stacking/intoxicated/proc/resist_debuff()
-	is_resisting = TRUE
 	if(length(debuff_owner.do_actions))
 		is_resisting = FALSE
 		return
+	is_resisting = TRUE
 	if(!do_after(debuff_owner, 5 SECONDS, TRUE, debuff_owner, BUSY_ICON_GENERIC))
 		debuff_owner.balloon_alert("Interrupted")
 		is_resisting = FALSE

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -506,7 +506,7 @@
 		return
 	if(HAS_TRAIT(debuff_owner, TRAIT_INTOXICATION_RESISTANT) || (debuff_owner.get_soft_armor(BIO) > 65))
 		stack_decay = 2
-	var/debuff_damage = SENTINEL_INTOXICATED_BASE_DAMAGE + round(stacks / 10) * is_resisting ? 0.7 : 1 // If they're resisting, reduce the damage by 30%
+	var/debuff_damage = SENTINEL_INTOXICATED_BASE_DAMAGE + round(stacks / 10) * is_resisting ? 0.7 : 1 // If they're resisting, reduce the damage taken by 30%.
 	debuff_owner.adjustFireLoss(debuff_damage)
 	playsound(debuff_owner.loc, "sound/bullets/acid_impact1.ogg", 4)
 	particle_holder.particles.spawning = 1 + round(stacks / 2)

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -184,8 +184,7 @@
 	xeno_owner.gain_plasma(drain_potency * 3.5)
 	xeno_owner.do_attack_animation(xeno_target, ATTACK_EFFECT_DRAIN_STING)
 	playsound(owner.loc, 'sound/effects/alien_tail_swipe1.ogg', 30)
-	xeno_owner.visible_message(message = span_xenowarning("\A [xeno_owner] stings [xeno_target]!"), self_message = span_xenowarning("We sting [xeno_target]!"), ignored_mob = xeno_target)
-	to_chat(xeno_target, span_userdanger("You're stung by [xeno_owner]!")) // We proudly tell our target they're fucked.
+	xeno_owner.visible_message(message = span_xenowarning("\A [xeno_owner] stings [xeno_target]!"), self_message = span_xenowarning("We sting [xeno_target]!"))
 	debuff.stacks -= round(debuff.stacks * 0.7)
 	succeed_activate()
 	add_cooldown()

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -184,6 +184,8 @@
 	xeno_owner.gain_plasma(drain_potency * 3.5)
 	xeno_owner.do_attack_animation(xeno_target, ATTACK_EFFECT_DRAIN_STING)
 	playsound(owner.loc, 'sound/effects/alien_tail_swipe1.ogg', 30)
+	xeno_owner.visible_message(message = span_xenowarning("\A [xeno_owner] stings [xeno_target]!"), self_message = span_xenowarning("We sting [xeno_target]!"), ignored_mob = xeno_target)
+	to_chat(xeno_target, span_userdanger("You're stung by [xeno_owner]!")) // We proudly tell our target they're fucked.
 	debuff.stacks -= round(debuff.stacks * 0.7)
 	succeed_activate()
 	add_cooldown()


### PR DESCRIPTION
## About The Pull Request

You may have noticed that you can spam resist to immediately rid yourself of the intoxication debuff. I talked about it with Lewd and Ivan and we came to the conclusion that making the resist itself stronger but removing the stacking would be the best way to go.

This PR ups the resist time from 3 seconds to 5 seconds and ups the amount removed from 3 stacks to 8 stacks. This makes the resist 1.6 times stronger than previously. (3 / 3 = 1 and 8 / 5 = 1.6)

The resist timer now also repeats itself on it's own, similarly to repairing things.

This PR also adds messages to the sting since I noticed it lacks them unlike most other abilities, making you unable to see the sting in chat log unless you got buffed by it, which has it's own message.
## Why It's Good For The Game

Resist spam is unintuitive and can be affected by lag, this should even the mechanic out for all players. It's also an unintended "mechanic" that was embraced only because of it's balance implications. (Which pissed off my OCD for whatever reason, leading me to making my first TGMC PR in months, lol.)

This prevents you from ridding yourself of a 30 stack instantly simply because the sentinel missed one shot, that's just plain dumb and completely negates the punishment factor of the debuff. 3 seconds is also short enough for this to be done in the middle of combat, which it shouldn't since it's meant to force you to retreat and stop you from rushing.
## Changelog
:cl:
balance: Resisting intoxication takes 5 seconds instead of 3 seconds and removes 8 stacks instead of 3 stacks. This makes it 1.6 times more effective in general, but harder to use in the middle of combat.
qol: Resisting intoxication now automatically repeats itself, similarly to repairing things.
fix: You can't stack intoxication resists anymore to remove it almost instantly.
/:cl:
