### PR TITLE
Prevents King's Psychic Summon from summoning xenos in other z levels

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -132,7 +132,7 @@
 					continue
 				else
 					neuro_applied = TRUE
-			defile_strength_multiplier *= 2
+			defile_strength_multiplier *= 1.5
 	if(living_target.has_status_effect(STATUS_EFFECT_INTOXICATED))
 		var/datum/status_effect/stacking/intoxicated/debuff = living_target.has_status_effect(STATUS_EFFECT_INTOXICATED)
 		defile_reagent_amount += debuff.stacks

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -132,7 +132,7 @@
 					continue
 				else
 					neuro_applied = TRUE
-			defile_strength_multiplier *= 1.5
+			defile_strength_multiplier *= 2
 	if(living_target.has_status_effect(STATUS_EFFECT_INTOXICATED))
 		var/datum/status_effect/stacking/intoxicated/debuff = living_target.has_status_effect(STATUS_EFFECT_INTOXICATED)
 		defile_reagent_amount += debuff.stacks

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
@@ -485,16 +485,22 @@
 	xeno_message("King: \The [owner] has begun a psychic summon in <b>[get_area(owner)]</b>!", hivenumber = X.hivenumber)
 	var/list/allxenos = X.hive.get_all_xenos()
 	for(var/mob/living/carbon/xenomorph/sister AS in allxenos)
+		if(sister.z != owner.z)
+			continue
 		sister.add_filter("summonoutline", 2, outline_filter(1, COLOR_VIOLET))
 
 	if(!do_after(X, 10 SECONDS, FALSE, X, BUSY_ICON_HOSTILE))
 		add_cooldown(5 SECONDS)
 		for(var/mob/living/carbon/xenomorph/sister AS in allxenos)
+			if(sister.z != owner.z)
+				continue
 			sister.remove_filter("summonoutline")
 		return fail_activate()
 
 	allxenos = X.hive.get_all_xenos() //refresh the list to account for any changes during the channel
 	for(var/mob/living/carbon/xenomorph/sister AS in allxenos)
+		if(sister.z != owner.z)
+			continue
 		sister.remove_filter("summonoutline")
 		sister.forceMove(get_turf(X))
 	log_game("[key_name(owner)] has summoned hive ([length(allxenos)] Xenos) in [AREACOORD(owner)]")


### PR DESCRIPTION
## About The Pull Request
Adds a check in the Psychic Summon ability that prevents xenos in a different z level from being summoned.

## Why It's Good For The Game
Two reasons:
- King being able to summon other xenos in different Z levels lends itself to some serious cheese -- be it bypassing a FOB siege entirely, easy shipside sweeps, or cases where xenos are stuck shipside with no way of getting back groundside while marines are also groundside (bonus points if you nuke).
- From an administrative standpoint, the admin team has had to deal with various cases where Psychic Summon was used in this manner. The headmins have ultimately decided that it is best to deal with this by preventing it from happening in the first place via code.

## Changelog
:cl: Lewdcifer
balance: Psychic Summon can no longer summon xenos in a different Z level.
/:cl: