### PR TITLE
fixes only the first arty piece having a cam

### DIFF
--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -180,6 +180,15 @@
 		user.balloon_alert(user, "The barrel is steaming hot. Wait till it cools off.")
 		return
 
+	if(istype(I,/obj/item/hud_tablet/artillery))
+		var/obj/item/hud_tablet/artillery/tablet = I
+		if(tablet.active_camera == null)
+			user.balloon_alert(user, "You need to activate a camera first.")
+			return
+		impact_cam = tablet.active_camera
+		user.balloon_alert(user, "You reset the internal camera to the tablet's.")
+
+
 	if(istype(I, /obj/item/mortal_shell))
 		var/obj/item/mortal_shell/mortar_shell = I
 

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -67,10 +67,15 @@
 	///Used for remote targeting by AI
 	var/obj/item/ai_target_beacon/ai_targeter
 
+	// used for keeping track of different mortars and their types for cams
+	var/static/list/id_by_type = list()
+
 /obj/machinery/deployable/mortar/Initialize(mapload, _internal_item, deployer)
 	. = ..()
+
 	impact_cam = new
 	impact_cam.forceMove(src)
+	impact_cam.c_tag = "[strip_improper(name)] #[++id_by_type[type]]"
 
 /obj/machinery/deployable/mortar/Destroy()
 	QDEL_NULL(impact_cam)
@@ -179,15 +184,6 @@
 	if(firing)
 		user.balloon_alert(user, "The barrel is steaming hot. Wait till it cools off.")
 		return
-
-	if(istype(I,/obj/item/hud_tablet/artillery))
-		var/obj/item/hud_tablet/artillery/tablet = I
-		if(tablet.active_camera == null)
-			user.balloon_alert(user, "You need to activate a camera first.")
-			return
-		impact_cam = tablet.active_camera
-		user.balloon_alert(user, "You reset the internal camera to the tablet's.")
-
 
 	if(istype(I, /obj/item/mortal_shell))
 		var/obj/item/mortal_shell/mortar_shell = I


### PR DESCRIPTION
## About The Pull Request

This PR fixes arty pieces not being able to see where the shots land on the impact cam 

## Why It's Good For The Game

This will add back the dopamine from using artillery for multiple pieces

## Changelog

:cl:

fix: Artillery pieces now each have their own camera on tablets, and they work again

/:cl:
