### PR TITLE
Robo FC spawns with gear

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -860,6 +860,10 @@ GLOBAL_LIST_INIT(human_body_parts, list(BODY_ZONE_HEAD,
 ///Slowdown for warlocks moving through liquid
 #define WARLOCK_WATER_SLOWDOWN 0
 
-#define SPECIES_HUMAN "species_human"
 
+//Species defines
+
+///Human species or those that functional behave like them. Default species
+#define SPECIES_HUMAN "species_human"
+///Combat robot species
 #define SPECIES_COMBAT_ROBOT "species_combat_robot"

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -859,3 +859,7 @@ GLOBAL_LIST_INIT(human_body_parts, list(BODY_ZONE_HEAD,
 #define BOILER_WATER_SLOWDOWN 0
 ///Slowdown for warlocks moving through liquid
 #define WARLOCK_WATER_SLOWDOWN 0
+
+#define SPECIES_HUMAN "species_human"
+
+#define SPECIES_COMBAT_ROBOT "species_combat_robot"

--- a/code/datums/jobs/job/job.dm
+++ b/code/datums/jobs/job/job.dm
@@ -300,7 +300,7 @@ GLOBAL_PROTECT(exp_specialmap)
 		equip_to_slot_or_del(id_card, SLOT_WEAR_ID)
 		job.outfit.handle_id(src)
 
-		get_role_outfit(job)
+		equip_role_outfit(job)
 
 	if((job.job_flags & JOB_FLAG_ALLOWS_PREFS_GEAR) && player)
 		equip_preference_gear(player)
@@ -310,19 +310,16 @@ GLOBAL_PROTECT(exp_specialmap)
 
 	hud_set_job(faction)
 
-/mob/living/carbon/human/proc/get_role_outfit(datum/job/assigned_role)
+///finds and equips a valid outfit for a specified job and species
+/mob/living/carbon/human/proc/equip_role_outfit(datum/job/assigned_role)
 	if(!assigned_role.multiple_outfits)
 		assigned_role.outfit.equip(src)
 		return
 
 	var/list/valid_outfits
 
-	var/species_type = SPECIES_HUMAN
-	if(isrobot(src))
-		species_type = SPECIES_COMBAT_ROBOT
-
 	for(var/datum/outfit/variant AS in assigned_role.outfits)
-		if(variant.species == species_type)
+		if(variant.species == src.species.species_type)
 			valid_outfits += variant
 
 	var/datum/outfit/chosen_variant = pick(valid_outfits)

--- a/code/datums/jobs/job/job.dm
+++ b/code/datums/jobs/job/job.dm
@@ -299,14 +299,8 @@ GLOBAL_PROTECT(exp_specialmap)
 			QDEL_NULL(wear_id)
 		equip_to_slot_or_del(id_card, SLOT_WEAR_ID)
 		job.outfit.handle_id(src)
-		///if there is only one outfit, just equips it
-		if (!job.multiple_outfits)
-			job.outfit.equip(src)
-		///chooses an outfit from the list under the job
-		if (job.multiple_outfits)
-			var/datum/outfit/variant = pick(job.outfits)
-			variant = new variant
-			variant.equip(src)
+
+		get_role_outfit(job)
 
 	if((job.job_flags & JOB_FLAG_ALLOWS_PREFS_GEAR) && player)
 		equip_preference_gear(player)
@@ -315,6 +309,26 @@ GLOBAL_PROTECT(exp_specialmap)
 		job.equip_spawning_squad(src, assigned_squad, player)
 
 	hud_set_job(faction)
+
+/mob/living/carbon/human/proc/get_role_outfit(datum/job/assigned_role)
+	if(!assigned_role.multiple_outfits)
+		assigned_role.outfit.equip(src)
+		return
+
+	var/list/valid_outfits
+
+	var/species_type = SPECIES_HUMAN
+	if(isrobot(src))
+		species_type = SPECIES_COMBAT_ROBOT
+
+	for(var/datum/outfit/variant AS in assigned_role.outfits)
+		if(variant.species == species_type)
+			valid_outfits += variant
+
+	var/datum/outfit/chosen_variant = pick(valid_outfits)
+	chosen_variant = new chosen_variant
+	chosen_variant.equip(src)
+
 
 /datum/job/proc/equip_spawning_squad(mob/living/carbon/human/new_character, datum/squad/assigned_squad, client/player)
 	return

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -108,6 +108,11 @@ Godspeed, captain! And remember, you are not above the law."})
 	minimal_access = ALL_MARINE_ACCESS
 	display_order = JOB_DISPLAY_ORDER_EXECUTIVE_OFFICER
 	outfit = /datum/outfit/job/command/fieldcommander
+	multiple_outfits = TRUE
+	outfits = list(
+		/datum/outfit/job/command/fieldcommander,
+		/datum/outfit/job/command/fieldcommander_robot,
+	)
 	exp_requirements = XP_REQ_EXPERIENCED
 	exp_type = EXP_TYPE_REGULAR_ALL
 	job_flags = JOB_FLAG_LATEJOINABLE|JOB_FLAG_ROUNDSTARTJOINABLE|JOB_FLAG_ALLOWS_PREFS_GEAR|JOB_FLAG_PROVIDES_BANK_ACCOUNT|JOB_FLAG_ADDTOMANIFEST|JOB_FLAG_ISCOMMAND|JOB_FLAG_BOLD_NAME_ON_SELECTION|JOB_FLAG_PROVIDES_SQUAD_HUD|JOB_FLAG_CAN_SEE_ORDERS|JOB_FLAG_ALWAYS_VISIBLE_ON_MINIMAP
@@ -132,6 +137,10 @@ Godspeed, captain! And remember, you are not above the law."})
 	access = ALL_MARINE_REBEL_ACCESS
 	minimal_access = ALL_MARINE_REBEL_ACCESS
 	outfit = /datum/outfit/job/command/fieldcommander/rebel
+	outfits = list(
+		/datum/outfit/job/command/fieldcommander,
+		/datum/outfit/job/command/fieldcommander_robot/rebel,
+	)
 	jobworth = list(
 		/datum/job/xenomorph = LARVA_POINTS_SHIPSIDE,
 		/datum/job/terragov/squad/smartgunner/rebel = SMARTIE_POINTS_REGULAR,
@@ -181,10 +190,31 @@ Make the TGMC proud!"})
 	back = /obj/item/storage/backpack/marine/satchel
 	suit_store = /obj/item/storage/holster/belt/pistol/m4a3/fieldcommander
 
+/datum/outfit/job/command/fieldcommander_robot
+	name = FIELD_COMMANDER
+	jobtype = /datum/job/terragov/command/fieldcommander
+	species = SPECIES_COMBAT_ROBOT
+
+	id = /obj/item/card/id/dogtag/fc
+	belt = /obj/item/storage/holster/blade/officer/full
+	ears = /obj/item/radio/headset/mainship/mcom
+	w_uniform = /obj/item/clothing/under/marine/robotic
+	wear_suit = /obj/item/clothing/suit/modular/robot
+	shoes = null
+	gloves = null
+	head = null
+	r_store = /obj/item/storage/pouch/general/large/command
+	l_store = /obj/item/hud_tablet/fieldcommand
+	back = /obj/item/storage/backpack/marine/satchel
+	suit_store = /obj/item/storage/holster/belt/pistol/m4a3/fieldcommander
+
 /datum/outfit/job/command/fieldcommander/rebel
 	jobtype = /datum/job/terragov/command/fieldcommander/rebel
 	ears = /obj/item/radio/headset/mainship/mcom/rebel
 
+/datum/outfit/job/command/fieldcommander_robot/rebel
+	jobtype = /datum/job/terragov/command/fieldcommander/rebel
+	ears = /obj/item/radio/headset/mainship/mcom/rebel
 
 //Staff Officer
 /datum/job/terragov/command/staffofficer

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -202,7 +202,7 @@ Make the TGMC proud!"})
 	wear_suit = /obj/item/clothing/suit/modular/robot
 	shoes = null
 	gloves = null
-	head = null
+	head = /obj/item/clothing/head/modular/robot
 	r_store = /obj/item/storage/pouch/general/large/command
 	l_store = /obj/item/hud_tablet/fieldcommand
 	back = /obj/item/storage/backpack/marine/satchel

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -26,6 +26,8 @@
 	var/accessory = null
 
 	var/can_be_admin_equipped = TRUE // Set to FALSE if your outfit requires runtime parameters
+	///the species this outfit is designed for
+	var/species = SPECIES_HUMAN
 
 
 /datum/outfit/proc/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -7,6 +7,8 @@
 	///Species name
 	var/name
 	var/name_plural
+	///what kind of species it is considered
+	var/species_type = SPECIES_HUMAN
 
 	///Normal icon file
 	var/icobase = 'icons/mob/human_races/r_human.dmi'
@@ -391,6 +393,7 @@
 /datum/species/robot
 	name = "Combat Robot"
 	name_plural = "Combat Robots"
+	species_type = SPECIES_COMBAT_ROBOT
 	icobase = 'icons/mob/human_races/r_robot.dmi'
 	damage_mask_icon = 'icons/mob/dam_mask_robot.dmi'
 	brute_damage_icon_state = "robot_brute"


### PR DESCRIPTION
## About The Pull Request
Fixes #12941 more or less
Robo FC spawns with robot uniform and armour instead of being naked. This means he actually gets his binos and such.

Adds the support more generally for species specific outfits, but I didn't add any to the other ship roles because A: We have no non combat gear for robots, and B: They're expendable **combat** robots, why are they staff officers and doctors to begin with?

If someone adds gear they can add them though. Same goes for if we add some other snowflake race in the futre.
## Why It's Good For The Game
Not spawning with important gear due to a game pref is bad.
## Changelog
:cl:
fix: Field Commander robots now spawn with robot equipment
code: Adds support for species specific outfits
/:cl:
