### PR TITLE
Fixes inflatables not being opaque

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -38,6 +38,7 @@
 	name = "generic inflatable"
 	desc = "You shouldn't be seeing this."
 	density = TRUE
+	opacity = TRUE
 	flags_pass = NONE
 	icon = 'icons/obj/inflatable.dmi'
 	max_integrity = 50


### PR DESCRIPTION

## About The Pull Request

Forgot this line. Sad.
## Why It's Good For The Game

They aren't supposed to be seethrough.
## Changelog
:cl:
fix: Fixes inflatables not being opaque
/:cl:
