### PR TITLE
Warlock nerf

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2880,8 +2880,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	if(ismecha(O))
 		var/obj/vehicle/sealed/mecha/mech_victim = O
 		mech_victim.take_damage(rand(200, 400), BURN, ENERGY, 0, armour_penetration = penetration)
-	else
-		O.take_damage(damage, BURN, ENERGY, 0, armour_penetration = penetration)
 
 /datum/ammo/energy/xeno/psy_blast/psy_lance/on_hit_mob(mob/M, obj/projectile/P)
 	if(!isxeno(M))


### PR DESCRIPTION

## About The Pull Request
Muh Mope etc.

Psylance no longer does bonus damage to objects hit (it still has a  large bonus against mechs specifically however).
## Why It's Good For The Game
Less able to insta murder turrets behind cades.
## Changelog
:cl:
balance: Psylance no longer does bonus damage to objects other than mechs
/:cl:
