### PR TITLE
New sunder no longer scales on existing sunder

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -40,7 +40,7 @@
 	adjust_stagger(max(0, ex_slowdown - 2)) //Stagger 2 less than slowdown
 
 	//Sunder
-	adjust_sunder(max(0, 50 * (3 - severity) * bomb_sunder_multiplier * get_sunder()))
+	adjust_sunder(max(0, 50 * (3 - severity) * bomb_sunder_multiplier))
 
 	//Damage
 	var/ex_damage = 40 + rand(0, 20) + 50*(4 - severity)  //changed so overall damage stays similar

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -915,7 +915,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 			feedback_flags |= (BULLET_FEEDBACK_FIRE)
 
 	if(proj.ammo.flags_ammo_behavior & AMMO_SUNDERING)
-		adjust_sunder(proj.sundering * get_sunder())
+		adjust_sunder(proj.sundering)
 
 	if(damage)
 		var/shrapnel_roll = do_shrapnel_roll(proj, damage)


### PR DESCRIPTION
## About The Pull Request
![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/72712909/e5aad79f-05cd-47b7-a5fa-50546705a71c)

## Why It's Good For The Game
Sunder scaling on applied sunder excessively hit weapons that have high firerate and low sunder. As an example:

A projectile that does 100 sunder will bring a xeno's armor% down from 100% to 0%.
A projectile that does 50 sunder and is shot twice will first bring down the armor% from 100% to 50%, and then for the second shot have the sunder value multiplied by 0.5 to do 25 and leave the xeno with 25% armor remaining rather than 0.
This pattern keeps going for guns that have lower sunder per shot.

## Changelog

:cl:
balance: Projectile sunder is no longer multiplied by the % of remaining armor of the struck xeno

/:cl:

