### PR TITLE
Fixes broken entertainment monitors

### DIFF
--- a/_maps/map_files/Orion_Military_Outpost/orionoutpost.dmm
+++ b/_maps/map_files/Orion_Military_Outpost/orionoutpost.dmm
@@ -522,10 +522,6 @@
 /obj/structure/bed/chair,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/orion_outpost/ground/outposts)
-"dk" = (
-/obj/machinery/computer/security/telescreen/entertainment,
-/turf/closed/wall/mainship/gray,
-/area/orion_outpost/surface/building/administration)
 "dm" = (
 /obj/structure/flora/grass/tallgrass{
 	color = "#7a8c54"
@@ -12610,7 +12606,7 @@ Ub
 FI
 pN
 pN
-dk
+pN
 VO
 DX
 pN

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -53371,7 +53371,7 @@ hhf
 hhf
 hhf
 hhf
-fQO
+hhf
 hhf
 dLx
 dLx

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -10337,7 +10337,6 @@
 "nkX" = (
 /obj/machinery/optable,
 /obj/item/tank/anesthetic,
-/obj/item/tank/anesthetic,
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},

--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -3413,10 +3413,6 @@
 	dir = 1
 	},
 /area/centcom/valhalla/primary/fore)
-"eqR" = (
-/obj/machinery/status_display,
-/turf/closed/wall,
-/area/centcom/valhalla/medical/medbay)
 "ete" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -3924,6 +3920,10 @@
 	},
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla/starboard_hallway)
+"fcK" = (
+/obj/machinery/status_display,
+/turf/closed/wall,
+/area/centcom/valhalla/primary/aft)
 "fdg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/warning_stripes/thick{
@@ -4841,10 +4841,6 @@
 	},
 /turf/open/floor/plating,
 /area/centcom/valhalla/crew_quarters/captain)
-"gsI" = (
-/obj/machinery/status_display,
-/turf/closed/wall,
-/area/centcom/valhalla/security/checkpoint)
 "gtc" = (
 /turf/open/floor/tile/dark,
 /area/centcom/valhalla/ai_monitored/storage/secure)
@@ -9390,10 +9386,6 @@
 	dir = 8
 	},
 /area/centcom/valhalla/starboard_hallway)
-"mKV" = (
-/obj/machinery/status_display,
-/turf/closed/wall,
-/area/centcom/valhalla/library)
 "mLC" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/warning_stripes/thick{
@@ -10194,9 +10186,9 @@
 /turf/open/floor/plating,
 /area/centcom/valhalla/security/brig)
 "nFT" = (
-/obj/machinery/vending/boozeomat,
-/turf/closed/wall/mainship,
-/area/tdome)
+/obj/machinery/status_display,
+/turf/closed/wall/r_wall,
+/area/centcom/valhalla/security/brig)
 "nGE" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/warning_stripes/thick{
@@ -10503,6 +10495,10 @@
 	dir = 8
 	},
 /area/centcom/valhalla/secondary/entry)
+"ogD" = (
+/obj/machinery/status_display,
+/turf/closed/wall,
+/area/centcom/valhalla/security/checkpoint)
 "ogI" = (
 /obj/effect/turf_decal/warning_stripes/box,
 /turf/open/floor/tile/dark/gray,
@@ -10662,6 +10658,10 @@
 	dir = 9
 	},
 /area/centcom/valhalla/crew_quarters)
+"opn" = (
+/obj/machinery/status_display,
+/turf/closed/wall,
+/area/centcom/valhalla/library)
 "orB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -11152,8 +11152,8 @@
 /area/centcom/valhalla/security/brig/interiorcavern)
 "oZI" = (
 /obj/machinery/status_display,
-/turf/closed/wall/r_wall,
-/area/centcom/valhalla/security/brig)
+/turf/closed/wall,
+/area/centcom/valhalla/janitor)
 "oZR" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 4
@@ -11309,9 +11309,9 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/centcom/valhalla/medical/chemistry)
 "pjq" = (
-/obj/machinery/status_display,
-/turf/closed/wall,
-/area/centcom/valhalla/janitor)
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/wood,
+/area/tdome/tdomeobserve)
 "pjR" = (
 /obj/effect/turf_decal/warning_stripes/box,
 /turf/open/floor/tile/dark/gray,
@@ -12961,6 +12961,10 @@
 /area/centcom/valhalla/crew_quarters)
 "rsu" = (
 /obj/machinery/newscaster,
+/turf/closed/wall,
+/area/centcom/valhalla/medical/medbay)
+"rtr" = (
+/obj/machinery/status_display,
 /turf/closed/wall,
 /area/centcom/valhalla/medical/medbay)
 "rtA" = (
@@ -16156,10 +16160,6 @@
 	},
 /turf/open/floor/engine,
 /area/centcom/valhalla/engine/engineering)
-"vCZ" = (
-/obj/machinery/status_display,
-/turf/closed/wall,
-/area/centcom/valhalla/primary/aft)
 "vDx" = (
 /obj/structure/prop/mainship/pipeprop/pump/on{
 	name = "Gas to Cooling Loop"
@@ -20706,7 +20706,7 @@ xrI
 xrI
 lIC
 lIC
-nFT
+lIC
 sji
 sqp
 nzE
@@ -21395,7 +21395,7 @@ xrI
 xrI
 xrI
 lIC
-hUu
+pjq
 hUu
 ncf
 hUu
@@ -26208,7 +26208,7 @@ ipO
 grx
 ipO
 lvE
-oZI
+nFT
 mZM
 ojM
 vLH
@@ -26231,7 +26231,7 @@ lmF
 mDO
 wXk
 lOR
-mKV
+opn
 acu
 klg
 vnN
@@ -27327,7 +27327,7 @@ jhC
 uIP
 vmM
 qFW
-pjq
+oZI
 fhh
 bYd
 iHX
@@ -27756,7 +27756,7 @@ ckN
 cDn
 aWh
 lda
-eqR
+rtr
 tfU
 wXW
 woP
@@ -29967,7 +29967,7 @@ ufQ
 nhm
 xeT
 xMI
-gsI
+ogD
 gzn
 cUs
 rDY
@@ -30243,14 +30243,14 @@ vhv
 nhm
 xeT
 xMI
-gsI
+ogD
 dqB
 iuT
 qun
 pYe
 oke
 iFb
-gsI
+ogD
 xgK
 fHt
 rYF
@@ -30391,7 +30391,7 @@ uyh
 uyh
 xgK
 fHt
-vCZ
+fcK
 lkM
 xMI
 vAV

--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -1079,13 +1079,9 @@
 /turf/open/floor/carpet/side,
 /area/tdome/tdomeobserve)
 "bme" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32
-	},
-/turf/open/floor/tile/dark,
-/area/centcom/valhalla/library)
+/obj/machinery/status_display,
+/turf/closed/wall,
+/area/centcom/valhalla/crew_quarters)
 "bmt" = (
 /obj/machinery/computer/atmoscontrol{
 	dir = 8
@@ -1149,11 +1145,9 @@
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/centcom/valhalla/xenocave)
 "bue" = (
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
-/turf/open/floor/tile/dark/gray,
-/area/centcom/valhalla/primary/aft)
+/obj/machinery/status_display,
+/turf/closed/wall/r_wall/unmeltable,
+/area/centcom/valhalla/quartermaster/storage)
 "bur" = (
 /obj/structure/window/framed/colony/reinforced/hull,
 /obj/machinery/door/poddoor/shutters/mainship/open{
@@ -2626,8 +2620,8 @@
 /area/centcom/valhalla/crew_quarters/captain)
 "dye" = (
 /obj/machinery/status_display,
-/turf/closed/wall/r_wall/unmeltable,
-/area/centcom/valhalla/quartermaster/storage)
+/turf/closed/wall,
+/area/centcom/valhalla/crew_quarters/heads/hop)
 "dyf" = (
 /obj/effect/turf_decal/warning_stripes/thick,
 /turf/open/floor/plating,
@@ -2738,9 +2732,6 @@
 /turf/open/floor/plating,
 /area/centcom/valhalla/medical/medbay)
 "dDN" = (
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
 /turf/open/floor/tile/black{
 	dir = 8
 	},
@@ -2773,12 +2764,9 @@
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla/security/brig/interiorcavern)
 "dFG" = (
-/obj/structure/table/woodentable,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/tdome/tdomeobserve)
+/obj/machinery/status_display,
+/turf/closed/wall/mainship,
+/area/tdome)
 "dFY" = (
 /obj/item/tool/wrench,
 /obj/effect/turf_decal/warning_stripes/thick,
@@ -3035,20 +3023,6 @@
 	dir = 5
 	},
 /area/centcom/valhalla/ai_monitored/storage/secure)
-"dPY" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/black{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/black{
-	dir = 1
-	},
-/turf/open/floor/tile/vault{
-	dir = 5
-	},
-/area/centcom/valhalla/bridge)
 "dPZ" = (
 /obj/machinery/photocopier,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -3130,9 +3104,6 @@
 /turf/open/floor/tile/red/yellowfull,
 /area/tdome/tdomeadmin)
 "dSu" = (
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/warning_stripes/box/small{
 	dir = 1
 	},
@@ -3406,9 +3377,6 @@
 /turf/open/floor/wood/broken/six,
 /area/centcom/valhalla/library)
 "eoT" = (
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/black{
 	dir = 8
 	},
@@ -3445,6 +3413,10 @@
 	dir = 1
 	},
 /area/centcom/valhalla/primary/fore)
+"eqR" = (
+/obj/machinery/status_display,
+/turf/closed/wall,
+/area/centcom/valhalla/medical/medbay)
 "ete" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -3548,9 +3520,6 @@
 /turf/open/floor/plating,
 /area/centcom/valhalla/security/brig/interiorcavern)
 "eBc" = (
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
 /obj/structure/sign/securearea{
 	pixel_x = 32;
 	pixel_y = -32
@@ -3669,10 +3638,10 @@
 /area/centcom/valhalla/bridge)
 "eKN" = (
 /obj/machinery/status_display{
-	pixel_y = -32
+	pixel_x = 32
 	},
-/turf/open/floor/tile/escape,
-/area/centcom/valhalla/secondary/exit)
+/turf/closed/wall/r_wall,
+/area/centcom/valhalla/engine/atmos_monitoring)
 "eLn" = (
 /obj/structure/table,
 /obj/item/clothing/mask/cigarette/cigar/cohiba{
@@ -4104,9 +4073,6 @@
 "fpS" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
-	},
-/obj/machinery/status_display{
-	pixel_x = 32
 	},
 /obj/structure/table,
 /turf/open/floor/grimy,
@@ -4875,6 +4841,10 @@
 	},
 /turf/open/floor/plating,
 /area/centcom/valhalla/crew_quarters/captain)
+"gsI" = (
+/obj/machinery/status_display,
+/turf/closed/wall,
+/area/centcom/valhalla/security/checkpoint)
 "gtc" = (
 /turf/open/floor/tile/dark,
 /area/centcom/valhalla/ai_monitored/storage/secure)
@@ -5380,10 +5350,6 @@
 /obj/machinery/door/firedoor{
 	dir = 2
 	},
-/obj/machinery/door/airlock/highsecurity{
-	locked = 1;
-	name = "AI Vault Chamber"
-	},
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
 	},
@@ -5393,6 +5359,10 @@
 	id = "securestoragelockdown";
 	name = "Secure Storage Heavy Blast Shutters"
 	},
+/obj/machinery/door/airlock/mainship/generic{
+	dir = 2
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/tile/dark,
 /area/centcom/valhalla/ai_monitored/storage/secure)
 "hiA" = (
@@ -5749,9 +5719,6 @@
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla/security/brig)
 "hHi" = (
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/warning_stripes/thick/corner,
 /obj/effect/turf_decal/warning_stripes/thick/corner{
 	dir = 1
@@ -6032,17 +5999,10 @@
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla/starboard_hallway)
 "hZl" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
 /turf/open/floor/carpet/side{
 	dir = 1
 	},
 /area/tdome/tdomeobserve)
-"hZF" = (
-/obj/machinery/status_display,
-/turf/closed/wall/r_wall,
-/area/centcom/valhalla/storage/eva)
 "hZN" = (
 /obj/structure/table/reinforced,
 /obj/item/tool/crowbar,
@@ -6538,9 +6498,6 @@
 /area/centcom/valhalla/security/brig/interiorcavern)
 "iNM" = (
 /obj/machinery/teleport/station,
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/black{
 	dir = 8
 	},
@@ -6957,13 +6914,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/centcom/valhalla/crew_quarters/bar)
-"jty" = (
-/obj/structure/closet/cabinet,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -32
-	},
-/turf/open/floor/grimy,
-/area/centcom/valhalla/crew_quarters)
 "jtz" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/green{
@@ -7025,9 +6975,6 @@
 "jwO" = (
 /obj/structure/table,
 /obj/item/taperecorder,
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
 /turf/open/floor/tile/dark,
 /area/centcom/valhalla/library)
 "jxj" = (
@@ -7781,9 +7728,6 @@
 /area/centcom/valhalla/crew_quarters/toilet)
 "ksc" = (
 /obj/item/storage/fancy/candle_box,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
 /obj/structure/rack,
 /turf/open/floor/wood,
 /area/centcom/valhalla/library)
@@ -8245,9 +8189,7 @@
 /area/centcom/valhalla/primary/aft)
 "kZb" = (
 /obj/structure/closet/cabinet,
-/obj/item/clothing/suit/storage/marine/imperial/sergeant/veteran,
 /obj/item/clothing/head/helmet/marine/imperial/sergeant/veteran,
-/obj/item/weapon/chainsword,
 /obj/item/clothing/under/marine/imperial,
 /obj/item/clothing/shoes/marine/imperial,
 /obj/item/weapon/gun/energy/lasgun/lasrifle,
@@ -8316,7 +8258,7 @@
 	},
 /area/centcom/valhalla/port)
 "lfP" = (
-/obj/machinery/computer/security/telescreen/entertainment,
+/obj/machinery/status_display,
 /turf/closed/wall,
 /area/centcom/valhalla/port)
 "lgF" = (
@@ -8579,9 +8521,6 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/explosive/grenade/chem_grenade/cleaner,
 /obj/item/explosive/grenade/chem_grenade/cleaner,
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
 /turf/open/floor/tile/lightred,
 /area/centcom/valhalla/janitor)
 "luM" = (
@@ -8652,9 +8591,6 @@
 /obj/structure/table/reinforced,
 /obj/item/book/manual/chef_recipes,
 /obj/item/taperecorder,
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
 /obj/item/attachable/flashlight,
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
@@ -8876,9 +8812,6 @@
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla/hydroponics)
 "lXg" = (
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -8976,13 +8909,6 @@
 "mcp" = (
 /turf/open/floor/tile/chapel,
 /area/centcom/valhalla/chapel/main)
-"mcr" = (
-/obj/structure/table/woodentable,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -32
-	},
-/turf/open/floor/wood,
-/area/tdome/tdomeobserve)
 "mcN" = (
 /obj/item/storage/box/visual/grenade/teargas{
 	pixel_x = 3;
@@ -9464,6 +9390,10 @@
 	dir = 8
 	},
 /area/centcom/valhalla/starboard_hallway)
+"mKV" = (
+/obj/machinery/status_display,
+/turf/closed/wall,
+/area/centcom/valhalla/library)
 "mLC" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/warning_stripes/thick{
@@ -10692,9 +10622,6 @@
 /obj/machinery/computer/secure_data{
 	dir = 8
 	},
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
 /obj/structure/table/reinforced,
 /turf/open/floor/tile/dark/red2{
 	dir = 4
@@ -10982,9 +10909,6 @@
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla/secondary/exit)
 "oKJ" = (
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
 /obj/machinery/vending/tool/nopower,
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla/storage/primary)
@@ -11227,9 +11151,9 @@
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla/security/brig/interiorcavern)
 "oZI" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall,
-/area/centcom/valhalla/security/checkpoint)
+/obj/machinery/status_display,
+/turf/closed/wall/r_wall,
+/area/centcom/valhalla/security/brig)
 "oZR" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 4
@@ -11385,13 +11309,9 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/centcom/valhalla/medical/chemistry)
 "pjq" = (
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
-/turf/open/floor/tile/vault{
-	dir = 5
-	},
-/area/centcom/valhalla/library)
+/obj/machinery/status_display,
+/turf/closed/wall,
+/area/centcom/valhalla/janitor)
 "pjR" = (
 /obj/effect/turf_decal/warning_stripes/box,
 /turf/open/floor/tile/dark/gray,
@@ -11962,7 +11882,9 @@
 /obj/effect/turf_decal/tile/black{
 	dir = 8
 	},
-/obj/structure/sign/atmosplaque,
+/obj/structure/sign/atmosplaque{
+	dir = 4
+	},
 /turf/open/floor/tile/vault{
 	dir = 5
 	},
@@ -12082,9 +12004,6 @@
 /turf/open/floor/tile/red/redblue/full,
 /area/tdome/tdomeobserve)
 "qun" = (
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
 /turf/open/floor/tile/dark/red2{
 	dir = 4
 	},
@@ -13202,9 +13121,6 @@
 	},
 /area/centcom/valhalla/security/checkpoint)
 "rEs" = (
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -13348,12 +13264,6 @@
 	},
 /turf/open/floor/gcircuit,
 /area/centcom/valhalla/engine/engineering)
-"rPr" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -32
-	},
-/turf/open/floor/tile/white,
-/area/tdome/tdomeobserve)
 "rPH" = (
 /obj/machinery/vending/snack,
 /obj/machinery/firealarm{
@@ -14725,9 +14635,6 @@
 /area/centcom/valhalla/medical/morgue)
 "tAJ" = (
 /obj/structure/closet/cabinet,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
 /turf/open/floor/grimy,
 /area/centcom/valhalla/crew_quarters)
 "tAQ" = (
@@ -14759,9 +14666,6 @@
 /area/centcom/valhalla/starboard)
 "tBc" = (
 /obj/structure/closet/cabinet,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
 /turf/open/floor/carpet/side{
 	dir = 5
 	},
@@ -14803,9 +14707,6 @@
 	},
 /area/centcom/valhalla/crew_quarters/bar)
 "tEm" = (
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 10
 	},
@@ -16255,6 +16156,10 @@
 	},
 /turf/open/floor/engine,
 /area/centcom/valhalla/engine/engineering)
+"vCZ" = (
+/obj/machinery/status_display,
+/turf/closed/wall,
+/area/centcom/valhalla/primary/aft)
 "vDx" = (
 /obj/structure/prop/mainship/pipeprop/pump/on{
 	name = "Gas to Cooling Loop"
@@ -16502,9 +16407,6 @@
 /area/centcom/valhalla/engine/engineering)
 "vOT" = (
 /obj/structure/closet/cabinet,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -32
-	},
 /turf/open/floor/wood/broken/seven,
 /area/centcom/valhalla/crew_quarters)
 "vQc" = (
@@ -16561,11 +16463,6 @@
 	},
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla/quartermaster/miningdock)
-"vRY" = (
-/obj/structure/table/woodentable,
-/obj/machinery/computer/security/telescreen/entertainment,
-/turf/open/floor/wood,
-/area/tdome/tdomeobserve)
 "vSy" = (
 /turf/closed/wall,
 /area/centcom/valhalla/quartermaster/storage)
@@ -17153,9 +17050,6 @@
 /turf/open/floor/tile/dark/gray,
 /area/centcom/valhalla/engine/engineering)
 "wrj" = (
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/warning_stripes/thick/corner{
 	dir = 1
 	},
@@ -20129,8 +20023,8 @@ gUR
 dIY
 dIY
 dIY
-rPr
-lIC
+dIY
+dFG
 meN
 xtI
 gBi
@@ -20537,7 +20431,7 @@ xrI
 xrI
 xrI
 xrI
-lIC
+dFG
 hZl
 blM
 lIC
@@ -21088,11 +20982,11 @@ xrI
 xrI
 lIC
 ibs
+tsg
+tsg
+tsg
+tsg
 dFG
-tsg
-tsg
-mcr
-lIC
 qvl
 aDr
 iZT
@@ -21224,7 +21118,7 @@ xrI
 xrI
 xrI
 xrI
-lIC
+dFG
 ePE
 ePE
 ePE
@@ -21641,7 +21535,7 @@ xrI
 lIC
 ldg
 kmB
-vRY
+tsg
 hlk
 hUu
 ndg
@@ -21914,8 +21808,8 @@ xrI
 xrI
 xrI
 xrI
-lIC
 dFG
+tsg
 hlk
 hUu
 kmB
@@ -22890,7 +22784,7 @@ xrI
 xrI
 xrI
 xrI
-lIC
+dFG
 meN
 xtI
 uwK
@@ -24376,7 +24270,7 @@ llp
 ndm
 rlp
 khV
-vLH
+eKN
 lXg
 mLF
 nuE
@@ -26062,7 +25956,7 @@ mDO
 qFW
 uEH
 srV
-bme
+pSb
 cYU
 acu
 kkv
@@ -26314,7 +26208,7 @@ ipO
 grx
 ipO
 lvE
-mvn
+oZI
 mZM
 ojM
 vLH
@@ -26337,7 +26231,7 @@ lmF
 mDO
 wXk
 lOR
-srV
+mKV
 acu
 klg
 vnN
@@ -26630,7 +26524,7 @@ oOW
 gPw
 gPw
 uah
-lfP
+ycV
 fmR
 fmR
 fmR
@@ -27433,7 +27327,7 @@ jhC
 uIP
 vmM
 qFW
-qzG
+pjq
 fhh
 bYd
 iHX
@@ -27447,7 +27341,7 @@ njt
 mYF
 epY
 pYX
-pjq
+ivQ
 hMy
 srV
 qFW
@@ -27862,7 +27756,7 @@ ckN
 cDn
 aWh
 lda
-jYM
+eqR
 tfU
 wXW
 woP
@@ -28111,13 +28005,13 @@ uYH
 uYH
 qUc
 rYK
-uIP
+bme
 tAJ
 qBK
 uIP
 tbW
 udp
-uIP
+bme
 xgS
 vOT
 uIP
@@ -28525,15 +28419,15 @@ xil
 qFW
 tgW
 sbe
-uIP
+bme
 tBc
 uby
 uIP
 tdj
 ujt
-uIP
+bme
 qBK
-jty
+tAJ
 uIP
 tgW
 syo
@@ -30073,7 +29967,7 @@ ufQ
 nhm
 xeT
 xMI
-uyh
+gsI
 gzn
 cUs
 rDY
@@ -30349,14 +30243,14 @@ vhv
 nhm
 xeT
 xMI
-uyh
+gsI
 dqB
 iuT
 qun
 pYe
 oke
 iFb
-uyh
+gsI
 xgK
 fHt
 rYF
@@ -30494,10 +30388,10 @@ uyh
 uqg
 uyh
 uyh
-oZI
+uyh
 xgK
 fHt
-nhm
+vCZ
 lkM
 xMI
 vAV
@@ -30774,7 +30668,7 @@ pQh
 fhO
 kGq
 eGd
-bue
+xgK
 jJC
 vAV
 biW
@@ -30851,7 +30745,7 @@ bFh
 xTn
 xTn
 cRJ
-dPY
+xTn
 elK
 xTn
 xTn
@@ -31139,7 +31033,7 @@ yhG
 fZE
 kDw
 yhG
-hZF
+yhG
 yhG
 yhG
 rXP
@@ -31816,7 +31710,7 @@ vGP
 vGP
 bcm
 aVk
-bcm
+dye
 uVb
 aLi
 fSA
@@ -32643,7 +32537,7 @@ fWu
 smd
 bLb
 aDS
-wcJ
+bue
 uHR
 bzq
 fgt
@@ -32813,7 +32707,7 @@ wff
 xzU
 wff
 qaH
-eKN
+sWR
 xfa
 xWb
 xfa
@@ -33057,7 +32951,7 @@ xmJ
 xFT
 yfo
 fmR
-wcJ
+bue
 iwx
 dSO
 euB
@@ -33471,13 +33365,13 @@ xrI
 xrI
 xrI
 iDZ
-dye
+wcJ
 uft
 cok
 vSy
 cok
 cFb
-dye
+wcJ
 vVU
 wcJ
 vVU

--- a/_maps/modularmaps/EORG/cs_office.dmm
+++ b/_maps/modularmaps/EORG/cs_office.dmm
@@ -349,7 +349,6 @@
 /area/deathmatch)
 "iI" = (
 /obj/structure/table/woodentable,
-/obj/machinery/computer/security/telescreen/entertainment,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -1264,13 +1263,8 @@
 	},
 /area/deathmatch)
 "DM" = (
-/obj/machinery/computer/security/telescreen/entertainment,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/tile/dark/blue2{
-	dir = 4
-	},
+/obj/machinery/status_display,
+/turf/closed/wall/mainship/gray,
 /area/deathmatch)
 "DP" = (
 /obj/structure/bed/chair/sofa/right{
@@ -1528,8 +1522,8 @@
 /turf/open/floor/tile/cmo,
 /area/deathmatch)
 "KA" = (
-/obj/machinery/computer/security/telescreen/entertainment,
-/turf/closed/wall/mainship/gray,
+/obj/machinery/status_display,
+/turf/closed/wall/mainship/gray/outer,
 /area/deathmatch)
 "KB" = (
 /obj/structure/bed/chair/comfy/black{
@@ -2162,7 +2156,6 @@
 /area/deathmatch)
 "XK" = (
 /obj/structure/table/woodentable,
-/obj/machinery/computer/security/telescreen/entertainment,
 /turf/open/floor/tile/dark2,
 /area/deathmatch)
 "XS" = (
@@ -2724,7 +2717,7 @@ WY
 WY
 GX
 bL
-Nm
+DM
 ry
 XK
 WY
@@ -3110,7 +3103,7 @@ ZD
 ZD
 ZD
 ZD
-Xv
+KA
 kj
 ZJ
 ZJ
@@ -3254,7 +3247,7 @@ ZD
 ZD
 ZD
 ZD
-Xv
+KA
 kj
 ZJ
 Zx
@@ -3500,7 +3493,7 @@ Xv
 Xv
 Xv
 Nm
-KA
+Nm
 WN
 mE
 eH
@@ -4123,7 +4116,7 @@ wM
 UJ
 lx
 yY
-Nm
+DM
 Ag
 dZ
 Xq
@@ -4171,7 +4164,7 @@ Xv
 Nm
 mO
 tn
-KA
+Nm
 vU
 QF
 Tp
@@ -4210,7 +4203,7 @@ WK
 Qc
 ot
 dH
-DM
+Yn
 xj
 oU
 Xv

--- a/_maps/modularmaps/EORG/de_dust2.dmm
+++ b/_maps/modularmaps/EORG/de_dust2.dmm
@@ -419,6 +419,9 @@
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/plating/ground/dirt,
 /area/deathmatch)
+"MP" = (
+/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
+/area/deathmatch)
 "Ng" = (
 /obj/vehicle/train/cargo/engine,
 /turf/open/floor/plating/ground/dirt,
@@ -562,55 +565,55 @@
 /area/deathmatch)
 
 (1,1,1) = {"
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+MP
 aa
 aa
-ez
-ez
-ez
-aa
-aa
-aa
-ez
-ez
-ez
+MP
+MP
+MP
 aa
 aa
 aa
-aa
-aa
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
+MP
+MP
+MP
 aa
 aa
 aa
 aa
-ez
+aa
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+aa
+aa
+aa
+aa
+MP
 "}
 (2,1,1) = {"
-ez
+MP
 YD
 YD
 YD
@@ -655,10 +658,10 @@ YD
 FE
 FE
 YD
-ez
+MP
 "}
 (3,1,1) = {"
-ez
+MP
 YD
 pI
 pI
@@ -703,10 +706,10 @@ FE
 FE
 FE
 YD
-ez
+MP
 "}
 (4,1,1) = {"
-ez
+MP
 YD
 pI
 pI
@@ -754,7 +757,7 @@ YD
 aa
 "}
 (5,1,1) = {"
-ez
+MP
 YD
 pI
 pI
@@ -802,7 +805,7 @@ xg
 aa
 "}
 (6,1,1) = {"
-ez
+MP
 YD
 YD
 YD
@@ -850,7 +853,7 @@ xg
 aa
 "}
 (7,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -898,7 +901,7 @@ Ng
 aa
 "}
 (8,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -946,7 +949,7 @@ FE
 aa
 "}
 (9,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -994,7 +997,7 @@ FE
 aa
 "}
 (10,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -1042,7 +1045,7 @@ FE
 aa
 "}
 (11,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -1090,7 +1093,7 @@ FE
 aa
 "}
 (12,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -1138,7 +1141,7 @@ YD
 aa
 "}
 (13,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -1186,7 +1189,7 @@ YD
 aa
 "}
 (14,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -1234,7 +1237,7 @@ FE
 aa
 "}
 (15,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -1282,7 +1285,7 @@ FE
 aa
 "}
 (16,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -1330,7 +1333,7 @@ yY
 aa
 "}
 (17,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -1378,7 +1381,7 @@ Uq
 aa
 "}
 (18,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -1426,7 +1429,7 @@ Uq
 aa
 "}
 (19,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -1474,7 +1477,7 @@ Uq
 aa
 "}
 (20,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -1522,7 +1525,7 @@ yY
 aa
 "}
 (21,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -1570,7 +1573,7 @@ FE
 aa
 "}
 (22,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -1618,7 +1621,7 @@ FE
 aa
 "}
 (23,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -1666,7 +1669,7 @@ FE
 aa
 "}
 (24,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -1714,7 +1717,7 @@ FE
 aa
 "}
 (25,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -1762,7 +1765,7 @@ YD
 aa
 "}
 (26,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -1810,7 +1813,7 @@ YD
 aa
 "}
 (27,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -1858,7 +1861,7 @@ YD
 aa
 "}
 (28,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -1906,7 +1909,7 @@ YD
 aa
 "}
 (29,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -1954,7 +1957,7 @@ YD
 aa
 "}
 (30,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -2002,7 +2005,7 @@ YD
 aa
 "}
 (31,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -2050,7 +2053,7 @@ YD
 aa
 "}
 (32,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -2095,10 +2098,10 @@ YD
 ez
 ez
 ez
-ez
+MP
 "}
 (33,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -2143,10 +2146,10 @@ ez
 ez
 ez
 ez
-ez
+MP
 "}
 (34,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -2191,10 +2194,10 @@ ez
 ez
 ez
 ez
-ez
+MP
 "}
 (35,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -2239,10 +2242,10 @@ ez
 ez
 ez
 ez
-ez
+MP
 "}
 (36,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -2287,10 +2290,10 @@ ez
 ez
 ez
 ez
-ez
+MP
 "}
 (37,1,1) = {"
-ez
+MP
 ez
 ez
 YD
@@ -2335,10 +2338,10 @@ ez
 ez
 ez
 ez
-ez
+MP
 "}
 (38,1,1) = {"
-ez
+MP
 ez
 ez
 YD
@@ -2383,10 +2386,10 @@ ez
 ez
 ez
 ez
-ez
+MP
 "}
 (39,1,1) = {"
-ez
+MP
 ez
 ez
 YD
@@ -2431,10 +2434,10 @@ ez
 ez
 ez
 ez
-ez
+MP
 "}
 (40,1,1) = {"
-ez
+MP
 ez
 ez
 YD
@@ -2479,10 +2482,10 @@ ez
 ez
 ez
 ez
-ez
+MP
 "}
 (41,1,1) = {"
-ez
+MP
 ez
 ez
 YD
@@ -2527,10 +2530,10 @@ ez
 ez
 ez
 ez
-ez
+MP
 "}
 (42,1,1) = {"
-ez
+MP
 ez
 ez
 YD
@@ -2575,10 +2578,10 @@ ez
 ez
 ez
 ez
-ez
+MP
 "}
 (43,1,1) = {"
-ez
+MP
 ez
 ez
 YD
@@ -2623,10 +2626,10 @@ ez
 ez
 ez
 ez
-ez
+MP
 "}
 (44,1,1) = {"
-ez
+MP
 ez
 ez
 YD
@@ -2671,10 +2674,10 @@ ez
 ez
 ez
 ez
-ez
+MP
 "}
 (45,1,1) = {"
-ez
+MP
 ez
 ez
 ez
@@ -2719,20 +2722,20 @@ ez
 ez
 ez
 ez
-ez
+MP
 "}
 (46,1,1) = {"
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+MP
 aa
 aa
 aa
@@ -2740,13 +2743,13 @@ aa
 aa
 aa
 aa
-ez
-ez
-ez
-ez
-ez
-ez
-ez
+MP
+MP
+MP
+MP
+MP
+MP
+MP
 aa
 aa
 aa
@@ -2755,17 +2758,17 @@ aa
 aa
 aa
 aa
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
-ez
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+MP
+MP
 "}


### PR DESCRIPTION

## About The Pull Request

Title.
Entertainment monitors in a couple of maps got broken by the status_display changes. This PR fixes them by replacing them entirely.

## Why It's Good For The Game

Big bad error icon bad, fix good.

## Changelog
:cl:
fix: Fixed entertainment monitors erroring out.
/:cl:
