### PR TITLE
Unmanned Vehicles now leave behind robot gibs when destroyed

### DIFF
--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -73,9 +73,10 @@
 	SSminimaps.add_marker(src, z, MINIMAP_FLAG_MARINE, "uav")
 
 /obj/vehicle/unmanned/Destroy()
-	. = ..()
 	GLOB.unmanned_vehicles -= src
 	QDEL_NULL(flash)
+	robogibs(src)
+	return ..()
 
 /obj/vehicle/unmanned/take_damage(damage_amount, damage_type, damage_flag, effects, attack_dir, armour_penetration)
 	. = ..()

--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -73,8 +73,11 @@
 	SSminimaps.add_marker(src, z, MINIMAP_FLAG_MARINE, "uav")
 
 /obj/vehicle/unmanned/Destroy()
+	. = ..()
 	GLOB.unmanned_vehicles -= src
 	QDEL_NULL(flash)
+
+/obj/vehicle/unmanned/obj_destruction()
 	robogibs(src)
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request

Destroying an unmanned vehicle (+ droids because subtype) leaves behind gibs and sparks instead of being banished to the shadow realm

## Why It's Good For The Game
looks cool
## Changelog
:cl:
add: robot gibs for unmanned vehicles
/:cl:
