### PR TITLE
Fixes resin doors not being damagable in melee

### DIFF
--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -76,11 +76,10 @@
 
 
 /obj/structure/mineral_door/attackby(obj/item/W, mob/living/user)
-	if((W.flags_item & NOBLUDGEON) && !W.force)
-		attack_hand(user)
+	. = ..()
+	if(QDELETED(src))
 		return
 
-	user.changeNext_move(W.attack_speed)
 	var/multiplier = 1
 	if(istype(W, /obj/item/tool/pickaxe/plasmacutter) && !user.do_actions)
 		var/obj/item/tool/pickaxe/plasmacutter/P = W
@@ -92,9 +91,8 @@
 			P.cut_apart(user, src.name, src, PLASMACUTTER_BASE_COST * PLASMACUTTER_VLOW_MOD) //Minimal energy cost.
 	if(W.damtype == BURN && istype(src, /obj/structure/mineral_door/resin)) //Burn damage deals extra vs resin structures (mostly welders).
 		multiplier += 1 //generally means we do double damage to resin doors
-	user.do_attack_animation(src, used_item = W)
-	if(!istype(W, /obj/item/tool/pickaxe/plasmacutter))
-		to_chat(user, "You hit [src] with [name]!")
+
+	take_damage(W.force * multiplier - W.force, W.damtype)
 
 /obj/structure/mineral_door/Destroy()
 	if(material_type)

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -150,7 +150,10 @@
 		SMOOTH_GROUP_SURVIVAL_TITANIUM_WALLS,
 		SMOOTH_GROUP_MINERAL_STRUCTURES,
 	)
+	soft_armor = list(MELEE = 50, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 15, BIO = 0, FIRE = 0, ACID = 0)
 	trigger_sound = "alien_resin_move"
+	hit_sound = "alien_resin_move"
+	destroy_sound = "alien_resin_move"
 
 	///The delay before the door closes automatically after being open
 	var/close_delay = 10 SECONDS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Apparently this never called parent but used the stupid hardness system!

Gave doors 50 soft armor against melee so it feels the same as it was pre refactor.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bug fix.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed resin doors not being damagable in melee
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
