### PR TITLE
Fix Surt module unable to be placed on MK1 Helm

### DIFF
--- a/code/modules/clothing/modular_armor/mark_one.dm
+++ b/code/modules/clothing/modular_armor/mark_one.dm
@@ -31,6 +31,7 @@
 		/obj/item/armor_module/greyscale/visor/marine/old/eva/skull,
 		/obj/item/armor_module/greyscale/visor/marine/old/eod,
 		/obj/item/armor_module/greyscale/visor/marine/old/assault,
+		/obj/item/armor_module/module/fire_proof_helmet,
 	)
 
 	starting_attachments = list(/obj/item/armor_module/greyscale/visor/marine/old, /obj/item/armor_module/storage/helmet)


### PR DESCRIPTION

## About The Pull Request

**_Should_** fix the Surt module not being able to be placed on the MK.I Jaeger helmets

## Why It's Good For The Game
less bug good?
me no like bug

also fixes #12953

## Changelog


:cl:
fix: Surt Helm now can be placed on MK.I Jaeger Helm
/:cl:


