### PR TITLE
Gets rid of gyroscopic stabilizer's damage debuff

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1149,7 +1149,6 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	scatter_unwielded_mod = -2
 	recoil_unwielded_mod = -1
 	aim_mode_movement_mult = -0.5
-	shot_marine_damage_falloff = -0.1
 
 /obj/item/attachable/lasersight
 	name = "laser sight"


### PR DESCRIPTION

## About The Pull Request
So time ago someone decided to give gyroscopic stabilizer a 10% damage debuff per marine the bullet went over in aim mode. Problem is it's fucking impossible to tell unless you explicitly get told about it by a codediver or were around for the PR. Gyroscopic stabilizer's aim mode speed buff already competes with vgrip's speed buff that even applies outside of aim mode so it's not a braindead choice to need that debuff anyway.

## Why It's Good For The Game
Hard to convey mechanics bad

## Changelog

:cl:
balance: Gyroscopic stabilizer no longer has a 10% damage penalty per marine the bullet on aim mode goes through.
/:cl:

