### PR TITLE
Railgun nerfs

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1342,7 +1342,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	max_range = 21
 	damage = 100
 	penetration = 30
-	sundering = 100
+	sundering = 50
 
 /datum/ammo/bullet/railgun/hvap/on_hit_mob(mob/M, obj/projectile/P)
 	staggerstun(M, P, stagger = 2, knockback = 3)
@@ -1351,9 +1351,9 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	name = "smart armor piercing railgun slug"
 	hud_state = "railgun_smart"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING|AMMO_PASS_THROUGH_TURF|AMMO_PASS_THROUGH_MOVABLE|AMMO_IFF
-	damage = 75
+	damage = 100
 	penetration = 20
-	sundering = 50
+	sundering = 20
 
 /datum/ammo/bullet/railgun/smart/on_hit_mob(mob/M, obj/projectile/P)
 	staggerstun(M, P, stagger = 3, slowdown = 3)

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -929,13 +929,13 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 		/obj/item/attachable/scope/marine,
 	)
 
-	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER
+	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_WIELDED_STABLE_FIRING_ONLY|GUN_AMMO_COUNTER
 	reciever_flags = AMMO_RECIEVER_MAGAZINES|AMMO_RECIEVER_AUTO_EJECT|AMMO_RECIEVER_CYCLE_ONLY_BEFORE_FIRE
 
 	fire_delay = 3 SECONDS
 	burst_amount = 1
 	accuracy_mult = 2
-	recoil = 0
+	recoil = 3
 	scatter = 0
 	movement_acc_penalty_mult = 6
 


### PR DESCRIPTION

## About The Pull Request
Muh xope etc.

100 sunder weapons are dumb, they'll all go in the bin eventually.
Reduced sunder of HVAP from 100 to 50, and for the IFF one 50 to 20 (but increased its damage)
This is still very significant sunder, it just means a p90 won't completely delete you after the fact.

Also made it fully wielded fire only.
## Why It's Good For The Game
100 to 0 sunder is bad gameplay.
## Changelog
:cl:
balance: reduced sunder of HVAP and IFF railgun rounds
balance: railgun must be fully wielded to fire
/:cl:
