### PR TITLE
Nerfs Defile strength scaling

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -132,7 +132,7 @@
 					continue
 				else
 					neuro_applied = TRUE
-			defile_strength_multiplier *= 2
+			defile_strength_multiplier *= 1.5
 	if(living_target.has_status_effect(STATUS_EFFECT_INTOXICATED))
 		var/datum/status_effect/stacking/intoxicated/debuff = living_target.has_status_effect(STATUS_EFFECT_INTOXICATED)
 		defile_reagent_amount += debuff.stacks


### PR DESCRIPTION
## About The Pull Request
Nerfs the scaling for Defiler's strength based on existing chems. Instead of multiplying its strength by 2 for every chem present, it will now do so by 1.5.
### Bear in mind this might not be enough. I might have to nerf it some more later down the line if this proves to be an underwhelming nerf.

## Why It's Good For The Game
Defile being such an instakill sentence with just two chems is probably not okay.

## Changelog
:cl: Lewdcifer
balance: Defile strength scaling per chem reduced from 2 to 1.5.
/:cl: