### PR TITLE
Prison pool fix

### DIFF
--- a/_maps/modularmaps/prison/civresgym.dmm
+++ b/_maps/modularmaps/prison/civresgym.dmm
@@ -18,7 +18,7 @@
 /area/template_noop)
 "m" = (
 /obj/item/toy/inflatable_duck,
-/turf/open/nostromowater,
+/turf/open/liquid/water/sea,
 /area/template_noop)
 "n" = (
 /obj/machinery/light/small{
@@ -41,7 +41,7 @@
 /turf/open/floor/prison/bright_clean/two,
 /area/template_noop)
 "x" = (
-/turf/open/nostromowater,
+/turf/open/liquid/water/sea,
 /area/template_noop)
 "C" = (
 /obj/machinery/light/small{

--- a/code/game/turfs/liquid_turfs.dm
+++ b/code/game/turfs/liquid_turfs.dm
@@ -103,7 +103,7 @@
 
 /turf/open/liquid/water/sea
 	name = "water"
-	icon_state = "water"
+	icon_state = "seadeep"
 
 /turf/open/liquid/water/river
 	name = "river"


### PR DESCRIPTION

## About The Pull Request
Fixes a prison pool not loading due to an old typepath somehow getting missed.
## Why It's Good For The Game
Space pool of death bad.
## Changelog
:cl:
fix: Prison station no longer has a pool leading directly to deep space
/:cl:
