### PR TITLE
fixed acid spray dealing double damage to all objects

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -85,9 +85,11 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	if(T.density)
 		return
 	var/is_blocked = FALSE
+	var/list/acided_objs = list()
 	for (var/obj/O in T)
 		if(is_type_in_typecache(O, GLOB.acid_spray_hit))
 			O.acid_spray_act(owner)
+			acided_objs += O
 		if(!O.CanPass(source_spray, get_turf(source_spray)))
 			is_blocked = TRUE
 	if(is_blocked)
@@ -98,7 +100,8 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	var/obj/effect/xenomorph/spray/spray = new(T, xeno_owner.xeno_caste.acid_spray_duration, xeno_owner.xeno_caste.acid_spray_damage, xeno_owner)
 	var/turf/next_normal_turf = get_step(T, facing)
 	for (var/atom/movable/A AS in T)
-		A.acid_spray_act(owner)
+		if(!acided_objs.Find(A))
+			A.acid_spray_act(owner)
 		if(((A.density && !(A.flags_pass & PASSPROJECTILE) && !(A.flags_atom & ON_BORDER)) || !A.Exit(source_spray, facing)) && !isxeno(A))
 			is_blocked = TRUE
 	if(!is_blocked)

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -98,7 +98,7 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	var/obj/effect/xenomorph/spray/spray = new(T, xeno_owner.xeno_caste.acid_spray_duration, xeno_owner.xeno_caste.acid_spray_damage, xeno_owner)
 	var/turf/next_normal_turf = get_step(T, facing)
 	for (var/atom/movable/A AS in T)
-			A.acid_spray_act(owner)
+		A.acid_spray_act(owner)
 		if(((A.density && !(A.flags_pass & PASSPROJECTILE) && !(A.flags_atom & ON_BORDER)) || !A.Exit(source_spray, facing)) && !isxeno(A))
 			is_blocked = TRUE
 	if(!is_blocked)

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -85,13 +85,11 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	if(T.density)
 		return
 	var/is_blocked = FALSE
-	var/list/acided_objs = list()
 	for (var/obj/O in T)
-		if(is_type_in_typecache(O, GLOB.acid_spray_hit))
-			O.acid_spray_act(owner)
-			acided_objs += O
 		if(!O.CanPass(source_spray, get_turf(source_spray)))
 			is_blocked = TRUE
+			O.acid_spray_act(owner)
+			break
 	if(is_blocked)
 		return
 
@@ -100,7 +98,6 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	var/obj/effect/xenomorph/spray/spray = new(T, xeno_owner.xeno_caste.acid_spray_duration, xeno_owner.xeno_caste.acid_spray_damage, xeno_owner)
 	var/turf/next_normal_turf = get_step(T, facing)
 	for (var/atom/movable/A AS in T)
-		if(!acided_objs.Find(A))
 			A.acid_spray_act(owner)
 		if(((A.density && !(A.flags_pass & PASSPROJECTILE) && !(A.flags_atom & ON_BORDER)) || !A.Exit(source_spray, facing)) && !isxeno(A))
 			is_blocked = TRUE


### PR DESCRIPTION
## About The Pull Request

If an obj has already been hit by acid spray once in a tile check, it will not be hit again by the atom/moveable acid spray check below.

## Why It's Good For The Game

This bug has made praetorian acid spray 2x as effective on all defensive structures and objs that are also moveable, which is unintended. 

## Changelog

:cl:
fix: prae acid spray no longer deals double damage to all objects that are also atom/moveables
/:cl:
