### PR TITLE
Volkite power pack tweaks

### DIFF
--- a/code/modules/projectiles/magazines/energy.dm
+++ b/code/modules/projectiles/magazines/energy.dm
@@ -107,10 +107,10 @@
 	flags_equip_slot = ITEM_SLOT_BACK
 	flags_magazine_features = MAGAZINE_REFUND_IN_CHAMBER|MAGAZINE_WORN
 	w_class = WEIGHT_CLASS_HUGE
-	slowdown = 0.3
-	maxcharge = 4800
+	slowdown = 0.2
+	maxcharge = 3000
 	self_recharge = TRUE
-	charge_amount = 32
+	charge_amount = 100
 	charge_delay = 2 SECONDS
 
 ///Handles draining power from the powerpack, returns the value of the charge drained to MouseDrop where it's added to the cell.


### PR DESCRIPTION

## About The Pull Request
Max charge reduced to 3000 from 4800.
Charge rate increased to 100 from 32 per 2 seconds.
Slowdown decreased to 0.2 from 0.3.

The power pack has a pretty comically low charge rate considering how fast you fire (a culverin can only fire 0.5 times per second instead of its actual 6.6 times per second, if you're running on empty), which can easily lead to prolonged downtime where you can't really use your bullet hose.

This change reduces the single burst fire time (20 seconds from full to empty instead of 26 seconds), but significantly increases the charge rate.

This should allow the culverin to still perform as originally intended, while being a bit less frustrating to use at times.

Reduces the slowdown since no other backpack has slowdown, and both guns that use it already have high slowdown to begin with.
## Why It's Good For The Game
Better playability/less annoying to use powerpack.
## Changelog
:cl:
balance: SOM powerpack max charge decreased from 4800 to 3000
balance: SOM powerpack charge rate increased from 32 to 100 per 2 seconds
balance: SOM powerpack slowdown decreased  from 0.3 to 0.2
/:cl:
