### PR TITLE
Fix typo for cell charger

### DIFF
--- a/code/game/objects/machinery/cell_charger.dm
+++ b/code/game/objects/machinery/cell_charger.dm
@@ -5,6 +5,7 @@
 	icon_state = "ccharger0"
 	anchored = TRUE
 	use_power = IDLE_POWER_USE
+	wrenchable = TRUE
 	idle_power_usage = 5
 	active_power_usage = 40000	//40 kW. (this the power drawn when charging)
 	power_channel = EQUIP


### PR DESCRIPTION

## About The Pull Request
Wrenchable = TRUE
^ For the codex to add the description
## Why It's Good For The Game
typo fix
## Changelog
:cl:
spellcheck: Cell charger properly indicates that it can be unwrenched.
/:cl:
