### PR TITLE
Seasonal Galore

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -30,9 +30,10 @@ SUBSYSTEM_DEF(persistence)
 		/datum/season_datum/weapons/guns/rifle_seasonal_one,
 		/datum/season_datum/weapons/guns/pistol_seasonal_two,
 		/datum/season_datum/weapons/guns/rifle_seasonal_two,
+		/datum/season_datum/weapons/guns/rifle_seasonal_three,
 		/datum/season_datum/weapons/guns/copsandrobbers_seasonal,
 		/datum/season_datum/weapons/guns/shotgun_seasonal,
-		/datum/season_datum/weapons/guns/rifle_seasonal_three
+		/datum/season_datum/weapons/guns/lever_seasonal,
 		)
 	)
 	///The saved list of custom outfits names
@@ -220,6 +221,22 @@ SUBSYSTEM_DEF(persistence)
 		/obj/item/ammo_magazine/rifle/alf_machinecarbine = -1,
 		)
 
+/datum/season_datum/weapons/guns/rifle_seasonal_three
+name = "Warsaw Pact vs NATO"
+	description = "Hot Guns from the Cold War"
+	item_list = list(
+		/obj/item/weapon/gun/rifle/mpi_km= -1,
+		/obj/item/ammo_magazine/rifle/mpi_km/plum = -1,
+		/obj/item/ammo_magazine/packet/pwarsaw = -1,
+		/obj/item/weapon/gun/rifle/m16 = -1,
+		/obj/item/ammo_magazine/rifle/m16 = -1,
+		/obj/item/weapon/gun/rifle/famas = -1,
+		/obj/item/ammo_magazine/rifle/famas = -1,
+		/obj/item/ammo_magazine/packet/pnato = -1,
+		/obj/item/weapon/gun/rifle/sniper/svd = -1,
+		/obj/item/ammo_magazine/sniper/svd = -1,
+		)
+
 /datum/season_datum/weapons/guns/pistol_seasonal_one
 	name = "High Noon"
 	description = "Revolvers? They are yours my friend. Bouncy, single-action, or with buckshot"
@@ -273,22 +290,6 @@ SUBSYSTEM_DEF(persistence)
 		/obj/item/weapon/gun/shotgun/combat = -1,
 		/obj/item/weapon/gun/shotgun/pump = -1,
 		/obj/item/weapon/gun/shotgun/pump/cmb = -1,
-		)
-
-/datum/season_datum/weapons/guns/rifle_seasonal_three
-name = "Warsaw Pact vs NATO"
-	description = "Hot Guns from the Cold War"
-	item_list = list(
-		/obj/item/weapon/gun/rifle/mpi_km= -1,
-		/obj/item/ammo_magazine/rifle/mpi_km/plum = -1,
-		/obj/item/ammo_magazine/packet/pwarsaw = -1,
-		/obj/item/weapon/gun/rifle/m16 = -1,
-		/obj/item/ammo_magazine/rifle/m16 = -1,
-		/obj/item/weapon/gun/rifle/famas = -1,
-		/obj/item/ammo_magazine/rifle/famas = -1,
-		/obj/item/ammo_magazine/packet/pnato = -1,
-		/obj/item/weapon/gun/rifle/sniper/svd = -1,
-		/obj/item/ammo_magazine/sniper/svd = -1,
 		)
 
 /datum/season_datum/weapons/guns/lever_seasonal

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -32,6 +32,7 @@ SUBSYSTEM_DEF(persistence)
 		/datum/season_datum/weapons/guns/rifle_seasonal_two,
 		/datum/season_datum/weapons/guns/copsandrobbers_seasonal,
 		/datum/season_datum/weapons/guns/shotgun_seasonal,
+		/datum/season_datum/weapons/guns/rifle_seasonal_three
 		)
 	)
 	///The saved list of custom outfits names
@@ -190,15 +191,9 @@ SUBSYSTEM_DEF(persistence)
 	var/list/item_list = list()
 
 /datum/season_datum/weapons/guns/rifle_seasonal_one
-	name = "AK47, M16 and Storm Weapons"
+	name = "World War 2"
 	description = "Old Earth guns. Antique and obsolete, but no less deadly"
 	item_list = list(
-		/obj/item/weapon/gun/rifle/mpi_km= -1,
-		/obj/item/ammo_magazine/rifle/mpi_km/plum = -1,
-		/obj/item/ammo_magazine/packet/pwarsaw = -1,
-		/obj/item/weapon/gun/rifle/m16 = -1,
-		/obj/item/ammo_magazine/rifle/m16 = -1,
-		/obj/item/ammo_magazine/packet/pnato = -1,
 		/obj/item/weapon/gun/rifle/mkh = -1,
 		/obj/item/ammo_magazine/rifle/mkh = -1,
 		/obj/item/weapon/gun/smg/ppsh = -1,
@@ -206,6 +201,8 @@ SUBSYSTEM_DEF(persistence)
 		/obj/item/ammo_magazine/smg/ppsh/extended = -1,
 		/obj/item/weapon/gun/rifle/garand = -1,
 		/obj/item/ammo_magazine/rifle/garand = -1,
+		/obj/item/weapon/gun/pistol/m1911 = -1,
+		/obj/item/ammo_magazine/pistol/m1911 = -1,
 		)
 
 /datum/season_datum/weapons/guns/rifle_seasonal_two
@@ -254,7 +251,7 @@ SUBSYSTEM_DEF(persistence)
 
 /datum/season_datum/weapons/guns/copsandrobbers_seasonal
 	name = "SWAT and terrorists"
-	description = "Three classic SMGs, and no one's favorite burst revolver."
+	description = "Four classic SMGs, and no one's favorite burst revolver."
 	item_list = list(
 		/obj/item/weapon/gun/smg/uzi = -1,
 		/obj/item/ammo_magazine/smg/uzi = -1,
@@ -263,6 +260,8 @@ SUBSYSTEM_DEF(persistence)
 		/obj/item/storage/holster/m25 = -1,
 		/obj/item/weapon/gun/smg/mp7 = -1,
 		/obj/item/ammo_magazine/smg/mp7 = -1,
+		/obj/item/weapon/gun/smg/skorpion = -1,
+		/obj/item/ammo_magazine/smg/skorpion = -1,
 		/obj/item/weapon/gun/revolver/cmb = -1,
 		/obj/item/ammo_magazine/revolver/cmb = -1,
 		)
@@ -274,4 +273,31 @@ SUBSYSTEM_DEF(persistence)
 		/obj/item/weapon/gun/shotgun/combat = -1,
 		/obj/item/weapon/gun/shotgun/pump = -1,
 		/obj/item/weapon/gun/shotgun/pump/cmb = -1,
+		)
+
+/datum/season_datum/weapons/guns/rifle_seasonal_three
+name = "Warsaw Pact vs NATO"
+	description = "Hot Guns from the Cold War"
+	item_list = list(
+		/obj/item/weapon/gun/rifle/mpi_km= -1,
+		/obj/item/ammo_magazine/rifle/mpi_km/plum = -1,
+		/obj/item/ammo_magazine/packet/pwarsaw = -1,
+		/obj/item/weapon/gun/rifle/m16 = -1,
+		/obj/item/ammo_magazine/rifle/m16 = -1,
+		/obj/item/weapon/gun/rifle/famas = -1,
+		/obj/item/ammo_magazine/rifle/famas = -1,
+		/obj/item/ammo_magazine/packet/pnato = -1,
+		/obj/item/weapon/gun/rifle/sniper/svd = -1,
+		/obj/item/ammo_magazine/sniper/svd = -1,
+		)
+
+/datum/season_datum/weapons/guns/lever_seasonal
+name = "Lever actions"
+	description = "Yee Haw, pardner"
+	item_list = list(
+		/obj/item/weapon/gun/shotgun/pump/lever = -1,
+		/obj/item/weapon/gun/shotgun/pump/lever/mbx900 = -1,
+		/obj/item/ammo_magazine/shotgun/mbx900 = -1,
+		/obj/item/ammo_magazine/shotgun/mbx900/buckshot = -1,
+		/obj/item/ammo_magazine/shotgun/mbx900/tracking = -1,
 		)

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -222,7 +222,7 @@ SUBSYSTEM_DEF(persistence)
 		)
 
 /datum/season_datum/weapons/guns/rifle_seasonal_three
-name = "Warsaw Pact vs NATO"
+	name = "Warsaw Pact vs NATO"
 	description = "Hot Guns from the Cold War"
 	item_list = list(
 		/obj/item/weapon/gun/rifle/mpi_km= -1,

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -293,7 +293,7 @@ SUBSYSTEM_DEF(persistence)
 		)
 
 /datum/season_datum/weapons/guns/lever_seasonal
-name = "Lever actions"
+	name = "Lever actions"
 	description = "Yee Haw, pardner"
 	item_list = list(
 		/obj/item/weapon/gun/shotgun/pump/lever = -1,


### PR DESCRIPTION

## About The Pull Request
Adds essentially the rest of the import guns to seasonals, shuffles some guns around for more coherent seasons
## Why It's Good For The Game
These guns are essentially side grades of what marines get (skorpion= MP19, FAMAS = AR18, Garand/SVD = DMR, 1911 = P45, Levergun = Repeater etc), and seasonals exist to cycle req hell import guns.
## Changelog
:cl:
add: added more seasonal guns
/:cl:
