### PR TITLE
Shrike Primo rework

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -750,7 +750,7 @@
 #define COMSIG_XENOABILITY_PSYCHIC_CURE "xenoability_psychic_cure"
 #define COMSIG_XENOABILITY_UNRELENTING_FORCE "xenoability_unrelenting_force"
 #define COMSIG_XENOABILITY_UNRELENTING_FORCE_SELECT "xenoability_unrelenting_force_select"
-#define COMSIG_XENOABILITY_GRAV_NADE "xenoability_grav_nade"
+#define COMSIG_XENOABILITY_PSYCHIC_VORTEX "xenoability_psychic_vortex"
 
 #define COMSIG_XENOABILITY_RAVAGER_CHARGE "xenoability_ravager_charge"
 #define COMSIG_XENOABILITY_RAVAGE "xenoability_ravage"

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -544,11 +544,11 @@
 	hotkey_keys = list("F")
 
 
-/datum/keybinding/xeno/gravity_grenade
+/datum/keybinding/xeno/psychic_storm
 	name = "gravnade"
-	full_name = "Shrike: Gravity Grenade"
+	full_name = "Shrike: Psychic Vortex"
 	description = ""
-	keybind_signal = COMSIG_XENOABILITY_GRAV_NADE
+	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_VORTEX
 	hotkey_keys = list("X")
 
 /datum/keybinding/xeno/screech

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -351,6 +351,7 @@
 #define VORTEX_RANGE 6
 #define VORTEX_PULL_WINDUP_TIME 2 SECONDS
 #define VORTEX_PUSH_WINDUP_TIME 1 SECONDS
+#define VORTEX_ABILITY_TRAIT
 /datum/action/xeno_action/activable/psychic_vortex
 	name = "Pyschic vortex"
 	action_icon_state = "vortex"
@@ -370,7 +371,7 @@
 /datum/action/xeno_action/activable/psychic_vortex/use_ability(atom/target)
 	succeed_activate()
 	add_cooldown()
-	addtimer(CALLBACK(owner, TYPE_PROC_REF(/mob, update_icons)), 2 SECONDS)
+	addtimer(CALLBACK(owner, TYPE_PROC_REF(/mob, update_icons)), 1 SECONDS)
 	var/mob/living/carbon/xenomorph/xeno = owner
 	owner.icon_state = "[xeno.xeno_caste.caste_name][xeno.is_a_rouny ? " rouny" : ""] Screeching"
 	if(target) // Keybind use doesn't have a target
@@ -386,8 +387,8 @@
 					continue
 				victim.throw_at(owner, 6, 1, owner, FALSE)
 
-	for(var/turf/affected_tile in view(VORTEX_RANGE, owner.loc))
-		affected_tile.Shake(4, 4, 3 SECONDS)
+	for(var/turf/affected_tile in range(VORTEX_RANGE, owner.loc))
+		affected_tile.Shake(4, 4, 5 SECONDS)
 		for(var/i in affected_tile)
 			var/atom/movable/affected = i
 			if(!ishuman(affected) && !istype(affected, /obj/item) && !isdroid(affected))
@@ -403,4 +404,17 @@
 			for(var/x in 1 to 6)
 				throwlocation = get_step(throwlocation, owner.dir)
 			affected.throw_at(owner, 6, 1, owner, FALSE)
+
+	var/turf/targetturf = get_turf(owner)
+	targetturf = locate(targetturf.x + rand(1, 6), targetturf.y + rand(1, 6), targetturf.z)
+	if(do_after(owner, VORTEX_PUSH_WINDUP_TIME, FALSE, owner, BUSY_ICON_DANGER))
+		for(var/atom/movable/victim in range(VORTEX_RANGE, owner.loc))
+			if(victim.anchored)
+				continue
+			if((isliving(victim)))
+				var/mob/livingtarget = victim
+				if(livingtarget.stat == DEAD)
+					continue
+				victim.throw_at(targetturf, 6, 1, owner, FALSE)
+
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -409,6 +409,8 @@
 	targetturf = locate(targetturf.x + rand(1, 6), targetturf.y + rand(1, 6), targetturf.z)
 	if(do_after(owner, VORTEX_PUSH_WINDUP_TIME, FALSE, owner, BUSY_ICON_DANGER))
 		for(var/atom/movable/victim in range(VORTEX_RANGE, owner.loc))
+			if(victim == owner)
+				continue
 			if(victim.anchored)
 				continue
 			if((isliving(victim)))
@@ -417,4 +419,30 @@
 					continue
 				victim.throw_at(targetturf, 6, 1, owner, FALSE)
 
+	if(do_after(owner, VORTEX_PULL_WINDUP_TIME, FALSE, owner, BUSY_ICON_DANGER))
+		for(var/atom/movable/victim in view(VORTEX_RANGE, owner.loc))
+			if(victim.anchored)
+				continue
+			if((isliving(victim)))
+				var/mob/livingtarget = victim
+				if(livingtarget.stat == DEAD)
+					continue
+			victim.throw_at(owner, 6, 1, owner, FALSE)
 
+	for(var/turf/affected_tile in range(VORTEX_RANGE, owner.loc))
+		affected_tile.Shake(4, 4, 5 SECONDS)
+		for(var/i in affected_tile)
+			var/atom/movable/affected = i
+			if(!ishuman(affected) && !istype(affected, /obj/item) && !isdroid(affected))
+				affected.Shake(4, 4, 20)
+				continue
+			if(ishuman(affected))
+				var/mob/living/carbon/human/H = affected
+				if(H.stat == DEAD)
+					continue
+				H.apply_effects(0, 1)
+				shake_camera(H, 2, 1)
+			var/throwlocation = affected.loc
+			for(var/x in 1 to 6)
+				throwlocation = get_step(throwlocation, owner.dir)
+			affected.throw_at(owner, 6, 1, owner, FALSE)

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -348,7 +348,7 @@
 // ***************************************
 // *********** Psychic Vortex
 // ***************************************
-#define VORTEX_RANGE 6
+#define VORTEX_RANGE 5
 #define VORTEX_PULL_WINDUP_TIME 2 SECONDS
 #define VORTEX_PUSH_WINDUP_TIME 1 SECONDS
 #define VORTEX_ABILITY_TRAIT
@@ -357,7 +357,7 @@
 	action_icon_state = "vortex"
 	desc = "Channel a sizable vortex of psychic energy, drawing in nearby enemies."
 	ability_name = "Psychic vortex"
-	plasma_cost = 500
+	plasma_cost = 600
 	cooldown_timer = 3 MINUTES
 	keybind_flags = XACT_KEYBIND_USE_ABILITY
 	keybinding_signals = list(
@@ -377,6 +377,7 @@
 	if(target) // Keybind use doesn't have a target
 		owner.face_atom(target)
 
+	playsound(owner, 'sound/effects/seedling_chargeup.ogg', 60)
 	if(!do_after(owner, VORTEX_PULL_WINDUP_TIME, FALSE, owner, BUSY_ICON_DANGER))
 		for(var/atom/movable/victim in view(VORTEX_RANGE, owner.loc))
 			if(victim.anchored)
@@ -385,7 +386,7 @@
 				var/mob/livingtarget = victim
 				if(livingtarget.stat == DEAD)
 					continue
-				victim.throw_at(owner, 6, 1, owner, FALSE)
+				victim.throw_at(owner, 5, 1, owner, FALSE)
 
 	for(var/turf/affected_tile in range(VORTEX_RANGE, owner.loc))
 		affected_tile.Shake(4, 4, 5 SECONDS)
@@ -401,12 +402,12 @@
 				H.apply_effects(1, 1)
 				shake_camera(H, 2, 1)
 			var/throwlocation = affected.loc
-			for(var/x in 1 to 6)
+			for(var/x in 1 to 5)
 				throwlocation = get_step(throwlocation, owner.dir)
-			affected.throw_at(owner, 6, 1, owner, FALSE)
+			affected.throw_at(owner, 5, 1, owner, FALSE)
 
 	var/turf/targetturf = get_turf(owner)
-	targetturf = locate(targetturf.x + rand(1, 6), targetturf.y + rand(1, 6), targetturf.z)
+	targetturf = locate(targetturf.x + rand(1, 5), targetturf.y + rand(1, 5), targetturf.z)
 	if(do_after(owner, VORTEX_PUSH_WINDUP_TIME, FALSE, owner, BUSY_ICON_DANGER))
 		for(var/atom/movable/victim in range(VORTEX_RANGE, owner.loc))
 			if(victim == owner)
@@ -417,7 +418,7 @@
 				var/mob/livingtarget = victim
 				if(livingtarget.stat == DEAD)
 					continue
-				victim.throw_at(targetturf, 6, 1, owner, FALSE)
+				victim.throw_at(targetturf, 5, 1, owner, FALSE)
 
 	if(do_after(owner, VORTEX_PULL_WINDUP_TIME, FALSE, owner, BUSY_ICON_DANGER))
 		for(var/atom/movable/victim in view(VORTEX_RANGE, owner.loc))
@@ -427,7 +428,7 @@
 				var/mob/livingtarget = victim
 				if(livingtarget.stat == DEAD)
 					continue
-			victim.throw_at(owner, 6, 1, owner, FALSE)
+			victim.throw_at(owner, 5, 1, owner, FALSE)
 
 	for(var/turf/affected_tile in range(VORTEX_RANGE, owner.loc))
 		affected_tile.Shake(4, 4, 5 SECONDS)
@@ -443,6 +444,6 @@
 				H.apply_effects(0, 1)
 				shake_camera(H, 2, 1)
 			var/throwlocation = affected.loc
-			for(var/x in 1 to 6)
+			for(var/x in 1 to 5)
 				throwlocation = get_step(throwlocation, owner.dir)
-			affected.throw_at(owner, 6, 1, owner, FALSE)
+			affected.throw_at(owner, 5, 1, owner, FALSE)

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -208,5 +208,5 @@
 		/datum/action/xeno_action/rally_hive,
 		/datum/action/xeno_action/rally_minion,
 		/datum/action/xeno_action/blessing_menu,
-		/datum/action/xeno_action/activable/gravity_grenade,
+		/datum/action/xeno_action/activable/psychic_vortex,
 	)


### PR DESCRIPTION
## About The Pull Request
Reworks shrikes primo into a multistage 'vortex' currently work in progress.
TODO: Fix tile shake, add stage 2 and stage 3.
## Why It's Good For The Game
Shrike primo has always sat in a bad place, not being very useful compared to most if not being the absolute bottom of the barrel of primo's. This gives it a much beefier affect and allows for more dynamic choices of primordial spending.
## Changelog
:cl:
Balance: Reworks Shrike primo to be more competitive choice
Add: Psychic Vortex, shrike primo ability
/:cl:
