### PR TITLE
Fixes inflatable door opacity

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -196,7 +196,6 @@
 	open = !open
 	flick("door_[open ? "opening" : "closing"]", src)
 	density = !density
-	opacity = !opacity
 	update_icon()
 	addtimer(VARSET_CALLBACK(src, switching_states, FALSE), 1 SECONDS)
 


### PR DESCRIPTION

## About The Pull Request

Just so they're always transparent.
## Why It's Good For The Game

Closed doors being opaque when the walls aren't doesn't make sense.
## Changelog
:cl:
fix: Fixed inflatable door opacity
/:cl:
