### PR TITLE
Chooses an In_Ammo_Box sprite for the Mosin clips. (Copies the Garand's style.)

### DIFF
--- a/code/modules/projectiles/magazines/shotguns.dm
+++ b/code/modules/projectiles/magazines/shotguns.dm
@@ -70,7 +70,7 @@ one type of shotgun ammo, but I think it helps in referencing it. ~N
 	caliber = CALIBER_762X54
 	max_rounds = 4
 	w_class = WEIGHT_CLASS_SMALL
-	icon_state_mini = "clip"
+	icon_state_mini = "mag_sniper"
 
 /obj/item/ammo_magazine/rifle/martini
 	name = "box of .557/440 rifle rounds"


### PR DESCRIPTION
## About The Pull Request

Gives the Mosin Clips the same mini_sprites as the Garand clips...Even though they don't look like clips. Anyhow, It's better than a red X.

![Mosin_Box_A](https://user-images.githubusercontent.com/38842059/233864749-db554ee7-de14-4667-afa7-accf10e16395.PNG)

Notably this shouldn't be merged with PR #12798 because it does the same thing.

## Why It's Good For The Game

Red X bad, this isn't perfect but uh....It's a start?

## Changelog
:cl: Skye
fix: Gives the mosin clips an already existing mini_sprite
/:cl:
