### PR TITLE
Gives FC more skills

### DIFF
--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -382,6 +382,14 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	police = SKILL_POLICE_MP
 	powerloader = SKILL_POWERLOADER_TRAINED
 	cqc = SKILL_CQC_TRAINED
+	melee_weapons = SKILL_MELEE_DEFAULT
+	firearms = SKILL_FIREARMS_TRAINED
+	pistols = SKILL_PISTOLS_TRAINED
+	shotguns = SKILL_SHOTGUNS_TRAINED
+	rifles = SKILL_RIFLES_TRAINED
+	smgs = SKILL_SMGS_TRAINED
+	heavy_weapons = SKILL_HEAVY_WEAPONS_TRAINED
+	smartgun = SKILL_SMART_TRAINED
 
 /datum/skills/so
 	name = STAFF_OFFICER


### PR DESCRIPTION

## About The Pull Request
Gives FC more gun and weapon skills, 
**Including SG skill**
## Why It's Good For The Game
Considering marines can only have one per round and once deceased, there is no way of replacing said role,
FC should be the master of combat it was always meant to be. (Also, paves the way for cool FC kits to make the role more interesting and less of a marine wrangling CBT role)
SG skill also makes sense because FC can help support the frontlines instead of having to unga bunga.
<s>I can probably remove this if it's too powercreepy.</s>
## Changelog
:cl:
balance: gives FC all weapon skills including SG skill.
/:cl:
