### PR TITLE
Adjusts the Sulaco's armories to allow for basic use at roundstart.

### DIFF
--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -2155,6 +2155,9 @@
 /area/sulaco/bridge)
 "akv" = (
 /obj/machinery/floodlight/combat,
+/obj/machinery/vending/nanomed{
+	dir = 8
+	},
 /turf/open/floor/prison/red{
 	dir = 5
 	},
@@ -2494,9 +2497,6 @@
 /turf/open/floor/prison,
 /area/sulaco/bar)
 "amW" = (
-/obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
-	dir = 1
-	},
 /obj/machinery/door/poddoor/shutters/mainship/cic/armory{
 	dir = 2
 	},
@@ -10987,7 +10987,6 @@
 /area/sulaco/maintenance/lower_maint)
 "cub" = (
 /obj/structure/sign/prop1,
-/obj/machinery/vending/nanomed,
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/bridge)
 "cuo" = (
@@ -23208,12 +23207,6 @@
 	},
 /turf/open/floor/wood,
 /area/sulaco/marine/chapel/chapel_office)
-"sOb" = (
-/obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
-	dir = 1
-	},
-/turf/closed/wall/mainship/gray,
-/area/sulaco/bridge)
 "sOt" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -47688,7 +47681,7 @@ aEH
 acc
 pLJ
 sBO
-sOb
+tbJ
 anY
 apb
 apv
@@ -48716,7 +48709,7 @@ aEH
 akv
 alD
 ghk
-sOb
+tbJ
 aBR
 qWq
 nWn

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -585,6 +585,7 @@
 /obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/suit/armor/bulletproof,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/prison/red{
 	dir = 9
 	},
@@ -2158,6 +2159,9 @@
 /obj/machinery/vending/nanomed{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/cobweb{
+	dir = 4
+	},
 /turf/open/floor/prison/red{
 	dir = 5
 	},
@@ -2641,7 +2645,6 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_north_maint)
 "anY" = (
-/obj/machinery/door_control/mainship/cic/armory,
 /obj/structure/cable,
 /obj/machinery/power/apc/mainship/hardened{
 	dir = 4
@@ -8022,7 +8025,6 @@
 /turf/open/floor/mainship/ai,
 /area/sulaco/command/ai)
 "aOK" = (
-/obj/structure/safe,
 /obj/item/weapon/chainofcommand,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
 /obj/item/storage/bible{
@@ -8033,6 +8035,7 @@
 /obj/item/ore/diamond,
 /obj/structure/sign/prop1,
 /obj/item/storage/fancy/cigar,
+/obj/structure/safe,
 /turf/open/floor/wood,
 /area/sulaco/cap_office)
 "aOP" = (
@@ -10248,6 +10251,12 @@
 /obj/effect/soundplayer,
 /turf/closed/wall/mainship/gray/outer,
 /area/shuttle/distress/arrive_1)
+"bmG" = (
+/obj/effect/ai_node,
+/turf/open/floor/prison/red{
+	dir = 1
+	},
+/area/sulaco/bridge)
 "bmI" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
@@ -11987,6 +11996,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
+"dKT" = (
+/obj/machinery/vending/nanomed{
+	pixel_y = 25
+	},
+/turf/open/floor/prison/red{
+	dir = 5
+	},
+/area/sulaco/bridge)
 "dLr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -13653,6 +13670,10 @@
 /obj/structure/closet/walllocker/emerglocker{
 	dir = 4
 	},
+/obj/machinery/door_control/mainship/cic/armory{
+	dir = 1
+	},
+/obj/structure/sign/security,
 /turf/open/floor/prison/red/full{
 	dir = 1
 	},
@@ -17474,10 +17495,12 @@
 	},
 /area/sulaco/research)
 "llL" = (
-/obj/machinery/door/airlock/mainship/command/CPToffice,
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/poddoor/opened/bridge,
-/turf/open/floor/plating,
+/obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
+	dir = 1
+	},
+/turf/open/floor/prison/red/full{
+	dir = 1
+	},
 /area/sulaco/bridge)
 "llY" = (
 /obj/machinery/light/mainship/small{
@@ -17631,6 +17654,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean,
 /area/mainship/command/self_destruct)
+"lwq" = (
+/obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
+	dir = 1
+	},
+/turf/closed/wall/mainship/gray,
+/area/sulaco/bridge)
 "lwx" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/machinery/door/firedoor/mainship,
@@ -20269,11 +20298,11 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
 "oXE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb{
-	dir = 1
+/obj/machinery/vending/armor_supply,
+/obj/machinery/light/mainship,
+/turf/open/floor/prison/red{
+	dir = 10
 	},
-/turf/open/floor/plating,
 /area/sulaco/bridge)
 "oYo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -21234,12 +21263,11 @@
 	},
 /area/mainship/living/basketball)
 "qpo" = (
-/obj/machinery/light/mainship/small,
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/effect/ai_node,
-/turf/open/floor/plating,
+/obj/machinery/vending/weapon,
+/turf/open/floor/prison/red,
 /area/sulaco/bridge)
 "qpD" = (
 /obj/machinery/door_control/mainship/mech{
@@ -23144,14 +23172,14 @@
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
 "sJR" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
+/obj/machinery/light/mainship,
+/obj/structure/rack,
+/obj/item/weapon/gun/rifle/standard_lmg,
+/obj/item/ammo_magazine/standard_lmg,
+/obj/item/ammo_magazine/standard_lmg,
+/turf/open/floor/prison/red{
+	dir = 6
 	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/machinery/door/poddoor/opened/bridge,
-/turf/open/floor/plating,
 /area/sulaco/bridge)
 "sKM" = (
 /obj/machinery/camera/autoname{
@@ -26689,7 +26717,8 @@
 	},
 /area/sulaco/medbay/cmo)
 "xzG" = (
-/turf/open/floor/plating,
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/prison/red,
 /area/sulaco/bridge)
 "xzL" = (
 /obj/structure/rack,
@@ -47681,7 +47710,7 @@ aEH
 acc
 pLJ
 sBO
-tbJ
+lwq
 anY
 apb
 apv
@@ -47695,7 +47724,7 @@ aAZ
 aCv
 geL
 tbJ
-xzG
+arZ
 oXE
 aEH
 qDO
@@ -47938,7 +47967,7 @@ gNS
 agA
 asd
 aAU
-amW
+llL
 aBR
 apu
 asd
@@ -47951,8 +47980,8 @@ auV
 sPp
 aAU
 aBR
-sJR
-xzG
+amW
+bmG
 qpo
 aEH
 qDO
@@ -48195,7 +48224,7 @@ aEH
 aku
 asd
 aAU
-amW
+llL
 aBR
 apu
 asd
@@ -48208,8 +48237,8 @@ asd
 asr
 aAU
 tOJ
-tbJ
-xzG
+amW
+apu
 xzG
 aEH
 qDO
@@ -48452,7 +48481,7 @@ aEH
 agA
 mqC
 aAU
-amW
+llL
 aBR
 apu
 mqC
@@ -48466,8 +48495,8 @@ azE
 azB
 ldh
 tbJ
-xzG
-xzG
+dKT
+sJR
 aEH
 qDO
 aaa
@@ -48709,7 +48738,7 @@ aEH
 akv
 alD
 ghk
-tbJ
+lwq
 aBR
 qWq
 nWn
@@ -48724,10 +48753,10 @@ aBR
 soQ
 tbJ
 tbJ
-llL
+tbJ
 aEH
+cyv
 mDu
-wRO
 wRO
 wRO
 wRO


### PR DESCRIPTION

## About The Pull Request

Okie-dokie, originally this was going to be something that fixed the Sulaco having two sets of shutters stacked for some reason.

Found out the reason why and we've made a slight compromise, adds a tiny sub-armory in the Sulaco's CIC with all the basics, while allowing the SD variant to open when it's supposed to.

![Armory_CIC](https://user-images.githubusercontent.com/38842059/235330754-0e4226de-99ac-4064-9ab5-fd2f8f524a3c.PNG)

![Armory_CIC_B](https://user-images.githubusercontent.com/38842059/235330781-1c7d7607-6aef-497b-936c-27fdcb0ba17a.PNG)

![CIC_C](https://user-images.githubusercontent.com/38842059/235330788-88737bb7-4109-4818-949e-6429dd9f906b.PNG)

## Why It's Good For The Game

Allows the most basic stuff from the usual CIC armories to be accessed roundstart.

## Changelog
:cl: Skye
qol: Allows the basic armory goods to be accessed on the Sulaco ship map.
/:cl:
