### PR TITLE
Fixes droppods facing you west and not unbuckling mobs once the pod gets picked up by a powerloader

### DIFF
--- a/code/game/objects/structures/droppod.dm
+++ b/code/game/objects/structures/droppod.dm
@@ -56,11 +56,17 @@ GLOBAL_LIST_INIT(blocked_droppod_tiles, typecacheof(list(/turf/open/space/transi
 		return INITIALIZE_HINT_QDEL
 
 /obj/structure/droppod/Destroy()
-	for(var/atom/movable/ejectee AS in contents) // dump them out, just in case no mobs get deleted
+	for(var/atom/movable/ejectee AS in buckled_mobs) // dump them out, just in case no mobs get deleted
 		ejectee.forceMove(loc)
 	QDEL_NULL(reserved_area)
 	QDEL_LIST(interaction_actions)
 	GLOB.droppod_list -= src // todo should be active pods only for iterative checks
+	return ..()
+
+
+/obj/structure/droppod/attack_powerloader(mob/living/user, obj/item/powerloader_clamp/attached_clamp)
+	for(var/atom/movable/ejectee AS in buckled_mobs) // dump them out, just in case no mobs get deleted
+		ejectee.forceMove(loc)
 	return ..()
 
 ///Disables launching upon dropship hijack
@@ -359,18 +365,6 @@ GLOBAL_LIST_INIT(blocked_droppod_tiles, typecacheof(list(/turf/open/space/transi
 	icon_state = "launch_bay"
 	density = FALSE
 	resistance_flags = INDESTRUCTIBLE
-
-/obj/structure/drop_pod_launcher/attack_powerloader(mob/living/user, obj/item/powerloader_clamp/attached_clamp)
-	if(!istype(attached_clamp.loaded, /obj/structure/droppod))
-		return ..()
-	for(var/atom/movable/ejectee AS in contents) // dump them out, just in case no mobs get deleted
-		ejectee.forceMove(loc)
-	user.visible_message(span_notice("[user] drops [attached_clamp.loaded] onto [src] and it clicks into place!"),
-	span_notice("You drop [attached_clamp.loaded] onto [src] and it clicks into place!"))
-	attached_clamp.loaded.forceMove(get_turf(src))
-	attached_clamp.loaded = null
-	playsound(src, 'sound/machines/hydraulics_1.ogg', 40, 1)
-	attached_clamp.update_icon()
 
 #undef DROPPOD_READY
 #undef DROPPOD_ACTIVE

--- a/code/game/objects/structures/droppod.dm
+++ b/code/game/objects/structures/droppod.dm
@@ -51,13 +51,12 @@ GLOBAL_LIST_INIT(blocked_droppod_tiles, typecacheof(list(/turf/open/space/transi
 	RegisterSignal(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_SHUTTERS_EARLY, COMSIG_GLOB_TADPOLE_LAUNCHED), PROC_REF(allow_drop))
 	GLOB.droppod_list += src
 	update_icon()
-	setDir(SOUTH)
 	if((!locate(/obj/structure/drop_pod_launcher) in get_turf(src)) && mapload)
 		stack_trace("Droppod [REF(src)] was created without a drop pod launcher under it at [x],[y],[z]")
 		return INITIALIZE_HINT_QDEL
 
 /obj/structure/droppod/Destroy()
-	for(var/atom/movable/ejectee AS in contents) // dump them out, just in case no mobs det deleted
+	for(var/atom/movable/ejectee AS in contents) // dump them out, just in case no mobs get deleted
 		ejectee.forceMove(loc)
 	QDEL_NULL(reserved_area)
 	QDEL_LIST(interaction_actions)
@@ -93,6 +92,7 @@ GLOBAL_LIST_INIT(blocked_droppod_tiles, typecacheof(list(/turf/open/space/transi
 		if(!silent)
 			balloon_alert(buckling_mob, "Already used")
 		return FALSE
+	setDir(SOUTH) //this is dirty but supply elevator still tehnically being a shuttle forced my hand TODO: undirty this
 	. = ..()
 	if(!.)
 		return
@@ -363,6 +363,8 @@ GLOBAL_LIST_INIT(blocked_droppod_tiles, typecacheof(list(/turf/open/space/transi
 /obj/structure/drop_pod_launcher/attack_powerloader(mob/living/user, obj/item/powerloader_clamp/attached_clamp)
 	if(!istype(attached_clamp.loaded, /obj/structure/droppod))
 		return ..()
+	for(var/atom/movable/ejectee AS in contents) // dump them out, just in case no mobs get deleted
+		ejectee.forceMove(loc)
 	user.visible_message(span_notice("[user] drops [attached_clamp.loaded] onto [src] and it clicks into place!"),
 	span_notice("You drop [attached_clamp.loaded] onto [src] and it clicks into place!"))
 	attached_clamp.loaded.forceMove(get_turf(src))


### PR DESCRIPTION

## About The Pull Request

Fixes droppods facing you west and not unbuckling mobs once the pod gets picked up by a powerloader.

No, `DIRLOCK` didn't work. :(
## Why It's Good For The Game

Bugs bad.
## Changelog
:cl:
fix: Fixes droppods facing you west and not unbuckling mobs once the pod gets picked up by a powerloader
/:cl:
