### PR TITLE
Rolls minion agressivity ability into rally/command

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1166,49 +1166,35 @@
 
 /datum/action/xeno_action/rally_minion
 	name = "Rally Minions"
-	action_icon_state = "rally_minions"
-	desc = "Rallies the minions around you, asking them to follow you if they don't have a leader already. 60 second cooldown."
+	action_icon_state = "minion_agressive"
+	desc = "Rallies the minions around you, asking them to follow you if they don't have a leader already. Rightclick to change minion behaviour."
 	ability_name = "rally minions"
 	plasma_cost = 0
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_RALLY_MINION,
+		KEYBINDING_ALTERNATE = COMSIG_XENOABILITY_MINION_BEHAVIOUR,
 	)
 	keybind_flags = XACT_KEYBIND_USE_ABILITY
 	cooldown_timer = 10 SECONDS
 	use_state_flags = XACT_USE_LYING|XACT_USE_BUCKLED
+	///If minions should be agressive
+	var/minions_agressive = TRUE
+
+/datum/action/xeno_action/rally_minion/update_button_icon()
+	action_icon_state = minions_agressive ? "minion_agressive" : "minion_passive"
+	return ..()
 
 /datum/action/xeno_action/rally_minion/action_activate()
 	succeed_activate()
 	add_cooldown()
 	owner.emote("roar")
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_AI_MINION_RALLY, owner)
-	var/mob/living/carbon/xenomorph/xenoowner = owner
-	var/datum/action/xeno_action/set_agressivity/set_agressivity = xenoowner.actions_by_path[/datum/action/xeno_action/set_agressivity]
-	if(set_agressivity)
-		SEND_SIGNAL(owner, COMSIG_ESCORTING_ATOM_BEHAVIOUR_CHANGED, set_agressivity.minions_agressive) //New escorting ais should have the same behaviour as old one
+	SEND_SIGNAL(owner, COMSIG_ESCORTING_ATOM_BEHAVIOUR_CHANGED, minions_agressive) //New escorting ais should have the same behaviour as old one
 
-/datum/action/xeno_action/set_agressivity
-	name = "Set minions behavior"
-	action_icon_state = "minion_agressive"
-	desc = "Order the minions escorting you to be either agressive or passive."
-	ability_name = "set_agressivity"
-	plasma_cost = 0
-	keybinding_signals = list(
-		KEYBINDING_NORMAL = COMSIG_XENOABILITY_MINION_BEHAVIOUR,
-	)
-	keybind_flags = XACT_KEYBIND_USE_ABILITY
-	use_state_flags = XACT_USE_LYING|XACT_USE_BUCKLED
-	///If minions should be agressive
-	var/minions_agressive = TRUE
-
-/datum/action/xeno_action/set_agressivity/action_activate()
+/datum/action/xeno_action/rally_minion/alternate_action_activate()
 	minions_agressive = !minions_agressive
 	SEND_SIGNAL(owner, COMSIG_ESCORTING_ATOM_BEHAVIOUR_CHANGED, minions_agressive)
 	update_button_icon()
-
-/datum/action/xeno_action/set_agressivity/update_button_icon()
-	action_icon_state = minions_agressive ? "minion_agressive" : "minion_passive"
-	return ..()
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
@@ -27,16 +27,23 @@
 
 /datum/action/xeno_action/activable/command_minions
 	name = "Command minions"
-	action_icon_state = "rally_minions"
-	desc = "Command all minions, ordering them to converge on this location."
+	action_icon_state = "minion_agressive"
+	desc = "Command all minions, ordering them to converge on this location. Rightclick to change minion behaviour."
 	ability_name = "command minions"
 	plasma_cost = 100
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_RALLY_MINION,
+		KEYBINDING_ALTERNATE = COMSIG_XENOABILITY_MINION_BEHAVIOUR,
 	)
 	keybind_flags = XACT_KEYBIND_USE_ABILITY
 	cooldown_timer = 60 SECONDS
 	use_state_flags = XACT_USE_LYING|XACT_USE_BUCKLED
+	///If minions should be agressive
+	var/minions_agressive = TRUE
+
+/datum/action/xeno_action/activable/command_minions/update_button_icon()
+	action_icon_state = minions_agressive ? "minion_agressive" : "minion_passive"
+	return ..()
 
 /datum/action/xeno_action/activable/command_minions/use_ability(atom/target)
 	var/turf_targeted = get_turf(target)
@@ -45,6 +52,11 @@
 	new /obj/effect/ai_node/goal(turf_targeted, owner)
 	succeed_activate()
 	add_cooldown()
+
+/datum/action/xeno_action/activable/command_minions/alternate_action_activate()
+	minions_agressive = !minions_agressive
+	SEND_SIGNAL(owner, COMSIG_ESCORTING_ATOM_BEHAVIOUR_CHANGED, minions_agressive)
+	update_button_icon()
 
 /datum/action/xeno_action/activable/psychic_cure/hivemind/can_use_action(silent = FALSE, override_flags, selecting = FALSE)
 	if (owner.status_flags & INCORPOREAL)

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -58,7 +58,6 @@
 		/datum/action/xeno_action/pheromones/emit_frenzy,
 		/datum/action/xeno_action/rally_hive,
 		/datum/action/xeno_action/rally_minion,
-		/datum/action/xeno_action/set_agressivity,
 		/datum/action/xeno_action/blessing_menu,
 	)
 
@@ -187,6 +186,5 @@
 		/datum/action/xeno_action/pheromones/emit_frenzy,
 		/datum/action/xeno_action/rally_hive,
 		/datum/action/xeno_action/rally_minion,
-		/datum/action/xeno_action/set_agressivity,
 		/datum/action/xeno_action/blessing_menu,
 	)

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -73,9 +73,7 @@
 		/datum/action/xeno_action/activable/queen_give_plasma,
 		/datum/action/xeno_action/hive_message,
 		/datum/action/xeno_action/rally_hive,
-		/datum/action/xeno_action/rally_minion,
 		/datum/action/xeno_action/activable/command_minions,
-		/datum/action/xeno_action/set_agressivity,
 	)
 
 
@@ -232,8 +230,6 @@
 		/datum/action/xeno_action/activable/queen_give_plasma,
 		/datum/action/xeno_action/hive_message,
 		/datum/action/xeno_action/rally_hive,
-		/datum/action/xeno_action/rally_minion,
 		/datum/action/xeno_action/activable/command_minions,
-		/datum/action/xeno_action/set_agressivity,
 		/datum/action/xeno_action/ready_charge/queen_charge,
 	)

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -71,7 +71,6 @@
 		/datum/action/xeno_action/pheromones/emit_frenzy,
 		/datum/action/xeno_action/rally_hive,
 		/datum/action/xeno_action/rally_minion,
-		/datum/action/xeno_action/set_agressivity,
 		/datum/action/xeno_action/blessing_menu,
 	)
 
@@ -208,7 +207,6 @@
 		/datum/action/xeno_action/pheromones/emit_frenzy,
 		/datum/action/xeno_action/rally_hive,
 		/datum/action/xeno_action/rally_minion,
-		/datum/action/xeno_action/set_agressivity,
 		/datum/action/xeno_action/blessing_menu,
 		/datum/action/xeno_action/activable/gravity_grenade,
 	)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
@@ -24,10 +24,6 @@
 	if(!actions_by_path[/datum/action/xeno_action/rally_minion])
 		var/datum/action/xeno_action/rally_minion/rally = new /datum/action/xeno_action/rally_minion
 		rally.give_action(src)
-	if(!actions_by_path[/datum/action/xeno_action/set_agressivity])
-		var/datum/action/xeno_action/set_agressivity/minions_behaviour = new /datum/action/xeno_action/set_agressivity
-		minions_behaviour.give_action(src)
-
 
 
 ///Helper proc for removing the rally hive ability appropriately
@@ -41,7 +37,4 @@
 
 	if(rally_minion)
 		rally_minion.remove_action(src)
-	var/datum/action/xeno_action/set_agressivity/minions_behaviour = actions_by_path[/datum/action/xeno_action/set_agressivity]
-	if(minions_behaviour)
-		minions_behaviour.remove_action(src)
 


### PR DESCRIPTION

## About The Pull Request

making more space on queen ability bar

## Changelog
:cl:
qol: Toggling minion aggressivity is now the right click ability of command/rally minions
balance: Removes rally minions from queen since they have command minions
/:cl:
