### PR TITLE
Adds the ak47 to the proper seasonal instead of 2 mag types

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -193,7 +193,7 @@ SUBSYSTEM_DEF(persistence)
 	name = "AK47, M16 and Storm Weapons"
 	description = "Old Earth guns. Antique and obsolete, but no less deadly"
 	item_list = list(
-		/obj/item/ammo_magazine/rifle/mpi_km/plum = -1,
+		/obj/item/weapon/gun/rifle/mpi_km= -1,
 		/obj/item/ammo_magazine/rifle/mpi_km = -1,
 		/obj/item/ammo_magazine/packet/pwarsaw = -1,
 		/obj/item/weapon/gun/rifle/m16 = -1,

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -194,7 +194,7 @@ SUBSYSTEM_DEF(persistence)
 	description = "Old Earth guns. Antique and obsolete, but no less deadly"
 	item_list = list(
 		/obj/item/weapon/gun/rifle/mpi_km= -1,
-		/obj/item/ammo_magazine/rifle/mpi_km = -1,
+		/obj/item/ammo_magazine/rifle/mpi_km/plum = -1,
 		/obj/item/ammo_magazine/packet/pwarsaw = -1,
 		/obj/item/weapon/gun/rifle/m16 = -1,
 		/obj/item/ammo_magazine/rifle/m16 = -1,


### PR DESCRIPTION

## About The Pull Request

Yeah, you get 2 mag types but not the gun itself. Funny.
## Why It's Good For The Game

Not intended.
## Changelog
:cl:
fix: Adds the ak47 to the proper seasonal instead of 2 mag types
/:cl:
