### PR TITLE
Fixes stack Destroy() runtime

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -75,7 +75,7 @@
 
 
 /obj/item/stack/Destroy()
-	if(usr?.interactee == src)
+	if(usr && usr.interactee == src)
 		usr << browse(null, "window=stack")
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request

This runtimes if (for example) a roomba moves on its own and qdels a stack of metal. There is no usr (or rather it is 0, somehow) so it runtimes and fails to delete. Not good.
## Why It's Good For The Game

Failed dels bad.
## Changelog
:cl:
fix: Fixed stack Destroy() runtime
/:cl:
