### PR TITLE
Fixes cloaking for scout droids

### DIFF
--- a/code/modules/vehicles/unmanned/unmanned_droid.dm
+++ b/code/modules/vehicles/unmanned/unmanned_droid.dm
@@ -79,7 +79,7 @@
 
 /obj/vehicle/unmanned/droid/scout/on_remote_toggle(datum/source, is_on, mob/user)
 	. = ..()
-	SEND_SIGNAL(src, COMSIG_UNMANNED_ABILITY_UPDATED)
+	SEND_SIGNAL(src, COMSIG_UNMANNED_ABILITY_UPDATED, CLOAK_ABILITY)
 
 ///runs checks for cloaking then begins to cloak it
 /obj/vehicle/unmanned/droid/scout/proc/cloak_drone(datum/source)


### PR DESCRIPTION

## About The Pull Request

Add the CLOAK_ABILITY to scout droids (thanks to fsh#4154 on discord)
## Why It's Good For The Game

Allows scout droids to cloak again which was broken by pull #10864
## Changelog

:cl:
fix: Scout droids being able to cloak again
/:cl:
