### PR TITLE
You no longer keep healthscan/defib gloves after being delimbed.

### DIFF
--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -350,6 +350,10 @@
 	else
 		UnregisterSignal(user, COMSIG_HUMAN_MELEE_UNARMED_ATTACK)
 
+/obj/item/defibrillator/gloves/unequipped(mob/living/carbon/human/user, slot)
+	. = ..()
+	UnregisterSignal(user, COMSIG_HUMAN_MELEE_UNARMED_ATTACK) //Unregisters in the case of getting delimbed
+
 //when you are wearing these gloves, this will call the normal attack code to begin defibing the target
 /obj/item/defibrillator/gloves/proc/on_unarmed_attack(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(istype(user) && istype(target))

--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -298,6 +298,10 @@ REAGENT SCANNER
 	else
 		UnregisterSignal(user, COMSIG_HUMAN_MELEE_UNARMED_ATTACK)
 
+/obj/item/healthanalyzer/gloves/unequipped(mob/living/carbon/human/user, slot)
+	. = ..()
+	UnregisterSignal(user, COMSIG_HUMAN_MELEE_UNARMED_ATTACK) //Unregisters in the case of getting delimbed
+
 //when you are wearing these gloves, this will call the normal attack code to health scan the target
 /obj/item/healthanalyzer/gloves/proc/on_unarmed_attack(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(istype(user) && istype(target))


### PR DESCRIPTION

## About The Pull Request
Bugfix.
Currently, you keep the defib/healthscan gloves effect if you get delimbed because unregister only gets called on equip.
## Why It's Good For The Game
Bugfix
## Changelog
:cl:
fix: You can no longer magically health scan/defib after being delimbed while wearing scan/defib gloves.
/:cl:
