### PR TITLE
Removes portable atmospherics machinery's var of non existant type

### DIFF
--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -6,7 +6,6 @@
 	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 100, BOMB = 0, BIO = 100, FIRE = 60, ACID = 30)
 	anchored = FALSE
 
-	var/datum/gas_mixture/air_contents
 	var/obj/machinery/atmospherics/components/unary/portables_connector/connected_port
 	var/obj/item/tank/holding
 


### PR DESCRIPTION

## About The Pull Request

`/datum/gas_mixture` doesn't exist in the code. This var is also unused. 
## Why It's Good For The Game

Unused vars of unknown type aren't.
## Changelog
:cl:
fix: Removed portable atmospherics machinery's var of non existant type
/:cl:
