### PR TITLE
Weight Benches should no longer disappear

### DIFF
--- a/code/game/objects/structures/benchpress.dm
+++ b/code/game/objects/structures/benchpress.dm
@@ -71,6 +71,10 @@
 		"5" = image(icon = 'icons/obj/structures/benchpress.dmi', icon_state = "benchpress_5"),
 	)
 	var/choice = show_radial_menu(user, src, radial_options, null, 64, null, TRUE, TRUE)
+
+	if(!choice)
+		return
+		
 	plates = text2num(choice)
 	update_icon()
 	flick("swap_[plates]", src)

--- a/code/modules/clothing/modular_armor/mark_one.dm
+++ b/code/modules/clothing/modular_armor/mark_one.dm
@@ -31,6 +31,7 @@
 		/obj/item/armor_module/greyscale/visor/marine/old/eva/skull,
 		/obj/item/armor_module/greyscale/visor/marine/old/eod,
 		/obj/item/armor_module/greyscale/visor/marine/old/assault,
+		/obj/item/armor_module/module/fire_proof_helmet,
 	)
 
 	starting_attachments = list(/obj/item/armor_module/greyscale/visor/marine/old, /obj/item/armor_module/storage/helmet)


### PR DESCRIPTION

## About The Pull Request

Makes it so that the Weight Bench no longer gets banished to the shadowrealm if you dont wish to change the weights.

## Why It's Good For The Game

The TGMC can now stop having to buy a new weight bench everytime someone changes their mind

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

fix: Weight Benches no longer disappear when unselecting the radial wheel.

/:cl:
