### PR TITLE
Makes Unboxer require less clicks.

### DIFF
--- a/code/modules/factory/unboxer.dm
+++ b/code/modules/factory/unboxer.dm
@@ -63,6 +63,10 @@
 	if(!anchored)
 		balloon_alert(user, "Must be anchored!")
 		return
+	change_state()
+
+///Turns the unboxer on/off
+/obj/machinery/unboxer/proc/change_state()
 	on = !on
 	if(on)
 		START_PROCESSING(SSmachines, src)
@@ -77,9 +81,7 @@
 
 /obj/machinery/unboxer/process()
 	if(production_amount_left <= 0)
-		balloon_alert_to_viewers("No material left!")
-		STOP_PROCESSING(SSmachines, src)
-		update_icon()
+		change_state()
 		return
 	new production_type(get_step(src, dir))
 	production_amount_left--
@@ -97,6 +99,8 @@
 	production_amount_left += to_refill
 	refill.refill_amount -= to_refill
 	visible_message(span_notice("[user] restocks \the [src] with \the [refill]!"), span_notice("You restock \the [src] with [refill]!"))
+	if(!on)
+		change_state()
 	if(refill.refill_amount <= 0)
 		qdel(refill)
 		new /obj/item/stack/sheet/metal(user.loc)//simulates leftover trash


### PR DESCRIPTION

## About The Pull Request
Unboxer will turn on when refilled, and will turn off when empty.
## Why It's Good For The Game
It's weird having to click 3 times after you put a refill in a unboxer, this solves that by making the machine turn off when it empties, and turn on when you put a refill. 
You can still manually turn it on/off outside of that.
## Changelog
:cl:
qol: Unboxer no longer requires 3 clicks when you put a new refill
/:cl:
