### PR TITLE
Fixes the psi gen fix fix by making the math actually not stupid

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -125,7 +125,7 @@
 #define SILO_PRICE 800
 #define XENO_TURRET_PRICE 100
 
-//How many psych point one gen gives every second
+//How many psy points a hive gets if all generators are corrupted
 #define GENERATOR_PSYCH_POINT_OUTPUT 1
 //How many psy points are gave for each marine psy drained at low pop
 #define PSY_DRAIN_REWARD_MAX 90

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -15,7 +15,6 @@ GLOBAL_LIST_EMPTY(brig_closets)
 GLOBAL_LIST_EMPTY(supply_pad_list)
 GLOBAL_LIST_EMPTY(supply_beacon)
 
-GLOBAL_LIST_EMPTY(xeno_tunnels_by_hive)						//list of all /obj/structure/xeno/tunnel
 GLOBAL_LIST_EMPTY(machines)					        //NOTE: this is a list of ALL machines now. The processing machines list is SSmachine.processing !
 GLOBAL_LIST_EMPTY(faxmachines)
 GLOBAL_LIST_EMPTY(mainship_lights)					//list of mainship lights, used for altering intensity and color during red and delta security levels
@@ -28,6 +27,7 @@ GLOBAL_LIST_EMPTY(nuke_spawn_locs)
 GLOBAL_LIST_EMPTY(nuke_disk_list)					//list of all /obj/item/disk/nuclear
 GLOBAL_LIST_EMPTY(nightfall_toggleable_lights)		//list of all atoms which light can be shut down
 GLOBAL_LIST_EMPTY(zones_to_control)					//list of all areas that needs to be controlled to gain point in Civil War
+GLOBAL_LIST_EMPTY(generators_on_ground)
 
 GLOBAL_LIST_EMPTY(chemical_reactions_list)				///list of all /datum/chemical_reaction datums index by reactants, Used during chemical reactions
 GLOBAL_LIST_EMPTY(chemical_reagents_list)				///list of all /datum/reagent datums instances indexed by reagent typepath. Used by chemistry stuff
@@ -39,6 +39,7 @@ GLOBAL_LIST_EMPTY(wire_color_directory)
 GLOBAL_LIST_EMPTY(ai_status_displays)
 GLOBAL_LIST_EMPTY(alert_consoles)			// Station alert consoles, /obj/machinery/computer/station_alert
 
+GLOBAL_LIST_EMPTY(xeno_tunnels_by_hive)						//list of all /obj/structure/xeno/tunnel
 GLOBAL_LIST_EMPTY(xeno_resin_silo_turfs)
 GLOBAL_LIST_EMPTY(xeno_weed_node_turfs)
 GLOBAL_LIST_EMPTY(xeno_resin_door_turfs)

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -27,7 +27,6 @@ GLOBAL_LIST_EMPTY(nuke_spawn_locs)
 GLOBAL_LIST_EMPTY(nuke_disk_list)					//list of all /obj/item/disk/nuclear
 GLOBAL_LIST_EMPTY(nightfall_toggleable_lights)		//list of all atoms which light can be shut down
 GLOBAL_LIST_EMPTY(zones_to_control)					//list of all areas that needs to be controlled to gain point in Civil War
-GLOBAL_LIST_EMPTY(generators_on_ground)
 
 GLOBAL_LIST_EMPTY(chemical_reactions_list)				///list of all /datum/chemical_reaction datums index by reactants, Used during chemical reactions
 GLOBAL_LIST_EMPTY(chemical_reagents_list)				///list of all /datum/reagent datums instances indexed by reagent typepath. Used by chemistry stuff

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -48,7 +48,6 @@ GLOBAL_LIST_EMPTY(xeno_resin_turrets_by_hive)
 GLOBAL_LIST_EMPTY(xeno_spawners_by_hive)
 GLOBAL_LIST_EMPTY(xeno_structures_by_hive)
 GLOBAL_LIST_EMPTY(xeno_critical_structures)
-GLOBAL_LIST_EMPTY(xeno_generators_by_hive)
 
 GLOBAL_LIST_EMPTY(shuttle_controls_list)
 GLOBAL_LIST_EMPTY(lz1_shuttle_console_turfs_list)

--- a/code/modules/power/groundmap_geothermal.dm
+++ b/code/modules/power/groundmap_geothermal.dm
@@ -3,6 +3,8 @@
 #define GEOTHERMAL_MEDIUM_DAMAGE 2
 #define GEOTHERMAL_HEAVY_DAMAGE 3
 
+GLOBAL_VAR_INIT(generators_on_ground, 0)
+
 /obj/machinery/power/geothermal
 	name = "\improper G-11 geothermal generator"
 	icon = 'icons/turf/geothermal.dmi'
@@ -97,9 +99,9 @@
 
 /obj/machinery/power/geothermal/process()
 	if(corrupted && corruption_on)
-		if((length(GLOB.humans_by_zlevel["2"]) > 0.2 * length(GLOB.alive_human_list_faction[FACTION_TERRAGOV])))
+		if((length(GLOB.humans_by_zlevel["2"]) > 0.2 * length(GLOB.alive_human_list_faction[FACTION_TERRAGOV])) && GLOB.xeno_generators_by_hive[corrupted] > 0)
 			//You get points proportional to the % of generators corrupted (for example, if 66% of generators are corrupted the hive gets 0.66 points per second)
-			SSpoints.add_psy_points(corrupted, GENERATOR_PSYCH_POINT_OUTPUT * (GLOB.xeno_generators_by_hive[corrupted] / GLOB.generators_on_ground))
+			SSpoints.add_psy_points(corrupted, GENERATOR_PSYCH_POINT_OUTPUT * (GLOB.xeno_generators_by_hive[corrupted] / GLOB.generators_on_ground) / GLOB.xeno_generators_by_hive[corrupted])
 		return
 	if(!is_on || buildstate || !anchored || !powernet) //Default logic checking
 		return PROCESS_KILL

--- a/code/modules/power/groundmap_geothermal.dm
+++ b/code/modules/power/groundmap_geothermal.dm
@@ -36,7 +36,10 @@
 		GLOB.xeno_generators_by_hive = list()
 
 	if(corrupted)
-		GLOB.xeno_generators_by_hive[corrupted] += 1
+		corrupt(corrupted)
+
+	if(is_ground_level(z))
+		GLOB.generators_on_ground += 1
 
 /obj/machinery/power/geothermal/examine(mob/user, distance, infix, suffix)
 	. = ..()
@@ -94,8 +97,9 @@
 
 /obj/machinery/power/geothermal/process()
 	if(corrupted && corruption_on)
-		if((length(GLOB.humans_by_zlevel["2"]) > 0.2 * length(GLOB.alive_human_list_faction[FACTION_TERRAGOV])) && GLOB.xeno_generators_by_hive[corrupted] > 0)
-			SSpoints.add_psy_points(corrupted, GENERATOR_PSYCH_POINT_OUTPUT / GLOB.xeno_generators_by_hive[corrupted])
+		if((length(GLOB.humans_by_zlevel["2"]) > 0.2 * length(GLOB.alive_human_list_faction[FACTION_TERRAGOV])))
+			//You get points proportional to the % of generators corrupted (for example, if 66% of generators are corrupted the hive gets 0.66 points per second)
+			SSpoints.add_psy_points(corrupted, GENERATOR_PSYCH_POINT_OUTPUT * (GLOB.xeno_generators_by_hive[corrupted] / GLOB.generators_on_ground))
 		return
 	if(!is_on || buildstate || !anchored || !powernet) //Default logic checking
 		return PROCESS_KILL

--- a/code/modules/power/groundmap_geothermal.dm
+++ b/code/modules/power/groundmap_geothermal.dm
@@ -43,6 +43,11 @@ GLOBAL_VAR_INIT(generators_on_ground, 0)
 	if(is_ground_level(z))
 		GLOB.generators_on_ground += 1
 
+/obj/machinery/power/geothermal/Destroy() //just in case
+	if(is_ground_level(z))
+		GLOB.generators_on_ground -= 1
+	return ..()
+
 /obj/machinery/power/geothermal/examine(mob/user, distance, infix, suffix)
 	. = ..()
 	if(corrupted)

--- a/code/modules/power/groundmap_geothermal.dm
+++ b/code/modules/power/groundmap_geothermal.dm
@@ -34,9 +34,6 @@ GLOBAL_VAR_INIT(generators_on_ground, 0)
 	update_icon()
 	SSminimaps.add_marker(src, z, hud_flags = MINIMAP_FLAG_ALL, iconstate = "generator")
 
-	if(!GLOB.xeno_generators_by_hive)
-		GLOB.xeno_generators_by_hive = list()
-
 	if(corrupted)
 		corrupt(corrupted)
 
@@ -104,9 +101,9 @@ GLOBAL_VAR_INIT(generators_on_ground, 0)
 
 /obj/machinery/power/geothermal/process()
 	if(corrupted && corruption_on)
-		if((length(GLOB.humans_by_zlevel["2"]) > 0.2 * length(GLOB.alive_human_list_faction[FACTION_TERRAGOV])) && GLOB.xeno_generators_by_hive[corrupted] > 0)
+		if((length(GLOB.humans_by_zlevel["2"]) > 0.2 * length(GLOB.alive_human_list_faction[FACTION_TERRAGOV])))
 			//You get points proportional to the % of generators corrupted (for example, if 66% of generators are corrupted the hive gets 0.66 points per second)
-			SSpoints.add_psy_points(corrupted, GENERATOR_PSYCH_POINT_OUTPUT * (GLOB.xeno_generators_by_hive[corrupted]/(GLOB.generators_on_ground**2)))
+			SSpoints.add_psy_points(corrupted, GENERATOR_PSYCH_POINT_OUTPUT / GLOB.generators_on_ground)
 		return
 	if(!is_on || buildstate || !anchored || !powernet) //Default logic checking
 		return PROCESS_KILL
@@ -242,7 +239,6 @@ GLOBAL_VAR_INIT(generators_on_ground, 0)
 		user.visible_message(span_notice("[user] burns [src]'s resin off."),
 		span_notice("You burn [src]'s resin off."))
 		cut_overlay(GLOB.welding_sparks)
-		GLOB.xeno_generators_by_hive[corrupted] -= 1
 		corrupted = 0
 		stop_processing()
 		update_icon()
@@ -324,7 +320,6 @@ GLOBAL_VAR_INIT(generators_on_ground, 0)
 
 /obj/machinery/power/geothermal/proc/corrupt(hivenumber)
 	corrupted = hivenumber
-	GLOB.xeno_generators_by_hive[corrupted] += 1
 	is_on = FALSE
 	power_gen_percent = 0
 	cur_tick = 0

--- a/code/modules/power/groundmap_geothermal.dm
+++ b/code/modules/power/groundmap_geothermal.dm
@@ -106,7 +106,7 @@ GLOBAL_VAR_INIT(generators_on_ground, 0)
 	if(corrupted && corruption_on)
 		if((length(GLOB.humans_by_zlevel["2"]) > 0.2 * length(GLOB.alive_human_list_faction[FACTION_TERRAGOV])) && GLOB.xeno_generators_by_hive[corrupted] > 0)
 			//You get points proportional to the % of generators corrupted (for example, if 66% of generators are corrupted the hive gets 0.66 points per second)
-			SSpoints.add_psy_points(corrupted, GENERATOR_PSYCH_POINT_OUTPUT * (GLOB.xeno_generators_by_hive[corrupted] / GLOB.generators_on_ground) / GLOB.xeno_generators_by_hive[corrupted])
+			SSpoints.add_psy_points(corrupted, GENERATOR_PSYCH_POINT_OUTPUT * (GLOB.xeno_generators_by_hive[corrupted]/(GLOB.generators_on_ground**2)))
 		return
 	if(!is_on || buildstate || !anchored || !powernet) //Default logic checking
 		return PROCESS_KILL
@@ -242,10 +242,10 @@ GLOBAL_VAR_INIT(generators_on_ground, 0)
 		user.visible_message(span_notice("[user] burns [src]'s resin off."),
 		span_notice("You burn [src]'s resin off."))
 		cut_overlay(GLOB.welding_sparks)
+		GLOB.xeno_generators_by_hive[corrupted] -= 1
 		corrupted = 0
 		stop_processing()
 		update_icon()
-		GLOB.xeno_generators_by_hive[corrupted] -= 1
 		return
 
 	if(user.skills.getRating(SKILL_ENGINEER) < SKILL_ENGINEER_ENGI)


### PR DESCRIPTION

## About The Pull Request

Makes the psi output based off the ratio of currently corrupted generators and generators on the ground. Why wasn't it like this? I have no idea. 

If you manage to corrupt the gens shipside you get extra psi, wow.
## Why It's Good For The Game

Psi gen math being sane is neat.
## Changelog
:cl:
fix: Fixes the psi gen fix fix by making the math actually not stupid. Psi is based off ratio of generators corrupted to uncorrupted.
/:cl:
