### PR TITLE
Squad Leaders can now use the FOB Construction Drone

### DIFF
--- a/code/modules/mining/remote_fob/remote_fob_computer.dm
+++ b/code/modules/mining/remote_fob/remote_fob_computer.dm
@@ -7,7 +7,7 @@
 	icon = 'icons/Marine/remotefob.dmi'
 	icon_state = "fobpc"
 	interaction_flags = INTERACT_MACHINE_DEFAULT
-	req_one_access = list(ACCESS_MARINE_REMOTEBUILD, ACCESS_MARINE_CE, ACCESS_MARINE_ENGINEERING)
+	req_one_access = list(ACCESS_MARINE_REMOTEBUILD, ACCESS_MARINE_CE, ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_LEADER)
 	resistance_flags = RESIST_ALL
 	networks = FALSE
 	off_action = new/datum/action/innate/camera_off/remote_fob


### PR DESCRIPTION
## About The Pull Request
Per title.

## Why It's Good For The Game
- Not a lot of people want to build FOB even when SLs _do_ want to. Giving SLs the ability to build FOB sounds good, so that there's statistically more chances for FOB to be built.
- Squad Leaders are, y'know, leaders. Building FOBs sounds like something a leader would do.

## Changelog
:cl: Lewdcifer
add: Squad Leaders can now use the FOB construction drone.
/:cl: