### PR TITLE
Fixes containers not putting items into themselves

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -48,9 +48,9 @@
 	return INITIALIZE_HINT_LATELOAD
 
 
-/obj/structure/closet/LateInitialize(mapload)
+/obj/structure/closet/LateInitialize()
 	. = ..()
-	if(mapload && !opened)		// if closed, any item at the crate's loc is put in the contents
+	if(!opened)		// if closed, any item at the crate's loc is put in the contents
 		take_contents()
 		update_icon()
 	PopulateContents()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -44,16 +44,20 @@
 
 /obj/structure/closet/Initialize(mapload, ...)
 	. = ..()
+
+	if(mapload && !opened)
+		. = INITIALIZE_HINT_LATELOAD
+
 	RegisterSignal(src, COMSIG_MOVABLE_SHUTTLE_CRUSH, PROC_REF(shuttle_crush))
-	return INITIALIZE_HINT_LATELOAD
-
-
-/obj/structure/closet/LateInitialize()
-	. = ..()
-	if(!opened)		// if closed, any item at the crate's loc is put in the contents
-		take_contents()
-		update_icon()
 	PopulateContents()
+	update_icon()
+
+
+/obj/structure/closet/LateInitialize(mapload)
+	. = ..()	// if closed, any item at the crate's loc is put in the contents
+
+	take_contents()
+
 
 
 /obj/structure/closet/deconstruct(disassembled = TRUE)


### PR DESCRIPTION

## About The Pull Request

Title.
Containers and closets are broken and don't scoop items into themselves like they should, I have fixed this.

## Why It's Good For The Game

Bugs bad, ancient bugs worse.

## Changelog
:cl:
fix: Closets and crates now properly put items inside themselves during load.
/:cl:
