### PR TITLE
Experimental Hugger changes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -684,7 +684,7 @@
 	name = "neuro hugger"
 	desc = "This strange creature has a single prominent sharp proboscis."
 	color = COLOR_DARK_ORANGE
-	impact_time = 1 SECONDS
+	impact_time = 0 SECONDS
 	activate_time = 1.5 SECONDS
 	jump_cooldown = 1.5 SECONDS
 	proximity_time = 0.5 SECONDS
@@ -708,7 +708,7 @@
 	name = "acid hugger"
 	desc = "This repulsive looking thing is bloated with throbbing, putrescent green sacks of flesh."
 	color = COLOR_GREEN
-	impact_time = 1 SECONDS
+	impact_time = 0 SECONDS
 	activate_time = 1.5 SECONDS
 	jump_cooldown = 1.5 SECONDS
 	proximity_time = 0.5 SECONDS
@@ -738,7 +738,7 @@
 	name = "resin hugger"
 	desc = "This truly bizzare, bloated creature drips with purple, viscous resin."
 	color = COLOR_STRONG_VIOLET
-	impact_time = 1 SECONDS
+	impact_time = 0 SECONDS
 	activate_time = 1.5 SECONDS
 	jump_cooldown = 1.5 SECONDS
 	proximity_time = 0.5 SECONDS
@@ -771,7 +771,7 @@
 	name = "clawed hugger"
 	desc = "This nasty little creature is a nightmarish scrabble of muscle and sharp, long claws."
 	color = COLOR_RED
-	impact_time = 0.5 SECONDS
+	impact_time = 0 SECONDS
 	activate_time = 1.2 SECONDS
 	jump_cooldown = 1.2 SECONDS
 	proximity_time = 0.5 SECONDS


### PR DESCRIPTION

## About The Pull Request
This PR aims to make changes to the Facehugger activation time when a carrier throws and directly hits a marine.

## Why It's Good For The Game
Currently playing carrier doesn't feel as fun, nor impactful as it used to, even after a long break.  Having talked to a fellow Carrier enjoyer we thought it would at least be interesting to see how carrier changes when rewarding risk more with direct hits and less safe gameplay.
Makes Carrier slightly less Utility focused as it is now and more viable in combat since of those 6/10 huggers you throw that don't get shot down by stray bullets instantly, 2 of them might directly hit and actually do something instead of sitting there, activating with BYOND lag an dying before they can act.
Doesn't change Larva hugger since it's by far the strongest hugger if it actually hits a marine, up for change though.

## Changelog

:cl:
balance: 'Rebalances' Huggers to be instant if directly hitting a marine
/:cl:

