### PR TITLE
A couple of combat robot balance changes

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -466,6 +466,14 @@
 		clear_fullscreen("robothalf")
 		clear_fullscreen("robotlow")
 
+/mob/living/carbon/human/species/robot/updatehealth()
+	. = ..()
+
+	if(health > -25)
+		return
+	adjust_stagger(1)
+	adjust_slowdown(1)
+
 ///Lets a robot repair itself over time at the cost of being stunned and blind
 /datum/action/repair_self
 	name = "Activate autorepair"
@@ -485,7 +493,7 @@
 	if(!. || !ishuman(owner))
 		return
 	var/mob/living/carbon/human/howner = owner
-	howner.apply_status_effect(STATUS_EFFECT_REPAIR_MODE, 5 SECONDS)
+	howner.apply_status_effect(STATUS_EFFECT_REPAIR_MODE, 10 SECONDS)
 	howner.balloon_alert_to_viewers("Repairing")
 
 /datum/species/robot/alpharii


### PR DESCRIPTION
## About The Pull Request
Robots now suffer from stagger and slowdown when below -25 health.

Repair mode is now 10 seconds instead of 5.

Robots have been powercrept repeatedly since they were added, and while they still have the very important drawback of no sprint, they have a significant number of strong advantages over humans, that makes them superior in many instances.

The staggerslow change is a fairly mild change mainly in response to robots:
A: Not having a crit at all meaning they effectively have 33% more hp than humans.
B: Cannot be crit dragged so are significantly harder to perma.
C: Being immune to pain and therefore the staggerslow associated with high pain
D: Being a one click revive regardless of damage, and having no permenant damage from death or draining.

The maintenance mode change is because 5 seconds means there isn't actually very much risk in using it, which is supposed to be its drawback. As unless there is a hunter literally around the corner waiting for you to use the ability, you'll be lucky to get a second or two of defenselessness before they turn back on.
## Why It's Good For The Game
Robots will actually have at least some penalties for operating at very low health (a human is easily perma staggered and slowed before they even reach this health due to pain).

Repair mode has a bit more drawback and can't be used quite so risk free.
## Changelog
:cl:
balance: Repair mode for combat robots now lasts 10 seconds instead of 5. Repair per second unchanged
balance: Combat robots now suffer from stagger and slow under -25 health
/:cl:
