### PR TITLE
Fixes two args having the same name in the squeak component

### DIFF
--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -109,7 +109,7 @@
 	UnregisterSignal(user, COMSIG_MOVABLE_DISPOSING)
 
 
-/datum/component/squeak/proc/disposing_react(datum/source, obj/structure/disposalholder/holder, obj/machinery/disposal/source)
+/datum/component/squeak/proc/disposing_react(datum/source, obj/structure/disposalholder/holder, obj/machinery/disposal/disposal_unit)
 	SIGNAL_HANDLER
 	//We don't need to worry about unregistering this signal as it will happen for us automaticaly when the holder is qdeleted
 	RegisterSignal(holder, COMSIG_ATOM_DIR_CHANGE, PROC_REF(holder_dir_change))


### PR DESCRIPTION

## About The Pull Request

Uh oh, how will the proc know which we're referring to!

Found via opendream:tm:
## Why It's Good For The Game

Arg ambiguity isn't.
## Changelog
:cl:
fix: Fixes two args having the same name in the squeak component
/:cl:
