### PR TITLE
Rocket fix

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1787,7 +1787,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	drop_nade(get_turf(M))
 
 /datum/ammo/rocket/on_hit_obj(obj/O, obj/projectile/P)
-	drop_nade(get_turf(O))
+	drop_nade(O.density ? P.loc : O.loc)
 
 /datum/ammo/rocket/on_hit_turf(turf/T, obj/projectile/P)
 	drop_nade(T.density ? P.loc : T)


### PR DESCRIPTION

## About The Pull Request
Small fix to rockets, most notably incendiary ones. They will no longer detonate on the turf of an object they hit, as this causes various issues like going through windows/stopping most of the spread.
## Why It's Good For The Game
Bug fix good.
## Changelog
:cl:
fix: fixed some odd behavior when firing rockets at dense objects like windows or airlocks
/:cl:
