### PR TITLE
Stops the Weight Bench from being deleted when select wheel is closed

### DIFF
--- a/code/game/objects/structures/benchpress.dm
+++ b/code/game/objects/structures/benchpress.dm
@@ -72,6 +72,8 @@
 	)
 	var/choice = show_radial_menu(user, src, radial_options, null, 64, null, TRUE, TRUE)
 	plates = text2num(choice)
+	if(!choice)
+		return
 	update_icon()
 	flick("swap_[plates]", src)
 

--- a/code/game/objects/structures/benchpress.dm
+++ b/code/game/objects/structures/benchpress.dm
@@ -71,9 +71,9 @@
 		"5" = image(icon = 'icons/obj/structures/benchpress.dmi', icon_state = "benchpress_5"),
 	)
 	var/choice = show_radial_menu(user, src, radial_options, null, 64, null, TRUE, TRUE)
-	plates = text2num(choice)
 	if(!choice)
 		return
+	plates = text2num(choice)
 	update_icon()
 	flick("swap_[plates]", src)
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -466,13 +466,11 @@
 		clear_fullscreen("robothalf")
 		clear_fullscreen("robotlow")
 
-/mob/living/carbon/human/species/robot/updatehealth()
-	. = ..()
-
-	if(health > -25)
+/datum/species/robot/handle_unique_behavior(mob/living/carbon/human/H)
+	if(H.health > -25) //Staggerslowed if below crit threshold.
 		return
-	adjust_stagger(1)
-	adjust_slowdown(1)
+	H.adjust_stagger(2, capped = 10)
+	H.adjust_slowdown(1)
 
 ///Lets a robot repair itself over time at the cost of being stunned and blind
 /datum/action/repair_self


### PR DESCRIPTION
## About The Pull Request

Makes it so that the Weight Bench no longer gets banished to the shadowrealm if you dont wish to change the weights.

## Why It's Good For The Game

The TGMC can now stop having to buy a new weight bench everytime someone changes their mind and banishes the Weight bench
Also fixes #12949

## Changelog
:cl:

fix: Weight Benches no longer disappear when unselecting the radial wheel.

/:cl:
