### PR TITLE
Tfoot smoke eats xeno smoke

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -296,6 +296,13 @@
 	expansion_speed = 3
 	smoke_traits = SMOKE_XENO
 
+/obj/effect/particle_effect/smoke/xeno/effect_smoke(obj/effect/particle_effect/smoke/S)
+	. = ..()
+	if(!.)
+		return
+	if(S.smoke_traits & SMOKE_PLASMALOSS)
+		lifetime -= 2
+
 //Xeno acid smoke.
 /obj/effect/particle_effect/smoke/xeno/burn
 	lifetime = 6


### PR DESCRIPTION

## About The Pull Request
All forms of Tanglefoot smoke now reduces the lifetime of any xeno type smoke found on the same tile.

This means xeno smoke can still spread through tangle, but will rapidly get removed.

Also technically applies to WP smoke since that has the same anti plasma properties.
## Why It's Good For The Game
Adds a limited counter measure to smoke spam.
## Changelog
:cl:
balance: Tanglefoot gas now quickly removes xeno smoke occupying the same space
/:cl:
