### PR TITLE
Greyscale fixes

### DIFF
--- a/code/modules/clothing/modular_armor/attachments.dm
+++ b/code/modules/clothing/modular_armor/attachments.dm
@@ -237,6 +237,7 @@
 	greyscale_colors = COLOR_VERY_LIGHT_GRAY
 
 	flags_attach_features = ATTACH_REMOVABLE|ATTACH_SAME_ICON|ATTACH_APPLY_ON_MOB
+	appearance_flags = KEEP_APART|TILE_BOUND
 
 /obj/item/armor_module/greyscale/on_attach(obj/item/attaching_to, mob/user)
 	. = ..()

--- a/code/modules/clothing/modular_armor/attachments/cape.dm
+++ b/code/modules/clothing/modular_armor/attachments/cape.dm
@@ -13,7 +13,6 @@
 	secondary_color = TRUE
 	attachments_by_slot = list(ATTACHMENT_SLOT_CAPE_HIGHLIGHT)
 	starting_attachments = list(/obj/item/armor_module/greyscale/cape_highlight)
-	appearance_flags = KEEP_APART|TILE_BOUND
 	///True if the hood is up, false if not.
 	var/hood = FALSE
 


### PR DESCRIPTION
## About The Pull Request
Fixes some attachments going fully black.

I added the flag for capes instead of all greyscale for some reason.
## Why It's Good For The Game
Bug fix good. closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/13025
## Changelog
:cl:
fix: fixed some greyscale attachments showing entirely black
/:cl:
