### PR TITLE
Adds basic squishing to both the codebase, and the rocket hammer.

### DIFF
--- a/code/datums/elements/squish.dm
+++ b/code/datums/elements/squish.dm
@@ -1,0 +1,25 @@
+#define SHORT 5/7
+#define TALL 7/5
+
+/**
+ * squish.dm - (Mostly) ported from /tg/. All credit to the original author.
+*/
+
+/datum/element/squish
+	element_flags = ELEMENT_DETACH
+
+/datum/element/squish/Attach(datum/target, duration=20 SECONDS)
+	. = ..()
+	if(!iscarbon(target))
+		return ELEMENT_INCOMPATIBLE
+
+	var/mob/living/carbon/C = target
+	addtimer(CALLBACK(src, PROC_REF(Detach), C), duration)
+	C.transform = C.transform.Scale(TALL, SHORT)
+
+/datum/element/squish/Detach(mob/living/carbon/C)
+	. = ..()
+	C.transform = C.transform.Scale(SHORT, TALL)
+
+#undef SHORT
+#undef TALL

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -560,7 +560,7 @@
 
 	M.apply_damage(additional_damage, BRUTE, user.zone_selected, updating_health = TRUE)
 	M.visible_message(span_danger("[user]'s rocket sledge hits [M.name], smashing them!"), span_userdanger("You [user]'s rocket sledge smashes you!"))
-	M.AddElement(/datum/element/squish, 80 SECONDS)
+	M.AddElement(/datum/element/squish, 10 SECONDS)
 
 	if(reagents.get_reagent_amount(/datum/reagent/fuel) < fuel_used * 2)
 		playsound(loc, 'sound/items/weldingtool_off.ogg', 50)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -560,6 +560,7 @@
 
 	M.apply_damage(additional_damage, BRUTE, user.zone_selected, updating_health = TRUE)
 	M.visible_message(span_danger("[user]'s rocket sledge hits [M.name], smashing them!"), span_userdanger("You [user]'s rocket sledge smashes you!"))
+	M.AddElement(/datum/element/squish, 80 SECONDS)
 
 	if(reagents.get_reagent_amount(/datum/reagent/fuel) < fuel_used * 2)
 		playsound(loc, 'sound/items/weldingtool_off.ogg', 50)

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -392,6 +392,7 @@
 #include "code\datums\elements\scalping.dm"
 #include "code\datums\elements\shrapnel_removal.dm"
 #include "code\datums\elements\special_clothing_overlay.dm"
+#include "code\datums\elements\squish.dm"
 #include "code\datums\elements\undertile.dm"
 #include "code\datums\elements\wall_speedup.dm"
 #include "code\datums\elements\windowshutter.dm"


### PR DESCRIPTION
## About The Pull Request

Added the squish element, and applied it to the rocket sledge.
![squish](https://user-images.githubusercontent.com/79433629/230752543-5e07e537-1add-4ad7-99e2-1cadbecf1479.png)

## Why It's Good For The Game

It's funny, and adds something to the codebase that can be used in future projects. Works on marines and xenos.

## Changelog

:cl: QuarianCommando
add: Rocket Sledge now reduces the stature of targets, both literally and metaphorically.
code: Squish element added to datums.
/:cl: