### PR TITLE
Dispenser buff/nerf

### DIFF
--- a/code/game/objects/items/storage/dispenser.dm
+++ b/code/game/objects/items/storage/dispenser.dm
@@ -63,7 +63,7 @@
 
 /obj/item/storage/backpack/dispenser
 	name = "TX-9000 provisions dispenser"
-	desc = "The TX-9000 also known as \"Dispenser\" is a machine capable of holding a big amount of items on it, while also healing nearby synthetics. Your allies will often ask you to lay down one of those."
+	desc = "The TX-9000 also known as \"Dispenser\" is a machine capable of holding a big amount of items on it."
 	icon = 'icons/obj/items/storage/storage_48.dmi'
 	icon_state = "dispenser"
 	flags_equip_slot = ITEM_SLOT_BACK

--- a/code/game/objects/items/storage/dispenser.dm
+++ b/code/game/objects/items/storage/dispenser.dm
@@ -8,8 +8,6 @@
 	resistance_flags = XENO_DAMAGEABLE
 	flags_pass = PASSABLE
 	coverage = 60
-	///list of human mobs we're currently affecting in our area.
-	var/list/mob/living/carbon/human/affecting_list
 	///if the dispenser has finished deploying and is fully active and can be used.
 	var/active = FALSE
 

--- a/code/game/objects/items/storage/dispenser.dm
+++ b/code/game/objects/items/storage/dispenser.dm
@@ -22,7 +22,6 @@
 ///finishes deploying after the deploy timer
 /obj/machinery/deployable/dispenser/proc/deploy()
 	active = TRUE
-	START_PROCESSING(SSobj, src)
 
 /obj/machinery/deployable/dispenser/attack_hand(mob/living/user)
 	. = ..()
@@ -44,13 +43,6 @@
 		return
 	active = FALSE
 	balloon_alert_to_viewers("Undeploying...")
-	for(var/turf/turfs AS in RANGE_TURFS(2, src))
-		UnregisterSignal(turfs, COMSIG_ATOM_ENTERED)
-	for(var/mob/living/carbon/human/affecting AS in affecting_list)
-		qdel(affecting_list[affecting])
-		UnregisterSignal(affecting, COMSIG_PARENT_QDELETING)
-	affecting_list = null
-	STOP_PROCESSING(SSobj, src)
 	flick("dispenser_undeploy", src)
 	playsound(src, 'sound/machines/dispenser/dispenser_undeploy.ogg', 50)
 	addtimer(CALLBACK(src, PROC_REF(disassemble), user), 4 SECONDS)

--- a/code/game/objects/items/storage/dispenser.dm
+++ b/code/game/objects/items/storage/dispenser.dm
@@ -21,54 +21,8 @@
 
 ///finishes deploying after the deploy timer
 /obj/machinery/deployable/dispenser/proc/deploy()
-	affecting_list = list()
-	for(var/mob/living/carbon/human/human in view(2, src))
-		if(!(human.species.species_flags & ROBOTIC_LIMBS)) // can only affect robots
-			continue
-		RegisterSignal(human, COMSIG_PARENT_QDELETING, PROC_REF(on_affecting_qdel))
-		affecting_list[human] = beam(human, "blood_light", maxdistance = 3)
-		RegisterSignal(affecting_list[human], COMSIG_PARENT_QDELETING, PROC_REF(on_beam_qdel))
-		human.playsound_local(get_turf(src), 'sound/machines/dispenser/dispenser_heal.ogg', 50)
-	for(var/turf/turfs AS in RANGE_TURFS(2, src))
-		RegisterSignal(turfs, COMSIG_ATOM_ENTERED, PROC_REF(entered_tiles))
 	active = TRUE
 	START_PROCESSING(SSobj, src)
-
-/obj/machinery/deployable/dispenser/process()
-	for(var/mob/living/carbon/human/affecting AS in affecting_list)
-		if(!line_of_sight(src, affecting, 2))
-			qdel(affecting_list[affecting])
-			affecting_list -= affecting
-			UnregisterSignal(affecting, COMSIG_PARENT_QDELETING)
-			continue
-		affecting.heal_overall_damage(2, 2, TRUE, TRUE)
-
-///checks if a mob that moved close is elligible to get heal beamed.
-/obj/machinery/deployable/dispenser/proc/entered_tiles(datum/source, mob/living/carbon/human/entering)
-	SIGNAL_HANDLER
-	if(!ishuman(entering) || !(entering.species.species_flags & ROBOTIC_LIMBS)) // can only affect robots
-		return
-	if(entering in affecting_list)
-		return
-	if(!line_of_sight(src, entering))
-		return
-
-	RegisterSignal(entering, COMSIG_PARENT_QDELETING, PROC_REF(on_affecting_qdel))
-	entering.playsound_local(get_turf(src), 'sound/machines/dispenser/dispenser_heal.ogg', 50)
-	affecting_list[entering] = beam(entering, "blood_light", maxdistance = 3)
-	RegisterSignal(affecting_list[entering], COMSIG_PARENT_QDELETING, PROC_REF(on_beam_qdel))
-
-///cleans human from affecting_list when it gets qdeletted
-/obj/machinery/deployable/dispenser/proc/on_affecting_qdel(datum/source)
-	SIGNAL_HANDLER
-	affecting_list -= source
-
-///cleans human from affecting_list when the beam gets qdeletted
-/obj/machinery/deployable/dispenser/proc/on_beam_qdel(datum/source)
-	SIGNAL_HANDLER
-	var/datum/beam/beam = source
-	UnregisterSignal(beam.target, COMSIG_PARENT_QDELETING)
-	affecting_list -= beam.target
 
 /obj/machinery/deployable/dispenser/attack_hand(mob/living/user)
 	. = ..()

--- a/code/game/objects/items/storage/dispenser.dm
+++ b/code/game/objects/items/storage/dispenser.dm
@@ -57,7 +57,7 @@
 	icon = 'icons/obj/items/storage/storage_48.dmi'
 	icon_state = "dispenser"
 	flags_equip_slot = ITEM_SLOT_BACK
-	max_storage_space = 62
+	max_storage_space = 72
 	max_integrity = 250
 
 /obj/item/storage/backpack/dispenser/Initialize(mapload, ...)

--- a/code/game/objects/items/storage/dispenser.dm
+++ b/code/game/objects/items/storage/dispenser.dm
@@ -67,7 +67,7 @@
 	icon = 'icons/obj/items/storage/storage_48.dmi'
 	icon_state = "dispenser"
 	flags_equip_slot = ITEM_SLOT_BACK
-	max_storage_space = 48
+	max_storage_space = 62
 	max_integrity = 250
 
 /obj/item/storage/backpack/dispenser/Initialize(mapload, ...)


### PR DESCRIPTION
## About The Pull Request
Dispenser loses healing ability. Storage up to 72. DOES NOT REVERT THE NERF THAT MAKES IT NOT FIT BULKY OBJECTS.

## Why It's Good For The Game
Locks the dispenser purely to a storage niche. Marines can carry this amount of storage by just carrying around two backpacks in hands if not dragging a crate that lets you also carry bulky+ objects too. Healing hardly does much nowadays given robots have maintenance for healing and it's only ever something people bring up as an issue when it comes to walance.

This does NOT allow dispensers to carry bulky objects again. You're still only ever allowed to put objects you'd put in a normal backpack. Essentially, the dispenser ideally has 3 backpacks worth of storage at the tradeoff of needing to deploy it to access it at all and the risk of it being destroyed and all its contents deleted.

## Changelog

:cl:
balance: Dispenser no longer heals. Storage up to 72 from 48.
/:cl:

