### PR TITLE
King required increased to 20 from 12

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -24,7 +24,7 @@
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_YOUNG_THRESHOLD
 	maximum_active_caste = 1
-	evolve_min_xenos = 12
+	evolve_min_xenos = 20
 	death_evolution_delay = 7 MINUTES
 
 	// *** Flags *** //


### PR DESCRIPTION
## About The Pull Request
You now need 20 xenos for a king rather than 12, this makes king only really appear on super high pop.
## Why It's Good For The Game
Makes king more rare rather than something that occurs basically every midpop round and since mechs are also locked to super highpop.
## Changelog
:cl:
balance: King now needs 20 xenos to evolve to
/:cl:
