### PR TITLE
Shoulder holster can no longer carry mp19

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/uniform.dm
+++ b/code/modules/clothing/modular_armor/attachments/uniform.dm
@@ -146,8 +146,6 @@
 		/obj/item/ammo_magazine/pistol,
 		/obj/item/weapon/gun/revolver,
 		/obj/item/ammo_magazine/revolver,
-		/obj/item/weapon/gun/smg/standard_machinepistol,
-		/obj/item/ammo_magazine/smg/standard_machinepistol,
 		/obj/item/weapon/gun/energy/lasgun/lasrifle/standard_marine_pistol,
 		/obj/item/cell/lasgun/lasrifle,
 	)


### PR DESCRIPTION

## About The Pull Request
This removes MP19 from fitting inside the shoulder holster webbing.
## Why It's Good For The Game
MP19 is not a pistol, it doesn't fit in pistol belt, it should not fit in pistol holster webbing.
## Changelog
:cl:
balance: MP19 no longer fits in pistol webbing.
/:cl:
