### PR TITLE
Boiler Smoke is Transparent

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -309,6 +309,10 @@
 	opacity = FALSE
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_ACID|SMOKE_GASP|SMOKE_COUGH
 
+/obj/effect/particle_effect/smoke/xeno/burn/transparent
+	alpha = 120
+	opacity = FALSE
+
 //Xeno neurotox smoke.
 /obj/effect/particle_effect/smoke/xeno/neuro
 	color = "#ffbf58" //Mustard orange?
@@ -324,6 +328,10 @@
 	alpha = 60
 	opacity = FALSE
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_NEURO|SMOKE_GASP|SMOKE_COUGH|SMOKE_NEURO_LIGHT //Light neuro smoke doesn't extinguish
+
+/obj/effect/particle_effect/smoke/xeno/neuro/transparent
+	alpha = 120
+	opacity = FALSE
 
 /obj/effect/particle_effect/smoke/xeno/toxic
 	lifetime = 2
@@ -386,6 +394,9 @@
 /datum/effect_system/smoke_spread/xeno/acid/light
 	smoke_type = /obj/effect/particle_effect/smoke/xeno/burn/light
 
+/datum/effect_system/smoke_spread/xeno/acid/transparent
+	smoke_type = /obj/effect/particle_effect/smoke/xeno/burn/transparent
+
 /datum/effect_system/smoke_spread/xeno/neuro
 	smoke_type = /obj/effect/particle_effect/smoke/xeno/neuro
 
@@ -394,6 +405,9 @@
 
 /datum/effect_system/smoke_spread/xeno/neuro/light
 	smoke_type = /obj/effect/particle_effect/smoke/xeno/neuro/light
+
+/datum/effect_system/smoke_spread/xeno/neuro/transparent
+	smoke_type = /obj/effect/particle_effect/smoke/xeno/neuro/transparent
 
 /datum/effect_system/smoke_spread/xeno/toxic
 	smoke_type = /obj/effect/particle_effect/smoke/xeno/toxic

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3419,7 +3419,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	drop_nade(T.density ? P.loc : T, P.firer)
 
 /datum/ammo/xeno/boiler_gas/set_smoke()
-	smoke_system = new /datum/effect_system/smoke_spread/xeno/neuro()
+	smoke_system = new /datum/effect_system/smoke_spread/xeno/neuro/transparent()
 
 /datum/ammo/xeno/boiler_gas/drop_nade(turf/T, atom/firer, range = 1)
 	set_smoke()
@@ -3466,7 +3466,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	airburst(victim, proj)
 
 /datum/ammo/xeno/boiler_gas/corrosive/set_smoke()
-	smoke_system = new /datum/effect_system/smoke_spread/xeno/acid()
+	smoke_system = new /datum/effect_system/smoke_spread/xeno/acid/transparent()
 
 /datum/ammo/xeno/boiler_gas/lance
 	name = "pressurized glob of gas"


### PR DESCRIPTION

## About The Pull Request

https://github.com/tgstation/TerraGov-Marine-Corps/assets/98577688/cc92a818-f0c9-479e-bb10-3e06bf3f53ac

ignore the irobot clip playing
## Why It's Good For The Game
ever since smokening pr made smokes actually effective its been hard to counter a good boiler main reason is you cant see it to even counter it via long range weapons
## Changelog
:cl:
balance: boiler smoke is now transparent
/:cl:
