### PR TITLE
fixes aqua ghosts

### DIFF
--- a/code/game/turfs/liquid_turfs.dm
+++ b/code/game/turfs/liquid_turfs.dm
@@ -60,7 +60,7 @@
 	if(!carbon_leaver.get_filter(MOB_LIQUID_TURF_MASK))
 		return
 
-	var/turf/open/liquid/new_turf = get_step(src, direction)
+	var/turf/open/liquid/new_turf = carbon_leaver.loc
 	if(istype(new_turf))
 		if(length(new_turf.canSmoothWith))
 			if(!new_turf.has_catwalk && CHECK_MULTIPLE_BITFIELDS(new_turf.smoothing_junction, (SOUTH_JUNCTION|EAST_JUNCTION|WEST_JUNCTION)))


### PR DESCRIPTION

## About The Pull Request
Fixes the water overlay getting stuck if you are teleported out of the water (such as medivac).
## Why It's Good For The Game
Bug fix.
## Changelog
:cl:
fix: fixed water overlays getting stuck if you are teleported out of the liquid turf
/:cl:
