### PR TITLE
Squad marine role now shows as Recommended in lobby job selection

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -60,7 +60,7 @@
 #define SQUAD_SMARTGUNNER "Squad Smartgunner"
 #define SQUAD_CORPSMAN "Squad Corpsman"
 #define SQUAD_ENGINEER "Squad Engineer"
-#define SQUAD_MARINE "Squad Marine"
+#define SQUAD_MARINE "Squad Marine \[Recommended]"
 #define SQUAD_VATGROWN "Squad VatGrown"
 #define SILICON_AI "AI"
 


### PR DESCRIPTION

## About The Pull Request
Squad marine role now shows as Recommended in lobby job selection

## Why It's Good For The Game
Squad marine role now shows as Recommended in lobby job selection
also should help in pointing rookies what role they should probably focus on getting competent at first given it's also the role that has the newcomer guide on vendor

## Changelog

:cl:
qol: Squad marine role now shows as Recommended in lobby job selection
/:cl:

