### PR TITLE
Swaps dexaline for isotonic in lifesaver belt

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -107,7 +107,7 @@
 	new /obj/item/storage/pill_bottle/tricordrazine(src)
 	new /obj/item/storage/pill_bottle/dylovene(src)
 	new /obj/item/storage/pill_bottle/inaprovaline(src)
-	new /obj/item/storage/pill_bottle/dexalin(src)
+	new /obj/item/storage/pill_bottle/isotonic(src)
 	new /obj/item/storage/pill_bottle/spaceacillin(src)
 	new /obj/item/storage/pill_bottle/alkysine(src)
 	new /obj/item/storage/pill_bottle/imidazoline(src)


### PR DESCRIPTION

## About The Pull Request
Swaps the dexaline pill bottle in lifesaver belt for an isotonic solution pill bottle

## Why It's Good For The Game
Dexaline's use is redundant in most cases when you have inaprovaline. As it is, the default loadout has no real blood replenishing options so a corpsman has to go out of their way to get one. Shouldn't be too big a change given both are available from vendors anyway, so more of a qol change than balance.

## Changelog

:cl:
balance: Dexaline pill bottle in lifesaver belts replaced with Isotonic Solution pill bottle
/:cl:

