### PR TITLE
Fixes Evac cryo pod ghosting you immediately if you start getting into it.

### DIFF
--- a/code/game/objects/machinery/cryopod.dm
+++ b/code/game/objects/machinery/cryopod.dm
@@ -262,7 +262,7 @@
 	if(helper && user != helper)
 		if(user.stat == DEAD)
 			to_chat(helper, span_notice("[user] is dead!"))
-			return
+			return FALSE
 
 		helper.visible_message(span_notice("[helper] starts putting [user] into [src]."),
 		span_notice("You start putting [user] into [src]."))
@@ -272,18 +272,16 @@
 
 	var/mob/initiator = helper ? helper : user
 	if(!do_after(initiator, 20, TRUE, user, BUSY_ICON_GENERIC))
-		return
+		return FALSE
 
 	if(!QDELETED(occupant))
 		to_chat(initiator, span_warning("[src] is occupied."))
-		return
+		return FALSE
 
 	user.forceMove(src)
 	occupant = user
 	update_icon()
-
-	if(istype(src, /obj/machinery/cryopod/evacuation)) //Will ghost you if it's an evac pod
-		user.ghostize(FALSE)
+	return TRUE
 
 /obj/machinery/cryopod/proc/go_out()
 	if(QDELETED(occupant))

--- a/code/game/objects/machinery/cryopod.dm
+++ b/code/game/objects/machinery/cryopod.dm
@@ -279,9 +279,11 @@
 		return
 
 	user.forceMove(src)
-
 	occupant = user
 	update_icon()
+
+	if(istype(src, /obj/machinery/cryopod/evacuation)) //Will ghost you if it's an evac pod
+		user.ghostize(FALSE)
 
 /obj/machinery/cryopod/proc/go_out()
 	if(QDELETED(occupant))

--- a/code/modules/shuttle/escape_pod.dm
+++ b/code/modules/shuttle/escape_pod.dm
@@ -157,10 +157,6 @@
 		M.cryopods += src
 		linked_to_shuttle = TRUE
 
-/obj/machinery/cryopod/evacuation/climb_in(mob/living/carbon/user, mob/helper)
-	. = ..()
-	user.ghostize(FALSE)
-
 /obj/machinery/door/airlock/evacuation
 	name = "\improper Evacuation Airlock"
 	icon = 'icons/obj/doors/mainship/pod_doors.dmi'

--- a/code/modules/shuttle/escape_pod.dm
+++ b/code/modules/shuttle/escape_pod.dm
@@ -159,7 +159,7 @@
 
 /obj/machinery/cryopod/evacuation/climb_in(mob/living/carbon/user, mob/helper)
 	. = ..()
-	if(. == TRUE)
+	if(.)
 		user.ghostize(FALSE)
 
 /obj/machinery/door/airlock/evacuation

--- a/code/modules/shuttle/escape_pod.dm
+++ b/code/modules/shuttle/escape_pod.dm
@@ -157,6 +157,11 @@
 		M.cryopods += src
 		linked_to_shuttle = TRUE
 
+/obj/machinery/cryopod/evacuation/climb_in(mob/living/carbon/user, mob/helper)
+	. = ..()
+	if(. == TRUE)
+		user.ghostize(FALSE)
+
 /obj/machinery/door/airlock/evacuation
 	name = "\improper Evacuation Airlock"
 	icon = 'icons/obj/doors/mainship/pod_doors.dmi'


### PR DESCRIPTION

## About The Pull Request
Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/12371
## Why It's Good For The Game
bugfix
## Changelog
:cl:
fix: Cancelling the channel to enter a cryo pod on the evac shuttle will no longer ghost you.
/:cl:
