### PR TITLE
Removes location params from Initialize defs

### DIFF
--- a/code/controllers/subsystem/advanced_pathfinding.dm
+++ b/code/controllers/subsystem/advanced_pathfinding.dm
@@ -147,7 +147,7 @@ GLOBAL_LIST_EMPTY(goal_nodes)
 	///The image added to the creator screen
 	var/image/goal_image
 
-/obj/effect/ai_node/goal/Initialize(mapload, loc, mob/creator)
+/obj/effect/ai_node/goal/Initialize(mapload, mob/creator)
 	. = ..()
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_AI_GOAL_SET, identifier, src)
 	RegisterSignal(SSdcs, COMSIG_GLOB_AI_GOAL_SET, PROC_REF(clean_goal_node))

--- a/code/game/objects/structures/supplypod.dm
+++ b/code/game/objects/structures/supplypod.dm
@@ -246,7 +246,7 @@ GLOBAL_LIST_INIT(pod_styles, list(\
 	icon_state = ""
 
 
-/obj/effect/DPfall/Initialize(mapload, dropLocation, obj/structure/closet/supplypod/pod)
+/obj/effect/DPfall/Initialize(mapload, obj/structure/closet/supplypod/pod)
 	if(pod.style == STYLE_SEETHROUGH)
 		pixel_x = -16
 		pixel_y = 0

--- a/code/modules/ai/presets/zombie_presets.dm
+++ b/code/modules/ai/presets/zombie_presets.dm
@@ -12,7 +12,7 @@
 	. = ..()
 	AddComponent(/datum/component/ai_controller, /datum/ai_behavior/xeno/zombie/patrolling , null)
 
-/mob/living/carbon/human/species/zombie/ai/follower/Initialize(mapload, loc, atom_to_escort)
+/mob/living/carbon/human/species/zombie/ai/follower/Initialize(mapload, atom_to_escort)
 	. = ..()
 	AddComponent(/datum/component/ai_controller, /datum/ai_behavior/xeno/zombie, atom_to_escort)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -188,7 +188,7 @@
 	///All the projectiles currently frozen by this obj
 	var/list/frozen_projectiles = list()
 
-/obj/effect/xeno/shield/Initialize(mapload, loc, creator)
+/obj/effect/xeno/shield/Initialize(mapload, creator)
 	. = ..()
 	owner = creator
 	dir = owner.dir

--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
@@ -73,7 +73,7 @@
 	var/list/mob/living/carbon/human/leash_victims = list()
 
 /// Humans caught get beamed and registered for proc/check_dist, aoe_leash also gains increased integrity for each caught human
-/obj/structure/xeno/aoe_leash/Initialize(mapload, location, hivenumber)
+/obj/structure/xeno/aoe_leash/Initialize(mapload, _hivenumber)
 	. = ..()
 	for(var/mob/living/carbon/human/victim in GLOB.humans_by_zlevel["[z]"])
 		if(get_dist(src, victim) > leash_radius)

--- a/code/modules/organs/limb_objects.dm
+++ b/code/modules/organs/limb_objects.dm
@@ -6,7 +6,7 @@
 		slot_r_hand_str = 'icons/mob/inhands/items/bodyparts_right.dmi',
 	)
 
-/obj/item/limb/Initialize(mapload, loc, mob/living/carbon/human/H)
+/obj/item/limb/Initialize(mapload, mob/living/carbon/human/H)
 	. = ..()
 	if(!istype(H))
 		return

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -947,7 +947,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	///The icon of the laser beam that will be created
 	var/effect_icon = "beam"
 
-/obj/projectile/hitscan/Initialize(mapload, loc, effect_icon)
+/obj/projectile/hitscan/Initialize(mapload, effect_icon)
 	. = ..()
 	if(effect_icon)
 		src.effect_icon = effect_icon

--- a/code/modules/projectiles/tracer.dm
+++ b/code/modules/projectiles/tracer.dm
@@ -7,7 +7,7 @@
 	appearance_flags = NONE
 	move_resist = INFINITY
 
-/atom/movable/hitscan_projectile_effect/Initialize(mapload, loc, angle_override, p_x, p_y, scaling = 1, effect_icon)
+/atom/movable/hitscan_projectile_effect/Initialize(mapload, angle_override, p_x, p_y, scaling = 1, effect_icon)
 	. = ..()
 	icon_state = effect_icon
 	pixel_x = p_x

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -7,12 +7,12 @@
 	///Which hive(number) do we belong to?
 	var/hivenumber = XENO_HIVE_NORMAL
 
-/obj/structure/xeno/Initialize(mapload, location, hivenumber)
+/obj/structure/xeno/Initialize(mapload, _hivenumber)
 	. = ..()
 	if(!(xeno_structure_flags & IGNORE_WEED_REMOVAL))
 		RegisterSignal(loc, COMSIG_TURF_WEED_REMOVED, PROC_REF(weed_removed))
-	if(hivenumber) ///because admins can spawn them
-		src.hivenumber = hivenumber
+	if(_hivenumber) ///because admins can spawn them
+		hivenumber = _hivenumber
 	LAZYADDASSOC(GLOB.xeno_structures_by_hive, hivenumber, src)
 	if(xeno_structure_flags & CRITICAL_STRUCTURE)
 		GLOB.xeno_critical_structures += src
@@ -84,7 +84,7 @@
 		COMSIG_ATOM_ENTERED = PROC_REF(trigger_trap),
 	)
 
-/obj/structure/xeno/trap/Initialize(mapload)
+/obj/structure/xeno/trap/Initialize(mapload, _hivenumber)
 	. = ..()
 	RegisterSignal(src, COMSIG_MOVABLE_SHUTTLE_CRUSH, PROC_REF(shuttle_crush))
 	AddElement(/datum/element/connect_loc, listen_connections)
@@ -289,7 +289,7 @@ TUNNEL
 	///What hivelord created that tunnel. Can be null
 	var/mob/living/carbon/xenomorph/hivelord/creator = null
 
-/obj/structure/xeno/tunnel/Initialize(mapload)
+/obj/structure/xeno/tunnel/Initialize(mapload, _hivenumber)
 	. = ..()
 	LAZYADDASSOC(GLOB.xeno_tunnels_by_hive, hivenumber, src)
 	prepare_huds()
@@ -453,9 +453,9 @@ TUNNEL
 	///What xeno created this well
 	var/mob/living/carbon/xenomorph/creator = null
 
-/obj/structure/xeno/acidwell/Initialize(mapload, loc, creator)
+/obj/structure/xeno/acidwell/Initialize(mapload, _creator)
 	. = ..()
-	src.creator = creator
+	creator = _creator
 	RegisterSignal(creator, COMSIG_PARENT_QDELETING, PROC_REF(clear_creator))
 	update_icon()
 	var/static/list/connections = list(
@@ -650,7 +650,7 @@ TUNNEL
 	///Countdown to the next time we generate a jelly
 	var/nextjelly = 0
 
-/obj/structure/xeno/resin_jelly_pod/Initialize(mapload)
+/obj/structure/xeno/resin_jelly_pod/Initialize(mapload, _hivenumber)
 	. = ..()
 	add_overlay(image(icon, "resinpod_inside", layer + 0.01, dir))
 	START_PROCESSING(SSslowprocess, src)
@@ -721,7 +721,7 @@ TUNNEL
 	COOLDOWN_DECLARE(silo_damage_alert_cooldown)
 	COOLDOWN_DECLARE(silo_proxy_alert_cooldown)
 
-/obj/structure/xeno/silo/Initialize(mapload)
+/obj/structure/xeno/silo/Initialize(mapload, _hivenumber)
 	. = ..()
 	center_turf = get_step(src, NORTHEAST)
 	if(!istype(center_turf))
@@ -897,7 +897,7 @@ TUNNEL
 	SSminimaps.remove_marker(src)
 	SSminimaps.add_marker(src, z, MINIMAP_FLAG_XENO, "xeno_turret[firing ? "_firing" : "_passive"]")
 
-/obj/structure/xeno/xeno_turret/Initialize(mapload)
+/obj/structure/xeno/xeno_turret/Initialize(mapload, _hivenumber)
 	. = ..()
 	ammo = GLOB.ammo_list[ammo]
 	potential_hostiles = list()
@@ -1136,7 +1136,7 @@ TUNNEL
 	///boost amt to be added per tower per cycle
 	var/boost_amount = 0.25
 
-/obj/structure/xeno/evotower/Initialize(mapload)
+/obj/structure/xeno/evotower/Initialize(mapload, _hivenumber)
 	. = ..()
 	GLOB.hive_datums[hivenumber].evotowers += src
 	set_light(2, 2, LIGHT_COLOR_GREEN)
@@ -1167,7 +1167,7 @@ TUNNEL
 	///boost amt to be added per tower per cycle
 	var/boost_amount = 0.2
 
-/obj/structure/xeno/maturitytower/Initialize(mapload)
+/obj/structure/xeno/maturitytower/Initialize(mapload, _hivenumber)
 	. = ..()
 	GLOB.hive_datums[hivenumber].maturitytowers += src
 	set_light(2, 2, LIGHT_COLOR_GREEN)
@@ -1200,7 +1200,7 @@ TUNNEL
 	///Radius (in tiles) of the pheromones given by this tower.
 	var/aura_radius = 32
 
-/obj/structure/xeno/pherotower/Initialize(mapload)
+/obj/structure/xeno/pherotower/Initialize(mapload, _hivenumber)
 	. = ..()
 	SSminimaps.add_marker(src, z, MINIMAP_FLAG_XENO, "phero")
 	GLOB.hive_datums[hivenumber].pherotowers += src
@@ -1262,7 +1262,7 @@ TUNNEL
 	COOLDOWN_DECLARE(spawner_proxy_alert_cooldown)
 	var/linked_minions = list()
 
-/obj/structure/xeno/spawner/Initialize(mapload)
+/obj/structure/xeno/spawner/Initialize(mapload, _hivenumber)
 	. = ..()
 	LAZYADDASSOC(GLOB.xeno_spawners_by_hive, hivenumber, src)
 	SSspawning.registerspawner(src, INFINITY, GLOB.xeno_ai_spawnable, 0, 0, CALLBACK(src, PROC_REF(on_spawn)))
@@ -1370,7 +1370,7 @@ TUNNEL
 	///How long does it take for the plant to be useable
 	var/maturation_time = 2 MINUTES
 
-/obj/structure/xeno/plant/Initialize(mapload)
+/obj/structure/xeno/plant/Initialize(mapload, _hivenumber)
 	. = ..()
 	addtimer(CALLBACK(src, PROC_REF(on_mature)), maturation_time)
 


### PR DESCRIPTION

## About The Pull Request

Removes the location param from Initialize defs due to it going completely unused in all cases and only causing issues, like args that were meant to be other args being passed into it with mapload being a thing now.

Fixes xeno structure lists not updating, warlock shields, laser weapon tracers being invisible and probably like 20 more.
## Why It's Good For The Game

Bugs bad.
## Changelog
:cl:
fix: Removes location params from Initialize defs, this fixes things like laser weapon tracers being invisible and structures not breaking on alamo departure during hijack
/:cl:
