### PR TITLE
Removes unused mech var with nonexistant type

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -155,9 +155,6 @@
 	var/datum/effect_system/smoke_spread/bad/smoke_system = new
 
 	////Action vars
-	///Ref to any active thrusters we might have
-	var/obj/item/mecha_parts/mecha_equipment/thrusters/active_thrusters
-
 	///Bool for energy shield on/off
 	var/defense_mode = FALSE
 


### PR DESCRIPTION

## About The Pull Request

`/obj/item/mecha_parts/mecha_equipment/thrusters` doesn't exist. This var is unused.

Found with opendream:tm:
## Why It's Good For The Game

Unused vars of nonexistant type aren't.
## Changelog
:cl:
fix: Removes unused mech var with nonexistant type
/:cl:
