### PR TITLE
Changes the light mode common radio color to green

### DIFF
--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -418,7 +418,7 @@ em {
 }
 
 .radio {
-  color: #4e4e4e;
+  color: #158c15;
 }
 
 .deptradio {


### PR DESCRIPTION

## About The Pull Request

Before:
![dreamseeker_txg7y0uDaL](https://github.com/tgstation/TerraGov-Marine-Corps/assets/22431091/d7391055-63ed-4d31-8729-e93c2f49195e)

After:
![dreamseeker_DbP8GHuVYL](https://github.com/tgstation/TerraGov-Marine-Corps/assets/22431091/7625fd49-ee92-43dc-b14d-b2f614ef80ba)

Whoever thought gray on white background was a good idea should be shot.
## Why It's Good For The Game

More readable.
## Changelog
:cl:
qol: Changed the light mode common radio color to green
/:cl:
