### PR TITLE
Water slowdown refactor

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -846,3 +846,14 @@ GLOBAL_LIST_INIT(human_body_parts, list(BODY_ZONE_HEAD,
 #define AURA_HUMAN_MOVE "move"
 #define AURA_HUMAN_HOLD "hold"
 #define AURA_HUMAN_FOCUS "focus"
+
+//slowdown defines for liquid turfs
+
+///Default slowdown for mobs moving through liquid
+#define MOB_WATER_SLOWDOWN 1.75
+///Slowdown for xenos moving through liquid
+#define XENO_WATER_SLOWDOWN 1.3
+///Slowdown for boilers moving through liquid
+#define BOILER_WATER_SLOWDOWN 0
+///Slowdown for warlocks moving through liquid
+#define WARLOCK_WATER_SLOWDOWN 0

--- a/code/game/turfs/liquid_turfs.dm
+++ b/code/game/turfs/liquid_turfs.dm
@@ -3,11 +3,12 @@
 ///The height of the mask itself in the icon state. Changes to the icon requires a change to this define
 #define MOB_LIQUID_TURF_MASK_HEIGHT 32
 
-
 /turf/open/liquid //Basic liquid turf parent
 	name = "liquid"
 	icon = 'icons/turf/ground_map.dmi'
 	can_bloody = FALSE
+	///Multiplier on any slowdown applied to a mob moving through this turf
+	var/slowdown_multiplier = 1
 	///How high up on the mob water overlays sit
 	var/mob_liquid_height = 11
 	///How far down the mob visually drops down when in water
@@ -26,38 +27,42 @@
 		return FALSE
 	. = TRUE
 
-	if(!iscarbon(arrived))
+	if(!ismob(arrived))
 		return
 
 	if(length(canSmoothWith) && !CHECK_MULTIPLE_BITFIELDS(smoothing_junction, (SOUTH_JUNCTION|EAST_JUNCTION|WEST_JUNCTION)))
 		return
 
-	var/mob/living/carbon/carbon_mob = arrived
-	var/icon/carbon_icon = icon(carbon_mob.icon)
-	var/height_to_use = (64 - carbon_icon.Height()) * 0.5 //gives us the right height based on carbon's icon height relative to the 64 high alpha mask
+	var/mob/arrived_mob = arrived
+	var/icon/mob_icon = icon(arrived_mob.icon)
+	var/height_to_use = (64 - mob_icon.Height()) * 0.5 //gives us the right height based on carbon's icon height relative to the 64 high alpha mask
 
-	if(carbon_mob.get_filter(MOB_LIQUID_TURF_MASK))
+	if(arrived_mob.get_filter(MOB_LIQUID_TURF_MASK))
 		var/turf/open/liquid/old_turf = old_loc
 		if(!istype(old_turf))
 			CRASH("orphaned liquid alpha mask")
 		if(mob_liquid_height != old_turf.mob_liquid_height)
-			animate(carbon_mob.get_filter(MOB_LIQUID_TURF_MASK), y = ((64 - carbon_icon.Height()) * 0.5) - (MOB_LIQUID_TURF_MASK_HEIGHT - mob_liquid_height), time = carbon_mob.cached_multiplicative_slowdown + carbon_mob.next_move_slowdown)
+			animate(arrived_mob.get_filter(MOB_LIQUID_TURF_MASK), y = ((64 - mob_icon.Height()) * 0.5) - (MOB_LIQUID_TURF_MASK_HEIGHT - mob_liquid_height), time = arrived_mob.cached_multiplicative_slowdown + arrived_mob.next_move_slowdown)
 		if(mob_liquid_depth != old_turf.mob_liquid_depth)
-			animate(carbon_mob, pixel_y = carbon_mob.pixel_y + mob_liquid_depth - old_turf.mob_liquid_depth, time = carbon_mob.cached_multiplicative_slowdown + carbon_mob.next_move_slowdown, flags = ANIMATION_PARALLEL)
+			animate(arrived_mob, pixel_y = arrived_mob.pixel_y + mob_liquid_depth - old_turf.mob_liquid_depth, time = arrived_mob.cached_multiplicative_slowdown + arrived_mob.next_move_slowdown, flags = ANIMATION_PARALLEL)
+
+		arrived_mob.next_move_slowdown += (arrived_mob.get_liquid_slowdown() * slowdown_multiplier) //slowdown applied after the animate as it will effect the timing
 		return
 
 	//The mask is spawned below the mob, then the animate() raises it up, giving the illusion of dropping into water, combining with the animate to actual drop the pixel_y into the water
-	carbon_mob.add_filter(MOB_LIQUID_TURF_MASK, 1, alpha_mask_filter(0, height_to_use - MOB_LIQUID_TURF_MASK_HEIGHT, icon('icons/turf/alpha_64.dmi', "liquid_alpha"), null, MASK_INVERSE))
+	arrived_mob.add_filter(MOB_LIQUID_TURF_MASK, 1, alpha_mask_filter(0, height_to_use - MOB_LIQUID_TURF_MASK_HEIGHT, icon('icons/turf/alpha_64.dmi', "liquid_alpha"), null, MASK_INVERSE))
 
-	animate(carbon_mob.get_filter(MOB_LIQUID_TURF_MASK), y = height_to_use - (MOB_LIQUID_TURF_MASK_HEIGHT - mob_liquid_height), time = carbon_mob.cached_multiplicative_slowdown + carbon_mob.next_move_slowdown)
-	animate(carbon_mob, pixel_y = carbon_mob.pixel_y + mob_liquid_depth, time = carbon_mob.cached_multiplicative_slowdown + carbon_mob.next_move_slowdown, flags = ANIMATION_PARALLEL)
+	animate(arrived_mob.get_filter(MOB_LIQUID_TURF_MASK), y = height_to_use - (MOB_LIQUID_TURF_MASK_HEIGHT - mob_liquid_height), time = arrived_mob.cached_multiplicative_slowdown + arrived_mob.next_move_slowdown)
+	animate(arrived_mob, pixel_y = arrived_mob.pixel_y + mob_liquid_depth, time = arrived_mob.cached_multiplicative_slowdown + arrived_mob.next_move_slowdown, flags = ANIMATION_PARALLEL)
+
+	arrived_mob.next_move_slowdown += (arrived_mob.get_liquid_slowdown() * slowdown_multiplier)
 
 /turf/open/liquid/Exited(atom/movable/leaver, direction)
 	. = ..()
-	if(!iscarbon(leaver))
+	if(!ismob(leaver))
 		return
-	var/mob/living/carbon/carbon_leaver = leaver
-	if(!carbon_leaver.get_filter(MOB_LIQUID_TURF_MASK))
+	var/mob/mob_leaver = leaver
+	if(!mob_leaver.get_filter(MOB_LIQUID_TURF_MASK))
 		return
 
 	var/turf/open/liquid/new_turf = get_step(src, direction)
@@ -68,13 +73,10 @@
 		else if(!new_turf.has_catwalk)
 			return
 
-	var/icon/carbon_icon = icon(carbon_leaver.icon)
-	animate(carbon_leaver.get_filter(MOB_LIQUID_TURF_MASK), y = ((64 - carbon_icon.Height()) * 0.5) - MOB_LIQUID_TURF_MASK_HEIGHT, time = carbon_leaver.cached_multiplicative_slowdown + carbon_leaver.next_move_slowdown)
-	animate(carbon_leaver, pixel_y = carbon_leaver.pixel_y - mob_liquid_depth, time = carbon_leaver.cached_multiplicative_slowdown + carbon_leaver.next_move_slowdown, flags = ANIMATION_PARALLEL)
-	addtimer(CALLBACK(carbon_leaver, TYPE_PROC_REF(/atom, remove_filter), MOB_LIQUID_TURF_MASK), carbon_leaver.cached_multiplicative_slowdown + carbon_leaver.next_move_slowdown)
-
-///Default slowdown for mobs moving through water
-#define MOB_WATER_SLOWDOWN 1.75
+	var/icon/carbon_icon = icon(mob_leaver.icon)
+	animate(mob_leaver.get_filter(MOB_LIQUID_TURF_MASK), y = ((64 - carbon_icon.Height()) * 0.5) - MOB_LIQUID_TURF_MASK_HEIGHT, time = mob_leaver.cached_multiplicative_slowdown + mob_leaver.next_move_slowdown)
+	animate(mob_leaver, pixel_y = mob_leaver.pixel_y - mob_liquid_depth, time = mob_leaver.cached_multiplicative_slowdown + mob_leaver.next_move_slowdown, flags = ANIMATION_PARALLEL)
+	addtimer(CALLBACK(mob_leaver, TYPE_PROC_REF(/atom, remove_filter), MOB_LIQUID_TURF_MASK), mob_leaver.cached_multiplicative_slowdown + mob_leaver.next_move_slowdown)
 
 /turf/open/liquid/water
 	name = "river"
@@ -98,12 +100,6 @@
 
 	if(carbon_mob.on_fire)
 		carbon_mob.ExtinguishMob()
-
-	if(isxeno(carbon_mob))
-		var/mob/living/carbon/xenomorph/xeno = carbon_mob
-		xeno.next_move_slowdown += xeno.xeno_caste.water_slowdown
-	else
-		carbon_mob.next_move_slowdown += MOB_WATER_SLOWDOWN
 
 /turf/open/liquid/water/sea
 	name = "water"
@@ -138,6 +134,7 @@
 /turf/open/liquid/water/river/autosmooth/deep
 	mob_liquid_height = 18
 	mob_liquid_depth = -8
+	slowdown_multiplier = 1.5
 
 //Desert River
 /turf/open/liquid/water/river/desertdam
@@ -206,6 +203,7 @@
 	light_power = 1.4
 	light_color = LIGHT_COLOR_LAVA
 	minimap_color = MINIMAP_LAVA
+	slowdown_multiplier = 1.5
 
 /turf/open/liquid/lava/is_weedable()
 	return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/boiler.dm
@@ -20,6 +20,9 @@
 	var/corrosive_ammo = 0
 	var/neuro_ammo = 0
 
+/mob/living/carbon/xenomorph/boiler/get_liquid_slowdown()
+	return BOILER_WATER_SLOWDOWN
+
 ///updates the boiler's glow, based on its base glow/color, and its ammo reserves. More green ammo = more green glow; more yellow = more yellow.
 /mob/living/carbon/xenomorph/boiler/proc/update_boiler_glow()
 	var/current_ammo = corrosive_ammo + neuro_ammo

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -71,8 +71,6 @@
 		/datum/action/xeno_action/activable/spray_acid/line/boiler,
 	)
 
-	water_slowdown = -0.5
-
 /datum/xeno_caste/boiler/young
 	upgrade_name = "Young"
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/castedatum_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/castedatum_warlock.dm
@@ -32,8 +32,6 @@
 		/datum/action/xeno_action/psychic_whisper,
 	)
 
-	water_slowdown = 0
-
 /datum/xeno_caste/warlock/young
 	upgrade_name = "Young"
 	upgrade = XENO_UPGRADE_ZERO

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/warlock.dm
@@ -22,3 +22,6 @@
 /mob/living/carbon/xenomorph/warlock/Initialize(mapload)
 	. = ..()
 	ammo = GLOB.ammo_list[/datum/ammo/energy/xeno/psy_blast]
+
+/mob/living/carbon/xenomorph/warlock/get_liquid_slowdown()
+	return WARLOCK_WATER_SLOWDOWN

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -233,8 +233,6 @@
 	var/vent_exit_speed = XENO_DEFAULT_VENT_EXIT_TIME
 	///Whether the caste enters and crawls through vents silently
 	var/silent_vent_crawl = FALSE
-	///how much water slows down this caste
-	var/water_slowdown = 1.3
 	// The amount of xenos that must be alive in the hive for this caste to be able to evolve
 	var/evolve_min_xenos = 0
 	// How many of this caste may be alive at once

--- a/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
@@ -38,3 +38,5 @@
 	if(rally_minion)
 		rally_minion.remove_action(src)
 
+/mob/living/carbon/xenomorph/get_liquid_slowdown()
+	return XENO_WATER_SLOWDOWN

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -464,3 +464,7 @@ GLOBAL_LIST_INIT(organ_rel_size, list(
 /mob/proc/set_skills(datum/skills/new_skillset)
 	skills = new_skillset
 	SEND_SIGNAL(src, COMSIG_MOB_SKILLS_CHANGED, skills)
+
+///Returns the slowdown applied to the mob when moving through liquids like water
+/mob/proc/get_liquid_slowdown()
+	return MOB_WATER_SLOWDOWN


### PR DESCRIPTION

## About The Pull Request
Some minor rework of how water slowdown is applied.

Slowdown is now define based via a proc.
All liquid turfs apply slowdown, and have a multiplier var to adjust slowdown.

This means you can no longer swim through lava faster than ankle deep water.

Lava and deep water have  a x1.5 modifier.

Killed the water slowdown xeno caste var.
Removed the weird negative slowdown boilers have (yes, they currently go through water FASTER than dry land), and make it just 0. I guess they float or whatever.

Make liquid turf effects apply to all mobs instead of just carbons.
## Why It's Good For The Game
Better code good.
More adjustable stuff good too.
## Changelog
:cl:
balance: Boilers no longer travel on water faster than land (just equal speed)
balance: Lava now applies slowdown similar to water
refactor: Tiny refactor of how water slowdown works
/:cl:
