### PR TITLE
acid well changes and minor grenade code

### DIFF
--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -98,7 +98,6 @@
 
 /obj/item/explosive/grenade/sticky/prime()
 	if(stuck_to)
-		stuck_to.cut_overlay(saved_overlay)
 		clean_refs()
 	return ..()
 
@@ -107,6 +106,7 @@
 
 ///Cleans references to prevent hard deletes.
 /obj/item/explosive/grenade/sticky/proc/clean_refs()
+	stuck_to.cut_overlay(saved_overlay)
 	SIGNAL_HANDLER
 	UnregisterSignal(stuck_to, COMSIG_PARENT_QDELETING)
 	stuck_to = null
@@ -124,7 +124,6 @@
 	flame_radius(0.5, get_turf(src))
 	playsound(loc, "incendiary_explosion", 35)
 	if(stuck_to)
-		stuck_to.cut_overlay(saved_overlay)
 		clean_refs()
 	qdel(src)
 
@@ -141,6 +140,7 @@
 	new /obj/flamer_fire(get_turf(src), 25, 25)
 
 /obj/item/explosive/grenade/sticky/trailblazer/clean_refs()
+	stuck_to.cut_overlay(saved_overlay)
 	UnregisterSignal(stuck_to, COMSIG_MOVABLE_MOVED)
 	return ..()
 

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -600,9 +600,15 @@ TUNNEL
 
 	var/datum/effect_system/smoke_spread/xeno/acid/acid_smoke
 
-	for(var/obj/item/explosive/grenade/sticky/sticky_bomb in stepper.contents)
-		sticky_bomb.clean_refs()
-		qdel(sticky_bomb)
+	if(charges >= 2)
+		for(var/obj/item/explosive/grenade/sticky/sticky_bomb in stepper.contents)
+			sticky_bomb.clean_refs()
+			qdel(sticky_bomb)
+			if(isxeno(stepper))
+				charges--
+				charges--
+				update_icon()
+				return
 	if(isxeno(stepper))
 		if(!(stepper.on_fire))
 			return

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -600,9 +600,6 @@ TUNNEL
 
 	var/datum/effect_system/smoke_spread/xeno/acid/acid_smoke
 
-	for(var/obj/item/explosive/grenade/sticky/trailblazer/fire_bomb in stepper.contents)
-		fire_bomb.clean_refs()
-		qdel(fire_bomb)
 	for(var/obj/item/explosive/grenade/sticky/sticky_bomb in stepper.contents)
 		sticky_bomb.clean_refs()
 		qdel(sticky_bomb)

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -600,6 +600,12 @@ TUNNEL
 
 	var/datum/effect_system/smoke_spread/xeno/acid/acid_smoke
 
+	for(var/obj/item/explosive/grenade/sticky/trailblazer/fire_bomb in stepper.contents)
+		fire_bomb.clean_refs()
+		qdel(fire_bomb)
+	for(var/obj/item/explosive/grenade/sticky/sticky_bomb in stepper.contents)
+		sticky_bomb.clean_refs()
+		qdel(sticky_bomb)
 	if(isxeno(stepper))
 		if(!(stepper.on_fire))
 			return

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -605,10 +605,11 @@ TUNNEL
 			sticky_bomb.clean_refs()
 			qdel(sticky_bomb)
 			if(isxeno(stepper))
-				charges--
-				charges--
+				charges-= 2
+				acid_smoke = new(get_turf(stepper))
+				acid_smoke.set_up(1, src)
+				acid_smoke.start()
 				update_icon()
-				return
 	if(isxeno(stepper))
 		if(!(stepper.on_fire))
 			return

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -604,12 +604,13 @@ TUNNEL
 		for(var/obj/item/explosive/grenade/sticky/sticky_bomb in stepper.contents)
 			sticky_bomb.clean_refs()
 			qdel(sticky_bomb)
-			if(isxeno(stepper))
-				charges-= 2
-				acid_smoke = new(get_turf(stepper))
-				acid_smoke.set_up(1, src)
-				acid_smoke.start()
-				update_icon()
+		charges -= 2
+		acid_smoke = new(get_turf(stepper))
+		acid_smoke.set_up(1, src)
+		acid_smoke.start()
+		update_icon()
+		if(!charges)
+			return
 	if(isxeno(stepper))
 		if(!(stepper.on_fire))
 			return


### PR DESCRIPTION
## About The Pull Request

Acid wells now clear stickies from both marines and xenos. Minor changes to grenade code
## Why It's Good For The Game

Gives an active way for xenos to avoid death if prepared or near acid wells. Takes two charges to clear stickies.
## Changelog
:cl:
add: Acid wells remove sticky grenades
code: Changes to grenade code, specifically clear_refs

/:cl:
