### PR TITLE
Inflatable map replacement

### DIFF
--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -11301,7 +11301,7 @@
 /turf/open/floor/plating,
 /area/ice_colony/underground/maintenance/north)
 "bey" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 9
 	},
@@ -11315,7 +11315,7 @@
 /turf/closed/wall/r_wall,
 /area/ice_colony/underground/hangar)
 "beC" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 1
 	},
@@ -11504,7 +11504,7 @@
 /turf/open/floor/plating,
 /area/ice_colony/underground/maintenance/north)
 "bfw" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 8
 	},
@@ -23373,7 +23373,7 @@
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/hallway/south_east)
 "caB" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/ice_colony/exterior/underground/caves/ice_se)
 "caD" = (
@@ -24747,7 +24747,7 @@
 	},
 /area/ice_colony/surface/hydroponics/lobby)
 "fkV" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 10
 	},
@@ -29402,7 +29402,7 @@
 	},
 /area/ice_colony/surface/engineering/tool)
 "plZ" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 9
 	},

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -1130,7 +1130,7 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/kitchen)
 "aDt" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand4)
 "aDJ" = (
@@ -1933,7 +1933,7 @@
 /turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
 /area/lv624/ground/jungle7)
 "aYF" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/tile/red/yellowfull,
 /area/lv624/ground/sand4)
 "aYI" = (

--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -2344,7 +2344,7 @@
 /turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "bAF" = (
-/obj/structure/inflatable{
+/obj/structure/inflatable/wall{
 	dir = 8
 	},
 /obj/item/ammo_magazine/rifle/tx11{
@@ -2509,10 +2509,10 @@
 	},
 /area/gelida/indoors/a_block/admin)
 "bFV" = (
-/obj/structure/inflatable{
+/obj/structure/inflatable/wall{
 	dir = 8
 	},
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/admin)
 "bFY" = (
@@ -3236,7 +3236,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/cargo)
 "ceV" = (
-/obj/structure/inflatable{
+/obj/structure/inflatable/wall{
 	dir = 1
 	},
 /turf/open/floor/plating{
@@ -4180,7 +4180,7 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/a_block/security)
 "cJm" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /obj/effect/spawner/gibspawner/xeno,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/w_rockies)
@@ -4539,7 +4539,7 @@
 /turf/open/floor/mainship/black/full,
 /area/gelida/outdoors/rock)
 "cUS" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/admin)
 "cVg" = (
@@ -5104,10 +5104,10 @@
 	},
 /area/gelida/indoors/a_block/dorm_north)
 "dnt" = (
-/obj/structure/inflatable{
+/obj/structure/inflatable/wall{
 	dir = 1
 	},
-/obj/structure/inflatable{
+/obj/structure/inflatable/wall{
 	dir = 8
 	},
 /turf/open/floor/plating/ground/snow/layer0,
@@ -8016,7 +8016,7 @@
 /turf/open/floor/carpet,
 /area/gelida/indoors/c_block/garage)
 "faq" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/w_rockies)
@@ -9344,7 +9344,7 @@
 /turf/open/floor/mainship/black/full,
 /area/gelida/caves/west_caves)
 "gbZ" = (
-/obj/structure/inflatable{
+/obj/structure/inflatable/wall{
 	dir = 8
 	},
 /turf/open/floor/prison/plate,
@@ -10290,7 +10290,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/garage)
 "gGH" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/shuttle/dropship/eight,
 /area/gelida/landing_zone_forecon/UD6_Tornado)
 "gGM" = (
@@ -10781,7 +10781,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/indoors/a_block/corpo)
 "gUC" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/admin)
 "gUR" = (
@@ -14812,7 +14812,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/dorms)
 "jIt" = (
-/obj/structure/inflatable{
+/obj/structure/inflatable/wall{
 	dir = 1
 	},
 /turf/open/floor/prison/plate,
@@ -15452,7 +15452,7 @@
 /turf/open/floor/carpet,
 /area/gelida/indoors/a_block/executive)
 "kax" = (
-/obj/structure/inflatable{
+/obj/structure/inflatable/wall{
 	dir = 4
 	},
 /obj/effect/landmark/start/job/survivor,
@@ -18860,7 +18860,7 @@
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/bridges/corpo)
 "mnA" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/shuttle/dropship/five,
 /area/gelida/landing_zone_forecon/UD6_Tornado)
 "mnC" = (
@@ -19781,7 +19781,7 @@
 	},
 /area/gelida/outdoors/colony_streets/south_street)
 "mWs" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/shuttle/dropship/floor,
 /area/gelida/landing_zone_forecon/UD6_Tornado)
 "mWv" = (
@@ -22804,7 +22804,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/bridges/garden_bridge)
 "oUK" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/prison/blue{
 	dir = 8
 	},
@@ -23518,7 +23518,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/structure/inflatable{
+/obj/structure/inflatable/wall{
 	dir = 8
 	},
 /obj/structure/cable,
@@ -25243,7 +25243,7 @@
 	},
 /area/gelida/landing_zone_forecon/UD6_Tornado)
 "qwW" = (
-/obj/structure/inflatable{
+/obj/structure/inflatable/wall{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -26285,7 +26285,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/garage)
 "rcu" = (
-/obj/structure/inflatable{
+/obj/structure/inflatable/wall{
 	dir = 8
 	},
 /obj/item/ammo_magazine/rifle/tx11{
@@ -26792,7 +26792,7 @@
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/lone_buildings/storage_blocks)
 "rqp" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/w_rockies)
 "rqw" = (
@@ -27214,7 +27214,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/cargo)
 "rGi" = (
-/obj/structure/inflatable{
+/obj/structure/inflatable/wall{
 	dir = 1
 	},
 /turf/open/floor/prison/blue{
@@ -27505,7 +27505,7 @@
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/a_block/admin)
 "rQh" = (
-/obj/structure/inflatable{
+/obj/structure/inflatable/wall{
 	dir = 8
 	},
 /turf/open/floor/prison/blue/plate{
@@ -28234,7 +28234,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/south_west_street)
 "sqT" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/gelida/outdoors/w_rockies)
 "sqU" = (
@@ -29516,7 +29516,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/hallway)
 "tdi" = (
-/obj/structure/inflatable{
+/obj/structure/inflatable/wall{
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -31160,11 +31160,11 @@
 /area/gelida/indoors/a_block/dorms)
 "ujA" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/shuttle/dropship/four,
 /area/gelida/landing_zone_forecon/UD6_Tornado)
 "ujG" = (
-/obj/structure/inflatable{
+/obj/structure/inflatable/wall{
 	dir = 8
 	},
 /obj/item/ammo_magazine/rifle/tx11{
@@ -32509,7 +32509,7 @@
 /turf/open/floor/prison/darkbrown/full,
 /area/gelida/indoors/c_block/mining)
 "vgb" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/prison/blue/plate{
 	dir = 1
 	},
@@ -33971,7 +33971,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/gelida/indoors/a_block/corpo)
 "wcj" = (
-/obj/structure/inflatable{
+/obj/structure/inflatable/wall{
 	dir = 1
 	},
 /obj/item/weapon/gun/rifle/m41a,
@@ -34353,7 +34353,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/gelida/outdoors/w_rockies)
 "wqi" = (
-/obj/structure/inflatable{
+/obj/structure/inflatable/wall{
 	dir = 8
 	},
 /obj/machinery/power/apc/drained,
@@ -35758,7 +35758,7 @@
 	},
 /area/gelida/outdoors/colony_streets/north_street)
 "xrC" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/prison/darkred/full,
 /area/gelida/indoors/a_block/security)
 "xrD" = (

--- a/_maps/modularmaps/EORG/cs_mansion.dmm
+++ b/_maps/modularmaps/EORG/cs_mansion.dmm
@@ -231,7 +231,7 @@
 /area/deathmatch)
 "nN" = (
 /obj/effect/decal/cleanable/cobweb2,
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/wood,
 /area/deathmatch)
 "nP" = (
@@ -493,7 +493,7 @@
 /turf/open/floor/grass,
 /area/deathmatch)
 "zt" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/wood,
 /area/deathmatch)
 "zM" = (

--- a/_maps/modularmaps/EORG/cs_office.dmm
+++ b/_maps/modularmaps/EORG/cs_office.dmm
@@ -228,7 +228,7 @@
 	},
 /area/deathmatch)
 "gn" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /obj/machinery/light,
 /turf/open/floor/tile/arrival,
 /area/deathmatch)
@@ -476,7 +476,7 @@
 /turf/open/floor/plating,
 /area/deathmatch)
 "lH" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/stairs,
 /area/deathmatch)
 "mg" = (
@@ -715,7 +715,7 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/deathmatch)
 "ro" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/tile/arrival,
 /area/deathmatch)
 "rp" = (
@@ -1147,7 +1147,7 @@
 /turf/open/floor/tile/dark/blue2/corner,
 /area/deathmatch)
 "Aq" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/tile/arrival{
 	dir = 1
 	},
@@ -1939,7 +1939,7 @@
 /obj/structure/platform{
 	dir = 1
 	},
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/deathmatch)
 "To" = (
@@ -2251,7 +2251,7 @@
 /turf/open/floor/tile/dark2,
 /area/deathmatch)
 "Zx" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/tile/dark/gray,
 /area/deathmatch)
 "Zy" = (

--- a/_maps/modularmaps/EORG/de_dust2.dmm
+++ b/_maps/modularmaps/EORG/de_dust2.dmm
@@ -39,7 +39,7 @@
 /turf/open/floor/plating/ground/dirt,
 /area/deathmatch)
 "gA" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/tile,
 /area/deathmatch)
 "gC" = (
@@ -125,7 +125,7 @@
 /turf/open/floor/industrial,
 /area/deathmatch)
 "nz" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/industrial,
 /area/deathmatch)
 "nE" = (
@@ -452,7 +452,7 @@
 /turf/open/floor/industrial,
 /area/deathmatch)
 "QP" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/plating/ground/dirt,
 /area/deathmatch)
 "Sh" = (

--- a/_maps/modularmaps/EORG/de_inferno.dmm
+++ b/_maps/modularmaps/EORG/de_inferno.dmm
@@ -22,7 +22,7 @@
 /turf/open/floor/plating/asteroidfloor,
 /area/deathmatch)
 "aD" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/plating/asteroidplating,
 /area/deathmatch)
 "aH" = (
@@ -44,7 +44,7 @@
 /turf/open/floor/wood,
 /area/deathmatch)
 "bk" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/wood/broken,
 /area/deathmatch)
 "bl" = (
@@ -74,7 +74,7 @@
 /turf/open/ground/grass,
 /area/deathmatch)
 "by" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/wood,
 /area/deathmatch)
 "bB" = (
@@ -257,7 +257,7 @@
 /turf/open/floor/wood/broken,
 /area/deathmatch)
 "dB" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/plating/asteroidfloor,
 /area/deathmatch)
 "dF" = (
@@ -900,7 +900,7 @@
 	},
 /area/deathmatch)
 "tq" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/asteroidplating,
 /area/deathmatch)
@@ -1194,7 +1194,7 @@
 /turf/open/floor/wood,
 /area/deathmatch)
 "GT" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/asteroidfloor,
 /area/deathmatch)

--- a/_maps/modularmaps/big_red/bigredcheckpointsouthvar3.dmm
+++ b/_maps/modularmaps/big_red/bigredcheckpointsouthvar3.dmm
@@ -86,7 +86,7 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/southcheckpoint)
 "u" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/podhatch/floor,
 /area/bigredv2/outside/southcheckpoint)
 "v" = (

--- a/_maps/modularmaps/lv624/southsandtemple4.dmm
+++ b/_maps/modularmaps/lv624/southsandtemple4.dmm
@@ -537,7 +537,7 @@
 /area/lv624/ground/jungle8)
 "Vu" = (
 /obj/effect/turf_decal/sandytile,
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/sandtemple)
 "VY" = (
@@ -577,7 +577,7 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
 "Yf" = (
-/obj/structure/inflatable,
+/obj/structure/inflatable/wall,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/sandtemple)
 "Yg" = (


### PR DESCRIPTION

## About The Pull Request

Replaces the generic inflatable structures with walls like they should be.
## Why It's Good For The Game

Inflatable is a parent, its supposed to be a wall.
## Changelog
:cl:
fix: Replaced instances of generic inflatables with inflatable walls
/:cl:
