### PR TITLE
MP-19 holster rebalance.

### DIFF
--- a/code/game/objects/items/storage/holsters.dm
+++ b/code/game/objects/items/storage/holsters.dm
@@ -356,4 +356,5 @@
 	var/obj/item/new_item = new /obj/item/weapon/gun/smg/standard_machinepistol(src)
 	INVOKE_ASYNC(src, PROC_REF(handle_item_insertion), new_item)
 	for(var/I in 1 to (storage_slots-1))
-		new /obj/item/ammo_magazine/smg/standard_machinepistol
+		var/obj/item/new_magazine = new /obj/item/ammo_magazine/smg/standard_machinepistol
+		INVOKE_ASYNC(src, PROC_REF(handle_item_insertion), new_magazine)

--- a/code/game/objects/items/storage/holsters.dm
+++ b/code/game/objects/items/storage/holsters.dm
@@ -21,6 +21,9 @@
 	var/list/holsterable_allowed = list()
 	///records the specific special item currently in the holster
 	var/holstered_item = null
+	///Any holster is only capable of holding a single firearm
+	storage_type_limits = list(/obj/item/weapon/gun = 1)
+
 
 /obj/item/storage/holster/equipped(mob/user, slot)
 	if (slot == SLOT_BACK || slot == SLOT_BELT || slot == SLOT_S_STORE)	//add more if needed
@@ -334,17 +337,23 @@
 		/obj/item/weapon/gun/smg/standard_machinepistol/compact,
 		/obj/item/weapon/gun/smg/standard_machinepistol/vgrip,
 	)
-
-	storage_slots = 4
-	max_storage_space = 10
-	max_w_class = WEIGHT_CLASS_BULKY
-
+	bypass_w_limit = list(
+		/obj/item/weapon/gun/smg/standard_machinepistol,
+		/obj/item/weapon/gun/smg/standard_machinepistol/compact,
+		/obj/item/weapon/gun/smg/standard_machinepistol/vgrip,
+	)
 	can_hold = list(
 		/obj/item/weapon/gun/smg/standard_machinepistol,
 		/obj/item/ammo_magazine/smg/standard_machinepistol,
 	)
 
+	storage_slots = 7
+	max_storage_space = 15
+	max_w_class = WEIGHT_CLASS_BULKY
+
 /obj/item/storage/holster/t19/full/Initialize()
 	. = ..()
 	var/obj/item/new_item = new /obj/item/weapon/gun/smg/standard_machinepistol(src)
 	INVOKE_ASYNC(src, PROC_REF(handle_item_insertion), new_item)
+	for(var/I in 1 to (storage_slots-1))
+		new /obj/item/ammo_magazine/smg/standard_machinepistol

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -13,9 +13,12 @@
 		slot_r_hand_str = 'icons/mob/inhands/items/containers_right.dmi',
 	)
 	w_class = WEIGHT_CLASS_NORMAL
-	var/list/can_hold = list() //List of objects which this item can store (if set, it can't store anything else)
-	var/list/cant_hold = list() //List of objects which this item can't store (in effect only if can_hold isn't set)
-	var/list/bypass_w_limit = list() //a list of objects which this item can store despite not passing the w_class limit
+	///List of objects which this item can store (if set, it can't store anything else)
+	var/list/can_hold = list()
+	///List of objects which this item can't store (in effect only if can_hold isn't set)
+	var/list/cant_hold = list()
+	///List of objects which this item can store despite not passing the w_class limit
+	var/list/bypass_w_limit = list()
 	/**
 	 * Associated list of types and their max count, formatted as
 	 * 	storage_type_limits = list(

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -35,6 +35,7 @@
 			/obj/item/ammo_magazine/smg/standard_smg = -1,
 			/obj/item/weapon/gun/smg/standard_machinepistol = -1,
 			/obj/item/ammo_magazine/smg/standard_machinepistol = -1,
+			/obj/item/storage/holster/t19/full = -1,
 		),
 		"Marksman" = list(
 			/obj/item/weapon/gun/rifle/standard_dmr = -1,
@@ -253,6 +254,7 @@
 			/obj/item/ammo_magazine/smg/standard_smg = -1,
 			/obj/item/weapon/gun/smg/standard_machinepistol = -1,
 			/obj/item/ammo_magazine/smg/standard_machinepistol = -1,
+			/obj/item/storage/holster/t19/full = -1,
 		),
 		"Marksman" = list(
 			/obj/item/weapon/gun/rifle/standard_dmr = -1,
@@ -447,6 +449,7 @@
 			/obj/item/ammo_magazine/smg/standard_smg = -1,
 			/obj/item/weapon/gun/smg/standard_machinepistol = -1,
 			/obj/item/ammo_magazine/smg/standard_machinepistol = -1,
+			/obj/item/storage/holster/t19/full = -1,
 		),
 		"Marksman" = list(
 			/obj/item/weapon/gun/rifle/standard_dmr = -1,
@@ -653,6 +656,7 @@
 			/obj/item/ammo_magazine/smg/standard_smg = -1,
 			/obj/item/weapon/gun/smg/standard_machinepistol = -1,
 			/obj/item/ammo_magazine/smg/standard_machinepistol = -1,
+			/obj/item/storage/holster/t19/full = -1,
 		),
 		"Marksman" = list(
 			/obj/item/weapon/gun/rifle/standard_dmr = -1,


### PR DESCRIPTION

## About The Pull Request
max storage 15 and 7 slots. 
It can fit the gun + 6 mags //OR// unfolded gun + vertgrip + 5 mags
Same strength as a magazine belt, but holds a specific gun and ammo type 
Holsters can now only hold 1 gun, not a bunch.
Adds MP-19 Holster to the marine vendor. (Like DB belt)
## Why It's Good For The Game
MP-19 is a terrible choice in most cases when compared to other belts.
This should bring it up to par in terms of being a viable option.
## Changelog
:cl:
balance: MP-19 Belt has some more space for ammo but can only hold 1 gun.
/:cl:
