### PR TITLE
All supply beacons lose their signal when destroyed + fixes dead signals in the supply console

### DIFF
--- a/code/game/objects/machinery/squad_supply/supply_beacon.dm
+++ b/code/game/objects/machinery/squad_supply/supply_beacon.dm
@@ -143,7 +143,7 @@
 	var/faction = ""
 
 /datum/supply_beacon/New(_name, turf/_drop_location, _faction, life_time = 0 SECONDS)
-	name= _name
+	name =  _name
 	drop_location = _drop_location
 	faction = _faction
 	GLOB.supply_beacon[name] = src
@@ -152,5 +152,5 @@
 
 /// Remove that beacon from the list of glob supply beacon
 /datum/supply_beacon/Destroy()
-	GLOB.supply_beacon[name] = null
+	GLOB.supply_beacon -= name
 	return ..()

--- a/code/game/objects/machinery/squad_supply/supply_console.dm
+++ b/code/game/objects/machinery/squad_supply/supply_console.dm
@@ -74,7 +74,7 @@
 			if(!istype(supply_beacon_choice))
 				return
 			supply_beacon = supply_beacon_choice
-			RegisterSignal(supply_beacon, COMSIG_PARENT_QDELETING, PROC_REF(clean_supply_beacon))
+			RegisterSignal(supply_beacon, COMSIG_PARENT_QDELETING, PROC_REF(clean_supply_beacon), override = TRUE)
 			refresh_pad()
 		if("set_x")
 			var/new_x = text2num(params["set_x"])

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -623,6 +623,12 @@
 	/// Reference to the datum used by the supply drop console
 	var/datum/supply_beacon/beacon_datum
 
+/obj/item/armor_module/module/antenna/Destroy()
+	if(beacon_datum)
+		UnregisterSignal(beacon_datum, COMSIG_PARENT_QDELETING)
+		QDEL_NULL(beacon_datum)
+	return ..()
+
 /obj/item/armor_module/module/antenna/activate(mob/living/user)
 	var/turf/location = get_turf(src)
 	if(beacon_datum)

--- a/code/modules/reqs/supply.dm
+++ b/code/modules/reqs/supply.dm
@@ -618,6 +618,12 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	/// Reference to the datum used by the supply drop console
 	var/datum/supply_beacon/beacon_datum
 
+/obj/item/storage/backpack/marine/radiopack/Destroy()
+	if(beacon_datum)
+		UnregisterSignal(beacon_datum, COMSIG_PARENT_QDELETING)
+		QDEL_NULL(beacon_datum)
+	return ..()
+
 /obj/item/storage/backpack/marine/radiopack/examine(mob/user)
 	. = ..()
 	. += span_notice("Right-Click with empty hand to open requisitions interface.")

--- a/code/modules/vehicles/unmanned/unmanned_droid.dm
+++ b/code/modules/vehicles/unmanned/unmanned_droid.dm
@@ -47,6 +47,9 @@
 		UnregisterSignal(user, COMSIG_UNMANNED_COORDINATES)
 
 /obj/vehicle/unmanned/droid/Destroy()
+	if(beacon_datum)
+		UnregisterSignal(beacon_datum, COMSIG_PARENT_QDELETING)
+		QDEL_NULL(beacon_datum)
 	if(!remote_user) //No remote user, no need to do this.
 		return ..()
 	var/mob/living/living_user = remote_user.resolve()


### PR DESCRIPTION

## About The Pull Request

Comes with a bonus signal override fix for the console.
## Why It's Good For The Game

Bugs bad.
## Changelog
:cl:
balance: Supply beacons now lose their signal when the source of the signal is destoryed
fix: Fixed the req console keeping dead signals in the list
fix: Fixed a signal override in the req console
/:cl:
