### PR TITLE
Clicking a UI Slot will return the item inside the slot

### DIFF
--- a/code/_onclick/hud/screen_objects/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/screen_objects.dm
@@ -71,7 +71,7 @@
 	var/list/object_overlays = list()
 
 
-/atom/movable/screen/inventory/Click()
+/atom/movable/screen/inventory/Click(location, control, params)
 	// At this point in client Click() code we have passed the 1/10 sec check and little else
 	// We don't even know if it's a middle click
 	if(world.time <= usr.next_move)
@@ -83,9 +83,15 @@
 	if(istype(usr.loc, /obj/vehicle/multitile/root/cm_armored)) // stops inventory actions in a mech/tank
 		return TRUE
 
+	//If there is an item in the slot you are clicking on, this will relay the click to the item within the slot
+	var/atom/item_in_slot = usr.get_item_by_slot(slot_id)
+	if(item_in_slot)
+		return item_in_slot.Click()
+
 	if(!istype(src, /atom/movable/screen/inventory/hand) && usr.attack_ui(slot_id)) // until we get a proper hands refactor
 		usr.update_inv_l_hand()
 		usr.update_inv_r_hand()
+		return TRUE
 
 /atom/movable/screen/inventory/hand
 	name = "l_hand"
@@ -98,15 +104,11 @@
 	if(active)
 		add_overlay("hand_active")
 
-/atom/movable/screen/inventory/hand/Click()
-	if(world.time <= usr.next_move)
-		return TRUE
-	if(usr.incapacitated() || !iscarbon(usr))
-		return TRUE
-	if (istype(usr.loc, /obj/vehicle/multitile/root/cm_armored))
-		return TRUE
-	var/mob/living/carbon/C = usr
-	C.activate_hand(hand_tag)
+/atom/movable/screen/inventory/hand/Click(location, control, params)
+	. = ..()
+	if(.)
+		var/mob/living/carbon/C = usr
+		C.activate_hand(hand_tag)
 
 /atom/movable/screen/inventory/hand/right
 	name = "r_hand"

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -416,7 +416,6 @@
 	unwield(user)
 	if(ishandslot(slot))
 		set_gun_user(user)
-		mouse_opacity = MOUSE_OPACITY_OPAQUE
 	else
 		set_gun_user(null)
 	return ..()
@@ -428,10 +427,6 @@
 	if(!length(chamber_items) || !chamber_items[current_chamber_position] || chamber_items[current_chamber_position].loc == src)
 		return
 	drop_connected_mag(chamber_items[current_chamber_position], user)
-
-/obj/item/weapon/gun/unequipped(mob/user, slot)
-	. = ..()
-	mouse_opacity = initial(mouse_opacity) //So that it doesnt remain opaque when you drop or discard the gun
 
 ///Set the user in argument as gun_user
 /obj/item/weapon/gun/proc/set_gun_user(mob/user)


### PR DESCRIPTION
## About The Pull Request
Guns are no longer opaque
Makes it so clicking on a UI box will relay your click to click on whatever item is inside the box.
Closes https://github.com/tgstation/TerraGov-Marine-Corps/pull/12758
## Why It's Good For The Game
- Guns are no longer opaque: No more gun64 causing backpacks/pockets to become unclickable
- Things are easier to click on, clicking on the UI box will return whatever you have inside the box.
## Changelog
:cl:
add: Clicking on a UI box will click on whatever is inside the box.
del: Guns are no longer opaque
/:cl:
