### PR TITLE
Fixes nades erroniously appearing primed when they aren't

### DIFF
--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -84,7 +84,7 @@
 /obj/item/explosive/grenade/update_overlays()
 	. = ..()
 	if(active && dangerous)
-		overlays += new /obj/effect/overlay/danger
+		. += new /obj/effect/overlay/danger
 
 
 /obj/item/explosive/grenade/proc/prime()

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -83,7 +83,7 @@
 
 /obj/item/explosive/grenade/update_overlays()
 	. = ..()
-	if(active)
+	if(active && dangerous)
 		overlays += new /obj/effect/overlay/danger
 
 

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -83,7 +83,7 @@
 
 /obj/item/explosive/grenade/update_overlays()
 	. = ..()
-	if(dangerous)
+	if(active)
 		overlays += new /obj/effect/overlay/danger
 
 


### PR DESCRIPTION

## About The Pull Request

Yes. Tested by putting a nade into a GL and taking it out, usually this makes it appear like it's about to go off (with the flashing !)
## Why It's Good For The Game

Bug bad.
## Changelog
:cl:
fix: Fixed nades erroniously appearing primed when they aren't
/:cl:
