### PR TITLE
Fixes quickbuild drag not working

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -200,7 +200,7 @@
 	SIGNAL_HANDLER
 
 	var/list/modifiers = params2list(params)
-	if(toggled && !modifiers[BUTTON] == LEFT_CLICK)
+	if(toggled && !(modifiers[BUTTON] == LEFT_CLICK))
 		dragging = TRUE
 		preshutter_build_resin(get_turf(object))
 


### PR DESCRIPTION

## About The Pull Request

Negation logic is hard and so is doing even the most basic test.
## Why It's Good For The Game

Bug bad.
## Changelog
:cl:
fix: Fixed quickbuild drag not working
/:cl:
