### PR TITLE
Moves the button for Tcomms in Theseus

### DIFF
--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -2765,6 +2765,7 @@
 "bcY" = (
 /obj/machinery/camera/autoname/mainship,
 /obj/machinery/computer/telecomms/server/preset,
+/obj/machinery/door_control/mainship/tcomms,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "bda" = (
@@ -11167,7 +11168,6 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "hJa" = (
-/obj/machinery/door_control/mainship/tcomms,
 /obj/structure/table/mainship/nometal,
 /obj/machinery/alarm,
 /turf/open/floor/mainship/mono,


### PR DESCRIPTION

## About The Pull Request
Instead of having it be HIDDEN BEHIND AN AIR ALARM, it is now actually visible
Oh and also you can't lock yourself inside tcomms as easily anymore, i guess
## Why It's Good For The Game
Hidden buttons bad, visibility good.
![tcomms](https://user-images.githubusercontent.com/80391698/233802113-41e4da1e-e5f8-40cc-bc45-5f536955e155.png)

## Changelog
:cl:
fix: made Theseus's tcomms button easier to spot instead of being hidden behind an air alarm
/:cl:
