### PR TITLE
Fixes robot crit stagger

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -466,12 +466,11 @@
 		clear_fullscreen("robothalf")
 		clear_fullscreen("robotlow")
 
-/mob/living/carbon/human/species/robot/Life()
-	. = ..()
-	if(health > -25)
+/datum/species/robot/handle_unique_behavior(mob/living/carbon/human/H)
+	if(H.health > -25) //Staggerslowed if below crit threshold.
 		return
-	adjust_stagger(2, capped = 10)
-	adjust_slowdown(1)
+	H.adjust_stagger(2, capped = 10)
+	H.adjust_slowdown(1)
 
 ///Lets a robot repair itself over time at the cost of being stunned and blind
 /datum/action/repair_self

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -466,12 +466,11 @@
 		clear_fullscreen("robothalf")
 		clear_fullscreen("robotlow")
 
-/mob/living/carbon/human/species/robot/updatehealth()
+/mob/living/carbon/human/species/robot/Life()
 	. = ..()
-
 	if(health > -25)
 		return
-	adjust_stagger(1)
+	adjust_stagger(2, capped = 10)
 	adjust_slowdown(1)
 
 ///Lets a robot repair itself over time at the cost of being stunned and blind


### PR DESCRIPTION
## About The Pull Request
Title.
Currently, due for some reason happening in updatehealth() (???), robots will only get staggerslowed anytime their health is updated, means, damage, repairs, a bunch of other random procs called by a variety of things.
This is very inconsistant and very much not a stable "you are staggerslowed below -25 health", instead varying between "no effect" and "staggerstacked into next year"

This PR improves that behavior by moving the staggerslow adjustment into Life(), which is called consistantly, aswell as establishes a cap on stagger stack buildup (slow overlaps instead of stacking) to avoid being permanently staggered after going out of crit.
## Why It's Good For The Game
Fix man good?
## Changelog
:cl:
fix: Combat robot crit staggerslow now behaves consistently.
/:cl:
