### PR TITLE
Allows DB to take extended barrel and barrel charger

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -208,6 +208,8 @@
 		/obj/item/attachable/scope,
 		/obj/item/attachable/scope/marine,
 		/obj/item/attachable/scope/mini,
+		/obj/item/attachable/extended_barrel,
+		/obj/item/attachable/heavy_barrel,
 	)
 
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY


### PR DESCRIPTION

## About The Pull Request
Title

## Why It's Good For The Game
The other shotguns can take them anyway. This'd give the db a proper use other than 4 db juggling at pb range where projectile speed is irrelevant anyway. It also competes with bayonet, actually making it a worse attachment when it comes to PBing.

Potential (non)issues:
"Flechette/slug hitscan": The other shotguns have this and hasn't been a problem.
"DB can fit miniscope": Lacking aim mode it'd turn it into a martini downgrade since it'd just turn into an FF machine. Slugs don't do stagger nor knockdown or anything at range, and flechette being multiple projectiles get hit by damage falloff [number of projectiles] times as hard. Sniper buckshot is funny. What's more, if you're running DB as a scoped gun, wouldn't you be better off going with the SR127 since you don't need to unwield out of the scope every 2 shots and it can take barrel charger too?

Also it'd be hilarious to see marines thinking that last part is viable and causing absurd levels of ff with slugs that go so fast they can't even check who's knocking them over.

## Changelog

:cl:
balance: DB can now take Extended Barrel and Barrel Charger attachments

/:cl:

