### PR TITLE
Chooses an alternative In_Ammo_Box sprite for the Mosin clips. (Loose bullets)

### DIFF
--- a/code/modules/projectiles/magazines/shotguns.dm
+++ b/code/modules/projectiles/magazines/shotguns.dm
@@ -70,7 +70,7 @@ one type of shotgun ammo, but I think it helps in referencing it. ~N
 	caliber = CALIBER_762X54
 	max_rounds = 4
 	w_class = WEIGHT_CLASS_SMALL
-	icon_state_mini = "clip"
+	icon_state_mini = "bullets"
 
 /obj/item/ammo_magazine/rifle/martini
 	name = "box of .557/440 rifle rounds"


### PR DESCRIPTION

## About The Pull Request

This variant instead gives the Mosin clips the bog standard loose bullets mini_sprite. I thought they looked neater, should be more distinct too, so may as-well see what sticks. Either way, both PRs give a mini_sprite.

![Mosin_Box_B](https://user-images.githubusercontent.com/38842059/233864976-ea74f3f1-4513-4f70-9261-4aeeaecf6e76.PNG)


Notably this shouldn't be merged along with PR #12797  because it does the same thing.

## Why It's Good For The Game

Red X is still bad. But this time...More boolets!

## Changelog
:cl: Skye
fix: Gives the mosin clips a different already existing mini_sprite
/:cl:
