### PR TITLE
Adds organ damage to embryo growth

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -69,6 +69,8 @@
 
 /obj/item/alien_embryo/proc/process_growth()
 
+	var/mob/living/carbon/human/H = affected_mob
+
 	if(stage <= 4)
 		counter += 2.5 //Free burst time in ~7/8 min.
 
@@ -76,7 +78,7 @@
 		counter += 10 //Accelerates larval growth massively. Voluntarily drinking larval jelly while infected is straight-up suicide. Larva hits Stage 5 in exactly ONE minute.
 
 	if(affected_mob.reagents.get_reagent_amount(/datum/reagent/medicine/larvaway))
-		counter -= 1 //Halves larval growth progress, for some tradeoffs. Larval toxin purges this
+		counter -= 1.25 //Halves larval growth progress, for some tradeoffs. Larval toxin purges this
 
 	if(boost_timer)
 		counter += 2.5 //Doubles larval growth progress. Burst time in ~4 min.
@@ -86,9 +88,13 @@
 		counter = 0
 		stage++
 		log_combat(affected_mob, null, "had their embryo advance to stage [stage]")
-		var/mob/living/carbon/C = affected_mob
-		C.med_hud_set_status()
+		H.med_hud_set_status()
 		affected_mob.jitter(stage * 5)
+
+	var/datum/internal_organ/O = H.internal_organs_by_name[pick("heart", "liver", "lungs", "kidneys", "appendix")]
+	O.take_damage(O.min_broken_damage * 0.01 * stage, silent = TRUE) //It needs to get nutrition somehow after all.
+	if(prob(stage))
+		to_chat(affected_mob, span_warning("It feels like something is chewing at your insides.")) //We use custom handling for this since otherwise they would either get no warning or chat spam.
 
 	switch(stage)
 		if(2)

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -70,18 +70,22 @@
 /obj/item/alien_embryo/proc/process_growth()
 
 	var/mob/living/carbon/human/H = affected_mob
+	var/organ_damage_multiplier = 1
 
 	if(stage <= 4)
 		counter += 2.5 //Free burst time in ~7/8 min.
 
 	if(affected_mob.reagents.get_reagent_amount(/datum/reagent/consumable/larvajelly))
 		counter += 10 //Accelerates larval growth massively. Voluntarily drinking larval jelly while infected is straight-up suicide. Larva hits Stage 5 in exactly ONE minute.
+		organ_damage_multiplier *= 5 //Uh oh...
 
 	if(affected_mob.reagents.get_reagent_amount(/datum/reagent/medicine/larvaway))
 		counter -= 1.25 //Halves larval growth progress, for some tradeoffs. Larval toxin purges this
+		organ_damage_multiplier *= 0.2 //Also reduces the overall organ damage by 60% as an added benefit.
 
 	if(boost_timer)
 		counter += 2.5 //Doubles larval growth progress. Burst time in ~4 min.
+		organ_damage_multiplier *= 2
 		adjust_boost_timer(-1)
 
 	if(stage < 5 && counter >= 120)
@@ -92,7 +96,7 @@
 		affected_mob.jitter(stage * 5)
 
 	var/datum/internal_organ/O = H.internal_organs_by_name[pick("heart", "liver", "lungs", "kidneys", "appendix")]
-	O.take_damage(O.min_broken_damage * 0.01 * stage, silent = TRUE) //It needs to get nutrition somehow after all.
+	O.take_damage(O.min_broken_damage * 0.01 * stage * organ_damage_multiplier, silent = TRUE) //It needs to get nutrition somehow after all.
 	if(prob(stage))
 		to_chat(affected_mob, span_warning("It feels like something is chewing at your insides.")) //We use custom handling for this since otherwise they would either get no warning or chat spam.
 


### PR DESCRIPTION
## About The Pull Request

So, we have a problem with people just plain ignoring embryos. Even with call of younger, there are still cases where for example the carrier dies or the victim simply relocates to an area where the carrier isn't present. In these cases the victim just keeps fighting as if they don't have an embryo eating their insides.

This PR intends to change that by inflicting organ damage over time. As long as you stay at stage 0, you will get no organ damage. Stage 1 deals very minor organ damage. By the time you reach stage 4, you'll be collapsing on the floor due to pain from organ damage and gasping for air due to heart and lung damage.

This also serves to make reviving people who have burst harder since it used to be a permadeath but marine cope removed that so I'm now soft-readding it by making revival more difficult. (The minor organ damage it causes right now really isn't that bad, this pretty much breaks all of the victim's organs without any intervention.)

This PR also increases the significance of larvaway, not only making it halve the embryo's growth speed once more instead of reducing it by 40% (the comment next to the line still said it reduced it by half, which it wasn't doing by the looks of things), but also by making it reduce the overall organ damage caused during the course of the embryo's growth to be reduced by 60% on top of slowing it down by half.
## Why It's Good For The Game

Larva bursting not being significant simply doesn't seem healthy to the game. Burst rates are already very low as evidenced by round end reports since people have gotten really good at removing them, so they aren't as much of a threat anymore.

This PR serves to reintroduce some of that threat and prevent marines from simply walking it off, albeit they can still do that if they prepare with larvaway or a questionable amount of painkillers. Corpsmen can also mitigate it with peridaxon plus or by simply using a stasis bag like a normal person, so there's definitely ways of dealing with it.

Call of younger is a neat addition and fixes part of the problem, but it doesn't provide that constant nuisance that having an embryo should really give you. Not to mention, it needs to get nutrition somehow, so this makes sense. If call of younger didn't exist, I would've probably tried to readd the permadeath, but that seems excessive now.
## Changelog
:cl:
add: Embryos now deal organ damage over time. This is affected by things that affect growth, however taking larvaway provides an additional 60% bonus reduction to the overall damage.
fix: Larvaway halves embryo growth speed once more! Turns out it was reduced to 40% at some point, likely silently.
/:cl:
