### PR TITLE
Big Red LZ1 Changes

### DIFF
--- a/_maps/modularmaps/big_red/bigredlzvar1.dmm
+++ b/_maps/modularmaps/big_red/bigredlzvar1.dmm
@@ -733,6 +733,9 @@
 /area/bigredv2/outside/space_port)
 "tg" = (
 /obj/structure/closet/secure_closet/injection,
+/obj/structure/sign/safety/hazard{
+	dir = 1
+	},
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "to" = (
@@ -846,6 +849,9 @@
 "wR" = (
 /obj/item/shard,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/safety/hazard{
+	dir = 1
+	},
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "wS" = (
@@ -4388,7 +4394,7 @@ GX
 VL
 GX
 pB
-Ym
+yn
 wR
 dw
 dw
@@ -4428,7 +4434,7 @@ GX
 GX
 GX
 pB
-Ym
+yn
 Wk
 lY
 fU
@@ -4468,7 +4474,7 @@ GX
 GX
 GX
 pB
-Ym
+yn
 tg
 aZ
 fU

--- a/_maps/modularmaps/big_red/bigredlzvar2.dmm
+++ b/_maps/modularmaps/big_red/bigredlzvar2.dmm
@@ -11,6 +11,9 @@
 "aG" = (
 /obj/item/shard,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/safety/hazard{
+	dir = 1
+	},
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "aY" = (
@@ -191,8 +194,8 @@
 /area/bigredv2/outside/space_port)
 "fs" = (
 /obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/northwest)
+/turf/closed/mineral/smooth/bigred,
+/area/bigredv2/caves/rock)
 "fu" = (
 /obj/machinery/light{
 	dir = 8
@@ -223,7 +226,7 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/telecomm)
 "fC" = (
-/obj/structure/sign/safety/vent{
+/obj/structure/sign/safety/hazard{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -424,6 +427,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/vending/cigarette/colony,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/space_port)
 "kM" = (
@@ -462,6 +466,12 @@
 	},
 /turf/open/floor/plating/warning,
 /area/bigredv2/outside/space_port)
+"ln" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/rock)
 "lz" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -487,6 +497,11 @@
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/marshal_office)
+"mC" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/rock)
 "mH" = (
 /obj/machinery/power/apc/drained{
 	dir = 4
@@ -533,7 +548,7 @@
 /area/bigredv2/outside/marshal_office)
 "nF" = (
 /obj/structure/sign/safety/hazard{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
@@ -574,6 +589,10 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
+/area/bigredv2/outside/space_port)
+"pf" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/tile/dark,
 /area/bigredv2/outside/space_port)
 "pR" = (
 /obj/machinery/button/door/open_only/landing_zone,
@@ -676,12 +695,12 @@
 	},
 /area/bigredv2/outside/marshal_office)
 "rT" = (
-/obj/machinery/vending/cigarette/colony,
-/obj/machinery/status_display{
-	pixel_y = 31
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
 	},
-/turf/open/floor/tile/dark,
-/area/bigredv2/outside/space_port)
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/rock)
 "sc" = (
 /obj/effect/turf_decal/warning_stripes/linethick{
 	dir = 8
@@ -816,6 +835,9 @@
 /area/bigredv2/outside/marshal_office)
 "vN" = (
 /obj/structure/closet/secure_closet/injection,
+/obj/structure/sign/safety/hazard{
+	dir = 1
+	},
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "wd" = (
@@ -823,7 +845,9 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/space_port)
 "wp" = (
-/obj/structure/filingcabinet,
+/obj/structure/sign/safety/hazard{
+	dir = 1
+	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/space_port)
 "ws" = (
@@ -1328,6 +1352,13 @@
 	dir = 8
 	},
 /area/bigredv2/outside/marshal_office)
+"Lg" = (
+/obj/structure/closet/firecloset,
+/obj/structure/sign/safety/hazard{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/space_port)
 "Lx" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand/autosmooth{
@@ -1893,6 +1924,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/telecomm)
+"YY" = (
+/obj/machinery/status_display{
+	pixel_y = 31
+	},
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/space_port)
 "Zb" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -2409,7 +2446,7 @@ gM
 gM
 Jc
 Ei
-qX
+ln
 LR
 "}
 (13,1,1) = {"
@@ -2729,8 +2766,8 @@ gM
 gM
 ZL
 Ei
-qX
-zH
+Wt
+LR
 "}
 (21,1,1) = {"
 LR
@@ -2769,8 +2806,8 @@ gM
 gM
 hg
 Ei
-qX
-Zg
+Wt
+LR
 "}
 (22,1,1) = {"
 LR
@@ -2809,8 +2846,8 @@ gM
 gM
 ZL
 Ei
-qX
-zH
+Wt
+LR
 "}
 (23,1,1) = {"
 LR
@@ -3260,9 +3297,9 @@ LR
 LR
 Wt
 Ei
-UH
+nF
 RK
-UH
+nF
 UH
 UH
 NS
@@ -3343,7 +3380,7 @@ Ob
 Ob
 wB
 Ei
-UH
+fC
 UH
 UH
 UH
@@ -3383,7 +3420,7 @@ zH
 zH
 wB
 Ei
-nF
+UH
 Ox
 ba
 Ox
@@ -3461,7 +3498,7 @@ Zp
 zH
 zH
 Wk
-Yz
+rT
 Ei
 EY
 ix
@@ -3501,7 +3538,7 @@ zH
 zH
 zH
 yt
-Yz
+rT
 Ei
 wp
 ix
@@ -3541,9 +3578,9 @@ yt
 zH
 zH
 zH
-Yz
-Ei
 rT
+Ei
+RG
 RG
 RG
 RG
@@ -3580,10 +3617,10 @@ zH
 zH
 zH
 zH
-LR
-Yz
+zH
+rT
 Ei
-uR
+Lg
 RG
 ig
 RG
@@ -3616,7 +3653,7 @@ ZT
 LR
 LR
 LR
-LR
+zH
 Wk
 zH
 yt
@@ -3655,7 +3692,7 @@ ZT
 (44,1,1) = {"
 LR
 LR
-LR
+zH
 zH
 zH
 Wk
@@ -3695,15 +3732,15 @@ lh
 (45,1,1) = {"
 LR
 LR
-LR
+zH
 zH
 yt
 zH
 LR
 LR
 Yz
-Ei
-RG
+YY
+pf
 RG
 RG
 Ta
@@ -3734,11 +3771,11 @@ Wf
 "}
 (46,1,1) = {"
 LR
+zH
+zH
+zH
+zH
 LR
-LR
-zH
-zH
-zH
 LR
 LR
 Yz
@@ -3774,11 +3811,11 @@ lh
 "}
 (47,1,1) = {"
 LR
+zH
+yt
+zH
+zH
 LR
-LR
-zH
-zH
-zH
 LR
 LR
 Yz
@@ -3814,8 +3851,8 @@ lh
 "}
 (48,1,1) = {"
 LR
-LR
-LR
+zH
+zH
 zH
 zH
 zH
@@ -3855,7 +3892,7 @@ lh
 (49,1,1) = {"
 LR
 LR
-LR
+zH
 yt
 zH
 zH
@@ -3881,8 +3918,8 @@ fL
 fL
 fL
 fL
-Ob
-Ob
+mC
+mC
 fL
 bp
 bp
@@ -3920,9 +3957,9 @@ LR
 LR
 LR
 LR
-zH
-zH
-zH
+LR
+LR
+LR
 LR
 Dd
 LR
@@ -3960,8 +3997,8 @@ LR
 LR
 LR
 LR
-zH
-yt
+LR
+LR
 LR
 LR
 Dd
@@ -4000,9 +4037,9 @@ LR
 LR
 LR
 LR
-zH
+LR
 fs
-zH
+LR
 LR
 Dd
 LR
@@ -4040,9 +4077,9 @@ LR
 LR
 LR
 LR
-zH
-yt
-zH
+LR
+LR
+LR
 LR
 Dd
 LR
@@ -4077,11 +4114,11 @@ LR
 LR
 LR
 LR
-Wk
-yt
-zH
-yt
-Wk
+LR
+LR
+LR
+LR
+LR
 LR
 LR
 Dd
@@ -4117,11 +4154,11 @@ LR
 LR
 LR
 LR
-zH
-zH
-yh
-yh
-yh
+LR
+LR
+Dd
+Dd
+Dd
 Dd
 Dd
 LR
@@ -4157,7 +4194,7 @@ LR
 LR
 LR
 LR
-zH
+LR
 yh
 Sw
 Sw
@@ -4319,7 +4356,7 @@ zH
 zH
 yt
 yh
-Sw
+He
 aG
 PJ
 PJ
@@ -4359,7 +4396,7 @@ zH
 zH
 zH
 yh
-Sw
+He
 Yf
 Rw
 Yf
@@ -4399,7 +4436,7 @@ Zg
 zH
 zH
 yh
-Sw
+He
 vN
 te
 Rw

--- a/_maps/modularmaps/big_red/bigredlzvar3.dmm
+++ b/_maps/modularmaps/big_red/bigredlzvar3.dmm
@@ -561,6 +561,9 @@
 /area/bigredv2/outside/space_port)
 "mR" = (
 /obj/structure/closet/secure_closet/injection,
+/obj/structure/sign/safety/hazard{
+	dir = 1
+	},
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "mX" = (
@@ -639,6 +642,15 @@
 "pm" = (
 /obj/machinery/landinglight/ds1,
 /turf/open/floor/marking/asteroidwarning,
+/area/bigredv2/outside/space_port)
+"pp" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/sign/safety/hazard{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
 "pE" = (
 /obj/structure/window/reinforced,
@@ -1285,7 +1297,6 @@
 /obj/structure/sign/safety/hazard{
 	dir = 4
 	},
-/obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
 "Gh" = (
@@ -1413,6 +1424,9 @@
 "Jn" = (
 /obj/item/shard,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/safety/hazard{
+	dir = 1
+	},
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "Js" = (
@@ -1600,6 +1614,9 @@
 /obj/structure/table,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/console)
+"Os" = (
+/turf/closed/mineral/smooth/bigred,
+/area/bigredv2/caves/northwest)
 "Ow" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/toolbox,
@@ -1929,6 +1946,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/space_port)
+"WL" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/mineral/smooth/bigred,
+/area/bigredv2/caves/northwest)
 "WN" = (
 /obj/structure/rack,
 /obj/machinery/light{
@@ -2526,7 +2549,7 @@ PV
 fd
 Bk
 Bi
-wT
+Os
 "}
 (13,1,1) = {"
 wT
@@ -2565,8 +2588,8 @@ PV
 PV
 PV
 Bk
-pG
-wT
+WL
+Os
 "}
 (14,1,1) = {"
 wT
@@ -2605,8 +2628,8 @@ PV
 PV
 KK
 Bk
-pG
-wT
+WL
+Os
 "}
 (15,1,1) = {"
 wT
@@ -2645,8 +2668,8 @@ hb
 hb
 Mm
 Bk
-pG
-wT
+WL
+Os
 "}
 (16,1,1) = {"
 wT
@@ -2685,8 +2708,8 @@ qE
 ry
 yc
 Bk
-pG
-wT
+WL
+Os
 "}
 (17,1,1) = {"
 wT
@@ -2725,8 +2748,8 @@ PV
 wV
 yc
 Bk
-pG
-wT
+WL
+Os
 "}
 (18,1,1) = {"
 wT
@@ -2765,8 +2788,8 @@ KH
 CG
 yc
 Bk
-pG
-wT
+WL
+Os
 "}
 (19,1,1) = {"
 wT
@@ -2805,8 +2828,8 @@ PV
 PV
 yc
 Bk
-pG
-wT
+WL
+Os
 "}
 (20,1,1) = {"
 wT
@@ -2845,8 +2868,8 @@ PV
 PV
 yc
 Bk
-Bi
-hI
+WL
+Os
 "}
 (21,1,1) = {"
 wT
@@ -2885,8 +2908,8 @@ PV
 PV
 Wh
 Bk
-Bi
-Mb
+WL
+Os
 "}
 (22,1,1) = {"
 wT
@@ -2925,8 +2948,8 @@ PV
 PV
 yc
 Bk
-Bi
-hI
+WL
+Os
 "}
 (23,1,1) = {"
 wT
@@ -3916,9 +3939,9 @@ iu
 iu
 iu
 iu
-iu
 FT
-om
+wg
+pp
 iu
 iu
 iu
@@ -4078,7 +4101,7 @@ wT
 wT
 hI
 TI
-wT
+hI
 wT
 cR
 wT
@@ -4154,8 +4177,8 @@ wT
 wT
 wT
 wT
-wT
-wT
+hI
+hI
 hI
 TI
 hI
@@ -4435,7 +4458,7 @@ hI
 hI
 TI
 tk
-iD
+tB
 Jn
 RQ
 RQ
@@ -4475,7 +4498,7 @@ hI
 hI
 hI
 tk
-iD
+tB
 HO
 Nr
 HO
@@ -4515,7 +4538,7 @@ Mb
 hI
 hI
 tk
-iD
+tB
 mR
 Pv
 Nr

--- a/_maps/modularmaps/big_red/bigredlzvar4.dmm
+++ b/_maps/modularmaps/big_red/bigredlzvar4.dmm
@@ -682,6 +682,9 @@
 "sd" = (
 /obj/item/shard,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/safety/hazard{
+	dir = 1
+	},
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "sf" = (
@@ -1985,6 +1988,9 @@
 /area/bigredv2/outside/marshal_office)
 "ZA" = (
 /obj/structure/closet/secure_closet/injection,
+/obj/structure/sign/safety/hazard{
+	dir = 1
+	},
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "ZU" = (
@@ -4389,7 +4395,7 @@ DP
 sf
 DP
 VA
-oA
+Di
 sd
 qP
 qP
@@ -4429,7 +4435,7 @@ DP
 DP
 DP
 VA
-oA
+Di
 DZ
 hy
 SO
@@ -4469,7 +4475,7 @@ DP
 DP
 DP
 VA
-oA
+Di
 ZA
 iK
 SO

--- a/_maps/modularmaps/big_red/bigredlzvar5.dmm
+++ b/_maps/modularmaps/big_red/bigredlzvar5.dmm
@@ -880,6 +880,9 @@
 /area/bigredv2/outside/marshal_office)
 "we" = (
 /obj/structure/closet/secure_closet/injection,
+/obj/structure/sign/safety/hazard{
+	dir = 1
+	},
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "ws" = (
@@ -1050,6 +1053,9 @@
 "AI" = (
 /obj/item/shard,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/safety/hazard{
+	dir = 1
+	},
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "AP" = (
@@ -4381,7 +4387,7 @@ Xr
 Xr
 OH
 LG
-fF
+Av
 AI
 hq
 hq
@@ -4421,7 +4427,7 @@ OH
 Xr
 Xr
 LG
-fF
+Av
 uk
 CO
 yZ
@@ -4461,7 +4467,7 @@ oT
 Xr
 Xr
 LG
-fF
+Av
 we
 oP
 yZ

--- a/_maps/modularmaps/big_red/bigredlzvar6.dmm
+++ b/_maps/modularmaps/big_red/bigredlzvar6.dmm
@@ -696,6 +696,9 @@
 "sa" = (
 /obj/item/shard,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/safety/hazard{
+	dir = 1
+	},
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "sb" = (
@@ -892,6 +895,9 @@
 /area/bigredv2/outside/space_port)
 "vD" = (
 /obj/structure/closet/secure_closet/injection,
+/obj/structure/sign/safety/hazard{
+	dir = 1
+	},
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "vH" = (
@@ -4473,7 +4479,7 @@ os
 os
 Vs
 hq
-jH
+JN
 sa
 KB
 KB
@@ -4513,8 +4519,8 @@ os
 os
 os
 hq
-jH
-aP
+JN
+lu
 lu
 aP
 QR
@@ -4553,7 +4559,7 @@ We
 os
 os
 hq
-jH
+JN
 vD
 oC
 lu

--- a/_maps/modularmaps/big_red/bigredlzvar7.dmm
+++ b/_maps/modularmaps/big_red/bigredlzvar7.dmm
@@ -741,6 +741,9 @@
 "qt" = (
 /obj/item/shard,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/safety/hazard{
+	dir = 1
+	},
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "qu" = (
@@ -1256,6 +1259,9 @@
 /area/bigredv2/outside/marshal_office)
 "DV" = (
 /obj/structure/closet/secure_closet/injection,
+/obj/structure/sign/safety/hazard{
+	dir = 1
+	},
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "Eo" = (
@@ -4513,7 +4519,7 @@ ok
 fW
 ok
 GY
-Ly
+Ws
 qt
 FJ
 FJ
@@ -4553,7 +4559,7 @@ ok
 ok
 ok
 GY
-Ly
+Ws
 Cw
 Ro
 Pg
@@ -4593,7 +4599,7 @@ ok
 ok
 ok
 GY
-Ly
+Ws
 DV
 nh
 Pg


### PR DESCRIPTION
## About The Pull Request

All Big Red LZ1 shall have 4 or 3 flanks as par standard of landing zones NOT to exceed or equal to 5 flanks. 

Some of Big Red LZ1 map modules have either 4 or 3 flanks, reduced from 5 flanks.

Annihilate this potential breach to FOB from all Big Red LZ1 map modules.

![image](https://user-images.githubusercontent.com/6610922/234470344-a84b8c40-98f0-413c-8b92-aaec175dbd4a.png)

Change part of northern cave tunneling to LZ1 in light of reducing flank.

![image](https://user-images.githubusercontent.com/6610922/234470430-198a7b95-8b50-489f-ab8d-85d06657cba8.png)

Allow xenomorphs to have an easier time making a funny hole from marshal to caves linking to LZ1.

![image](https://user-images.githubusercontent.com/6610922/234470597-95d4c744-455f-44e5-9896-d4c009262686.png)

## Why It's Good For The Game

No LZ with the exception of Big Red have more than 4 flanks. RipGrayson noted that Shiryu added an additional flank for some reason.

Due to the reduced flank, I ensure that xenomorphs can still contest against marines' FOB.

## Changelog

:cl:
balance: Some of Big Red LZ1 map modules have either 4 or 3 flanks, reduced from 5 flanks. This means that there are less fronts for xenomorphs to engage LZ1 but still maintaining the standard 3 or 4 flanks that engineers must consider when building FOB.
balance: Allow xenomorphs to have an easier time making a funny hole from marshal to caves linking to LZ1.
/:cl:

