### PR TITLE
Orbital Warheads trigger their effect when hit by an explosion above light explosions (+ makes them less useful as cades)

### DIFF
--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -327,11 +327,21 @@
 
 /obj/structure/ob_ammo/warhead
 	name = "theoretical orbital ammo"
+	interaction_flags = INTERACT_CHECK_INCAPACITATED | INTERACT_POWERLOADER_PICKUP_ALLOWED_BYPASS_ANCHOR //xeno climby
+	hard_armor = list(MELEE = 100, BULLET = 80, LASER = 100, ENERGY = 100, BOMB = 0, BIO = 100, FIRE = 100, ACID = 100) // only booms
+	climb_delay = 0.5 SECONDS //i imagine them as waist high so they should be just easy to vault over
 	var/warhead_kind
 
 ///Explode the warhead
 /obj/structure/ob_ammo/warhead/proc/warhead_impact()
 	return
+
+/obj/structure/ob_ammo/warhead/ex_act(severity)
+	if(severity < EXPLODE_LIGHT && severity > EXPLODE_NONE)
+		visible_message(span_danger("A chain reaction is triggered in [src]!"))
+		warhead_impact(loc)
+		qdel(src)
+	return ..()
 
 /obj/structure/ob_ammo/warhead/explosive
 	name = "\improper HE orbital warhead"


### PR DESCRIPTION

## About The Pull Request

OBs trigger their effect when hit with an explosion that has a severity above EXPLODE_LIGHT (no hedp nades)
They get 0.5 second climb time and can be climbed over
They receive 80 hard armor for bullets and 0 armor for BOMB, 100 for all other damage

## Why It's Good For The Game

Accidentally wiping off REQ or OB room from the face of the earth is always pretty funny
Theyre useless as cades (trigger their normal destruction effect), and have a 0.5s climb time and can be climbed by xenos
Having them be triggered by explosives (not HEDP or frag or anything else) opens up interesting combos and/or teamwork moments, though its always likely that triggering them just outright kills you and your team

## Changelog
:cl:
balance: Orbital Warheads can be triggered by heavy or higher explosives, have received incredible armor and a drastically short climb time
/:cl:
