### PR TITLE
Queen is no longer immune to rocket sledge stun

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -585,7 +585,7 @@
 		else
 			stun = 1
 
-	if(!M.IsStun() && !M.IsParalyzed() && !isxenoqueen(M)) //Prevent chain stunning. Queen is protected.
+	if(!M.IsStun() && !M.IsParalyzed()) //Prevent chain stunning
 		M.apply_effects(stun,weaken)
 
 	return ..()


### PR DESCRIPTION
## About The Pull Request
Removes xeno queen immunity to rocket sledge.
## Why It's Good For The Game
This is snowflake as fuck. Queen is not immune to powerfist, vali, or any other form of knockback/displacement. Just look at grenade explosions knocking her around. Come on, specific castes (outside of rav endure/defender fortify) should not just have magic immunity to an expensive req weapon for no reason.

Queen has 0 reason to be in melee range of a rocket sledge user anyways. If the Queen is getting sledged, they are either being outskilled by a very opportunistic sledge user, or the sledge user is suicide charging the entire hive. Queen has all the tools to beat a sledger, oze stin, roar and acid/resin spit. Resin spit being especially brutal against melee builds because of the massive slow down caused by resin.

No other T4 in the game is immune to rocket sledge either. Both Shrike and King are perfectly stunnable using it, only Queen has this magic immunity.
## Changelog
:cl:
balance: Xeno Queen is no longer immune to rocket sledge.
/:cl:
