### PR TITLE
Runner can't begin evasion if on fire

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -227,10 +227,14 @@
 
 /datum/action/xeno_action/evasion/can_use_action(silent = FALSE, override_flags)
 	. = ..()
+	var/mob/living/carbon/xenomorph/xeno_owner = owner
 
 	if(evade_active) //Can't evade while we're already evading.
 		if(!silent)
-			owner.balloon_alert(owner, "Already evading")
+			xeno_owner.balloon_alert(xeno_owner, "Already evading")
+		return FALSE
+	if(xeno_owner.on_fire)
+		xeno_owner.balloon_alert(xeno_owner, "Can't while on fire!")
 		return FALSE
 
 /datum/action/xeno_action/evasion/action_activate()

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -227,12 +227,14 @@
 
 /datum/action/xeno_action/evasion/can_use_action(silent = FALSE, override_flags)
 	. = ..()
-	var/mob/living/carbon/xenomorph/xeno_owner = owner
 
 	if(evade_active) //Can't evade while we're already evading.
 		if(!silent)
-			xeno_owner.balloon_alert(xeno_owner, "Already evading")
+			owner.balloon_alert(owner, "Already evading")
 		return FALSE
+
+	var/mob/living/carbon/xenomorph/xeno_owner = owner
+
 	if(xeno_owner.on_fire)
 		xeno_owner.balloon_alert(xeno_owner, "Can't while on fire!")
 		return FALSE


### PR DESCRIPTION

## About The Pull Request

Title. With the way it's currently done the evasion only gets interrupted on the first life tick, which can be a bit (relatively). Seems like an oversight.
## Why It's Good For The Game

Bug bad.
## Changelog
:cl:
fix: Fixed runner being able to start evasion while on fire
/:cl:
