### PR TITLE
Hunter no longer breaks stealth when staring at weeds.

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -125,6 +125,7 @@
 
 
 /obj/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
+	// SHOULD_CALL_PARENT(TRUE) // TODO: fix this
 	if(X.status_flags & INCORPOREAL) //Ghosts can't attack machines
 		return FALSE
 	if(SEND_SIGNAL(src, COMSIG_OBJ_ATTACK_ALIEN, X) & COMPONENT_NO_ATTACK_ALIEN)

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -127,15 +127,13 @@
 /obj/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
 	if(X.status_flags & INCORPOREAL) //Ghosts can't attack machines
 		return FALSE
-	if(istype(src, /obj/alien/weeds)) //Xenos are unable to attack weeds
-		return
-	SEND_SIGNAL(X, COMSIG_XENOMORPH_ATTACK_OBJ, src)
-	// SHOULD_CALL_PARENT(TRUE) // TODO: fix this
-	if(SEND_SIGNAL(src, COMSIG_OBJ_ATTACK_ALIEN, X) & COMPONENT_NO_ATTACK_ALIEN)
-		return FALSE
 	if(!(resistance_flags & XENO_DAMAGEABLE))
 		to_chat(X, span_warning("We stare at \the [src] cluelessly."))
 		return FALSE
+	if(SEND_SIGNAL(src, COMSIG_OBJ_ATTACK_ALIEN, X) & COMPONENT_NO_ATTACK_ALIEN)
+		return FALSE
+	SEND_SIGNAL(X, COMSIG_XENOMORPH_ATTACK_OBJ, src)
+	// SHOULD_CALL_PARENT(TRUE) // TODO: fix this
 	if(effects)
 		X.visible_message(span_danger("[X] has slashed [src]!"),
 		span_danger("We slash [src]!"))

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -127,10 +127,10 @@
 /obj/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
 	if(X.status_flags & INCORPOREAL) //Ghosts can't attack machines
 		return FALSE
+	if(SEND_SIGNAL(src, COMSIG_OBJ_ATTACK_ALIEN, X) & COMPONENT_NO_ATTACK_ALIEN)
+		return FALSE
 	if(!(resistance_flags & XENO_DAMAGEABLE))
 		to_chat(X, span_warning("We stare at \the [src] cluelessly."))
-		return FALSE
-	if(SEND_SIGNAL(src, COMSIG_OBJ_ATTACK_ALIEN, X) & COMPONENT_NO_ATTACK_ALIEN)
 		return FALSE
 	SEND_SIGNAL(X, COMSIG_XENOMORPH_ATTACK_OBJ, src)
 	if(effects)

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -127,6 +127,8 @@
 /obj/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
 	if(X.status_flags & INCORPOREAL) //Ghosts can't attack machines
 		return FALSE
+	if(istype(src, /obj/alien/weeds)) //Xenos are unable to attack weeds
+		return
 	SEND_SIGNAL(X, COMSIG_XENOMORPH_ATTACK_OBJ, src)
 	// SHOULD_CALL_PARENT(TRUE) // TODO: fix this
 	if(SEND_SIGNAL(src, COMSIG_OBJ_ATTACK_ALIEN, X) & COMPONENT_NO_ATTACK_ALIEN)

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -133,7 +133,6 @@
 	if(SEND_SIGNAL(src, COMSIG_OBJ_ATTACK_ALIEN, X) & COMPONENT_NO_ATTACK_ALIEN)
 		return FALSE
 	SEND_SIGNAL(X, COMSIG_XENOMORPH_ATTACK_OBJ, src)
-	// SHOULD_CALL_PARENT(TRUE) // TODO: fix this
 	if(effects)
 		X.visible_message(span_danger("[X] has slashed [src]!"),
 		span_danger("We slash [src]!"))

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -128,12 +128,12 @@
 	// SHOULD_CALL_PARENT(TRUE) // TODO: fix this
 	if(X.status_flags & INCORPOREAL) //Ghosts can't attack machines
 		return FALSE
+	SEND_SIGNAL(X, COMSIG_XENOMORPH_ATTACK_OBJ, src)
 	if(SEND_SIGNAL(src, COMSIG_OBJ_ATTACK_ALIEN, X) & COMPONENT_NO_ATTACK_ALIEN)
 		return FALSE
 	if(!(resistance_flags & XENO_DAMAGEABLE))
 		to_chat(X, span_warning("We stare at \the [src] cluelessly."))
 		return FALSE
-	SEND_SIGNAL(X, COMSIG_XENOMORPH_ATTACK_OBJ, src)
 	if(effects)
 		X.visible_message(span_danger("[X] has slashed [src]!"),
 		span_danger("We slash [src]!"))

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -59,10 +59,11 @@
 	// TODO: attack_alien() overrides are a mess and need a lot of work to make them require parentcalling
 	RegisterSignal(owner, list(
 		COMSIG_XENOMORPH_GRAB,
-		COMSIG_XENOMORPH_ATTACK_OBJ,
 		COMSIG_XENOMORPH_THROW_HIT,
 		COMSIG_XENOMORPH_FIRE_BURNING,
 		COMSIG_LIVING_ADD_VENTCRAWL), PROC_REF(cancel_stealth))
+
+	RegisterSignal(owner, COMSIG_XENOMORPH_ATTACK_OBJ, PROC_REF(on_obj_attack))
 
 	RegisterSignal(owner, list(SIGNAL_ADDTRAIT(TRAIT_KNOCKEDOUT), SIGNAL_ADDTRAIT(TRAIT_FLOORED)), PROC_REF(cancel_stealth))
 
@@ -100,6 +101,12 @@
 	can_sneak_attack = FALSE
 	REMOVE_TRAIT(owner, TRAIT_TURRET_HIDDEN, STEALTH_TRAIT)
 	owner.alpha = 255 //no transparency/translucency
+
+///Signal wrapper to verify that an object is damageable before breaking stealth
+/datum/action/xeno_action/stealth/proc/on_obj_attack(datum/source, obj/attacked)
+	SIGNAL_HANDLER
+	if(attacked.resistance_flags & XENO_DAMAGEABLE)
+		cancel_stealth()
 
 /datum/action/xeno_action/stealth/proc/sneak_attack_cooldown()
 	if(!stealth || can_sneak_attack)


### PR DESCRIPTION
## About The Pull Request
Does wizard magic with signals so it no longer breaks stealth when staring at weeds.
## Why It's Good For The Game
Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/12457
## Changelog
:cl:
fix:Hunter no longer breaks stealth while staring at weeds cluelessly  
/:cl:
