### PR TITLE
Tac-reloadable guns are opaque (so when in hands)

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -430,6 +430,10 @@
 		return
 	drop_connected_mag(chamber_items[current_chamber_position], user)
 
+/obj/item/weapon/gun/unequipped(mob/user, slot)
+	. = ..()
+	mouse_opacity = MOUSE_OPACITY_ICON //So that it doesnt remain opaque when you drop or discard the gun
+
 ///Set the user in argument as gun_user
 /obj/item/weapon/gun/proc/set_gun_user(mob/user)
 	active_attachable?.set_gun_user(user)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -413,12 +413,12 @@
 		O.emp_act(severity)
 
 /obj/item/weapon/gun/equipped(mob/user, slot)
-	unwield(user)
 	if(ishandslot(slot))
 		set_gun_user(user)
 		mouse_opacity = MOUSE_OPACITY_OPAQUE
 	else
 		set_gun_user(null)
+	unwield(user)
 	return ..()
 
 /obj/item/weapon/gun/removed_from_inventory(mob/user)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -413,8 +413,8 @@
 		O.emp_act(severity)
 
 /obj/item/weapon/gun/equipped(mob/user, slot)
-	if(ishandslot(slot) || slot == SLOT_BACK || slot == SLOT_BELT || slot == SLOT_S_STORE)	//add more if needed
-		mouse_opacity = MOUSE_OPACITY_OPAQUE //so it's easier to click when properly equipped.
+	if(ishandslot(slot))	//Same slots as tac reload
+		mouse_opacity = MOUSE_OPACITY_OPAQUE
 	unwield(user)
 	if(ishandslot(slot))
 		set_gun_user(user)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -417,8 +417,8 @@
 	if(ishandslot(slot))
 		set_gun_user(user)
 		mouse_opacity = MOUSE_OPACITY_OPAQUE
-		return ..()
-	set_gun_user(null)
+	else
+		set_gun_user(null)
 	return ..()
 
 /obj/item/weapon/gun/removed_from_inventory(mob/user)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -413,11 +413,10 @@
 		O.emp_act(severity)
 
 /obj/item/weapon/gun/equipped(mob/user, slot)
-	if(ishandslot(slot))	//Same slots as tac reload
-		mouse_opacity = MOUSE_OPACITY_OPAQUE
 	unwield(user)
 	if(ishandslot(slot))
 		set_gun_user(user)
+		mouse_opacity = MOUSE_OPACITY_OPAQUE
 		return ..()
 	set_gun_user(null)
 	return ..()
@@ -432,7 +431,7 @@
 
 /obj/item/weapon/gun/unequipped(mob/user, slot)
 	. = ..()
-	mouse_opacity = MOUSE_OPACITY_ICON //So that it doesnt remain opaque when you drop or discard the gun
+	mouse_opacity = initial(mouse_opacity) //So that it doesnt remain opaque when you drop or discard the gun
 
 ///Set the user in argument as gun_user
 /obj/item/weapon/gun/proc/set_gun_user(mob/user)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -413,6 +413,8 @@
 		O.emp_act(severity)
 
 /obj/item/weapon/gun/equipped(mob/user, slot)
+	if(ishandslot(slot) || slot == SLOT_BACK || slot == SLOT_BELT || slot == SLOT_S_STORE)	//add more if needed
+		mouse_opacity = MOUSE_OPACITY_OPAQUE //so it's easier to click when properly equipped.
 	unwield(user)
 	if(ishandslot(slot))
 		set_gun_user(user)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -413,12 +413,12 @@
 		O.emp_act(severity)
 
 /obj/item/weapon/gun/equipped(mob/user, slot)
+	unwield(user)
 	if(ishandslot(slot))
 		set_gun_user(user)
 		mouse_opacity = MOUSE_OPACITY_OPAQUE
 	else
 		set_gun_user(null)
-	unwield(user)
 	return ..()
 
 /obj/item/weapon/gun/removed_from_inventory(mob/user)


### PR DESCRIPTION
## About The Pull Request
Guns that are in-hand are opaque. 
## Why It's Good For The Game
This makes it easier to click on them when you are trying to insert/remove a magazine.
This makes it easier to click drag a magazine onto the sprite when attempting to do a tactical reload.
## Changelog
:cl:
qol: Equipped guns are easier to click on
/:cl:
