### PR TITLE
Makes xenos not able to start pulling critical humans

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -281,7 +281,7 @@
 	if(L.buckled)
 		return FALSE //to stop xeno from pulling marines on roller beds.
 	if(ishuman(L))
-		if(L.stat == DEAD) //Can't drag dead human bodies.
+		if(L.stat) //Can't drag dead/crit human bodies.
 			to_chat(usr,span_xenowarning("This looks gross, better not touch it."))
 			return FALSE
 		pull_speed += XENO_DEADHUMAN_DRAG_SLOWDOWN


### PR DESCRIPTION

## About The Pull Request

Xenos cant start pulling crit or dead humans

## Why It's Good For The Game

CRITDRAG FUCKING SUCKS

## Changelog
:cl:
balance: As a xeno, you can no longer start pulling critical (and/or dead) marines
/:cl:
