### PR TITLE
Remove override on cape highlight

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/cape.dm
+++ b/code/modules/clothing/modular_armor/attachments/cape.dm
@@ -66,10 +66,10 @@
 /obj/item/armor_module/greyscale/cape_highlight
 	name = "Cape Highlight"
 	desc = "A cape to improve on the design of the 7E badge, this cape is capable of six colors, for all your fashion needs. This variation of the cape functions more as a scarf. \n Interact with facepaint to color. Attaches onto a uniform. Activate it to toggle the hood."
-	icon_state = "highlight"
+	icon_state = "cape_highlight"
 	slot = ATTACHMENT_SLOT_CAPE_HIGHLIGHT
 	flags_attach_features = ATTACH_SAME_ICON|ATTACH_APPLY_ON_MOB
-	icon_state = "cape_highlight"
+
 	greyscale_config = /datum/greyscale_config/cape
 	greyscale_colors = COLOR_MAROON
 	secondary_color = TRUE


### PR DESCRIPTION

## About The Pull Request

Code fix. I saw this during kama code, and I went, "That's weird".

## Why It's Good For The Game

Cleaner code.

## Changelog

:cl:
code: remove unneeded override in cape highlight
/:cl:

