### PR TITLE
Corpsman vendor has QC+ and Peri+ hypos

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -98,6 +98,8 @@ GLOBAL_LIST_INIT(medic_gear_listed_products, list(
 		/obj/item/reagent_containers/hypospray/autoinjector/combat_advanced = list(CAT_MEDSUP, "Injector (Advanced)", 5, "black"),
 		/obj/item/reagent_containers/hypospray/autoinjector/quickclotplus = list(CAT_MEDSUP, "Injector (QuickclotPlus)", 1, "orange"),
 		/obj/item/reagent_containers/hypospray/autoinjector/peridaxon_plus = list(CAT_MEDSUP, "Injector (Peridaxon Plus)", 1, "orange"),
+		/obj/item/reagent_containers/hypospray/advanced/quickclotplus = list(CAT_MEDSUP, "Hypospray (QuickclotPlus)", 4, "black"),
+		/obj/item/reagent_containers/hypospray/advanced/peridaxonplus = list(CAT_MEDSUP, "Hypospray (Peridaxon Plus)", 7, "black"),
 		/obj/item/reagent_containers/hypospray/autoinjector/synaptizine = list(CAT_MEDSUP, "Injector (Synaptizine)", 4, "orange"),
 		/obj/item/reagent_containers/hypospray/autoinjector/neuraline = list(CAT_MEDSUP, "Injector (Neuraline)", 14, "orange"),
 		/obj/item/reagent_containers/hypospray/advanced = list(CAT_MEDSUP, "Hypospray", 2, "orange"),

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -498,7 +498,7 @@
 /obj/item/reagent_containers/hypospray/advanced/quickclotplus
 	name = "Quickclot+ hypospray"
 	desc = "A hypospray loaded with quick-clot plus, a chemical designed to remove internal bleeding. Use with antitoxin. !DO NOT USE IN ACTIVE COMBAT!"
-	amount_per_transfer_from_this = 3
+	amount_per_transfer_from_this = 5
 	list_reagents = list(
 		/datum/reagent/medicine/quickclotplus = 60,
 	)

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -485,6 +485,25 @@
 	)
 	description_overlay = "Na"
 
+/obj/item/reagent_containers/hypospray/advanced/peridaxonplus
+	name = "Peridaxon+ hypospray"
+	desc = "A hypospray loaded with Peridaxon Plus, a chemical that heals organs while causing a buildup of toxins. Use with antitoxin. !DO NOT USE IN ACTIVE COMBAT!"
+	amount_per_transfer_from_this = 3
+	list_reagents = list(
+		/datum/reagent/medicine/peridaxon_plus = 20,
+		/datum/reagent/medicine/hyronalin = 40,
+	)
+	description_overlay = "Pe+"
+
+/obj/item/reagent_containers/hypospray/advanced/quickclotplus
+	name = "Quickclot+ hypospray"
+	desc = "A hypospray loaded with quick-clot plus, a chemical designed to remove internal bleeding. Use with antitoxin. !DO NOT USE IN ACTIVE COMBAT!"
+	amount_per_transfer_from_this = 3
+	list_reagents = list(
+		/datum/reagent/medicine/quickclotplus = 60,
+	)
+	description_overlay = "Qk"
+
 /obj/item/reagent_containers/hypospray/advanced/big
 	name = "big hypospray"
 	desc = "MK2 medical hypospray, which manages to fit even more reagents. Comes complete with an internal reagent analyzer and digital labeler. Handy. This one is a 120 unit version."

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -502,7 +502,7 @@
 	list_reagents = list(
 		/datum/reagent/medicine/quickclotplus = 60,
 	)
-	description_overlay = "Qk"
+	description_overlay = "Qk+"
 
 /obj/item/reagent_containers/hypospray/advanced/big
 	name = "big hypospray"


### PR DESCRIPTION

## About The Pull Request
Literally just the injectors stuffed into basic hyposprays.

## Why It's Good For The Game
Less busywork for whoever wants to vend the injectors and put them in hypos. QC+ is same cost as 4 injectors. Peri+ is the same cost as 7 injectors, since even if you have some leftover in an injector you still need to spend 7 to get them. Zero balance impact, the vendors even have empty hyposprays to vend to say nothing of the rest of vendable hypos to empty and refill.

## Changelog

:cl:
qol: Corpsman vendor now has hypospray option for QC+ and Peri+
/:cl:

