### PR TITLE
Boiler bombard cooldown increase

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -50,7 +50,7 @@
 	// *** Boiler Abilities *** //
 	max_ammo = 4
 	bomb_strength = 1 //Multiplier to the effectiveness of the boiler glob.
-	bomb_delay = 32 SECONDS
+	bomb_delay = 45 SECONDS
 	ammo_multiplier = 1.5 SECONDS
 
 	acid_spray_duration = 10 SECONDS
@@ -109,7 +109,7 @@
 	max_ammo = 5
 	bomb_strength = 1.1
 
-	bomb_delay = 32 SECONDS
+	bomb_delay = 45 SECONDS
 
 /datum/xeno_caste/boiler/elder
 	upgrade_name = "Elder"
@@ -145,7 +145,7 @@
 	max_ammo = 6
 	bomb_strength = 1.2
 
-	bomb_delay = 32 SECONDS
+	bomb_delay = 42 SECONDS
 
 /datum/xeno_caste/boiler/ancient
 	upgrade_name = "Ancient"
@@ -182,7 +182,7 @@
 	max_ammo = 7
 	bomb_strength = 1.3
 
-	bomb_delay = 27 SECONDS
+	bomb_delay = 40 SECONDS
 
 /datum/xeno_caste/boiler/primordial
 	upgrade_name = "Primordial"
@@ -217,7 +217,7 @@
 	max_ammo = 7
 	bomb_strength = 1.3
 
-	bomb_delay = 27 SECONDS
+	bomb_delay = 40 SECONDS
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,


### PR DESCRIPTION

## About The Pull Request

Originally, boiler was not as problematic given that there was disincentive to throw acid globs into already existing smoke. As this is no longer the case, boiler now entirely commands the xeno meta, and at ancient tier while fully loaded with globs (there is no reason not to do this) gets an 18-20 second cooldown on smokes (to get it to reload at 18 seconds, you need to step out after firing, and then load a glob before 18 seconds elapse, it seems to work retroactively in that way).

Boiler glob smoke persists for roughly 15 seconds before entirely dissipating.

You can see the issue here, as well as why double boiler has been especially problematic for gameplay, and otherwise incredibly unfun, given the extensive range of boiler in addition to the innate x-ray vision of xenos. The cooldowns are the problem, not the damage, the range of the boiler, or anything else. It's the fact boilers can at roundstart completely pin a pushout from marine FOB and leave a lot of people wondering why that is okay.

Comparably, the best boilers can get through the proposed changes is a 30 second cooldown when fully loaded with acid globules at Ancient maturity. 15 seconds is more than enough for marines to either decide to get their shit together and push the boiler out together, or they can just skill issue themselves and do nothing. All that matters is marines are given a chance to do something rather than eat AOE globules or lances due to the unforgivingly quick cooldowns of a fully loaded offscreen boiler.

## Why It's Good For The Game

Balance is good. High damage gamechanging abilities are okay. Low cooldowns for high damage gamechanging abilities is not okay. Imagine if queen screech was 18 second cooldown, or shrike screech. Nah. Let's not.

## Changelog
:cl:
balance: Boiler bombard cooldown increased (nerf).
/:cl:
