### PR TITLE
Reverts larval hugger to manual removal.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -441,9 +441,6 @@
 		if(species?.species_flags & (IS_SYNTHETIC|ROBOTIC_LIMBS))
 			return FALSE
 
-	if(on_fire)
-		return FALSE
-
 	if(check_mask)
 		if(wear_mask)
 			var/obj/item/W = wear_mask


### PR DESCRIPTION
## About The Pull Request

As the title states, this is a revert back to previous larval huggers being able to hug a human without being able to burn them off, requiring manual removal by a squad mate. https://github.com/tgstation/TerraGov-Marine-Corps/pull/1937

## Why It's Good For The Game

Ahem, this is going to be a heavily debated topic to some people. Alright, so the reason behind why I think this is a necessary change is based around several reasons. It's been 4 years since the PR for it, to which many things have changed significantly within the codebase, while it was much simpler in those terms where perhaps burning huggers off was necessary, it has no place currently in modern TGMC.

:cl:
balance: Facehuggers can no longer be burned off
/:cl:
