### PR TITLE
Fixes flare opacity

### DIFF
--- a/code/game/objects/items/storage/holsters.dm
+++ b/code/game/objects/items/storage/holsters.dm
@@ -382,9 +382,12 @@
 	if(!istype(I, /obj/item/weapon/gun/grenade_launcher/single_shot/flare))
 		return ..()
 	var/obj/item/weapon/gun/grenade_launcher/single_shot/flare/flare_gun = I
+	if(flare_gun.in_chamber)
+		return
 	for(var/obj/item/flare in contents)
+		remove_from_storage(flare, get_turf(user), user)
+		user.put_in_any_hand_if_possible(flare)
 		flare_gun.reload(flare, user)
-		orient2hud()
 		return
 
 /obj/item/storage/holster/flarepouch/full/Initialize(mapload)


### PR DESCRIPTION

## About The Pull Request
Fixes flares sometimes having full tile opacity.
Fixes #12051 

It turns out this was happening when a flare was right click loaded into a flaregun from a flarepouch, as the item wasn't being correctly removed from storage.

Also adds a check so you don't try reload the flaregun when its already loaded.
## Why It's Good For The Game
Being able to click a tile is good.
## Changelog
:cl:
fix: fixed flares sometimes having full tile opacity
/:cl:
