### PR TITLE
Smooth crate/object pushing skill for RO and CPT (+ spatial agent)

### DIFF
--- a/code/__DEFINES/skills.dm
+++ b/code/__DEFINES/skills.dm
@@ -21,6 +21,7 @@
 #define SKILL_POLICE "police"
 #define SKILL_POWERLOADER "powerloader"
 #define SKILL_LARGE_VEHICLE "large_vehicle"
+#define SKILL_PUSH "push"
 ////////////////////////////////////////////////
 
 //firearms skill (general knowledge of guns) (hidden skill)
@@ -153,3 +154,7 @@
 #define SKILL_TASK_DIFFICULT 100
 #define SKILL_TASK_CHALLENGING 150
 #define SKILL_TASK_FORMIDABLE 200
+
+// pushing skill
+#define SKILL_PUSH_SKILL_ISSUE 0 //pushes normally
+#define SKILL_PUSH_TRAINED 1 // smooth

--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -62,11 +62,11 @@ engineer = 0, construction = 0, leadership = 0, medical = 0, surgery = 0, pilot 
 	var/police = SKILL_POLICE_DEFAULT
 	var/powerloader = SKILL_POWERLOADER_DEFAULT
 	var/large_vehicle = SKILL_LARGE_VEHICLE_DEFAULT
-
+	var/push = SKILL_PUSH_SKILL_ISSUE
 
 /datum/skills/New(cqc, melee_weapons,\
 firearms, pistols, shotguns, rifles, smgs, heavy_weapons, smartgun,\
-engineer, construction, leadership, medical, surgery, pilot, police, powerloader, large_vehicle)
+engineer, construction, leadership, medical, surgery, pilot, police, powerloader, large_vehicle, push)
 	if(!isnull(cqc))
 		src.cqc = cqc
 	if(!isnull(melee_weapons))
@@ -103,12 +103,14 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 		src.powerloader = powerloader
 	if(!isnull(large_vehicle))
 		src.large_vehicle = large_vehicle
+	if(!isnull(push))
+		src.push = push
 	tag = SKILLSIDSRC(src)
 
 /// returns/gets a new skills datum with values changed according to the args passed
 /datum/skills/proc/modifyRating(cqc, melee_weapons,\
 firearms, pistols, shotguns, rifles, smgs, heavy_weapons, smartgun,\
-engineer, construction, leadership, medical, surgery, pilot, police, powerloader, large_vehicle)
+engineer, construction, leadership, medical, surgery, pilot, police, powerloader, large_vehicle, push)
 	return getSkills(src.cqc+cqc,\
 	src.melee_weapons+melee_weapons,\
 	src.firearms+firearms,\
@@ -126,7 +128,8 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	src.pilot+pilot,\
 	src.police+police,\
 	src.powerloader+powerloader,\
-	src.large_vehicle+large_vehicle)
+	src.large_vehicle+large_vehicle,\
+	src.push+push)
 
 /// acts as [/proc/modifyRating] but instead modifies all values rather than several specific ones
 /datum/skills/proc/modifyAllRatings(difference)
@@ -147,7 +150,8 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	src.pilot+difference,\
 	src.police+difference,\
 	src.powerloader+difference,\
-	src.large_vehicle+difference)
+	src.large_vehicle+difference,\
+	src.push+difference)
 
 /// acts as [/proc/modifyRating] but sets the rating directly rather than modify it
 /datum/skills/proc/setRating(cqc, melee_weapons,\
@@ -170,7 +174,8 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 		(isnull(pilot) ? src.pilot : pilot),\
 		(isnull(police) ? src.police : police),\
 		(isnull(powerloader) ? src.powerloader : powerloader),\
-		(isnull(large_vehicle) ? src.large_vehicle : large_vehicle))
+		(isnull(large_vehicle) ? src.large_vehicle : large_vehicle),\
+		(isnull(push) ? src.push : push))
 
 /datum/skills/vv_edit_var(var_name, var_value)
 	if(var_name == NAMEOF(src, tag))
@@ -209,6 +214,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 		SKILL_POLICE = police,
 		SKILL_POWERLOADER = powerloader,
 		SKILL_LARGE_VEHICLE = large_vehicle,
+		SKILL_PUSH = push
 	)
 
 /datum/skills/civilian
@@ -370,6 +376,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	smgs = SKILL_SMGS_TRAINED
 	heavy_weapons = SKILL_HEAVY_WEAPONS_TRAINED
 	smartgun = SKILL_SMART_TRAINED
+	push = SKILL_PUSH_TRAINED
 
 
 /datum/skills/fo
@@ -418,6 +425,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	leadership = SKILL_LEAD_TRAINED
 	powerloader = SKILL_POWERLOADER_MASTER
 	police = SKILL_POLICE_MP
+	push = SKILL_PUSH_TRAINED
 
 /datum/skills/st
 	name = SHIP_TECH
@@ -604,6 +612,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	police = SKILL_POLICE_MP
 	powerloader = SKILL_POWERLOADER_MASTER
 	large_vehicle = SKILL_LARGE_VEHICLE_TRAINED
+	push = SKILL_PUSH_TRAINED
 
 /*======  I.o.M.  ======*/
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -467,7 +467,8 @@
 	if(pulling == AM)
 		stop_pulling()
 	AM.Move(get_step(AM.loc, dir_to_target), dir_to_target, glide_size)
-	Move(get_step(loc, dir_to_target), dir_to_target, glide_size)
+	if(skills.push >= SKILL_PUSH_TRAINED)
+		Move(get_step(loc, dir_to_target), dir_to_target, glide_size)
 	now_pushing = FALSE
 
 


### PR DESCRIPTION

## About The Pull Request

adds object pushing skill
everyone is UNTRAINED by default so they get normal object pushing
RO, Captain, Spatial Agent, are trained with this skill
untrained skill
https://user-images.githubusercontent.com/70376633/233832507-34610ed6-9184-4a3a-94ce-7c75a95fdb9a.mp4

with skill
https://user-images.githubusercontent.com/70376633/233832526-02d97f99-8405-4726-8d6a-94cc3ea79be9.mp4

## Why It's Good For The Game

RO and the relevant roles shouldnt get janky ass crate pushing and theyre all shipside roles
RO has nothing to do groundside, CPT isnt allowed groundside, Spatial Agent is admeme

## Changelog
:cl:
add: Object/crate pushing skill for RO, CPT, Spatial Agent - Being trained allows you to smoothly push objects. Others do not get this
/:cl:
