### PR TITLE
Revert "Clicking a UI Slot will return the item inside the slot (#127…

### DIFF
--- a/code/_onclick/hud/screen_objects/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/screen_objects.dm
@@ -71,7 +71,7 @@
 	var/list/object_overlays = list()
 
 
-/atom/movable/screen/inventory/Click(location, control, params)
+/atom/movable/screen/inventory/Click()
 	// At this point in client Click() code we have passed the 1/10 sec check and little else
 	// We don't even know if it's a middle click
 	if(world.time <= usr.next_move)
@@ -83,15 +83,9 @@
 	if(istype(usr.loc, /obj/vehicle/multitile/root/cm_armored)) // stops inventory actions in a mech/tank
 		return TRUE
 
-	//If there is an item in the slot you are clicking on, this will relay the click to the item within the slot
-	var/atom/item_in_slot = usr.get_item_by_slot(slot_id)
-	if(item_in_slot)
-		return item_in_slot.Click()
-
 	if(!istype(src, /atom/movable/screen/inventory/hand) && usr.attack_ui(slot_id)) // until we get a proper hands refactor
 		usr.update_inv_l_hand()
 		usr.update_inv_r_hand()
-		return TRUE
 
 /atom/movable/screen/inventory/hand
 	name = "l_hand"
@@ -104,11 +98,15 @@
 	if(active)
 		add_overlay("hand_active")
 
-/atom/movable/screen/inventory/hand/Click(location, control, params)
-	. = ..()
-	if(.)
-		var/mob/living/carbon/C = usr
-		C.activate_hand(hand_tag)
+/atom/movable/screen/inventory/hand/Click()
+	if(world.time <= usr.next_move)
+		return TRUE
+	if(usr.incapacitated() || !iscarbon(usr))
+		return TRUE
+	if (istype(usr.loc, /obj/vehicle/multitile/root/cm_armored))
+		return TRUE
+	var/mob/living/carbon/C = usr
+	C.activate_hand(hand_tag)
 
 /atom/movable/screen/inventory/hand/right
 	name = "r_hand"

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -416,6 +416,7 @@
 	unwield(user)
 	if(ishandslot(slot))
 		set_gun_user(user)
+		mouse_opacity = MOUSE_OPACITY_OPAQUE
 	else
 		set_gun_user(null)
 	return ..()
@@ -427,6 +428,10 @@
 	if(!length(chamber_items) || !chamber_items[current_chamber_position] || chamber_items[current_chamber_position].loc == src)
 		return
 	drop_connected_mag(chamber_items[current_chamber_position], user)
+
+/obj/item/weapon/gun/unequipped(mob/user, slot)
+	. = ..()
+	mouse_opacity = initial(mouse_opacity) //So that it doesnt remain opaque when you drop or discard the gun
 
 ///Set the user in argument as gun_user
 /obj/item/weapon/gun/proc/set_gun_user(mob/user)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
Reverts Clicking UI SLOT PR





## About The Pull Request
Reverts Clicking UI SLOT PR

## Why It's Good For The Game
This should have been made into a preference in the gun category before being merged, It favors Tac-Reloading and makes it easier but the issue is not every gun can Tac-Reload, and this new system makes it much more difficult to reload with anything that can't and is generally scuffed to work around. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

del: removes guns hogging hand slots. 

/:cl:

