### PR TITLE
Autominer mod uninstall fix

### DIFF
--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -159,7 +159,6 @@
 				required_ticks = initial(required_ticks)
 			if(MINER_AUTOMATED)
 				upgrade = new /obj/item/minerupgrade/automatic
-				stop_processing()
 		upgrade.forceMove(user.loc)
 		miner_upgrade_type = null
 		update_icon()


### PR DESCRIPTION

## About The Pull Request
Repaired miners not processing is bad.
## Why It's Good For The Game
Fixes #12914 
## Changelog
:cl:
fix: Uninstalling autominer mod doesn't break the miner
/:cl:
