### PR TITLE
Makes Defender's Fortify Charge feel smoother to use

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -143,9 +143,6 @@
 	var/mob/living/carbon/xenomorph/defender/defender = X
 	if(defender.fortify)
 		var/datum/action/xeno_action/fortify/fortify_action = X.actions_by_path[/datum/action/xeno_action/fortify]
-		if(fortify_action.cooldown_id)
-			to_chat(X, span_xenowarning("We cannot yet untuck ourselves from our fortified stance!"))
-			return fail_activate()
 
 		fortify_action.set_fortify(FALSE, TRUE)
 		fortify_action.add_cooldown()
@@ -307,6 +304,9 @@
 		CD.set_crest_defense(FALSE, TRUE)
 		CD.add_cooldown()
 		to_chat(X, span_xenowarning("We tuck our lowered crest into ourselves."))
+
+	var/datum/action/xeno_action/activable/forward_charge/combo_cooldown = X.actions_by_path[/datum/action/xeno_action/activable/forward_charge]
+	combo_cooldown.add_cooldown(cooldown_timer)
 
 	set_fortify(TRUE, was_crested)
 	add_cooldown()


### PR DESCRIPTION
## About The Pull Request
I read someone complain about the Fortify Charge combo being "buggy" in Discord. Not being able to immediately charge out of Fortify is intentional (#7523), it's just that the way it works right now can lead to players thinking the behavior is buggy like I think it's the same problem #11972 is talking of. 

Instead of checking if Fortify is on cooldown, it just adds a cooldown to charge after fortifying. 

How it works right now:
[old.webm](https://user-images.githubusercontent.com/94504089/233837397-5ec6e0ed-6fbb-48ba-a631-fd1a9965e0b3.webm)

This PR:
[new.webm](https://user-images.githubusercontent.com/94504089/233837404-9524873a-6d6b-4d17-9f6f-79961c3343b7.webm)

## Why It's Good For The Game
QoL. Personally, I think it feels better to use.

## Changelog
:cl:
qol: defender's fortify charge combo should feel smoother to use
/:cl: