### PR TITLE
Adds a proximity check for sentries to prevent stacking

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -145,6 +145,9 @@
 #define ENERGY_OVERCHARGE_AMMO_COST 80
 #define ENERGY_OVERCHARGE_FIRE_DELAY 10
 
+//Define sentry
+#define SENTRY_DEPLOY_RANGE_LIMIT 2 // Range within which another sentry cannot be deployed.
+
 //Define stagger damage multipliers
 #define STAGGER_DAMAGE_MULTIPLIER 0.5 //-50% damage dealt by the staggered target after all other mods.
 

--- a/code/datums/elements/deployable_item.dm
+++ b/code/datums/elements/deployable_item.dm
@@ -77,6 +77,11 @@ GLOBAL_LIST_EMPTY(deployable_items)
 		if(user.do_actions)
 			user.balloon_alert(user, "You are already doing something!")
 			return
+		if(istype(item_to_deploy, /obj/item/weapon/gun/sentry))
+			for(var/obj/machinery/deployable/mounted/sentry in orange(SENTRY_DEPLOY_RANGE_LIMIT, location))
+				if(get_dist_euclide_square(sentry, item_to_deploy) >= SENTRY_DEPLOY_RANGE_LIMIT)
+					user.balloon_alert(user, "Another sentry is too close")
+					return
 		user.balloon_alert(user, "You start deploying...")
 		user.setDir(get_dir(user, location)) //Face towards deploy location for ease of deploy.
 		var/newdir = user.dir //Save direction before the doafter for ease of deploy


### PR DESCRIPTION
## About The Pull Request
Adds a proximity check in code for sentry deployment. If there is another sentry within two tiles of range, you will be unable to deploy it.

## Why It's Good For The Game
Prevents bullshit like this:
![image](https://user-images.githubusercontent.com/59634950/233241838-bbbb7c3b-87ab-49b3-88a9-fafbabdf2c55.png)

This, on the other hand, feels more fair for xenos:
![image](https://user-images.githubusercontent.com/59634950/233241811-23e22079-40d1-4ff3-9320-169d29277ce6.png)


## Changelog
:cl: Lewdcifer
balance: Sentries can no longer be deployed within two tiles of each other.
/:cl: