### PR TITLE
BFA change

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -72,8 +72,10 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	var/recoil_mod = 0
 	///If positive, adds recoil, if negative, lowers it. but for onehanded firing. Recoil can't go below 0.
 	var/recoil_unwielded_mod = 0
-	///Modifier to scatter from wielded burst fire, works off a multiplier.
+	///Additive to burst scatter modifier from burst fire, works off a multiplier.
 	var/burst_scatter_mod = 0
+	///additive modifier to burst fire accuracy.
+	var/burst_accuracy_mod = 0
 	///Adds silenced to weapon. changing its fire sound, muzzle flash, and volume. TRUE or FALSE
 	var/silence_mod = FALSE
 	///Adds an x-brightness flashlight to the weapon, which can be toggled on and off.
@@ -236,6 +238,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 		master_gun.aim_slowdown					+= aim_speed_mod
 		master_gun.wield_delay					+= wield_delay_mod
 		master_gun.burst_scatter_mult			+= burst_scatter_mod
+		master_gun.burst_accuracy_bonus			+= burst_accuracy_mod
 		master_gun.movement_acc_penalty_mult	+= movement_acc_penalty_mod
 		master_gun.shell_speed_mod				+= attach_shell_speed_mod
 		master_gun.scope_zoom					+= scope_zoom_mod
@@ -286,6 +289,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 		master_gun.aim_slowdown					-= aim_speed_mod
 		master_gun.wield_delay					-= wield_delay_mod
 		master_gun.burst_scatter_mult			-= burst_scatter_mod
+		master_gun.burst_accuracy_bonus			-= burst_accuracy_mod
 		master_gun.movement_acc_penalty_mult	-= movement_acc_penalty_mod
 		master_gun.shell_speed_mod				-= attach_shell_speed_mod
 		master_gun.scope_zoom					-= scope_zoom_mod
@@ -1194,11 +1198,9 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	desc = "A mechanism re-assembly kit that allows for automatic fire, or more shots per burst if the weapon already has the ability. \nIncreases scatter and decreases accuracy."
 	icon_state = "rapidfire"
 	slot = ATTACHMENT_SLOT_UNDER
-	accuracy_mod = -0.10
 	burst_mod = 2
-	scatter_mod = 3
-	accuracy_unwielded_mod = -0.20
-	scatter_unwielded_mod = 5
+	burst_scatter_mod = 1
+	burst_accuracy_mod = -0.1
 
 
 //Foldable/deployable attachments

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -209,10 +209,10 @@
 	var/min_scatter = -360
 	///Minimum scatter when wielded
 	var/min_scatter_unwielded = -360
-	///Multiplier. Increases or decreases how much bonus scatter is added when burst firing (wielded only).
+	///Multiplier. Increases or decreases how much bonus scatter is added when burst firing, based off burst size
 	var/burst_scatter_mult = 1
-	///Additive number added to accuracy_mult. Defaults to 0 (no change).
-	var/burst_accuracy_mult = 0
+	///Additive number added to accuracy_mult.
+	var/burst_accuracy_bonus = 0
 	///same vars as above but for unwielded firing.
 	var/accuracy_mult_unwielded = 1
 	///Multiplier. Increased and decreased through attachments. Multiplies the accuracy/scatter penalty of the projectile when firing while moving.
@@ -1717,10 +1717,10 @@
 
 	if(gun_firemode == GUN_FIREMODE_BURSTFIRE || gun_firemode == GUN_FIREMODE_AUTOBURST)
 		if(wielded_fire)
-			gun_accuracy_mult += burst_accuracy_mult
+			gun_accuracy_mult += burst_accuracy_bonus
 			gun_scatter += burst_amount * burst_scatter_mult
 		else
-			gun_accuracy_mult += burst_accuracy_mult * 2
+			gun_accuracy_mult += burst_accuracy_bonus * 2
 			gun_scatter += burst_amount * burst_scatter_mult * 2
 
 	if(dual_wield) //akimbo firing gives terrible scatter

--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -39,7 +39,7 @@
 	burst_delay = 0.1 SECONDS
 	extra_delay = 1 SECONDS
 	accuracy_mult = 1.2 //it's got a bipod
-	burst_accuracy_mult = 1
+	burst_accuracy_bonus = 1
 	burst_scatter_mult = 0
 
 	flags_item = IS_DEPLOYABLE|TWOHANDED

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -80,7 +80,7 @@
 	burst_amount = 1
 	autoburst_delay = 0.1 SECONDS
 	autoburst_delay = 0.1 SECONDS //this makes it fuller auto
-	burst_accuracy_mult = 0.3
+	burst_accuracy_bonus = -0.3
 	burst_scatter_mult = 25
 
 /obj/item/weapon/gun/smg/standard_machinepistol/compact
@@ -458,7 +458,7 @@
 	burst_delay = 0.1 SECONDS
 	extra_delay = 0.1 SECONDS
 	autoburst_delay = 0.1 SECONDS //this makes it fuller auto
-	burst_accuracy_mult = -0.3
+	burst_accuracy_bonus = -0.3
 	burst_scatter_mult = 15
 
 	akimbo_additional_delay = 0.7


### PR DESCRIPTION

## About The Pull Request
Changes the Burst Fire Assembly to decrease burst scatter and accuracy specifically.

Currently the BFA reduces scatter and accuracy generally, so even if you fire it on semi/auto, it still penalises you which is kinda wack.

The stats will be more or less the same, although the scatter may be very slightly higher for guns with large bursts (like BFA t18).

Also fixes a bug with MP19. I accidentally left out a minus, so it was MORE accurate instead of less, when burstfiring. Whoops.
## Why It's Good For The Game
BFA specifically effecting burst is good.
Bug fix good.
## Changelog
:cl:
balance: BFA now only penalises burst accuracy and scatter, not semiauto or autofire stats
fix: fixed MP19 being more accurate than it should be burstfiring
/:cl:
