### PR TITLE
Make xenos have all abilities if spawned prior to game start

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1215,7 +1215,7 @@
 /mob/living/carbon/xenomorph/proc/add_abilities()
 	for(var/action_path in xeno_caste.actions)
 		var/datum/action/xeno_action/action = new action_path()
-		if(SSticker.mode?.flags_xeno_abilities & action.gamemode_flags)
+		if(!SSticker.mode || SSticker.mode.flags_xeno_abilities & action.gamemode_flags)
 			action.give_action(src)
 
 


### PR DESCRIPTION

## About The Pull Request

Annoying when testing

:cl:
qol: Makes xenos have all abilities if spawned prior to game start
/:cl:
