### PR TITLE
Changes FAMAS stats to be more in line with other rifles.

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -782,8 +782,9 @@
 	burst_delay = 0.15 SECONDS
 	accuracy_mult = 1.15
 	wield_delay = 0.5 SECONDS
-	scatter = 1.5
-	movement_acc_penalty_mult = 5
+	damage_mult = 1.1
+	scatter = 1
+	movement_acc_penalty_mult = 4
 
 /obj/item/weapon/gun/rifle/famas/freelancermedic
 	starting_attachment_types = list(/obj/item/attachable/lasersight, /obj/item/attachable/magnetic_harness, /obj/item/attachable/bayonet)

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -782,9 +782,8 @@
 	burst_delay = 0.15 SECONDS
 	accuracy_mult = 1.15
 	wield_delay = 0.5 SECONDS
-	damage_mult = 1.2
-	scatter = 1
-	movement_acc_penalty_mult = 4
+	scatter = 1.5
+	movement_acc_penalty_mult = 5
 
 /obj/item/weapon/gun/rifle/famas/freelancermedic
 	starting_attachment_types = list(/obj/item/attachable/lasersight, /obj/item/attachable/magnetic_harness, /obj/item/attachable/bayonet)


### PR DESCRIPTION
## About The Pull Request

Removes the damage multiplier from the FAMAS, adds 50% more scatter, and increases the movement penalty on accuracy.

## Why It's Good For The Game

FAMAS is currently just using up LOC since its' removal from seasonals, since nobody spends req points on import weapons. If the weapon being dogshit is what it takes for it to be used again, then so be it.

## Changelog

:cl: QuarianCommando
balance: FAMAS stats adjusted to be more in-line with other rifles.
/:cl:
