### PR TITLE
Acid on walls gets deleted if the wall gets deleted

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -135,7 +135,7 @@
 	DISABLE_BITFIELD(flags_atom, INITIALIZED)
 	soft_armor = null
 	hard_armor = null
-	current_acid = null
+	QDEL_NULL(current_acid)
 	..()
 	return QDEL_HINT_IWILLGC
 


### PR DESCRIPTION

## About The Pull Request

To not have acid floating even after the wall is gone. (from it being destroyed from a charge or explosion, etc)
## Why It's Good For The Game

Bug.
## Changelog
:cl:
fix: Acid on walls gets deleted if the wall gets deleted
/:cl:
