### PR TITLE
Thirds non-laser CAS weapon costs.

### DIFF
--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -329,6 +329,13 @@
 	ammo_type = CAS_LASER_BATTERY
 	cas_effect = /obj/effect/overlay/blinking_laser/laser
 
+/obj/structure/ship_ammo/laser_battery/focused
+	name = "focused laser battery"
+	desc = "A specialized laser battery designed for extreme precision. Moving this will require some sort of lifter."
+	ammo_used_per_firing = 10
+	laze_radius = 1
+	point_cost = 100
+
 /obj/structure/ship_ammo/laser_battery/examine(mob/user)
 	. = ..()
 	. += "It's at [round(100*ammo_count/max_ammo_count)]% charge."

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -329,13 +329,6 @@
 	ammo_type = CAS_LASER_BATTERY
 	cas_effect = /obj/effect/overlay/blinking_laser/laser
 
-/obj/structure/ship_ammo/laser_battery/focused
-	name = "focused laser battery"
-	desc = "A specialized laser battery designed for extreme precision. Moving this will require some sort of lifter."
-	ammo_used_per_firing = 10
-	laze_radius = 1
-	point_cost = 100
-
 /obj/structure/ship_ammo/laser_battery/examine(mob/user)
 	. = ..()
 	. += "It's at [round(100*ammo_count/max_ammo_count)]% charge."

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -859,7 +859,7 @@
 	desc = "A dismounted GAU-21 'Rattler' 30mm rotary cannon. It seems to be missing its feed links and has exposed connection wires. Capable of firing 5200 rounds a minute, feared by many for its power. Earned the nickname 'Rattler' from the vibrations it would cause on dropships in its inital production run. Moving this will require some sort of lifter."
 	icon_state = "30mm_cannon"
 	firing_sound = 'sound/weapons/gunship_chaingun.ogg'
-	point_cost = 100
+	point_cost = 150
 	dropship_equipment_flags = USES_AMMO|IS_WEAPON|IS_INTERACTABLE
 	ammo_type_used = CAS_30MM
 
@@ -887,7 +887,7 @@
 	desc = "A rocket pod weapon system capable of launching a single laser-guided rocket. Moving this will require some sort of lifter."
 	firing_sound = 'sound/weapons/gunship_rocket.ogg'
 	firing_delay = 5
-	point_cost = 100
+	point_cost = 200
 	ammo_type_used = CAS_MISSILE
 
 /obj/structure/dropship_equipment/weapon/rocket_pod/deplete_ammo()
@@ -911,7 +911,7 @@
 	icon = 'icons/Marine/mainship_props64.dmi'
 	firing_sound = 'sound/weapons/gunship_rocketpod.ogg'
 	firing_delay = 10 //1 seconds
-	point_cost = 100
+	point_cost = 200
 	ammo_type_used = CAS_MINI_ROCKET
 
 /obj/structure/dropship_equipment/weapon/minirocket_pod/update_icon()
@@ -935,7 +935,7 @@
 	icon = 'icons/Marine/mainship_props64.dmi'
 	firing_sound = 'sound/weapons/gunship_laser.ogg'
 	firing_delay = 50 //5 seconds
-	point_cost = 450
+	point_cost = 600
 	dropship_equipment_flags = USES_AMMO|IS_WEAPON|IS_INTERACTABLE
 	ammo_type_used = CAS_LASER_BATTERY
 

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -859,7 +859,7 @@
 	desc = "A dismounted GAU-21 'Rattler' 30mm rotary cannon. It seems to be missing its feed links and has exposed connection wires. Capable of firing 5200 rounds a minute, feared by many for its power. Earned the nickname 'Rattler' from the vibrations it would cause on dropships in its inital production run. Moving this will require some sort of lifter."
 	icon_state = "30mm_cannon"
 	firing_sound = 'sound/weapons/gunship_chaingun.ogg'
-	point_cost = 400
+	point_cost = 150
 	dropship_equipment_flags = USES_AMMO|IS_WEAPON|IS_INTERACTABLE
 	ammo_type_used = CAS_30MM
 
@@ -887,7 +887,7 @@
 	desc = "A rocket pod weapon system capable of launching a single laser-guided rocket. Moving this will require some sort of lifter."
 	firing_sound = 'sound/weapons/gunship_rocket.ogg'
 	firing_delay = 5
-	point_cost = 600
+	point_cost = 100
 	ammo_type_used = CAS_MISSILE
 
 /obj/structure/dropship_equipment/weapon/rocket_pod/deplete_ammo()
@@ -911,7 +911,7 @@
 	icon = 'icons/Marine/mainship_props64.dmi'
 	firing_sound = 'sound/weapons/gunship_rocketpod.ogg'
 	firing_delay = 10 //1 seconds
-	point_cost = 600
+	point_cost = 100
 	ammo_type_used = CAS_MINI_ROCKET
 
 /obj/structure/dropship_equipment/weapon/minirocket_pod/update_icon()
@@ -935,7 +935,7 @@
 	icon = 'icons/Marine/mainship_props64.dmi'
 	firing_sound = 'sound/weapons/gunship_laser.ogg'
 	firing_delay = 50 //5 seconds
-	point_cost = 600
+	point_cost = 450
 	dropship_equipment_flags = USES_AMMO|IS_WEAPON|IS_INTERACTABLE
 	ammo_type_used = CAS_LASER_BATTERY
 

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -859,7 +859,7 @@
 	desc = "A dismounted GAU-21 'Rattler' 30mm rotary cannon. It seems to be missing its feed links and has exposed connection wires. Capable of firing 5200 rounds a minute, feared by many for its power. Earned the nickname 'Rattler' from the vibrations it would cause on dropships in its inital production run. Moving this will require some sort of lifter."
 	icon_state = "30mm_cannon"
 	firing_sound = 'sound/weapons/gunship_chaingun.ogg'
-	point_cost = 150
+	point_cost = 100
 	dropship_equipment_flags = USES_AMMO|IS_WEAPON|IS_INTERACTABLE
 	ammo_type_used = CAS_30MM
 


### PR DESCRIPTION
## About The Pull Request

Thirds all non-laser CAS weapon costs in the printer.

## Why It's Good For The Game

All shipmaps start with two of each non-laser weapon already, and using more is never efficient, as it means you are not using some of the starting PO ammo. This enables fringe gimmick strategies (FIVE 30MMS BAYBEE) without really powercreeping the PO, as they still have to actually pay for all the ammo they want to use.

## Changelog
:cl:
balance: Divided the cost of non-laser CAS weapons by three.
/:cl:
