### PR TITLE
Improves xeno tanks

### DIFF
--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -159,6 +159,10 @@
 		if(EXPLODE_LIGHT)
 			take_damage(50)
 
+/obj/structure/xenoautopsy/tank/Destroy()
+	occupant = null
+	return ..()
+
 /obj/structure/xenoautopsy/tank/escaped
 	name = "broken cryo tank"
 	icon_state = "tank_escaped"

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -127,27 +127,70 @@
 	name = "cryo tank"
 	icon_state = "tank_empty"
 	desc = "It is empty."
+	density = TRUE
+	max_integrity = 100
+	resistance_flags = UNACIDABLE
+	hit_sound = 'sound/effects/Glasshit.ogg'
+	destroy_sound = "shatter"
+	///Whatever is contained in the tank
+	var/obj/occupant
+	///What this tank is replaced by when broken
+	var/obj/structure/broken_state = /obj/structure/xenoautopsy/tank/escaped
+
+
+/obj/structure/xenoautopsy/tank/deconstruct(disassembled = TRUE)
+	if(!broken_state)
+		return ..()
+
+	new broken_state(loc)
+	new /obj/item/shard(loc)
+
+	if(occupant)
+		occupant = new occupant(loc) //needed for the hugger variant
+
+	return ..()
+
+/obj/structure/xenoautopsy/tank/ex_act(severity)
+	switch(severity)
+		if(EXPLODE_DEVASTATE)
+			qdel(src)
+		if(EXPLODE_HEAVY)
+			take_damage(100)
+		if(EXPLODE_LIGHT)
+			take_damage(50)
 
 /obj/structure/xenoautopsy/tank/escaped
 	name = "broken cryo tank"
 	icon_state = "tank_escaped"
 	desc = "Something broke it..."
+	broken_state = null
 
 /obj/structure/xenoautopsy/tank/broken
 	icon_state = "tank_broken"
 	desc = "Something broke it..."
+	broken_state = null
 
 /obj/structure/xenoautopsy/tank/alien
 	icon_state = "tank_alien"
 	desc = "There is something big inside..."
+	occupant = /obj/item/alien_embryo
 
 /obj/structure/xenoautopsy/tank/hugger
 	icon_state = "tank_hugger"
 	desc = "There is something spider-like inside..."
+	occupant = /obj/item/clothing/mask/facehugger
+
+/obj/structure/xenoautopsy/tank/hugger/deconstruct(disassembled = TRUE)
+	. = ..()
+
+	var/obj/item/clothing/mask/facehugger/hugger = occupant
+	hugger.go_active()
 
 /obj/structure/xenoautopsy/tank/larva
 	icon_state = "tank_larva"
 	desc = "There is something worm-like inside..."
+	occupant = /obj/item/alien_embryo
+	broken_state = /obj/structure/xenoautopsy/tank/broken
 
 /obj/item/alienjar
 	name = "sample jar"


### PR DESCRIPTION

## About The Pull Request
Minor ground map fluff change.

Those decorative little cryo tank things you see on maps with huggers/larva in them are lorewise responsible for most if not all the xeno outbreaks that the marines have to deal with. Gameplay wise though, they do nothing.

Now they can actually be broken to release the living huggers inside (or dead larva).
## Why It's Good For The Game
Muh immersion
## Changelog
:cl:
add: hugger tanks found groundside can now be broken to release the living hugger inside
/:cl:
