### PR TITLE
Nerfs silo scaling rating on Nuclear War

### DIFF
--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/infestation/distress/nuclear_war
 	name = "Nuclear War"
 	config_tag = "Nuclear War"
-	silo_scaling = 2
+	silo_scaling = 1.5
 
 /datum/game_mode/infestation/distress/nuclear_war/post_setup()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Per title.

## Why It's Good For The Game
Throughout recent rounds, xenos have proven to be _very_ numerous, and they even had several larvae to boot. Marines are unable to keep up with the sheer amount of xenos, and short of xenos making considerable mistakes, marines are unable to keep up.

This is the solution I propose: reduce the silo scaling and therefore reduce the overall number of xenos, given that I do not think it is particularly related to xeno balance or whatever, moreso just how many xenos there are in any given round.

## Changelog
:cl: Lewdcifer
balance: Nuclear War silo scaling reduced from 2 > 1.5 (this means less xenos).
/:cl: