### PR TITLE
Sentry ammo is now the same weight as the sentry.

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -10,7 +10,7 @@
 		slot_r_hand_str = 'icons/mob/items_righthand_1.dmi',
 		)
 	max_integrity = 250
-	w_class 	= 3
+	w_class 	= WEIGHT_CLASS_NORMAL
 	throwforce 	= 5
 	throw_speed = 4
 	throw_range = 5

--- a/code/modules/projectiles/magazines/sentries.dm
+++ b/code/modules/projectiles/magazines/sentries.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_magazine/sentry
 	name = "\improper M30 box magazine (10x28mm Caseless)"
 	desc = "A drum of 50 10x28mm caseless rounds for the ST-571 sentry gun. Just feed it into the sentry gun's ammo port when its ammo is depleted."
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "ua571c"
 	flags_magazine = NONE //can't be refilled or emptied by hand
 	caliber = CALIBER_10X28
@@ -21,7 +21,7 @@
 /obj/item/ammo_magazine/sentry_premade/dumb
 	name = "M30 box magazine (10x28mm Caseless)"
 	desc = "A box of 50 10x28mm caseless rounds for the ST-571 Sentry Gun. Just feed it into the sentry gun's ammo port when its ammo is depleted."
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	flags_magazine = NONE //can't be refilled or emptied by hand
 	caliber = CALIBER_10X28
 	max_rounds = 500


### PR DESCRIPTION

## About The Pull Request
Weight clast = 3 -> WEIGHT_CLASS_NORMAL
Sentry ammo set to WEIGHT_CLASS_NORMAL
## Why It's Good For The Game
It makes no sense for the ammo to be heavier than the sentry.
## Changelog
:cl:
balance: Sentry ammo is now sentry sized (Normal)
/:cl:
