### PR TITLE
Makes the weather sound preference actually work

### DIFF
--- a/code/datums/looping_sounds/weather_sounds.dm
+++ b/code/datums/looping_sounds/weather_sounds.dm
@@ -1,51 +1,32 @@
-/datum/looping_sound/active_outside_ashstorm
+/datum/looping_sound/active_ashstorm
 	mid_sounds = list(
 		'sound/weather/ashstorm/outside/active_mid1.ogg'=1,
 		'sound/weather/ashstorm/outside/active_mid1.ogg'=1,
 		'sound/weather/ashstorm/outside/active_mid1.ogg'=1,
-	)
-	mid_length = 80
-	start_sound = 'sound/weather/ashstorm/outside/active_start.ogg'
-	start_length = 130
-	end_sound = 'sound/weather/ashstorm/outside/active_end.ogg'
-	volume = 75
-
-/datum/looping_sound/active_inside_ashstorm
-	mid_sounds = list(
 		'sound/weather/ashstorm/inside/active_mid1.ogg'=1,
 		'sound/weather/ashstorm/inside/active_mid2.ogg'=1,
 		'sound/weather/ashstorm/inside/active_mid3.ogg'=1,
 	)
 	mid_length = 80
-	start_sound = 'sound/weather/ashstorm/inside/active_start.ogg'
+	start_sound ='sound/weather/ashstorm/outside/active_start.ogg'
 	start_length = 130
-	end_sound = 'sound/weather/ashstorm/inside/active_end.ogg'
-	volume = 55
+	end_sound = 'sound/weather/ashstorm/outside/active_end.ogg'
+	volume = 65
 
-/datum/looping_sound/weak_outside_ashstorm
+/datum/looping_sound/weak_ashstorm
 	mid_sounds = list(
 		'sound/weather/ashstorm/outside/weak_mid1.ogg'=1,
 		'sound/weather/ashstorm/outside/weak_mid2.ogg'=1,
 		'sound/weather/ashstorm/outside/weak_mid3.ogg'=1,
-	)
-	mid_length = 80
-	start_sound = 'sound/weather/ashstorm/outside/weak_start.ogg'
-	start_length = 130
-	end_sound = 'sound/weather/ashstorm/outside/weak_end.ogg'
-	volume = 50
-
-/datum/looping_sound/weak_inside_ashstorm
-	mid_sounds = list(
 		'sound/weather/ashstorm/inside/weak_mid1.ogg'=1,
 		'sound/weather/ashstorm/inside/weak_mid2.ogg'=1,
 		'sound/weather/ashstorm/inside/weak_mid3.ogg'=1,
 	)
 	mid_length = 80
-	start_sound = 'sound/weather/ashstorm/inside/weak_start.ogg'
+	start_sound = 'sound/weather/ashstorm/outside/weak_start.ogg'
 	start_length = 130
-	end_sound = 'sound/weather/ashstorm/inside/weak_end.ogg'
-	volume = 30
-
+	end_sound = 'sound/weather/ashstorm/outside/weak_end.ogg'
+	volume = 40
 
 /datum/looping_sound/acidrain
 	mid_sounds = list(

--- a/code/datums/weather/weather_types/acid_rain.dm
+++ b/code/datums/weather/weather_types/acid_rain.dm
@@ -27,23 +27,30 @@
 	probability = 40
 	repeatable = FALSE
 
-	var/datum/looping_sound/acidrain/midsound = new(list(), FALSE, TRUE)
+	var/datum/looping_sound/acidrain/sound_active_acidrain = new(list(), FALSE, TRUE)
 
 /datum/weather/acid_rain/telegraph()
 	. = ..()
-	var/list/eligible_areas = list()
-	for (var/z in impacted_z_levels)
-		eligible_areas += SSmapping.areas_in_z["[z]"]
+	var/list/impacted_mobs = list()
+	var/list/eligible_mobs = list()
+	for(var/z in impacted_z_levels)
+		eligible_mobs += GLOB.humans_by_zlevel["[z]"]
+	for(var/i in 1 to length(eligible_mobs))
+		var/mob/impacted_mob = eligible_mobs[i]
+		if(impacted_mob?.client?.prefs?.toggles_sound & SOUND_WEATHER)
+			continue
+		impacted_mobs |= impacted_mob
+		CHECK_TICK
 
-	midsound.output_atoms = eligible_areas
+	sound_active_acidrain.output_atoms = impacted_mobs
 
 /datum/weather/acid_rain/start()
 	. = ..()
-	midsound.start()
+	sound_active_acidrain.start()
 
 /datum/weather/acid_rain/end()
 	. = ..()
-	midsound.stop()
+	sound_active_acidrain.stop()
 
 /datum/weather/acid_rain/weather_act(mob/living/L)
 	if(L.stat == DEAD)

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -24,54 +24,42 @@
 
 	barometer_predictable = TRUE
 
-	var/datum/looping_sound/active_outside_ashstorm/sound_ao = new(list(), FALSE, TRUE)
-	var/datum/looping_sound/active_inside_ashstorm/sound_ai = new(list(), FALSE, TRUE)
-	var/datum/looping_sound/weak_outside_ashstorm/sound_wo = new(list(), FALSE, TRUE)
-	var/datum/looping_sound/weak_inside_ashstorm/sound_wi = new(list(), FALSE, TRUE)
+	var/datum/looping_sound/active_ashstorm/sound_active_ashstorm = new(list(), FALSE, TRUE)
+	var/datum/looping_sound/weak_ashstorm/sound_weak_ashstorm = new(list(), FALSE, TRUE)
 
 /datum/weather/ash_storm/telegraph()
 	. = ..()
-	var/list/inside_areas = list()
-	var/list/outside_areas = list()
-	var/list/eligible_areas = list()
-	for (var/z in impacted_z_levels)
-		eligible_areas += SSmapping.areas_in_z["[z]"]
-	for(var/i in 1 to length(eligible_areas))
-		var/area/place = eligible_areas[i]
-		if(place.outside)
-			outside_areas += place
-		else
-			inside_areas += place
+	var/list/impacted_mobs = list()
+	var/list/eligible_mobs = list()
+	for(var/z in impacted_z_levels)
+		eligible_mobs += GLOB.humans_by_zlevel["[z]"]
+	for(var/i in 1 to length(eligible_mobs))
+		var/mob/impacted_mob = eligible_mobs[i]
+		if(impacted_mob?.client?.prefs?.toggles_sound & SOUND_WEATHER)
+			continue
+		impacted_mobs |= impacted_mob
 		CHECK_TICK
 
-	sound_ao.output_atoms = outside_areas
-	sound_ai.output_atoms = inside_areas
-	sound_wo.output_atoms = outside_areas
-	sound_wi.output_atoms = inside_areas
+	sound_active_ashstorm.output_atoms = impacted_mobs
+	sound_weak_ashstorm.output_atoms = impacted_mobs
 
-	sound_wo.start()
-	sound_wi.start()
+	sound_weak_ashstorm.start()
 
 /datum/weather/ash_storm/start()
 	. = ..()
-	sound_wo.stop()
-	sound_wi.stop()
+	sound_weak_ashstorm.stop()
 
-	sound_ao.start()
-	sound_ai.start()
+	sound_active_ashstorm.start()
 
 /datum/weather/ash_storm/wind_down()
 	. = ..()
-	sound_ao.stop()
-	sound_ai.stop()
+	sound_active_ashstorm.stop()
 
-	sound_wo.start()
-	sound_wi.start()
+	sound_weak_ashstorm.start()
 
 /datum/weather/ash_storm/end()
 	. = ..()
-	sound_wo.stop()
-	sound_wi.stop()
+	sound_weak_ashstorm.stop()
 
 /datum/weather/ash_storm/proc/is_storm_immune(atom/L)
 	while (L && !isturf(L))


### PR DESCRIPTION

## About The Pull Request

Combines the ash/sandstorm looping sounds into two (active/weak). This means they won't exactly always be appropriate, but not like there's much difference between the outside/inside variations at all.

Accomplishes this by making the sounds play directly to mobs instead of to areas based on preferences.
## Why It's Good For The Game

The weather sound preference actually working is nice. Not everyone wants the weather sfx to make it hard to hear anything.
## Changelog
:cl:
fix: Made the weather sound preference actually work
/:cl:
