### PR TITLE
Updates Xeno Toxin Hud Desc

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -20,10 +20,16 @@
 			msg += "<span style='font-weight: bold; color: purple;'>You sense this creature is dead.</span>\n"
 		else if(stat || !client)
 			msg += "[span_xenowarning("It doesn't seem responsive.")]\n"
-		if(reagents.get_reagent_amount(/datum/reagent/toxin/xeno_transvitox))
-			msg += "Transvitox: 40% brute/burn injuries received are converted to toxin\n"
+		if(reagents.get_reagent_amount(/datum/reagent/toxin/xeno_neurotoxin))
+			msg += "Neurotoxin: Causes increasingly intense pain and stamina damage over time, incrementing at the 20th and 45th cycle of metabolism\n"
 		if(reagents.get_reagent_amount(/datum/reagent/toxin/xeno_hemodile))
-			msg += "Hemodile: 20% stamina damage received, when damaged, and slowed by 25% (inject neurotoxin for 50% slow)\n"
+			msg += "Hemodile: Slows down the target, doubling in power with each other xeno-based toxin present.\n"
+		if(reagents.get_reagent_amount(/datum/reagent/toxin/xeno_transvitox))
+			msg += "Transvitox: Converts burns to toxin over time, as well as causing incoming brute damage to deal additional toxin damage. Both effects intensifying with each xeno-based toxin presnt. Toxin damage is capped at 180.\n"
+		if(reagents.get_reagent_amount(/datum/reagent/toxin/xeno_ozelomelyn))
+			msg += "Ozelomelyn: Rapidly purges all medicine in the body, causes toxin damage capped at 40. Metabolizes very quickly.\n"
+		if(reagents.get_reagent_amount(/datum/reagent/toxin/xeno_sanguinal))
+			msg += "Sanguinal: Causes brute damage and bleeding from the brute damage. Does additional damage types in the presence of other xeno-based toxins. Toxin damage for Neuro, Stamina damage for Hemodile, and Burn damage for Transvitox.\n"
 		msg += "</span>"
 		return list(msg)
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -21,7 +21,7 @@
 		else if(stat || !client)
 			msg += "[span_xenowarning("It doesn't seem responsive.")]\n"
 		if(reagents.get_reagent_amount(/datum/reagent/toxin/xeno_neurotoxin))
-			msg += "Neurotoxin: Causes increasingly intense pain and stamina damage over time, incrementing at the 20th and 45th cycle of metabolism\n"
+			msg += "Neurotoxin: Causes increasingly intense pain and stamina damage over time, incrementing in intensity at the 40 second and the minute and a half mark of metabolism.\n"
 		if(reagents.get_reagent_amount(/datum/reagent/toxin/xeno_hemodile))
 			msg += "Hemodile: Slows down the target, doubling in power with each other xeno-based toxin present.\n"
 		if(reagents.get_reagent_amount(/datum/reagent/toxin/xeno_transvitox))

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -348,7 +348,7 @@
 /datum/action/xeno_action/select_reagent
 	name = "Select Reagent"
 	action_icon_state = "select_reagent0"
-	desc = "Selects which reagent to use for reagent slash and noxious gas. Hemodile slows by 25%, increased to 50% with neurotoxin present, and deals 20% of damage received as stamina damage. Transvitox converts brute/burn damage to toxin based on 40% of damage received up to 45 toxin on target, upon reaching which causes a stun. Neurotoxin deals increasing stamina damage the longer it remains in the victim's system and prevents stamina regeneration."
+	desc = "Selects which reagent to use for reagent slash and noxious gas. Neuro causes increasing pain and stamina damage. Hemodile slows targets down, multiplied by each other xeno-based toxin. Transvitox converts burns to toxin, and causes additional toxin damage when they take brute damage, both effects multiplied by other xeno-based toxins. Ozelomelyn purges all medicines from their system rapidly and causes minor toxin damage."
 	use_state_flags = XACT_USE_BUSY|XACT_USE_LYING
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_SELECT_REAGENT,


### PR DESCRIPTION
## About The Pull Request

Hey all, Dagger the Defiler main here. 

I've been on a mission to make sure all the info that you can find on Defiler is correct, to avoid misinformation. Since Defiler can tend to be a pretty complex caste for some. I love Defiler, and you should too. (But not enough to, yknow, get it nerfed 😅 )

Just a small quick change to a feature that has been left deprecated since Afflictor became a part of Defiler, and the Reagent Sight feature was never updated. Hopefully shouldn't break anything.

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/81834422/aecd07d1-f32e-4473-a1af-938586cf5dce)

All this does is update the descriptions displayed when examining a human with any of the toxins present in them. Certainly not a massive gamechanger but very convenient to have.

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/81834422/347d1002-a5de-4a2a-84ae-e3aba0244785)

Also updates the ability description for Select Reagent, which seemingly also had deprecated info. (Yes I know that it is HUMOROUSLY long, but it was sorta like that before too. All that info had to be readily available from the start SOMEHOW)

## Why It's Good For The Game

I think we all can agree that updated info is very nice to have.

## Changelog
:cl:
qol: Updates Xeno Toxin hud examine description info.
qol: Updates Defiler Select Reagent ability description info.
/:cl:
