### PR TITLE
Quickbuild no longer triggers on left click

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -200,7 +200,7 @@
 	SIGNAL_HANDLER
 
 	var/list/modifiers = params2list(params)
-	if(toggled && !modifiers["left"])
+	if(toggled && !modifiers[BUTTON] == LEFT_CLICK)
 		dragging = TRUE
 		preshutter_build_resin(get_turf(object))
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -198,7 +198,9 @@
 /// Helper for handling the start of mouse-down and to begin the drag-building
 /datum/action/xeno_action/activable/secrete_resin/proc/start_resin_drag(mob/user, atom/object, turf/location, control, params)
 	SIGNAL_HANDLER
-	if(toggled)
+
+	var/list/modifiers = params2list(params)
+	if(toggled && (modifiers["right"] || modifiers["middle"]))
 		dragging = TRUE
 		preshutter_build_resin(get_turf(object))
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -200,7 +200,7 @@
 	SIGNAL_HANDLER
 
 	var/list/modifiers = params2list(params)
-	if(toggled && (modifiers["right"] || modifiers["middle"]))
+	if(toggled && !modifiers["left"])
 		dragging = TRUE
 		preshutter_build_resin(get_turf(object))
 


### PR DESCRIPTION

## About The Pull Request

This is a bugfix, building isn't meant to trigger on left click.
## Why It's Good For The Game

Not randomly placing a wall while destroying stuff is rather neat for sanity's sake.
## Changelog
:cl:
fix: Quickbuild no longer triggers on left click.
/:cl:
