### PR TITLE
Toolbelt and tool pouch can now hold the exact same things

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -45,28 +45,30 @@
 	desc = "The M276 is the standard load-bearing equipment of the TGMC. It consists of a modular belt with various clips. This version lacks any combat functionality, and is commonly used by engineers to transport important tools."
 	icon_state = "utilitybelt"
 	item_state = "utility"
+	max_w_class = WEIGHT_CLASS_NORMAL
 	can_hold = list(
-		/obj/item/tool/crowbar,
 		/obj/item/tool/screwdriver,
-		/obj/item/tool/weldingtool,
 		/obj/item/tool/wirecutters,
+		/obj/item/tool/weldingtool,
 		/obj/item/tool/wrench,
+		/obj/item/tool/crowbar,
+		/obj/item/stack/cable_coil,
 		/obj/item/tool/multitool,
 		/obj/item/flashlight,
-		/obj/item/stack/cable_coil,
 		/obj/item/t_scanner,
 		/obj/item/tool/analyzer,
 		/obj/item/tool/taperoll/engineering,
+		/obj/item/tool/extinguisher/mini,
+		/obj/item/tool/shovel/etool,
 	)
-
 
 /obj/item/storage/belt/utility/full/Initialize()
 	. = ..()
-	new /obj/item/tool/screwdriver(src)
-	new /obj/item/tool/wrench(src)
-	new /obj/item/tool/weldingtool(src)
-	new /obj/item/tool/crowbar(src)
-	new /obj/item/tool/wirecutters(src)
+	new /obj/item/tool/screwdriver (src)
+	new /obj/item/tool/wirecutters (src)
+	new /obj/item/tool/weldingtool (src)
+	new /obj/item/tool/wrench (src)
+	new /obj/item/tool/crowbar (src)
 	new /obj/item/stack/cable_coil(src,30,pick("red","yellow","orange"))
 	new /obj/item/tool/multitool(src)
 

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -677,15 +677,19 @@
 	max_w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "tools"
 	can_hold = list(
-		/obj/item/tool/wirecutters,
-		/obj/item/tool/shovel/etool,
 		/obj/item/tool/screwdriver,
-		/obj/item/tool/crowbar,
+		/obj/item/tool/wirecutters,
 		/obj/item/tool/weldingtool,
-		/obj/item/tool/multitool,
 		/obj/item/tool/wrench,
+		/obj/item/tool/crowbar,
 		/obj/item/stack/cable_coil,
+		/obj/item/tool/multitool,
+		/obj/item/flashlight,
+		/obj/item/t_scanner,
+		/obj/item/tool/analyzer,
+		/obj/item/tool/taperoll/engineering,
 		/obj/item/tool/extinguisher/mini,
+		/obj/item/tool/shovel/etool,
 	)
 
 /obj/item/storage/pouch/tools/full/Initialize()


### PR DESCRIPTION

## About The Pull Request
Makes tool belt and tool pouch have the same can_hold list.
buffs toolbelt to max_w_class normal (same as tool pouch)
## Why It's Good For The Game
It's a bit weird that the pouch variant of the tool storage is better than the belt variant.
It's also weird that they dont hold the same things.
This normalizes it.
## Changelog
:cl:
refactor: Toolbelt and tool pouch can hold the same items.
/:cl:
