### PR TITLE
Removes `mapload` as a param from `LateInitialize()`

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -755,7 +755,7 @@ Proc for attack log creation, because really why not
 
 
 ///called if Initialize returns INITIALIZE_HINT_LATELOAD
-/atom/proc/LateInitialize(mapload)
+/atom/proc/LateInitialize()
 	set waitfor = FALSE
 
 

--- a/code/game/objects/items/radio/headset.dm
+++ b/code/game/objects/items/radio/headset.dm
@@ -175,7 +175,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	. = ..()
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/item/radio/headset/mainship/LateInitialize(mapload)
+/obj/item/radio/headset/mainship/LateInitialize()
 	. = ..()
 	camera = new /obj/machinery/camera/headset(src)
 
@@ -523,7 +523,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	frequency = FREQ_ALPHA //default frequency is alpha squad channel, not FREQ_COMMON
 	minimap_type = /datum/action/minimap/marine
 
-/obj/item/radio/headset/mainship/marine/alpha/LateInitialize(mapload)
+/obj/item/radio/headset/mainship/marine/alpha/LateInitialize()
 	. = ..()
 	camera.network += list("alpha")
 
@@ -551,7 +551,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	frequency = FREQ_BRAVO
 	minimap_type = /datum/action/minimap/marine
 
-/obj/item/radio/headset/mainship/marine/bravo/LateInitialize(mapload)
+/obj/item/radio/headset/mainship/marine/bravo/LateInitialize()
 	. = ..()
 	camera.network += list("bravo")
 
@@ -579,7 +579,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	frequency = FREQ_CHARLIE
 	minimap_type = /datum/action/minimap/marine
 
-/obj/item/radio/headset/mainship/marine/charlie/LateInitialize(mapload)
+/obj/item/radio/headset/mainship/marine/charlie/LateInitialize()
 	. = ..()
 	camera.network += list("charlie")
 
@@ -608,7 +608,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	frequency = FREQ_DELTA
 	minimap_type = /datum/action/minimap/marine
 
-/obj/item/radio/headset/mainship/marine/delta/LateInitialize(mapload)
+/obj/item/radio/headset/mainship/marine/delta/LateInitialize()
 	. = ..()
 	camera.network += list("delta")
 
@@ -645,7 +645,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	frequency = FREQ_ALPHA_REBEL //default frequency is alpha squad channel, not FREQ_COMMON
 	minimap_type = /datum/action/minimap/marine/rebel
 
-/obj/item/radio/headset/mainship/marine/rebel/alpha/LateInitialize(mapload)
+/obj/item/radio/headset/mainship/marine/rebel/alpha/LateInitialize()
 	. = ..()
 	camera.network += list("alpha_rebel")
 
@@ -672,7 +672,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	frequency = FREQ_BRAVO_REBEL
 	minimap_type = /datum/action/minimap/marine/rebel
 
-/obj/item/radio/headset/mainship/marine/rebel/bravo/LateInitialize(mapload)
+/obj/item/radio/headset/mainship/marine/rebel/bravo/LateInitialize()
 	. = ..()
 	camera.network += list("bravo_rebel")
 
@@ -699,7 +699,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	frequency = FREQ_CHARLIE_REBEL
 	minimap_type = /datum/action/minimap/marine/rebel
 
-/obj/item/radio/headset/mainship/marine/rebel/charlie/LateInitialize(mapload)
+/obj/item/radio/headset/mainship/marine/rebel/charlie/LateInitialize()
 	. = ..()
 	camera.network += list("charlie_rebel")
 
@@ -727,7 +727,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	frequency = FREQ_DELTA_REBEL
 	minimap_type = /datum/action/minimap/marine/rebel
 
-/obj/item/radio/headset/mainship/marine/rebel/delta/LateInitialize(mapload)
+/obj/item/radio/headset/mainship/marine/rebel/delta/LateInitialize()
 	. = ..()
 	camera.network += list("delta_rebel")
 
@@ -852,7 +852,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	frequency = FREQ_ZULU
 	minimap_type = /datum/action/minimap/som
 
-/obj/item/radio/headset/mainship/som/zulu/LateInitialize(mapload)
+/obj/item/radio/headset/mainship/som/zulu/LateInitialize()
 	. = ..()
 	camera.network += list("zulu")
 
@@ -876,7 +876,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	frequency = FREQ_YANKEE
 	minimap_type = /datum/action/minimap/som
 
-/obj/item/radio/headset/mainship/som/yankee/LateInitialize(mapload)
+/obj/item/radio/headset/mainship/som/yankee/LateInitialize()
 	. = ..()
 	camera.network += list("yankee")
 
@@ -900,7 +900,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	frequency = FREQ_XRAY
 	minimap_type = /datum/action/minimap/som
 
-/obj/item/radio/headset/mainship/som/xray/LateInitialize(mapload)
+/obj/item/radio/headset/mainship/som/xray/LateInitialize()
 	. = ..()
 	camera.network += list("xray")
 
@@ -924,7 +924,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	frequency = FREQ_WHISKEY
 	minimap_type = /datum/action/minimap/som
 
-/obj/item/radio/headset/mainship/som/whiskey/LateInitialize(mapload)
+/obj/item/radio/headset/mainship/som/whiskey/LateInitialize()
 	. = ..()
 	camera.network += list("whiskey")
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -44,17 +44,19 @@
 
 /obj/structure/closet/Initialize(mapload, ...)
 	. = ..()
+
+	if(mapload && !opened) // if closed, any item at the crate's loc is put in the contents
+		. = INITIALIZE_HINT_LATELOAD
+
 	RegisterSignal(src, COMSIG_MOVABLE_SHUTTLE_CRUSH, PROC_REF(shuttle_crush))
-	return INITIALIZE_HINT_LATELOAD
-
-
-/obj/structure/closet/LateInitialize(mapload)
-	. = ..()
-	if(mapload && !opened)		// if closed, any item at the crate's loc is put in the contents
-		take_contents()
-		update_icon()
 	PopulateContents()
+	update_icon()
 
+
+/obj/structure/closet/LateInitialize()
+	. = ..()
+
+	take_contents()
 
 /obj/structure/closet/deconstruct(disassembled = TRUE)
 	dump_contents()

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -346,7 +346,7 @@
 	return INITIALIZE_HINT_LATELOAD
 
 
-/obj/structure/table/flipped/LateInitialize(mapload)
+/obj/structure/table/flipped/LateInitialize()
 	. = ..()
 	if(!flipped)
 		flip(dir, TRUE)
@@ -434,7 +434,7 @@
 	return INITIALIZE_HINT_LATELOAD
 
 
-/obj/structure/table/reinforced/flipped/LateInitialize(mapload)
+/obj/structure/table/reinforced/flipped/LateInitialize()
 	. = ..()
 	if(!flipped)
 		flip(dir, TRUE)

--- a/code/game/turfs/floor_types.dm
+++ b/code/game/turfs/floor_types.dm
@@ -309,7 +309,7 @@
 	return INITIALIZE_HINT_LATELOAD
 
 
-/turf/open/floor/light/LateInitialize(mapload)
+/turf/open/floor/light/LateInitialize()
 	update_icon()
 
 /turf/open/floor/light/plating
@@ -480,7 +480,7 @@
 	return INITIALIZE_HINT_LATELOAD
 
 
-/turf/open/floor/grass/LateInitialize(mapload)
+/turf/open/floor/grass/LateInitialize()
 	update_icon()
 	for(var/direction in GLOB.cardinals)
 		if(!istype(get_step(src,direction), /turf/open/floor))

--- a/code/modules/factory/parts.dm
+++ b/code/modules/factory/parts.dm
@@ -20,7 +20,7 @@
 	..()
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/item/factory_part/LateInitialize(mapload)
+/obj/item/factory_part/LateInitialize()
 	advance_stage()
 
 ///once the part is processed this proc updates iconstate, result, completion etc


### PR DESCRIPTION

## About The Pull Request

Pointless param that never gets passed as an arg anywhere, only causes confusion as it is right now and there's no reason for it to exist anyhow.
## Why It's Good For The Game

Unused params bad.
## Changelog
:cl:
fix: Lockers shouldn't spill in contents that were mapped in after
code: Removed mapload as a param from LateInitialize
/:cl:
