### PR TITLE
Fixes the self destruct

### DIFF
--- a/code/game/objects/machinery/self_destruct.dm
+++ b/code/game/objects/machinery/self_destruct.dm
@@ -8,6 +8,8 @@
 	var/active_state = SELF_DESTRUCT_MACHINE_INACTIVE
 	///Whether only marines can activate this. left here in case of admins feeling nice or events
 	var/marine_only_activate = TRUE
+	///When the self destruct sequence was initiated
+	var/started_at = 0
 	
 
 /obj/machinery/self_destruct/Initialize(mapload)
@@ -58,15 +60,14 @@
 		ui.open()
 
 /obj/machinery/self_destruct/console/ui_data(mob/user)
-	var/obj/machinery/self_destruct/rod/I = SSevacuation.dest_rods[SSevacuation.dest_index]
-
 	var/list/data = list()
 	data["dest_status"] = active_state
-	if(I.activate_time)
-		data["detonation_pcent"] = round(((world.time - I.activate_time)  / (SELF_DESTRUCT_ROD_STARTUP_TIME)), 0.01)  // percentage of time left to detonation
-		data["detonation_time"] = DisplayTimeText((SELF_DESTRUCT_ROD_STARTUP_TIME) - (world.time - I.activate_time), 10) //amount of time left to detonation
+	if(active_state == SELF_DESTRUCT_MACHINE_ARMED)
+		data["detonation_pcent"] = min(round(((world.time - started_at)  / (SELF_DESTRUCT_ROD_STARTUP_TIME)), 0.01), 1)  // percentage of time left to detonation
+		data["detonation_time"] = DisplayTimeText(max(0, (SELF_DESTRUCT_ROD_STARTUP_TIME) - (world.time - started_at)), 1) //amount of time left to detonation
 	else
 		data["detonation_pcent"] = 0
+		data["detonation_time"] = "Inactive"
 	return data
 
 
@@ -82,6 +83,7 @@
 			active_state = SELF_DESTRUCT_MACHINE_ARMED
 			var/obj/machinery/self_destruct/rod/I = SSevacuation.dest_rods[SSevacuation.dest_index]
 			I.activate_time = world.time
+			started_at = world.time
 			SSevacuation.initiate_self_destruct()
 			. = TRUE
 

--- a/tgui/packages/tgui/interfaces/SelfDestruct.js
+++ b/tgui/packages/tgui/interfaces/SelfDestruct.js
@@ -65,8 +65,8 @@ export const SelfDestruct = (props, context) => {
                 />
               </>
             )) ||
-            (dest_status === 0 && <span className="idle">OFFLINE</span>) ||
-            <span className="bad">ERROR</span>}
+            (dest_status === 0 && <span className="idle">OFFLINE</span>) || (
+              <span className="bad">ERROR</span>)}
         </Section>
       </Window.Content>
     </Window>

--- a/tgui/packages/tgui/interfaces/SelfDestruct.js
+++ b/tgui/packages/tgui/interfaces/SelfDestruct.js
@@ -66,7 +66,8 @@ export const SelfDestruct = (props, context) => {
               </>
             )) ||
             (dest_status === 0 && <span className="idle">OFFLINE</span>) || (
-              <span className="bad">ERROR</span>)}
+              <span className="bad">ERROR</span>
+            )}
         </Section>
       </Window.Content>
     </Window>

--- a/tgui/packages/tgui/interfaces/SelfDestruct.js
+++ b/tgui/packages/tgui/interfaces/SelfDestruct.js
@@ -64,7 +64,9 @@ export const SelfDestruct = (props, context) => {
                   onClick={() => act('dest_cancel')}
                 />
               </>
-            )) || <span className="bad">ERROR</span>}
+            )) ||
+            (dest_status === 0 && <span className="idle">OFFLINE</span>) ||
+            <span className="bad">ERROR</span>}
         </Section>
       </Window.Content>
     </Window>


### PR DESCRIPTION
## About The Pull Request
#12888 broke the self destruct interface, making it display error when all rods are armed.
This fixes that glaring issue.
Additionally, the timer was also just broken in the first place. This makes the timer actually work instead of resetting for each rod, and also adjusts it to display in 1 second intervals instead of rounding down to the next 10 (feels more tense to have every single second tick down individually)
Also adds a very small note to the control part informing the user it is "offline", instead of elifing into the emergency case and displaying error when looking at it while disabled.
## Why It's Good For The Game
Fix man good.
## Changelog
:cl:
fix: The self destruct core no longer requires admin intervention to finish / blow up the ship.
fix: The time display on the self destruct UI should be more sane now.
/:cl:
