### PR TITLE
Nerfs combat droid fire rate

### DIFF
--- a/code/modules/vehicles/unmanned/unmanned_turrets.dm
+++ b/code/modules/vehicles/unmanned/unmanned_turrets.dm
@@ -35,6 +35,6 @@
 	turret_pattern = PATTERN_DROID
 	turret_type = TURRET_TYPE_DROIDLASER
 	ammo_type = /datum/ammo/energy/lasgun/marine/overcharge
-	fire_delay = 2.5
+	fire_delay = 0.25 SECONDS
 	current_rounds = 300
 	max_rounds = 300

--- a/code/modules/vehicles/unmanned/unmanned_turrets.dm
+++ b/code/modules/vehicles/unmanned/unmanned_turrets.dm
@@ -14,7 +14,7 @@
 	///This var must match the unmanned vehicles turret_pattern then be added
 	var/turret_pattern = PATTERN_TRACKED
 	/// The fire rate of this turret in byond tick
-	var/fire_delay = 1
+	var/fire_delay = 0.1 SECONDS
 	///Typepath of the ammo to reload it.
 	var/magazine_type = /obj/item/ammo_magazine/box11x35mm
 
@@ -24,7 +24,7 @@
 	icon_state = "heavy_cannon_obj"
 	turret_type = TURRET_TYPE_HEAVY
 	ammo_type = /datum/ammo/bullet/machinegun
-	fire_delay = 2
+	fire_delay = 0.2 SECONDS
 	current_rounds = 50
 	max_rounds = 50
 	magazine_type = /obj/item/ammo_magazine/box12x40mm //I think this is the correct one?

--- a/code/modules/vehicles/unmanned/unmanned_turrets.dm
+++ b/code/modules/vehicles/unmanned/unmanned_turrets.dm
@@ -35,6 +35,6 @@
 	turret_pattern = PATTERN_DROID
 	turret_type = TURRET_TYPE_DROIDLASER
 	ammo_type = /datum/ammo/energy/lasgun/marine/overcharge
-	fire_delay = 1.5
+	fire_delay = 2.5
 	current_rounds = 300
 	max_rounds = 300


### PR DESCRIPTION

## About The Pull Request

This is your fault, Jazzy.

## Why It's Good For The Game

Something with a superior damage and armor penetration model to the AR-21 should not have the fire rate of a SMG. Fire rate is now 4 times a second instead of close to 7.

## Changelog
:cl:
balance: Combat droid energetic cannon fire rate down to 0.25 from 0.15.
/:cl:
