### PR TITLE
Removes miniscope from grenade launchers

### DIFF
--- a/code/modules/projectiles/guns/grenade_launchers.dm
+++ b/code/modules/projectiles/guns/grenade_launchers.dm
@@ -113,7 +113,6 @@ The Grenade Launchers
 	attachable_allowed = list(
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/flashlight,
-		/obj/item/attachable/scope/mini,
 		/obj/item/attachable/stock/t70stock,
 	)
 	starting_attachment_types = list(/obj/item/attachable/stock/t70stock)


### PR DESCRIPTION
## About The Pull Request

The definition of a xeno cope PR, though I've already held the opinion that B17 or gl should be nerfed months ago.

This PR removes your ability to attach miniscopes to grenade launchers.
## Why It's Good For The Game

Anyways, miniscope with gl allows you to essentially turn the grenade launcher into, well, a sniper. Why is this a problem? Well, the longer flight time of the grenade allows it to essentially turn into a wider AoE RR since it's detonation timer is much lower than normal. It also allows the gl to have straight up uncanny chasing power, which combined with it's knockback makes it plain OP and a pain to deal with. (Resulting in massive xeno cope.)

Now, while you may think you can counter a B17 that's using gl by just going in cqc, well, you can't! They'll pull out a shotgun and use their insane armor values (75 by the way.) to take 5 hits for free before their health HUD even shows up! All while destroying your ass with a shotgun. It's no surprise this setup always fucks the entire hive over whenever it shows up. However, I can't simply nerf B17 due to how it's current balancing is reliant on the fact it's above tyr2 in armor values.

TLDR; RR with a scope.
## Changelog
:cl:
balance: Miniscopes can no longer be attached to grenade launchers.
/:cl:
