### PR TITLE
Dropship Fabricator is Indestructible

### DIFF
--- a/code/game/objects/machinery/dropship_part_fabricator.dm
+++ b/code/game/objects/machinery/dropship_part_fabricator.dm
@@ -10,6 +10,7 @@
 	idle_power_usage = 20
 	icon = 'icons/obj/machines/drone_fab.dmi'
 	icon_state = "drone_fab_idle"
+	resistance_flags = RESIST_ALL
 	/// List of everything in queue
 	var/list/queue = list()
 	/// Whether the fabricator is currently printing something or not


### PR DESCRIPTION

## About The Pull Request
be playing cas po
someone lets a xeno through and it melts the fab
you cannot fix it or replace it
now your entire job of playing cas is useless
## Why It's Good For The Game
cas po should be able to play the entire purpose of their job 
## Changelog
:cl:
balance: dropship fabricator is indestructible
/:cl:
