### PR TITLE
Medical Rig belt has isotonic instead of dexalin

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -273,7 +273,7 @@
 	new /obj/item/storage/pill_bottle/tricordrazine(src)
 	new /obj/item/storage/pill_bottle/dylovene(src)
 	new /obj/item/storage/pill_bottle/inaprovaline(src)
-	new /obj/item/storage/pill_bottle/dexalin(src)
+	new /obj/item/storage/pill_bottle/isotonic(src)
 	new /obj/item/storage/pill_bottle/spaceacillin(src)
 	new /obj/item/storage/pill_bottle/alkysine(src)
 	new /obj/item/storage/pill_bottle/imidazoline(src)


### PR DESCRIPTION
## About The Pull Request
Medical Rig belt has isotonic instead of dexalin
## Why It's Good For The Game
Isotonic > Dex
Also, same reasoning as https://github.com/tgstation/TerraGov-Marine-Corps/pull/12695
"Dexaline's use is redundant in most cases when you have inaprovaline. As it is, the default loadout has no real blood replenishing options so a corpsman has to go out of their way to get one. Shouldn't be too big a change given both are available from vendors anyway, so more of a qol change than balance."
I feel like this also applies to doctors (or corpsman who opt to take the medrig belt instead of lifesaver)
## Changelog
:cl:
balance: Medical rig belt has isotonic instead of dexalin.
/:cl:
