### PR TITLE
Reduce Laspistol Wield Time

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -493,7 +493,7 @@
 	attachable_offset = list("muzzle_x" = 23, "muzzle_y" = 22,"rail_x" = 12, "rail_y" = 22, "under_x" = 16, "under_y" = 14, "stock_x" = 22, "stock_y" = 12)
 
 	akimbo_additional_delay = 0.9
-	wield_delay = 0.6 SECONDS
+	wield_delay = 0.2 SECONDS
 	scatter = 2
 	scatter_unwielded = 4
 	fire_delay = 0.15 SECONDS


### PR DESCRIPTION

## About The Pull Request
Changes laspistol wield time from 0.6 to 0.2 seconds.
## Why It's Good For The Game
Brings laspistol wield time in line with all other pistols. I don't know why this pistol specifically has one this long given its designation as a pistol. Ironically it has a longer wield time than the lasrifle. Additionally, laspistol has worse unwielded accuracy than its ballistic counterparts, so I think that this would make wielding more rewarding and realistic as a quick defense option.
## Changelog
:cl:
balance: TE Laser Pistol wield time reduced from 0.6 to 0.2 seconds.
/:cl:
