### PR TITLE
Acid well change rework plus bug squish

### DIFF
--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -600,17 +600,18 @@ TUNNEL
 
 	var/datum/effect_system/smoke_spread/xeno/acid/acid_smoke
 
-	if(charges >= 2)
+	var/grenade_removed = FALSE
+	if(charges >= 1)
 		for(var/obj/item/explosive/grenade/sticky/sticky_bomb in stepper.contents)
 			sticky_bomb.clean_refs()
-			qdel(sticky_bomb)
-			charges -= 2
+			sticky_bomb.forceMove(loc)
+			grenade_removed = TRUE
+		if(grenade_removed)
+			charges -= 1
 			acid_smoke = new(get_turf(stepper))
-			acid_smoke.set_up(1, src)
+			acid_smoke.set_up(0, src)
 			acid_smoke.start()
 			update_icon()
-			if(!charges)
-				return
 	if(isxeno(stepper))
 		if(!(stepper.on_fire))
 			return

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -601,17 +601,16 @@ TUNNEL
 	var/datum/effect_system/smoke_spread/xeno/acid/acid_smoke
 
 	var/grenade_removed = FALSE
-	if(charges >= 1)
-		for(var/obj/item/explosive/grenade/sticky/sticky_bomb in stepper.contents)
-			sticky_bomb.clean_refs()
-			sticky_bomb.forceMove(loc)
-			grenade_removed = TRUE
-		if(grenade_removed)
-			charges -= 1
-			acid_smoke = new(get_turf(stepper))
-			acid_smoke.set_up(0, src)
-			acid_smoke.start()
-			update_icon()
+	for(var/obj/item/explosive/grenade/sticky/sticky_bomb in stepper.contents)
+		sticky_bomb.clean_refs()
+		sticky_bomb.forceMove(loc)
+		grenade_removed = TRUE
+	if(grenade_removed)
+		charges -= 1
+		acid_smoke = new(get_turf(stepper))
+		acid_smoke.set_up(0, src)
+		acid_smoke.start()
+		update_icon()
 	if(isxeno(stepper))
 		if(!(stepper.on_fire))
 			return

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -600,21 +600,22 @@ TUNNEL
 
 	var/datum/effect_system/smoke_spread/xeno/acid/acid_smoke
 
+	var/charges_reduced = FALSE
 	if(isxeno(stepper))
+		if(charges == 0)
+			return
 		for(var/obj/item/explosive/grenade/sticky/sticky_bomb in stepper.contents)
 			if(sticky_bomb.stuck_to == stepper)
 				sticky_bomb.clean_refs()
 				sticky_bomb.forceMove(loc)
+				charges -= 1
 		if(!(stepper.on_fire))
 			return
-		acid_smoke = new(get_turf(stepper)) //spawn acid smoke when charges are actually used
-		acid_smoke.set_up(0, src) //acid smoke in the immediate vicinity
-		acid_smoke.start()
 		stepper.ExtinguishMob()
-		charges--
-		update_icon()
-		return
+		charges -= 1
 
+	if(isxeno(stepper))
+		return
 	stepper.next_move_slowdown += charges * 2 //Acid spray has slow down so this should too; scales with charges, Min 2 slowdown, Max 10
 	stepper.apply_damage(charges * 10, BURN, BODY_ZONE_PRECISE_L_FOOT, ACID,  penetration = 33)
 	stepper.apply_damage(charges * 10, BURN, BODY_ZONE_PRECISE_R_FOOT, ACID,  penetration = 33)
@@ -627,11 +628,15 @@ TUNNEL
 	span_danger("We are immersed in [src]'s acid!") , null, 5)
 	playsound(stepper, "sound/bullets/acid_impact1.ogg", 10 * charges)
 	new /obj/effect/temp_visual/acid_bath(get_turf(stepper))
-	acid_smoke = new(get_turf(stepper)) //spawn acid smoke when charges are actually used
-	acid_smoke.set_up(0, src) //acid smoke in the immediate vicinity
-	acid_smoke.start()
 	charges = 0
-	update_icon()
+
+	if(charges -= 1)
+		charges_reduced = TRUE
+	if(charges_reduced)
+		acid_smoke = new(get_turf(stepper)) //spawn acid smoke when charges are actually used
+		acid_smoke.set_up(0, src) //acid smoke in the immediate vicinity
+		acid_smoke.start()
+		update_icon()
 
 /obj/structure/xeno/resin_jelly_pod
 	name = "Resin jelly pod"

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -600,18 +600,11 @@ TUNNEL
 
 	var/datum/effect_system/smoke_spread/xeno/acid/acid_smoke
 
-	var/grenade_removed = FALSE
-	for(var/obj/item/explosive/grenade/sticky/sticky_bomb in stepper.contents)
-		sticky_bomb.clean_refs()
-		sticky_bomb.forceMove(loc)
-		grenade_removed = TRUE
-	if(grenade_removed)
-		charges -= 1
-		acid_smoke = new(get_turf(stepper))
-		acid_smoke.set_up(0, src)
-		acid_smoke.start()
-		update_icon()
 	if(isxeno(stepper))
+		for(var/obj/item/explosive/grenade/sticky/sticky_bomb in stepper.contents)
+			if(sticky_bomb.stuck_to == stepper)
+				sticky_bomb.clean_refs()
+				sticky_bomb.forceMove(loc)
 		if(!(stepper.on_fire))
 			return
 		acid_smoke = new(get_turf(stepper)) //spawn acid smoke when charges are actually used
@@ -626,6 +619,10 @@ TUNNEL
 	stepper.apply_damage(charges * 10, BURN, BODY_ZONE_PRECISE_L_FOOT, ACID,  penetration = 33)
 	stepper.apply_damage(charges * 10, BURN, BODY_ZONE_PRECISE_R_FOOT, ACID,  penetration = 33)
 	stepper.ExtinguishMob()
+	for(var/obj/item/explosive/grenade/sticky/sticky_bomb in stepper.contents)
+		if(sticky_bomb.stuck_to == stepper)
+			sticky_bomb.clean_refs()
+			sticky_bomb.forceMove(loc)
 	stepper.visible_message(span_danger("[stepper] is immersed in [src]'s acid!") , \
 	span_danger("We are immersed in [src]'s acid!") , null, 5)
 	playsound(stepper, "sound/bullets/acid_impact1.ogg", 10 * charges)

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -604,13 +604,13 @@ TUNNEL
 		for(var/obj/item/explosive/grenade/sticky/sticky_bomb in stepper.contents)
 			sticky_bomb.clean_refs()
 			qdel(sticky_bomb)
-		charges -= 2
-		acid_smoke = new(get_turf(stepper))
-		acid_smoke.set_up(1, src)
-		acid_smoke.start()
-		update_icon()
-		if(!charges)
-			return
+			charges -= 2
+			acid_smoke = new(get_turf(stepper))
+			acid_smoke.set_up(1, src)
+			acid_smoke.start()
+			update_icon()
+			if(!charges)
+				return
 	if(isxeno(stepper))
 		if(!(stepper.on_fire))
 			return


### PR DESCRIPTION
## About The Pull Request
Reworks acid well sticky interactions to drop the grenades instead of Q-del, also fixes bugs
## Why It's Good For The Game
Qdel bad, easier to use but still allows the grenades to explode so not an instant get out of jail free card. bug squished.
## Changelog
:cl:
feature: acid wells cause stickies to drop instead of Qdel
fix: fixes acid wells triggering on their own
/:cl:
