### PR TITLE
Replaces some flags defined with ints with defines

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -398,7 +398,6 @@
 	sharp = IS_SHARP_ITEM_BIG
 	w_class = WEIGHT_CLASS_BULKY
 	flags_item = TWOHANDED
-	resistance_flags = NONE
 
 	/// Lists the information in the codex
 	var/codex_info = {"<b>Reagent info:</b><BR>

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -398,6 +398,7 @@
 	sharp = IS_SHARP_ITEM_BIG
 	w_class = WEIGHT_CLASS_BULKY
 	flags_item = TWOHANDED
+	resistance_flags = NONE
 
 	/// Lists the information in the codex
 	var/codex_info = {"<b>Reagent info:</b><BR>

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -2,7 +2,7 @@
 	icon = 'icons/obj/structures/structures.dmi'
 	var/climbable = FALSE
 	var/climb_delay = 50
-	var/flags_barrier = 0
+	var/flags_barrier = NONE
 	var/broken = FALSE //similar to machinery's stat BROKEN
 	obj_flags = CAN_BE_HIT
 	anchored = TRUE

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -359,7 +359,7 @@
 	basestate = "rwindow"
 	max_integrity = 1500
 	reinf = TRUE
-	resistance_flags = 10 // I have no clue what those are.
+	resistance_flags = UNACIDABLE|XENO_DAMAGEABLE
 
 /obj/structure/window/reinforced/tinted
 	name = "tinted window"

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -14,7 +14,7 @@
 	flags_equip_slot = ITEM_SLOT_EYES
 	flags_armor_protection = EYES
 	var/deactive_state = "degoggles"
-	var/vision_flags = 0
+	var/vision_flags = NONE
 	var/darkness_view = 2 //Base human is 2
 	var/invis_view = SEE_INVISIBLE_LIVING
 	var/invis_override = 0 //Override to allow glasses to set higher than normal see_invis

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -77,7 +77,7 @@
 	flags_inventory = COVEREYES|COVERMOUTH
 	flags_inv_hide = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEALLHAIR
 	item_state="cueball"
-	flags_inventory = 0
+	flags_inventory = NONE
 	flags_armor_protection = HEAD|FACE|EYES
 
 /obj/item/clothing/head/greenbandanna

--- a/code/modules/mob/living/carbon/human/life/life_helpers.dm
+++ b/code/modules/mob/living/carbon/human/life/life_helpers.dm
@@ -72,7 +72,7 @@
 //This proc returns a number made up of the flags for body parts which you are protected on. (such as HEAD, CHEST, GROIN, etc. See setup.dm for the full list)
 /mob/living/carbon/human/proc/get_flags_heat_protection_flags(temperature) //Temperature is the temperature you're being exposed to.
 
-	var/thermal_protection_flags = 0
+	var/thermal_protection_flags = NONE
 
 	//Handle normal clothing
 	if(head)
@@ -131,7 +131,7 @@
 //See proc/get_flags_heat_protection_flags(temperature) for the description of this proc.
 /mob/living/carbon/human/proc/get_flags_cold_protection_flags(temperature, deficit = 0)
 
-	var/thermal_protection_flags = 0
+	var/thermal_protection_flags = NONE
 
 	//Handle normal clothing
 	if(head)

--- a/code/modules/mob/living/simple_animal/hostile/shade.dm
+++ b/code/modules/mob/living/simple_animal/hostile/shade.dm
@@ -18,7 +18,7 @@
 	melee_damage = 12
 	attacktext = "metaphysically strikes"
 	stop_automated_movement = TRUE
-	status_flags = 0
+	status_flags = NONE
 	faction = list("cult")
 	status_flags = CANPUSH
 	del_on_death = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -90,7 +90,7 @@
 	attacktext = "slashes"
 	attack_sound = 'sound/weapons/blade1.ogg'
 	armour_penetration = 35
-	status_flags = 0
+	status_flags = NONE
 	projectile_deflect_chance = 50
 
 

--- a/code/modules/vehicles/multitile/hardpoints.dm
+++ b/code/modules/vehicles/multitile/hardpoints.dm
@@ -910,7 +910,7 @@ Currently only has the tank hardpoints
 
 //Special ammo magazines for hardpoint modules. Some aren't here since you can use normal magazines on them
 /obj/item/ammo_magazine/tank
-	flags_magazine = 0 //No refilling
+	flags_magazine = NONE //No refilling
 	var/point_cost = 0
 
 /obj/item/ammo_magazine/tank/ltb_cannon


### PR DESCRIPTION

## About The Pull Request

Because `resistance_flags = 10` isn't as easy to read.
## Why It's Good For The Game

Clearer code good.
## Changelog
:cl:
code: Replaces some flags defined with ints with defines
/:cl:
