### PR TITLE
Makes large fuel tanks slightly cheaper.

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -565,12 +565,12 @@ WEAPONS
 /datum/supply_packs/weapons/napalm
 	name = "FL-84 normal fuel tank"
 	contains = list(/obj/item/ammo_magazine/flamer_tank/large)
-	cost = 60
+	cost = 40
 
 /datum/supply_packs/weapons/napalm_X
 	name = "FL-84 X fuel tank"
 	contains = list(/obj/item/ammo_magazine/flamer_tank/large/X)
-	cost = 300
+	cost = 120
 
 /datum/supply_packs/weapons/back_fuel_tank
 	name = "Standard back fuel tank"


### PR DESCRIPTION

## About The Pull Request
Large Flamer tank 60 -> 40
Large xfuel tank 300 -> 120
## Why It's Good For The Game
I personally think these are too expensive.
The large tanks contain 15% of the capacity of the back tank, yet are 50% of the cost.
I am reducing the cost to 20% the price of a back tank.
## Changelog
:cl:
balance: Large Flamer tank 60 points -> 40 points
balance: Large xfuel tank 300 points -> 120 points
/:cl:
