### PR TITLE
Shipside medvendors are now shipside

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -4442,7 +4442,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engine_core)
 "nd" = (
-/obj/machinery/vending/medical,
+/obj/machinery/vending/medical/shipside,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/general)
 "ne" = (

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -4497,7 +4497,7 @@
 /obj/machinery/light/mainship{
 	dir = 8
 	},
-/obj/machinery/vending/medical,
+/obj/machinery/vending/medical/shipside,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "fFa" = (

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -356,7 +356,7 @@
 	},
 /area/sulaco/medbay/chemistry)
 "abk" = (
-/obj/machinery/vending/medical,
+/obj/machinery/vending/medical/shipside,
 /obj/item/radio/intercom/general{
 	dir = 1
 	},
@@ -8310,7 +8310,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "aQM" = (
-/obj/machinery/vending/medical,
+/obj/machinery/vending/medical/shipside,
 /obj/item/radio/intercom/general{
 	dir = 8
 	},
@@ -8359,7 +8359,7 @@
 /turf/open/floor/cult,
 /area/sulaco/morgue)
 "aRa" = (
-/obj/machinery/vending/medical,
+/obj/machinery/vending/medical/shipside,
 /obj/machinery/alarm{
 	dir = 4
 	},
@@ -8466,7 +8466,7 @@
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
 "aRG" = (
-/obj/machinery/vending/medical,
+/obj/machinery/vending/medical/shipside,
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
 "aRH" = (
@@ -11232,7 +11232,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
 "cHd" = (
-/obj/machinery/vending/medical,
+/obj/machinery/vending/medical/shipside,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 8
 	},
@@ -13029,7 +13029,7 @@
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay/west)
 "fjF" = (
-/obj/machinery/vending/medical,
+/obj/machinery/vending/medical/shipside,
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay/west)
 "fkB" = (
@@ -24493,7 +24493,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria/kitchen)
 "uux" = (
-/obj/machinery/vending/medical,
+/obj/machinery/vending/medical/shipside,
 /turf/open/floor/prison,
 /area/sulaco/marine)
 "uuN" = (

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -1929,7 +1929,7 @@
 /turf/open/floor/wood,
 /area/mainship/living/basketball)
 "aCI" = (
-/obj/machinery/vending/medical,
+/obj/machinery/vending/medical/shipside,
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/alpha)
@@ -19245,7 +19245,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engine_core)
 "vHX" = (
-/obj/machinery/vending/medical,
+/obj/machinery/vending/medical/shipside,
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},


### PR DESCRIPTION

## About The Pull Request

Wrong typepaths led to wrenchable nanomeds

## Why It's Good For The Game

idk walance or something. At the very least, consistency

## Changelog
:cl:
fix: All shipside med vendors are properly the unwrenchable variant
/:cl:
