### PR TITLE
Adds custom grenades to requisitions for 250 points for 2 grenades

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -852,6 +852,11 @@ EXPLOSIVES
 	cost = 100
 	available_against_xeno_only = TRUE
 
+/datum/supply_packs/explosives/customnade
+	name = "custom grenade casing"
+	contains = list(/obj/item/explosive/grenade/chem_grenade, /obj/item/explosive/grenade/chem_grenade)
+	cost = 250
+
 /*******************************************************************************
 ARMOR
 *******************************************************************************/


### PR DESCRIPTION

## About The Pull Request

Adds 2 custom grenades for 250 req points

## Why It's Good For The Game

Chemistry should have an use aside from producing 3500 kilos of crack which 1 marine instantly doses into their bloodstream

## Changelog
:cl:
add: 2 custom grenade casings for 250 points in req
/:cl:
