### PR TITLE
Increases firerate of laser rifle

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -427,7 +427,7 @@
 	wield_delay = 0.5 SECONDS
 	scatter = 0
 	scatter_unwielded = 10
-	fire_delay = 0.2 SECONDS
+	fire_delay = 0.15 SECONDS
 	accuracy_mult_unwielded = 0.55
 	damage_falloff_mult = 0.2
 	mode_list = list(
@@ -444,7 +444,7 @@
 /datum/lasrifle/base/energy_rifle_mode/standard
 	rounds_per_shot = 12
 	ammo_datum_type = /datum/ammo/energy/lasgun/marine
-	fire_delay = 0.2 SECONDS
+	fire_delay = 0.15 SECONDS
 	fire_sound = 'sound/weapons/guns/fire/Laser Rifle Standard.ogg'
 	message_to_user = "You set the laser rifle's charge mode to standard fire."
 	fire_mode = GUN_FIREMODE_AUTOMATIC
@@ -454,7 +454,7 @@
 /datum/lasrifle/base/energy_rifle_mode/overcharge
 	rounds_per_shot = 30
 	ammo_datum_type = /datum/ammo/energy/lasgun/marine/overcharge
-	fire_delay = 0.45 SECONDS
+	fire_delay = 0.35 SECONDS
 	fire_sound = 'sound/weapons/guns/fire/Laser overcharge standard.ogg'
 	message_to_user = "You set the laser rifle's charge mode to overcharge."
 	fire_mode = GUN_FIREMODE_AUTOMATIC


### PR DESCRIPTION
## About The Pull Request
Laser rifle firerate change from to:
Standard, 0.2 > 0.15
Overcharged, 0.45 > 0.35

## Why It's Good For The Game
Comparing it to the AR12 as a sidegrade choice, the laser rifle sacrifices aim mode, attachments, and space efficiency for a hitscan projectile that as it turns out has less dps vs <85 armor mobs and less damage per mag to boot. Extended/Barrel charger bullet speed mods made hitscan have less of a difference, and sunder rework also made the sunder change less impactful given xenos get less sunder the more they have. Ballistics also have the option of grabbing ammo packets for more efficient ammo storage (150 rounds for the space of a mag in the backpack, or the gigantic ammo pack for like 2400 rounds), which lasguns do not have other than an engilocked item that isn't even available in req or the big dense recharger made obsolete by just bringing more ammo boxes much like a normal gun. A faster firerate will allow the lasrifle standard shot to have mildly more DPS while still sacrificing attachments and aim mode than the AR12

The closest equivalent to overcharge mode in relation to standard shot is BR64's additional stats at the cost of firerate to the AR12. BR64 in relation to AR12 gets 50% more fire delay (0.2 to 0.3), 30% more damage, a whooping 200% more pen, and 150% more sunder for ~70% of the magcount. Overcharge in relation to standard has _over 100%_ the fire delay (0.2 vs 0.45), 100% more damage, 100% more pen, and 100% more sunder for 40% of the magcount. Fair stats on their own, though reduced to 0.35 to keep it equivalent to standard. End result is overcharge mode will still be proportional to the stats of standard shot while keeping its drawbacks and mag inefficiency.

Vanilla stats:
![image](https://user-images.githubusercontent.com/72712909/236705514-2ded2db9-e81b-47c3-a932-9000408a98d1.png)

Proposed stats:
![image](https://user-images.githubusercontent.com/72712909/236705498-147464e3-7622-4368-bc04-e78373373a3d.png)

## Changelog

:cl:
balance: Lasrifle firerate: Standard shot, 0.2 > 0.15. Overcharge: 0.45 > 0.35.
/:cl:

