### PR TITLE
Tadpole water landing fix

### DIFF
--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -30,7 +30,7 @@
 	/// Vertical offset from the console of the origin tile when using it
 	var/y_offset = 0
 	/// Turfs that can be landed on
-	var/list/whitelist_turfs = list(/turf/open/ground, /turf/open/floor)
+	var/list/whitelist_turfs = list(/turf/open/ground, /turf/open/floor, /turf/open/liquid/water)
 	/// Are we able to see hidden ports when using the console
 	var/see_hidden = FALSE
 	/// Delay of the place_action


### PR DESCRIPTION

## About The Pull Request
Tadpole can land in water again.

Turns out there is a funny whitelist of turfs it can land on, honk.
## Why It's Good For The Game
Bug fix good.
## Changelog
:cl:
fix: fixed tadpole being unable to land in water
/:cl:
