### PR TITLE
Synth vendor no longer has the base satchel and IMP pack

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -605,8 +605,6 @@ GLOBAL_LIST_INIT(synthetic_clothes_listed_products, list(
 		/obj/item/clothing/suit/suspenders = list(CAT_SMR, "Suspenders", 0, "synth-cosmetic"),
 		/obj/item/clothing/suit/apron = list(CAT_SMR, "Apron", 0, "synth-cosmetic"),
 		/obj/item/clothing/suit/apron/overalls = list(CAT_SMR, "Overalls", 0, "synth-cosmetic"),
-		/obj/item/storage/backpack/marine/satchel = list(CAT_BAK, "Satchel", 0, "black"),
-		/obj/item/storage/backpack/marine = list(CAT_BAK, "Lightweight IMP backpack", 0, "black"),
 		/obj/item/storage/backpack/industrial = list(CAT_BAK, "Industrial backpack", 0, "black"),
 		/obj/item/storage/backpack/marine/corpsman = list(CAT_BAK, "TGMC corpsman backpack", 0, "black"),
 		/obj/item/storage/backpack/marine/tech = list(CAT_BAK, "TGMC technician backpack", 0, "black"),


### PR DESCRIPTION

## About The Pull Request
Removes 2 noob trap options from the synth vendor, IMP and satchel.
## Why It's Good For The Game
You spawn with a satchel as a synth so there is no reason to have it in the vendor.
The IMP backpack is a noob trap when it's infinitely vendable in the clothes vendor.
I only left the industrial backpack because I dont think it's vendable elsewhere despite being only a slight reskin.
## Changelog
:cl:
del: Synth vendor no longer has satchel or IMP backpack.
/:cl:
