### PR TITLE
BR modular loot removal

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -17266,6 +17266,9 @@
 /area/mainship/command/airoom)
 "YX" = (
 /obj/effect/landmark/start/job/ai,
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
 "YZ" = (

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -326,9 +326,9 @@
 /area/mainship/medical/lower_medical)
 "axo" = (
 /obj/machinery/door_display/research_cell/cell{
-	dir = 1
+	pixel_y = 2
 	},
-/turf/open/floor/mainship/sterile/dark,
+/turf/closed/wall/mainship/white,
 /area/mainship/medical/medical_science)
 "axA" = (
 /obj/structure/cable,
@@ -10502,6 +10502,13 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"nyw" = (
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/hallways/port_hallway)
 "nyy" = (
 /obj/effect/soundplayer,
 /obj/structure/sign/science,
@@ -18043,6 +18050,9 @@
 /area/mainship/engineering/engineering_workshop)
 "xdy" = (
 /obj/effect/landmark/start/job/ai,
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
 "xdN" = (
@@ -41291,12 +41301,12 @@ rGg
 kQn
 fbP
 sXo
-gmc
+axo
 qIt
 nNo
 fFD
 xYE
-axo
+rGg
 gmc
 kEP
 rKn
@@ -49518,7 +49528,7 @@ pyV
 pgh
 pgh
 tBj
-xyS
+hGT
 hUf
 cNy
 hUf
@@ -49785,7 +49795,7 @@ gbM
 gbM
 gbM
 gbM
-ekk
+nyw
 eel
 ekk
 ekx
@@ -50041,7 +50051,7 @@ vAn
 vAn
 eZp
 vmD
-pvX
+vmD
 vmD
 acn
 vmD

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -2594,13 +2594,6 @@
 /obj/item/tool/pen,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/briefing)
-"dig" = (
-/obj/machinery/status_display{
-	pixel_x = 15
-	},
-/obj/effect/soundplayer,
-/turf/closed/wall/mainship,
-/area/mainship/living/briefing)
 "dit" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/mainship/tcomms,
@@ -11128,9 +11121,7 @@
 	},
 /area/mainship/living/briefing)
 "orC" = (
-/obj/machinery/status_display{
-	pixel_x = -15
-	},
+/obj/machinery/status_display,
 /obj/effect/soundplayer,
 /turf/closed/wall/mainship,
 /area/mainship/living/briefing)
@@ -53101,7 +53092,7 @@ kDx
 kDx
 plN
 oLC
-dig
+orC
 gnS
 kwS
 nGn

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -1449,12 +1449,12 @@
 	},
 /area/mainship/hallways/bow_hallway)
 "aqJ" = (
-/obj/machinery/status_display{
-	pixel_y = 30
-	},
 /obj/structure/table/mainship/nometal,
 /obj/structure/paper_bin,
 /obj/item/tool/pen,
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
 "ars" = (
@@ -1727,7 +1727,7 @@
 /area/mainship/medical/medical_science)
 "awS" = (
 /obj/machinery/status_display{
-	pixel_y = 30
+	pixel_y = 32
 	},
 /turf/open/floor/mainship/orange{
 	dir = 1
@@ -4548,7 +4548,7 @@
 /obj/structure/paper_bin,
 /obj/item/tool/pen,
 /obj/machinery/status_display{
-	pixel_y = 30
+	pixel_y = 32
 	},
 /turf/open/floor/mainship/orange{
 	dir = 9
@@ -8583,10 +8583,10 @@
 /area/mainship/medical/lower_medical)
 "dvk" = (
 /obj/structure/closet,
-/obj/machinery/status_display{
-	pixel_y = 30
-	},
 /obj/item/toy/plush/slime,
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/port_emb)
 "dvy" = (
@@ -9199,7 +9199,7 @@
 /area/mainship/medical/operating_room_three)
 "ext" = (
 /obj/machinery/status_display{
-	pixel_y = 30
+	pixel_y = 32
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
@@ -9444,9 +9444,6 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "eWQ" = (
-/obj/machinery/status_display{
-	pixel_y = 32
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -9455,6 +9452,9 @@
 	dir = 1
 	},
 /obj/effect/ai_node,
+/obj/machinery/status_display{
+	pixel_y = 34
+	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -10757,9 +10757,6 @@
 /area/mainship/hallways/port_hallway)
 "hbF" = (
 /obj/structure/cable,
-/obj/machinery/firealarm{
-	dir = 8
-	},
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
@@ -10868,7 +10865,7 @@
 /area/mainship/command/cic)
 "hjE" = (
 /obj/machinery/status_display{
-	pixel_y = 30
+	pixel_y = 32
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
@@ -12280,15 +12277,11 @@
 	},
 /area/mainship/command/cic)
 "jQK" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door_display/research_cell/cell/cell1{
-	dir = 4
+	pixel_y = 2
 	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/medical_science)
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/surgery_hallway)
 "jRe" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
@@ -13903,7 +13896,7 @@
 /area/mainship/hallways/aft_hallway)
 "mxY" = (
 /obj/machinery/status_display{
-	pixel_y = 30
+	pixel_y = 32
 	},
 /turf/open/floor/mainship/silver{
 	dir = 1
@@ -14535,12 +14528,12 @@
 "nyj" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/storage/box/cups,
-/obj/item/tool/kitchen/utensil/spoon,
-/obj/item/tool/kitchen/utensil/spoon,
-/obj/item/tool/kitchen/utensil/spoon,
-/obj/item/tool/kitchen/utensil/fork,
-/obj/item/tool/kitchen/utensil/fork,
-/obj/item/tool/kitchen/utensil/fork,
+/obj/effect/spawner/random/food_or_drink/kitchen,
+/obj/effect/spawner/random/food_or_drink/kitchen,
+/obj/effect/spawner/random/food_or_drink/kitchen,
+/obj/effect/spawner/random/food_or_drink/kitchen,
+/obj/effect/spawner/random/food_or_drink/kitchen,
+/obj/effect/spawner/random/food_or_drink/kitchen,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/grunt_rnr)
 "nzG" = (
@@ -15095,7 +15088,7 @@
 /area/mainship/medical/lower_medical)
 "osZ" = (
 /obj/machinery/status_display{
-	pixel_y = 32
+	pixel_y = 34
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
@@ -56697,7 +56690,7 @@ ckd
 ckd
 bDw
 bvX
-blP
+jQK
 bHk
 aDE
 ehB
@@ -57473,7 +57466,7 @@ iOm
 bIw
 nCT
 poH
-jQK
+poH
 bIw
 poH
 poH
@@ -69531,11 +69524,11 @@ aai
 aal
 abR
 rhS
-bhJ
+vXq
 vXq
 tBH
 vXq
-bhJ
+vXq
 rhS
 tNX
 qEl
@@ -70045,11 +70038,11 @@ bfU
 rbR
 abR
 nUz
-vXq
+bhJ
 tgF
 lBr
 qVQ
-vXq
+bhJ
 dvM
 abR
 nMO

--- a/_maps/map_files/debugdalus/tgs_debugdalus.dmm
+++ b/_maps/map_files/debugdalus/tgs_debugdalus.dmm
@@ -964,6 +964,9 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "aez" = (

--- a/_maps/modularmaps/big_red/bigredcargoareavar3.dmm
+++ b/_maps/modularmaps/big_red/bigredcargoareavar3.dmm
@@ -148,7 +148,7 @@
 /obj/machinery/light{
 	dir = 1;
 	},
-/obj/effect/spawner/random/misc/structure/supplycrate/case/small,
+/obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "kd" = (
@@ -203,7 +203,7 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "nq" = (
-/obj/effect/spawner/random/engineering/structure/tank/fuelweighted/barrel,
+/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "pJ" = (
@@ -351,7 +351,7 @@
 /area/bigredv2/outside/nw)
 "Av" = (
 /obj/machinery/light,
-/obj/effect/spawner/random/engineering/structure/tank/fuelweighted/barrel,
+/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "AE" = (
@@ -608,7 +608,7 @@
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
 "Wd" = (
-/obj/effect/spawner/random/misc/structure/supplycrate/case/double,
+/obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "Wl" = (

--- a/_maps/modularmaps/big_red/bigredcargoareavar4.dmm
+++ b/_maps/modularmaps/big_red/bigredcargoareavar4.dmm
@@ -216,7 +216,7 @@
 /area/bigredv2/caves/west)
 "pG" = (
 /obj/machinery/light,
-/obj/effect/spawner/random/engineering/structure/tank/fuelweighted/barrel,
+/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "pR" = (
@@ -366,7 +366,7 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "zy" = (
-/obj/effect/spawner/random/misc/structure/supplycrate/case/double,
+/obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "zR" = (
@@ -723,7 +723,7 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "UP" = (
-/obj/effect/spawner/random/engineering/structure/tank/fuelweighted/barrel,
+/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "Vv" = (
@@ -800,7 +800,7 @@
 /obj/machinery/light{
 	dir = 1;
 	},
-/obj/effect/spawner/random/misc/structure/supplycrate/case/small,
+/obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "Yd" = (

--- a/_maps/modularmaps/big_red/bigredcargoareavar5.dmm
+++ b/_maps/modularmaps/big_red/bigredcargoareavar5.dmm
@@ -162,7 +162,7 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "kP" = (
-/obj/effect/spawner/random/misc/structure/supplycrate/case/double,
+/obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "lr" = (
@@ -348,7 +348,7 @@
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/nw)
 "yf" = (
-/obj/effect/spawner/random/engineering/structure/tank/fuelweighted/barrel,
+/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "ym" = (
@@ -424,7 +424,7 @@
 /obj/machinery/light{
 	dir = 1;
 	},
-/obj/effect/spawner/random/misc/structure/supplycrate/case/small,
+/obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "Cz" = (
@@ -721,7 +721,7 @@
 /area/bigredv2/caves/rock)
 "UG" = (
 /obj/machinery/light,
-/obj/effect/spawner/random/engineering/structure/tank/fuelweighted/barrel,
+/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "UL" = (

--- a/_maps/modularmaps/big_red/bigredcargoareavar6.dmm
+++ b/_maps/modularmaps/big_red/bigredcargoareavar6.dmm
@@ -64,7 +64,7 @@
 	},
 /area/bigredv2/outside/nw)
 "fA" = (
-/obj/effect/spawner/random/engineering/structure/tank/fuelweighted/barrel,
+/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "fF" = (
@@ -245,7 +245,7 @@
 /area/bigredv2/outside/nw)
 "tb" = (
 /obj/machinery/light,
-/obj/effect/spawner/random/engineering/structure/tank/fuelweighted/barrel,
+/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "th" = (
@@ -350,7 +350,7 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "yR" = (
-/obj/effect/spawner/random/misc/structure/supplycrate/case/double,
+/obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "zm" = (
@@ -542,7 +542,7 @@
 /obj/machinery/light{
 	dir = 1;
 	},
-/obj/effect/spawner/random/misc/structure/supplycrate/case/small,
+/obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "JA" = (

--- a/_maps/modularmaps/big_red/bigredsecornervar3.dmm
+++ b/_maps/modularmaps/big_red/bigredsecornervar3.dmm
@@ -8,6 +8,9 @@
 /area/bigredv2/caves/southeast)
 "aA" = (
 /obj/machinery/door/airlock/mainship/research,
+/obj/effect/turf_decal/sandedge{
+	dir = 8
+	},
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 5
 	},
@@ -122,7 +125,7 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/undergroundrobotics)
 "gd" = (
-/obj/structure/largecrate/supply/ammo/m41a,
+/obj/structure/largecrate/random/case,
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 4
 	},
@@ -201,6 +204,9 @@
 /area/bigredv2/caves/undergroundrobotics)
 "jg" = (
 /obj/machinery/door/airlock/mainship/research,
+/obj/effect/turf_decal/sandedge{
+	dir = 8
+	},
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 6
 	},
@@ -253,13 +259,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/undergroundrobotics)
-"ld" = (
-/obj/machinery/camera/autoname/mainship/dropship_one{
-	dir = 4;
-	pixel_x = -16
-	},
-/turf/closed/wall/r_wall,
-/area/bigredv2/caves/undergroundrobotics)
 "lL" = (
 /obj/effect/landmark/weed_node,
 /obj/machinery/light,
@@ -287,7 +286,7 @@
 /turf/open/ground/grass,
 /area/bigredv2/caves/undergroundrobotics)
 "nb" = (
-/obj/structure/largecrate/supply/explosives/mines,
+/obj/structure/largecrate/random/case/double,
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 6
 	},
@@ -323,6 +322,9 @@
 /area/bigredv2/caves/undergroundrobotics)
 "oF" = (
 /obj/machinery/door/airlock/mainship/research,
+/obj/effect/turf_decal/sandedge{
+	dir = 4
+	},
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 10
 	},
@@ -385,7 +387,7 @@
 /turf/open/floor/tile/blue,
 /area/bigredv2/caves/undergroundrobotics)
 "qE" = (
-/obj/structure/largecrate/supply/explosives/mines,
+/obj/structure/largecrate/random/case/double,
 /turf/open/floor/tile/blue/taupebluecorner,
 /area/bigredv2/caves/undergroundrobotics)
 "qJ" = (
@@ -405,6 +407,7 @@
 /area/bigredv2/caves/undergroundrobotics)
 "qZ" = (
 /obj/structure/table/reinforced,
+/obj/item/mecha_parts/mecha_equipment/repair_droid,
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 10
 	},
@@ -422,13 +425,6 @@
 "rJ" = (
 /obj/machinery/light,
 /turf/open/floor/tile/blue/taupeblue,
-/area/bigredv2/caves/undergroundrobotics)
-"sy" = (
-/obj/machinery/camera/autoname/mainship/dropship_one{
-	dir = 8;
-	pixel_x = 16
-	},
-/turf/closed/wall,
 /area/bigredv2/caves/undergroundrobotics)
 "tk" = (
 /obj/structure/filingcabinet,
@@ -560,7 +556,7 @@
 /area/bigredv2/caves/undergroundrobotics)
 "Ck" = (
 /obj/structure/table/reinforced,
-/obj/item/mecha_parts/mecha_equipment/generator/nuclear,
+/obj/item/mecha_parts/mecha_equipment/drill,
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 8
 	},
@@ -600,7 +596,7 @@
 	},
 /area/bigredv2/caves/undergroundrobotics)
 "El" = (
-/obj/structure/largecrate/supply/explosives/mines,
+/obj/structure/largecrate/random/case/double,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/undergroundrobotics)
 "EL" = (
@@ -631,7 +627,7 @@
 /obj/item/paper,
 /obj/item/flashlight/pen,
 /obj/item/flashlight/combat,
-/obj/item/folder,
+/obj/effect/spawner/random/misc/folder,
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 4
 	},
@@ -706,10 +702,6 @@
 /turf/open/floor/tile/blue,
 /area/bigredv2/caves/undergroundrobotics)
 "KA" = (
-/obj/machinery/camera/autoname/mainship/dropship_one{
-	dir = 4;
-	pixel_x = -16
-	},
 /obj/effect/ai_node,
 /turf/open/floor/tile/blue/taupeblue,
 /area/bigredv2/caves/undergroundrobotics)
@@ -765,13 +757,16 @@
 /area/bigredv2/caves/undergroundrobotics)
 "MA" = (
 /obj/machinery/door/airlock/mainship/research,
+/obj/effect/turf_decal/sandedge{
+	dir = 4
+	},
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 9
 	},
 /area/bigredv2/caves/undergroundrobotics)
 "MZ" = (
 /obj/structure/table/reinforced,
-/obj/item/mecha_parts/mecha_equipment/gravcatapult,
+/obj/item/mecha_parts/mecha_equipment/generator,
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 9
 	},
@@ -799,7 +794,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/largecrate/supply/ammo/m41a_box,
+/obj/structure/largecrate/random/case,
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 4
 	},
@@ -3605,7 +3600,7 @@ Ho
 qD
 Ho
 IT
-ld
+Pi
 dj
 dj
 dj
@@ -3803,7 +3798,7 @@ Ko
 HN
 HN
 HN
-sy
+IT
 Ok
 WD
 ry

--- a/_maps/modularmaps/big_red/bigredsecornervar6.dmm
+++ b/_maps/modularmaps/big_red/bigredsecornervar6.dmm
@@ -47,10 +47,6 @@
 /obj/machinery/prop/computer/rdservercontrol,
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/secomplex)
-"dV" = (
-/obj/structure/largecrate/supply/weapons/hpr,
-/turf/open/floor/tile/dark,
-/area/bigredv2/caves/secomplex)
 "eE" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -96,7 +92,7 @@
 /area/bigredv2/caves/secomplex)
 "gC" = (
 /obj/effect/landmark/weed_node,
-/obj/item/stack/sheet/metal,
+/obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 8
 	},
@@ -111,7 +107,7 @@
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southeast)
 "hw" = (
-/obj/effect/spawner/random/misc/structure/supplycrate/case/double,
+/obj/structure/largecrate/random/case/double,
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/secomplex)
 "im" = (
@@ -129,7 +125,7 @@
 /turf/open/floor/tile/damaged/panel,
 /area/bigredv2/caves/secomplex)
 "iV" = (
-/obj/structure/largecrate/guns,
+/obj/effect/spawner/random/misc/structure/supplycrate,
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/secomplex)
 "jb" = (
@@ -176,10 +172,6 @@
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/mainship/mono,
 /area/bigredv2/caves/secomplex)
-"kI" = (
-/obj/structure/largecrate/supply/supplies/flares,
-/turf/open/floor/tile/dark,
-/area/bigredv2/caves/secomplex)
 "kX" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -188,7 +180,7 @@
 /area/bigredv2/caves/secomplex)
 "lc" = (
 /obj/item/limb/l_arm,
-/obj/item/stack/sheet/metal,
+/obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/mainship/mono,
 /area/bigredv2/caves/secomplex)
 "le" = (
@@ -199,7 +191,9 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "lC" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	dir = 2
+	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "lH" = (
@@ -213,10 +207,6 @@
 	dir = 2
 	},
 /turf/open/shuttle/escapepod,
-/area/bigredv2/caves/secomplex)
-"mc" = (
-/obj/effect/spawner/random/misc/structure/barrel/green,
-/turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "mH" = (
 /obj/structure/table/mainship,
@@ -306,7 +296,7 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "te" = (
-/obj/item/stack/sheet/metal,
+/obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/tile/blue,
 /area/bigredv2/caves/secomplex)
 "tp" = (
@@ -337,8 +327,8 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "ur" = (
-/obj/structure/largecrate/supply/supplies/metal,
 /obj/effect/landmark/weed_node,
+/obj/effect/spawner/random/misc/structure/supplycrate/secureweighted,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "uy" = (
@@ -394,8 +384,8 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "xa" = (
-/obj/structure/largecrate/supply/explosives/mines,
 /obj/effect/landmark/weed_node,
+/obj/structure/largecrate/random/case/double,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "xg" = (
@@ -408,10 +398,6 @@
 /area/bigredv2/caves/secomplex)
 "xn" = (
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/caves/secomplex)
-"xw" = (
-/obj/structure/largecrate/supply/supplies/sandbags,
-/turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "yj" = (
 /obj/effect/decal/cleanable/blood/gibs,
@@ -429,13 +415,9 @@
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/mainship/mono,
 /area/bigredv2/caves/secomplex)
-"yU" = (
-/obj/structure/largecrate/supply/supplies/metal,
-/turf/open/floor/tile/dark,
-/area/bigredv2/caves/secomplex)
 "za" = (
-/obj/structure/largecrate/supply/supplies/plasteel,
 /obj/effect/decal/cleanable/cobweb2,
+/obj/effect/spawner/random/misc/structure/supplycrate/secureweighted,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "zh" = (
@@ -457,10 +439,6 @@
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
-/area/bigredv2/caves/secomplex)
-"Af" = (
-/obj/structure/largecrate/supply/weapons/sentries,
-/turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "Am" = (
 /obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
@@ -492,7 +470,7 @@
 /turf/closed/mineral/smooth/bigred,
 /area/bigredv2/caves/rock)
 "DE" = (
-/obj/effect/spawner/random/misc/structure/supplycrate/case,
+/obj/structure/largecrate/random/case,
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/secomplex)
 "Em" = (
@@ -583,7 +561,7 @@
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
 "JW" = (
-/obj/structure/closet/crate/secure/gear,
+/obj/effect/spawner/random/misc/structure/table_parts,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "Kf" = (
@@ -642,7 +620,7 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "Nw" = (
-/obj/item/stack/sheet/metal,
+/obj/effect/spawner/random/engineering/metal,
 /turf/open/floor/mainship/mono,
 /area/bigredv2/caves/secomplex)
 "Ny" = (
@@ -651,13 +629,6 @@
 	name = "Maintenance Hatch"
 	},
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/secomplex)
-"Oh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	on = 1;
-	welded = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
 /area/bigredv2/caves/secomplex)
 "OG" = (
 /obj/effect/landmark/weed_node,
@@ -702,17 +673,17 @@
 /turf/open/floor/mainship/mono,
 /area/bigredv2/caves/secomplex)
 "QG" = (
-/obj/effect/spawner/random/misc/structure/barrel/blue,
+/obj/effect/spawner/random/misc/structure/barrel,
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "QK" = (
-/obj/effect/spawner/random/engineering/structure/tank/fuelweighted/barrel,
+/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "QY" = (
-/obj/structure/largecrate/machine,
+/obj/effect/spawner/random/misc/structure/supplycrate/secureweighted,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "Rb" = (
@@ -857,7 +828,7 @@
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southeast)
 "Yn" = (
-/obj/effect/spawner/random/misc/structure/barrel/blue,
+/obj/effect/spawner/random/misc/structure/barrel,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/secomplex)
 "YO" = (
@@ -2476,7 +2447,7 @@ im
 im
 le
 SG
-Oh
+xn
 SG
 le
 zI
@@ -4676,8 +4647,8 @@ le
 TA
 kd
 le
-dV
-Af
+QY
+QY
 yr
 yr
 le
@@ -5093,7 +5064,7 @@ le
 QY
 zE
 JW
-kI
+QY
 le
 QD
 YX
@@ -5162,7 +5133,7 @@ zn
 yr
 yr
 yr
-mc
+Yn
 le
 lc
 YX
@@ -5300,7 +5271,7 @@ zn
 yr
 gG
 yr
-yU
+QY
 le
 Tw
 GZ
@@ -5368,7 +5339,7 @@ kd
 le
 QK
 yr
-xw
+QY
 ur
 le
 QD
@@ -5437,7 +5408,7 @@ vT
 le
 QG
 Yn
-xw
+QY
 za
 le
 SG


### PR DESCRIPTION

## About The Pull Request

Apparently a number of BR modulars (specifically the ones created by vilereaver41) have huge amounts of loot in them. I have opted to remove the loot.

How much loot I hear you ask?
400 metal,
200 sandbags,
60 plasteel 
100 flares
500 mines (!!!)
30ish guns of random quality
2 sentries 

## Why It's Good For The Game

No free loot groundside, not in that quantity anyway.
![Z7HeRxU](https://user-images.githubusercontent.com/49290523/233703310-1fbc7db1-e611-4913-ae5c-217aac35138f.png)


## Changelog
:cl:
balance: Removed a bunch of free loot from BR
fix: Fixed a couple of broken spawner typepaths
/:cl:
