### PR TITLE
razorwire construction option changed to a ratio of 2 metal for 1 razorwire, with 2 razorwire being made with 4 metal

### DIFF
--- a/code/game/objects/items/stacks/barbed_wire.dm
+++ b/code/game/objects/items/stacks/barbed_wire.dm
@@ -27,10 +27,6 @@
 /obj/item/stack/barbed_wire/full
 	amount = 20
 
-/obj/item/stack/barbed_wire/attackby(obj/item/I, mob/user, params)
-	. = ..()
-
-
 /obj/item/stack/razorwire
 	name = "razor wire assembly"
 	desc = "A bundle of barbed wire supported by metal rods. Used to deny access to areas under pain of entanglement and injury. A classic fortification since the 1900s."

--- a/code/game/objects/items/stacks/barbed_wire.dm
+++ b/code/game/objects/items/stacks/barbed_wire.dm
@@ -27,6 +27,23 @@
 /obj/item/stack/barbed_wire/full
 	amount = 20
 
+/obj/item/stack/barbed_wire/attackby(obj/item/I, mob/user, params)
+	. = ..()
+
+	if(!istype(I,/obj/item/stack/rods))
+		return
+
+	var/obj/item/stack/rods/R = I
+	if(R.amount < 4)
+		to_chat(user, span_warning("You need [4 - R.amount] more [R] to make a razor wire obstacle!"))
+		return
+
+	R.use(4)
+	use(1)
+
+	var/obj/structure/razorwire/M = new /obj/item/stack/razorwire(user.loc, 3)
+	to_chat(user, span_notice("You combine the rods and barbed wire into [M]!"))
+
 /obj/item/stack/razorwire
 	name = "razor wire assembly"
 	desc = "A bundle of barbed wire supported by metal rods. Used to deny access to areas under pain of entanglement and injury. A classic fortification since the 1900s."

--- a/code/game/objects/items/stacks/barbed_wire.dm
+++ b/code/game/objects/items/stacks/barbed_wire.dm
@@ -30,7 +30,7 @@
 /obj/item/stack/barbed_wire/attackby(obj/item/I, mob/user, params)
 	. = ..()
 
-	if(!istype(I,/obj/item/stack/rods))
+	if(!istype(I, /obj/item/stack/rods))
 		return
 
 	var/obj/item/stack/rods/R = I

--- a/code/game/objects/items/stacks/barbed_wire.dm
+++ b/code/game/objects/items/stacks/barbed_wire.dm
@@ -30,19 +30,6 @@
 /obj/item/stack/barbed_wire/attackby(obj/item/I, mob/user, params)
 	. = ..()
 
-	if(!istype(I, /obj/item/stack/rods))
-		return
-
-	var/obj/item/stack/rods/R = I
-	if(R.amount < 4)
-		to_chat(user, span_warning("You need [4 - R.amount] more [R] to make a razor wire obstacle!"))
-		return
-
-	R.use(4)
-	use(1)
-
-	var/obj/structure/razorwire/M = new /obj/item/stack/razorwire(user.loc, 1)
-	to_chat(user, span_notice("You combine the rods and barbed wire into [M]!"))
 
 /obj/item/stack/razorwire
 	name = "razor wire assembly"

--- a/code/game/objects/items/stacks/barbed_wire.dm
+++ b/code/game/objects/items/stacks/barbed_wire.dm
@@ -34,14 +34,14 @@
 		return
 
 	var/obj/item/stack/rods/R = I
-	if(R.amount < 4)
-		to_chat(user, span_warning("You need [4 - R.amount] more [R] to make a razor wire obstacle!"))
+	if(R.amount < 8)
+		to_chat(user, span_warning("You need [8 - R.amount] more [R] to make a razor wire obstacle!"))
 		return
 
-	R.use(4)
+	R.use(8)
 	use(1)
 
-	var/obj/structure/razorwire/M = new /obj/item/stack/razorwire(user.loc, 3)
+	var/obj/structure/razorwire/M = new /obj/item/stack/razorwire(user.loc, 2)
 	to_chat(user, span_notice("You combine the rods and barbed wire into [M]!"))
 
 /obj/item/stack/razorwire

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -18,12 +18,12 @@
 
 	if(istype(W, /obj/item/stack/barbed_wire)) // making razorwire obstacles
 		var/obj/item/stack/barbed_wire/B = W
-		if(amount < 4)
-			to_chat(user, span_warning("You need at least [4 - amount] more [src] to make razorwire obstacles!"))
+		if(amount < 8)
+			to_chat(user, span_warning("You need at least [8 - amount] more [src] to make razorwire obstacles!"))
 			return
-		use(4)
+		use(8)
 		B.use(1)
-		var/obj/structure/razorwire/M = new /obj/item/stack/razorwire(user.loc, 3)
+		var/obj/structure/razorwire/M = new /obj/item/stack/razorwire(user.loc, 2)
 		to_chat(user, span_notice("You combine the rods and barbed wire into [M]!"))
 
 	if (iswelder(W))

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -15,15 +15,6 @@
 
 /obj/item/stack/rods/attackby(obj/item/W as obj, mob/user as mob)
 	..()
-	if(istype(W, /obj/item/stack/barbed_wire)) //making razorwire obstacles
-		var/obj/item/stack/barbed_wire/B = W
-		if(amount < 4)
-			to_chat(user, span_warning("You need [4 - amount] more [src] to make a razor wire obstacle!"))
-			return
-		use(4)
-		B.use(1)
-		var/obj/structure/razorwire/M = new/obj/item/stack/razorwire(user.loc, 1)
-		to_chat(user, span_notice("You combine the rods and barbed wire into [M]!"))
 
 	if (iswelder(W))
 		var/obj/item/tool/weldingtool/WT = W

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -16,6 +16,16 @@
 /obj/item/stack/rods/attackby(obj/item/W as obj, mob/user as mob)
 	..()
 
+	if(istype(W, /obj/item/stack/barbed_wire)) // making razorwire obstacles
+		var/obj/item/stack/barbed_wire/B = W
+		if(amount < 4)
+			to_chat(user, span_warning("You need at least [4 - amount] more [src] to make razorwire obstacles!"))
+			return
+		use(4)
+		B.use(1)
+		var/obj/structure/razorwire/M = new /obj/item/stack/razorwire(user.loc, 3)
+		to_chat(user, span_notice("You combine the rods and barbed wire into [M]!"))
+
 	if (iswelder(W))
 		var/obj/item/tool/weldingtool/WT = W
 

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -12,8 +12,8 @@
 */
 GLOBAL_LIST_INIT(metal_recipes, list ( \
 	new/datum/stack_recipe("metal barricade", /obj/structure/barricade/metal, 4, time = 8 SECONDS, max_per_turf = STACK_RECIPE_ONE_DIRECTIONAL_PER_TILE, on_floor = TRUE, skill_req = SKILL_CONSTRUCTION_METAL), \
-	new/datum/stack_recipe("barbed wire", /obj/item/stack/barbed_wire, 2, 1, 20, time = 1 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), \
-	new/datum/stack_recipe("razor wire", /obj/item/stack/razorwire, 3, 1, 20, time = 5 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), \
+	new/datum/stack_recipe("barbed wire", /obj/item/stack/barbed_wire, 1, 1, 20, time = 1 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), \
+	new/datum/stack_recipe("razor wire", /obj/item/stack/razorwire, 2, 1, 20, time = 5 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), \
 	null, \
 	new/datum/stack_recipe("apc frame", /obj/item/frame/apc, 2), \
 	new/datum/stack_recipe("wall girder", /obj/structure/girder, 8, time = 10 SECONDS, max_per_turf = STACK_RECIPE_ONE_PER_TILE, on_floor = TRUE, skill_req = SKILL_CONSTRUCTION_ADVANCED), \
@@ -100,9 +100,9 @@ GLOBAL_LIST_INIT(metal_radial_images, list(
 		if("barricade")
 			create_object(user, new/datum/stack_recipe("metal barricade", /obj/structure/barricade/metal, 4, time = 8 SECONDS, max_per_turf = STACK_RECIPE_ONE_DIRECTIONAL_PER_TILE, on_floor = TRUE, skill_req = SKILL_CONSTRUCTION_METAL), 1)
 		if("barbedwire")
-			create_object(user, new/datum/stack_recipe("barbed wire", /obj/item/stack/barbed_wire, 2, 1, 20, time = 1 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), 1)
+			create_object(user, new/datum/stack_recipe("barbed wire", /obj/item/stack/barbed_wire, 1, 1, 20, time = 1 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), 1)
 		if("razorwire")
-			create_object(user, new/datum/stack_recipe("razor wire", /obj/item/stack/razorwire, 3, 1, 20, time = 5 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), 1)
+			create_object(user, new/datum/stack_recipe("razor wire", /obj/item/stack/razorwire, 2, 1, 20, time = 5 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), 1)
 
 	return FALSE
 

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -13,7 +13,7 @@
 GLOBAL_LIST_INIT(metal_recipes, list ( \
 	new/datum/stack_recipe("metal barricade", /obj/structure/barricade/metal, 4, time = 8 SECONDS, max_per_turf = STACK_RECIPE_ONE_DIRECTIONAL_PER_TILE, on_floor = TRUE, skill_req = SKILL_CONSTRUCTION_METAL), \
 	new/datum/stack_recipe("barbed wire", /obj/item/stack/barbed_wire, 2, 1, 20, time = 1 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), \
-	new/datum/stack_recipe("razor wire", /obj/item/stack/razorwire, 3, 3, 20, time = 5 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), \
+	new/datum/stack_recipe("razor wire", /obj/item/stack/razorwire, 4, 2, 20, time = 5 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), \
 	null, \
 	new/datum/stack_recipe("apc frame", /obj/item/frame/apc, 2), \
 	new/datum/stack_recipe("wall girder", /obj/structure/girder, 8, time = 10 SECONDS, max_per_turf = STACK_RECIPE_ONE_PER_TILE, on_floor = TRUE, skill_req = SKILL_CONSTRUCTION_ADVANCED), \
@@ -102,7 +102,7 @@ GLOBAL_LIST_INIT(metal_radial_images, list(
 		if("barbedwire")
 			create_object(user, new/datum/stack_recipe("barbed wire", /obj/item/stack/barbed_wire, 2, 1, 20, time = 1 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), 1)
 		if("razorwire")
-			create_object(user, new/datum/stack_recipe("razor wire", /obj/item/stack/razorwire, 3, 3, 20, time = 5 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), 1)
+			create_object(user, new/datum/stack_recipe("razor wire", /obj/item/stack/razorwire, 4, 2, 20, time = 5 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), 1)
 
 	return FALSE
 

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -13,7 +13,7 @@
 GLOBAL_LIST_INIT(metal_recipes, list ( \
 	new/datum/stack_recipe("metal barricade", /obj/structure/barricade/metal, 4, time = 8 SECONDS, max_per_turf = STACK_RECIPE_ONE_DIRECTIONAL_PER_TILE, on_floor = TRUE, skill_req = SKILL_CONSTRUCTION_METAL), \
 	new/datum/stack_recipe("barbed wire", /obj/item/stack/barbed_wire, 2, 1, 20, time = 1 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), \
-	new/datum/stack_recipe("razor wire", /obj/item/stack/razorwire, 2, 1, 20, time = 5 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), \
+	new/datum/stack_recipe("razor wire", /obj/item/stack/razorwire, 3, 3, 20, time = 5 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), \
 	null, \
 	new/datum/stack_recipe("apc frame", /obj/item/frame/apc, 2), \
 	new/datum/stack_recipe("wall girder", /obj/structure/girder, 8, time = 10 SECONDS, max_per_turf = STACK_RECIPE_ONE_PER_TILE, on_floor = TRUE, skill_req = SKILL_CONSTRUCTION_ADVANCED), \
@@ -102,7 +102,7 @@ GLOBAL_LIST_INIT(metal_radial_images, list(
 		if("barbedwire")
 			create_object(user, new/datum/stack_recipe("barbed wire", /obj/item/stack/barbed_wire, 2, 1, 20, time = 1 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), 1)
 		if("razorwire")
-			create_object(user, new/datum/stack_recipe("razor wire", /obj/item/stack/razorwire, 2, 1, 20, time = 5 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), 1)
+			create_object(user, new/datum/stack_recipe("razor wire", /obj/item/stack/razorwire, 3, 3, 20, time = 5 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), 1)
 
 	return FALSE
 

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -12,7 +12,7 @@
 */
 GLOBAL_LIST_INIT(metal_recipes, list ( \
 	new/datum/stack_recipe("metal barricade", /obj/structure/barricade/metal, 4, time = 8 SECONDS, max_per_turf = STACK_RECIPE_ONE_DIRECTIONAL_PER_TILE, on_floor = TRUE, skill_req = SKILL_CONSTRUCTION_METAL), \
-	new/datum/stack_recipe("barbed wire", /obj/item/stack/barbed_wire, 1, 1, 20, time = 1 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), \
+	new/datum/stack_recipe("barbed wire", /obj/item/stack/barbed_wire, 2, 1, 20, time = 1 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), \
 	new/datum/stack_recipe("razor wire", /obj/item/stack/razorwire, 2, 1, 20, time = 5 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), \
 	null, \
 	new/datum/stack_recipe("apc frame", /obj/item/frame/apc, 2), \
@@ -100,7 +100,7 @@ GLOBAL_LIST_INIT(metal_radial_images, list(
 		if("barricade")
 			create_object(user, new/datum/stack_recipe("metal barricade", /obj/structure/barricade/metal, 4, time = 8 SECONDS, max_per_turf = STACK_RECIPE_ONE_DIRECTIONAL_PER_TILE, on_floor = TRUE, skill_req = SKILL_CONSTRUCTION_METAL), 1)
 		if("barbedwire")
-			create_object(user, new/datum/stack_recipe("barbed wire", /obj/item/stack/barbed_wire, 1, 1, 20, time = 1 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), 1)
+			create_object(user, new/datum/stack_recipe("barbed wire", /obj/item/stack/barbed_wire, 2, 1, 20, time = 1 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), 1)
 		if("razorwire")
 			create_object(user, new/datum/stack_recipe("razor wire", /obj/item/stack/razorwire, 2, 1, 20, time = 5 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), 1)
 

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -22,7 +22,7 @@
 		if(obj_integrity > max_integrity * 0.5)
 			new sheet_type(loc)
 		var/obj/item/stack/rods/salvage = new sheet_type2(loc)
-		salvage.amount = min(1, round(4 * (obj_integrity / max_integrity) ) )
+		salvage.amount = max(1, round(4 * (obj_integrity / max_integrity) ) )
 	else
 		if(prob(50))
 			new sheet_type(loc)

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -11,7 +11,7 @@
 	climbable = TRUE
 	resistance_flags = XENO_DAMAGEABLE
 	var/list/entangled_list
-	var/sheet_type = /obj/item/stack/sheet/metal
+	var/sheet_type = /obj/item/stack/barbed_wire
 	var/sheet_type2 = /obj/item/stack/rods
 	var/table_prefix = "" //used in update_icon()
 	max_integrity = RAZORWIRE_MAX_HEALTH

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -11,7 +11,7 @@
 	climbable = TRUE
 	resistance_flags = XENO_DAMAGEABLE
 	var/list/entangled_list
-	var/sheet_type = /obj/item/stack/barbed_wire
+	var/sheet_type = /obj/item/stack/sheet/metal
 	var/sheet_type2 = /obj/item/stack/rods
 	var/table_prefix = "" //used in update_icon()
 	max_integrity = RAZORWIRE_MAX_HEALTH


### PR DESCRIPTION
## About The Pull Request

1 units of razorwire now costs 2 metal. This will change how much stuff engineers can build and reinforce. This does not affect razorBURN grenades. Only handbuild razorwire.

## Why It's Good For The Game

Compared to razorburn, razorwire is very expensive. I believe this should make it so that razorwire is good for prepared positions, and razorburn remains good for quick plans. This does not change the actual damage, effects, or the fact crushers can delete razorwire at 50 integrity. Only the cost. 

## Changelog

:cl:
balance: razorwire construction options now makes 2 razorwire instead of 1 for 4 metal.
fix: Changed a min to a max to allow deconstructing razorwire
/:cl: