### PR TITLE
Fixes synth erroneously being marked as "cold" on both minimap and examine

### DIFF
--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -232,7 +232,7 @@
 	if(!issynth(H) && !isrobot(H) && heart && prob(25))
 		heart.take_damage(5) //Allow the defibrillator to possibly worsen heart damage. Still rare enough to just be the "clone damage" of the defib
 
-	if(HAS_TRAIT(H, TRAIT_UNDEFIBBABLE) || H.suiciding) //synthetic species have no expiration date
+	if(HAS_TRAIT(H, TRAIT_UNDEFIBBABLE) || H.suiciding)
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient's brain has decayed too much. No remedy possible."))
 		return
 

--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -232,7 +232,7 @@
 	if(!issynth(H) && !isrobot(H) && heart && prob(25))
 		heart.take_damage(5) //Allow the defibrillator to possibly worsen heart damage. Still rare enough to just be the "clone damage" of the defib
 
-	if((HAS_TRAIT(H, TRAIT_UNDEFIBBABLE ) && !issynth(H)) || H.suiciding) //synthetic species have no expiration date
+	if(HAS_TRAIT(H, TRAIT_UNDEFIBBABLE) || H.suiciding) //synthetic species have no expiration date
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient's brain has decayed too much. No remedy possible."))
 		return
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -45,6 +45,8 @@
 
 
 /mob/living/carbon/human/proc/set_undefibbable()
+	if(issynth(src)) //synths do not dnr.
+		return
 	SEND_SIGNAL(src, COMSIG_HUMAN_SET_UNDEFIBBABLE)
 	ADD_TRAIT(src, TRAIT_UNDEFIBBABLE , TRAIT_UNDEFIBBABLE)
 	SSmobs.stop_processing(src) //Last round of processing.


### PR DESCRIPTION

## About The Pull Request

Because synths do not go cold!
## Why It's Good For The Game

Bug bad. 
## Changelog
:cl:
fix: Fixes synth erroneously being marked as "cold" on both minimap and examine
/:cl:
