### PR TITLE
Adds a damage multiplier var for akimbo, nerfs revolver akimbo firing delay

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -164,6 +164,8 @@
 	var/lower_akimbo_accuracy = 1
 	///If fire delay is 1 second, and akimbo_additional_delay is 0.5, then you'll have to wait 1 second * 0.5 to fire the second gun
 	var/akimbo_additional_delay = 0.5
+	///Damage multiplier applied to akimbo.
+	var/akimbo_damage_multiplier = 0.75
 	///Delay for the gun winding up before firing.
 	var/windup_delay = 0
 	///Sound played during windup.
@@ -1690,9 +1692,10 @@
 			iff_signal = sentry.iff_signal
 		projectile_to_fire.iff_signal = iff_signal
 	projectile_to_fire.damage_marine_falloff = iff_marine_damage_falloff
-	//no point blank bonus when akimbo
+
 	if(dual_wield)
-		projectile_to_fire.point_blank_range = 0
+		projectile_to_fire.point_blank_range = 0	// no point blank bonus when akimbo
+		projectile_to_fire.damage *= akimbo_damage_multiplier	// damage multiplier applied when akimbo
 
 ///Sets the projectile accuracy and scatter
 /obj/item/weapon/gun/proc/setup_bullet_accuracy()

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -16,7 +16,7 @@
 	actions_types = list(/datum/action/item_action/aim_mode)
 	aim_speed_modifier = 0.75
 	aim_fire_delay = 0.25 SECONDS
-	akimbo_additional_delay = 0.08 SECONDS
+	akimbo_additional_delay = 0.8
 	wield_delay = 0.2 SECONDS //If you modify your revolver to be two-handed, it will still be fast to aim
 	gun_skill_category = SKILL_PISTOLS
 

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -16,6 +16,7 @@
 	actions_types = list(/datum/action/item_action/aim_mode)
 	aim_speed_modifier = 0.75
 	aim_fire_delay = 0.25 SECONDS
+	akimbo_additional_delay = 0.08 SECONDS
 	wield_delay = 0.2 SECONDS //If you modify your revolver to be two-handed, it will still be fast to aim
 	gun_skill_category = SKILL_PISTOLS
 


### PR DESCRIPTION
## About The Pull Request
Adds a damage multiplier for akimbo. This is a var in every gun, and is set to 0.75 by default (meaning all akimbo damage gets a -25% damage modifier).
Additionally, nerfs the akimbo firing delay for revolvers.

## Why It's Good For The Game
Akimbo has a lot of damage in general, and a lot of firing speed on revolvers. This PR aims to amend that by tackling the damage output akimbo can generate, as well as introducing a firing speed nerf for dual wielding revolvers.

## Changelog
:cl: Lewdcifer
code: All guns now have a damage multiplier var for akimbo.
balance: All guns will now receive a -25% damage modifier when dual wielded.
balance: Revolvers now have an additional delay of 80 milliseconds.
/:cl: