### PR TITLE
Removes the medscanner gloves from the Marinemed

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1113,7 +1113,6 @@
 		),
 		"Misc" = list(
 			/obj/item/defibrillator = 8,
-			/obj/item/healthanalyzer/gloves = 8,
 			/obj/item/healthanalyzer = 16,
 			/obj/item/bodybag/cryobag = 24,
 		),

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -211,7 +211,6 @@
 			/obj/item/reagent_containers/glass/beaker/large = -1,
 			/obj/item/reagent_containers/glass/beaker/vial = -1,
 			/obj/item/clothing/glasses/hud/health = 6,
-			/obj/item/healthanalyzer/gloves = 6,
 			/obj/item/roller = 6,
 		),
 	)

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -211,6 +211,7 @@
 			/obj/item/reagent_containers/glass/beaker/large = -1,
 			/obj/item/reagent_containers/glass/beaker/vial = -1,
 			/obj/item/clothing/glasses/hud/health = 6,
+			/obj/item/healthanalyzer/gloves = 6,
 			/obj/item/roller = 6,
 		),
 	)


### PR DESCRIPTION
## About The Pull Request

This PR removes the new Medscanner gloves from the normal MarineMed, as really it shouldn't make sense that a common marine can get their hands on it.

[updating the pic, please stand by]

## Why It's Good For The Game

It's more of a balancing stuff, since it's pretty much a flat upgrade from the default marine gloves as it is right now.

## Changelog

:cl:
removed: Removed the Medscanner gloves from the Marinemed
/:cl:
