### PR TITLE
Allows droppods to be bought in req

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -4,7 +4,7 @@
 /area/mainship/hallways/hangar)
 "ab" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /obj/machinery/light/mainship{
 	dir = 1
 	},
@@ -23,7 +23,7 @@
 /area/mainship/living/tankerbunks)
 "ae" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar/droppod)
@@ -44,7 +44,7 @@
 /area/mainship/hallways/hangar)
 "ah" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /obj/machinery/light/mainship{
 	dir = 4
 	},
@@ -13925,7 +13925,7 @@
 /area/mainship/engineering/engineering_workshop)
 "OQ" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /obj/machinery/light/mainship{
 	dir = 8
 	},
@@ -15619,7 +15619,7 @@
 /area/mainship/engineering/engineering_workshop)
 "TY" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar/droppod)
 "TZ" = (

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -1587,7 +1587,7 @@
 /area/mainship/living/commandbunks)
 "bTS" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar/droppod)
 "bUC" = (
@@ -5446,7 +5446,7 @@
 /area/mainship/squads/general)
 "hbh" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /obj/effect/decal/cleanable/blood/writing{
 	desc = "It looks like a writing in blood. It says, 'I am missing and forgotten.'";
 	dir = 4
@@ -7033,7 +7033,7 @@
 /area/mainship/hallways/port_hallway)
 "jhK" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /obj/machinery/light/mainship{
 	dir = 4
 	},
@@ -13975,7 +13975,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "sbg" = (
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /obj/structure/droppod/leader,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar/droppod)
@@ -16551,7 +16551,7 @@
 /area/mainship/command/cic)
 "vfU" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /obj/machinery/light/mainship{
 	dir = 8
 	},

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -15531,7 +15531,7 @@
 /area/sulaco/bridge)
 "iHe" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/prison/cleanmarked,
 /area/sulaco/hangar/droppod)
@@ -17424,7 +17424,7 @@
 /area/sulaco/engineering)
 "lfa" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /obj/machinery/light/mainship{
 	dir = 8
 	},
@@ -18055,7 +18055,7 @@
 /area/sulaco/hallway/central_hall3)
 "lYE" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /obj/machinery/light/mainship{
 	dir = 4
 	},
@@ -22253,7 +22253,7 @@
 /area/sulaco/hangar)
 "rFM" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /turf/open/floor/prison/cleanmarked,
 /area/sulaco/hangar/droppod)
 "rGe" = (
@@ -22476,7 +22476,7 @@
 /turf/open/floor/prison,
 /area/sulaco/bar)
 "rTz" = (
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /obj/structure/droppod/leader,
 /turf/open/floor/prison/cleanmarked,
 /area/sulaco/hangar/droppod)

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -3693,7 +3693,7 @@
 	dir = 4
 	},
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar/droppod)
 "bkS" = (
@@ -5042,7 +5042,7 @@
 /area/mainship/engineering/lower_engine_monitoring)
 "byG" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar/droppod)
 "byW" = (
@@ -9980,7 +9980,7 @@
 /turf/open/floor/mainship/orange,
 /area/mainship/hull/port_hull)
 "fLr" = (
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /obj/structure/droppod/leader,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar/droppod)

--- a/_maps/map_files/Twin_Pillars/Twin_Pillars.dmm
+++ b/_maps/map_files/Twin_Pillars/Twin_Pillars.dmm
@@ -12849,7 +12849,7 @@
 /area/mainship/engineering/lower_engineering)
 "lBe" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar/rebel)
 "lBn" = (
@@ -17220,7 +17220,7 @@
 /area/mainship/engineering/engineering_workshop/rebel)
 "pqH" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -17367,7 +17367,7 @@
 /area/mainship/hallways/aft_hallway)
 "pxO" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "pxU" = (
@@ -21867,7 +21867,7 @@
 /area/mainship/hallways/aft_hallway/rebel)
 "tus" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -23766,7 +23766,7 @@
 /area/mainship/command/cic/rebel)
 "vdN" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -25385,7 +25385,7 @@
 /area/mainship/command/corporateliaison/rebel)
 "wxD" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -26609,7 +26609,7 @@
 /area/mainship/command/cic/rebel)
 "xBF" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -27005,7 +27005,7 @@
 /area/mainship/hallways/hangar/rebel)
 "xPx" = (
 /obj/structure/droppod,
-/obj/structure/dropprop,
+/obj/structure/drop_pod_launcher,
 /obj/machinery/light{
 	dir = 1
 	},

--- a/code/game/objects/structures/droppod.dm
+++ b/code/game/objects/structures/droppod.dm
@@ -18,6 +18,7 @@ GLOBAL_LIST_INIT(blocked_droppod_tiles, typecacheof(list(/turf/open/space/transi
 	anchored = TRUE
 	layer = ABOVE_OBJ_LAYER
 	resistance_flags = XENO_DAMAGEABLE
+	interaction_flags = INTERACT_OBJ_DEFAULT|INTERACT_POWERLOADER_PICKUP_ALLOWED_BYPASS_ANCHOR
 	soft_armor = list(MELEE = 50, BULLET = 70, LASER = 70, ENERGY = 100, BOMB = 70, BIO = 100, FIRE = 0, ACID = 0)
 	max_integrity = 50
 	flags_atom = PREVENT_CONTENTS_EXPLOSION
@@ -50,6 +51,10 @@ GLOBAL_LIST_INIT(blocked_droppod_tiles, typecacheof(list(/turf/open/space/transi
 	RegisterSignal(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_SHUTTERS_EARLY, COMSIG_GLOB_TADPOLE_LAUNCHED), PROC_REF(allow_drop))
 	GLOB.droppod_list += src
 	update_icon()
+	set_dir(SOUTH)
+	if((!locate(/obj/structure/drop_pod_launcher) in get_turf(src)) && mapload)
+		stack_trace("Droppod [REF(src)] was created without a drop pod launcher under it at [x],[y],[z]")
+		return INITIALIZE_HINT_QDEL
 
 /obj/structure/droppod/Destroy()
 	for(var/atom/movable/ejectee AS in contents) // dump them out, just in case no mobs det deleted
@@ -153,11 +158,18 @@ GLOBAL_LIST_INIT(blocked_droppod_tiles, typecacheof(list(/turf/open/space/transi
 		to_chat(user, span_notice("Unable to launch, the ship has not yet reached the combat area."))
 		return
 	#endif
+
+	if(!locate(/obj/structure/drop_pod_launcher) in get_turf(src))
+		to_chat(user, span_notice("Error. Cannot launch [name] without a droppod launcher."))
+		return
+
 	if(!launch_allowed)
 		to_chat(user, span_notice("Error. Ship calibration unavailable. Please %#&ç:*"))
 		return
+
 	if(drop_state != DROPPOD_READY)
 		return
+
 	if(!checklanding(user))
 		return
 
@@ -340,15 +352,23 @@ GLOBAL_LIST_INIT(blocked_droppod_tiles, typecacheof(list(/turf/open/space/transi
 		choosing = FALSE
 	return ..()
 
-/obj/structure/dropprop	//Just a prop for now but if the pods are someday made movable make a requirement to have these on the turf
+/obj/structure/drop_pod_launcher
 	name = "Zeus pod launch bay"
 	desc = "A hatch in the ground wih support for a Zeus drop pod launch."
 	icon = 'icons/obj/structures/droppod.dmi'
 	icon_state = "launch_bay"
 	density = FALSE
-	anchored = TRUE
-	layer = ABOVE_TURF_LAYER
 	resistance_flags = INDESTRUCTIBLE
+
+/obj/structure/drop_pod_launcher/attack_powerloader(mob/living/user, obj/item/powerloader_clamp/attached_clamp)
+	if(!istype(attached_clamp.loaded, /obj/structure/droppod))
+		return ..()
+	user.visible_message(span_notice("[user] drops [attached_clamp.loaded] onto [src] and it clicks into place!"),
+	span_notice("You drop [attached_clamp.loaded] onto [src] and it clicks into place!"))
+	attached_clamp.loaded.forceMove(get_turf(src))
+	attached_clamp.loaded = null
+	playsound(src, 'sound/machines/hydraulics_1.ogg', 40, 1)
+	attached_clamp.update_icon()
 
 #undef DROPPOD_READY
 #undef DROPPOD_ACTIVE

--- a/code/game/objects/structures/droppod.dm
+++ b/code/game/objects/structures/droppod.dm
@@ -51,7 +51,7 @@ GLOBAL_LIST_INIT(blocked_droppod_tiles, typecacheof(list(/turf/open/space/transi
 	RegisterSignal(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_SHUTTERS_EARLY, COMSIG_GLOB_TADPOLE_LAUNCHED), PROC_REF(allow_drop))
 	GLOB.droppod_list += src
 	update_icon()
-	set_dir(SOUTH)
+	setDir(SOUTH)
 	if((!locate(/obj/structure/drop_pod_launcher) in get_turf(src)) && mapload)
 		stack_trace("Droppod [REF(src)] was created without a drop pod launcher under it at [x],[y],[z]")
 		return INITIALIZE_HINT_QDEL

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -136,6 +136,18 @@ OPERATIONS
 	contains = list(/obj/item/spacecash/c500)
 	cost = 50
 
+/datum/supply_packs/operations/droppod
+	name = "drop pod"
+	contains = list(/obj/structure/droppod)
+	containertype = null
+	cost = 50
+
+/datum/supply_packs/operations/droppod_leader
+	name = "leader drop pod"
+	contains = list(/obj/structure/droppod/leader)
+	containertype = null
+	cost = 100
+
 /*******************************************************************************
 WEAPONS
 *******************************************************************************/


### PR DESCRIPTION

## About The Pull Request

Allows droppods to be bought in req. 50 points each, 100 points for leader pod. You can move them with a powerloader and they will only launch on a pod launch bay.
## Why It's Good For The Game

Most even semi highpop rounds tend to run out of pods relatively quickly with no way to restock them. This PR rectifies that.
## Changelog
:cl:
balance: Allowed droppods to be bought in req, 50 points for a normal pod and 100 for a leader pod. Move them with a powerloader.
/:cl:
