### PR TITLE
Remove three miners close to landing zone in Icy Cave redux

### DIFF
--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -2794,10 +2794,6 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/outside/center)
-"pD" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
 "pE" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -12187,7 +12183,7 @@ WI
 SI
 SI
 WI
-pD
+WI
 WI
 WI
 SI
@@ -16888,7 +16884,7 @@ Dn
 SI
 XO
 WI
-pD
+WI
 WI
 KZ
 tO
@@ -20000,7 +19996,7 @@ JT
 Ai
 WY
 ow
-Er
+ow
 li
 li
 my


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/6610922/234097091-cd74b8c5-b692-4713-b097-3cdc96ca5e0a.png)


## Why It's Good For The Game

Icy Cave is under maintained, therefore it produces rounds where marines benefit more from taking a walk to miners from landing zone. We've done this with other maps for the same reason.

Xander notes that xenomorphs cannot weed these area until marines open shutters, making these miners easy to capture and gain req points faster than any planetside maps.

## Changelog

:cl:
del: Remove three miners close to landing zone in Icy Cave
balance: Remove three miners close to landing zone in Icy Cave
/:cl:

